### PR TITLE
feat: datacollection buttondropdown

### DIFF
--- a/packages/react/src/components/value-display/__stories__/ValueDisplay.stories.tsx
+++ b/packages/react/src/components/value-display/__stories__/ValueDisplay.stories.tsx
@@ -16,7 +16,7 @@ function Cell({
   return renderProperty(item, property, "table")
 }
 const meta = {
-  title: "Data Collection/Cell Types",
+  title: "Value Display",
   component: Cell,
   parameters: {
     layout: "padded",

--- a/packages/react/src/experimental/OneDataCollection/__stories__/actions/actions.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/actions/actions.mdx
@@ -9,7 +9,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as ActionsStories from "./collection-actions.stories"
 import * as ItemActionsStories from "./item-actions.stories"
-import * as IndexStories from "./index.stories"
+import * as IndexStories from "../index.stories"
 
 <Meta title="Data collection/Actions" />
 
@@ -43,6 +43,31 @@ const dataSource = useDataCollectionSource({
 })
 ```
 
+You can also pass an array of actions and they will be rendered as a
+F0ButtonDropdown, with the first action as main action.
+
+````tsx
+const dataSource = useDataCollectionSource({
+  primaryActions: () => [
+    {
+      label: "Action 1",
+      icon: <Icon />,
+      onClick: () => console.log("Action 1"),
+    },
+    {
+      label: "Action 2",
+      icon: <Icon />,
+      onClick: () => console.log("Action 2"),
+    },
+    {
+      label: "Action 3",
+      icon: <Icon />,
+      onClick: () => console.log("Action 3"),
+    },
+  ],
+})
+
+
 - **Secondary actions**: Are an array of actions and by defualt are displayed a
   dropdown. But you can define the number of actions to display as a secondary
   button using the `expanded` property. You can also hide the label of the
@@ -70,7 +95,7 @@ const dataSource = useDataCollectionSource({
     ],
   },
 })
-```
+````
 
 Or as array of actions
 
@@ -98,6 +123,10 @@ const dataSource = useDataCollectionSource({
 #### Basic example
 
 <Canvas of={ActionsStories.BasicActionsExample} />
+
+#### Multiple primary actions
+
+<Canvas of={ActionsStories.MultiplePrimaryActionsExample} />
 
 #### With expanded actions
 

--- a/packages/react/src/experimental/OneDataCollection/__stories__/actions/collection-actions.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/actions/collection-actions.stories.tsx
@@ -1,18 +1,18 @@
 import { FiltersDefinition } from "@/components/OneFilterPicker/types"
 import { SummariesDefinition } from "@/experimental/OneDataCollection/summary.ts"
 import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
-import { Ai } from "@/icons/app"
+import { Ai, Person } from "@/icons/app"
 import { Meta, StoryObj } from "@storybook/react-vite"
 import {
   DataCollectionSource,
   useDataCollectionSource,
-} from "../hooks/useDataCollectionSource"
-import { OneDataCollection } from "../index"
-import { ItemActionsDefinition } from "../item-actions"
-import { NavigationFiltersDefinition } from "../navigationFilters/types"
-import { GroupingDefinition } from "../types"
-import { Visualization } from "../visualizations/collection/types"
-import { buildSecondaryActions } from "./mockData"
+} from "../../hooks/useDataCollectionSource"
+import { OneDataCollection } from "../../index"
+import { ItemActionsDefinition } from "../../item-actions"
+import { NavigationFiltersDefinition } from "../../navigationFilters/types"
+import { GroupingDefinition } from "../../types"
+import { Visualization } from "../../visualizations/collection/types"
+import { buildSecondaryActions } from "../mockData"
 
 const meta = {
   title: "Data Collection/Collection Actions",
@@ -163,6 +163,35 @@ export const BasicActionsExample: Story = {
         icon: Ai,
         onClick: () => console.log(`Creating a user`),
       }),
+      secondaryActions: {
+        expanded: 0,
+        actions: buildSecondaryActions,
+      },
+    })
+
+    return <BaseStory dataSource={dataSource} />
+  },
+}
+
+// Basic story showing all action types
+export const MultiplePrimaryActionsExample: Story = {
+  render: () => {
+    const dataSource = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: () => Promise.resolve({ records: mockUsers }),
+      },
+      primaryActions: () => [
+        {
+          label: "Create user",
+          icon: Ai,
+          onClick: () => console.log(`Creating a user`),
+        },
+        {
+          label: "Create admin",
+          icon: Person,
+          onClick: () => console.log(`Creating a admin`),
+        },
+      ],
       secondaryActions: {
         expanded: 0,
         actions: buildSecondaryActions,

--- a/packages/react/src/experimental/OneDataCollection/__stories__/actions/item-actions.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/actions/item-actions.stories.tsx
@@ -1,8 +1,8 @@
 import { Ai, Download, Pencil, Upload } from "@/icons/app"
 import { Meta, StoryObj } from "@storybook/react-vite"
-import { OneDataCollection } from ".."
-import { useDataCollectionSource } from "../hooks/useDataCollectionSource"
-import { ItemActionsDefinition } from "../item-actions"
+import { OneDataCollection } from "../.."
+import { useDataCollectionSource } from "../../hooks/useDataCollectionSource"
+import { ItemActionsDefinition } from "../../item-actions"
 
 const meta = {
   title: "Data Collection/Item Actions",

--- a/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/cell-types.mdx
@@ -25,5 +25,5 @@ the datacollection, the type is the cell type to render and the value depends on
 that type
 
 {/* prettier-ignore */}
-> Check <LinkTo kind="ValueDisplay" story="Documentation">ValueDisplay</LinkTo>
+> Check <LinkTo kind="Components/ValueDisplay" story="Documentation">ValueDisplay</LinkTo>
 > for details.

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.mdx
@@ -2,7 +2,7 @@ import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as DataCollectionStories from "./index.stories"
-import * as ActionDataCollectionStories from "./collection-actions.stories"
+import * as ActionDataCollectionStories from "./actions/collection-actions.stories"
 import * as DataCollectionTableViewStories from "./visualizations/table/table.stories"
 
 <Meta title="Data collection" />

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -2102,19 +2102,3 @@ export const TableWithSecondaryActions: Story = {
     )
   },
 }
-
-export const TotalItemsSummary: Story = {
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'The `totalItemSummary` useDataCollectionSource prop allows you to customize how the total number of items is displayed in the collection header. It receives a function that takes the total count as a parameter and returns a string to be displayed. By default, if no `totalItemSummary` is provided, it will display "{count} items".',
-      },
-    },
-  },
-  render: () => (
-    <ExampleComponent
-      totalItemSummary={(totalItems) => `Total items: ${totalItems}`}
-    />
-  ),
-}

--- a/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/mockData.tsx
@@ -864,6 +864,7 @@ export const ExampleComponent = ({
    * Enable Apollo-like cache behavior for testing optimistic updates
    */
   enableCache = true,
+  hideFilters,
 }: {
   useObservable?: boolean
   usePresets?: boolean
@@ -895,7 +896,7 @@ export const ExampleComponent = ({
   onSelectItems?: OnSelectItemsCallback<MockUser, FiltersType>
   onBulkAction?: OnBulkActionCallback<MockUser, FiltersType>
   navigationFilters?: NavigationFiltersDefinition
-  totalItemSummary?: (totalItems: number) => string
+  totalItemSummary?: true | ((totalItems: number) => string)
   grouping?: GroupingDefinition<MockUser> | undefined
   currentGrouping?: GroupingState<MockUser, GroupingDefinition<MockUser>>
   paginationType?: PaginationType
@@ -906,6 +907,7 @@ export const ExampleComponent = ({
   tableAllowColumnHiding?: boolean
   onStateChange?: (state: DataCollectionStatusComplete) => void
   enableCache?: boolean
+  hideFilters?: boolean
 }) => {
   // Create a cache instance to simulate Apollo cache behavior
   const cache = useMemo(() => {
@@ -959,7 +961,7 @@ export const ExampleComponent = ({
 
   const dataSource = useDataCollectionSource(
     {
-      filters,
+      filters: hideFilters ? undefined : filters,
       navigationFilters,
       presets: usePresets ? filterPresets : undefined,
       sortings,

--- a/packages/react/src/experimental/OneDataCollection/__stories__/persistence.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/persistence.mdx
@@ -7,8 +7,8 @@ import {
 } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
-import * as ActionsStories from "./collection-actions.stories"
-import * as ItemActionsStories from "./item-actions.stories"
+import * as ActionsStories from "./actions/collection-actions.stories"
+import * as ItemActionsStories from "./actions/item-actions.stories"
 import * as IndexStories from "./index.stories"
 
 <Meta title="Data collection/Status Persistence" />

--- a/packages/react/src/experimental/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -8,7 +8,7 @@ import {
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as DataCollectionStories from "./index.stories"
-import * as ActionDataCollectionStories from "./collection-actions.stories"
+import * as ActionDataCollectionStories from "./actions/collection-actions.stories"
 
 <Meta title="Data collection/Selectable and bulk actions" />
 

--- a/packages/react/src/experimental/OneDataCollection/__stories__/top-header.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/top-header.mdx
@@ -5,6 +5,7 @@ import {
   Unstyled,
   Story,
 } from "@storybook/addon-docs/blocks"
+import LinkTo from "@storybook/addon-links/react"
 import * as EmptyState from "./empty-states.stories"
 
 <Meta title="Data collection/Top Header" />
@@ -16,21 +17,6 @@ import * as EmptyState from "./empty-states.stories"
 The top header is the header that is displayed at the top of the data
 collection. It is used to display total items summary, actions, etc.
 
-## Total items summary
-
-The total items summary is the summary of the total number of items in the data
-collection. It is displayed in the top header.
-
-You can customize the total items summary by providing a function that takes the
-total number of items as a parameter and returns a string to be displayed. By
-default, if no `totalItemSummary` is provided, it will display "{count} items".
-
-```tsx
-<OneDataCollection
-  source={useDataCollectionSource({
-    ...
-    totalItemSummary={(totalItems) => `Total items: ${totalItems}`}
-    ...
-  })}
-/>
-```
+{/* prettier-ignore */}
+ Check <LinkTo kind="Components/Data Collection/Total Items Summary" story="Documentation">Total
+items summary</LinkTo>

--- a/packages/react/src/experimental/OneDataCollection/__stories__/total-items-summary/total-items-summary.mdx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/total-items-summary/total-items-summary.mdx
@@ -1,0 +1,60 @@
+import {
+  Canvas,
+  Meta,
+  Controls,
+  Unstyled,
+  Story,
+} from "@storybook/addon-docs/blocks"
+import LinkTo from "@storybook/addon-links/react"
+import * as TotalItemsSummaryStories from "./total-items-summary.stories"
+
+<Meta of={TotalItemsSummaryStories} />
+
+# Total Items Summary
+
+## Introduction
+
+The Total Items Summary is a component that displays the total number of items
+in the data collection. It is displayed in the top right of the data collection.
+
+## Setting Up Total Items Summary
+
+To enable the Total Items Summary in your data collection component, provide the
+`totalItemSummary` property to the `useDataCollectionSource` hook.
+
+```tsx
+const source = useDataCollectionSource({
+  totalItemSummary: true,
+})
+```
+
+This will display the total number of items in the data collection with the
+default text.
+
+### Example
+
+<Canvas of={TotalItemsSummaryStories.TotalItemsSummary} />
+
+## Customizing the Total Items Summary
+
+You can customize the Total Items Summary by providing a function that takes the
+total number of items as a parameter and returns a string to be displayed.
+
+```tsx
+const source = useDataCollectionSource({
+  totalItemSummary: (totalItems) => `Total items: ${totalItems}`,
+  ...
+})
+```
+
+### Example
+
+<Canvas of={TotalItemsSummaryStories.TotalItemsSummaryCustom} />
+
+## Position of the Total Items Summary
+
+The Total Items Summary is displayed in the top right of the data collection. If
+you have filters, it will be displayed over the filters, in the same row as the
+navigation filters. If not, it will be displayed in the place of the filters.
+
+<Canvas of={TotalItemsSummaryStories.TotalItemsSummaryWithFilters} />

--- a/packages/react/src/experimental/OneDataCollection/__stories__/total-items-summary/total-items-summary.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/total-items-summary/total-items-summary.stories.tsx
@@ -1,0 +1,81 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+import { ExampleComponent } from "../mockData"
+
+const meta = {
+  title: "Data Collection/Total Items Summary",
+  component: ExampleComponent,
+  tags: ["autodocs", "experimental", "internal"],
+} satisfies Meta<typeof ExampleComponent>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const TotalItemsSummary: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `totalItemSummary` useDataCollectionSource prop allows you to customize how the total number of items is displayed in the collection header. It receives a function that takes the total count as a parameter and returns a string to be displayed.",
+      },
+      source: {
+        code: `
+            const source = useDataCollectionSource({
+              totalItemSummary: true
+              ....
+            })
+            <OneDataCollection source={source} .../>
+            `,
+      },
+    },
+  },
+  render: () => <ExampleComponent totalItemSummary={true} />,
+}
+
+export const TotalItemsSummaryCustom: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+        const source = useDataCollectionSource({
+          totalItemSummary: (totalItems) =>
+            \`Total items in the datacollection: \${totalItems}\`
+          ....
+        })
+        <OneDataCollection source={source} .../>
+        `,
+      },
+    },
+  },
+  render: () => (
+    <ExampleComponent
+      totalItemSummary={(totalItems) =>
+        `Total items in the datacollection: ${totalItems}`
+      }
+    />
+  ),
+}
+
+export const TotalItemsSummaryWithFilters: Story = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+            const source = useDataCollectionSource({
+              totalItemSummary: (totalItems) =>
+                \`Total items in the datacollection: \${totalItems}\`
+              ....
+            })
+            <OneDataCollection source={source} .../>
+            `,
+      },
+    },
+  },
+  render: () => (
+    <ExampleComponent
+      hideFilters={true}
+      totalItemSummary={(totalItems) =>
+        `Total items in the datacollection: ${totalItems}`
+      }
+    />
+  ),
+}

--- a/packages/react/src/experimental/OneDataCollection/__tests__/index.spec.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__tests__/index.spec.tsx
@@ -12,13 +12,10 @@ import {
 import { PromiseState } from "@/lib/promise-to-observable"
 import { defaultTranslations, I18nProvider } from "@/lib/providers/i18n"
 import {
-  act,
-  render,
-  renderHook,
-  screen,
-  waitFor,
-  within,
-} from "@testing-library/react"
+  zeroRender as render,
+  zeroRenderHook as renderHook,
+} from "@/testing/test-utils"
+import { act, screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { LayoutGrid } from "lucide-react"
 import { describe, expect, test, vi } from "vitest"
@@ -1012,8 +1009,7 @@ describe("Collections", () => {
             },
           },
         ]}
-      />,
-      { wrapper: TestWrapper }
+      />
     )
 
     // Check that our data is rendered
@@ -1146,8 +1142,7 @@ describe("Collections", () => {
             },
           },
         ]}
-      />,
-      { wrapper: TestWrapper }
+      />
     )
 
     // Verify that all four initial users are displayed

--- a/packages/react/src/experimental/OneDataCollection/actions.tsx
+++ b/packages/react/src/experimental/OneDataCollection/actions.tsx
@@ -9,6 +9,7 @@ import {
  */
 export type PrimaryActionsDefinition = () =>
   | Pick<DropdownItemObject, "onClick" | "label" | "icon">
+  | Pick<DropdownItemObject, "onClick" | "label" | "icon">[]
   | undefined
 
 /**

--- a/packages/react/src/experimental/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -1,6 +1,7 @@
+import { Button } from "@/components/Actions/Button"
+import { OneDropdownButton } from "@/components/Actions/OneDropdownButton"
 import { Ellipsis } from "@/icons/app"
 import { useState } from "react"
-import { Button } from "../../../../components/Actions/Button"
 import { Dropdown } from "../../../Navigation/Dropdown"
 import {
   PrimaryActionsDefinition,
@@ -18,7 +19,10 @@ export const CollectionActions = ({
   secondaryActions,
   otherActions,
 }: CollectionActionProps) => {
-  const primaryActionsButton = (primaryActions && [primaryActions]) || []
+  const primaryActionsButtons = (
+    Array.isArray(primaryActions) ? primaryActions : [primaryActions]
+  ).filter((item) => item !== undefined)
+
   const secondaryActionsButtons = (secondaryActions || []).filter(
     (action) => action.type !== "separator"
   )
@@ -27,7 +31,7 @@ export const CollectionActions = ({
   const [open, onOpenChange] = useState(false)
 
   if (
-    primaryActionsButton.length === 0 &&
+    primaryActionsButtons.length === 0 &&
     secondaryActionsButtons.length === 0 &&
     dropdownActions.length === 0
   )
@@ -35,16 +39,27 @@ export const CollectionActions = ({
 
   return (
     <div className="flex flex-row-reverse items-center gap-2">
-      {primaryActionsButton.map((action) => (
+      {primaryActionsButtons.length === 1 ? (
         <Button
           size="md"
-          key={action.label}
-          onClick={action.onClick}
-          icon={action.icon}
+          onClick={primaryActionsButtons[0].onClick}
+          icon={primaryActionsButtons[0].icon}
           variant="default"
-          label={action.label}
+          label={primaryActionsButtons[0].label}
         />
-      ))}
+      ) : (
+        <OneDropdownButton
+          size="md"
+          items={primaryActionsButtons.map((action, index) => ({
+            label: action.label,
+            icon: action.icon,
+            value: index.toString(),
+          }))}
+          onClick={(value) => {
+            primaryActionsButtons[Number(value)]?.onClick?.()
+          }}
+        />
+      )}
 
       {secondaryActionsButtons?.map((action) => (
         <Button

--- a/packages/react/src/experimental/OneDataCollection/components/Search/Search.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/Search/Search.tsx
@@ -6,10 +6,14 @@ import {
 } from "motion/react"
 import { useId, useRef, useState } from "react"
 import { useOnClickOutside } from "usehooks-ts"
-import { F0Icon } from "../../components/F0Icon"
-import { CrossedCircle, Search as SearchIcon, Spinner } from "../../icons/app"
-import { useI18n } from "../../lib/providers/i18n"
-import { cn, focusRing } from "../../lib/utils"
+import { F0Icon } from "../../../../components/F0Icon"
+import {
+  CrossedCircle,
+  Search as SearchIcon,
+  Spinner,
+} from "../../../../icons/app"
+import { useI18n } from "../../../../lib/providers/i18n"
+import { cn, focusRing } from "../../../../lib/utils"
 
 interface SearchProps {
   value?: string

--- a/packages/react/src/experimental/OneDataCollection/components/Search/index.ts
+++ b/packages/react/src/experimental/OneDataCollection/components/Search/index.ts
@@ -1,0 +1,1 @@
+export * from "./Search"

--- a/packages/react/src/experimental/OneDataCollection/components/TotalItemsSummary/TotalItemsSummary.tsx
+++ b/packages/react/src/experimental/OneDataCollection/components/TotalItemsSummary/TotalItemsSummary.tsx
@@ -1,0 +1,23 @@
+import { Skeleton } from "@/ui/skeleton"
+
+type TotalItemsSummaryProps = {
+  /** Whether the total item summary is ready */
+  isReady: boolean
+  /** The total item summary result */
+  totalItemSummaryResult?: string | null
+}
+
+export const TotalItemsSummary = ({
+  isReady,
+  totalItemSummaryResult,
+}: TotalItemsSummaryProps) => {
+  return (
+    <div className="flex flex-1 flex-shrink items-center gap-4 text-lg font-semibold">
+      {!isReady ? (
+        <Skeleton className="h-5 w-24" />
+      ) : (
+        <div className="flex h-5 items-center"> {totalItemSummaryResult}</div>
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/experimental/OneDataCollection/components/TotalItemsSummary/index.ts
+++ b/packages/react/src/experimental/OneDataCollection/components/TotalItemsSummary/index.ts
@@ -1,0 +1,1 @@
+export * from "./TotalItemsSummary"

--- a/packages/react/src/experimental/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/experimental/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -133,7 +133,11 @@ export type DataCollectionSourceDefinition<
   dataAdapter: DataCollectionDataAdapter<R, Filters, NavigationFilters>
   /** Bulk actions that can be performed on the collection */
   bulkActions?: BulkActionsDefinition<R, Filters>
-  totalItemSummary?: (totalItems: number) => string
+  /** Total items summary that can be displayed on the collection
+   * If true, the total items summary will be displayed on the collection
+   * If a function is provided, the total items summary will be displayed on the collection
+   */
+  totalItemSummary?: boolean | ((totalItems: number) => string | null)
 
   /** Item filter that can be used to filter the items before they are displayed */
   itemPreFilter?: (item: R) => boolean


### PR DESCRIPTION
## Description

- feat: allow to pass multiple items in collection primary actions (and render it as dropdownbutton if more than one
- feat: totalItemsCount renders in the bottom toolbar (same as settings) if no filters
- feat: totalItemsCount allow to pass it as boolean or function 
- docs: improve totalItemsCount docs

## Screenshots (if applicable)

<img width="519" height="316" alt="image" src="https://github.com/user-attachments/assets/c68bd1b5-de60-41a5-a33b-3c980e81a013" />
<img width="1457" height="366" alt="image" src="https://github.com/user-attachments/assets/15fed5ec-e406-4dde-97ac-0bfcd2949626" />


<!-- Attach any relevant screenshots, especially for visual or responsive checks -->

[Link to Figma Design](Figma URL here)

## Implementation details

<!-- What have you changed? Why? -->
