### PR TITLE
FCT 37583 fix zindex tooltip in table

### DIFF
--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -449,6 +449,9 @@ export const RendererTypes: Story = {
       dataAdapter: {
         fetchData: createPromiseDataFetch(),
       },
+      search: {
+        enabled: true,
+      },
     })
 
     return (

--- a/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/experimental/OneDataCollection/__stories__/index.stories.tsx
@@ -544,6 +544,7 @@ export const RendererTypes: Story = {
                   render: (item) => ({
                     type: "avatarList",
                     value: {
+                      max: 1,
                       avatarList: [
                         {
                           type: "person",

--- a/packages/react/src/ui/hover-card.tsx
+++ b/packages/react/src/ui/hover-card.tsx
@@ -13,16 +13,18 @@ const HoverCardContent = React.forwardRef<
   React.ElementRef<typeof HoverCardPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
 >(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
-  <HoverCardPrimitive.Content
-    ref={ref}
-    align={align}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 w-[200px] rounded bg-f1-background-inverse font-medium text-f1-foreground-inverse outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-[200px] rounded bg-f1-background-inverse font-medium text-f1-foreground-inverse outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
 ))
 HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
 


### PR DESCRIPTION
## Description

HoverCard component wasn't using portal and some zindex issue were happening


## Screenshots (if applicable)

Before :
<img width="1474" height="652" alt="image" src="https://github.com/user-attachments/assets/c109e08a-d043-4dcb-b0f8-373aa8e1ea6d" />

After:
<img width="356" height="235" alt="image" src="https://github.com/user-attachments/assets/1ce3d818-c5b1-4735-8b22-a9b1634766e0" />


## Implementation details

<!-- What have you changed? Why? -->
