### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "1.228.1",
+  "packages/react": "1.228.2",
   "packages/react-native": "0.20.0",
   "packages/core": "1.29.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.228.2](https://github.com/factorialco/f0/compare/f0-react-v1.228.1...f0-react-v1.228.2) (2025-10-07)
+
+
+### Bug Fixes
+
+* polish loading states for data collection when using cache ([#2761](https://github.com/factorialco/f0/issues/2761)) ([a762840](https://github.com/factorialco/f0/commit/a762840f4f048c8504ba5ccb266fca2fd9268d5b))
+
 ## [1.228.1](https://github.com/factorialco/f0/compare/f0-react-v1.228.0...f0-react-v1.228.1) (2025-10-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "1.228.1",
+  "version": "1.228.2",
   "main": "dist/f0.js",
   "typings": "dist/f0.d.ts",
   "private": false,


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 1.228.2</summary>

## [1.228.2](https://github.com/factorialco/f0/compare/f0-react-v1.228.1...f0-react-v1.228.2) (2025-10-07)


### Bug Fixes

* polish loading states for data collection when using cache ([#2761](https://github.com/factorialco/f0/issues/2761)) ([a762840](https://github.com/factorialco/f0/commit/a762840f4f048c8504ba5ccb266fca2fd9268d5b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).