### PR TITLE
fix(OneDataCollection): make Table settings column list scrollable

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -56,7 +56,7 @@ export const SortAndHideSettings = ({
 
   return (
     <div className="relative -mr-2 flex flex-col gap-2">
-      <ScrollArea className="max-h-56">
+      <ScrollArea viewportClassName="max-h-56">
         <SortAndHideList
           items={items}
           onChange={onChange}

--- a/packages/react/src/ui/scrollarea.tsx
+++ b/packages/react/src/ui/scrollarea.tsx
@@ -15,6 +15,14 @@ const ScrollArea = forwardRef<
   ElementRef<typeof ScrollAreaPrimitive.Root>,
   ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> & {
     showBar?: boolean
+    /**
+     * Classes applied to the scroll viewport. Use this (rather than
+     * `className`, which targets the root) to constrain the scrollable height
+     * — e.g. `max-h-56`. The root only sets `max-height`, which is not a
+     * definite height, so a `max-h-*` there leaves the viewport's `height:100%`
+     * unresolved and the content clips instead of scrolling.
+     */
+    viewportClassName?: string
     viewportRef?: React.RefObject<HTMLDivElement>
     onScrollTop?: () => void
     onScrollBottom?: () => void
@@ -30,6 +38,7 @@ const ScrollArea = forwardRef<
       className,
       children,
       showBar = true,
+      viewportClassName,
       viewportRef,
       onScrollTop,
       onScrollBottom,
@@ -76,7 +85,10 @@ const ScrollArea = forwardRef<
       >
         <ScrollAreaPrimitive.Viewport
           ref={localViewportRef}
-          className="size-full snap-none rounded-[inherit] [&>div]:!block"
+          className={cn(
+            "size-full snap-none rounded-[inherit] [&>div]:!block",
+            viewportClassName
+          )}
           tabIndex={0}
           data-scroll-container
         >


### PR DESCRIPTION
## What

Fixes the **Table settings** popover (per-column show/hide + drag-to-reorder) in `OneDataCollection`, where the column list was clipped at `max-h-56` and never scrolled. Any table with more columns than fit (~9+) had its lower columns unreachable — mouse wheel, trackpad, and scrollbar all did nothing. A column that's `hidden: true` by default and lives past the fold could never be revealed through the UI.

## Root cause (regression)

Introduced in #4311, which refactored the table column settings into the shared `SortAndHideSettings`.

Radix `ScrollArea`'s viewport renders with `overflow-y: scroll` and `height: 100%` (`size-full`). A percentage height only resolves against a parent with a **definite** height. The refactor swapped the original definite `h-[200px]` for `max-h-56` (max-height only) on the ScrollArea **root**:

```diff
- <ScrollArea className="h-[200px]">   // definite → viewport 100% = 200px → scrolls
+ <ScrollArea className="max-h-56">     // max-height only → viewport height collapses to auto
```

With only `max-height` on the root, the viewport's `height: 100%` computes to `auto`, grows to full content height, never overflows itself — and the root's `overflow-hidden` clips the surplus rows instead of scrolling.

## Fix

The height constraint has to live on the **viewport** (which already carries `overflow-y: scroll`), not the root.

- `ui/scrollarea.tsx` — add a `viewportClassName` prop, merged onto the viewport via `cn`, with a doc comment explaining the root-vs-viewport pitfall.
- `OneDataCollection/Settings/SortAndHideSettings.tsx` — `className="max-h-56"` → `viewportClassName="max-h-56"`.

This restores scrolling for long lists while preserving the shrink-to-fit behavior for short ones. The `sticky bottom-0` "Show all / Hide all" footer continues to stick to the viewport bottom during scroll.

## Notes for reviewer

- Please verify in Storybook with a ≥9-column table (e.g. the 11-column IT ticket case from the report) that the list scrolls and short lists still shrink.
- There's a latent variant of the same pitfall in `OneFilterPicker`'s `InFilter` compact mode (`max-h-[360px]` on the ScrollArea root) — left out of scope here, but worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)