### PR TITLE
feat(F0Select): Cancel closes dropdown + applySelectionLabel [FCT-56953]

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -115,6 +115,7 @@ const F0SelectComponent = forwardRef(function Select<
     placeholder,
     onChange,
     withApplySelection = false,
+    hideApplySelectionCancel = false,
     onChangeSelectedOption,
     value,
     options = [],
@@ -1021,6 +1022,16 @@ const F0SelectComponent = forwardRef(function Select<
       .map((item) => String(item.id))
   }, [selectedState.items])
 
+  // Resolve whether the apply-selection "Cancel" button should render.
+  // `hideApplySelectionCancel` may hide it always (`true`) or only while the
+  // staged selection is empty (`"when-empty"`). Deferred apply is unaffected.
+  const hasStagedSelection =
+    selectedItemsValues.length > 0 || !!selectedState.allSelected
+  const showCancelButton =
+    hasDeferredApply &&
+    hideApplySelectionCancel !== true &&
+    !(hideApplySelectionCancel === "when-empty" && !hasStagedSelection)
+
   /**
    * Common props for the select primitive
    */
@@ -1101,7 +1112,7 @@ const F0SelectComponent = forwardRef(function Select<
             showApplyButton={showApplyButton}
             onApply={handleApply}
             onCancel={handleCancel}
-            showCancelButton={hasDeferredApply}
+            showCancelButton={showCancelButton}
           />
         ) : null
       }

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -115,7 +115,7 @@ const F0SelectComponent = forwardRef(function Select<
     placeholder,
     onChange,
     withApplySelection = false,
-    hideApplySelectionCancel = false,
+    applySelectionLabel,
     onChangeSelectedOption,
     value,
     options = [],
@@ -819,9 +819,13 @@ const F0SelectComponent = forwardRef(function Select<
     debouncedHandleChangeOpenLocal(open)
   }
 
+  // "Cancel" aborts the apply-selection flow by closing the dropdown. The
+  // close path (`handleChangeOpenLocal`) restores the committed selection, so
+  // staged changes are discarded — matching what clicking outside does, and
+  // what users expect from a Cancel action.
   const handleCancel = useCallback(() => {
-    restoreCommittedSelection()
-  }, [restoreCommittedSelection])
+    handleChangeOpenLocal(false)
+  }, [handleChangeOpenLocal])
 
   const handleApply = useCallback(() => {
     if (hasDeferredApply) {
@@ -1022,16 +1026,6 @@ const F0SelectComponent = forwardRef(function Select<
       .map((item) => String(item.id))
   }, [selectedState.items])
 
-  // Resolve whether the apply-selection "Cancel" button should render.
-  // `hideApplySelectionCancel` may hide it always (`true`) or only while the
-  // staged selection is empty (`"when-empty"`). Deferred apply is unaffected.
-  const hasStagedSelection =
-    selectedItemsValues.length > 0 || !!selectedState.allSelected
-  const showCancelButton =
-    hasDeferredApply &&
-    hideApplySelectionCancel !== true &&
-    !(hideApplySelectionCancel === "when-empty" && !hasStagedSelection)
-
   /**
    * Common props for the select primitive
    */
@@ -1110,9 +1104,10 @@ const F0SelectComponent = forwardRef(function Select<
           <SelectBottomActions
             actions={actions}
             showApplyButton={showApplyButton}
+            applyLabel={applySelectionLabel}
             onApply={handleApply}
             onCancel={handleCancel}
-            showCancelButton={showCancelButton}
+            showCancelButton={hasDeferredApply}
           />
         ) : null
       }

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -819,10 +819,6 @@ const F0SelectComponent = forwardRef(function Select<
     debouncedHandleChangeOpenLocal(open)
   }
 
-  // "Cancel" aborts the apply-selection flow by closing the dropdown. The
-  // close path (`handleChangeOpenLocal`) restores the committed selection, so
-  // staged changes are discarded — matching what clicking outside does, and
-  // what users expect from a Cancel action.
   const handleCancel = useCallback(() => {
     handleChangeOpenLocal(false)
   }, [handleChangeOpenLocal])

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -182,6 +182,12 @@ const meta: Meta = {
       description:
         "When true in multi-select mode, selection changes are staged until Apply is clicked. Clicking Apply confirms the selection through `onChange`, while clicking outside or Cancel discards the staged changes.",
     },
+    hideApplySelectionCancel: {
+      description:
+        'Controls the Cancel button in the apply-selection footer (deferred apply is always preserved). `false` (default) shows it, `true` always hides it, and `"when-empty"` hides it while nothing is staged and shows it once at least one item is selected. Only has an effect when `withApplySelection` is enabled.',
+      control: "select",
+      options: [false, true, "when-empty"],
+    },
     actions: {
       description:
         "<p>List of action buttons that will be displayed at the bottom of the select dropdown. Each action should have a label, onClick handler, optional icon, and variant.</p>" +
@@ -1094,6 +1100,56 @@ export const MultipleWithApply: Story = {
       description: `${item.jobTitle} · ${item.departmentName}`,
     }),
     withApplySelection: true,
+  },
+}
+
+/**
+ * Apply-selection footer without the Cancel button. Selection is still staged
+ * and only committed on "Apply selection" (closing the dropdown discards it),
+ * but the redundant Cancel action is hidden and Apply is right-aligned.
+ */
+export const MultipleWithApplyNoCancel: Story = {
+  args: {
+    label: "Select Team Members",
+    placeholder: "Search employees...",
+    multiple: true,
+    value: ["2", "5"],
+    clearable: true,
+    showSearchBox: true,
+    source: employeeNonPaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: `${item.jobTitle} · ${item.departmentName}`,
+    }),
+    withApplySelection: true,
+    hideApplySelectionCancel: true,
+  },
+}
+
+/**
+ * Apply-selection footer where Cancel only appears once something is staged.
+ * With nothing selected the footer shows just "Apply selection"; check an item
+ * and the Cancel button appears so the staged change can be discarded.
+ */
+export const MultipleWithApplyCancelWhenEmpty: Story = {
+  args: {
+    label: "Select Team Members",
+    placeholder: "Search employees...",
+    multiple: true,
+    value: [],
+    clearable: true,
+    showSearchBox: true,
+    source: employeeNonPaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: `${item.jobTitle} · ${item.departmentName}`,
+    }),
+    withApplySelection: true,
+    hideApplySelectionCancel: "when-empty",
   },
 }
 

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -182,11 +182,10 @@ const meta: Meta = {
       description:
         "When true in multi-select mode, selection changes are staged until Apply is clicked. Clicking Apply confirms the selection through `onChange`, while clicking outside or Cancel discards the staged changes.",
     },
-    hideApplySelectionCancel: {
+    applySelectionLabel: {
       description:
-        'Controls the Cancel button in the apply-selection footer (deferred apply is always preserved). `false` (default) shows it, `true` always hides it, and `"when-empty"` hides it while nothing is staged and shows it once at least one item is selected. Only has an effect when `withApplySelection` is enabled.',
-      control: "select",
-      options: [false, true, "when-empty"],
+        'Custom label for the apply button in the apply-selection footer. Defaults to the translated "Apply selection". Only has an effect when `withApplySelection` is enabled.',
+      control: "text",
     },
     actions: {
       description:
@@ -1104,11 +1103,11 @@ export const MultipleWithApply: Story = {
 }
 
 /**
- * Apply-selection footer without the Cancel button. Selection is still staged
- * and only committed on "Apply selection" (closing the dropdown discards it),
- * but the redundant Cancel action is hidden and Apply is right-aligned.
+ * Apply-selection footer with a custom apply-button label. Consumers pass an
+ * already-translated string; the default is "Apply selection". Clicking Cancel
+ * closes the dropdown and discards the staged selection.
  */
-export const MultipleWithApplyNoCancel: Story = {
+export const MultipleWithApplyCustomLabel: Story = {
   args: {
     label: "Select Team Members",
     placeholder: "Search employees...",
@@ -1124,32 +1123,7 @@ export const MultipleWithApplyNoCancel: Story = {
       description: `${item.jobTitle} · ${item.departmentName}`,
     }),
     withApplySelection: true,
-    hideApplySelectionCancel: true,
-  },
-}
-
-/**
- * Apply-selection footer where Cancel only appears once something is staged.
- * With nothing selected the footer shows just "Apply selection"; check an item
- * and the Cancel button appears so the staged change can be discarded.
- */
-export const MultipleWithApplyCancelWhenEmpty: Story = {
-  args: {
-    label: "Select Team Members",
-    placeholder: "Search employees...",
-    multiple: true,
-    value: [],
-    clearable: true,
-    showSearchBox: true,
-    source: employeeNonPaginatedSource,
-    mapOptions: (item: Employee) => ({
-      value: item.value,
-      label: item.label,
-      avatar: item.avatar,
-      description: `${item.jobTitle} · ${item.departmentName}`,
-    }),
-    withApplySelection: true,
-    hideApplySelectionCancel: "when-empty",
+    applySelectionLabel: "Add to schedule",
   },
 }
 

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -815,6 +815,91 @@ describe("Select", () => {
     )
   })
 
+  it("hides the cancel button but keeps deferred apply when hideApplySelectionCancel is set", async () => {
+    const handleChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        multiple
+        options={mockOptions}
+        value={[]}
+        onChange={handleChange}
+        withApplySelection
+        hideApplySelectionCancel
+      />
+    )
+
+    await openSelect(user)
+
+    // Cancel is hidden, Apply is still present.
+    expect(
+      screen.queryByRole("button", { name: "Cancel" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Apply selection" })
+    ).toBeInTheDocument()
+
+    // Selection is still deferred until Apply is clicked.
+    await user.click(screen.getByText("Option 1"))
+    expect(handleChange).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole("button", { name: "Apply selection" }))
+
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith(
+        ["option1"],
+        expect.any(Array),
+        expect.any(Array)
+      )
+    })
+    expect(handleChange).toHaveBeenCalledTimes(1)
+  })
+
+  it("shows the cancel button only once something is staged when hideApplySelectionCancel is 'when-empty'", async () => {
+    const handleChange = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        multiple
+        options={mockOptions}
+        value={[]}
+        onChange={handleChange}
+        withApplySelection
+        hideApplySelectionCancel="when-empty"
+      />
+    )
+
+    await openSelect(user)
+
+    // Nothing staged yet: Cancel is hidden, Apply is present.
+    expect(
+      screen.queryByRole("button", { name: "Cancel" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Apply selection" })
+    ).toBeInTheDocument()
+
+    // Staging an item reveals Cancel.
+    await user.click(screen.getByText("Option 1"))
+    expect(
+      await screen.findByRole("button", { name: "Cancel" })
+    ).toBeInTheDocument()
+    expect(handleChange).not.toHaveBeenCalled()
+
+    // Cancel clears the staged selection and hides itself again.
+    await user.click(screen.getByRole("button", { name: "Cancel" }))
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: "Cancel" })
+      ).not.toBeInTheDocument()
+    })
+    expect(handleChange).not.toHaveBeenCalled()
+  })
+
   describe("asList mode", () => {
     it("preserves selection after searching and clicking an item", async () => {
       const handleChange = vi.fn()

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -753,7 +753,7 @@ describe("Select", () => {
     )
   })
 
-  it("cancels staged changes without closing when cancel button is clicked", async () => {
+  it("closes the dropdown and discards staged changes when cancel is clicked", async () => {
     const handleChange = vi.fn()
     const user = userEvent.setup()
 
@@ -762,61 +762,34 @@ describe("Select", () => {
         {...defaultSelectProps}
         multiple
         options={mockOptions}
-        value={["option1", "option2"]}
+        value={["option1"]}
         onChange={handleChange}
         withApplySelection
       />
     )
 
     await openSelect(user)
-    await user.click(screen.getByText("Option 2"))
+    await user.click(screen.getByText("Option 2")) // stage an addition
     await user.click(screen.getByRole("button", { name: "Cancel" }))
 
-    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    // Cancel now closes the dropdown (like clicking outside) and commits nothing.
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    })
     expect(handleChange).not.toHaveBeenCalled()
 
-    await user.click(screen.getByText("Option 3"))
+    // The staged addition was discarded: reopening and applying without changes
+    // emits nothing, proving Option 2 did not persist.
+    await openSelect(user)
     await user.click(screen.getByRole("button", { name: "Apply selection" }))
 
-    expect(handleChange).toHaveBeenCalledWith(
-      expect.arrayContaining(["option1", "option2", "option3"]),
-      expect.arrayContaining([
-        {
-          id: "option1",
-          name: "Option 1",
-          description: "Description 1",
-        },
-        {
-          id: "option2",
-          name: "Option 2",
-          description: "Description 2",
-        },
-        {
-          id: "option3",
-          name: "Option 3",
-          description: "Description 3",
-        },
-      ]),
-      expect.arrayContaining([
-        expect.objectContaining({
-          label: "Option 1",
-          value: "option1",
-          description: "Description 1",
-        }),
-        expect.objectContaining({
-          label: "Option 2",
-          value: "option2",
-        }),
-        expect.objectContaining({
-          label: "Option 3",
-          value: "option3",
-        }),
-      ])
-    )
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    })
+    expect(handleChange).not.toHaveBeenCalled()
   })
 
-  it("hides the cancel button but keeps deferred apply when hideApplySelectionCancel is set", async () => {
-    const handleChange = vi.fn()
+  it("renders a custom apply-button label when applySelectionLabel is provided", async () => {
     const user = userEvent.setup()
 
     render(
@@ -825,79 +798,20 @@ describe("Select", () => {
         multiple
         options={mockOptions}
         value={[]}
-        onChange={handleChange}
+        onChange={vi.fn()}
         withApplySelection
-        hideApplySelectionCancel
+        applySelectionLabel="Add to schedule"
       />
     )
 
     await openSelect(user)
 
-    // Cancel is hidden, Apply is still present.
     expect(
-      screen.queryByRole("button", { name: "Cancel" })
+      screen.getByRole("button", { name: "Add to schedule" })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Apply selection" })
     ).not.toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: "Apply selection" })
-    ).toBeInTheDocument()
-
-    // Selection is still deferred until Apply is clicked.
-    await user.click(screen.getByText("Option 1"))
-    expect(handleChange).not.toHaveBeenCalled()
-
-    await user.click(screen.getByRole("button", { name: "Apply selection" }))
-
-    await waitFor(() => {
-      expect(handleChange).toHaveBeenCalledWith(
-        ["option1"],
-        expect.any(Array),
-        expect.any(Array)
-      )
-    })
-    expect(handleChange).toHaveBeenCalledTimes(1)
-  })
-
-  it("shows the cancel button only once something is staged when hideApplySelectionCancel is 'when-empty'", async () => {
-    const handleChange = vi.fn()
-    const user = userEvent.setup()
-
-    render(
-      <F0Select
-        {...defaultSelectProps}
-        multiple
-        options={mockOptions}
-        value={[]}
-        onChange={handleChange}
-        withApplySelection
-        hideApplySelectionCancel="when-empty"
-      />
-    )
-
-    await openSelect(user)
-
-    // Nothing staged yet: Cancel is hidden, Apply is present.
-    expect(
-      screen.queryByRole("button", { name: "Cancel" })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.getByRole("button", { name: "Apply selection" })
-    ).toBeInTheDocument()
-
-    // Staging an item reveals Cancel.
-    await user.click(screen.getByText("Option 1"))
-    expect(
-      await screen.findByRole("button", { name: "Cancel" })
-    ).toBeInTheDocument()
-    expect(handleChange).not.toHaveBeenCalled()
-
-    // Cancel clears the staged selection and hides itself again.
-    await user.click(screen.getByRole("button", { name: "Cancel" }))
-    await waitFor(() => {
-      expect(
-        screen.queryByRole("button", { name: "Cancel" })
-      ).not.toBeInTheDocument()
-    })
-    expect(handleChange).not.toHaveBeenCalled()
   })
 
   describe("asList mode", () => {

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -769,17 +769,14 @@ describe("Select", () => {
     )
 
     await openSelect(user)
-    await user.click(screen.getByText("Option 2")) // stage an addition
+    await user.click(screen.getByText("Option 2"))
     await user.click(screen.getByRole("button", { name: "Cancel" }))
 
-    // Cancel now closes the dropdown (like clicking outside) and commits nothing.
     await waitFor(() => {
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
     })
     expect(handleChange).not.toHaveBeenCalled()
 
-    // The staged addition was discarded: reopening and applying without changes
-    // emits nothing, proving Option 2 did not persist.
     await openSelect(user)
     await user.click(screen.getByRole("button", { name: "Apply selection" }))
 

--- a/packages/react/src/components/F0Select/components/SelectBottomActions.tsx
+++ b/packages/react/src/components/F0Select/components/SelectBottomActions.tsx
@@ -16,6 +16,7 @@ interface SelectBottomActionsProps {
   showCancelButton?: boolean
   onApply?: () => void
   onCancel?: () => void
+  applyLabel?: string
 }
 
 export const SelectBottomActions = ({
@@ -24,6 +25,7 @@ export const SelectBottomActions = ({
   onApply,
   onCancel,
   showCancelButton,
+  applyLabel,
 }: SelectBottomActionsProps) => {
   const i18n = useI18n()
 
@@ -49,7 +51,10 @@ export const SelectBottomActions = ({
       )}
       {showApplyButton && (
         <div className={showCancelButton ? "" : "ml-auto"}>
-          <F0Button onClick={onApply} label={i18n.select.applySelection} />
+          <F0Button
+            onClick={onApply}
+            label={applyLabel ?? i18n.select.applySelection}
+          />
         </div>
       )}
     </div>

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -31,6 +31,18 @@ export type { FiltersState, OnSelectItemsCallback, SelectedItemsState }
  */
 type F0SelectBaseProps<T extends string, R = unknown> = {
   withApplySelection?: boolean
+  /**
+   * Controls the "Cancel" button in the apply-selection footer. The
+   * deferred-apply behaviour is always preserved (changes are staged and only
+   * committed on "Apply selection"; closing the dropdown discards them). Has no
+   * effect unless `withApplySelection` is enabled in multi-select mode.
+   * - `false` (default): Cancel is always shown.
+   * - `true`: Cancel is always hidden.
+   * - `"when-empty"`: Cancel is hidden while nothing is staged and appears once
+   *   at least one item is selected — for surfaces where an explicit cancel is
+   *   only meaningful after the user has staged a change.
+   */
+  hideApplySelectionCancel?: boolean | "when-empty"
   onChangeSelectedOption?: (
     option: F0SelectItemObject<T, ResolvedRecordType<R>> | undefined,
     checked: boolean

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -32,17 +32,13 @@ export type { FiltersState, OnSelectItemsCallback, SelectedItemsState }
 type F0SelectBaseProps<T extends string, R = unknown> = {
   withApplySelection?: boolean
   /**
-   * Controls the "Cancel" button in the apply-selection footer. The
-   * deferred-apply behaviour is always preserved (changes are staged and only
-   * committed on "Apply selection"; closing the dropdown discards them). Has no
-   * effect unless `withApplySelection` is enabled in multi-select mode.
-   * - `false` (default): Cancel is always shown.
-   * - `true`: Cancel is always hidden.
-   * - `"when-empty"`: Cancel is hidden while nothing is staged and appears once
-   *   at least one item is selected — for surfaces where an explicit cancel is
-   *   only meaningful after the user has staged a change.
+   * Custom label for the apply button in the apply-selection footer. Defaults
+   * to the translated "Apply selection". Pass an already-translated string.
+   * Only has an effect when `withApplySelection` is enabled in multi-select
+   * mode. Keep it short — some locales (e.g. German, French) run long and can
+   * overflow the footer.
    */
-  hideApplySelectionCancel?: boolean | "when-empty"
+  applySelectionLabel?: string
   onChangeSelectedOption?: (
     option: F0SelectItemObject<T, ResolvedRecordType<R>> | undefined,
     checked: boolean

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -31,13 +31,6 @@ export type { FiltersState, OnSelectItemsCallback, SelectedItemsState }
  */
 type F0SelectBaseProps<T extends string, R = unknown> = {
   withApplySelection?: boolean
-  /**
-   * Custom label for the apply button in the apply-selection footer. Defaults
-   * to the translated "Apply selection". Pass an already-translated string.
-   * Only has an effect when `withApplySelection` is enabled in multi-select
-   * mode. Keep it short — some locales (e.g. German, French) run long and can
-   * overflow the footer.
-   */
   applySelectionLabel?: string
   onChangeSelectedOption?: (
     option: F0SelectItemObject<T, ResolvedRecordType<R>> | undefined,


### PR DESCRIPTION
## What

Two changes to `F0Select`'s apply-selection footer, agreed with the Foundation team on [FCT-56953](https://factorialmakers.atlassian.net/browse/FCT-56953):

1. **"Cancel" now closes the dropdown** (discarding the staged selection, exactly like clicking outside) instead of clearing the staged selection *in place* and staying open.
2. **New `applySelectionLabel?: string` prop** to relabel the apply button. Defaults to the translated `"Apply selection"`.

## Why

In the Shifts planner action bar, the apply-selection Cancel button was confusing: it discarded the staged selection but kept the popover open, duplicating the deselect checkbox, and users expected "Cancel" to close/abort. See the Slack thread with Foundation (Saúl / Marcos / Raúl).

Resolution:
- **Cancel = close** matches user expectation and unifies behaviour with click-outside (no more "sometimes discards, sometimes not" inconsistency). This is an intentional, **Foundation-approved global** behaviour change to the shared component — we'll monitor for any complaints.
- The real per-surface need (Shifts wants the primary action to read **"Add to schedule"**) is solved by an **opt-in** label prop; the fallback stays `"Apply selection"`, so **no other consumer changes**.

This supersedes the earlier `hideApplySelectionCancel` / `"when-empty"` idea, which the team felt was too inconsistent for such a core component — that prop has been dropped.

## Implementation

- `handleCancel` now calls the close handler; the existing close path restores the committed selection, so staged changes are discarded.
- `applySelectionLabel` is threaded to `SelectBottomActions`, defaulting to `i18n.select.applySelection`. Consumers pass an already-translated string (keeps DE/FR length in the consumer's hands).

## Testing

- Updated unit test: Cancel closes the dropdown and discards the staged addition (no commit).
- New unit test: custom apply-button label renders.
- Full `F0Select` suite green; `oxlint` / `oxfmt` clean; no F0Select type errors.
- Storybook: **F0Select → Multiple With Apply Custom Label**.

## Consumers / rollout

- factorial [PR #108123](https://github.com/factorialco/factorial/pull/108123) consumes `applySelectionLabel="Add to schedule"` — needs an `@factorialco/f0-react` release + bump there.
- Draft pending final Foundation sign-off on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FCT-56953]: https://factorialmakers.atlassian.net/browse/FCT-56953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ