### PR TITLE
fix: add min-w-0 to TwoColumnLayout to enable horizontal scroll

### DIFF
--- a/packages/react/src/layouts/TwoColumnLayout/index.tsx
+++ b/packages/react/src/layouts/TwoColumnLayout/index.tsx
@@ -33,7 +33,7 @@ const _TwoColumnLayout = forwardRef<HTMLDivElement, TwoColumnLayoutProps>(
         >
           <main
             className={cn(
-              "sm:min-h-xs order-2 h-fit border-0 px-4 py-5 sm:flex-1 sm:border-solid md:order-2 md:px-6",
+              "sm:min-h-xs order-2 h-fit min-w-0 border-0 px-4 py-5 sm:flex-1 sm:border-solid md:order-2 md:px-6",
               sticky
                 ? "md:h-full md:max-h-full md:overflow-y-auto"
                 : "min-h-full",


### PR DESCRIPTION
## Description
When using a DataCollection with table visualization inside TwoColumnLayout, the table's horizontal scrollbar never appeared.
  
This made call-to-action columns unreachable when the viewport narrowed (e.g. opening OneChat).

## Screenshots (if applicable)
<img width="1486" height="1293" alt="image" src="https://github.com/user-attachments/assets/e581a195-518e-450d-b9a0-59a55cd8d9d7" />


## Implementation details
Flex items default to min-width: auto, which prevents them from shrinking below their content's intrinsic width. The main element stretched to match the table, so the table never detected overflow.

Adding min-w-0 allows main to shrink within the available space, letting the table's overflow-auto trigger correctly.