### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.184.0",
+  "packages/react": "1.185.0",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.185.0](https://github.com/factorialco/f0/compare/f0-react-v1.184.0...f0-react-v1.185.0) (2025-09-15)
+
+
+### Features
+
+* **F0ChipList:** export F0ChipList component ([#2586](https://github.com/factorialco/f0/issues/2586)) ([6051524](https://github.com/factorialco/f0/commit/60515240d6650ea373cc993ea2872e0e69736a7b))
+
 ## [1.184.0](https://github.com/factorialco/f0/compare/f0-react-v1.183.0...f0-react-v1.184.0) (2025-09-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.184.0",
+  "version": "1.185.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.185.0</summary>

## [1.185.0](https://github.com/factorialco/f0/compare/f0-react-v1.184.0...f0-react-v1.185.0) (2025-09-15)


### Features

* **F0ChipList:** export F0ChipList component ([#2586](https://github.com/factorialco/f0/issues/2586)) ([6051524](https://github.com/factorialco/f0/commit/60515240d6650ea373cc993ea2872e0e69736a7b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).