### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.227.0",
+  "packages/react": "1.228.0",
   "packages/react-native": "0.20.0",
   "packages/core": "1.29.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.228.0](https://github.com/factorialco/f0/compare/f0-react-v1.227.0...f0-react-v1.228.0) (2025-10-06)
+
+
+### Features
+
+* ellipsis in text and person display-values ([#2767](https://github.com/factorialco/f0/issues/2767)) ([c11a86b](https://github.com/factorialco/f0/commit/c11a86b749b905798e06059cbf4db318e6fa1fe9))
+
 ## [1.227.0](https://github.com/factorialco/f0/compare/f0-react-v1.226.0...f0-react-v1.227.0) (2025-10-06)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.227.0",
+  "version": "1.228.0",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.228.0</summary>

## [1.228.0](https://github.com/factorialco/f0/compare/f0-react-v1.227.0...f0-react-v1.228.0) (2025-10-06)


### Features

* ellipsis in text and person display-values ([#2767](https://github.com/factorialco/f0/issues/2767)) ([c11a86b](https://github.com/factorialco/f0/commit/c11a86b749b905798e06059cbf4db318e6fa1fe9))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).