### PR TITLE
fix: emit preset event with filter values

### DIFF
--- a/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/components/OneFilterPicker/OneFilterPicker.tsx
@@ -195,11 +195,8 @@ const FiltersPresets = () => {
   const { presets, value, setFiltersValue, emitPresetClick } =
     useContext(FiltersContext)
 
-  const handlePresetClick = (
-    presetFilter: FiltersState<FiltersDefinition>,
-    presetLabel: string
-  ) => {
-    emitPresetClick(presetLabel)
+  const handlePresetClick = (presetFilter: FiltersState<FiltersDefinition>) => {
+    emitPresetClick(presetFilter)
     setFiltersValue(presetFilter)
   }
 

--- a/packages/react/src/components/OneFilterPicker/components/FiltersPresets.test.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersPresets.test.tsx
@@ -36,13 +36,10 @@ describe("FiltersPresets", () => {
     await user.click(getByText("Engineering Active"))
 
     // Should call onPresetsChange with the preset's filter
-    expect(mockOnPresetsChange).toHaveBeenCalledWith(
-      {
-        department: ["engineering"],
-        status: ["active"],
-      },
-      "Engineering Active"
-    )
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({
+      department: ["engineering"],
+      status: ["active"],
+    })
   })
 
   it("should deselect preset when clicked and already selected", async () => {
@@ -65,7 +62,7 @@ describe("FiltersPresets", () => {
     await user.click(getByText("Engineering Active"))
 
     // Should call onPresetsChange with empty filters to deselect
-    expect(mockOnPresetsChange).toHaveBeenCalledWith({}, "Engineering Active")
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({})
   })
 
   it("should toggle between different presets correctly", async () => {
@@ -83,25 +80,19 @@ describe("FiltersPresets", () => {
 
     // Click on first preset
     await user.click(getByText("Engineering Active"))
-    expect(mockOnPresetsChange).toHaveBeenCalledWith(
-      {
-        department: ["engineering"],
-        status: ["active"],
-      },
-      "Engineering Active"
-    )
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({
+      department: ["engineering"],
+      status: ["active"],
+    })
 
     // Reset mock
     mockOnPresetsChange.mockClear()
 
     // Click on second preset
     await user.click(getByText("Marketing Only"))
-    expect(mockOnPresetsChange).toHaveBeenCalledWith(
-      {
-        department: ["marketing"],
-      },
-      "Marketing Only"
-    )
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({
+      department: ["marketing"],
+    })
   })
 
   it("should work with dropdown preset items", async () => {
@@ -123,6 +114,6 @@ describe("FiltersPresets", () => {
     await user.click(getByText("Marketing Only"))
 
     // Should deselect the preset
-    expect(mockOnPresetsChange).toHaveBeenCalledWith({}, "Marketing Only")
+    expect(mockOnPresetsChange).toHaveBeenCalledWith({})
   })
 })

--- a/packages/react/src/components/OneFilterPicker/components/FiltersPresets.tsx
+++ b/packages/react/src/components/OneFilterPicker/components/FiltersPresets.tsx
@@ -6,7 +6,7 @@ import { FiltersDefinition, FiltersState, PresetsDefinition } from "../types"
 
 interface FilterPresetsProps<Filters extends FiltersDefinition> {
   value: FiltersState<Filters>
-  onPresetsChange: (filter: FiltersState<Filters>, label: string) => void
+  onPresetsChange: (filter: FiltersState<Filters>) => void
   presets: PresetsDefinition<Filters>
 }
 
@@ -29,8 +29,7 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
         selected={isSelected}
         onClick={() =>
           onPresetsChange?.(
-            isSelected ? ({} as FiltersState<Filters>) : preset.filter,
-            preset.label
+            isSelected ? ({} as FiltersState<Filters>) : preset.filter
           )
         }
         data-visible={isVisible}
@@ -55,8 +54,7 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
         )}
         onClick={() =>
           onPresetsChange?.(
-            isSelected ? ({} as FiltersState<Filters>) : preset.filter,
-            preset.label
+            isSelected ? ({} as FiltersState<Filters>) : preset.filter
           )
         }
         data-visible={true}

--- a/packages/react/src/components/OneFilterPicker/context.ts
+++ b/packages/react/src/components/OneFilterPicker/context.ts
@@ -10,7 +10,7 @@ export type FiltersContextType<Definition extends FiltersDefinition> = {
   isFiltersOpen: boolean
   setIsFiltersOpen: (isOpen: boolean) => void
   emitFilterChange: (filters: FiltersState<Definition>) => void
-  emitPresetClick: (preset: string) => void
+  emitPresetClick: (filters: FiltersState<Definition>) => void
 }
 
 export const FiltersContext = createContext<

--- a/packages/react/src/experimental/OneDataCollection/useEventEmitter.ts
+++ b/packages/react/src/experimental/OneDataCollection/useEventEmitter.ts
@@ -35,17 +35,23 @@ export const useEventEmitter = <Sortings extends SortingsDefinition>({
 
   const emitFilterChange = useCallback(
     (filters: FiltersState<FiltersDefinition>) => {
-      const newFilter = Object.entries(filters ?? {}).find(
+      if (!filters) return
+
+      const changedFilter = Object.entries(filters).find(
         ([field, value]) => latestFilters.current?.[field] !== value
       )
 
-      if (!newFilter || !isScalar(newFilter[1])) return
+      if (!changedFilter) return
+
+      const [field, value] = changedFilter
+
+      if (!isScalar(value)) return
 
       latestFilters.current = filters
 
       onEvent("datacollection.filter-change", {
-        name: newFilter?.[0],
-        value: newFilter?.[1],
+        name: field,
+        value: value,
       })
     },
     [onEvent]
@@ -73,17 +79,23 @@ export const useEventEmitter = <Sortings extends SortingsDefinition>({
 
   const emitPresetClick = useCallback(
     (filters: FiltersState<FiltersDefinition>) => {
-      const newFilter = Object.entries(filters ?? {}).find(
+      if (!filters) return
+
+      const changedFilter = Object.entries(filters).find(
         ([field, value]) => latestFilters.current?.[field] !== value
       )
 
-      if (!newFilter || !isScalar(newFilter[1])) return
+      if (!changedFilter) return
+
+      const [field, value] = changedFilter
+
+      if (!isScalar(value)) return
 
       latestFilters.current = filters
 
       onEvent("datacollection.preset-click", {
-        name: newFilter?.[0],
-        value: newFilter?.[1],
+        name: field,
+        value: value,
       })
     },
     [onEvent]

--- a/packages/react/src/experimental/OneDataCollection/useEventEmitter.ts
+++ b/packages/react/src/experimental/OneDataCollection/useEventEmitter.ts
@@ -72,9 +72,18 @@ export const useEventEmitter = <Sortings extends SortingsDefinition>({
   )
 
   const emitPresetClick = useCallback(
-    (preset: string) => {
+    (filters: FiltersState<FiltersDefinition>) => {
+      const newFilter = Object.entries(filters ?? {}).find(
+        ([field, value]) => latestFilters.current?.[field] !== value
+      )
+
+      if (!newFilter || !isScalar(newFilter[1])) return
+
+      latestFilters.current = filters
+
       onEvent("datacollection.preset-click", {
-        name: preset,
+        name: newFilter?.[0],
+        value: newFilter?.[1],
       })
     },
     [onEvent]


### PR DESCRIPTION
## Description

We were emitting the preset onClick event with the label instead of with the filter value it triggers, which is way more useful for event tracking.