### PR TITLE
fix(useSelectable): keep pre-selected multi-select values checked when their option loads first

### DIFF
--- a/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useSelectable.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
-import { DataSource, PaginationInfo } from "../types"
+import { DataSource, PaginationInfo, SelectedItemsState } from "../types"
 import { Data, GROUP_ID_SYMBOL } from "../useData"
 import { useSelectable } from "../useSelectable/useSelectable"
 
@@ -1428,6 +1428,134 @@ describe("useSelectable", () => {
         expect(count).toBeGreaterThanOrEqual(0)
         expect(count).toBe(2)
       })
+    })
+  })
+
+  // Regression: pre-selected value stuck unchecked when its option row loads
+  // before the (async) controlled value resolves. Mirrors F0Select's config
+  // (allPagesSelection + infinite-scroll + additive multi-select). The options
+  // page is added to `data` first — so the pre-selected on-page item is seeded
+  // as checked:false — and only then does the external `selectedState` arrive
+  // marking it checked:true. The additive merge used to ignore that, leaving
+  // the item unchecked (selector shows one fewer than are actually selected).
+  describe("pre-selected value arriving after its option row", () => {
+    const makeData = (ids: number[]): Data<TestRecord> => {
+      const records = ids.map((id) => ({
+        id,
+        name: `Item ${id}`,
+        group: "group1",
+        [GROUP_ID_SYMBOL]: undefined,
+      }))
+      return {
+        type: "flat",
+        records,
+        groups: [
+          { key: "all", label: "All", records, itemCount: records.length },
+        ],
+      }
+    }
+
+    const cursorInfo: PaginationInfo = {
+      type: "infinite-scroll",
+      total: 100,
+      perPage: 25,
+      cursor: "0",
+      hasNextPage: true,
+    }
+
+    const externalValue = (ids: number[]): SelectedItemsState<TestRecord> => ({
+      allSelected: false,
+      items: new Map(ids.map((id) => [id, { id, checked: true }])),
+      groups: new Map(),
+    })
+
+    it("keeps every externally-selected id checked, even the one already on the page", async () => {
+      const emptyData = makeData([])
+      // 42 is on the loaded page; 51 and 38 are off-page (not in records).
+      const pageData = makeData([42, 1, 2, 3])
+
+      const { result, rerender } = renderHook(
+        ({ data, selectedState }) =>
+          useSelectable({
+            data,
+            paginationInfo: cursorInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            allPagesSelection: true,
+            resetOnPageChange: false,
+            preserveSelectionOnDatasetChange: true,
+            selectedState,
+          }),
+        {
+          initialProps: {
+            data: emptyData,
+            selectedState: undefined as
+              | SelectedItemsState<TestRecord>
+              | undefined,
+          },
+        }
+      )
+
+      // 1) Options page loads while the value is still unresolved.
+      rerender({ data: pageData, selectedState: undefined })
+      // 2) The controlled value resolves, selecting all three assignees.
+      rerender({ data: pageData, selectedState: externalValue([42, 51, 38]) })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.size).toBe(3)
+      })
+      expect(result.current.selectedItems.has(42)).toBe(true)
+      expect(result.current.selectedItems.has(51)).toBe(true)
+      expect(result.current.selectedItems.has(38)).toBe(true)
+      expect([...result.current.selectionStatus.selectedIds].sort()).toEqual([
+        38, 42, 51,
+      ])
+    })
+
+    it("does not override a local selection the external value omits (stays additive)", async () => {
+      const pageData = makeData([7, 8, 9])
+
+      const { result, rerender } = renderHook(
+        ({ selectedState }) =>
+          useSelectable({
+            data: pageData,
+            paginationInfo: cursorInfo,
+            source: mockSource,
+            onSelectItems: vi.fn(),
+            selectionMode: "multi",
+            allPagesSelection: true,
+            resetOnPageChange: false,
+            preserveSelectionOnDatasetChange: true,
+            selectedState,
+          }),
+        {
+          initialProps: {
+            selectedState: externalValue([7]),
+          },
+        }
+      )
+
+      await waitFor(() =>
+        expect(result.current.selectedItems.has(7)).toBe(true)
+      )
+
+      // User adds 8 locally (not yet reflected in the external value).
+      act(() => {
+        result.current.handleSelectItemChange(pageData.records[1], true)
+      })
+      await waitFor(() =>
+        expect(result.current.selectedItems.has(8)).toBe(true)
+      )
+
+      // External value updates to a different id set that omits 8; the merge
+      // must not silently drop the still-pending local selection.
+      rerender({ selectedState: externalValue([7, 9]) })
+
+      await waitFor(() => {
+        expect(result.current.selectedItems.has(9)).toBe(true)
+      })
+      expect(result.current.selectedItems.has(8)).toBe(true)
     })
   })
 })

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -408,26 +408,32 @@ export function useSelectable<
               checked: itemState.checked,
               item,
             })
-          } else if (existingItem.item === undefined && item !== undefined) {
-            mergedItems.set(itemStateId, {
-              ...existingItem,
-              item,
-              // Single-select: external `checked` wins over stale local state.
-              ...(isMultiSelection ? {} : { checked: itemState.checked }),
-            })
-          } else if (
-            !isMultiSelection &&
-            existingItem.checked !== itemState.checked
-          ) {
-            // Single-select: external `checked` wins over stale local state.
-            // Only clone when actually flipping; otherwise the entry stored
-            // in loop 1 already has the right shape and keeping the same
-            // reference avoids spurious re-renders / re-emits in consumers
-            // that compare `selectedState` deeply.
-            mergedItems.set(itemStateId, {
-              ...existingItem,
-              checked: itemState.checked,
-            })
+          } else {
+            // External selected state is authoritative about which items are
+            // selected. Single-select: it fully wins (checked true or false).
+            // Multi-select: the merge is otherwise additive so cross-page user
+            // selections survive, but an item the external state explicitly
+            // marks `checked: true` must still win over a stale local
+            // `checked: false` — otherwise a pre-selected value whose option
+            // row is loaded (and added as `checked: false`) *before* the
+            // controlled value resolves stays stuck unchecked (a race between
+            // the options page load and the async value; the selector then
+            // shows one fewer item than are actually selected).
+            const shouldSyncChecked =
+              existingItem.checked !== itemState.checked &&
+              (!isMultiSelection || itemState.checked)
+            const needsItem = existingItem.item === undefined && item !== undefined
+
+            // Only clone when something actually changes; otherwise keep the
+            // same reference to avoid spurious re-renders / re-emits in
+            // consumers that compare `selectedState` deeply.
+            if (needsItem || shouldSyncChecked) {
+              mergedItems.set(itemStateId, {
+                ...existingItem,
+                ...(needsItem ? { item } : {}),
+                ...(shouldSyncChecked ? { checked: itemState.checked } : {}),
+              })
+            }
           }
         }
 

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -422,7 +422,8 @@ export function useSelectable<
             const shouldSyncChecked =
               existingItem.checked !== itemState.checked &&
               (!isMultiSelection || itemState.checked)
-            const needsItem = existingItem.item === undefined && item !== undefined
+            const needsItem =
+              existingItem.item === undefined && item !== undefined
 
             // Only clone when something actually changes; otherwise keep the
             // same reference to avoid spurious re-renders / re-emits in


### PR DESCRIPTION
## Problem
In multi-select, a **pre-selected value gets stuck unchecked** when its option row loads *before* the controlled value resolves. `useSelectable`'s `updateLocalSelectedState` merges the external `selectedState` additively: for an item that already exists locally with a resolved record, it never flips `checked: false → true` to match the external state. The data-sync effect seeds loaded option rows as `checked: false`, so this is a **race**:

1. The options page loads → the selected item's row is added as `checked: false`.
2. The controlled value then resolves (`checked: true`) → the additive merge ignores it → the item stays unchecked.

Off-page selected items are never pre-seeded, so they arrive `checked: true` — only the on-page one is lost. The selector then reports **one fewer selected** than the controlled value contains, and committing the selection back drops it.

This reliably triggers with async form defaults (F0Form/form-definitions) and any paginated picker whose selected item is on the first page.

## Fix
Honor an external `checked: true` for already-present items in multi-select, while still ignoring external `checked: false` so cross-page manual selections stay additive. Single-select behavior is unchanged (external state remains the full source of truth).

## Tests
Added two regression tests to `useSelectable.test.tsx` (both fail before, pass after):
- **keeps every externally-selected id checked, even the one already on the page** — reproduces the race (options page → then external value); asserts all 3 stay selected. Before the fix it asserts `expected 2 to be 3`.
- **stays additive** — a local selection the external value omits is preserved; a newly-added external id whose row was pre-seeded still becomes selected.

Full suite: 31/31 `useSelectable` tests pass.

## Downstream
Reproduced in Factorial as **FCT-57267**: a task's *Assignees* editor showed "2 selected" for a 3-assignee task and dropped the third assignee on any edit. This is the shared-component root cause behind that ticket; the monorepo will bump `@factorialco/f0-react` once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)