### PR TITLE
feat: change positive callout icon

### DIFF
--- a/packages/react/src/experimental/Banners/F0Callout/CalloutInternal.tsx
+++ b/packages/react/src/experimental/Banners/F0Callout/CalloutInternal.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@/components/Actions/Button"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { OneEllipsis } from "@/components/OneEllipsis"
-import { CheckDouble, Cross, InfoCircle, Warning } from "@/icons/app"
+import { CheckCircle, Cross, InfoCircle, Warning } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
 import { cva } from "cva"
@@ -25,7 +25,7 @@ const calloutVariants = cva({
 })
 
 const variantIcons: Record<string, IconType> = {
-  positive: CheckDouble, // Using CheckDouble as the primary action icon for positive
+  positive: CheckCircle,
   warning: Warning,
   info: InfoCircle,
 }


### PR DESCRIPTION
## Description

From the design proposed we change the positive callout icon from CheckDouble to CheckCircle

## Screenshots (if applicable)
Before
<img width="516" height="231" alt="image" src="https://github.com/user-attachments/assets/9ced8217-b5a3-4573-8650-c69b52720e0f" />

After:
<img width="747" height="231" alt="image" src="https://github.com/user-attachments/assets/ac5fec86-d07b-426d-aa87-630c9a6cea0b" />


[Link to Figma Design](https://www.figma.com/design/1ofJHGsqfUuEl75ZB0atfo/%E2%9C%A8-Automations-and-smart-decision-making?node-id=6468-117748&t=EXxs0Vqjw5jwUWGC-0)
