### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.188.1",
+  "packages/react": "1.189.0",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.189.0](https://github.com/factorialco/f0/compare/f0-react-v1.188.1...f0-react-v1.189.0) (2025-09-16)
+
+
+### Features
+
+* product card one campaign ([#2594](https://github.com/factorialco/f0/issues/2594)) ([1e5999d](https://github.com/factorialco/f0/commit/1e5999df5ea724c4c4651c93e6712afecc52257d))
+
 ## [1.188.1](https://github.com/factorialco/f0/compare/f0-react-v1.188.0...f0-react-v1.188.1) (2025-09-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.188.1",
+  "version": "1.189.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.189.0</summary>

## [1.189.0](https://github.com/factorialco/f0/compare/f0-react-v1.188.1...f0-react-v1.189.0) (2025-09-16)


### Features

* product card one campaign ([#2594](https://github.com/factorialco/f0/issues/2594)) ([1e5999d](https://github.com/factorialco/f0/commit/1e5999df5ea724c4c4651c93e6712afecc52257d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).