### PR TITLE
feat(Card): full height for cards in DataCollection

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -103,6 +103,11 @@ export interface CardInternalProps {
    * Private prop
    */
   forceVerticalMetadata?: boolean
+
+  /**
+   * Whether the card should have a full height
+   */
+  fullHeight?: boolean
 }
 
 export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
@@ -124,6 +129,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
       onSelect,
       onClick,
       forceVerticalMetadata = false,
+      fullHeight = false,
     },
     ref
   ) {
@@ -132,6 +138,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
         className={cn(
           "group relative bg-f1-background shadow-none transition-all",
           compact && "p-3",
+          fullHeight && "h-full",
           (selectable || (otherActions && otherActions.length > 0)) &&
             !selected &&
             "hover:border-f1-border",
@@ -178,7 +185,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
           </div>
         )}
 
-        <div className="flex flex-col gap-2">
+        <div className="flex grow flex-col gap-2">
           <div className="flex flex-row items-start justify-between gap-1">
             <CardHeader
               className={cn(

--- a/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/experimental/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -253,6 +253,7 @@ const GroupCards = <
               link={itemHref}
               compact={compact ? compact : false}
               metadata={metadata}
+              fullHeight={true}
             />
           </motion.div>
         )


### PR DESCRIPTION
## Description

Cards in DataCollection are displayed in a grid, but their height varies depending on their content. For the grid to seem seamless, we need every card to have the same height on a row.

- Adds a fullHeight prop for the Card component.
  - It is open in case any team needs it outside of the DC.
- Set this prop in the Card visualization for the DC.

## Screenshots

<img width="545" height="595" alt="image" src="https://github.com/user-attachments/assets/0f0d7617-0175-492f-8fcc-562a80d226a4" />

_Horrible screenshot as everything seems broken, but you can notice how every card has the same height, no matter if it has more or less content than others_
