### PR TITLE
fix(ci): request team reviews with an org-scoped token

### DIFF
--- a/.github/workflows/review-policy.yaml
+++ b/.github/workflows/review-policy.yaml
@@ -30,5 +30,8 @@ jobs:
       - name: Evaluate review policy
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Only for requesting team reviews: the default Actions token has no
+          # org scope and 422s on every team ("Could not resolve to a node")
+          REVIEW_REQUEST_TOKEN: ${{ secrets.RELEASE_PLEASE_GH_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: pnpm --filter @factorialco/f0-ownership run review-policy

--- a/ownership/README.md
+++ b/ownership/README.md
@@ -38,6 +38,13 @@ Membership of the three policy teams is mirrored in [`teams.yml`](teams.yml)
 (`policy_teams`) because the default Actions token cannot read org team
 membership. Keep it in sync with the GitHub org teams.
 
+For the same reason the workflow passes `REVIEW_REQUEST_TOKEN` — a token with
+org scope — used only to add the pending teams as reviewers. Without it every
+request fails with `422 Could not resolve to a node`, and teams that are not
+code owners (typically `f0-designers`, pulled in by rule 3 or the
+`needs-design-review` label) never land in anyone's review queue. The comment
+and the commit status keep using the default token.
+
 ## How it works
 
 - Every direct child of `sds/` must have a `package.yml` manifest:

--- a/ownership/review-policy.ts
+++ b/ownership/review-policy.ts
@@ -24,6 +24,12 @@
  * required check in branch protection — the workflow job itself only fails
  * on real errors. Run it with: GITHUB_TOKEN, GITHUB_REPOSITORY and
  * PR_NUMBER set (DRY_RUN=1 skips the comment, status and review requests).
+ *
+ * Requesting a review from a team needs a token with org scope: the default
+ * Actions token cannot resolve teams and answers 422 "Could not resolve to a
+ * node". Set REVIEW_REQUEST_TOKEN to a token that can (a GitHub App
+ * installation token or a PAT with `read:org`) — everything else keeps using
+ * GITHUB_TOKEN, so the comment and the status stay authored by the bot.
  */
 import fs from "node:fs"
 import path from "node:path"
@@ -36,17 +42,17 @@ const FEAT_PATTERN = /^feat(\([^)]*\))?!?:/
 const DESIGN_LABEL = "needs-design-review"
 const COMMENT_MARKER = "<!-- comment-type: review-policy -->"
 
-const { GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, DRY_RUN } = process.env
+const { GITHUB_TOKEN, REVIEW_REQUEST_TOKEN, GITHUB_REPOSITORY, PR_NUMBER, DRY_RUN } = process.env
 if (!GITHUB_TOKEN || !GITHUB_REPOSITORY || !PR_NUMBER) {
   console.error("Missing required env vars: GITHUB_TOKEN, GITHUB_REPOSITORY, PR_NUMBER")
   process.exit(2)
 }
 
-async function api<T>(pathname: string, init?: RequestInit): Promise<T> {
+async function api<T>(pathname: string, init?: RequestInit, token = GITHUB_TOKEN): Promise<T> {
   const response = await fetch(`https://api.github.com${pathname}`, {
     ...init,
     headers: {
-      Authorization: `Bearer ${GITHUB_TOKEN}`,
+      Authorization: `Bearer ${token}`,
       Accept: "application/vnd.github+json",
       "X-GitHub-Api-Version": "2022-11-28",
       ...init?.headers,
@@ -280,18 +286,25 @@ if (DRY_RUN) {
 
   // Best-effort: put the PR in the queue of the teams that still need to
   // approve. The status check is the enforcement; failing to request a team
-  // review (e.g. token scope) must not fail the job on its own.
+  // review (e.g. token scope) must not fail the job on its own. One request
+  // per team, so a team GitHub cannot resolve does not drop the others.
   const alreadyRequested = pr.requested_teams.map((team) => team.slug)
   const toRequest = pending.map((r) => r.team).filter((slug) => !alreadyRequested.includes(slug))
-  if (toRequest.length > 0) {
+  for (const slug of toRequest) {
     try {
-      await api(`${prPath}/requested_reviewers`, {
-        method: "POST",
-        body: JSON.stringify({ team_reviewers: toRequest }),
-      })
-      console.log(`Requested review from: ${toRequest.join(", ")}`)
+      await api(
+        `${prPath}/requested_reviewers`,
+        { method: "POST", body: JSON.stringify({ team_reviewers: [slug] }) },
+        REVIEW_REQUEST_TOKEN || GITHUB_TOKEN
+      )
+      console.log(`Requested review from ${slug}`)
     } catch (error) {
-      console.warn(`Could not request team reviews (${(error as Error).message})`)
+      console.warn(
+        `Could not request a review from ${slug} (${(error as Error).message})` +
+          (REVIEW_REQUEST_TOKEN
+            ? ""
+            : " — REVIEW_REQUEST_TOKEN is not set, and the default Actions token cannot resolve org teams")
+      )
     }
   }
 }


### PR DESCRIPTION
## Description

The `Review policy` workflow classifies PRs correctly but has never managed to add the required teams as reviewers: every `POST /pulls/:n/requested_reviewers` answers `422 Could not resolve to a node`, because the default Actions token has no org scope and cannot resolve teams. The visible symptom is that adding the `needs-design-review` label (or opening a `feat:` PR) sets the status check to pending on an `f0-designers` approval, but no designer is ever assigned — [#4793](https://github.com/factorialco/f0/pull/4793) is the case that surfaced it, and the same failure is in the log of every run since the workflow landed.

## Implementation details

- fix: pass `REVIEW_REQUEST_TOKEN` (`RELEASE_PLEASE_GH_TOKEN`, already in the repo) to the review-request call only

  <details>
  <summary>Why only that call?</summary>

  The comment and the commit status work fine with the default token and stay authored by `github-actions`. Scoping the privileged token to the one call that needs org access keeps that blast radius small. If the secret is missing the code falls back to `GITHUB_TOKEN`, so nothing gets worse than today.
  </details>

- fix: request one team per call, so a team GitHub cannot resolve no longer drops the others from the same batch
- chore: log a hint pointing at `REVIEW_REQUEST_TOKEN` when a request fails
- docs: document the token requirement in `ownership/README.md`

## Verification

`DRY_RUN=1` against #4793 reproduces the same classification and comment as the live run. The review request itself can only be exercised once this is on `main` — the next run should log `Requested review from f0-designers` instead of the 422. If `RELEASE_PLEASE_GH_TOKEN` turns out to lack `read:org`, the follow-up is a GitHub App token via `actions/create-github-app-token`; the code needs no further change.