### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.186.1",
+  "packages/react": "1.186.2",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.186.2](https://github.com/factorialco/f0/compare/f0-react-v1.186.1...f0-react-v1.186.2) (2025-09-15)
+
+
+### Bug Fixes
+
+* **CommunityPost:** fix comment button growing unexpectedly ([#2563](https://github.com/factorialco/f0/issues/2563)) ([f9d1902](https://github.com/factorialco/f0/commit/f9d1902aebeb7d8e8a673861b518010bf7a322d9))
+
 ## [1.186.1](https://github.com/factorialco/f0/compare/f0-react-v1.186.0...f0-react-v1.186.1) (2025-09-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.186.1",
+  "version": "1.186.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.186.2</summary>

## [1.186.2](https://github.com/factorialco/f0/compare/f0-react-v1.186.1...f0-react-v1.186.2) (2025-09-15)


### Bug Fixes

* **CommunityPost:** fix comment button growing unexpectedly ([#2563](https://github.com/factorialco/f0/issues/2563)) ([f9d1902](https://github.com/factorialco/f0/commit/f9d1902aebeb7d8e8a673861b518010bf7a322d9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).