### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.189.2",
+  "packages/react": "1.189.3",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.189.3](https://github.com/factorialco/f0/compare/f0-react-v1.189.2...f0-react-v1.189.3) (2025-09-16)
+
+
+### Bug Fixes
+
+* dropdown item propagation ([#2589](https://github.com/factorialco/f0/issues/2589)) ([4d8805f](https://github.com/factorialco/f0/commit/4d8805fac05df2ca61194ee84017b56264152bb9))
+
 ## [1.189.2](https://github.com/factorialco/f0/compare/f0-react-v1.189.1...f0-react-v1.189.2) (2025-09-16)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.189.2",
+  "version": "1.189.3",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.189.3</summary>

## [1.189.3](https://github.com/factorialco/f0/compare/f0-react-v1.189.2...f0-react-v1.189.3) (2025-09-16)


### Bug Fixes

* dropdown item propagation ([#2589](https://github.com/factorialco/f0/issues/2589)) ([4d8805f](https://github.com/factorialco/f0/commit/4d8805fac05df2ca61194ee84017b56264152bb9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).