### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.201.6",
+  "packages/react": "1.201.7",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.201.7](https://github.com/factorialco/f0/compare/f0-react-v1.201.6...f0-react-v1.201.7) (2025-09-25)
+
+
+### Bug Fixes
+
+* final width ([0815066](https://github.com/factorialco/f0/commit/0815066a8ce419c26c0a6c779e8047c1cb1c1c4c))
+
 ## [1.201.6](https://github.com/factorialco/f0/compare/f0-react-v1.201.5...f0-react-v1.201.6) (2025-09-24)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.201.6",
+  "version": "1.201.7",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.201.7</summary>

## [1.201.7](https://github.com/factorialco/f0/compare/f0-react-v1.201.6...f0-react-v1.201.7) (2025-09-25)


### Bug Fixes

* final width ([0815066](https://github.com/factorialco/f0/commit/0815066a8ce419c26c0a6c779e8047c1cb1c1c4c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).