### PR TITLE
fix: i18n interpolation

### DIFF
--- a/packages/react/src/experimental/OneCalendar/granularities/week/__tests__/index.test.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/week/__tests__/index.test.tsx
@@ -11,7 +11,7 @@ describe("weekGranularity", () => {
     date: {
       granularities: {
         week: {
-          long: "Week of %{day} %{month} %{year}",
+          long: "Week of {{day}} {{month}} {{year}}",
         },
       },
     },

--- a/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
+++ b/packages/react/src/experimental/OneCalendar/granularities/week/index.tsx
@@ -65,9 +65,9 @@ export const weekGranularity: GranularityDefinition = {
     const formats: Record<DateStringFormat, string> = {
       default: formatDateToString(date, "'W'I yyyy"),
       long: i18n.date.granularities.week.long
-        .replace("%{month}", formatDateToString(date, "MMM"))
-        .replace("%{year}", formatDateToString(date, "yyyy"))
-        .replace("%{day}", formatDateToString(date, "d")),
+        .replace("{{month}}", formatDateToString(date, "MMM"))
+        .replace("{{year}}", formatDateToString(date, "yyyy"))
+        .replace("{{day}}", formatDateToString(date, "d")),
     }
     return formats[format] ?? formats.default
   },

--- a/packages/react/src/experimental/OneDataCollection/Settings/Settings.tsx
+++ b/packages/react/src/experimental/OneDataCollection/Settings/Settings.tsx
@@ -145,7 +145,7 @@ export const Settings = <
         ] ?? "-"
 
       return i18n.collections.visualizations.settings.replace(
-        "{%visualizationName}",
+        "{{visualizationName}}",
         visualizationName as string
       )
     },

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -74,7 +74,7 @@ export const defaultTranslations = {
       pagination: {
         of: "of",
       },
-      settings: "{%visualizationName} settings",
+      settings: "{{visualizationName}} settings",
       reset: "Reset to default",
     },
     itemsCount: "items",
@@ -135,7 +135,7 @@ export const defaultTranslations = {
       week: {
         currentDate: "This week",
         label: "Week",
-        long: "Week of %{day} %{month} %{year}",
+        long: "Week of {{day}} {{month}} {{year}}",
       },
       month: {
         currentDate: "This month",


### PR DESCRIPTION
## Description

Use {{ }} for the f0 interpolation replaces to avoid conflicts with the monorepo translation tool
%{XXX} makes the monorepo replace it and the placeholder are not available in f0

## Screenshots (if applicable)

<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
