### PR TITLE
feat(F0AiChatTextArea): add external control surface (apiRef, onChange, showSubmitButton)

### DIFF
--- a/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -1,5 +1,12 @@
 import { AnimatePresence, motion } from "motion/react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 
 import { F0AvatarAlert } from "@/components/avatars/F0AvatarAlert"
 import { useReducedMotion } from "@/lib/a11y"
@@ -82,6 +89,9 @@ export const F0AiChatTextArea = ({
   welcomeScreenSuggestions,
   onSuggestionClick,
   ref,
+  apiRef,
+  onChange,
+  showSubmitButton = true,
 }: F0AiChatTextAreaProps) => {
   const translation = useI18n()
   const shouldReduceMotion = useReducedMotion()
@@ -174,6 +184,31 @@ export const F0AiChatTextArea = ({
     tracking?.onDictationCancel?.()
     recorder.cancel()
   }, [recorder, tracking])
+
+  // Imperative handle for external control: populate the textarea, submit it
+  // (same path as the built-in button and Enter, so the full pipeline runs),
+  // or focus it. Mirrors the house pattern used by `F0RichTextEditorHandle`.
+  // The plain `ref` stays the container DOM node; this rides on `apiRef`.
+  useImperativeHandle(apiRef, () => ({
+    setContent: (content: string) => {
+      setInputValue(content)
+      setCursorPosition(content.length)
+    },
+    getContent: () => inputValue,
+    clear: () => {
+      setInputValue("")
+      setCursorPosition(0)
+    },
+    submit: () => formRef.current?.requestSubmit(),
+    focus: () => textareaRef.current?.focus(),
+  }))
+
+  // Notify the host of every content change (typing, dictation, mention
+  // insertion, setContent, clear-on-submit) so it can react to the value —
+  // e.g. enable/disable an external submit button.
+  useEffect(() => {
+    onChange?.(inputValue)
+  }, [inputValue, onChange])
 
   useEffect(() => {
     if (typeof window !== "undefined" && window.location.hash.length === 0) {
@@ -536,6 +571,7 @@ export const F0AiChatTextArea = ({
                     inProgress={inProgress}
                     hasDataToSend={hasDataToSend}
                     isPreSending={isPreSending || pendingSubmit}
+                    showSubmitButton={showSubmitButton}
                     canRecord={canRecord}
                     recordingStatus={recorder.status}
                     recordingStream={recorder.stream}

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -1,8 +1,13 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
 import { useRef, useState } from "react"
 
+import { ButtonInternal } from "@/components/F0Button/internal"
+
 import { F0AiChatTextArea } from "../F0AiChatTextArea"
-import type { F0AiChatTextAreaSubmitPayload } from "../types"
+import type {
+  F0AiChatTextAreaHandle,
+  F0AiChatTextAreaSubmitPayload,
+} from "../types"
 
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
 
@@ -396,5 +401,63 @@ export const Everything: Story = {
     disclaimer: DISCLAIMER,
     initialPendingContext: PENDING_CONTEXT,
     initialPendingQuote: PENDING_QUOTE,
+  },
+}
+
+/**
+ * External-control usage. `showSubmitButton={false}` hides the built-in button and
+ * external buttons drive the composer through `apiRef`: `setContent()` populates
+ * the textarea and `submit()` runs the full send pipeline. `onChange`
+ * mirrors the content into host state, so the external Send button stays
+ * disabled until something is typed. Enter still submits.
+ */
+export const ExternalControls: Story = {
+  render: () => {
+    const apiRef = useRef<F0AiChatTextAreaHandle>(null)
+    const containerRef = useRef<HTMLDivElement>(null)
+    const [value, setValue] = useState("")
+    const [submissions, setSubmissions] = useState<
+      F0AiChatTextAreaSubmitPayload[]
+    >([])
+
+    return (
+      <div className="flex w-[640px] flex-col gap-4">
+        <div className="flex gap-2">
+          <ButtonInternal
+            label="Populate (setContent)"
+            type="button"
+            variant="outline"
+            onClick={() => {
+              apiRef.current?.setContent("Draft my weekly update")
+              apiRef.current?.focus()
+            }}
+          />
+          <ButtonInternal
+            label="Submit (submit)"
+            type="button"
+            variant="default"
+            // Reacts to `onChange`: disabled while the textarea is empty.
+            disabled={value.trim().length === 0}
+            onClick={() => apiRef.current?.submit()}
+          />
+        </div>
+        <F0AiChatTextArea
+          ref={containerRef}
+          apiRef={apiRef}
+          showSubmitButton={false}
+          onChange={setValue}
+          placeholders={ROTATING_PLACEHOLDERS}
+          onSubmit={(payload) => setSubmissions((prev) => [...prev, payload])}
+        />
+        {submissions.length > 0 && (
+          <div className="rounded-md border border-f1-border p-3 text-sm">
+            <div className="pb-2 font-medium">Last submission</div>
+            <pre className="whitespace-pre-wrap text-xs">
+              {JSON.stringify(submissions[submissions.length - 1], null, 2)}
+            </pre>
+          </div>
+        )}
+      </div>
+    )
   },
 }

--- a/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.externalControls.test.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.externalControls.test.tsx
@@ -1,0 +1,125 @@
+import { act } from "@testing-library/react"
+import { createRef } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+import type { F0AiChatTextAreaHandle } from "../types"
+
+interface TextareaFieldMockProps {
+  inputValue: string
+}
+
+// Mirror the value-only mock used by the sibling tests so `setContent` is
+// observable through the rendered textarea.
+vi.mock("../components/TextareaField", () => ({
+  TextareaField: ({ inputValue }: TextareaFieldMockProps) => (
+    <textarea aria-label="Message" value={inputValue} readOnly />
+  ),
+}))
+
+describe("F0AiChatTextArea external controls", () => {
+  it("hides the built-in submit button when showSubmitButton is false", () => {
+    render(<F0AiChatTextArea onSubmit={vi.fn()} showSubmitButton={false} />)
+
+    expect(
+      screen.queryByRole("button", { name: /send message/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps the built-in submit button by default", () => {
+    render(<F0AiChatTextArea onSubmit={vi.fn()} />)
+
+    expect(
+      screen.getByRole("button", { name: /send message/i })
+    ).toBeInTheDocument()
+  })
+
+  it("populates the textarea via apiRef.setContent()", () => {
+    const apiRef = createRef<F0AiChatTextAreaHandle>()
+    render(<F0AiChatTextArea onSubmit={vi.fn()} apiRef={apiRef} />)
+
+    act(() => apiRef.current?.setContent("Draft my weekly update"))
+
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "Draft my weekly update"
+    )
+  })
+
+  it("reads the current value via apiRef.getContent()", () => {
+    const apiRef = createRef<F0AiChatTextAreaHandle>()
+    render(<F0AiChatTextArea onSubmit={vi.fn()} apiRef={apiRef} />)
+
+    expect(apiRef.current?.getContent()).toBe("")
+    act(() => apiRef.current?.setContent("hello world"))
+    expect(apiRef.current?.getContent()).toBe("hello world")
+  })
+
+  it("clears the textarea via apiRef.clear()", () => {
+    const apiRef = createRef<F0AiChatTextAreaHandle>()
+    render(<F0AiChatTextArea onSubmit={vi.fn()} apiRef={apiRef} />)
+
+    act(() => apiRef.current?.setContent("hello world"))
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue(
+      "hello world"
+    )
+
+    act(() => apiRef.current?.clear())
+    expect(screen.getByRole("textbox", { name: "Message" })).toHaveValue("")
+  })
+
+  it("notifies onChange so a host can react to the content", () => {
+    const onChange = vi.fn()
+    const apiRef = createRef<F0AiChatTextAreaHandle>()
+    render(
+      <F0AiChatTextArea
+        onSubmit={vi.fn()}
+        apiRef={apiRef}
+        onChange={onChange}
+      />
+    )
+
+    // Fires on mount with the initial (empty) value.
+    expect(onChange).toHaveBeenCalledWith("")
+
+    act(() => apiRef.current?.setContent("typing…"))
+    expect(onChange).toHaveBeenLastCalledWith("typing…")
+  })
+
+  it("submits via apiRef.submit() even with the button hidden", async () => {
+    const onSubmit = vi.fn()
+    const apiRef = createRef<F0AiChatTextAreaHandle>()
+    render(
+      <F0AiChatTextArea
+        onSubmit={onSubmit}
+        apiRef={apiRef}
+        showSubmitButton={false}
+      />
+    )
+
+    act(() => apiRef.current?.setContent("hello"))
+    act(() => apiRef.current?.submit())
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0][0].text).toBe("hello")
+  })
+
+  it("does not submit via apiRef.submit() when the textarea is empty", async () => {
+    const onSubmit = vi.fn()
+    const apiRef = createRef<F0AiChatTextAreaHandle>()
+    render(
+      <F0AiChatTextArea
+        onSubmit={onSubmit}
+        apiRef={apiRef}
+        showSubmitButton={false}
+      />
+    )
+
+    act(() => apiRef.current?.submit())
+
+    // Give any async submit path a tick to run before asserting it didn't.
+    await Promise.resolve()
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/components/ActionBar.tsx
@@ -24,6 +24,8 @@ interface ActionBarProps {
   inProgress?: boolean
   hasDataToSend: boolean
   isPreSending?: boolean
+  /** Render the built-in submit / stop button. Defaults to true. */
+  showSubmitButton?: boolean
   /** Voice dictation — when canRecord is false the microphone is hidden. */
   canRecord?: boolean
   recordingStatus?: RecorderStatus
@@ -43,6 +45,7 @@ export const ActionBar = ({
   inProgress,
   hasDataToSend,
   isPreSending,
+  showSubmitButton = true,
   canRecord,
   recordingStatus = "idle",
   recordingStream,
@@ -132,26 +135,27 @@ export const ActionBar = ({
             loading={recordingStatus === "transcribing"}
           />
         )}
-        {recordingStatus !== "transcribing" && inProgress ? (
-          <ButtonInternal
-            type="submit"
-            variant="neutral"
-            label={translation.ai.stopAnswerGeneration}
-            icon={SolidStop}
-            hideLabel
-          />
-        ) : (
-          <ButtonInternal
-            type="submit"
-            // Stays enabled while an attachment uploads so the click queues the
-            // send (fired once the upload finishes) instead of being a no-op.
-            disabled={!hasDataToSend || isPreSending}
-            variant={"default"}
-            label={translation.ai.sendMessage}
-            icon={ArrowUp}
-            hideLabel
-          />
-        )}
+        {showSubmitButton &&
+          (recordingStatus !== "transcribing" && inProgress ? (
+            <ButtonInternal
+              type="submit"
+              variant="neutral"
+              label={translation.ai.stopAnswerGeneration}
+              icon={SolidStop}
+              hideLabel
+            />
+          ) : (
+            <ButtonInternal
+              type="submit"
+              // Stays enabled while an attachment uploads so the click queues the
+              // send (fired once the upload finishes) instead of being a no-op.
+              disabled={!hasDataToSend || isPreSending}
+              variant={"default"}
+              label={translation.ai.sendMessage}
+              icon={ArrowUp}
+              hideLabel
+            />
+          ))}
       </div>
     </div>
   )

--- a/packages/react/src/sds/ai/F0AiChatTextArea/index.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/index.ts
@@ -2,6 +2,7 @@ export { F0AiChatTextArea } from "./F0AiChatTextArea"
 export { DropOverlay } from "./components/DropOverlay"
 export type {
   F0AiChatTextAreaProps,
+  F0AiChatTextAreaHandle,
   F0AiChatTextAreaSubmitPayload,
   AttachedFile,
   UserTextPart,

--- a/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/sds/ai/F0AiChatTextArea/types.ts
@@ -1,4 +1,4 @@
-import type { ReactNode, RefObject } from "react"
+import type { ReactNode, Ref, RefObject } from "react"
 
 import type {
   AiChatCreditWarning,
@@ -43,14 +43,57 @@ export type F0AiChatTextAreaSubmitPayload = {
   quote: PendingQuote | null
 }
 
+/**
+ * Imperative handle exposed via `apiRef` for driving the composer from
+ * outside — e.g. an external button that populates the textarea or submits
+ * it. Mirrors the house pattern used by `F0RichTextEditorHandle`.
+ */
+export type F0AiChatTextAreaHandle = {
+  /** Replace the textarea content; the caret moves to the end. */
+  setContent: (content: string) => void
+  /** Read the current textarea content (the value as of the last render). */
+  getContent: () => string
+  /** Clear the textarea content. */
+  clear: () => void
+  /** Run the full submit pipeline (same path as the built-in button and Enter). */
+  submit: () => void
+  /** Focus the textarea. */
+  focus: () => void
+}
+
 export type F0AiChatTextAreaProps = {
   ref: RefObject<HTMLDivElement>
+  /**
+   * Imperative handle for driving the composer from outside: `setContent()`
+   * populates, `submit()` sends, `clear()` empties, `focus()` focuses. Lets a
+   * host pair an external "send" button (with `showSubmitButton={false}`) or a
+   * "use template" button with the composer. Method names mirror
+   * `F0RichTextEditorHandle`. The plain `ref` stays the container DOM node; the
+   * handle rides on this separate prop.
+   */
+  apiRef?: Ref<F0AiChatTextAreaHandle>
+
+  /**
+   * Called whenever the textarea content changes — typing, dictation,
+   * @-mention insertion, `apiRef.setContent()`, or clear-on-submit. Mirror it
+   * into host state to react to the value, e.g. to enable/disable an external
+   * submit button. Fires once on mount with the initial value. Named `onChange`
+   * to mirror `RichTextEditor`.
+   */
+  onChange?: (value: string) => void
   /** Emitted when the user submits. Awaited so the textarea can stay disabled. */
   onSubmit: (payload: F0AiChatTextAreaSubmitPayload) => void | Promise<void>
   /** Called when the user clicks the stop button while a response is streaming. */
   onStop?: () => void
   /** Whether a response is currently streaming. Switches the submit button to "stop". */
   inProgress?: boolean
+
+  /**
+   * Render the built-in submit / stop button. Defaults to `true`. Set to
+   * `false` to hide it and drive submission from an external button via
+   * `apiRef.current?.submit()`. Enter-to-submit still works regardless.
+   */
+  showSubmitButton?: boolean
   /**
    * Optional gate run before submission. Return `false` to abort the send
    * (e.g. show a quota dialog). The textarea stays focused and the input


### PR DESCRIPTION
## Summary

Makes `F0AiChatTextArea` controllable from the outside without forking it. A host can now **populate**, **read**, **clear**, and **submit** the composer programmatically, **observe** its value, and **hide** the built-in submit button to wire up its own. All additions are optional and additive — the existing `ref` (container) and `onSubmit` contract are unchanged, so no current consumer is affected.

## Motivation

Two host requirements that weren't expressible before:

1. **Hide the built-in submit button and submit from an external button.**
2. **Populate the textarea from an external button** (e.g. a "use template" action).

…and, as a follow-on, **disable an external button based on what's typed**.

## API

Imperative handle exposed via `apiRef` — names mirror `RichTextEditorHandle`:

| Member | Purpose |
| --- | --- |
| `setContent(content)` | Replace the text (caret to end) |
| `getContent()` | Read the current text |
| `clear()` | Empty the textarea |
| `submit()` | Run the full submit pipeline |
| `focus()` | Focus the textarea |

New props:

- `apiRef?: Ref<F0AiChatTextAreaHandle>`
- `onChange?: (value: string) => void` — fires on every content change (typing, dictation, @-mention insert, `setContent`, clear-on-submit, and once on mount)
- `showSubmitButton?: boolean` (default `true`)

## Usage

```tsx
const api = useRef<F0AiChatTextAreaHandle>(null)
const [value, setValue] = useState("")

<F0AiChatTextArea
  apiRef={api}
  showSubmitButton={false}
  onChange={setValue}
  onSubmit={…}
  ref={containerRef}
/>
<Button disabled={!value.trim()} onClick={() => api.current?.submit()}>Send</Button>
// populate: api.current?.setContent("Draft my weekly update")
```

## Design notes

- `submit()` routes through the form's `requestSubmit()`, so it reuses the **entire** existing pipeline (`onBeforeSubmit` gate, mention transform, HTML/markdown escaping, upload-queueing, pending context/quote) — an external button behaves identically to the built-in one and to Enter.
- **Enter-to-submit still works** when the button is hidden.
- With `showSubmitButton={false}`, the **stop** button is hidden too while streaming; an external `submit()` still triggers `onStop` during `inProgress`, so external control covers both states.
- Naming follows the editor family (`setContent` / `clear` / `focus` / `onChange`, `*Handle` type). The one intentional divergence from `RichTextEditor`: the handle rides on a separate `apiRef` rather than the main `ref` (which stays the container DOM node) — chosen to keep this non-breaking.

## Testing

- New `F0AiChatTextArea.externalControls.test.tsx` (8 tests): button hide/show, `setContent` / `getContent` / `clear`, `onChange` notification, `submit()` with the button hidden, empty-submit no-op.
- New `ExternalControls` Storybook story demonstrating populate + submit + disabled-until-typed.
- Full `F0AiChatTextArea` suite green (31 tests); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
