### PR TITLE
feat: auto clear `AiChat` when closed after X minutes

### DIFF
--- a/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
@@ -1,6 +1,8 @@
+import { useCopilotChatInternal } from "@copilotkit/react-core"
 import { type WindowProps } from "@copilotkit/react-ui"
 import { AnimatePresence, motion } from "motion/react"
 import { createContext, useContext, useMemo, useState } from "react"
+import { useAutoClear } from "../hooks/useAutoClear"
 import { useAiChat } from "../providers/AiChatStateProvider"
 
 interface ChatWindowContextType {
@@ -18,8 +20,18 @@ const ChatWindowContext = createContext<ChatWindowContextType>({
 export const useChatWindowContext = () => useContext(ChatWindowContext)
 
 export const SidebarWindow = ({ children }: WindowProps) => {
-  const { open, shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation } =
-    useAiChat()
+  const {
+    open,
+    shouldPlayEntranceAnimation,
+    setShouldPlayEntranceAnimation,
+    autoClearMinutes,
+  } = useAiChat()
+  const { reset } = useCopilotChatInternal()
+  useAutoClear({
+    reset,
+    isOpen: open,
+    autoClearMinutes,
+  })
   const [messageContainerScrollTop, setMessageContainerScrollTop] = useState(0)
   const chatWindowContext = useMemo(
     () => ({

--- a/packages/react/src/experimental/AiChat/hooks/__tests__/useAutoClear.test.ts
+++ b/packages/react/src/experimental/AiChat/hooks/__tests__/useAutoClear.test.ts
@@ -1,0 +1,131 @@
+import { renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { useAutoClear } from "../useAutoClear"
+
+describe("useAutoClear", () => {
+  const mockReset = vi.fn()
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.clearAllTimers()
+    vi.clearAllMocks()
+    vi.useRealTimers()
+  })
+
+  const FIFTEEN_MINUTES = 15 * 60 * 1000
+  const TEN_MINUTES = 10 * 60 * 1000
+  const FIVE_MINUTES = 5 * 60 * 1000
+
+  describe("when chat is open", () => {
+    it("should not set any timer when chat is open", () => {
+      renderHook(() =>
+        useAutoClear({
+          reset: mockReset,
+          isOpen: true,
+          autoClearMinutes: 15,
+        })
+      )
+
+      vi.advanceTimersByTime(FIFTEEN_MINUTES)
+      expect(mockReset).not.toHaveBeenCalled()
+    })
+
+    it("should clear existing timer when chat opens", () => {
+      const { rerender } = renderHook(
+        ({ isOpen }) =>
+          useAutoClear({
+            reset: mockReset,
+            isOpen,
+            autoClearMinutes: 15,
+          }),
+        {
+          initialProps: { isOpen: false },
+        }
+      )
+
+      expect(vi.getTimerCount()).toBe(1)
+      rerender({ isOpen: true })
+      expect(vi.getTimerCount()).toBe(0)
+
+      vi.advanceTimersByTime(FIFTEEN_MINUTES)
+
+      expect(mockReset).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("when chat is closed", () => {
+    it("should set a 15-minute timer when chat is closed", () => {
+      renderHook(() =>
+        useAutoClear({
+          reset: mockReset,
+          isOpen: false,
+          autoClearMinutes: 15,
+        })
+      )
+
+      expect(vi.getTimerCount()).toBe(1)
+      expect(mockReset).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(FIFTEEN_MINUTES - 1)
+      expect(mockReset).not.toHaveBeenCalled()
+
+      vi.advanceTimersByTime(2)
+      expect(mockReset).toHaveBeenCalledTimes(1)
+    })
+
+    it("should set a new timer each time chat closes", () => {
+      const { rerender } = renderHook(
+        ({ isOpen }) =>
+          useAutoClear({
+            reset: mockReset,
+            isOpen,
+            autoClearMinutes: 15,
+          }),
+        {
+          initialProps: { isOpen: true },
+        }
+      )
+
+      expect(vi.getTimerCount()).toBe(0)
+      rerender({ isOpen: false })
+      expect(vi.getTimerCount()).toBe(1)
+
+      vi.advanceTimersByTime(FIVE_MINUTES)
+
+      rerender({ isOpen: true })
+      expect(vi.getTimerCount()).toBe(0)
+      rerender({ isOpen: false })
+      expect(vi.getTimerCount()).toBe(1)
+
+      // The first timer should have been cleared, so reset should not be called after original 15 minutes
+      vi.advanceTimersByTime(TEN_MINUTES + 1) // Total 15 minutes from first close
+      expect(mockReset).not.toHaveBeenCalled()
+
+      // But should be called after 15 minutes from second close
+      vi.advanceTimersByTime(FIVE_MINUTES)
+      expect(mockReset).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("cleanup", () => {
+    it("should clear timer on unmount", () => {
+      const { unmount } = renderHook(() =>
+        useAutoClear({
+          reset: mockReset,
+          isOpen: false,
+          autoClearMinutes: 15,
+        })
+      )
+
+      expect(vi.getTimerCount()).toBe(1)
+      unmount()
+      expect(vi.getTimerCount()).toBe(0)
+
+      vi.advanceTimersByTime(FIFTEEN_MINUTES)
+      expect(mockReset).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/react/src/experimental/AiChat/hooks/useAutoClear.ts
+++ b/packages/react/src/experimental/AiChat/hooks/useAutoClear.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react"
+
+interface UseAutoClearOptions {
+  autoClearMinutes: number | null
+  reset: () => void
+  isOpen: boolean
+}
+
+/**
+ * Custom hook that handles auto-clearing chat messages after a period of inactivity when chat is closed.
+ *
+ * @param autoClearMinutes - Number of minutes of inactivity before auto-clearing, or null to disable
+ * @param reset - Function to call when auto-clearing should occur
+ * @param isOpen - Whether the chat is currently open or closed
+ */
+export const useAutoClear = ({
+  autoClearMinutes,
+  reset,
+  isOpen,
+}: UseAutoClearOptions) => {
+  const closedTimer = useRef<NodeJS.Timeout | null>(null)
+
+  useEffect(() => {
+    if (isOpen) {
+      if (closedTimer.current) {
+        clearTimeout(closedTimer.current)
+        closedTimer.current = null
+      }
+    } else {
+      if (autoClearMinutes !== null) {
+        closedTimer.current = setTimeout(
+          () => {
+            reset()
+          },
+          autoClearMinutes * 60 * 1000
+        )
+      }
+    }
+
+    return () => {
+      if (closedTimer.current) {
+        clearTimeout(closedTimer.current)
+        closedTimer.current = null
+      }
+    }
+  }, [reset, isOpen, autoClearMinutes])
+}

--- a/packages/react/src/experimental/AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/experimental/AiChat/providers/AiChatStateProvider.tsx
@@ -25,7 +25,17 @@ type AiChatProviderReturnValue = {
   shouldPlayEntranceAnimation: boolean
   setShouldPlayEntranceAnimation: React.Dispatch<React.SetStateAction<boolean>>
   tmp_setAgent: (agent?: string) => void
+  /**
+   * Set the amount of minutes after which the chat will be cleared automatically
+   * Set `null` to disable auto-clearing
+   *
+   * @default 15
+   */
+  setAutoClearMinutes: React.Dispatch<React.SetStateAction<number | null>>
+  autoClearMinutes: number | null
 } & Pick<AiChatState, "greeting" | "agent">
+
+const DEFAULT_MINUTES_TO_RESET = 15
 
 export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   children,
@@ -38,6 +48,10 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   const [shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation] =
     useState(true)
   const [agent, setAgent] = useState<string | undefined>(initialAgent)
+
+  const [autoClearMinutes, setAutoClearMinutes] = useState<number | null>(
+    DEFAULT_MINUTES_TO_RESET
+  )
 
   const tmp_setAgent = (newAgent?: string) => {
     setAgent(newAgent)
@@ -68,6 +82,8 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         setShouldPlayEntranceAnimation,
         agent,
         tmp_setAgent,
+        setAutoClearMinutes,
+        autoClearMinutes: enabledInternal ? autoClearMinutes : null,
       }}
     >
       {children}
@@ -89,6 +105,8 @@ export function useAiChat(): AiChatProviderReturnValue {
       setShouldPlayEntranceAnimation: () => {},
       agent: undefined,
       tmp_setAgent: () => {},
+      setAutoClearMinutes: () => {},
+      autoClearMinutes: null,
     }
   }
 


### PR DESCRIPTION
## Description

Clears all the messages after 15 minutes of inactivity when the `AiChat` is closed. Can be disabled by setting the auto clear period to `null`

## Implementation details

Adds new `useAutoClear` hook which sets and clears timeout when the chat is closed/open