### PR TITLE
fix(One): fix misaligned chat window with frame

### DIFF
--- a/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
+++ b/packages/react/src/experimental/AiChat/components/ChatWindow.tsx
@@ -48,7 +48,7 @@ export const SidebarWindow = ({ children }: WindowProps) => {
         <motion.div
           key="chat-window"
           aria-hidden={!open}
-          className="relative flex h-full max-w-[360px] flex-col overflow-hidden bg-f1-special-page shadow xs:rounded-xl"
+          className="relative flex h-full max-w-[360px] flex-col overflow-hidden border border-solid border-f1-border-secondary bg-f1-special-page shadow xs:rounded-xl"
           initial={
             shouldPlayEntranceAnimation ? { opacity: 0, width: 0 } : false
           }


### PR DESCRIPTION
## Description

One chat window is visually misaligned with the main container. It was missing a border to look the same.

## Screenshots

### Before
<img width="1322" height="1312" alt="image" src="https://github.com/user-attachments/assets/909cc843-e864-43bf-8b09-120dfd897e06" />

### After
(It's easier to notice in dark mode)
<img width="2206" height="1478" alt="Capture-2025-09-19-113319" src="https://github.com/user-attachments/assets/2f0a8f08-b84b-4a60-b2a6-cc36a64e442e" />

