### PR TITLE
fix(datacollection): one col sticky

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -1036,6 +1036,66 @@ export const WithInfiniteScrollPagination: Story = {
   },
 }
 
+// This is a test to see if the table visualization works with one column
+export const WithInfiniteScrollPaginationOneCol: Story = {
+  render: () => {
+    // Create a fixed set of paginated users so we're not regenerating them on every render
+    const paginatedMockUsers = generateMockUsers(50)
+
+    const mockVisualizations = getMockVisualizations({
+      frozenColumns: 0,
+    })
+
+    const source = useDataSource({
+      filters,
+      presets: filterPresets,
+      sortings,
+      selectable: (item) => (item.id !== "user-1a" ? item.id : undefined),
+      bulkActions: (allSelected) => {
+        return {
+          primary: [
+            {
+              label: allSelected ? "Delete All" : "Delete",
+              icon: Delete,
+              id: "delete-all",
+            },
+          ],
+        }
+      },
+      dataAdapter: createDataAdapter({
+        data: paginatedMockUsers,
+        delay: 500,
+        paginationType: "infinite-scroll",
+        perPage: 10,
+      }),
+    })
+
+    return (
+      <div className="space-y-4" style={{ height: "500px", overflow: "auto" }}>
+        <OneDataCollection
+          source={source}
+          onSelectItems={(selectedItems) => {
+            console.log("Selected items", "->", selectedItems)
+          }}
+          onBulkAction={(action, selectedItems) => {
+            console.log(`Bulk action: ${action}`, "->", selectedItems)
+          }}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                columns: [{ label: "Name", render: (item) => item.name }],
+              },
+            },
+            mockVisualizations.card,
+            mockVisualizations.list,
+          ]}
+        />
+      </div>
+    )
+  },
+}
+
 export const WithSynchronousData: Story = {
   render: () => {
     const mockVisualizations = getMockVisualizations({

--- a/packages/react/src/experimental/OneDataCollection/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/index.tsx
@@ -492,7 +492,7 @@ const OneDataCollectionComp = <
   return (
     <div
       className={cn(
-        "flex flex-col gap-4",
+        "flex w-full flex-col gap-4",
         layout === "standard" && "-mx-6",
         fullHeight && "h-full"
       )}

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -19,6 +19,7 @@ import { cn } from "@/lib/utils"
 import { Checkbox } from "@/ui/checkbox"
 import { TableColumnDefinition } from ".."
 import { ItemActionsRow } from "../../../../components/itemActions/ItemActionsRow/ItemActionsRow"
+import { useSticky } from "../useSticky"
 
 export type RowProps<
   R extends RecordType,
@@ -91,6 +92,12 @@ const RowComponentInner = <
 
   const key = `table-row-${groupIndex}-${index}`
 
+  const { getStickyPosition } = useSticky(
+    frozenColumnsLeft,
+    columns,
+    !!source.selectable
+  )
+
   const {
     primaryItemActions,
     dropdownItemActions,
@@ -129,18 +136,7 @@ const RowComponentInner = <
           href={itemHref}
           onClick={itemOnClick}
           width={column.width}
-          sticky={
-            cellIndex < frozenColumnsLeft
-              ? {
-                  left: columns
-                    .slice(0, Math.max(0, cellIndex))
-                    .reduce(
-                      (acc, column) => acc + (column.width ?? 0),
-                      checkColumnWidth
-                    ),
-                }
-              : undefined
-          }
+          sticky={getStickyPosition(cellIndex)}
         >
           <div
             className={cn(

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -459,9 +459,9 @@ export const TableCollection = <
             paginationInfo.hasMore && (
               <tr>
                 <td
-                  colSpan={columns.length + (source.selectable ? 1 : 0)}
+                  colSpan={columns.length + (source.selectable ? 1 : 0) + 1}
                   ref={loadingIndicatorRef}
-                  className="h-10 w-full"
+                  className="h-10"
                   aria-hidden="true"
                 ></td>
               </tr>

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -35,6 +35,7 @@ import { isInfiniteScrollPagination, useData } from "../../../useData"
 import { useSelectable } from "../../../useSelectable"
 import { statusToChecked } from "../utils"
 import { Row } from "./components/Row"
+import { useSticky } from "./useSticky"
 
 export type WithOptionalSorting<
   R extends RecordType,
@@ -262,6 +263,13 @@ export const TableCollection = <
 
   const skeletonColumns =
     columns.length + (source.itemActions ? 1 : 0) + (source.selectable ? 1 : 0)
+
+  const { getStickyPosition, checkColumnWidth } = useSticky(
+    frozenColumnsLeft,
+    columns,
+    !!source.selectable
+  )
+
   /*
    * Initial loading
    */
@@ -280,10 +288,8 @@ export const TableCollection = <
     })
   }
 
-  const checkColumnWidth = source.selectable ? 52 : 0
-
   return (
-    <div className="flex h-full min-h-0 flex-col gap-4">
+    <div className="test flex h-full min-h-0 flex-col gap-4">
       <OneTable loading={isLoading}>
         <TableHeader sticky={true}>
           <TableRow>
@@ -315,18 +321,7 @@ export const TableCollection = <
                 )}
                 width={column.width}
                 align={column.align}
-                sticky={
-                  index < frozenColumnsLeft
-                    ? {
-                        left: columns
-                          .slice(0, Math.max(0, index))
-                          .reduce(
-                            (acc, column) => acc + (column.width ?? 0),
-                            checkColumnWidth
-                          ),
-                      }
-                    : undefined
-                }
+                sticky={getStickyPosition(index)}
                 {...column}
                 onSortClick={
                   sorting
@@ -496,18 +491,7 @@ export const TableCollection = <
                   key={`summary-${String(column.label)}`}
                   firstCell={cellIndex === 0}
                   width={column.width}
-                  sticky={
-                    cellIndex < frozenColumnsLeft
-                      ? {
-                          left: columns
-                            .slice(0, Math.max(0, cellIndex))
-                            .reduce(
-                              (acc, column) => acc + (column.width ?? 0),
-                              checkColumnWidth
-                            ),
-                        }
-                      : undefined
-                  }
+                  sticky={getStickyPosition(cellIndex)}
                 >
                   {cellIndex === 0 &&
                   !source.selectable &&

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/useSticky.ts
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/useSticky.ts
@@ -1,0 +1,37 @@
+import { SortingsDefinition } from "@/experimental/OneDataCollection/sortings"
+import { SummariesDefinition } from "@/experimental/OneDataCollection/summary"
+import { RecordType } from "@/experimental/OneDataCollection/types"
+import { useCallback } from "react"
+import { TableColumnDefinition } from "."
+
+export const useSticky = <
+  R extends RecordType,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+>(
+  frozenColumnsLeft: number,
+  columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>,
+  hasCheckColumn: boolean
+) => {
+  const checkColumnWidth = hasCheckColumn ? 52 : 0
+  const getStickyPosition = useCallback(
+    (cellIndex: number) => {
+      return cellIndex < frozenColumnsLeft && columns.length > 1
+        ? {
+            left: columns
+              .slice(0, Math.max(0, cellIndex))
+              .reduce(
+                (acc, column) => acc + (column.width ?? 0),
+                checkColumnWidth
+              ),
+          }
+        : undefined
+    },
+    [frozenColumnsLeft, columns, checkColumnWidth]
+  )
+
+  return {
+    getStickyPosition,
+    checkColumnWidth,
+  }
+}


### PR DESCRIPTION
## Description

- refactor: useSticky to wrap the sticky position logic
- fix: no sticky col if just one col
- fix: infinite scroll trigget colspan
- 
## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
