### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.215.0",
+  "packages/react": "1.216.0",
   "packages/react-native": "0.20.0",
   "packages/core": "1.29.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.216.0](https://github.com/factorialco/f0/compare/f0-react-v1.215.0...f0-react-v1.216.0) (2025-10-01)
+
+
+### Features
+
+* create sdm callout from the AiBanner component ([#2730](https://github.com/factorialco/f0/issues/2730)) ([5b96625](https://github.com/factorialco/f0/commit/5b96625cb7a849aa267535c26b8fc9b6a40fecfa))
+
 ## [1.215.0](https://github.com/factorialco/f0/compare/f0-react-v1.214.3...f0-react-v1.215.0) (2025-10-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.215.0",
+  "version": "1.216.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.216.0</summary>

## [1.216.0](https://github.com/factorialco/f0/compare/f0-react-v1.215.0...f0-react-v1.216.0) (2025-10-01)


### Features

* create sdm callout from the AiBanner component ([#2730](https://github.com/factorialco/f0/issues/2730)) ([5b96625](https://github.com/factorialco/f0/commit/5b96625cb7a849aa267535c26b8fc9b6a40fecfa))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).