### PR TITLE
feat: add itemFilter in useData

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/experimental/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -135,6 +135,9 @@ export type DataCollectionSourceDefinition<
   bulkActions?: BulkActionsDefinition<R, Filters>
   totalItemSummary?: (totalItems: number) => string
 
+  /** Item filter that can be used to filter the items before they are displayed */
+  itemFilter?: (item: R) => boolean
+
   /** Lanes configuration */
   lanes?: ReadonlyArray<Lane<Filters>>
 }

--- a/packages/react/src/experimental/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/experimental/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -136,7 +136,7 @@ export type DataCollectionSourceDefinition<
   totalItemSummary?: (totalItems: number) => string
 
   /** Item filter that can be used to filter the items before they are displayed */
-  itemFilter?: (item: R) => boolean
+  itemPreFilter?: (item: R) => boolean
 
   /** Lanes configuration */
   lanes?: ReadonlyArray<Lane<Filters>>

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -103,4 +103,7 @@ export type DataSource<
     item: Item,
     index?: number
   ) => string | number | symbol
+
+  /** Item filter that can be used to filter the items before they are displayed */
+  itemFilter?: (item: R) => boolean
 }

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -105,5 +105,5 @@ export type DataSource<
   ) => string | number | symbol
 
   /** Item filter that can be used to filter the items before they are displayed */
-  itemFilter?: (item: R) => boolean
+  itemPreFilter?: (item: R) => boolean
 }

--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -250,7 +250,7 @@ export function useData<
     currentGrouping,
     grouping,
     idProvider = defaultIdProvider,
-    itemFilter,
+    itemPreFilter,
   } = source
 
   const cleanup = useRef<(() => void) | undefined>()
@@ -269,10 +269,10 @@ export function useData<
   const { paginationInfo, setPaginationInfo } = usePaginationState()
 
   useEffect(() => {
-    if (itemFilter) {
+    if (itemPreFilter) {
       setRawData((currentData) => {
         const originalItemsCount = currentData.length
-        const filteredData = currentData.filter(itemFilter)
+        const filteredData = currentData.filter(itemPreFilter)
         const newItemsCount = filteredData.length
         const filteredItemsCount = originalItemsCount - newItemsCount
         setFilteredItemsCount(filteredItemsCount)
@@ -287,7 +287,7 @@ export function useData<
         return filteredData
       })
     }
-  }, [itemFilter, setRawData, setPaginationInfo])
+  }, [itemPreFilter, setRawData, setPaginationInfo])
 
   // We need to use a ref to get the latest paginationInfo value
   // because the paginationInfo is updated asynchronously


### PR DESCRIPTION
## Description

For infinite pagination especially we need a way to filter our items locally based on a condition (e.g. data present in the Apollo cache), for those cases we will be able to define a filtering function that will be iterated on all of our raw data elements and discard those that don't match our condition, updating the total count accordingly.
