### PR TITLE
feat: add value to two-columns-list title

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.stories.tsx
@@ -61,3 +61,20 @@ export const Progress: Story = {
     ],
   },
 }
+
+export const TitleWithValue: Story = {
+  args: {
+    title: "Work time balance",
+    titleValue: "-68h",
+    list: [
+      {
+        title: "Effective worked time",
+        info: "100h",
+      },
+      {
+        title: "Planned time",
+        info: "168h",
+      },
+    ],
+  },
+}

--- a/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
@@ -7,14 +7,14 @@ interface TwoColumnsItemType {
 
 interface TwoColumnsListType {
   title?: string
-  titleValue?: string | ReactNode
+  titleValue?: string
   list: TwoColumnsItemType[]
 }
 
 const Item = ({ title, info }: TwoColumnsItemType) => (
   <div className="flex items-center justify-between">
     <p className="flex text-f1-foreground-secondary">{title}</p>
-    <div className="basis-16 justify-self-end text-right font-medium">
+    <div className="max-w-32 flex-shrink-0 overflow-hidden text-ellipsis whitespace-nowrap text-right font-medium">
       {info}
     </div>
   </div>

--- a/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
@@ -7,6 +7,7 @@ interface TwoColumnsItemType {
 
 interface TwoColumnsListType {
   title?: string
+  titleValue?: string
   list: TwoColumnsItemType[]
 }
 
@@ -20,10 +21,15 @@ const Item = ({ title, info }: TwoColumnsItemType) => (
 )
 
 export const TwoColumnsList = forwardRef<HTMLDivElement, TwoColumnsListType>(
-  function TwoColumnsList({ title, list }, ref) {
+  function TwoColumnsList({ title, titleValue, list }, ref) {
     return (
       <div ref={ref} className="flex flex-col gap-2">
-        {title && <div className="font-medium">{title}</div>}
+        {title && (
+          <div className="flex items-center justify-between font-medium">
+            <div>{title}</div>
+            {titleValue && <div>{titleValue}</div>}
+          </div>
+        )}
         {list.map((item) => (
           <Item key={item.title} title={item.title} info={item.info} />
         ))}

--- a/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
@@ -25,7 +25,7 @@ export const TwoColumnsList = forwardRef<HTMLDivElement, TwoColumnsListType>(
     return (
       <div ref={ref} className="flex flex-col gap-2">
         {title && (
-          <div className="flex items-center justify-between font-medium">
+          <div className="flex items-center justify-between gap-2 font-medium">
             <div>{title}</div>
             {titleValue && <div>{titleValue}</div>}
           </div>

--- a/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
@@ -7,7 +7,7 @@ interface TwoColumnsItemType {
 
 interface TwoColumnsListType {
   title?: string
-  titleValue?: string
+  titleValue?: string | ReactNode
   list: TwoColumnsItemType[]
 }
 


### PR DESCRIPTION
## Description

- We need to be able to add the result from certain operations to the title of the `TwoColumnsList` component.

## Screenshots (if applicable)

<img width="810" height="250" alt="image" src="https://github.com/user-attachments/assets/fbaf048e-4ef2-4062-b04b-fe61497ba790" />


[Link to Figma Design](https://factorialmakers.atlassian.net/browse/FCT-35182)

## Implementation details

- Added an optional `titleValue` to the `TwoColumnsList` title
