### PR TITLE
fix/datenavigator fixes

### DIFF
--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -156,7 +156,7 @@ export function OneCalendar({
     inputValue: DateRangeString
   ) => {
     const newDate = granularity.fromString(inputValue, i18n)
-    const error = isSelectableDate(newDate?.[input])
+    const error = !isSelectableDate(newDate?.[input])
 
     setInputError((prev) => ({
       ...prev,

--- a/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/experimental/OneCalendar/OneCalendar.tsx
@@ -11,7 +11,7 @@ import {
   GranularityDefinitionSimple,
 } from "./granularities/index"
 import { CalendarMode, CalendarView, DateRange, DateRangeString } from "./types"
-import { isValidDate, toDateRange } from "./utils"
+import { isActiveDate, toDateRange } from "./utils"
 
 export interface OneCalendarProps {
   mode: CalendarMode
@@ -137,19 +137,34 @@ export function OneCalendar({
     setSelectFromInput(input, inputValue)
   }
 
+  const isSelectableDate = useCallback(
+    (date: Date | undefined | null) => {
+      if (!date) {
+        return false
+      }
+
+      return isActiveDate(date, granularity, {
+        minDate,
+        maxDate,
+      })
+    },
+    [granularity, minDate, maxDate]
+  )
+
   const setSelectFromInput = (
     input: "from" | "to",
     inputValue: DateRangeString
   ) => {
     const newDate = granularity.fromString(inputValue, i18n)
-    const error = newDate && newDate[input] && !isValidDate(newDate[input])
+    const error = isSelectableDate(newDate?.[input])
+
     setInputError((prev) => ({
       ...prev,
       [input]: error,
     }))
 
     if (!error) {
-      setSelected(newDate)
+      handleSelect(newDate)
     }
   }
   useEffect(() => {
@@ -174,13 +189,13 @@ export function OneCalendar({
       ? granularity.navigate(currentDate.from, direction)
       : undefined
 
-    if (isValidDate(newDate)) {
+    if (isSelectableDate(newDate)) {
       const newInputValue = {
         ...inputValue,
         [input]: granularity.toRangeString(newDate, i18n).from,
       }
-      setInputValue(newInputValue)
       setSelectFromInput(input, newInputValue)
+      setInputValue(newInputValue)
     }
   }
 

--- a/packages/react/src/experimental/OneCalendar/__tests__/formatDate.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/formatDate.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+import { formatDate } from "../utils"
+
+describe("formatDate", () => {
+  const testDate = new Date("2024-01-15T10:30:00Z")
+
+  it("should format date with simple pattern", () => {
+    const result = formatDate(testDate, "yyyy-MM-dd")
+    expect(result).toBe("2024-01-15")
+  })
+
+  it("should format date with full month name", () => {
+    const result = formatDate(testDate, "MMMM d, yyyy")
+    expect(result).toBe("January 15, 2024")
+  })
+
+  it("should format date with short month name", () => {
+    const result = formatDate(testDate, "MMM d, yyyy")
+    expect(result).toBe("Jan 15, 2024")
+  })
+
+  it("should format date with day of week", () => {
+    const result = formatDate(testDate, "EEEE, MMMM d, yyyy")
+    expect(result).toBe("Monday, January 15, 2024")
+  })
+
+  it("should format date with short day of week", () => {
+    const result = formatDate(testDate, "EEE, MMM d")
+    expect(result).toBe("Mon, Jan 15")
+  })
+
+  it("should format date with time", () => {
+    const result = formatDate(testDate, "yyyy-MM-dd HH:mm")
+    expect(result).toMatch(/2024-01-15 \d{2}:\d{2}/)
+  })
+
+  it("should format date with year only", () => {
+    const result = formatDate(testDate, "yyyy")
+    expect(result).toBe("2024")
+  })
+
+  it("should format date with month and year", () => {
+    const result = formatDate(testDate, "MM/yyyy")
+    expect(result).toBe("01/2024")
+  })
+
+  it("should format date with custom separator", () => {
+    const result = formatDate(testDate, "dd.MM.yyyy")
+    expect(result).toBe("15.01.2024")
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/formatDateRange.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/formatDateRange.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest"
+import { DateRange } from "../types"
+import { formatDateRange } from "../utils"
+
+describe("formatDateRange", () => {
+  const fromDate = new Date("2024-01-15")
+  const toDate = new Date("2024-01-31")
+
+  it("should format single date as DateRange", () => {
+    const result = formatDateRange(fromDate, "yyyy-MM-dd")
+
+    expect(result).toEqual({
+      from: "2024-01-15",
+      to: undefined,
+    })
+  })
+
+  it("should format DateRange with different from and to dates", () => {
+    const dateRange: DateRange = { from: fromDate, to: toDate }
+    const result = formatDateRange(dateRange, "yyyy-MM-dd")
+
+    expect(result).toEqual({
+      from: "2024-01-15",
+      to: "2024-01-31",
+    })
+  })
+
+  it("should format DateRange with same from and to dates", () => {
+    const dateRange: DateRange = { from: fromDate, to: fromDate }
+    const result = formatDateRange(dateRange, "yyyy-MM-dd")
+
+    expect(result).toEqual({
+      from: "2024-01-15",
+      to: undefined, // Same dates should result in undefined to
+    })
+  })
+
+  it("should format DateRange with only from date", () => {
+    const dateRange: DateRange = { from: fromDate }
+    const result = formatDateRange(dateRange, "yyyy-MM-dd")
+
+    expect(result).toEqual({
+      from: "2024-01-15",
+      to: undefined,
+    })
+  })
+
+  it("should return empty from when date is undefined", () => {
+    const result = formatDateRange(undefined, "yyyy-MM-dd")
+
+    expect(result).toEqual({
+      from: "",
+      to: undefined,
+    })
+  })
+
+  it("should return empty from when date is null", () => {
+    const result = formatDateRange(null, "yyyy-MM-dd")
+
+    expect(result).toEqual({
+      from: "",
+      to: undefined,
+    })
+  })
+
+  it("should format with different date patterns", () => {
+    const dateRange: DateRange = { from: fromDate, to: toDate }
+    const result = formatDateRange(dateRange, "MMM d, yyyy")
+
+    expect(result).toEqual({
+      from: "Jan 15, 2024",
+      to: "Jan 31, 2024",
+    })
+  })
+
+  it("should handle month names when same from and to", () => {
+    const sameDate = new Date("2024-06-15")
+    const dateRange: DateRange = { from: sameDate, to: sameDate }
+    const result = formatDateRange(dateRange, "MMMM d, yyyy")
+
+    expect(result).toEqual({
+      from: "June 15, 2024",
+      to: undefined,
+    })
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/formatDateToString.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/formatDateToString.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+import { DateRange } from "../types"
+import { formatDateToString } from "../utils"
+
+describe("formatDateToString", () => {
+  const fromDate = new Date("2024-01-15")
+  const toDate = new Date("2024-01-31")
+
+  it("should format single date as string", () => {
+    const result = formatDateToString(fromDate, "yyyy-MM-dd")
+    expect(result).toBe("2024-01-15")
+  })
+
+  it("should format DateRange with different from and to dates using separator", () => {
+    const dateRange: DateRange = { from: fromDate, to: toDate }
+    const result = formatDateToString(dateRange, "yyyy-MM-dd")
+    expect(result).toBe("2024-01-15 → 2024-01-31")
+  })
+
+  it("should format DateRange with same from and to dates without separator", () => {
+    const dateRange: DateRange = { from: fromDate, to: fromDate }
+    const result = formatDateToString(dateRange, "yyyy-MM-dd")
+    expect(result).toBe("2024-01-15")
+  })
+
+  it("should format DateRange with only from date", () => {
+    const dateRange: DateRange = { from: fromDate }
+    const result = formatDateToString(dateRange, "yyyy-MM-dd")
+    expect(result).toBe("2024-01-15")
+  })
+
+  it("should return dash when date is undefined", () => {
+    const result = formatDateToString(undefined, "yyyy-MM-dd")
+    expect(result).toBe("-")
+  })
+
+  it("should return dash when date is null", () => {
+    const result = formatDateToString(null, "yyyy-MM-dd")
+    expect(result).toBe("-")
+  })
+
+  it("should format with different date patterns", () => {
+    const dateRange: DateRange = { from: fromDate, to: toDate }
+    const result = formatDateToString(dateRange, "MMM d, yyyy")
+    expect(result).toBe("Jan 15, 2024 → Jan 31, 2024")
+  })
+
+  it("should handle month names format", () => {
+    const dateRange: DateRange = { from: fromDate, to: toDate }
+    const result = formatDateToString(dateRange, "MMMM d, yyyy")
+    expect(result).toBe("January 15, 2024 → January 31, 2024")
+  })
+
+  it("should format single date with complex pattern", () => {
+    const result = formatDateToString(fromDate, "EEEE, MMMM d, yyyy")
+    expect(result).toBe("Monday, January 15, 2024")
+  })
+
+  it("should handle year-only format", () => {
+    const differentYearDate = new Date("2025-01-15")
+    const dateRange: DateRange = { from: fromDate, to: differentYearDate }
+    const result = formatDateToString(dateRange, "yyyy")
+    expect(result).toBe("2024 → 2025")
+  })
+
+  it("should handle month/year format", () => {
+    const differentMonthDate = new Date("2024-03-15")
+    const dateRange: DateRange = { from: fromDate, to: differentMonthDate }
+    const result = formatDateToString(dateRange, "MM/yyyy")
+    expect(result).toBe("01/2024 → 03/2024")
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/formatDateToString.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/formatDateToString.test.ts
@@ -31,12 +31,12 @@ describe("formatDateToString", () => {
 
   it("should return dash when date is undefined", () => {
     const result = formatDateToString(undefined, "yyyy-MM-dd")
-    expect(result).toBe("-")
+    expect(result).toBe("")
   })
 
   it("should return dash when date is null", () => {
     const result = formatDateToString(null, "yyyy-MM-dd")
-    expect(result).toBe("-")
+    expect(result).toBe("")
   })
 
   it("should format with different date patterns", () => {

--- a/packages/react/src/experimental/OneCalendar/__tests__/getLocale.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/getLocale.test.ts
@@ -3,12 +3,6 @@ import { getLocale } from "../utils"
 
 describe("getLocale", () => {
   it("should return the correct locale for a simple language code", () => {
-    const locale = getLocale("en")
-    expect(locale).toBeDefined()
-    expect(locale?.code).toBe("en-US")
-  })
-
-  it("should return the correct locale for French", () => {
     const locale = getLocale("fr")
     expect(locale).toBeDefined()
     expect(locale?.code).toBe("fr")

--- a/packages/react/src/experimental/OneCalendar/__tests__/getLocale.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/getLocale.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+import { getLocale } from "../utils"
+
+describe("getLocale", () => {
+  it("should return the correct locale for a simple language code", () => {
+    const locale = getLocale("en")
+    expect(locale).toBeDefined()
+    expect(locale?.code).toBe("en-US")
+  })
+
+  it("should return the correct locale for French", () => {
+    const locale = getLocale("fr")
+    expect(locale).toBeDefined()
+    expect(locale?.code).toBe("fr")
+  })
+
+  it("should handle locale with country code by extracting base language", () => {
+    const locale = getLocale("pt-BR")
+    expect(locale).toBeDefined()
+    expect(locale?.code).toBe("pt")
+  })
+
+  it("should return undefined for unsupported locale", () => {
+    const locale = getLocale("xyz")
+    expect(locale).toBeUndefined()
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/isActiveDate.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/isActiveDate.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it, vi } from "vitest"
+import { GranularityDefinition } from "../granularities/types"
+import { DateRangeComplete } from "../types"
+import { isActiveDate } from "../utils"
+
+describe("isActiveDate", () => {
+  // Create a simpler mock that matches the expected interface
+  const createMockGranularity = (): GranularityDefinition => {
+    const mockToRange = vi.fn()
+
+    return {
+      calendarView: "day" as const,
+      label: vi.fn(),
+      toRangeString: vi.fn(),
+      toRange: mockToRange,
+      toString: vi.fn(),
+      fromString: vi.fn(),
+      navigateUIView: vi.fn(),
+      navigate: vi.fn(),
+      getViewDateFromDate: vi.fn(),
+      render: vi.fn(),
+      add: vi.fn(),
+      getPrevNext: vi.fn(),
+    }
+  }
+
+  it("should return true when date is undefined", () => {
+    const mockGranularity = createMockGranularity()
+    const result = isActiveDate(undefined, mockGranularity, {})
+
+    expect(result).toBe(true)
+  })
+
+  it("should return true when date is null", () => {
+    const mockGranularity = createMockGranularity()
+    const result = isActiveDate(null, mockGranularity, {})
+
+    expect(result).toBe(true)
+  })
+
+  it("should return true when date is valid and within constraints", () => {
+    const testDate = new Date("2024-01-15")
+    const mockDateRange: DateRangeComplete = {
+      from: new Date("2024-01-15T00:00:00"),
+      to: new Date("2024-01-15T23:59:59"),
+    }
+
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange).mockReturnValue(mockDateRange)
+
+    const result = isActiveDate(testDate, mockGranularity, {
+      minDate: new Date("2024-01-01"),
+      maxDate: new Date("2024-12-31"),
+    })
+
+    expect(result).toBe(true)
+    expect(mockGranularity.toRange).toHaveBeenCalledWith(testDate)
+  })
+
+  it("should return false when granularity returns null for date", () => {
+    const testDate = new Date("2024-01-15")
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange).mockReturnValue(null)
+
+    const result = isActiveDate(testDate, mockGranularity, {})
+
+    expect(result).toBe(false)
+  })
+
+  it("should return false when date range from is invalid", () => {
+    const testDate = new Date("2024-01-15")
+    const mockDateRange: DateRangeComplete = {
+      from: new Date("invalid"), // Invalid date
+      to: new Date("2024-01-15T23:59:59"),
+    }
+
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange).mockReturnValue(mockDateRange)
+
+    const result = isActiveDate(testDate, mockGranularity, {})
+
+    expect(result).toBe(false)
+  })
+
+  it("should return false when date is before minDate constraint", () => {
+    const testDate = new Date("2024-01-10")
+    const mockDateRange: DateRangeComplete = {
+      from: new Date("2024-01-10T00:00:00"),
+      to: new Date("2024-01-10T23:59:59"),
+    }
+    const minDateRange: DateRangeComplete = {
+      from: new Date("2024-01-15T00:00:00"),
+      to: new Date("2024-01-15T23:59:59"),
+    }
+
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange)
+      .mockReturnValueOnce(mockDateRange) // For testDate
+      .mockReturnValueOnce(minDateRange) // For minDate
+      .mockReturnValueOnce(null) // For maxDate (undefined)
+
+    const result = isActiveDate(testDate, mockGranularity, {
+      minDate: new Date("2024-01-15"),
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it("should return false when date is after maxDate constraint", () => {
+    const testDate = new Date("2024-01-20")
+    const mockDateRange: DateRangeComplete = {
+      from: new Date("2024-01-20T00:00:00"),
+      to: new Date("2024-01-20T23:59:59"),
+    }
+    const maxDateRange: DateRangeComplete = {
+      from: new Date("2024-01-15T00:00:00"),
+      to: new Date("2024-01-15T23:59:59"),
+    }
+
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange)
+      .mockReturnValueOnce(mockDateRange) // For testDate
+      .mockReturnValueOnce(null) // For minDate (undefined)
+      .mockReturnValueOnce(maxDateRange) // For maxDate
+
+    const result = isActiveDate(testDate, mockGranularity, {
+      maxDate: new Date("2024-01-15"),
+    })
+
+    expect(result).toBe(false)
+  })
+
+  it("should return true when no constraints are provided", () => {
+    const testDate = new Date("2024-01-15")
+    const mockDateRange: DateRangeComplete = {
+      from: new Date("2024-01-15T00:00:00"),
+      to: new Date("2024-01-15T23:59:59"),
+    }
+
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange).mockReturnValue(mockDateRange)
+
+    const result = isActiveDate(testDate, mockGranularity, {})
+
+    expect(result).toBe(true)
+  })
+
+  it("should return true when date equals minDate constraint", () => {
+    const testDate = new Date("2024-01-15")
+    const mockDateRange: DateRangeComplete = {
+      from: new Date("2024-01-15T00:00:00"),
+      to: new Date("2024-01-15T23:59:59"),
+    }
+
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange).mockReturnValue(mockDateRange)
+
+    const result = isActiveDate(testDate, mockGranularity, {
+      minDate: new Date("2024-01-15"),
+    })
+
+    expect(result).toBe(true)
+  })
+
+  it("should return true when date equals maxDate constraint", () => {
+    const testDate = new Date("2024-01-15")
+    const mockDateRange: DateRangeComplete = {
+      from: new Date("2024-01-15T00:00:00"),
+      to: new Date("2024-01-15T23:59:59"),
+    }
+
+    const mockGranularity = createMockGranularity()
+    vi.mocked(mockGranularity.toRange).mockReturnValue(mockDateRange)
+
+    const result = isActiveDate(testDate, mockGranularity, {
+      maxDate: new Date("2024-01-15"),
+    })
+
+    expect(result).toBe(true)
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/isAfterOrEqual.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/isAfterOrEqual.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest"
+import { isAfterOrEqual } from "../utils"
+
+describe("isAfterOrEqual", () => {
+  const baseDate = new Date("2024-01-15")
+  const earlierDate = new Date("2024-01-10")
+  const laterDate = new Date("2024-01-20")
+  const sameDate = new Date("2024-01-15")
+
+  it("should return false when date is before max date", () => {
+    const result = isAfterOrEqual(earlierDate, baseDate)
+    expect(result).toBe(false)
+  })
+
+  it("should return true when date is equal to max date", () => {
+    const result = isAfterOrEqual(sameDate, baseDate)
+    expect(result).toBe(true)
+  })
+
+  it("should return true when date is after max date", () => {
+    const result = isAfterOrEqual(laterDate, baseDate)
+    expect(result).toBe(true)
+  })
+
+  it("should return true when max date is undefined", () => {
+    const result = isAfterOrEqual(baseDate, undefined)
+    expect(result).toBe(true)
+  })
+
+  it("should return true when max date is undefined and date is earlier", () => {
+    const result = isAfterOrEqual(earlierDate, undefined)
+    expect(result).toBe(true)
+  })
+
+  it("should return true when max date is undefined and date is later", () => {
+    const result = isAfterOrEqual(laterDate, undefined)
+    expect(result).toBe(true)
+  })
+
+  it("should handle exact same timestamp", () => {
+    const timestamp = 1642204800000 // 2022-01-15
+    const date1 = new Date(timestamp)
+    const date2 = new Date(timestamp)
+    const result = isAfterOrEqual(date1, date2)
+    expect(result).toBe(true)
+  })
+
+  it("should handle different years", () => {
+    const date2023 = new Date("2023-01-15")
+    const date2024 = new Date("2024-01-15")
+
+    expect(isAfterOrEqual(date2023, date2024)).toBe(false)
+    expect(isAfterOrEqual(date2024, date2023)).toBe(true)
+  })
+
+  it("should handle time differences on same day", () => {
+    const morning = new Date("2024-01-15T08:00:00")
+    const evening = new Date("2024-01-15T20:00:00")
+
+    expect(isAfterOrEqual(morning, evening)).toBe(false)
+    expect(isAfterOrEqual(evening, morning)).toBe(true)
+  })
+
+  it("should handle leap year dates", () => {
+    const feb28 = new Date("2024-02-28")
+    const feb29 = new Date("2024-02-29")
+
+    expect(isAfterOrEqual(feb29, feb28)).toBe(true)
+    expect(isAfterOrEqual(feb28, feb29)).toBe(false)
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/isBeforeOrEqual.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/isBeforeOrEqual.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest"
+import { isBeforeOrEqual } from "../utils"
+
+describe("isBeforeOrEqual", () => {
+  const baseDate = new Date("2024-01-15")
+  const earlierDate = new Date("2024-01-10")
+  const laterDate = new Date("2024-01-20")
+  const sameDate = new Date("2024-01-15")
+
+  it("should return true when date is before min date", () => {
+    const result = isBeforeOrEqual(earlierDate, baseDate)
+    expect(result).toBe(true)
+  })
+
+  it("should return true when date is equal to min date", () => {
+    const result = isBeforeOrEqual(sameDate, baseDate)
+    expect(result).toBe(true)
+  })
+
+  it("should return false when date is after min date", () => {
+    const result = isBeforeOrEqual(laterDate, baseDate)
+    expect(result).toBe(false)
+  })
+
+  it("should return true when min date is undefined", () => {
+    const result = isBeforeOrEqual(baseDate, undefined)
+    expect(result).toBe(true)
+  })
+
+  it("should return true when min date is undefined and date is earlier", () => {
+    const result = isBeforeOrEqual(earlierDate, undefined)
+    expect(result).toBe(true)
+  })
+
+  it("should return true when min date is undefined and date is later", () => {
+    const result = isBeforeOrEqual(laterDate, undefined)
+    expect(result).toBe(true)
+  })
+
+  it("should handle exact same timestamp", () => {
+    const timestamp = 1642204800000 // 2022-01-15
+    const date1 = new Date(timestamp)
+    const date2 = new Date(timestamp)
+    const result = isBeforeOrEqual(date1, date2)
+    expect(result).toBe(true)
+  })
+
+  it("should handle different years", () => {
+    const date2023 = new Date("2023-01-15")
+    const date2024 = new Date("2024-01-15")
+
+    expect(isBeforeOrEqual(date2023, date2024)).toBe(true)
+    expect(isBeforeOrEqual(date2024, date2023)).toBe(false)
+  })
+
+  it("should handle time differences on same day", () => {
+    const morning = new Date("2024-01-15T08:00:00")
+    const evening = new Date("2024-01-15T20:00:00")
+
+    expect(isBeforeOrEqual(morning, evening)).toBe(true)
+    expect(isBeforeOrEqual(evening, morning)).toBe(false)
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/isValidDate.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/isValidDate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { isValidDate } from "../utils"
+
+describe("isValidDate", () => {
+  it("should return true for valid dates", () => {
+    const validDate = new Date("2024-01-15")
+    expect(isValidDate(validDate)).toBe(true)
+  })
+
+  it("should return true for current date", () => {
+    const currentDate = new Date()
+    expect(isValidDate(currentDate)).toBe(true)
+  })
+
+  it("should return false for invalid date objects", () => {
+    const invalidDate = new Date("invalid-date")
+    expect(isValidDate(invalidDate)).toBe(false)
+  })
+
+  it("should return false for NaN date", () => {
+    const nanDate = new Date(NaN)
+    expect(isValidDate(nanDate)).toBe(false)
+  })
+
+  it("should return false for undefined input", () => {
+    expect(isValidDate(undefined)).toBe(false)
+  })
+
+  it("should return false for null input", () => {
+    expect(isValidDate(null)).toBe(false)
+  })
+
+  it("should return true for date created from timestamp", () => {
+    const timestampDate = new Date(1642204800000) // 2022-01-15
+    expect(isValidDate(timestampDate)).toBe(true)
+  })
+
+  it("should return true for date created from valid string", () => {
+    const stringDate = new Date("2024-12-25")
+    expect(isValidDate(stringDate)).toBe(true)
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/isValidOrEmptyDate.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/isValidOrEmptyDate.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+import { isValidOrEmptyDate } from "../utils"
+
+describe("isValidOrEmptyDate", () => {
+  it("should return true for valid dates", () => {
+    const validDate = new Date("2024-01-15")
+    expect(isValidOrEmptyDate(validDate)).toBe(true)
+  })
+
+  it("should return true for current date", () => {
+    const currentDate = new Date()
+    expect(isValidOrEmptyDate(currentDate)).toBe(true)
+  })
+
+  it("should return true for undefined input", () => {
+    expect(isValidOrEmptyDate(undefined)).toBe(true)
+  })
+
+  it("should return true for null input", () => {
+    expect(isValidOrEmptyDate(null)).toBe(true)
+  })
+
+  it("should return false for invalid date objects", () => {
+    const invalidDate = new Date("invalid-date")
+    expect(isValidOrEmptyDate(invalidDate)).toBe(false)
+  })
+
+  it("should return false for NaN date", () => {
+    const nanDate = new Date(NaN)
+    expect(isValidOrEmptyDate(nanDate)).toBe(false)
+  })
+
+  it("should return true for date created from timestamp", () => {
+    const timestampDate = new Date(1642204800000) // 2022-01-15
+    expect(isValidOrEmptyDate(timestampDate)).toBe(true)
+  })
+
+  it("should return true for date created from valid string", () => {
+    const stringDate = new Date("2024-12-25")
+    expect(isValidOrEmptyDate(stringDate)).toBe(true)
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/toCalendarPickerMatcher.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/toCalendarPickerMatcher.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest"
+import { toCalendarPickerMatcher } from "../utils"
+
+describe("toCalendarPickerMatcher", () => {
+  const minDate = new Date("2024-01-01")
+  const maxDate = new Date("2024-12-31")
+
+  it("should return empty array when no dates are provided", () => {
+    const result = toCalendarPickerMatcher({})
+    expect(result).toEqual([])
+  })
+
+  it("should return before matcher when only minDate is provided", () => {
+    const result = toCalendarPickerMatcher({ minDate })
+    expect(result).toEqual([{ before: minDate }])
+  })
+
+  it("should return after matcher when only maxDate is provided", () => {
+    const result = toCalendarPickerMatcher({ maxDate })
+    expect(result).toEqual([{ after: maxDate }])
+  })
+
+  it("should return both matchers when both dates are provided", () => {
+    const result = toCalendarPickerMatcher({ minDate, maxDate })
+    expect(result).toEqual([{ before: minDate }, { after: maxDate }])
+  })
+
+  it("should handle undefined minDate and defined maxDate", () => {
+    const result = toCalendarPickerMatcher({ minDate: undefined, maxDate })
+    expect(result).toEqual([{ after: maxDate }])
+  })
+
+  it("should handle defined minDate and undefined maxDate", () => {
+    const result = toCalendarPickerMatcher({ minDate, maxDate: undefined })
+    expect(result).toEqual([{ before: minDate }])
+  })
+
+  it("should handle both dates as undefined", () => {
+    const result = toCalendarPickerMatcher({
+      minDate: undefined,
+      maxDate: undefined,
+    })
+    expect(result).toEqual([])
+  })
+
+  it("should preserve exact date references in matchers", () => {
+    const specificMinDate = new Date("2024-06-15T10:30:00")
+    const specificMaxDate = new Date("2024-08-20T14:45:00")
+
+    const result = toCalendarPickerMatcher({
+      minDate: specificMinDate,
+      maxDate: specificMaxDate,
+    })
+
+    expect(result).toEqual([
+      { before: specificMinDate },
+      { after: specificMaxDate },
+    ])
+
+    // Check that the actual date objects are the same reference
+    const matchers = result as Array<{ before?: Date; after?: Date }>
+    expect(matchers[0].before).toBe(specificMinDate)
+    expect(matchers[1].after).toBe(specificMaxDate)
+  })
+
+  it("should handle same minDate and maxDate", () => {
+    const sameDate = new Date("2024-07-15")
+    const result = toCalendarPickerMatcher({
+      minDate: sameDate,
+      maxDate: sameDate,
+    })
+
+    expect(result).toEqual([{ before: sameDate }, { after: sameDate }])
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/toDateRange.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/toDateRange.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest"
+import { DateRange } from "../types"
+import { toDateRange } from "../utils"
+
+describe("toDateRange", () => {
+  it("should convert a Date to a DateRange with only from property", () => {
+    const date = new Date("2024-01-15")
+    const result = toDateRange(date)
+
+    expect(result).toEqual({
+      from: date,
+    })
+  })
+
+  it("should return undefined when input is null", () => {
+    const result = toDateRange(null)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return undefined when input is undefined", () => {
+    const result = toDateRange(undefined)
+    expect(result).toBeUndefined()
+  })
+
+  it("should return the same DateRange when input is already a DateRange", () => {
+    const dateRange: DateRange = {
+      from: new Date("2024-01-01"),
+      to: new Date("2024-01-31"),
+    }
+    const result = toDateRange(dateRange)
+
+    expect(result).toEqual(dateRange)
+  })
+
+  it("should return DateRange with only from when to is undefined", () => {
+    const dateRange: DateRange = {
+      from: new Date("2024-01-01"),
+    }
+    const result = toDateRange(dateRange)
+
+    expect(result).toEqual(dateRange)
+    expect(result?.to).toBeUndefined()
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/toDateRangeString.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/toDateRangeString.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest"
+import { DateRangeString } from "../types"
+import { toDateRangeString } from "../utils"
+
+describe("toDateRangeString", () => {
+  it("should return undefined when input is undefined", () => {
+    const result = toDateRangeString(undefined)
+    expect(result).toBeUndefined()
+  })
+
+  it("should parse string with dash separator", () => {
+    const input = "2024-01-01 - 2024-01-31"
+    const result = toDateRangeString(input)
+
+    expect(result).toEqual({
+      from: "2024-01-01",
+      to: "2024-01-31",
+    })
+  })
+
+  it("should parse string with arrow separator", () => {
+    const input = "2024-01-01 → 2024-01-31"
+    const result = toDateRangeString(input)
+
+    expect(result).toEqual({
+      from: "2024-01-01",
+      to: "2024-01-31",
+    })
+  })
+
+  it("should parse string with only from date", () => {
+    const input = "2024-01-01"
+    const result = toDateRangeString(input)
+
+    expect(result).toEqual({
+      from: "2024-01-01",
+      to: undefined,
+    })
+  })
+
+  it("should return the same DateRangeString when input is already a DateRangeString", () => {
+    const dateRangeString: DateRangeString = {
+      from: "2024-01-01",
+      to: "2024-01-31",
+    }
+    const result = toDateRangeString(dateRangeString)
+
+    expect(result).toEqual(dateRangeString)
+  })
+
+  it("should return DateRangeString with only from when to is undefined", () => {
+    const dateRangeString: DateRangeString = {
+      from: "2024-01-01",
+    }
+    const result = toDateRangeString(dateRangeString)
+
+    expect(result).toEqual(dateRangeString)
+    expect(result?.to).toBeUndefined()
+  })
+
+  it("should handle complex date strings with dash separator", () => {
+    const input = "January 1, 2024 - December 31, 2024"
+    const result = toDateRangeString(input)
+
+    expect(result).toEqual({
+      from: "January 1, 2024",
+      to: "December 31, 2024",
+    })
+  })
+
+  it("should handle complex date strings with arrow separator", () => {
+    const input = "Jan 1 → Jan 31"
+    const result = toDateRangeString(input)
+
+    expect(result).toEqual({
+      from: "Jan 1",
+      to: "Jan 31",
+    })
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/__tests__/toGranularityDateRange.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/toGranularityDateRange.test.ts
@@ -1,3 +1,4 @@
+import { endOfDay, startOfDay } from "date-fns"
 import { describe, expect, it } from "vitest"
 import { DateRange } from "../types"
 import { toGranularityDateRange } from "../utils"
@@ -5,17 +6,12 @@ import { toGranularityDateRange } from "../utils"
 describe("toGranularityDateRange", () => {
   // Mock granularity functions
   const mockFromFn = (date: Date): Date => {
-    // Mock: start of day
-    const newDate = new Date(date)
-    newDate.setHours(0, 0, 0, 0)
-    return newDate
+    return startOfDay(date)
   }
 
   const mockToFn = (date: Date): Date => {
     // Mock: end of day
-    const newDate = new Date(date)
-    newDate.setHours(23, 59, 59, 999)
-    return newDate
+    return endOfDay(date)
   }
 
   it("should convert single date to DateRangeComplete using granularity functions", () => {
@@ -23,8 +19,8 @@ describe("toGranularityDateRange", () => {
     const result = toGranularityDateRange(inputDate, mockFromFn, mockToFn)
 
     expect(result).toEqual({
-      from: new Date("2024-01-15T00:00:00.000Z"),
-      to: new Date("2024-01-15T23:59:59.999Z"),
+      from: new Date("2024-01-15T00:00:00.000"),
+      to: new Date("2024-01-15T23:59:59.999"),
     })
   })
 
@@ -36,8 +32,8 @@ describe("toGranularityDateRange", () => {
     const result = toGranularityDateRange(inputRange, mockFromFn, mockToFn)
 
     expect(result).toEqual({
-      from: new Date("2024-01-15T00:00:00.000Z"),
-      to: new Date("2024-01-20T23:59:59.999Z"),
+      from: new Date("2024-01-15T00:00:00.000"),
+      to: new Date("2024-01-20T23:59:59.999"),
     })
   })
 
@@ -48,8 +44,8 @@ describe("toGranularityDateRange", () => {
     const result = toGranularityDateRange(inputRange, mockFromFn, mockToFn)
 
     expect(result).toEqual({
-      from: new Date("2024-01-15T00:00:00.000Z"),
-      to: new Date("2024-01-15T23:59:59.999Z"),
+      from: new Date("2024-01-15T00:00:00.000"),
+      to: new Date("2024-01-15T23:59:59.999"),
     })
   })
 
@@ -92,8 +88,8 @@ describe("toGranularityDateRange", () => {
     const result = toGranularityDateRange(leapYearDate, mockFromFn, mockToFn)
 
     expect(result).toEqual({
-      from: new Date("2024-02-29T00:00:00.000Z"),
-      to: new Date("2024-02-29T23:59:59.999Z"),
+      from: new Date("2024-02-29T00:00:00.000"),
+      to: new Date("2024-02-29T23:59:59.999"),
     })
   })
 

--- a/packages/react/src/experimental/OneCalendar/__tests__/toGranularityDateRange.test.ts
+++ b/packages/react/src/experimental/OneCalendar/__tests__/toGranularityDateRange.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest"
+import { DateRange } from "../types"
+import { toGranularityDateRange } from "../utils"
+
+describe("toGranularityDateRange", () => {
+  // Mock granularity functions
+  const mockFromFn = (date: Date): Date => {
+    // Mock: start of day
+    const newDate = new Date(date)
+    newDate.setHours(0, 0, 0, 0)
+    return newDate
+  }
+
+  const mockToFn = (date: Date): Date => {
+    // Mock: end of day
+    const newDate = new Date(date)
+    newDate.setHours(23, 59, 59, 999)
+    return newDate
+  }
+
+  it("should convert single date to DateRangeComplete using granularity functions", () => {
+    const inputDate = new Date("2024-01-15T12:30:00")
+    const result = toGranularityDateRange(inputDate, mockFromFn, mockToFn)
+
+    expect(result).toEqual({
+      from: new Date("2024-01-15T00:00:00.000Z"),
+      to: new Date("2024-01-15T23:59:59.999Z"),
+    })
+  })
+
+  it("should convert DateRange to DateRangeComplete using granularity functions", () => {
+    const inputRange: DateRange = {
+      from: new Date("2024-01-15T12:30:00"),
+      to: new Date("2024-01-20T14:45:00"),
+    }
+    const result = toGranularityDateRange(inputRange, mockFromFn, mockToFn)
+
+    expect(result).toEqual({
+      from: new Date("2024-01-15T00:00:00.000Z"),
+      to: new Date("2024-01-20T23:59:59.999Z"),
+    })
+  })
+
+  it("should use from date for to when DateRange has no to date", () => {
+    const inputRange: DateRange = {
+      from: new Date("2024-01-15T12:30:00"),
+    }
+    const result = toGranularityDateRange(inputRange, mockFromFn, mockToFn)
+
+    expect(result).toEqual({
+      from: new Date("2024-01-15T00:00:00.000Z"),
+      to: new Date("2024-01-15T23:59:59.999Z"),
+    })
+  })
+
+  it("should return null when input is undefined", () => {
+    const result = toGranularityDateRange(undefined, mockFromFn, mockToFn)
+    expect(result).toBeNull()
+  })
+
+  it("should return null when input is null", () => {
+    const result = toGranularityDateRange(null, mockFromFn, mockToFn)
+    expect(result).toBeNull()
+  })
+
+  it("should work with different granularity functions", () => {
+    // Mock: start/end of month
+    const monthFromFn = (date: Date): Date => {
+      const newDate = new Date(date)
+      newDate.setDate(1)
+      newDate.setHours(0, 0, 0, 0)
+      return newDate
+    }
+
+    const monthToFn = (date: Date): Date => {
+      const newDate = new Date(date)
+      newDate.setMonth(newDate.getMonth() + 1)
+      newDate.setDate(0) // Last day of previous month
+      newDate.setHours(23, 59, 59, 999)
+      return newDate
+    }
+
+    const inputDate = new Date("2024-01-15")
+    const result = toGranularityDateRange(inputDate, monthFromFn, monthToFn)
+
+    expect(result?.from.getDate()).toBe(1) // First day of month
+    expect(result?.to?.getDate()).toBe(31) // Last day of January
+  })
+
+  it("should handle edge case dates correctly", () => {
+    const leapYearDate = new Date("2024-02-29T12:00:00")
+    const result = toGranularityDateRange(leapYearDate, mockFromFn, mockToFn)
+
+    expect(result).toEqual({
+      from: new Date("2024-02-29T00:00:00.000Z"),
+      to: new Date("2024-02-29T23:59:59.999Z"),
+    })
+  })
+
+  it("should preserve timezone handling in granularity functions", () => {
+    const utcDate = new Date("2024-01-15T00:00:00.000Z")
+    const result = toGranularityDateRange(utcDate, mockFromFn, mockToFn)
+
+    expect(result?.from).toBeInstanceOf(Date)
+    expect(result?.to).toBeInstanceOf(Date)
+    expect(result?.from.getTime()).toBeLessThanOrEqual(
+      result?.to?.getTime() || 0
+    )
+  })
+})

--- a/packages/react/src/experimental/OneCalendar/utils.ts
+++ b/packages/react/src/experimental/OneCalendar/utils.ts
@@ -195,7 +195,7 @@ export const isActiveDate = (
   const maxDateWithGranularity = granularity.toRange(maxDate)
   return (
     !date ||
-    (dateWithGranularity &&
+    (!!dateWithGranularity?.from &&
       isValidDate(dateWithGranularity.from) &&
       (!minDateWithGranularity?.from ||
         isAfterOrEqual(

--- a/packages/react/src/experimental/OneCalendar/utils.ts
+++ b/packages/react/src/experimental/OneCalendar/utils.ts
@@ -3,6 +3,7 @@ import * as locales from "date-fns/locale"
 import { Matcher } from "react-day-picker"
 import { rangeSeparator } from "./granularities/consts"
 
+import { GranularityDefinition } from "./granularities"
 import { DateRange, DateRangeComplete, DateRangeString } from "./types"
 // Get the locale object from date-fns/locale
 
@@ -174,4 +175,34 @@ export const toCalendarPickerMatcher = ({
     res.push({ after: maxDate })
   }
   return res
+}
+
+/**
+ * Check if the date is active
+ * @param date
+ * @param granularity
+ * @param contraints
+ * @returns
+ */
+export const isActiveDate = (
+  date: Date | undefined | null,
+  granularity: GranularityDefinition,
+  { minDate, maxDate }: { minDate?: Date; maxDate?: Date }
+) => {
+  const dateWithGranularity = granularity.toRange(date)
+
+  const minDateWithGranularity = granularity.toRange(minDate)
+  const maxDateWithGranularity = granularity.toRange(maxDate)
+  return (
+    !date ||
+    (dateWithGranularity &&
+      isValidDate(dateWithGranularity.from) &&
+      (!minDateWithGranularity?.from ||
+        isAfterOrEqual(
+          dateWithGranularity.from,
+          minDateWithGranularity.from
+        )) &&
+      (!maxDateWithGranularity?.to ||
+        isBeforeOrEqual(dateWithGranularity.to, maxDateWithGranularity.to)))
+  )
 }


### PR DESCRIPTION


## Description

- **fix: onecalendar select date from input didnt trigger onSelect call back**
- **fix: onecalendar select date from input allowed to set a date not enabled (outside the min and max range)**
- **fix: onecalendar select date from input using arrows allows to navigate outside de range**
- **chore: add uitls tests**
## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
