### PR TITLE
fix: searchbox in select focus on load

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -369,9 +369,6 @@ const SelectComponent = forwardRef(function Select<
   const handleChangeOpenLocal = (open: boolean) => {
     onOpenChange?.(open)
     setOpenLocal(open)
-    setTimeout(() => {
-      searchInputRef.current?.focus()
-    }, 0)
   }
 
   // const collapsible = localSource.grouping?.collapsible
@@ -434,12 +431,43 @@ const SelectComponent = forwardRef(function Select<
     loadMore()
   }
 
+  const isLoadingOrLoadingMore = loading || isLoading || isLoadingMore
+
+  const loadingFocusInterval = useRef<NodeJS.Timeout | null>(null)
+  const clearLoadingFocusInterval = useCallback(() => {
+    if (loadingFocusInterval.current) {
+      clearInterval(loadingFocusInterval.current)
+      loadingFocusInterval.current = null
+    }
+  }, [loadingFocusInterval])
+
   // Focus the search input when the data is loaded or loading
+
   useEffect(() => {
-    setTimeout(() => {
+    if (!openLocal) {
+      clearLoadingFocusInterval()
+      return
+    }
+
+    requestAnimationFrame(() => {
       searchInputRef.current?.focus()
-    }, 10)
-  }, [data, loading, isLoading, isLoadingMore])
+    })
+
+    // When is loading we need to focus the search repeatedly until the data is loaded
+    if (isLoadingOrLoadingMore && !loadingFocusInterval.current) {
+      loadingFocusInterval.current = setInterval(() => {
+        searchInputRef.current?.focus()
+      }, 100)
+    } else if (!isLoadingOrLoadingMore && loadingFocusInterval.current) {
+      clearLoadingFocusInterval()
+    }
+  }, [data, isLoadingOrLoadingMore, openLocal, clearLoadingFocusInterval])
+
+  useEffect(() => {
+    setInterval(() => {
+      searchInputRef.current?.focus()
+    }, 100)
+  }, [openLocal])
 
   const i18n = useI18n()
 

--- a/packages/react/src/experimental/Forms/Fields/Select/index.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Select/index.tsx
@@ -434,11 +434,12 @@ const SelectComponent = forwardRef(function Select<
     loadMore()
   }
 
+  // Focus the search input when the data is loaded or loading
   useEffect(() => {
     setTimeout(() => {
       searchInputRef.current?.focus()
-    }, 0)
-  }, [data])
+    }, 10)
+  }, [data, loading, isLoading, isLoadingMore])
 
   const i18n = useI18n()
 


### PR DESCRIPTION
## Description


Fixed: In the select when typing the searchbox loses the focus when the load started.
