### PR TITLE
feat: accept special icons in product updates modules

### DIFF
--- a/packages/react/src/components/UpsellingKit/ProductCard/index.tsx
+++ b/packages/react/src/components/UpsellingKit/ProductCard/index.tsx
@@ -1,5 +1,10 @@
 import { Button } from "@/components/Actions/Button"
-import { F0AvatarModule, ModuleId } from "@/components/avatars/F0AvatarModule"
+import {
+  F0AvatarModule,
+  ModuleId,
+  modules,
+} from "@/components/avatars/F0AvatarModule"
+import { F0Icon, IconType } from "@/components/F0Icon"
 import CrossIcon from "@/icons/app/Cross"
 import { useEffect, useState } from "react"
 
@@ -11,7 +16,7 @@ export type ProductCardProps = {
   isVisible: boolean
   dismissable?: boolean
   trackVisibility?: (open: boolean) => void
-  module: ModuleId
+  module: ModuleId | IconType
   type?: "one-campaign" | undefined
 }
 
@@ -81,13 +86,28 @@ export function ProductCard({
               style={getCardStyles()}
               onClick={onClick}
             >
-              <F0AvatarModule module={props.module} size="lg" />
-              <div className="flex flex-1 flex-col">
-                <div>
-                  <h3 className="text-lg font-medium">{title}</h3>
-                  <p className="text-f1-foreground-secondary">{description}</p>
+              <>
+                {typeof props.module === "string" && props.module in modules ? (
+                  <F0AvatarModule module={props.module as ModuleId} size="lg" />
+                ) : (
+                  <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+                    <F0Icon
+                      icon={props.module as IconType}
+                      size="lg"
+                      className="!h-8 !w-8"
+                    />
+                  </div>
+                )}
+                <div className="flex flex-1 flex-col">
+                  <div>
+                    <h3 className="text-lg font-medium">{title}</h3>
+                    <p className="text-f1-foreground-secondary">
+                      {description}
+                    </p>
+                  </div>
                 </div>
-              </div>
+              </>
+
               {dismissable && (
                 <div className="h-6 w-6">
                   <Button

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.stories.tsx
@@ -1,3 +1,4 @@
+import One from "@/icons/special/One"
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useState } from "react"
 import { EllipsisHorizontal, Settings } from "../../../../icons/app"
@@ -280,7 +281,7 @@ export const WithProductUpdate: Story = {
             onClose: () => {
               alert("onClose")
             },
-            module: "discover",
+            module: One,
             dismissable: false,
             trackVisibility: (open) => {
               console.log("trackOpenChange", open)

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from "@/components/Actions/Button"
 import { ButtonInternal } from "@/components/Actions/Button/internal"
-import { F0Icon } from "@/components/F0Icon"
+import { F0Icon, IconType } from "@/components/F0Icon"
 import { ProductCard } from "@/components/UpsellingKit/ProductCard"
 import AlertCircle from "@/icons/app/AlertCircle"
 import ChevronRight from "@/icons/app/ChevronRight"
@@ -67,7 +67,7 @@ type ProductUpdatesProp = {
       title: string
       description: string
       onClick: () => void
-      module: ModuleId
+      module: ModuleId | IconType
       dismissable: boolean
       onClose?: () => void
       trackVisibility?: (open: boolean) => void


### PR DESCRIPTION
## Description

Making the modules inside the product card accept not only module icons but special icons like One

## Screenshots (if applicable)

<img width="510" height="629" alt="Screenshot 2025-10-02 at 8 37 12 AM" src="https://github.com/user-attachments/assets/bd510096-ad56-41f0-a885-41b80ef90e76" />
<img width="515" height="605" alt="Screenshot 2025-10-02 at 8 37 17 AM" src="https://github.com/user-attachments/assets/059c2fdd-82cf-4866-b463-703fab158c61" />
