### PR TITLE
feat(Icons): add One special icon

### DIFF
--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -102,7 +102,7 @@
     @media screen and (min-width: 820px) {
       padding-top: 64px !important;
       padding-left: 72px !important;
-      padding-right: 190px !important;
+      padding-right: 72px !important;
     }
   }
 
@@ -166,6 +166,23 @@
 
   .toc-list .toc-list-item > a.is-active-link {
     color: #e51943 !important;
+  }
+
+  .toc-wrapper:empty,
+  .toc-wrapper .toc-list:empty {
+    display: none !important;
+  }
+
+  .toc-wrapper .toc-list li:only-child:empty ~ * {
+    display: none !important;
+  }
+
+  aside.sbdocs-toc--custom:has(.toc-wrapper:empty) {
+    display: none !important;
+  }
+
+  .sbdocs-content {
+    max-width: 100% !important;
   }
 
   input[type="radio"] {

--- a/packages/react/docs/components/IconGrid.tsx
+++ b/packages/react/docs/components/IconGrid.tsx
@@ -90,7 +90,7 @@ export function IconGrid() {
   }, [searchTerm])
 
   return (
-    <div className="flex flex-col gap-4 pt-4">
+    <div className="flex flex-col gap-4">
       <div className="relative w-full">
         <input
           type="text"

--- a/packages/react/docs/icons.mdx
+++ b/packages/react/docs/icons.mdx
@@ -6,8 +6,6 @@ import LinkTo from "@storybook/addon-links/react"
 
 # Icons
 
-F0 icons are symbols used to represent actions, functionality, or content. To
-know how to use icons in code, visit the
-[Icon component documentation](/docs/components-icon--documentation).
+F0 icons are symbols used to represent actions, functionality, or content.
 
 <IconGrid />

--- a/packages/react/docs/icons.mdx
+++ b/packages/react/docs/icons.mdx
@@ -4,8 +4,4 @@ import LinkTo from "@storybook/addon-links/react"
 
 <Meta title="Foundations/Icons" />
 
-# Icons
-
-F0 icons are symbols used to represent actions, functionality, or content.
-
 <IconGrid />

--- a/packages/react/src/components/F0Icon/__stories__/F0Icon.stories.tsx
+++ b/packages/react/src/components/F0Icon/__stories__/F0Icon.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import * as AnimatedIcons from "@/icons/animated"
 import * as Icons from "@/icons/app"
 import * as ModuleIcons from "@/icons/modules"
+import * as SpecialIcons from "@/icons/special"
 import { ComponentProps } from "react"
 import { F0Icon } from "../index"
 
@@ -87,5 +88,22 @@ export const Animated: Story = {
         />
       </div>
     )
+  },
+}
+
+export const Special: Story = {
+  args: {
+    size: "md",
+    icon: SpecialIcons.One,
+  },
+  argTypes: {
+    icon: {
+      control: "select",
+      options: Object.keys(SpecialIcons),
+      mapping: SpecialIcons,
+    },
+    color: {
+      control: { type: "color" },
+    },
   },
 }

--- a/packages/react/src/icons/special/One.tsx
+++ b/packages/react/src/icons/special/One.tsx
@@ -1,0 +1,79 @@
+import type { SVGProps } from "react"
+import { Ref, forwardRef, useId } from "react"
+
+const pieces = [
+  {
+    id: "bottom",
+    path: "M11.9948 17.5244C14.2802 17.5244 16.5188 18.2872 18.2805 19.7631C16.5189 21.1914 14.2801 22 11.9948 22C9.61453 21.9999 7.42426 21.1436 5.71037 19.7631C7.47193 18.3348 9.70955 17.5245 11.9948 17.5244Z",
+  },
+  {
+    id: "left",
+    path: "M4.23721 5.71327C5.66526 7.47502 6.47496 9.71299 6.47503 11.9985C6.47502 14.2841 5.71292 16.5231 4.23721 18.2849C2.80903 16.5231 2 14.2841 2 11.9985C2.00007 9.61784 2.85682 7.42739 4.23721 5.71327Z",
+  },
+  {
+    id: "right",
+    path: "M19.7622 5.71327C21.1902 7.47502 21.9999 9.71299 22 11.9985C22 14.2841 21.2379 16.5231 19.7622 18.2849C18.334 16.5231 17.525 14.2841 17.525 11.9985C17.525 9.61784 18.3818 7.42739 19.7622 5.71327Z",
+  },
+  {
+    id: "top",
+    path: "M11.9948 2C14.2802 2 16.5188 2.76274 18.2805 4.2387C16.5189 5.66699 14.2801 6.47557 11.9948 6.47557C9.61453 6.4755 7.42426 5.61919 5.71037 4.2387C7.47193 2.81041 9.70955 2.00007 11.9948 2Z",
+  },
+]
+
+const SvgOne = (props: SVGProps<SVGSVGElement>, ref: Ref<SVGSVGElement>) => {
+  const hasColorClass =
+    (props.className?.includes("text-") &&
+      !props.className?.includes("text-current")) ||
+    props.style?.color !== undefined
+
+  const clipPathId = useId()
+
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      ref={ref}
+      {...props}
+    >
+      <defs>
+        {pieces.map((piece) => (
+          <clipPath key={piece.id} id={`${clipPathId}-${piece.id}`}>
+            <path d={piece.path} />
+          </clipPath>
+        ))}
+      </defs>
+
+      {hasColorClass
+        ? pieces.map((piece) => (
+            <path
+              key={piece.id}
+              d={piece.path}
+              fill="currentColor"
+              vectorEffect="non-scaling-stroke"
+            />
+          ))
+        : pieces.map((piece) => (
+            <foreignObject
+              key={piece.id}
+              x="0"
+              y="0"
+              width="24"
+              height="24"
+              clipPath={`url(#${clipPathId}-${piece.id})`}
+            >
+              <div
+                style={{
+                  width: "100%",
+                  height: "100%",
+                  background:
+                    "conic-gradient(from 0deg at 50% 50%, #E55619 0%, #A1ADE5 33%, #E51943 66%, #E55619 100%)",
+                }}
+              />
+            </foreignObject>
+          ))}
+    </svg>
+  )
+}
+const ForwardRef = forwardRef(SvgOne)
+export default ForwardRef

--- a/packages/react/src/icons/special/index.ts
+++ b/packages/react/src/icons/special/index.ts
@@ -1,0 +1,1 @@
+export { default as One } from "./One"


### PR DESCRIPTION
## Description

- Add a new `special` folder in icons, for logos or anything else that do not fit our icon library.
- Add One as icon.
   - Shows a gradient as color if no color is defined, but applies a color if it is defined through the `F0Icon` component.

## Screenshots

<img width="304" height="226" alt="image" src="https://github.com/user-attachments/assets/69d8baef-7fef-4850-949b-b86ec53908c3" />

_Regular icon_

<img width="281" height="209" alt="image" src="https://github.com/user-attachments/assets/9db11bc8-4676-467d-be7d-993ec785f5a7" />

_Icon with color applied_
