### PR TITLE
fix(Home): pulse avatar size

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarPulse/F0AvatarPulse.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPulse/F0AvatarPulse.tsx
@@ -78,11 +78,11 @@ export const F0AvatarPulse = ({
   const [showWave, setShowWave] = useState(!pulse)
 
   return (
-    <div className="relative h-14 w-14">
+    <div className="relative h-10 w-10">
       <AnimatePresence mode="popLayout" initial={showWave ? true : false}>
         {showWave ? (
           <motion.div
-            className="relative h-14 w-14 rounded-full bg-f1-background-warning"
+            className="relative h-10 w-10 rounded-full bg-f1-background-warning"
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.5 }}
@@ -128,7 +128,7 @@ export const F0AvatarPulse = ({
             initial={{ opacity: 0, scale: 0.5 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={{ opacity: 0, scale: 0.5 }}
-            className="relative"
+            className="relative h-10 w-10"
             transition={{
               scale: {
                 type: "spring",
@@ -146,13 +146,13 @@ export const F0AvatarPulse = ({
               type="rounded"
               name={[firstName, lastName]}
               src={src}
-              size="xl"
+              size="lg"
               color="random"
               aria-label={ariaLabel}
               aria-labelledby={ariaLabelledby}
             />
             {pulse ? (
-              <div className="absolute -bottom-1 -right-1 inline-flex rounded-sm bg-f1-background">
+              <div className="absolute -bottom-1.5 -right-1.5 inline-flex rounded-sm bg-f1-background">
                 <Button
                   variant="neutral"
                   size="sm"
@@ -180,7 +180,7 @@ export const F0AvatarPulse = ({
                   opacity: { delay: 0.25 },
                   scale: { delay: 0.25 },
                 }}
-                className="absolute -bottom-1 -right-1 rounded-sm bg-f1-background"
+                className="absolute -bottom-1.5 -right-1.5 rounded-sm bg-f1-background"
               >
                 <ActionButton
                   label={translations.actions.add}

--- a/packages/react/src/experimental/Navigation/DaytimePage/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/DaytimePage/index.stories.tsx
@@ -131,7 +131,6 @@ export const DaytimeHomeLayoutWithMoodNotSet: Story = {
         employeeFirstName: "Saul",
         employeeLastName: "Goodman",
         title: "Good morning, Saul!",
-        description: "How are you feeling today?",
         pulse: undefined,
         onPulseClick: () => {},
         employeeAvatar: "/avatars/person05.jpg",


### PR DESCRIPTION
## Description

Avatar in the home page seems huge, when Pulse is enabled. With a subtitle it looks ok, but without it (and that's how it is implemented), if seems completely unbalanced. Here I am making it a bit smaller, a bit more similar to the Module Avatar that we use in other sections.

## Screenshots

#### Before

<img width="380" height="131" alt="image" src="https://github.com/user-attachments/assets/83ca6fec-a6ec-4336-a5c8-2fe3eb89b756" />

#### After

<img width="342" height="112" alt="image" src="https://github.com/user-attachments/assets/b73141a6-67f4-4987-9234-da7b353e0293" />

https://github.com/user-attachments/assets/1e4d6c62-3fc9-46c7-b82e-8451dff70f38

