### PR TITLE
fix(DateNavigator): improve alignment

### DIFF
--- a/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -147,7 +147,7 @@ const DateNavigatorTrigger = forwardRef<
       <div
         ref={ref}
         className={cn(
-          "inline-flex cursor-auto appearance-none justify-between gap-1 rounded-md border-0 bg-f1-background px-1 ring-1 ring-inset ring-f1-border transition-all placeholder:text-f1-foreground-tertiary hover:ring-f1-border-hover",
+          "inline-flex cursor-auto appearance-none gap-1 rounded-md border-0 bg-f1-background px-1 ring-1 ring-inset ring-f1-border transition-all placeholder:text-f1-foreground-tertiary hover:ring-f1-border-hover",
           "[%>*] py-1",
           focusRing("focus:ring-f1-border-hover"),
           disabled &&
@@ -158,38 +158,45 @@ const DateNavigatorTrigger = forwardRef<
         // Prevent the date picker from being triggered when the user clicks on the input
         onClick={(e) => e.stopPropagation()}
       >
-        {navigation && (
-          <Button
+        <div
+          className={cn(
+            "flex flex-1 gap-1",
+            navigation ? "justify-between" : "justify-center"
+          )}
+        >
+          {navigation && (
+            <Button
+              size="sm"
+              variant="ghost"
+              icon={ChevronLeft}
+              label="Previous"
+              hideLabel
+              disabled={!nextPrev?.prev}
+              onClick={() => handleNavigation(nextPrev?.prev ?? false)}
+            />
+          )}
+          <ButtonInternal
             size="sm"
             variant="ghost"
-            icon={ChevronLeft}
-            label="Previous"
-            hideLabel
-            disabled={!nextPrev?.prev}
-            onClick={() => handleNavigation(nextPrev?.prev ?? false)}
+            label={label}
+            onClick={onClick}
+            disabled={disabled}
+            className={cn(highlighted && "bg-f1-background-secondary-hover")}
           />
-        )}
-        <ButtonInternal
-          size="sm"
-          variant="ghost"
-          label={label}
-          onClick={onClick}
-          disabled={disabled}
-          className={cn(highlighted && "bg-f1-background-secondary-hover")}
-        />
-        {navigation && (
-          <Button
-            variant="ghost"
-            icon={ChevronRight}
-            label="Next"
-            hideLabel
-            size="sm"
-            disabled={!nextPrev?.next}
-            onClick={() => handleNavigation(nextPrev?.next ?? false)}
-          />
-        )}
+          {navigation && (
+            <Button
+              variant="ghost"
+              icon={ChevronRight}
+              label="Next"
+              hideLabel
+              size="sm"
+              disabled={!nextPrev?.next}
+              onClick={() => handleNavigation(nextPrev?.next ?? false)}
+            />
+          )}
+        </div>
         {!hideGoToCurrent && currentDate && (
-          <div className="border-l-solid flex-1 border-[#f00]">
+          <div className="border-l-solid flex-shrink-0 border-[#f00]">
             <Button
               size="sm"
               variant="ghost"

--- a/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/experimental/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -147,7 +147,7 @@ const DateNavigatorTrigger = forwardRef<
       <div
         ref={ref}
         className={cn(
-          "inline-flex cursor-auto appearance-none gap-1 rounded-md border-0 bg-f1-background px-1 ring-1 ring-inset ring-f1-border transition-all placeholder:text-f1-foreground-tertiary hover:ring-f1-border-hover",
+          "inline-flex cursor-auto appearance-none justify-between gap-1 rounded-md border-0 bg-f1-background px-1 ring-1 ring-inset ring-f1-border transition-all placeholder:text-f1-foreground-tertiary hover:ring-f1-border-hover",
           "[%>*] py-1",
           focusRing("focus:ring-f1-border-hover"),
           disabled &&


### PR DESCRIPTION
## Description

This PR fixes visual alignment issues in the **Date Navigator** when it is rendered inside a container larger than its content.  
Currently, all elements are aligned to the left, which looks unbalanced.  

The expected behavior should be:

- **All elements visible**  
  - "Go to current" button aligned right  
  - Selected date centered on the left and navigation buttons distributed on the left and right  

- **Navigation hidden**  
  - Selected date centered  
  - "Go to current" button aligned right  

- **"Go to current" hidden**  
  - Navigation buttons distributed on the left and right  
  - Selected date centered  

- **Both hidden**  
  - Only the selected date, centered  

This ensures a consistent and visually balanced layout across different configurations.

---

## Screenshots

### Current behavior
<img width="606" height="192" alt="Old behavior" src="https://github.com/user-attachments/assets/1063da21-b662-4e78-a62d-33bdb7dd13dd" />

### New behavior
<img width="633" height="183" alt="New behavior 1" src="https://github.com/user-attachments/assets/c0fb4ec2-62e2-4fdb-97f3-261d2bd15079" />
<img width="603" height="175" alt="New behavior 2" src="https://github.com/user-attachments/assets/8a09ce0f-f8fb-4758-af08-d39b4fa5dcc8" />
<img width="621" height="181" alt="New behavior 3" src="https://github.com/user-attachments/assets/b9c28b86-1e58-4dc9-8e15-ac87f015de41" />
<img width="606" height="162" alt="Captura de pantalla 2025-09-22 a las 13 23 18" src="https://github.com/user-attachments/assets/ffaa8e65-8025-48a8-8fc7-3259ba792a32" />

---

## Implementation details

- This change **only affects** scenarios where the parent container is a flexbox with **column direction**.  
- In all other layouts, the current behavior remains unchanged.

Example where this improvement is required:

<img width="848" height="574" alt="Real use case" src="https://github.com/user-attachments/assets/a4d16fc3-b86d-4c58-b744-202722dc3d3a" />
