### PR TITLE
feat: add positive variant to AlertTag

### DIFF
--- a/packages/react/src/components/tags/F0TagAlert/F0TagAlert.tsx
+++ b/packages/react/src/components/tags/F0TagAlert/F0TagAlert.tsx
@@ -1,5 +1,5 @@
 import { F0Icon, IconType } from "@/components/F0Icon"
-import { AlertCircle, InfoCircle, Warning } from "@/icons/app"
+import { AlertCircle, CheckCircle, InfoCircle, Warning } from "@/icons/app"
 import { useTextFormatEnforcer } from "@/lib/text"
 import { cn } from "@/lib/utils"
 import { forwardRef } from "react"
@@ -10,6 +10,7 @@ const iconMap: Record<Level, IconType> = {
   info: InfoCircle,
   warning: Warning,
   critical: AlertCircle,
+  positive: CheckCircle,
 }
 
 export const F0TagAlert = forwardRef<HTMLDivElement, Props>(
@@ -25,6 +26,7 @@ export const F0TagAlert = forwardRef<HTMLDivElement, Props>(
             info: "bg-f1-background-info text-f1-foreground-info",
             warning: "bg-f1-background-warning text-f1-foreground-warning",
             critical: "bg-f1-background-critical text-f1-foreground-critical",
+            positive: "bg-f1-background-positive text-f1-foreground-positive",
           }[level]
         )}
         left={
@@ -37,6 +39,7 @@ export const F0TagAlert = forwardRef<HTMLDivElement, Props>(
                 info: "text-f1-icon-info",
                 warning: "text-f1-icon-warning",
                 critical: "text-f1-icon-critical",
+                positive: "text-f1-icon-positive",
               }[level]
             )}
           />

--- a/packages/react/src/components/tags/F0TagAlert/__storybook__/TagAlert.stories.tsx
+++ b/packages/react/src/components/tags/F0TagAlert/__storybook__/TagAlert.stories.tsx
@@ -33,3 +33,10 @@ export const CriticalAlertTag: Story = {
     level: "critical",
   },
 }
+
+export const PositiveAlertTag: Story = {
+  args: {
+    text: "Success",
+    level: "positive",
+  },
+}

--- a/packages/react/src/components/tags/F0TagAlert/types.ts
+++ b/packages/react/src/components/tags/F0TagAlert/types.ts
@@ -1,4 +1,4 @@
-export type Level = "info" | "warning" | "critical"
+export type Level = "info" | "warning" | "critical" | "positive"
 
 export type Props<Text extends string = string> = {
   text: Text extends "" ? never : Text


### PR DESCRIPTION
## Description

In order to have the green TagAlert in the new inbox, we need to add the positive variant to TagAlert component.

## Screenshots (if applicable)
<img width="852" height="207" alt="image" src="https://github.com/user-attachments/assets/27d93b5c-7b43-48eb-aaf7-fcc69f27005e" />


[Link to Figma Design](https://www.figma.com/design/1ofJHGsqfUuEl75ZB0atfo/%E2%9C%A8-Automations-and-smart-decision-making?node-id=6468-117748&t=EXxs0Vqjw5jwUWGC-0)
