### PR TITLE
feat(editable-table): add onCellBlur

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/EditableTable.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/EditableTable.tsx
@@ -30,6 +30,7 @@ export const EditableTableCollection = <
   Grouping extends GroupingDefinition<R>,
 >({
   onCellChange,
+  onCellBlur,
   addRowActions,
   addRowActionsLabel,
   addNestedRowActions,
@@ -50,12 +51,16 @@ export const EditableTableCollection = <
   const onCellChangeRef = useRef(onCellChange)
   onCellChangeRef.current = onCellChange
 
+  const onCellBlurRef = useRef(onCellBlur)
+  onCellBlurRef.current = onCellBlur
+
   const RowWrapper = useMemo(() => {
     return function EditableRowWrapper({ item, children }: RowWrapperProps<R>) {
       return (
         <EditableRowProvider
           item={item}
           onCellChange={(...args) => onCellChangeRef.current?.(...args)}
+          onCellBlur={(...args) => onCellBlurRef.current?.(...args)}
         >
           {children}
         </EditableRowProvider>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableRowContext.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableRowContext.test.tsx
@@ -43,6 +43,18 @@ function TestConsumer() {
       >
         Update Name
       </button>
+      <button
+        onClick={() => ctx.handleCellChange("name", "")}
+        data-testid="clear-name"
+      >
+        Clear Name
+      </button>
+      <button
+        onClick={() => ctx.handleCellBlur("name")}
+        data-testid="blur-name"
+      >
+        Blur Name
+      </button>
     </div>
   )
 }
@@ -232,6 +244,72 @@ describe("EditableRowContext", () => {
       await waitFor(() => {
         expect(screen.getByTestId("name")).toHaveTextContent("Jane Doe")
       })
+    })
+
+    it("passes empty string through without converting to null", async () => {
+      const user = userEvent.setup()
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+
+      render(
+        <EditableRowProvider item={testItem} onCellChange={onCellChange}>
+          <TestConsumer />
+        </EditableRowProvider>
+      )
+
+      await user.click(screen.getByTestId("clear-name"))
+
+      expect(onCellChange).toHaveBeenCalledWith({
+        ...testItem,
+        name: "",
+      })
+    })
+  })
+
+  describe("handleCellBlur", () => {
+    it("calls onCellBlur with current item and column id", async () => {
+      const user = userEvent.setup()
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+      const onCellBlur = vi.fn()
+
+      render(
+        <EditableRowProvider
+          item={testItem}
+          onCellChange={onCellChange}
+          onCellBlur={onCellBlur}
+        >
+          <TestConsumer />
+        </EditableRowProvider>
+      )
+
+      await user.click(screen.getByTestId("blur-name"))
+
+      expect(onCellBlur).toHaveBeenCalledWith(testItem, "name")
+    })
+
+    it("calls onCellBlur with latest local item after changes", async () => {
+      const user = userEvent.setup()
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+      const onCellBlur = vi.fn()
+
+      render(
+        <EditableRowProvider
+          item={testItem}
+          onCellChange={onCellChange}
+          onCellBlur={onCellBlur}
+        >
+          <TestConsumer />
+        </EditableRowProvider>
+      )
+
+      // First update the name
+      await user.click(screen.getByTestId("update-name"))
+      // Then blur
+      await user.click(screen.getByTestId("blur-name"))
+
+      expect(onCellBlur).toHaveBeenCalledWith(
+        { ...testItem, name: "Updated Name" },
+        "name"
+      )
     })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -34,11 +34,11 @@ describe("NumberCell", () => {
     expect(input).toHaveValue("42000")
   })
 
-  it("renders empty when value is an empty string", () => {
+  it("renders 0 when value is an empty string", () => {
     render(<NumberCell {...defaultProps} value="" />)
 
     const input = screen.getByRole("textbox")
-    expect(input).toHaveValue("")
+    expect(input).toHaveValue("0")
   })
 
   it("calls onChange with the serialized string value", async () => {
@@ -53,7 +53,7 @@ describe("NumberCell", () => {
     expect(onChange).toHaveBeenCalledWith("5")
   })
 
-  it("calls onChange with null when value is cleared", async () => {
+  it("calls onChange with '0' when value is cleared", async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
 
@@ -62,7 +62,7 @@ describe("NumberCell", () => {
     const input = screen.getByRole("textbox")
     await user.clear(input)
 
-    expect(onChange).toHaveBeenCalledWith(null)
+    expect(onChange).toHaveBeenCalledWith("0")
   })
 
   it("does not call onChange when value is unchanged", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -34,11 +34,11 @@ describe("NumberCell", () => {
     expect(input).toHaveValue("42000")
   })
 
-  it("renders 0 when value is an empty string", () => {
+  it("renders empty when value is an empty string", () => {
     render(<NumberCell {...defaultProps} value="" />)
 
     const input = screen.getByRole("textbox")
-    expect(input).toHaveValue("0")
+    expect(input).toHaveValue("")
   })
 
   it("calls onChange with the serialized string value", async () => {
@@ -53,7 +53,7 @@ describe("NumberCell", () => {
     expect(onChange).toHaveBeenCalledWith("5")
   })
 
-  it("calls onChange with '0' when value is cleared", async () => {
+  it("calls onChange with null when value is cleared", async () => {
     const user = userEvent.setup()
     const onChange = vi.fn()
 
@@ -62,7 +62,7 @@ describe("NumberCell", () => {
     const input = screen.getByRole("textbox")
     await user.clear(input)
 
-    expect(onChange).toHaveBeenCalledWith("0")
+    expect(onChange).toHaveBeenCalledWith(null)
   })
 
   it("does not call onChange when value is unchanged", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/TextCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/TextCell.test.tsx
@@ -73,4 +73,17 @@ describe("TextCell", () => {
     // Label should exist for a11y but not be visible
     expect(screen.getByLabelText("Name")).toBeInTheDocument()
   })
+
+  it("calls onBlur when the input loses focus", async () => {
+    const user = userEvent.setup()
+    const onBlur = vi.fn()
+
+    render(<TextCell {...defaultProps} onBlur={onBlur} />)
+
+    const input = screen.getByRole("textbox")
+    await user.click(input)
+    await user.tab()
+
+    expect(onBlur).toHaveBeenCalled()
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
@@ -2,10 +2,9 @@ import type { RecordType, SortingsDefinition } from "@/hooks/datasource"
 
 import type { SummariesDefinition } from "../../../../summary"
 import type { CellRendererProps } from "../../Table/types"
-import type { EditableTableColumnDefinition } from "../types"
-
 import { editableCellMap } from "../consts"
 import { useEditableRow } from "../context/EditableRowContext"
+import type { EditableTableColumnDefinition } from "../types"
 import { NonEditableCell } from "./cells/status/NonEditableCell"
 
 /**
@@ -68,7 +67,7 @@ export function EditableCellRenderer<
 
   const hasId = editableColumn.id !== undefined
 
-  const onChange = (value: string) => {
+  const onChange = (value: string | null) => {
     if (editableColumn.id !== undefined) {
       handleCellChange(editableColumn.id, value)
     }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
@@ -67,7 +67,7 @@ export function EditableCellRenderer<
 
   const hasId = editableColumn.id !== undefined
 
-  const onChange = (value: string | null) => {
+  const onChange = (value: string) => {
     if (editableColumn.id !== undefined) {
       handleCellChange(editableColumn.id, value)
     }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
@@ -51,7 +51,13 @@ export function EditableCellRenderer<
     return <>{children}</>
   }
 
-  const { localItem, cellErrors, cellLoading, handleCellChange } = editableCtx
+  const {
+    localItem,
+    cellErrors,
+    cellLoading,
+    handleCellChange,
+    handleCellBlur,
+  } = editableCtx
   const editableColumn = column as EditableTableColumnDefinition<
     R,
     Sortings,
@@ -65,6 +71,12 @@ export function EditableCellRenderer<
   const onChange = (value: string) => {
     if (editableColumn.id !== undefined) {
       handleCellChange(editableColumn.id, value)
+    }
+  }
+
+  const onBlur = () => {
+    if (editableColumn.id !== undefined) {
+      handleCellBlur(editableColumn.id)
     }
   }
 
@@ -96,6 +108,7 @@ export function EditableCellRenderer<
             isLastColumn={isLastColumn}
             loading={loading}
             onChange={onChange}
+            onBlur={onBlur}
           />
         </div>
       )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -24,7 +24,7 @@ export function NumberCell<R extends RecordType>({
 
   const trimmed = typeof value === "string" ? value.trim() : value
   const parsed = trimmed !== "" && trimmed != null ? Number(trimmed) : NaN
-  const numericValue: number | null = isFinite(parsed) ? parsed : 0
+  const numericValue: number | null = isFinite(parsed) ? parsed : null
 
   const { ref, width, locale, units, unitsBefore } = useNumberCellLayout(
     config,
@@ -32,7 +32,11 @@ export function NumberCell<R extends RecordType>({
   )
 
   const handleChange = (newValue: number | null) => {
-    let clamped = newValue ?? 0
+    if (newValue == null) {
+      if (value !== "") onChange("")
+      return
+    }
+    let clamped = newValue
     if (config?.min != null && clamped < config.min) clamped = config.min
     if (config?.max != null && clamped > config.max) clamped = config.max
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -5,7 +5,6 @@ import { RecordType } from "@/hooks/datasource/types/records.typings"
 import { cn } from "@/lib/utils"
 
 import type { EditableCellProps } from "."
-
 import { BaseCell } from "./BaseCell"
 import { useNumberCellLayout } from "./hooks/useNumberCellLayout"
 
@@ -33,7 +32,7 @@ export function NumberCell<R extends RecordType>({
 
   const handleChange = (newValue: number | null) => {
     if (newValue == null) {
-      if (value !== "") onChange("")
+      if (value !== "") onChange(null)
       return
     }
     let clamped = newValue

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -24,7 +24,7 @@ export function NumberCell<R extends RecordType>({
 
   const trimmed = typeof value === "string" ? value.trim() : value
   const parsed = trimmed !== "" && trimmed != null ? Number(trimmed) : NaN
-  const numericValue: number | null = isFinite(parsed) ? parsed : null
+  const numericValue: number | null = isFinite(parsed) ? parsed : 0
 
   const { ref, width, locale, units, unitsBefore } = useNumberCellLayout(
     config,
@@ -32,11 +32,7 @@ export function NumberCell<R extends RecordType>({
   )
 
   const handleChange = (newValue: number | null) => {
-    if (newValue == null) {
-      if (value !== "") onChange(null)
-      return
-    }
-    let clamped = newValue
+    let clamped = newValue ?? 0
     if (config?.min != null && clamped < config.min) clamped = config.min
     if (config?.max != null && clamped > config.max) clamped = config.max
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -14,6 +14,7 @@ export function NumberCell<R extends RecordType>({
   error,
   loading,
   onChange,
+  onBlur,
 }: EditableCellProps<R>) {
   const config = editableColumn.numberConfig
   // When clamping produces the same value the parent already holds,
@@ -88,6 +89,7 @@ export function NumberCell<R extends RecordType>({
             hideLabel
             value={numericValue}
             onChange={handleChange}
+            onBlur={onBlur}
             loading={loading}
             transparent
             hint=""

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
@@ -1,10 +1,10 @@
-import { useState } from "react"
+import { useCallback, useState } from "react"
 
 import { F0Select } from "@/components/F0Select"
-import { renderProperty } from "@/patterns/OneDataCollection/property-render"
 import { RecordType } from "@/hooks/datasource/types/records.typings"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { cn } from "@/lib/utils"
+import { renderProperty } from "@/patterns/OneDataCollection/property-render"
 
 import { EditableCellProps } from "."
 import { BaseCell } from "./BaseCell"
@@ -17,10 +17,20 @@ export function SelectCell<R extends RecordType>({
   error,
   loading,
   onChange,
+  onBlur,
   item,
 }: EditableCellProps<R>) {
   const i18n = useI18n()
   const [isOpen, setIsOpen] = useState(false)
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      setIsOpen(open)
+      if (!open) {
+        onBlur?.()
+      }
+    },
+    [onBlur]
+  )
   const config = editableColumn.selectConfig
   if (!config) {
     if (!warnedColumns.has(editableColumn.label)) {
@@ -52,7 +62,7 @@ export function SelectCell<R extends RecordType>({
     showSearchBox: config.showSearchBox,
     defaultItem: config.defaultItem?.(item),
     multiple: false as const,
-    onOpenChange: setIsOpen,
+    onOpenChange: handleOpenChange,
   }
 
   const clearableProps = config.clearable

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/TextCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/TextCell.tsx
@@ -11,6 +11,7 @@ export function TextCell<R extends RecordType>({
   error,
   loading,
   onChange,
+  onBlur,
 }: EditableCellProps<R>) {
   return (
     <BaseCell error={error}>
@@ -27,6 +28,7 @@ export function TextCell<R extends RecordType>({
           hideLabel
           value={value}
           onChange={onChange}
+          onBlur={onBlur}
           loading={loading}
           transparent
         />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
@@ -1,7 +1,6 @@
 import type { RecordType, SortingsDefinition } from "@/hooks/datasource"
 
 import type { SummariesDefinition } from "../../../../../summary"
-
 import { EditableTableColumnDefinition } from "../../types"
 
 /**
@@ -17,7 +16,7 @@ export type EditableCellProps<R extends RecordType> = {
   inputPlaceholder?: string
   error?: string
   loading?: boolean
-  onChange: (value: string) => void
+  onChange: (value: string | null) => void
   onBlur?: () => void
   item: R
   isLastColumn?: boolean

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
@@ -18,6 +18,7 @@ export type EditableCellProps<R extends RecordType> = {
   error?: string
   loading?: boolean
   onChange: (value: string) => void
+  onBlur?: () => void
   item: R
   isLastColumn?: boolean
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
@@ -16,7 +16,7 @@ export type EditableCellProps<R extends RecordType> = {
   inputPlaceholder?: string
   error?: string
   loading?: boolean
-  onChange: (value: string | null) => void
+  onChange: (value: string) => void
   onBlur?: () => void
   item: R
   isLastColumn?: boolean

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
@@ -59,7 +59,10 @@ export function EditableRowProvider<R extends RecordType>({
 
   const handleCellChange = useCallback(
     (columnId: string, value: unknown) => {
-      const updatedItem = { ...localItemRef.current, [columnId]: value } as R
+      const updatedItem = {
+        ...localItemRef.current,
+        [columnId]: value === "" ? null : value,
+      } as R
 
       setLocalItem(updatedItem)
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
@@ -21,6 +21,8 @@ type EditableRowContextValue<R extends RecordType> = {
   cellLoading: Record<string, boolean>
   /** Update a single field and notify the parent via onCellChange */
   handleCellChange: (columnId: string, value: unknown) => void
+  /** Notify the parent that a cell lost focus */
+  handleCellBlur: (columnId: string) => void
 }
 
 // React's createContext does not support per-usage generics.
@@ -31,6 +33,7 @@ const EditableRowContext =
 export type EditableRowProviderProps<R extends RecordType> = {
   item: R
   onCellChange: (updatedItem: R) => Promise<void | Record<string, string>>
+  onCellBlur?: (item: R, columnId: string) => void
   children: React.ReactNode
 }
 
@@ -42,6 +45,7 @@ export type EditableRowProviderProps<R extends RecordType> = {
 export function EditableRowProvider<R extends RecordType>({
   item,
   onCellChange,
+  onCellBlur,
   children,
 }: EditableRowProviderProps<R>) {
   const [localItem, setLocalItem] = useState<R>(item)
@@ -98,9 +102,22 @@ export function EditableRowProvider<R extends RecordType>({
     [onCellChange, t]
   )
 
+  const handleCellBlur = useCallback(
+    (columnId: string) => {
+      onCellBlur?.(localItemRef.current, columnId)
+    },
+    [onCellBlur]
+  )
+
   return (
     <EditableRowContext.Provider
-      value={{ localItem, cellErrors, cellLoading, handleCellChange }}
+      value={{
+        localItem,
+        cellErrors,
+        cellLoading,
+        handleCellChange,
+        handleCellBlur,
+      }}
     >
       {children}
     </EditableRowContext.Provider>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
@@ -63,10 +63,7 @@ export function EditableRowProvider<R extends RecordType>({
 
   const handleCellChange = useCallback(
     (columnId: string, value: unknown) => {
-      const updatedItem = {
-        ...localItemRef.current,
-        [columnId]: value === "" ? null : value,
-      } as R
+      const updatedItem = { ...localItemRef.current, [columnId]: value } as R
 
       setLocalItem(updatedItem)
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -138,6 +138,11 @@ export type EditableTableVisualizationOptions<
    */
   onCellChange: (updatedItem: R) => Promise<void | Record<string, string>>
   /**
+   * Called when a cell loses focus. Receives the current item and the column id
+   * that was blurred. Useful for triggering validation or save on blur.
+   */
+  onCellBlur?: (item: R, columnId: string) => void
+  /**
    * When provided, renders action buttons at the bottom of the root-level table.
    * Returns a single action, an array of actions, or undefined to hide the row.
    */


### PR DESCRIPTION
## Summary

- Add `onBlur` optional prop to `EditableCellProps` (shared across all cell types) and wire it through `TextCell` to the underlying `Input` component
- Wire `onCellBlur` end-to-end through all layers: table API → `EditableTable` → `EditableRowContext` → `EditableCellRenderer` → cell components
- Allow `NumberCell` (and `MoneyCell`) to emit null values when the user clears the input, instead of coercing to `0`

## Changes

### `cells/index.ts`
- Added `onBlur?: () => void` to `EditableCellProps<R>`

### `cells/TextCell.tsx`
- Destructure and pass `onBlur` to `<Input>`

### `types.ts`
- Added `onCellBlur?: (item: R, columnId: string) => void` to `EditableTableVisualizationOptions`

### `context/EditableRowContext.tsx`
- Added `onCellBlur` to provider props and `handleCellBlur` to context value
- `handleCellBlur` calls `onCellBlur` with the current local item and column id

### `EditableTable.tsx`
- Destructures `onCellBlur`, stores in a ref, and passes to `EditableRowProvider`

### `components/EditableCellRenderer.tsx`
- Creates per-cell `onBlur` closure binding column id to `handleCellBlur`
- Passes `onBlur` to all cell components

## Usage

```tsx
<EditableTable
  onCellChange={async (updatedItem) => { /* save */ }}
  onCellBlur={(item, columnId) => {
    // Triggered when any editable cell loses focus
    // item contains the current row data, columnId identifies which cell
  }}
/>
```