### PR TITLE
feat(F0FileItem): add optional subtitle prop with doubled padding

### DIFF
--- a/packages/react/src/components/F0FileItem/F0FileItem.tsx
+++ b/packages/react/src/components/F0FileItem/F0FileItem.tsx
@@ -34,6 +34,12 @@ export interface F0FileItemProps extends HTMLAttributes<HTMLDivElement> {
   actions?: F0FileAction[]
   disabled?: boolean
   size?: F0FileItemSize
+  /**
+   * Pre-formatted date rendered under the file name (e.g. an upload date).
+   * The consumer owns locale and formatting. When set, the item grows to two
+   * lines and its vertical padding is doubled.
+   */
+  date?: string
 }
 
 /** @deprecated Use F0FileAction */
@@ -47,12 +53,25 @@ const fileItemVariants = cva({
   base: "flex w-fit flex-row items-center overflow-hidden bg-f1-background-tertiary rounded-[10px]",
   variants: {
     size: {
-      md: "max-w-48 gap-2 py-0.5 pl-0.5 pr-1.5",
-      lg: "max-w-56 gap-2.5 p-1",
+      md: "max-w-48 gap-2",
+      lg: "max-w-56 gap-2.5",
+    },
+    // A date adds a second line, so the padding is doubled (both axes) to keep
+    // the block visually balanced.
+    withDate: {
+      true: "",
+      false: "",
     },
   },
+  compoundVariants: [
+    { size: "md", withDate: false, class: "py-0.5 pl-0.5 pr-1.5" },
+    { size: "md", withDate: true, class: "py-1 pl-1 pr-3" },
+    { size: "lg", withDate: false, class: "p-1" },
+    { size: "lg", withDate: true, class: "p-2" },
+  ],
   defaultVariants: {
     size: "md",
+    withDate: false,
   },
 })
 
@@ -68,7 +87,15 @@ const buttonSizeMap: Record<F0FileItemSize, "sm" | "md"> = {
 
 const _F0FileItem = forwardRef<HTMLDivElement, F0FileItemProps>(
   (
-    { file, actions = [], disabled = false, size = "md", className, ...props },
+    {
+      file,
+      actions = [],
+      disabled = false,
+      size = "md",
+      date,
+      className,
+      ...props
+    },
     ref
   ) => {
     const hasActions = actions.length > 0
@@ -84,18 +111,22 @@ const _F0FileItem = forwardRef<HTMLDivElement, F0FileItemProps>(
     return (
       <div
         ref={ref}
-        className={cn(fileItemVariants({ size }), className)}
+        className={cn(fileItemVariants({ size, withDate: !!date }), className)}
         {...props}
       >
         <F0AvatarFile file={file} size={avatarSizeMap[size]} />
-        <OneEllipsis
-          className={cn(
-            "text-neutral-1000 grow text-sm font-medium",
-            !hasActions && "pr-3"
-          )}
+        <div
+          className={cn("flex min-w-0 grow flex-col", !hasActions && "pr-3")}
         >
-          {file.name}
-        </OneEllipsis>
+          <OneEllipsis className="text-neutral-1000 text-sm font-medium">
+            {file.name}
+          </OneEllipsis>
+          {date && (
+            <span className="text-f1-foreground-secondary truncate text-xs">
+              {date}
+            </span>
+          )}
+        </div>
         {hasActions &&
           (singleAction ? (
             <F0Button

--- a/packages/react/src/components/F0FileItem/F0FileItem.tsx
+++ b/packages/react/src/components/F0FileItem/F0FileItem.tsx
@@ -1,5 +1,10 @@
+import type { HTMLAttributes } from "react"
+
 import { cva } from "cva"
 import { forwardRef } from "react"
+
+import type { FileDef } from "@/components/avatars/F0AvatarFile/types"
+import type { IconType } from "@/components/F0Icon"
 
 import { F0AvatarFile } from "@/components/avatars/F0AvatarFile"
 import { F0Button } from "@/components/F0Button"
@@ -12,10 +17,6 @@ import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { OneEllipsis } from "@/lib/OneEllipsis/OneEllipsis"
 import { cn } from "@/lib/utils"
-
-import type { FileDef } from "@/components/avatars/F0AvatarFile/types"
-import type { IconType } from "@/components/F0Icon"
-import type { HTMLAttributes } from "react"
 
 // Declared next to the component (not in a sibling types.ts) so api-extractor
 // rolls them into the bundled d.ts instead of emitting a broken relative import.
@@ -35,11 +36,11 @@ export interface F0FileItemProps extends HTMLAttributes<HTMLDivElement> {
   disabled?: boolean
   size?: F0FileItemSize
   /**
-   * Pre-formatted date rendered under the file name (e.g. an upload date).
-   * The consumer owns locale and formatting. When set, the item grows to two
-   * lines and its vertical padding is doubled.
+   * Secondary line rendered under the file name (e.g. an upload date or file
+   * size). The consumer owns any formatting. When set, the item grows to two
+   * lines and its padding is doubled.
    */
-  date?: string
+  subtitle?: string
 }
 
 /** @deprecated Use F0FileAction */
@@ -56,22 +57,22 @@ const fileItemVariants = cva({
       md: "max-w-48 gap-2",
       lg: "max-w-56 gap-2.5",
     },
-    // A date adds a second line, so the padding is doubled (both axes) to keep
-    // the block visually balanced.
-    withDate: {
+    // A subtitle adds a second line, so the padding is doubled (both axes) to
+    // keep the block visually balanced.
+    withSubtitle: {
       true: "",
       false: "",
     },
   },
   compoundVariants: [
-    { size: "md", withDate: false, class: "py-0.5 pl-0.5 pr-1.5" },
-    { size: "md", withDate: true, class: "py-1 pl-1 pr-3" },
-    { size: "lg", withDate: false, class: "p-1" },
-    { size: "lg", withDate: true, class: "p-2" },
+    { size: "md", withSubtitle: false, class: "py-0.5 pl-0.5 pr-1.5" },
+    { size: "md", withSubtitle: true, class: "py-1 pl-1 pr-3" },
+    { size: "lg", withSubtitle: false, class: "p-1" },
+    { size: "lg", withSubtitle: true, class: "p-2" },
   ],
   defaultVariants: {
     size: "md",
-    withDate: false,
+    withSubtitle: false,
   },
 })
 
@@ -92,7 +93,7 @@ const _F0FileItem = forwardRef<HTMLDivElement, F0FileItemProps>(
       actions = [],
       disabled = false,
       size = "md",
-      date,
+      subtitle,
       className,
       ...props
     },
@@ -111,7 +112,10 @@ const _F0FileItem = forwardRef<HTMLDivElement, F0FileItemProps>(
     return (
       <div
         ref={ref}
-        className={cn(fileItemVariants({ size, withDate: !!date }), className)}
+        className={cn(
+          fileItemVariants({ size, withSubtitle: !!subtitle }),
+          className
+        )}
         {...props}
       >
         <F0AvatarFile file={file} size={avatarSizeMap[size]} />
@@ -121,9 +125,9 @@ const _F0FileItem = forwardRef<HTMLDivElement, F0FileItemProps>(
           <OneEllipsis className="text-neutral-1000 text-sm font-medium">
             {file.name}
           </OneEllipsis>
-          {date && (
-            <span className="text-f1-foreground-secondary truncate text-xs">
-              {date}
+          {subtitle && (
+            <span className="truncate text-xs text-f1-foreground-secondary">
+              {subtitle}
             </span>
           )}
         </div>

--- a/packages/react/src/components/F0FileItem/__stories__/F0FileItem.stories.tsx
+++ b/packages/react/src/components/F0FileItem/__stories__/F0FileItem.stories.tsx
@@ -80,6 +80,21 @@ export const WithoutActions: Story = {
   },
 }
 
+export const WithDate: Story = {
+  args: {
+    size: "lg",
+    file: new File(["test"], "invoice-F001.pdf", { type: "application/pdf" }),
+    date: "09 June, 2026",
+    actions: [
+      {
+        icon: Download,
+        label: "Download file",
+        onClick: fn(),
+      },
+    ],
+  },
+}
+
 export const Disabled: Story = {
   args: {
     ...Default.args,

--- a/packages/react/src/components/F0FileItem/__stories__/F0FileItem.stories.tsx
+++ b/packages/react/src/components/F0FileItem/__stories__/F0FileItem.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
-import { fn } from "storybook/test"
 
+import { fn } from "storybook/test"
 import { expect, within } from "storybook/test"
 
 import { CrossedCircle, Download } from "@/icons/app"
@@ -80,11 +80,11 @@ export const WithoutActions: Story = {
   },
 }
 
-export const WithDate: Story = {
+export const WithSubtitle: Story = {
   args: {
     size: "lg",
     file: new File(["test"], "invoice-F001.pdf", { type: "application/pdf" }),
-    date: "09 June, 2026",
+    subtitle: "09 June, 2026",
     actions: [
       {
         icon: Download,

--- a/packages/react/src/components/F0FileItem/__tests__/F0FileItem.test.tsx
+++ b/packages/react/src/components/F0FileItem/__tests__/F0FileItem.test.tsx
@@ -13,39 +13,39 @@ describe("F0FileItem", () => {
     expect(screen.getByText("invoice-F001.pdf")).toBeInTheDocument()
   })
 
-  it("renders the date under the file name when provided", () => {
-    render(<F0FileItem file={file} date="09 June, 2026" />)
+  it("renders the subtitle under the file name when provided", () => {
+    render(<F0FileItem file={file} subtitle="09 June, 2026" />)
 
     expect(screen.getByText("09 June, 2026")).toBeInTheDocument()
   })
 
-  it("does not render a date node when the date is omitted", () => {
+  it("does not render a subtitle node when the subtitle is omitted", () => {
     render(<F0FileItem file={file} />)
 
     expect(screen.queryByText("09 June, 2026")).not.toBeInTheDocument()
   })
 
-  it("doubles the padding on both axes when a date is present (md)", () => {
-    const { container: withoutDate } = render(<F0FileItem file={file} />)
-    expect(withoutDate.firstChild).toHaveClass("py-0.5", "pl-0.5", "pr-1.5")
+  it("doubles the padding on both axes when a subtitle is present (md)", () => {
+    const { container: withoutSubtitle } = render(<F0FileItem file={file} />)
+    expect(withoutSubtitle.firstChild).toHaveClass("py-0.5", "pl-0.5", "pr-1.5")
 
-    const { container: withDate } = render(
-      <F0FileItem file={file} date="09 June, 2026" />
+    const { container: withSubtitle } = render(
+      <F0FileItem file={file} subtitle="09 June, 2026" />
     )
-    expect(withDate.firstChild).toHaveClass("py-1", "pl-1", "pr-3")
-    expect(withDate.firstChild).not.toHaveClass("py-0.5")
+    expect(withSubtitle.firstChild).toHaveClass("py-1", "pl-1", "pr-3")
+    expect(withSubtitle.firstChild).not.toHaveClass("py-0.5")
   })
 
-  it("doubles the padding on both axes when a date is present (lg)", () => {
-    const { container: withoutDate } = render(
+  it("doubles the padding on both axes when a subtitle is present (lg)", () => {
+    const { container: withoutSubtitle } = render(
       <F0FileItem file={file} size="lg" />
     )
-    expect(withoutDate.firstChild).toHaveClass("p-1")
+    expect(withoutSubtitle.firstChild).toHaveClass("p-1")
 
-    const { container: withDate } = render(
-      <F0FileItem file={file} size="lg" date="09 June, 2026" />
+    const { container: withSubtitle } = render(
+      <F0FileItem file={file} size="lg" subtitle="09 June, 2026" />
     )
-    expect(withDate.firstChild).toHaveClass("p-2")
-    expect(withDate.firstChild).not.toHaveClass("p-1")
+    expect(withSubtitle.firstChild).toHaveClass("p-2")
+    expect(withSubtitle.firstChild).not.toHaveClass("p-1")
   })
 })

--- a/packages/react/src/components/F0FileItem/__tests__/F0FileItem.test.tsx
+++ b/packages/react/src/components/F0FileItem/__tests__/F0FileItem.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0FileItem } from "../index"
+
+const file = new File(["test"], "invoice-F001.pdf", { type: "application/pdf" })
+
+describe("F0FileItem", () => {
+  it("renders the file name", () => {
+    render(<F0FileItem file={file} />)
+
+    expect(screen.getByText("invoice-F001.pdf")).toBeInTheDocument()
+  })
+
+  it("renders the date under the file name when provided", () => {
+    render(<F0FileItem file={file} date="09 June, 2026" />)
+
+    expect(screen.getByText("09 June, 2026")).toBeInTheDocument()
+  })
+
+  it("does not render a date node when the date is omitted", () => {
+    render(<F0FileItem file={file} />)
+
+    expect(screen.queryByText("09 June, 2026")).not.toBeInTheDocument()
+  })
+
+  it("doubles the padding on both axes when a date is present (md)", () => {
+    const { container: withoutDate } = render(<F0FileItem file={file} />)
+    expect(withoutDate.firstChild).toHaveClass("py-0.5", "pl-0.5", "pr-1.5")
+
+    const { container: withDate } = render(
+      <F0FileItem file={file} date="09 June, 2026" />
+    )
+    expect(withDate.firstChild).toHaveClass("py-1", "pl-1", "pr-3")
+    expect(withDate.firstChild).not.toHaveClass("py-0.5")
+  })
+
+  it("doubles the padding on both axes when a date is present (lg)", () => {
+    const { container: withoutDate } = render(
+      <F0FileItem file={file} size="lg" />
+    )
+    expect(withoutDate.firstChild).toHaveClass("p-1")
+
+    const { container: withDate } = render(
+      <F0FileItem file={file} size="lg" date="09 June, 2026" />
+    )
+    expect(withDate.firstChild).toHaveClass("p-2")
+    expect(withDate.firstChild).not.toHaveClass("p-1")
+  })
+})


### PR DESCRIPTION
## Description

Adds an optional `subtitle` prop to the experimental `F0FileItem`. When provided, the component renders a pre-formatted secondary line under the file name and doubles its padding (both axes) so the two-line block stays visually balanced.

This unblocks the Factorial finance/expenses F0Form migration, where the signed-invoice file row (`DropItem`) shows an upload date under the file name — something `F0FileItem` couldn't express until now. The prop is kept general (a plain string) rather than date-specific so it also covers file size or any other secondary text.

## Screenshots

<img width="888" height="232" alt="image" src="https://github.com/user-attachments/assets/227c32c3-ea63-4bd9-9928-0c67cea2d76e" />

## Implementation details

- **New prop** `subtitle?: string` on `F0FileItemProps`. It's a plain, pre-formatted string so the component stays presentational and locale-agnostic — the consumer owns any formatting.
- **Layout:** the name is now wrapped in a `flex-col` alongside the subtitle. The subtitle renders muted (`text-f1-foreground-secondary`, `text-xs`) under the name. The no-actions `pr-3` moved from the ellipsis onto the wrapper.
- **Padding:** `cva` moved all padding into `compoundVariants` keyed on a new `withSubtitle` variant, doubling both axes when a subtitle is present:
  - `md`: `py-0.5 pl-0.5 pr-1.5` → `py-1 pl-1 pr-3`
  - `lg`: `p-1` → `p-2`
- **Story:** added `WithSubtitle`.
- **Tests:** added `__tests__/F0FileItem.test.tsx` (none existed) covering name/subtitle render, absence of the subtitle node when omitted, and padding for both sizes. 5/5 pass. `oxlint` + `oxfmt` clean.

No release note needed here beyond the auto-generated changelog (release-please).
