### PR TITLE
feat: product card one campaign

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductCard/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductCard/index.tsx
@@ -12,6 +12,7 @@ export type ProductCardProps = {
   dismissable?: boolean
   trackVisibility?: (open: boolean) => void
   module: ModuleId
+  type?: "one-campaign" | undefined
 }
 
 export function ProductCard({
@@ -22,6 +23,7 @@ export function ProductCard({
   isVisible,
   dismissable = false,
   trackVisibility,
+  type,
   ...props
 }: ProductCardProps) {
   const [open, setOpen] = useState(isVisible)
@@ -40,33 +42,65 @@ export function ProductCard({
     }
   }
 
+  const getWrapperStyles = () => {
+    if (type === "one-campaign") {
+      return {
+        background: `linear-gradient(98.39deg, rgba(249, 115, 22, 0.49) 0%, rgba(229, 25, 67, 0.49) 20%, rgba(229, 25, 67, 0.49) 49.97%, rgba(229, 25, 67, 0.49) 80%, rgba(164, 165, 222, 0.49) 100%)`,
+        borderRadius: "12px",
+        padding: "1px",
+      }
+    }
+    return {}
+  }
+
+  const getCardStyles = () => {
+    if (type === "one-campaign") {
+      return {
+        background: "#fef7f8",
+        borderRadius: "11px",
+      }
+    }
+    return {}
+  }
+
+  const getCardClassName = () => {
+    if (type === "one-campaign") {
+      return "flex h-auto w-auto cursor-pointer flex-row gap-2 p-3 text-f1-foreground shadow-md hover:bg-f1-background-secondary"
+    }
+
+    return "flex h-auto w-auto cursor-pointer flex-row gap-2 rounded-md border-f1-border p-3 text-f1-foreground shadow-md hover:bg-f1-background-secondary"
+  }
+
   return (
     open && (
       <div>
         <div className="p-2">
-          <div
-            className="flex h-auto w-auto cursor-pointer flex-row gap-2 rounded-md border-f1-border p-3 text-f1-foreground shadow-md hover:bg-f1-background-secondary"
-            onClick={onClick}
-          >
-            <F0AvatarModule module={props.module} size="lg" />
-            <div className="flex flex-1 flex-col">
-              <div>
-                <h3 className="text-lg font-medium">{title}</h3>
-                <p className="text-f1-foreground-secondary">{description}</p>
+          <div style={getWrapperStyles()}>
+            <div
+              className={getCardClassName()}
+              style={getCardStyles()}
+              onClick={onClick}
+            >
+              <F0AvatarModule module={props.module} size="lg" />
+              <div className="flex flex-1 flex-col">
+                <div>
+                  <h3 className="text-lg font-medium">{title}</h3>
+                  <p className="text-f1-foreground-secondary">{description}</p>
+                </div>
               </div>
+              {dismissable && (
+                <div className="h-6 w-6">
+                  <Button
+                    variant="ghost"
+                    icon={CrossIcon}
+                    size="sm"
+                    hideLabel
+                    onClick={handleClose}
+                    label="Close"
+                  />
+                </div>
+              )}
             </div>
-            {dismissable && (
-              <div className="h-6 w-6">
-                <Button
-                  variant="ghost"
-                  icon={CrossIcon}
-                  size="sm"
-                  hideLabel
-                  onClick={handleClose}
-                  label="Close"
-                />
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -271,6 +271,23 @@ export const WithProductUpdate: Story = {
         },
         products: [
           {
+            title: "Factorial Next: AI Edition 2025",
+            description:
+              "Join the event to discover ONE, our most important launch yet. Live on 7 Oct at 16:30 (Spain)",
+            onClick: () => {
+              alert("onClick")
+            },
+            onClose: () => {
+              alert("onClose")
+            },
+            module: "discover",
+            dismissable: false,
+            trackVisibility: (open) => {
+              console.log("trackOpenChange", open)
+            },
+            type: "one-campaign",
+          },
+          {
             title: "Benefits",
             description:
               "Improve your team’s salary without impacting your budget through flexible compensation.",

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -70,6 +70,7 @@ type ProductUpdatesProp = {
       dismissable: boolean
       onClose?: () => void
       trackVisibility?: (open: boolean) => void
+      type?: "one-campaign" | undefined
     }>
   }
 }
@@ -490,6 +491,7 @@ const DiscoverMoreProducts = ({
                 isVisible={true}
                 trackVisibility={product.trackVisibility}
                 onClick={() => handleProductClick(product.onClick)}
+                type={product.type}
               />
             ))}
           </Carousel>


### PR DESCRIPTION
## Description

We need to make the prodcut card distinct for one campaign, so we are adding a type to be able to have a proper background and border. 

## Screenshots (if applicable)
<img width="542" height="837" alt="Screenshot 2025-09-15 at 2 55 54 PM" src="https://github.com/user-attachments/assets/2fa7ac28-3145-4f62-837a-59d093317a16" />

[Link to Figma Design](https://www.figma.com/design/6Zg3LO7NxYpDDpJlLgVFXW/One-GTM---25Q3?node-id=6043-11533&p=f&t=tbrq1Fw186JLSIXA-0)


