### PR TITLE
feat: searchbox in tableofcontent

### DIFF
--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
@@ -1,7 +1,7 @@
 import { F0Icon } from "@/components/F0Icon"
 import { OneEllipsis } from "@/components/OneEllipsis/OneEllipsis"
 import { Counter } from "@/experimental/Information/Counter"
-import { ChevronDown, ChevronRight, Handle } from "@/icons/app"
+import { ChevronDown, Handle } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
 import { Button } from "@/ui/button"
@@ -65,9 +65,12 @@ export function PrimitiveItem({
             onToggleExpanded?.(item.id)
           }}
           aria-label={translations.actions.toggle}
-          className="text-f1-icon"
+          className={cn(
+            "text-f1-icon transition-all",
+            !isExpanded && "-rotate-90"
+          )}
         >
-          <F0Icon icon={isExpanded ? ChevronDown : ChevronRight} size="sm" />
+          <F0Icon icon={ChevronDown} size="sm" />
         </Button>
       )}
       <div

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/__stories__/F0TableOfContent.stories.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/__stories__/F0TableOfContent.stories.tsx
@@ -2,8 +2,8 @@ import { Placeholder } from "@/icons/app"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useState } from "react"
 import { fn } from "storybook/test"
-import { F0TableOfContent } from "./index"
-import { TOCItem, TOCItemAction } from "./types"
+import { F0TableOfContent } from "../index"
+import { TOCItem, TOCItemAction } from "../types"
 
 const mockOtherActions: TOCItemAction[] = [
   {
@@ -192,6 +192,34 @@ export const Sortable: Story = {
     docs: {
       description: {
         story: "Shows drag & drop reordering",
+      },
+    },
+  },
+}
+
+export const WithSearchBox: Story = {
+  args: {
+    ...Collapsible.args,
+    showSearchBox: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Shows collapsible functionality with a search box.",
+      },
+    },
+  },
+}
+
+export const SortableWithSearchBox: Story = {
+  args: {
+    ...Sortable.args,
+    showSearchBox: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Shows drag & drop reordering with a search box.",
       },
     },
   },

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/__tests__/utils.test.ts
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/__tests__/utils.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest"
+import type { TOCItem } from "../types"
+import { filterTree, findExpandedPath } from "../utils"
+
+describe("filterTree", () => {
+  const mockTreeData: TOCItem[] = [
+    {
+      id: "1",
+      label: "Getting Started",
+      children: [
+        {
+          id: "1.1",
+          label: "Installation Guide",
+        },
+        {
+          id: "1.2",
+          label: "Quick Start Tutorial",
+          children: [
+            {
+              id: "1.2.1",
+              label: "Basic Setup",
+            },
+            {
+              id: "1.2.2",
+              label: "Advanced Configuration",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "2",
+      label: "Components",
+      children: [
+        {
+          id: "2.1",
+          label: "Button Component",
+        },
+        {
+          id: "2.2",
+          label: "Input Component",
+          children: [
+            {
+              id: "2.2.1",
+              label: "Text Input",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "3",
+      label: "API Reference",
+    },
+  ]
+
+  it("should return all items when search query is empty", () => {
+    const result = filterTree(mockTreeData, "")
+    expect(result).toEqual(mockTreeData)
+  })
+
+  it("should return all items when search query is only whitespace", () => {
+    const result = filterTree(mockTreeData, "   ")
+    expect(result).toEqual(mockTreeData)
+  })
+
+  it("should filter items by exact label match", () => {
+    const result = filterTree(mockTreeData, "API Reference")
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("3")
+    expect(result[0].label).toBe("API Reference")
+  })
+
+  it("should filter items by partial label match (case insensitive)", () => {
+    const result = filterTree(mockTreeData, "component")
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("2")
+    expect(result[0].label).toBe("Components")
+    expect(result[0].children).toHaveLength(2)
+  })
+
+  it("should preserve parent hierarchy when child matches", () => {
+    const result = filterTree(mockTreeData, "Installation Guide")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("1") // Parent "Getting Started"
+    expect(result[0].label).toBe("Getting Started")
+    expect(result[0].children).toHaveLength(1)
+    expect(result[0].children![0].id).toBe("1.1")
+    expect(result[0].children![0].label).toBe("Installation Guide")
+  })
+
+  it("should preserve deep hierarchy when deeply nested child matches", () => {
+    const result = filterTree(mockTreeData, "Basic Setup")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("1") // Root parent "Getting Started"
+    expect(result[0].label).toBe("Getting Started")
+    expect(result[0].children).toHaveLength(1)
+
+    const quickStart = result[0].children![0]
+    expect(quickStart.id).toBe("1.2") // Intermediate parent "Quick Start Tutorial"
+    expect(quickStart.label).toBe("Quick Start Tutorial")
+    expect(quickStart.children).toHaveLength(1)
+    expect(quickStart.children![0].id).toBe("1.2.1")
+    expect(quickStart.children![0].label).toBe("Basic Setup")
+  })
+
+  it("should include parent and matching children when both match", () => {
+    const result = filterTree(mockTreeData, "input")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("2") // "Components"
+    expect(result[0].children).toHaveLength(1)
+
+    const inputComponent = result[0].children![0]
+    expect(inputComponent.id).toBe("2.2")
+    expect(inputComponent.label).toBe("Input Component")
+    expect(inputComponent.children).toHaveLength(1)
+    expect(inputComponent.children![0].label).toBe("Text Input")
+  })
+
+  it("should filter multiple matching branches", () => {
+    const result = filterTree(mockTreeData, "guide")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("1") // "Getting Started"
+    expect(result[0].children).toHaveLength(1)
+    expect(result[0].children![0].id).toBe("1.1")
+    expect(result[0].children![0].label).toBe("Installation Guide")
+  })
+
+  it("should handle case insensitive search", () => {
+    const result = filterTree(mockTreeData, "BUTTON")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("2") // "Components"
+    expect(result[0].children).toHaveLength(1)
+    expect(result[0].children![0].id).toBe("2.1")
+    expect(result[0].children![0].label).toBe("Button Component")
+  })
+
+  it("should return empty array when no matches found", () => {
+    const result = filterTree(mockTreeData, "nonexistent")
+    expect(result).toEqual([])
+  })
+
+  it("should filter only matching children from parent with multiple children", () => {
+    const result = filterTree(mockTreeData, "Advanced Configuration")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("1") // "Getting Started"
+    expect(result[0].children).toHaveLength(1)
+
+    const quickStart = result[0].children![0]
+    expect(quickStart.id).toBe("1.2") // "Quick Start Tutorial"
+    expect(quickStart.children).toHaveLength(1) // Only matching child
+    expect(quickStart.children![0].id).toBe("1.2.2")
+    expect(quickStart.children![0].label).toBe("Advanced Configuration")
+  })
+
+  it("should handle partial word matches", () => {
+    const result = filterTree(mockTreeData, "start")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].id).toBe("1") // "Getting Started"
+    expect(result[0].children).toHaveLength(1)
+    expect(result[0].children![0].id).toBe("1.2") // "Quick Start Tutorial"
+  })
+
+  it("should preserve item properties when filtering", () => {
+    const itemsWithProps: TOCItem[] = [
+      {
+        id: "test",
+        label: "Test Item",
+        onClick: () => {},
+        disabled: true,
+        icon: undefined,
+        otherActions: [{ label: "Action", onClick: () => {} }],
+      },
+    ]
+
+    const result = filterTree(itemsWithProps, "test")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].onClick).toBeDefined()
+    expect(result[0].disabled).toBe(true)
+    expect(result[0].otherActions).toHaveLength(1)
+  })
+
+  it("should remove undefined children when no children match", () => {
+    const result = filterTree(mockTreeData, "API Reference")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].children).toBeUndefined() // No children, so children should be undefined
+  })
+})
+
+describe("findExpandedPath", () => {
+  const mockTreeData: TOCItem[] = [
+    {
+      id: "1",
+      label: "Getting Started",
+      children: [
+        {
+          id: "1.1",
+          label: "Installation",
+        },
+        {
+          id: "1.2",
+          label: "Quick Start",
+          children: [
+            {
+              id: "1.2.1",
+              label: "Setup",
+            },
+          ],
+        },
+      ],
+    },
+    {
+      id: "2",
+      label: "Components",
+    },
+  ]
+
+  it("should return empty set when activeItemId is undefined", () => {
+    const result = findExpandedPath(mockTreeData, undefined)
+    expect(result.size).toBe(0)
+  })
+
+  it("should return empty set when activeItemId is not found", () => {
+    const result = findExpandedPath(mockTreeData, "nonexistent")
+    expect(result.size).toBe(0)
+  })
+
+  it("should return empty set for top-level item", () => {
+    const result = findExpandedPath(mockTreeData, "2")
+    expect(result.size).toBe(0)
+  })
+
+  it("should return parent id for direct child", () => {
+    const result = findExpandedPath(mockTreeData, "1.1")
+    expect(result.size).toBe(1)
+    expect(result.has("1")).toBe(true)
+  })
+
+  it("should return all parent ids for deeply nested item", () => {
+    const result = findExpandedPath(mockTreeData, "1.2.1")
+    expect(result.size).toBe(2)
+    expect(result.has("1")).toBe(true)
+    expect(result.has("1.2")).toBe(true)
+  })
+})

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/types.ts
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/types.ts
@@ -43,4 +43,6 @@ export interface TOCProps {
   collapsible?: boolean
   sortable?: boolean
   onReorder?: (reorderedIds: IdStructure[]) => void
+  showSearchBox?: boolean
+  searchPlaceholder?: string
 }

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/utils.ts
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/utils.ts
@@ -34,3 +34,41 @@ export function findExpandedPath(
   findPath(items, activeItemId)
   return expandedIds
 }
+
+/**
+ * Search in tree and return the items that match the search query
+ */
+export function filterTree(items: TOCItem[], searchQuery: string): TOCItem[] {
+  if (!searchQuery.trim()) {
+    return items // Return all items if no search query
+  }
+
+  const query = searchQuery.toLowerCase().trim()
+
+  function filterItem(item: TOCItem): TOCItem | null {
+    // Check if current item matches
+    const itemMatches = item.label.toLowerCase().includes(query)
+
+    // Filter children recursively
+    const filteredChildren = item.children
+      ? (item.children.map(filterItem).filter(Boolean) as TOCItem[])
+      : undefined
+
+    // Include item if:
+    // 1. The item itself matches, OR
+    // 2. Any of its children match (to preserve hierarchy)
+    if (itemMatches || (filteredChildren && filteredChildren.length > 0)) {
+      return {
+        ...item,
+        children:
+          filteredChildren && filteredChildren.length > 0
+            ? filteredChildren
+            : undefined,
+      }
+    }
+
+    return null
+  }
+
+  return items.map(filterItem).filter(Boolean) as TOCItem[]
+}

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -52,6 +52,9 @@ export const defaultTranslations = {
     failedToLoadOptions: "Failed to load options",
     retry: "Retry",
   },
+  toc: {
+    search: "Search",
+  },
   collections: {
     sorting: {
       noSorting: "No sorting",


### PR DESCRIPTION
## Description

Add searchbox in `F0TableOfContent`
Allow to hide children counters

## Screenshots (if applicable)


<img width="343" height="505" alt="image" src="https://github.com/user-attachments/assets/002af7ff-a089-4f46-9a3c-4a3dd21e5287" />

[Link to Figma Design](https://www.figma.com/design/pZzg1KTe9lpKTSGPUZa8OJ/Components?node-id=15062-20382&t=Xzh5ZN1e5Ttia9Xy-0)

