### PR TITLE
fix(DataCollection): search clear icon color

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/search.tsx
+++ b/packages/react/src/experimental/OneDataCollection/search.tsx
@@ -126,11 +126,7 @@ export const Search = ({ value, onChange, loading = false }: SearchProps) => {
                     role="button"
                     aria-label={i18n.actions.clear}
                   >
-                    <F0Icon
-                      icon={CrossedCircle}
-                      className="text-f1-icon-secondary transition-colors hover:text-f1-icon"
-                      size="md"
-                    />
+                    <F0Icon icon={CrossedCircle} size="md" color="secondary" />
                   </motion.div>
                 </motion.div>
               </motion.div>
@@ -183,8 +179,8 @@ export const Search = ({ value, onChange, loading = false }: SearchProps) => {
                       >
                         <F0Icon
                           icon={CrossedCircle}
-                          className="text-f1-icon-secondary transition-colors hover:text-f1-icon"
                           size="md"
+                          color="secondary"
                         />
                       </motion.div>
                     </div>


### PR DESCRIPTION
## Description

Sets the correct color for the clear icon in the search field of the DataCollection. Since the [color prop change](https://github.com/factorialco/f0/pull/2239), this icon hasn't had the correct color applied.

## Screenshots

#### Before

<img width="222" height="64" alt="image" src="https://github.com/user-attachments/assets/ffe6fead-41c1-421c-9bfa-8048d9990ef7" />

#### After

<img width="225" height="70" alt="image" src="https://github.com/user-attachments/assets/fd17c0c1-aab1-48ae-bf1d-380da95ebb4b" />

