### PR TITLE
feat: datacollection allow to hide fields in cards and list views

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -239,6 +239,18 @@ export const getMockVisualizations = (options?: {
           render: (item) => item.department,
         },
         {
+          label: "Manager",
+          icon: Person,
+          render: (item) => ({
+            type: "person",
+            value: {
+              firstName: item.manager.split(" ")[0],
+              lastName: item.manager.split(" ")[1],
+            },
+          }),
+          hide: (item) => item.name.startsWith("D"),
+        },
+        {
           label: "Teammates",
           icon: Person,
           render: (item) => ({
@@ -318,6 +330,17 @@ export const getMockVisualizations = (options?: {
           label: "Role 2",
           render: (item) => item.role,
           sorting: "role",
+        },
+        {
+          label: "Manager",
+          render: (item) => ({
+            type: "person",
+            value: {
+              firstName: item.manager.split(" ")[0],
+              lastName: item.manager.split(" ")[1],
+            },
+          }),
+          hide: (item) => item.name.startsWith("D"),
         },
         {
           label: "Department",

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/card/card.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/card/card.mdx
@@ -1,0 +1,226 @@
+import {
+  Canvas,
+  Meta,
+  Controls,
+  Unstyled,
+  Story,
+} from "@storybook/addon-docs/blocks"
+import LinkTo from "@storybook/addon-links/react"
+import * as CardStories from "./card.stories"
+
+<Meta title="Data Collection/Visualizations/Card" />
+
+# Card Visualization
+
+## Introduction
+
+The Card visualization is a visualization that displays the data in a card
+format.
+
+## Examples
+
+<Canvas of={CardStories.BasicCardVisualization} />
+
+## Setting Up Card Visualization
+
+To enable the Card visualization in your data collection component, provide the
+`type: "card"` in the `visualizations` prop:
+
+```tsx
+<OneDataCollection
+  source={dataSource}
+  visualizations={[
+    {
+      type: "card",
+      options: {
+        cardProperties: [
+          { label: "Name", render: (item) => item.name },
+          { label: "Email", render: (item) => item.email },
+          { label: "Role", render: (item) => item.role },
+          { label: "Department", render: (item) => item.department },
+          { label: "Status", render: (item) => item.status },
+        ],
+      },
+    },
+  ]}
+/>
+```
+
+## Card Properties
+
+```ts
+type CardVisualizationOptions<T> = {
+  /**
+   * The properties to display in the card.
+   */
+  cardProperties: CardPropertyDefinition<T>[]
+  /**
+   * Returns the title to display for the card.
+   */
+  title: (item: T) => string
+  /**
+   * Returns the description to display for the card.
+   */
+  description?: (item: T) => string
+  /**
+   * Returns the avatar to display for the card.
+   */
+  avatar?: (item: T) => CardAvatarVariant
+  /**
+   * Returns the header image to display for the card.
+   */
+  image?: (item: T) => string
+  /**
+   * Whether the card is displayed in a compact layout.
+   */
+  compact?: boolean
+}
+```
+
+## Card Property Definition
+
+```ts
+type CardPropertyDefinition<T> = {
+  /**
+   * The label to display for the property.
+   */
+  label: string
+
+  /**
+   * The function to render the property.
+   */
+  render: (item: T) => DisplayValueDefinition
+  /**
+   * The icon to display for the property.
+   */
+  icon?: IconType
+  /**
+   * Allows you to hide the property for a given item.
+   */
+  hide?: (item: T) => boolean
+}
+```
+
+## Complete Example
+
+```tsx
+<OneDataCollection
+  source={dataSource}
+  visualizations={[
+    {
+      type: "card",
+      options: {
+        title: (item) => item.name,
+        description: (item) => item.role,
+        avatar: (item) => ({
+            type: "person",
+            firstName: item.name.split(" ")[0],
+            lastName: item.name.split(" ")[1],
+        }),
+        image: (item) => item.image,
+        cardProperties: [
+            {
+                label: "Email",
+                icon: Envelope,
+                render: (item) => item.email,
+            },
+            {
+                label: "Role",
+                icon: Briefcase,
+                render: (item) => item.role,
+            },
+            {
+                label: "Department",
+                icon: Building,
+                render: (item) => item.department,
+            },
+            {
+                label: "Manager",
+                icon: Person,
+                render: (item) => ({
+                    type: "person",
+                    value: {
+                        firstName: item.manager.split(" ")[0],
+                        lastName: item.manager.split(" ")[1],
+                    },
+                }),
+                hide: (item) => item.name.startsWith("D"),
+            },
+            {
+                label: "Teammates",
+                icon: Person,
+                render: (item) => ({
+                    type: "avatarList",
+                    value: {
+                    avatarList: [
+                        {
+                            type: "person",
+                            firstName: item.name,
+                            lastName: "Doe",
+                            src: "/avatars/person01.jpg",
+                        },
+                        {
+                            type: "person",
+                            firstName: "Dani",
+                            lastName: "Moreno",
+                            src: "/avatars/person04.jpg",
+                        },
+                        {
+                            type: "person",
+                            firstName: "Sergio",
+                            lastName: "Carracedo",
+                            src: "/avatars/person05.jpg",
+                        },
+                    ],
+                    },
+                }),
+            },
+            {
+                label: "Status",
+                icon: CheckCircle,
+                render: (item) => ({
+                    type: "status",
+                    value: {
+                        status: item.status === "active" ? "positive" : "critical",
+                        label: item.status.charAt(0).toUpperCase() + item.status.slice(1),
+                    },
+                }),
+            },
+        ],
+    },
+```
+
+## Item actions
+
+The card visualization supports item actions. To enable item actions, provide
+the `itemActions` prop to the `useDataCollectionSource` hook.
+
+```tsx
+<OneDataCollection
+  source={{
+    itemActions: (item) => [
+      { label: "Action 1", onClick: () => console.log("Action 1"), type: "primary" },
+      { label: "Action 2", onClick: () => console.log("Action 2"), type: "secondary" },
+      { label: "Action 3", onClick: () => console.log("Action 3"), type: "other" },
+      ...
+    ],
+  }}
+  visualizations={[
+    {
+      type: "card",
+      options: {
+        cardProperties: [
+          { label: "Name", render: (item) => item.name },
+          { label: "Email", render: (item) => item.email },
+          { label: "Role", render: (item) => item.role },
+          { label: "Department", render: (item) => item.department },
+          { label: "Status", render: (item) => item.status },
+        ],
+      },
+    },
+  ]}
+/>
+```
+
+The action type will make the action to be displayed in the card dropdown menu
+(other type), or in the card footer (primary type and secondary type).

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/card/card.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/card/card.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
-import { ExampleComponent, getMockVisualizations } from "../mockData"
+import { ExampleComponent, getMockVisualizations } from "../../mockData"
 
 const meta = {
   title: "Data Collection/Visualizations/Card",
@@ -20,7 +20,7 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const BasicListVisualization: Story = {
+export const BasicCardVisualization: Story = {
   render: () => {
     const mockVisualizations = getMockVisualizations()
     return <ExampleComponent visualizations={[mockVisualizations.card]} />

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list/list.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list/list.mdx
@@ -1,0 +1,212 @@
+import {
+  Canvas,
+  Meta,
+  Controls,
+  Unstyled,
+  Story,
+} from "@storybook/addon-docs/blocks"
+import LinkTo from "@storybook/addon-links/react"
+import * as ListStories from "./list.stories"
+
+<Meta title="Data Collection/Visualizations/List" />
+
+# List Visualization
+
+## Introduction
+
+The List visualization is a visualization that displays the data in a list
+format. It's an hybrid between the card and the table visualization, as there
+are fixed fiedlds (title, avatar, description) and dynamic fields (properties).
+
+## Examples
+
+<Canvas of={ListStories.BasicListVisualization} />
+
+## Setting Up List Visualization
+
+To enable the List visualization in your data collection component, provide the
+`type: "list"` in the `visualizations` prop:
+
+```tsx
+<OneDataCollection
+  source={dataSource}
+  visualizations={[
+    {
+      type: "list",
+      options: {
+        itemDefinition: (item) => ({
+          title: item.name,
+          description: [item.email, item.role],
+          avatar: {
+            type: "person",
+            firstName: item.name.split(" ")[0],
+            lastName: item.name.split(" ")[1],
+          },
+        }),
+        fields: [
+          { label: "Name", render: (item) => item.name, sorting: "name" },
+          { label: "Email", render: (item) => item.email, sorting: "email" },
+          { label: "Role", render: (item) => item.role },
+          { label: "Department", render: (item) => item.department },
+          { label: "Status", render: (item) => item.status },
+          { label: "Manager", render: (item) => item.manager },
+        ],
+      },
+    },
+  ]}
+/>
+```
+
+## List Properties
+
+```ts
+type ListVisualizationOptions<T> = {
+  /**
+   * The properties to display in the list.
+   */
+  fields: ListPropertyDefinition<T>[]
+
+  /**
+   * The definition of the item to display in the list.
+   */
+  itemDefinition: (item: T) => {
+    title: string
+    description?: string[]
+    avatar?: AvatarVariant & {
+      badge?: AvatarBadge
+    }
+  }
+}
+```
+
+## Card Property Definition
+
+```ts
+type CardPropertyDefinition<T> = {
+  /**
+   * The label to display for the property.
+   */
+  label: string
+
+  /**
+   * The function to render the property.
+   */
+  render: (item: T) => DisplayValueDefinition
+  /**
+   * The icon to display for the property.
+   */
+  icon?: IconType
+  /**
+   * Allows you to hide the property for a given item.
+   */
+  hide?: (item: T) => boolean
+}
+```
+
+## Complete Example
+
+```tsx
+<OneDataCollection
+  source={dataSource}
+  visualizations={[
+    {
+      type: "list",
+    options: {
+      itemDefinition: (item) => ({
+        title: item.name,
+        description: [item.email, item.role],
+        avatar: {
+          type: "person",
+          firstName: item.name.split(" ")[0],
+          lastName: item.name.split(" ")[1],
+          badge: {
+            type: "module",
+            module: "inbox",
+            tooltip: "Inbox",
+          },
+        },
+      }),
+      fields: [
+        {
+          label: "Email",
+          render: (item) => item.email,
+          sorting: "email",
+        },
+        {
+          label: "Role",
+          render: (item) => item.role,
+          sorting: "role",
+        },
+        {
+          label: "Email 2",
+          render: (item) => item.email,
+          sorting: "email",
+        },
+        {
+          label: "Role 2",
+          render: (item) => item.role,
+          sorting: "role",
+        },
+        {
+          label: "Manager",
+          render: (item) => ({
+            type: "person",
+            value: {
+              firstName: item.manager.split(" ")[0],
+              lastName: item.manager.split(" ")[1],
+            },
+          }),
+          hide: (item) => item.name.startsWith("D"),
+        },
+        {
+          label: "Department",
+          render: (item) => ({
+            type: "dotTag",
+            value: {
+              color: "yellow",
+              label: item.department,
+            },
+          }),
+        },
+      ],
+    },
+```
+
+## Item actions
+
+The list visualization supports item actions. To enable item actions, provide
+the `itemActions` prop to the `useDataCollectionSource` hook.
+
+```tsx
+<OneDataCollection
+  source={{
+    itemActions: (item) => [
+      { label: "Action 1", onClick: () => console.log("Action 1"), type: "primary" },
+      { label: "Action 2", onClick: () => console.log("Action 2"), type: "secondary" },
+      { label: "Action 3", onClick: () => console.log("Action 3"), type: "other" },
+      ...
+    ],
+  }}
+/>
+```
+
+The action type will make the action to be displayed in the list dropdown menu
+(other and secondary type), or in in a button (primary type).
+
+## Examples
+
+### List with grouping
+
+<Canvas of={ListStories.ListVisualizationWithGrouping} />
+
+### List with item actions and sorting
+
+<Canvas
+  of={ListStories.ListVisualizationWithGroupingAndAllGroupsOpenByDefault}
+/>
+
+### List with item actions and filtering
+
+<Canvas
+  of={ListStories.ListVisualizationWithGroupingAndAllGroupsOpenByDefault}
+/>

--- a/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list/list.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/visualizations/list/list.stories.tsx
@@ -5,7 +5,7 @@ import {
   generateMockUsers,
   getMockVisualizations,
   mockUsers,
-} from "../mockData"
+} from "../../mockData"
 
 const meta = {
   title: "Data Collection/Visualizations/List",

--- a/packages/react/src/experimental/OneDataCollection/property-render.ts
+++ b/packages/react/src/experimental/OneDataCollection/property-render.ts
@@ -34,6 +34,12 @@ export type PropertyDefinition<T> = {
    * }
    */
   render: (item: T) => RendererDefinition | string | number | undefined
+
+  /**
+   * Function that determines if the property should be hidden for a given item.
+   * Should return true if the property should be hidden, false otherwise.
+   */
+  hide?: (item: T) => boolean
 }
 
 export const renderProperty = <R extends RecordType>(

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -145,8 +145,14 @@ const GroupCards = <
   ): Array<CardMetadata> {
     return properties
       .map((property) => {
+        if (property.hide?.(item)) {
+          return null
+        }
+
         const result = property.render(item)
-        if (result === undefined) return null
+        if (result === undefined) {
+          return null
+        }
 
         const cardProperty = convertToCardMetadataProperty(result)
         if (!cardProperty) return null

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -127,13 +127,15 @@ export const Row = <
         />
       </div>
       <div className="flex flex-col items-start md:flex-row md:items-center [&>div]:justify-end">
-        {(fields || []).map((field) => (
-          <div key={String(field.label)} onClick={itemOnClick}>
-            <div className="flex items-center justify-center px-0 py-1 md:p-3 [&>span]:whitespace-nowrap">
-              {renderCell(item, field)}
+        {(fields || [])
+          .filter((field) => !field.hide?.(item))
+          .map((field) => (
+            <div key={String(field.label)} onClick={itemOnClick}>
+              <div className="flex items-center justify-center px-0 py-1 md:p-3 [&>span]:whitespace-nowrap">
+                {renderCell(item, field)}
+              </div>
             </div>
-          </div>
-        ))}
+          ))}
       </div>
       {source.itemActions && (
         <>

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Table/index.tsx
@@ -41,7 +41,7 @@ import { useSticky } from "./useSticky"
 export type WithOptionalSorting<
   R extends RecordType,
   Sortings extends SortingsDefinition,
-> = PropertyDefinition<R> & {
+> = Omit<PropertyDefinition<R>, "hide"> & {
   sorting?: SortingKey<Sortings>
 
   /**


### PR DESCRIPTION
## Description

- Allow to hide some fields or properties by item in Card and List visualizacion
- Improve List and Card visualization documentation
- 
## Screenshots (if applicable)

<img width="1098" height="740" alt="image" src="https://github.com/user-attachments/assets/3231ce14-7661-464f-81b0-ee9f71e0f109" />
## Implementation details

<!-- What have you changed? Why? -->
