### PR TITLE
fix(OneAlert): Action prop conditional 

### DIFF
--- a/packages/react/src/experimental/OneAlert/index.tsx
+++ b/packages/react/src/experimental/OneAlert/index.tsx
@@ -44,7 +44,7 @@ const buttonVariants: Record<AlertVariant, "outline" | "promote" | "critical"> =
 interface AlertProps extends VariantProps<typeof alertVariants> {
   title: string
   description: string
-  action: {
+  action?: {
     label: string
     onClick?: () => void
   }
@@ -77,27 +77,31 @@ export const OneAlert = ({
             </p>
           </div>
         </div>
-        <div className="flex flex-row justify-end gap-3">
-          {link && (
-            <a
-              href={link.href}
-              target="_blank"
-              rel="noreferrer"
-              className={cn(
-                "flex items-center gap-1 rounded-sm px-2 py-0.5 text-base font-medium text-f1-foreground no-underline transition-colors hover:bg-f1-background-secondary-hover [&>svg]:text-f1-foreground-secondary",
-                focusRing()
-              )}
-            >
-              {link.label}
-              <F0Icon icon={ExternalLink} size="sm" />
-            </a>
-          )}
-          <Button
-            label={action.label}
-            variant={buttonVariants[variant]}
-            onClick={action.onClick}
-          />
-        </div>
+        {(action || link) && (
+          <div className="flex flex-row items-center justify-end gap-3">
+            {link && (
+              <a
+                href={link.href}
+                target="_blank"
+                rel="noreferrer"
+                className={cn(
+                  "flex items-center gap-1 rounded-sm px-2 py-0.5 text-base font-medium text-f1-foreground no-underline transition-colors hover:bg-f1-background-secondary-hover [&>svg]:text-f1-foreground-secondary",
+                  focusRing()
+                )}
+              >
+                {link.label}
+                <F0Icon icon={ExternalLink} size="sm" />
+              </a>
+            )}
+            {action && (
+              <Button
+                label={action.label}
+                variant={buttonVariants[variant]}
+                onClick={action.onClick}
+              />
+            )}
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Description

This PR fixes two issues in the **Alert** component:

1. **Support for alerts without actions**  
   - Based on the Figma design, alerts should be allowed without an action button.  

2. **Button height misalignment with multi-line links**  
   - When an alert included both a link and an action, if the link text wrapped into two lines, the button’s height was incorrectly stretched.  
   - We might want to consider using a `OneEllipsis` component to prevent multi-line wrapping in the future.  

---

## Screenshots

### Before
<img width="797" height="252" alt="Alert before fix" src="https://github.com/user-attachments/assets/e1223608-8b31-48f0-b75c-3f937140eb65" />

### After
<img width="791" height="246" alt="Alert after fix 1" src="https://github.com/user-attachments/assets/5f0987c9-4fd8-4ef2-bc83-2eddda8b00c4" />
<img width="802" height="229" alt="Alert after fix 2" src="https://github.com/user-attachments/assets/42bedaa2-73a4-4eaf-80af-ab17e4b9e32d" />
<img width="790" height="219" alt="Alert after fix 3" src="https://github.com/user-attachments/assets/51076dc1-1d79-4ebd-ac41-0f8236bea873" />
<img width="632" height="105" alt="Alert after fix 4" src="https://github.com/user-attachments/assets/4ec1709e-9f19-4731-ad37-541657f03e7b" />

---

## Design Reference

[Figma – Alert component](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Components?node-id=921-3949&t=t41w8IEX3jaEBlXa-4)
