### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.183.0",
+  "packages/react": "1.184.0",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.184.0](https://github.com/factorialco/f0/compare/f0-react-v1.183.0...f0-react-v1.184.0) (2025-09-15)
+
+
+### Features
+
+* datenavigator show compare to date in navigation button ([#2547](https://github.com/factorialco/f0/issues/2547)) ([455508f](https://github.com/factorialco/f0/commit/455508f07dcf6f2ddbc2048121a804b125d2b520))
+
 ## [1.183.0](https://github.com/factorialco/f0/compare/f0-react-v1.182.1...f0-react-v1.183.0) (2025-09-12)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.183.0",
+  "version": "1.184.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.184.0</summary>

## [1.184.0](https://github.com/factorialco/f0/compare/f0-react-v1.183.0...f0-react-v1.184.0) (2025-09-15)


### Features

* datenavigator show compare to date in navigation button ([#2547](https://github.com/factorialco/f0/issues/2547)) ([455508f](https://github.com/factorialco/f0/commit/455508f07dcf6f2ddbc2048121a804b125d2b520))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).