### PR TITLE
feat(OneDataCollection): reach select-all with no selectable rows on page

### DIFF
--- a/packages/react/src/hooks/datasource/index.ts
+++ b/packages/react/src/hooks/datasource/index.ts
@@ -14,3 +14,4 @@ export type {
   UseSelectableReturn,
 } from "./useSelectable/typings"
 export * from "./useSelectable/useSelectable"
+export * from "./useSelectableTotal"

--- a/packages/react/src/hooks/datasource/itemNeighbors/useItemNeighbors.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/useItemNeighbors.ts
@@ -14,6 +14,7 @@ import {
 import { RecordType } from "../types/records.typings"
 import { SortingsStateMultiple } from "../types/sortings.typings"
 import { DataError } from "../useData"
+import { stableStringify } from "../utils"
 import { resolveItemNeighbors } from "./resolveItemNeighbors"
 
 export interface UseItemNeighborsOptions<
@@ -53,22 +54,6 @@ export interface UseItemNeighborsReturn<R extends RecordType> {
   neighbors: ItemNeighborsResponse<R> | null
   isResolving: boolean
   error: DataError | null
-}
-
-/** JSON-stringify with sorted object keys, so logically equal filter states
- *  always produce the same request key. */
-const stableStringify = (value: unknown): string => {
-  if (Array.isArray(value)) {
-    return `[${value.map(stableStringify).join(",")}]`
-  }
-  if (value !== null && typeof value === "object") {
-    const record = value as Record<string, unknown>
-    return `{${Object.keys(record)
-      .sort()
-      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
-      .join(",")}}`
-  }
-  return JSON.stringify(value) ?? "undefined"
 }
 
 const CACHE_MAX_ENTRIES = 50

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -16,6 +16,15 @@ import { SelectedItemsState } from "./selection.typings"
 import { SortingsDefinition, SortingsState } from "./sortings.typings"
 
 /**
+ * Options handed to `fetchSelectableTotal`: enough to scope the count to what
+ * the user is currently looking at.
+ */
+export type SelectableTotalOptions<Filters extends FiltersDefinition> = {
+  filters: FiltersState<Filters>
+  search?: string
+}
+
+/**
  * Defines the structure and configuration of a data source for a collection.
  * @template R - The type of records in the collection
  * @template Filters - The available filter configurations for the collection
@@ -81,6 +90,19 @@ export type DataSourceDefinition<
 
   /** Selectable items value under the checkbox column (undefined if not selectable) */
   selectable?: (item: R) => string | number | undefined
+  /**
+   * Resolves how many items match `selectable` across the whole dataset for the
+   * current filters/search.
+   *
+   * `selectable` is a client-side predicate, so F0 can only count the rows it
+   * has loaded — `paginationInfo.total` counts every record, selectable or not.
+   * Without this callback, a collection with non-selectable rows falls back to
+   * a cross-page "select all" label with no number rather than showing a wrong
+   * one. Sortings are not passed: they don't change a count.
+   */
+  fetchSelectableTotal?: (
+    options: SelectableTotalOptions<Filters>
+  ) => Promise<number>
   /** Default selected items */
   defaultSelectedItems?: SelectedItemsState<R>
   /**
@@ -143,6 +165,13 @@ export type DataSource<
   Sortings extends SortingsDefinition,
   Grouping extends GroupingDefinition<R>,
 > = DataSourceDefinition<R, Filters, Sortings, Grouping> & {
+  /**
+   * Total selectable items resolved from `fetchSelectableTotal` for the current
+   * filters/search. Undefined while in flight, on failure, or when the source
+   * doesn't provide the callback.
+   */
+  selectableTotal?: number
+
   /** Current state of applied filters */
   currentFilters: FiltersState<Filters>
   /** Function to update the current filters state */

--- a/packages/react/src/hooks/datasource/useDataSource.ts
+++ b/packages/react/src/hooks/datasource/useDataSource.ts
@@ -17,6 +17,7 @@ import {
   SortingsState,
 } from "./types"
 import { SearchOptions } from "./types/search.typings"
+import { useSelectableTotal } from "./useSelectableTotal"
 
 /**
  * Get the pagination type of a data adapter
@@ -212,8 +213,19 @@ export function useDataSource<
   }, [externalCurrentGrouping])
   /******************************************************************* */
 
+  /******************* SELECTABLE TOTAL ***************************************/
+  // Resolved here rather than per-visualization so a collection only ever
+  // issues one count per filter/search combination.
+  const selectableTotal = useSelectableTotal<FiltersSchema>({
+    fetchSelectableTotal: rest.fetchSelectableTotal,
+    filters: currentFilters,
+    search: debouncedCurrentSearch,
+  })
+  /******************************************************************* */
+
   return {
     ...rest,
+    selectableTotal,
     // Filters
     filters: memoizedFilters,
     currentFilters,

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -96,9 +96,13 @@ export function useSelectable<
     if (isPageOnlySelection) {
       return data.records?.length || 0
     }
-    const base = paginationInfo
-      ? paginationInfo.total
-      : (data.records?.length ?? 0)
+    // paginationInfo.total counts every record, selectable or not, so with a
+    // partially-selectable dataset checkedCount could never reach it and
+    // areAllKnownItemsSelected would never turn true. A consumer-provided
+    // selectable count fixes that; without one this keeps the old behaviour.
+    const base =
+      source.selectableTotal ??
+      (paginationInfo ? paginationInfo.total : (data.records?.length ?? 0))
     // nested/tree tables: paginationInfo.total counts top-level rows, not the selectable children
     return Math.max(base, renderedSelectableCount)
   }, [
@@ -106,6 +110,7 @@ export function useSelectable<
     data.records?.length,
     isPageOnlySelection,
     renderedSelectableCount,
+    source.selectableTotal,
   ])
 
   const currentPageIdentifier = useMemo(() => {

--- a/packages/react/src/hooks/datasource/useSelectableTotal.ts
+++ b/packages/react/src/hooks/datasource/useSelectableTotal.ts
@@ -6,6 +6,7 @@ import {
 } from "@/patterns/OneFilterPicker/types"
 
 import { SelectableTotalOptions } from "./types"
+import { stableStringify } from "./utils"
 
 /**
  * Resolves the consumer-provided count of selectable items for the current
@@ -47,7 +48,11 @@ export const useSelectableTotal = <Filters extends FiltersDefinition>({
     let stale = false
     setTotal(undefined)
 
-    fetchTotal({ filters, search })
+    // Called inside a `then` so a consumer callback that throws synchronously
+    // (rather than rejecting) lands in the catch below instead of escaping the
+    // effect and taking the whole collection down with it.
+    Promise.resolve()
+      .then(() => fetchTotal({ filters, search }))
       .then((value) => {
         if (!stale) setTotal(value)
       })
@@ -88,8 +93,12 @@ export const hasNonSelectableRecords = <R>(
  */
 export const useHasNonSelectableRows = (
   pageHasNonSelectableRows: boolean,
-  queryKey: string
+  query: { filters: unknown; search: string | undefined }
 ): boolean => {
+  // Stable stringify: two filter states with the same values but a different key
+  // order are the same dataset, and must not drop what we know about it.
+  const queryKey = stableStringify([query.filters, query.search])
+
   const seenRef = useRef(false)
   const queryKeyRef = useRef(queryKey)
 

--- a/packages/react/src/hooks/datasource/useSelectableTotal.ts
+++ b/packages/react/src/hooks/datasource/useSelectableTotal.ts
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from "react"
+
+import {
+  FiltersDefinition,
+  FiltersState,
+} from "@/patterns/OneFilterPicker/types"
+
+import { SelectableTotalOptions } from "./types"
+
+/**
+ * Resolves the consumer-provided count of selectable items for the current
+ * filters/search. Undefined while it is in flight, when the source doesn't
+ * provide the callback, or when the count fails — callers must be able to
+ * render without a number.
+ */
+export const useSelectableTotal = <Filters extends FiltersDefinition>({
+  fetchSelectableTotal,
+  filters,
+  search,
+}: {
+  fetchSelectableTotal?: (
+    options: SelectableTotalOptions<Filters>
+  ) => Promise<number>
+  filters: FiltersState<Filters>
+  search: string | undefined
+}): number | undefined => {
+  const [total, setTotal] = useState<number>()
+
+  // Consumers pass this inline (`fetchSelectableTotal={() => count(...)}`), so
+  // depending on its identity would refetch on every render. Only the query it
+  // is scoped to should retrigger it.
+  const fetchRef = useRef(fetchSelectableTotal)
+  fetchRef.current = fetchSelectableTotal
+  const isEnabled = !!fetchSelectableTotal
+
+  useEffect(() => {
+    const fetchTotal = fetchRef.current
+    if (!fetchTotal) return
+
+    // The count only means anything for one filter/search combination, so a
+    // response for the previous one must never overwrite the current state.
+    let stale = false
+    setTotal(undefined)
+
+    fetchTotal({ filters, search })
+      .then((value) => {
+        if (!stale) setTotal(value)
+      })
+      .catch(() => {
+        if (!stale) setTotal(undefined)
+      })
+
+    return () => {
+      stale = true
+    }
+  }, [isEnabled, filters, search])
+
+  return total
+}
+
+/**
+ * The total to show for a cross-page "select all", or undefined when no honest
+ * number is available.
+ *
+ * `paginationInfo.total` counts every record, selectable or not, so it can only
+ * stand in for the selectable total while every loaded row is selectable. Once
+ * we can see non-selectable rows, only a consumer-provided count is trustworthy
+ * — otherwise the UI must drop the number instead of showing a wrong one.
+ */
+export const resolveSelectableTotal = ({
+  fetchedTotal,
+  paginationTotal,
+  hasNonSelectableRows,
+}: {
+  fetchedTotal: number | undefined
+  paginationTotal: number | undefined
+  hasNonSelectableRows: boolean
+}): number | undefined =>
+  fetchedTotal ?? (hasNonSelectableRows ? undefined : paginationTotal)

--- a/packages/react/src/hooks/datasource/useSelectableTotal.ts
+++ b/packages/react/src/hooks/datasource/useSelectableTotal.ts
@@ -35,7 +35,12 @@ export const useSelectableTotal = <Filters extends FiltersDefinition>({
 
   useEffect(() => {
     const fetchTotal = fetchRef.current
-    if (!fetchTotal) return
+    if (!fetchTotal) {
+      // A source can drop the callback (e.g. it's conditional). Keeping the
+      // last resolved count would leave a number on screen that nothing backs.
+      setTotal(undefined)
+      return
+    }
 
     // The count only means anything for one filter/search combination, so a
     // response for the previous one must never overwrite the current state.
@@ -56,6 +61,45 @@ export const useSelectableTotal = <Filters extends FiltersDefinition>({
   }, [isEnabled, filters, search])
 
   return total
+}
+
+/**
+ * Whether any of these records fails the `selectable` predicate.
+ *
+ * Always derived from the fetched records, never from a rendered-row registry:
+ * a registry can hold lazily-loaded nested children, so its size says nothing
+ * about whether the loaded top-level rows are all selectable.
+ */
+export const hasNonSelectableRecords = <R>(
+  records: R[] | undefined,
+  selectable: ((item: R) => string | number | undefined) | undefined
+): boolean =>
+  !!selectable && (records ?? []).some((item) => selectable(item) === undefined)
+
+/**
+ * Sticky within one filter/search combination: once a non-selectable row has
+ * been seen, `paginationInfo.total` has been proven wrong as a selectable
+ * total, and paging onto a fully-selectable page doesn't make it right again.
+ * Resets when the query changes, since that's a different dataset.
+ *
+ * A ref rather than state: the value is only ever read during a render that is
+ * already happening because the page or the query changed, so nothing needs to
+ * be re-rendered when it flips.
+ */
+export const useHasNonSelectableRows = (
+  pageHasNonSelectableRows: boolean,
+  queryKey: string
+): boolean => {
+  const seenRef = useRef(false)
+  const queryKeyRef = useRef(queryKey)
+
+  if (queryKeyRef.current !== queryKey) {
+    queryKeyRef.current = queryKey
+    seenRef.current = false
+  }
+  if (pageHasNonSelectableRows) seenRef.current = true
+
+  return seenRef.current
 }
 
 /**

--- a/packages/react/src/hooks/datasource/useSelectableTotal.ts
+++ b/packages/react/src/hooks/datasource/useSelectableTotal.ts
@@ -34,6 +34,15 @@ export const useSelectableTotal = <Filters extends FiltersDefinition>({
   fetchRef.current = fetchSelectableTotal
   const isEnabled = !!fetchSelectableTotal
 
+  // Same identity rule as useHasNonSelectableRows: a filter state rebuilt with
+  // a different key order is the same query, so it must not spend another count
+  // request — nor blank the number out and back while that request is in
+  // flight. Read through a ref so the effect always sees the current values
+  // without depending on their identity.
+  const queryKey = stableStringify([filters, search])
+  const queryRef = useRef({ filters, search })
+  queryRef.current = { filters, search }
+
   useEffect(() => {
     const fetchTotal = fetchRef.current
     if (!fetchTotal) {
@@ -52,7 +61,7 @@ export const useSelectableTotal = <Filters extends FiltersDefinition>({
     // (rather than rejecting) lands in the catch below instead of escaping the
     // effect and taking the whole collection down with it.
     Promise.resolve()
-      .then(() => fetchTotal({ filters, search }))
+      .then(() => fetchTotal(queryRef.current))
       .then((value) => {
         if (!stale) setTotal(value)
       })
@@ -63,7 +72,7 @@ export const useSelectableTotal = <Filters extends FiltersDefinition>({
     return () => {
       stale = true
     }
-  }, [isEnabled, filters, search])
+  }, [isEnabled, queryKey])
 
   return total
 }

--- a/packages/react/src/hooks/datasource/useSelectableTotal.ts
+++ b/packages/react/src/hooks/datasource/useSelectableTotal.ts
@@ -96,7 +96,14 @@ export const useHasNonSelectableRows = (
   if (queryKeyRef.current !== queryKey) {
     queryKeyRef.current = queryKey
     seenRef.current = false
+    // The rows still on screen belong to the previous query — the fetch for the
+    // new one hasn't resolved yet — so this render's evidence says nothing
+    // about the new dataset. Taking it would carry "seen" across queries and
+    // strand the new one on the unknown-total path forever. The next render,
+    // once the new records land, provides the real answer.
+    return false
   }
+
   if (pageHasNonSelectableRows) seenRef.current = true
 
   return seenRef.current

--- a/packages/react/src/hooks/datasource/utils.ts
+++ b/packages/react/src/hooks/datasource/utils.ts
@@ -13,3 +13,19 @@ export const groupBy = <R>(array: R[], key: keyof R): Map<string, R[]> => {
 
   return result
 }
+
+/** JSON-stringify with sorted object keys, so logically equal filter states
+ *  always produce the same key. */
+export const stableStringify = (value: unknown): string => {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(",")}]`
+  }
+  if (value !== null && typeof value === "object") {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify(record[key])}`)
+      .join(",")}}`
+  }
+  return JSON.stringify(value) ?? "undefined"
+}

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -103,6 +103,11 @@ export const defaultTranslations = {
       allOnPage: "All {{count}} items on this page are selected",
       selectAllItems: "Select all {{total}} items",
       allItemsSelected: "All {{total}} items selected",
+      // Used when the selectable total is unknown: `selectable` is a
+      // client-side predicate, so without `fetchSelectableTotal` a collection
+      // with non-selectable rows has no honest number to show.
+      selectAllItemsUnknownTotal: "Select all items",
+      allItemsSelectedUnknownTotal: "All items selected",
     },
     noItemsSelected: "No items selected",
   },

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -21,9 +21,11 @@ import { F0ActionBar } from "@/components/F0ActionBar"
 import { OneEmptyState } from "@/components/OneEmptyState"
 import {
   GroupingDefinition,
+  hasNonSelectableRecords,
   OnSelectItemsCallback,
   RecordType,
   resolveSelectableTotal,
+  useHasNonSelectableRows,
 } from "@/hooks/datasource"
 import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
 import { DataError } from "@/hooks/datasource/useData"
@@ -890,16 +892,20 @@ const OneDataCollectionComp = <
   }
 
   const [totalItems, setTotalItems] = useState<undefined | number>(undefined)
-  // Whether any loaded record fails the `selectable` predicate. Once that's
-  // true, totalItems (every record, selectable or not) can't stand in for the
-  // selectable total.
-  const [hasNonSelectableRows, setHasNonSelectableRows] = useState(false)
+  // Whether the last loaded page contained a record that fails the `selectable`
+  // predicate. Once that's true, totalItems (every record, selectable or not)
+  // can't stand in for the selectable total.
+  const [pageHasNonSelectableRows, setPageHasNonSelectableRows] =
+    useState(false)
   const [isInitialLoading, setIsInitialLoading] = useState(true)
 
   const allItemsSelectedTotal = resolveSelectableTotal({
     fetchedTotal: source.selectableTotal,
     paginationTotal: totalItems,
-    hasNonSelectableRows,
+    hasNonSelectableRows: useHasNonSelectableRows(
+      pageHasNonSelectableRows,
+      JSON.stringify([source.currentFilters, source.debouncedCurrentSearch])
+    ),
   })
 
   const elementsRightActions = useMemo(
@@ -950,9 +956,8 @@ const OneDataCollectionComp = <
 
     setIsInitialLoading(isInitialLoadingFromCallback)
     setTotalItems(totalItems)
-    setHasNonSelectableRows(
-      !!source.selectable &&
-        (data ?? []).some((item) => source.selectable?.(item) === undefined)
+    setPageHasNonSelectableRows(
+      hasNonSelectableRecords(data, source.selectable)
     )
     setFirstDataLoaded(true)
     setEmptyStateType(getEmptyStateType(totalItems, filters, search))

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -23,6 +23,7 @@ import {
   GroupingDefinition,
   OnSelectItemsCallback,
   RecordType,
+  resolveSelectableTotal,
 } from "@/hooks/datasource"
 import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
 import { DataError } from "@/hooks/datasource/useData"
@@ -889,7 +890,17 @@ const OneDataCollectionComp = <
   }
 
   const [totalItems, setTotalItems] = useState<undefined | number>(undefined)
+  // Whether any loaded record fails the `selectable` predicate. Once that's
+  // true, totalItems (every record, selectable or not) can't stand in for the
+  // selectable total.
+  const [hasNonSelectableRows, setHasNonSelectableRows] = useState(false)
   const [isInitialLoading, setIsInitialLoading] = useState(true)
+
+  const allItemsSelectedTotal = resolveSelectableTotal({
+    fetchedTotal: source.selectableTotal,
+    paginationTotal: totalItems,
+    hasNonSelectableRows,
+  })
 
   const elementsRightActions = useMemo(
     () => [search?.enabled, visualizations.length > 1].some(Boolean),
@@ -931,6 +942,7 @@ const OneDataCollectionComp = <
     filters,
     isInitialLoading: isInitialLoadingFromCallback,
     search,
+    data,
   }: Parameters<OnLoadDataCallback<R, Filters>>[0]) => {
     if (isInitialLoadingFromCallback) {
       return
@@ -938,6 +950,10 @@ const OneDataCollectionComp = <
 
     setIsInitialLoading(isInitialLoadingFromCallback)
     setTotalItems(totalItems)
+    setHasNonSelectableRows(
+      !!source.selectable &&
+        (data ?? []).some((item) => source.selectable?.(item) === undefined)
+    )
     setFirstDataLoaded(true)
     setEmptyStateType(getEmptyStateType(totalItems, filters, search))
   }
@@ -1810,7 +1826,7 @@ const OneDataCollectionComp = <
               onUnselect={() => clearSelectedItemsFunc?.()}
               allPagesSelection={!!source.allPagesSelection}
               isAllItemsSelected={isAllItemsSelected}
-              totalItems={totalItems}
+              totalItems={allItemsSelectedTotal}
             />
           )}
         </>

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -902,10 +902,10 @@ const OneDataCollectionComp = <
   const allItemsSelectedTotal = resolveSelectableTotal({
     fetchedTotal: source.selectableTotal,
     paginationTotal: totalItems,
-    hasNonSelectableRows: useHasNonSelectableRows(
-      pageHasNonSelectableRows,
-      JSON.stringify([source.currentFilters, source.debouncedCurrentSearch])
-    ),
+    hasNonSelectableRows: useHasNonSelectableRows(pageHasNonSelectableRows, {
+      filters: source.currentFilters,
+      search: source.debouncedCurrentSearch,
+    }),
   })
 
   const elementsRightActions = useMemo(

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -991,6 +991,47 @@ export const WithCrossPageSelection: Story = {
   },
 }
 
+export const WithCrossPageSelectionAndNoSelectableRowsOnPage: Story = {
+  render: () => {
+    const paginatedMockUsers = generateMockUsers(50)
+    // Page 1 is entirely non-selectable. The header checkbox has nothing to act
+    // on, so the "Select all N items" CTA is offered on its own.
+    const lockedIds = new Set(
+      paginatedMockUsers.slice(0, 10).map((user) => user.id)
+    )
+
+    return (
+      <ExampleComponent
+        selectable={(item) => (lockedIds.has(item.id) ? undefined : item.id)}
+        // Without this the CTA would have to say "Select all items" with no
+        // number: paginationInfo.total is 50, but only 40 are selectable.
+        fetchSelectableTotal={async () =>
+          paginatedMockUsers.length - lockedIds.size
+        }
+        allPagesSelection={true}
+        dataAdapter={createDataAdapter({
+          data: paginatedMockUsers,
+          delay: 500,
+          paginationType: "pages",
+          perPage: 10,
+        })}
+        bulkActions={({ allSelected, selectedCount }) => ({
+          primary: [
+            {
+              label: allSelected
+                ? "Delete all items"
+                : `Delete ${selectedCount} selected item${selectedCount > 1 ? "s" : ""}`,
+              icon: Delete,
+              id: "delete-all",
+              critical: true,
+            },
+          ],
+        })}
+      />
+    )
+  },
+}
+
 export const WithInfiniteScrollSelection: Story = {
   render: () => {
     const paginatedMockUsers = generateMockUsers(50)

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -1341,6 +1341,7 @@ export const ExampleComponent = ({
   presets: presetsOverride,
   frozenColumns = 0,
   selectable,
+  fetchSelectableTotal,
   defaultSelectedItems,
   allPagesSelection,
   bulkActions,
@@ -1406,6 +1407,7 @@ export const ExampleComponent = ({
   >
   defaultSelectedItems?: SelectedItemsState<MockUser>
   selectable?: (item: MockUser) => string | number | undefined
+  fetchSelectableTotal?: () => Promise<number>
   allPagesSelection?: boolean
   bulkActions?: BulkActionsDefinition<MockUser, FiltersType>
   onSelectItems?: OnSelectItemsCallback<MockUser, FiltersType>
@@ -1532,6 +1534,7 @@ export const ExampleComponent = ({
         },
       ],
       selectable,
+      fetchSelectableTotal,
       defaultSelectedItems,
       allPagesSelection,
       bulkActions,

--- a/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
@@ -1,0 +1,132 @@
+import { screen, waitFor } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, test, vi } from "vitest"
+
+import { defaultTranslations, I18nProvider } from "@/lib/providers/i18n"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { useDataCollectionSource } from "../hooks/useDataCollectionSource"
+import { OneDataCollection } from "../index"
+
+const TestWrapper = ({ children }: { children: React.ReactNode }) => (
+  <I18nProvider translations={defaultTranslations}>{children}</I18nProvider>
+)
+
+type Row = { id: string; name: string; locked: boolean }
+
+const TOTAL = 20
+const PER_PAGE = 2
+// Only page 1 is locked, so 18 of the 20 records are actually selectable.
+const SELECTABLE_TOTAL = TOTAL - PER_PAGE
+
+const pageRecords = (currentPage: number): Row[] =>
+  Array.from({ length: PER_PAGE }, (_, i) => ({
+    id: `${currentPage}-${i}`,
+    name: `Row ${currentPage}-${i}`,
+    locked: currentPage === 1,
+  }))
+
+const columns = [{ label: "Name", render: (item: Row) => item.name }] as const
+
+const useTestSource = (fetchSelectableTotal?: () => Promise<number>) =>
+  useDataCollectionSource({
+    selectable: (item: Row) => (item.locked ? undefined : item.id),
+    allPagesSelection: true,
+    fetchSelectableTotal,
+    bulkActions: () => ({ primary: [{ label: "Archive", id: "archive" }] }),
+    dataAdapter: {
+      paginationType: "pages",
+      perPage: PER_PAGE,
+      fetchData: async (options) => {
+        const currentPage =
+          ("pagination" in options ? options.pagination?.currentPage : 1) ?? 1
+        return {
+          records: pageRecords(currentPage),
+          total: TOTAL,
+          currentPage,
+          perPage: PER_PAGE,
+          pagesCount: TOTAL / PER_PAGE,
+          type: "pages" as const,
+        }
+      },
+    },
+  })
+
+// The source must live in the same root as the collection: `selectableTotal`
+// resolves asynchronously, and a source snapshot taken from renderHook would
+// never carry the resolved value.
+const Harness = ({
+  fetchSelectableTotal,
+}: {
+  fetchSelectableTotal?: () => Promise<number>
+}) => (
+  <OneDataCollection
+    source={useTestSource(fetchSelectableTotal)}
+    visualizations={[{ type: "table", options: { columns } }]}
+  />
+)
+
+const renderCollection = (fetchSelectableTotal?: () => Promise<number>) =>
+  render(
+    <TestWrapper>
+      <Harness fetchSelectableTotal={fetchSelectableTotal} />
+    </TestWrapper>
+  )
+
+describe("select all with no selectable rows on the current page", () => {
+  test("offers the cross-page CTA and disables the inert header checkbox", async () => {
+    renderCollection()
+
+    await waitFor(() => {
+      expect(screen.getByText("Row 1-0")).toBeInTheDocument()
+    })
+
+    // The CTA must be offered without a prior selection — the header checkbox
+    // can't produce one on this page.
+    const cta = await screen.findByRole("button", { name: "Select all items" })
+
+    const [headerCheckbox] = screen.getAllByRole("checkbox")
+    expect(headerCheckbox).toBeDisabled()
+
+    await userEvent.setup().click(cta)
+
+    await waitFor(() => {
+      expect(screen.getAllByText("All items selected").length).toBeGreaterThan(
+        0
+      )
+    })
+  })
+
+  test("never shows paginationInfo.total as the selectable count", async () => {
+    // 20 records but only 18 selectable: showing "20" would be a lie, so the
+    // label drops the number entirely.
+    renderCollection()
+
+    await waitFor(() => {
+      expect(screen.getByText("Row 1-0")).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole("button", { name: `Select all ${TOTAL} items` })
+    ).not.toBeInTheDocument()
+  })
+
+  test("uses the consumer-provided selectable total when available", async () => {
+    const fetchSelectableTotal = vi.fn(async () => SELECTABLE_TOTAL)
+    renderCollection(fetchSelectableTotal)
+
+    const cta = await screen.findByRole("button", {
+      name: `Select all ${SELECTABLE_TOTAL} items`,
+    })
+
+    expect(fetchSelectableTotal).toHaveBeenCalled()
+
+    await userEvent.setup().click(cta)
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText(`All ${SELECTABLE_TOTAL} items selected`).length
+      ).toBeGreaterThan(0)
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
@@ -104,6 +104,24 @@ describe("useHasNonSelectableRows", () => {
     rerender({ page: false, query: "filters-b" })
     expect(result.current).toBe(false)
   })
+
+  test("ignores the stale page flag on the render the query changes", () => {
+    // Filters change before the new records arrive, so the rows still on screen
+    // — and the flag derived from them — belong to the previous query.
+    const { result, rerender } = renderHook(
+      ({ page, query }: { page: boolean; query: string }) =>
+        useHasNonSelectableRows(page, query),
+      { initialProps: { page: true, query: "filters-a" } }
+    )
+    expect(result.current).toBe(true)
+
+    rerender({ page: true, query: "filters-b" })
+    expect(result.current).toBe(false)
+
+    // Once the new page has actually loaded, its evidence counts again.
+    rerender({ page: true, query: "filters-b" })
+    expect(result.current).toBe(true)
+  })
 })
 
 describe("select all with no selectable rows on the current page", () => {

--- a/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
@@ -3,7 +3,11 @@ import { userEvent } from "@testing-library/user-event"
 import { describe, expect, test, vi } from "vitest"
 
 import { defaultTranslations, I18nProvider } from "@/lib/providers/i18n"
-import { zeroRender as render } from "@/testing/test-utils"
+import { useHasNonSelectableRows } from "@/hooks/datasource"
+import {
+  zeroRender as render,
+  zeroRenderHook as renderHook,
+} from "@/testing/test-utils"
 
 import { useDataCollectionSource } from "../hooks/useDataCollectionSource"
 import { OneDataCollection } from "../index"
@@ -72,6 +76,35 @@ const renderCollection = (fetchSelectableTotal?: () => Promise<number>) =>
       <Harness fetchSelectableTotal={fetchSelectableTotal} />
     </TestWrapper>
   )
+
+describe("useHasNonSelectableRows", () => {
+  test("stays true after paging onto a fully-selectable page", () => {
+    // paginationInfo.total has already been proven wrong for this query; a page
+    // that happens to be fully selectable doesn't make it right again.
+    const { result, rerender } = renderHook(
+      ({ page, query }: { page: boolean; query: string }) =>
+        useHasNonSelectableRows(page, query),
+      { initialProps: { page: true, query: "filters-a" } }
+    )
+    expect(result.current).toBe(true)
+
+    rerender({ page: false, query: "filters-a" })
+    expect(result.current).toBe(true)
+  })
+
+  test("resets when the query changes", () => {
+    const { result, rerender } = renderHook(
+      ({ page, query }: { page: boolean; query: string }) =>
+        useHasNonSelectableRows(page, query),
+      { initialProps: { page: true, query: "filters-a" } }
+    )
+    expect(result.current).toBe(true)
+
+    // Different filters mean a different dataset: nothing is known about it yet.
+    rerender({ page: false, query: "filters-b" })
+    expect(result.current).toBe(false)
+  })
+})
 
 describe("select all with no selectable rows on the current page", () => {
   test("offers the cross-page CTA and disables the inert header checkbox", async () => {

--- a/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
@@ -82,26 +82,26 @@ describe("useHasNonSelectableRows", () => {
     // paginationInfo.total has already been proven wrong for this query; a page
     // that happens to be fully selectable doesn't make it right again.
     const { result, rerender } = renderHook(
-      ({ page, query }: { page: boolean; query: string }) =>
-        useHasNonSelectableRows(page, query),
-      { initialProps: { page: true, query: "filters-a" } }
+      ({ page, filters }: { page: boolean; filters: object }) =>
+        useHasNonSelectableRows(page, { filters, search: undefined }),
+      { initialProps: { page: true, filters: { a: 1 } } }
     )
     expect(result.current).toBe(true)
 
-    rerender({ page: false, query: "filters-a" })
+    rerender({ page: false, filters: { a: 1 } })
     expect(result.current).toBe(true)
   })
 
   test("resets when the query changes", () => {
     const { result, rerender } = renderHook(
-      ({ page, query }: { page: boolean; query: string }) =>
-        useHasNonSelectableRows(page, query),
-      { initialProps: { page: true, query: "filters-a" } }
+      ({ page, filters }: { page: boolean; filters: object }) =>
+        useHasNonSelectableRows(page, { filters, search: undefined }),
+      { initialProps: { page: true, filters: { a: 1 } } }
     )
     expect(result.current).toBe(true)
 
     // Different filters mean a different dataset: nothing is known about it yet.
-    rerender({ page: false, query: "filters-b" })
+    rerender({ page: false, filters: { b: 2 } })
     expect(result.current).toBe(false)
   })
 
@@ -109,17 +109,31 @@ describe("useHasNonSelectableRows", () => {
     // Filters change before the new records arrive, so the rows still on screen
     // — and the flag derived from them — belong to the previous query.
     const { result, rerender } = renderHook(
-      ({ page, query }: { page: boolean; query: string }) =>
-        useHasNonSelectableRows(page, query),
-      { initialProps: { page: true, query: "filters-a" } }
+      ({ page, filters }: { page: boolean; filters: object }) =>
+        useHasNonSelectableRows(page, { filters, search: undefined }),
+      { initialProps: { page: true, filters: { a: 1 } } }
     )
     expect(result.current).toBe(true)
 
-    rerender({ page: true, query: "filters-b" })
+    rerender({ page: true, filters: { b: 2 } })
     expect(result.current).toBe(false)
 
     // Once the new page has actually loaded, its evidence counts again.
-    rerender({ page: true, query: "filters-b" })
+    rerender({ page: true, filters: { b: 2 } })
+    expect(result.current).toBe(true)
+  })
+
+  test("survives a filter state rebuilt with a different key order", () => {
+    // Same filters, different insertion order — same dataset, so what we know
+    // about it must not be thrown away.
+    const { result, rerender } = renderHook(
+      ({ page, filters }: { page: boolean; filters: object }) =>
+        useHasNonSelectableRows(page, { filters, search: undefined }),
+      { initialProps: { page: true, filters: { a: 1, b: 2 } } }
+    )
+    expect(result.current).toBe(true)
+
+    rerender({ page: false, filters: { b: 2, a: 1 } })
     expect(result.current).toBe(true)
   })
 })
@@ -160,6 +174,21 @@ describe("select all with no selectable rows on the current page", () => {
     expect(
       screen.queryByRole("button", { name: `Select all ${TOTAL} items` })
     ).not.toBeInTheDocument()
+  })
+
+  test("survives a callback that throws synchronously", async () => {
+    // Not an async function, so it throws instead of rejecting — that must not
+    // escape the effect and take the collection down.
+    const throwing = (() => {
+      throw new Error("count failed")
+    }) as unknown as () => Promise<number>
+
+    renderCollection(throwing)
+
+    // Falls back to the unknown-total label instead of crashing.
+    expect(
+      await screen.findByRole("button", { name: "Select all items" })
+    ).toBeInTheDocument()
   })
 
   test("uses the consumer-provided selectable total when available", async () => {

--- a/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
@@ -3,7 +3,7 @@ import { userEvent } from "@testing-library/user-event"
 import { describe, expect, test, vi } from "vitest"
 
 import { defaultTranslations, I18nProvider } from "@/lib/providers/i18n"
-import { useHasNonSelectableRows } from "@/hooks/datasource"
+import { useHasNonSelectableRows, useSelectableTotal } from "@/hooks/datasource"
 import {
   zeroRender as render,
   zeroRenderHook as renderHook,
@@ -76,6 +76,32 @@ const renderCollection = (fetchSelectableTotal?: () => Promise<number>) =>
       <Harness fetchSelectableTotal={fetchSelectableTotal} />
     </TestWrapper>
   )
+
+describe("useSelectableTotal", () => {
+  test("doesn't re-count when a filter state is rebuilt with a different key order", async () => {
+    const fetchSelectableTotal = vi.fn(async () => 18)
+
+    const { rerender } = renderHook(
+      ({ filters }: { filters: object }) =>
+        useSelectableTotal({
+          fetchSelectableTotal,
+          filters: filters as never,
+          search: undefined,
+        }),
+      { initialProps: { filters: { a: 1, b: 2 } } }
+    )
+
+    await waitFor(() => expect(fetchSelectableTotal).toHaveBeenCalledTimes(1))
+
+    // Same values, different insertion order: same query, no second request.
+    rerender({ filters: { b: 2, a: 1 } })
+    expect(fetchSelectableTotal).toHaveBeenCalledTimes(1)
+
+    // A real change does re-count.
+    rerender({ filters: { a: 9, b: 2 } })
+    await waitFor(() => expect(fetchSelectableTotal).toHaveBeenCalledTimes(2))
+  })
+})
 
 describe("useHasNonSelectableRows", () => {
   test("stays true after paging onto a fully-selectable page", () => {

--- a/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/selectAllNoSelectableRows.test.tsx
@@ -191,6 +191,21 @@ describe("select all with no selectable rows on the current page", () => {
     ).toBeInTheDocument()
   })
 
+  test("hides the CTA when the consumer reports zero selectable items", async () => {
+    // Nothing in the dataset is selectable, so "select all" would promise a
+    // selection that can't exist — and the empty selection that followed would
+    // render no bulk-action bar to undo it with.
+    renderCollection(async () => 0)
+
+    await waitFor(() => {
+      expect(screen.getByText("Row 1-0")).toBeInTheDocument()
+    })
+
+    expect(
+      screen.queryByRole("button", { name: /select all/i })
+    ).not.toBeInTheDocument()
+  })
+
   test("uses the consumer-provided selectable total when available", async () => {
     const fetchSelectableTotal = vi.fn(async () => SELECTABLE_TOTAL)
     renderCollection(fetchSelectableTotal)

--- a/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
@@ -86,8 +86,9 @@ export const OneDataCollectionActionBar = forwardRef<
 ) {
   const { t, ...i18n } = useI18n()
 
-  const showAllItemsSelected =
-    allPagesSelection && isAllItemsSelected && totalItems !== undefined
+  // No longer requires a known total: when the selectable total can't be
+  // trusted we still say "all items selected", just without a number.
+  const showAllItemsSelected = allPagesSelection && isAllItemsSelected
 
   // Prevent the Unselect button from clearing the selection while a bulk
   // action is in-flight. If it were clickable during loading/success, the
@@ -145,10 +146,12 @@ export const OneDataCollectionActionBar = forwardRef<
         {!!displayedSelectedNumber && (
           <div className="dark flex h-8 w-full items-center justify-between gap-3 px-2 sm:h-auto sm:w-fit sm:justify-start sm:pl-2 sm:pr-0">
             {showAllItemsSelected ? (
-              <span className="font-medium tabular-nums">
-                {t("status.selected.allItemsSelected", {
-                  total: totalItems ?? 0,
-                })}
+              <span className="font-medium tabular-nums text-f1-foreground">
+                {totalItems !== undefined
+                  ? t("status.selected.allItemsSelected", {
+                      total: totalItems,
+                    })
+                  : t("status.selected.allItemsSelectedUnknownTotal")}
               </span>
             ) : (
               <span className="flex items-center gap-1 font-medium tabular-nums">

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -437,6 +437,10 @@ export const TableCollection = <
     !!source.allPagesSelection &&
     (!allSelectedStatus.checked || allSelectedStatus.indeterminate) &&
     paginationInfo?.total !== undefined &&
+    // A count of exactly 0 means the consumer knows nothing in this dataset is
+    // selectable: offering "select all" would promise a selection that can't
+    // exist, and the resulting empty selection shows no bulk-action bar.
+    selectableTotal !== 0 &&
     // paginationTotal is an upper bound on the selectable total, so this still
     // gates correctly when the exact selectable count is unknown.
     paginationTotal > allSelectedStatus.selectedCount

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -24,7 +24,9 @@ import {
   SortingsDefinition,
   SortingsState,
   useGroups,
+  hasNonSelectableRecords,
   resolveSelectableTotal,
+  useHasNonSelectableRows,
   useSelectable,
 } from "@/hooks/datasource"
 import { Add } from "@/icons/app"
@@ -269,6 +271,14 @@ export const TableCollection = <
     getRenderedSelectableEntries: selectionRegistry.getEntries,
     renderedSelectableCount: selectionRegistry.ids.length,
   })
+
+  // Must sit above the loading early-return below: it holds state across
+  // renders, so it can't be called conditionally.
+  const hasNonSelectableRows = useHasNonSelectableRows(
+    hasNonSelectableRecords(data?.records, source.selectable),
+    JSON.stringify([source.currentFilters, source.debouncedCurrentSearch])
+  )
+
   const summaryData = useMemo(() => {
     // Early return if no summaries configuration or summaries data is available
 
@@ -410,8 +420,7 @@ export const TableCollection = <
   const selectableTotal = resolveSelectableTotal({
     fetchedTotal: source.selectableTotal,
     paginationTotal,
-    hasNonSelectableRows:
-      (data?.records.length ?? 0) > currentPageSelectableIds.length,
+    hasNonSelectableRows,
   })
 
   // True when the header checkbox should render as fully-checked: either the

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -24,6 +24,7 @@ import {
   SortingsDefinition,
   SortingsState,
   useGroups,
+  resolveSelectableTotal,
   useSelectable,
 } from "@/hooks/datasource"
 import { Add } from "@/icons/app"
@@ -391,11 +392,27 @@ export const TableCollection = <
     currentPageSelectableIds.length > 0 &&
     currentPageSelectableIds.every((id) => selectedItems.has(id))
 
+  // A page where `source.selectable` returns undefined for every record. The
+  // header checkbox can't act on anything there, and the cross-page CTA is
+  // gated behind having a selection — so without this the user is trapped and
+  // can never reach "select all items".
+  const hasNoSelectableRowsOnPage =
+    (data?.records.length ?? 0) > 0 && currentPageSelectableIds.length === 0
+
   // nested/tree tables: paginationInfo.total counts top-level rows, not selectable children
-  const selectableTotal = Math.max(
+  const paginationTotal = Math.max(
     paginationInfo?.total ?? 0,
     currentPageSelectableIds.length
   )
+
+  // Undefined when no honest number exists — the labels drop the count rather
+  // than showing paginationInfo.total, which includes non-selectable records.
+  const selectableTotal = resolveSelectableTotal({
+    fetchedTotal: source.selectableTotal,
+    paginationTotal,
+    hasNonSelectableRows:
+      (data?.records.length ?? 0) > currentPageSelectableIds.length,
+  })
 
   // True when the header checkbox should render as fully-checked: either the
   // Gmail-style "select across all pages" CTA is active, or every selectable
@@ -408,7 +425,9 @@ export const TableCollection = <
     !!source.allPagesSelection &&
     (!allSelectedStatus.checked || allSelectedStatus.indeterminate) &&
     paginationInfo?.total !== undefined &&
-    selectableTotal > allSelectedStatus.selectedCount
+    // paginationTotal is an upper bound on the selectable total, so this still
+    // gates correctly when the exact selectable count is unknown.
+    paginationTotal > allSelectedStatus.selectedCount
 
   const selectionHeaderColSpan =
     columns.length + (showItemActions ? actionColCount : 0)
@@ -520,7 +539,13 @@ export const TableCollection = <
                         onCheckedChange={handleSelectAll}
                         title={i18n.actions.selectAll}
                         hideLabel
-                        disabled={data?.records.length === 0}
+                        // Inert with nothing selectable on the page; stays
+                        // enabled once a cross-page selection exists so it can
+                        // still clear it.
+                        disabled={
+                          data?.records.length === 0 ||
+                          (hasNoSelectableRowsOnPage && !hasSelection)
+                        }
                       />
                     </div>
                   </TableHead>
@@ -597,7 +622,8 @@ export const TableCollection = <
                     </>
                   ))}
               </TableRow>
-              {hasSelection &&
+              {(hasSelection ||
+                (hasNoSelectableRowsOnPage && showSelectAllOption)) &&
                 source.selectable &&
                 !!source.allPagesSelection && (
                   <TableRow>
@@ -606,32 +632,44 @@ export const TableCollection = <
                       className="h-11 border-0 border-t border-solid border-f1-border-secondary bg-f1-background-secondary px-5"
                     >
                       <div className="flex items-center gap-3">
-                        <HighlightedCount
-                          text={
-                            allSelectedStatus.checked &&
-                            !allSelectedStatus.indeterminate
-                              ? t("status.selected.allItemsSelected", {
-                                  total: selectableTotal,
-                                })
-                              : allPageRowsSelected
-                                ? t("status.selected.allOnPage", {
-                                    count: allSelectedStatus.selectedCount,
-                                  })
-                                : `${allSelectedStatus.selectedCount} ${selectedText}`
-                          }
-                          count={
-                            allSelectedStatus.checked &&
-                            !allSelectedStatus.indeterminate
-                              ? selectableTotal
-                              : allSelectedStatus.selectedCount
-                          }
-                        />
+                        {hasSelection && (
+                          <HighlightedCount
+                            text={
+                              allSelectedStatus.checked &&
+                              !allSelectedStatus.indeterminate
+                                ? selectableTotal !== undefined
+                                  ? t("status.selected.allItemsSelected", {
+                                      total: selectableTotal,
+                                    })
+                                  : t(
+                                      "status.selected.allItemsSelectedUnknownTotal"
+                                    )
+                                : allPageRowsSelected
+                                  ? t("status.selected.allOnPage", {
+                                      count: allSelectedStatus.selectedCount,
+                                    })
+                                  : `${allSelectedStatus.selectedCount} ${selectedText}`
+                            }
+                            count={
+                              allSelectedStatus.checked &&
+                              !allSelectedStatus.indeterminate
+                                ? (selectableTotal ?? 0)
+                                : allSelectedStatus.selectedCount
+                            }
+                          />
+                        )}
                         {showSelectAllOption && (
                           <F0Button
                             variant="outline"
-                            label={t("status.selected.selectAllItems", {
-                              total: selectableTotal,
-                            })}
+                            label={
+                              selectableTotal !== undefined
+                                ? t("status.selected.selectAllItems", {
+                                    total: selectableTotal,
+                                  })
+                                : t(
+                                    "status.selected.selectAllItemsUnknownTotal"
+                                  )
+                            }
                             onClick={() => handleSelectAllItems(true)}
                             size="sm"
                           />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -276,7 +276,10 @@ export const TableCollection = <
   // renders, so it can't be called conditionally.
   const hasNonSelectableRows = useHasNonSelectableRows(
     hasNonSelectableRecords(data?.records, source.selectable),
-    JSON.stringify([source.currentFilters, source.debouncedCurrentSearch])
+    {
+      filters: source.currentFilters,
+      search: source.debouncedCurrentSearch,
+    }
   )
 
   const summaryData = useMemo(() => {


### PR DESCRIPTION
## Description

A table page where `selectable` returns `undefined` for every record trapped the user: the header checkbox was enabled but inert, and the cross-page "select all" CTA was gated behind having a selection that page could never produce. On top of that, the number in that CTA came from `paginationInfo.total`, which counts every record — selectable or not — so it was simply wrong on any partially-selectable dataset. Sources can now declare the real count via `fetchSelectableTotal`, and when they don't, the labels drop the number rather than showing a false one.

## Screenshots (if applicable)

Story: `Patterns/Data Collection/Miscellaneous → WithCrossPageSelectionAndNoSelectableRowsOnPage` (50 records, 10 non-selectable on page 1, `fetchSelectableTotal` resolving 40).

<img width="785" height="850" alt="Screenshot 2026-07-28 at 13 59 50" src="https://github.com/user-attachments/assets/21d207a1-1a72-4e56-a548-27fc552c4815" />

<img width="797" height="857" alt="Screenshot 2026-07-28 at 13 59 40" src="https://github.com/user-attachments/assets/8ef92bcf-7015-480e-92bc-2e741c140111" />

## Behavior change for existing consumers

No new required props and no API break — `fetchSelectableTotal` is optional. But one existing behavior changes without an opt-in, so it's worth being explicit about who sees it:

| Collection | Before | From now on |
| --- | --- | --- |
| Every row selectable (no conditional `selectable`) | "Select all 50 items" | **unchanged** — "Select all 50 items" |
| Some rows not selectable, no `fetchSelectableTotal` | "Select all 50 items" (wrong — only 40 are selectable) | "Select all items" |
| Some rows not selectable, `fetchSelectableTotal` provided | "Select all 50 items" (wrong) | "Select all 40 items" |

So collections without a conditional `selectable` are untouched: `paginationInfo.total` is still used whenever every loaded row is selectable. The number only disappears where it was provably wrong, and providing `fetchSelectableTotal` brings it back as a correct one. Same rule applies to the "all items selected" label in the bulk-action bar.

## Implementation details

- feat: offer the cross-page "select all" CTA when the current page has no selectable rows, so a fully non-selectable page is no longer a dead end
- feat: add `fetchSelectableTotal` to the data source — a consumer-provided count of selectable items for the current filters/search

  <details>
  <summary>Why a callback and not a field on the fetchData response?</summary>

  `selectable` is a client-side predicate, so F0 can only count the rows it has loaded. The honest cross-page total has to come from the backend either way, but a separate callback lets consumers add the count without touching a shared list query or resolver. It is resolved once per collection in `useDataSource` (so Table and the action bar read the same value), scoped to filters/search only — sortings don't change a count — with a staleness guard so a response for a previous filter set can never overwrite the current one, and a `catch` that falls back to no number. The effect deliberately does not depend on the callback's identity, so an inline arrow doesn't refetch on every render.
  </details>

- fix: never present `paginationInfo.total` as the selectable total once a non-selectable row is visible; fall back to `selectAllItemsUnknownTotal` / `allItemsSelectedUnknownTotal` instead
- fix: make `totalKnownItemsCount` use the selectable count, so `areAllKnownItemsSelected` can actually become true on partially-selectable datasets
- fix: disable the header checkbox while it has nothing to act on, and re-enable it once a cross-page selection exists so it can still clear it
- fix: give the "all items selected" label in the action bar an explicit `text-f1-foreground` — it had no color class inside the `dark` container and inherited the light-theme foreground, rendering black
- test: cover the CTA reachability, the disabled checkbox, the no-number fallback, and the consumer-provided total
- docs: add a story for a page with no selectable rows

## Known limitation

If the current page happens to be fully selectable while other pages are not, and no `fetchSelectableTotal` is provided, the CTA still shows `paginationInfo.total`. That case is undetectable client-side — the callback is the only fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
