### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.203.0",
+  "packages/react": "1.203.1",
   "packages/react-native": "0.20.0",
   "packages/core": "1.26.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.203.1](https://github.com/factorialco/f0/compare/f0-react-v1.203.0...f0-react-v1.203.1) (2025-09-25)
+
+
+### Bug Fixes
+
+* **datacollection:** list click area ([#2672](https://github.com/factorialco/f0/issues/2672)) ([c4ce8ed](https://github.com/factorialco/f0/commit/c4ce8ed312080660a0a0e6270f11ab09193f6287))
+
 ## [1.203.0](https://github.com/factorialco/f0/compare/f0-react-v1.202.0...f0-react-v1.203.0) (2025-09-25)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.203.0",
+  "version": "1.203.1",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.203.1</summary>

## [1.203.1](https://github.com/factorialco/f0/compare/f0-react-v1.203.0...f0-react-v1.203.1) (2025-09-25)


### Bug Fixes

* **datacollection:** list click area ([#2672](https://github.com/factorialco/f0/issues/2672)) ([c4ce8ed](https://github.com/factorialco/f0/commit/c4ce8ed312080660a0a0e6270f11ab09193f6287))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).