### PR TITLE
fix(datacollection): table oveflow iwth item actions

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/components/itemActions/ItemActionsRowContainer.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/itemActions/ItemActionsRowContainer.tsx
@@ -12,7 +12,7 @@ export const ItemActionsRowContainer = ({
   return (
     <aside
       className={cn(
-        "absolute -right-px bottom-0 top-0 z-20 hidden items-center justify-end gap-2 py-2 pl-20 pr-3 opacity-0 transition-all group-hover:opacity-100 md:flex",
+        "absolute bottom-0 right-0 top-0 z-20 hidden items-center justify-end gap-2 py-2 pl-20 pr-3 opacity-0 transition-all group-hover:opacity-100 md:flex",
         "bg-gradient-to-l from-[#F5F6F8] from-0% dark:from-[#192231]",
         "via-[#F5F6F8] via-60% dark:via-[#192231]",
         "to-transparent to-100%",


### PR DESCRIPTION
## Description

When a table row had an action the table horizontally overflows even when was not necessaty. Fixed that

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
