### PR TITLE
feat(F0Graph): fly to node on click with panel-aware centering (+ F0Drawer onWidthChange)

### DIFF
--- a/packages/react/src/components/dialog-alike/F0Drawer/internal/DrawerInternal.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/internal/DrawerInternal.tsx
@@ -25,6 +25,7 @@ export const DrawerInternal: FC<DrawerInternalProps> = ({
   setActiveTabId,
   disableContentPadding,
   container,
+  onWidthChange,
 }) => {
   const [localIsOpen, setLocalIsOpen] = useState(isOpen)
 
@@ -80,6 +81,7 @@ export const DrawerInternal: FC<DrawerInternalProps> = ({
       fullHeight
       onOpenChange={setLocalIsOpen}
       container={container}
+      onWidthChange={onWidthChange}
     >
       {_memoizedDialogLayout}
     </DialogWrapper>

--- a/packages/react/src/components/dialog-alike/F0Drawer/internal/internal-types.ts
+++ b/packages/react/src/components/dialog-alike/F0Drawer/internal/internal-types.ts
@@ -4,4 +4,12 @@ import { F0DrawerPosition, DrawerSize } from "../types"
 export type DrawerInternalProps = Omit<DialogAlikeInternalProps, "size"> & {
   size?: DrawerSize
   position?: F0DrawerPosition
+  /**
+   * Called with the drawer content's width in px on mount and whenever it
+   * changes, and with `0` when it closes. Use it to reserve space for the open
+   * drawer — e.g. offsetting a graph so a node isn't centered behind it —
+   * instead of hard-coding the width. The drawer slides in via a transform, not
+   * a width animation, so the reported value is final from the first frame.
+   */
+  onWidthChange?: (width: number) => void
 }

--- a/packages/react/src/components/dialog-alike/common/Wrapper.tsx
+++ b/packages/react/src/components/dialog-alike/common/Wrapper.tsx
@@ -91,6 +91,15 @@ export type DialogWrapperProps = {
    * side -> `#content`). Pass `null` to portal to `document.body`.
    */
   container?: HTMLElement | null
+
+  /**
+   * Called with the content box's width in px whenever it changes (mount and on
+   * resize), and with `0` once it unmounts. Lets a consumer react to the space
+   * the dialog occupies — e.g. offsetting a graph so a node isn't hidden behind a
+   * side drawer — without hard-coding the width. The slide-in animates a
+   * transform, not the width, so the reported value is final from first paint.
+   */
+  onWidthChange?: (width: number) => void
 }
 /**
  * This is a helper component to wrap the dialog content in a drawer or dialog component.
@@ -109,6 +118,7 @@ export const DialogWrapper = ({
   size = "md",
   fullHeight = false,
   container,
+  onWidthChange,
 }: DialogWrapperProps) => {
   // Use state to store the container element so we can trigger re-renders
   // when it's set. This ensures child components like F0Select get the
@@ -121,6 +131,26 @@ export const DialogWrapper = ({
     // Update state to trigger re-render so children get the new container
     setContainerElement(node)
   }, [])
+
+  // Report the content box's width to consumers that need to reserve space for
+  // the dialog (e.g. offsetting a graph so a node isn't hidden behind a side
+  // drawer). Observe the same node `setContentRef` captured; emit `0` on unmount
+  // so an offset can be cleared. Read through a ref so a changing callback
+  // identity doesn't re-create the observer.
+  const onWidthChangeRef = useRef(onWidthChange)
+  onWidthChangeRef.current = onWidthChange
+  useEffect(() => {
+    if (!containerElement || !onWidthChangeRef.current) return
+    const emit = () =>
+      onWidthChangeRef.current?.(containerElement.getBoundingClientRect().width)
+    emit()
+    const observer = new ResizeObserver(emit)
+    observer.observe(containerElement)
+    return () => {
+      observer.disconnect()
+      onWidthChangeRef.current?.(0)
+    }
+  }, [containerElement])
 
   const isSmallScreen = useIsSmallScreen()
 

--- a/packages/react/src/components/dialog-alike/common/Wrapper.tsx
+++ b/packages/react/src/components/dialog-alike/common/Wrapper.tsx
@@ -132,25 +132,29 @@ export const DialogWrapper = ({
     setContainerElement(node)
   }, [])
 
+  // The inner content box — the actually-sized element — reported by
+  // DialogContent via `contentBoxRef`. Measured (below) instead of
+  // `containerElement`, which is the full-viewport `fixed inset-0` positioner.
+  const [contentBox, setContentBox] = useState<HTMLDivElement | null>(null)
+
   // Report the content box's width to consumers that need to reserve space for
   // the dialog (e.g. offsetting a graph so a node isn't hidden behind a side
-  // drawer). Observe the same node `setContentRef` captured; emit `0` on unmount
-  // so an offset can be cleared. Read through a ref so a changing callback
-  // identity doesn't re-create the observer.
+  // drawer). Emit `0` on unmount so an offset can be cleared. Read the callback
+  // through a ref so a changing identity doesn't re-create the observer.
   const onWidthChangeRef = useRef(onWidthChange)
   onWidthChangeRef.current = onWidthChange
   useEffect(() => {
-    if (!containerElement || !onWidthChangeRef.current) return
+    if (!contentBox || !onWidthChangeRef.current) return
     const emit = () =>
-      onWidthChangeRef.current?.(containerElement.getBoundingClientRect().width)
+      onWidthChangeRef.current?.(contentBox.getBoundingClientRect().width)
     emit()
     const observer = new ResizeObserver(emit)
-    observer.observe(containerElement)
+    observer.observe(contentBox)
     return () => {
       observer.disconnect()
       onWidthChangeRef.current?.(0)
     }
-  }, [containerElement])
+  }, [contentBox])
 
   const isSmallScreen = useIsSmallScreen()
 
@@ -242,6 +246,7 @@ export const DialogWrapper = ({
         >
           <DialogContent
             ref={setContentRef}
+            contentBoxRef={setContentBox}
             container={container}
             defaultContainerId={defaultContainerId}
             wrapperClassName={dialogWrapperClassName({ position })}

--- a/packages/react/src/components/dialog-alike/common/__tests__/Wrapper.test.tsx
+++ b/packages/react/src/components/dialog-alike/common/__tests__/Wrapper.test.tsx
@@ -14,14 +14,19 @@ const { dialogContentSpy } = vi.hoisted(() => ({ dialogContentSpy: vi.fn() }))
 vi.mock("../dialog-primitive", () => ({
   // Passthrough so its children always render.
   Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
-  // forwardRef so the ref DialogWrapper passes doesn't warn; the spy records props.
-  DialogContent: forwardRef(function DialogContentMock(
-    props: { children?: ReactNode },
-    _ref
-  ) {
-    dialogContentSpy(props)
-    return <div data-testid="dialog-content">{props.children}</div>
-  }),
+  // forwardRef so the ref DialogWrapper passes doesn't warn; the spy records
+  // props. The ref is attached to the div so DialogWrapper's content-width
+  // observer has a real node to measure.
+  DialogContent: forwardRef<HTMLDivElement, { children?: ReactNode }>(
+    function DialogContentMock(props, ref) {
+      dialogContentSpy(props)
+      return (
+        <div ref={ref} data-testid="dialog-content">
+          {props.children}
+        </div>
+      )
+    }
+  ),
 }))
 
 // Force the desktop (Dialog) branch so DialogContent renders — on small screens
@@ -78,5 +83,51 @@ describe("DialogWrapper portal target", () => {
     expect(dialogContentSpy).toHaveBeenCalledWith(
       expect.objectContaining({ container })
     )
+  })
+})
+
+describe("DialogWrapper onWidthChange", () => {
+  const baseProps = {
+    isOpen: true,
+    onOpenChange: vi.fn(),
+    onClose: vi.fn(),
+    children: <div>Content</div>,
+    position: "right" as const,
+  }
+
+  // jsdom has no ResizeObserver and no real layout, so stub both: a no-op
+  // observer (mount already emits once directly) and a fixed measured width.
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      }
+    )
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      width: 492,
+    } as DOMRect)
+  })
+
+  it("reports the content width once the drawer mounts", () => {
+    const onWidthChange = vi.fn()
+    render(<DialogWrapper {...baseProps} onWidthChange={onWidthChange} />)
+
+    expect(onWidthChange).toHaveBeenCalledWith(492)
+  })
+
+  it("reports 0 when the drawer unmounts so the offset can be cleared", () => {
+    const onWidthChange = vi.fn()
+    const { unmount } = render(
+      <DialogWrapper {...baseProps} onWidthChange={onWidthChange} />
+    )
+    onWidthChange.mockClear()
+
+    unmount()
+
+    expect(onWidthChange).toHaveBeenCalledWith(0)
   })
 })

--- a/packages/react/src/components/dialog-alike/common/__tests__/Wrapper.test.tsx
+++ b/packages/react/src/components/dialog-alike/common/__tests__/Wrapper.test.tsx
@@ -15,18 +15,24 @@ vi.mock("../dialog-primitive", () => ({
   // Passthrough so its children always render.
   Dialog: ({ children }: { children?: ReactNode }) => <>{children}</>,
   // forwardRef so the ref DialogWrapper passes doesn't warn; the spy records
-  // props. The ref is attached to the div so DialogWrapper's content-width
-  // observer has a real node to measure.
-  DialogContent: forwardRef<HTMLDivElement, { children?: ReactNode }>(
-    function DialogContentMock(props, ref) {
-      dialogContentSpy(props)
-      return (
-        <div ref={ref} data-testid="dialog-content">
+  // props. The real DialogContent hands the inner content box to `contentBoxRef`
+  // (the element DialogWrapper measures), so the mock does the same with the div.
+  DialogContent: forwardRef<
+    HTMLDivElement,
+    {
+      children?: ReactNode
+      contentBoxRef?: (el: HTMLDivElement | null) => void
+    }
+  >(function DialogContentMock(props, ref) {
+    dialogContentSpy(props)
+    return (
+      <div ref={ref} data-testid="dialog-content">
+        <div ref={props.contentBoxRef} data-testid="dialog-content-box">
           {props.children}
         </div>
-      )
-    }
-  ),
+      </div>
+    )
+  }),
 }))
 
 // Force the desktop (Dialog) branch so DialogContent renders — on small screens
@@ -129,5 +135,23 @@ describe("DialogWrapper onWidthChange", () => {
     unmount()
 
     expect(onWidthChange).toHaveBeenCalledWith(0)
+  })
+
+  // Regression: the width must come from the inner content box (`contentBoxRef`),
+  // NOT the full-viewport `fixed inset-0` positioner the forwarded `ref` lands
+  // on. Give the two different widths and assert the box's wins.
+  it("measures the inner content box, not the full-viewport positioner", () => {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        const width =
+          this.getAttribute("data-testid") === "dialog-content-box" ? 492 : 1440
+        return { width } as DOMRect
+      }
+    )
+    const onWidthChange = vi.fn()
+    render(<DialogWrapper {...baseProps} onWidthChange={onWidthChange} />)
+
+    expect(onWidthChange).toHaveBeenCalledWith(492)
+    expect(onWidthChange).not.toHaveBeenCalledWith(1440)
   })
 })

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
@@ -40,6 +40,12 @@ export const DialogContent = forwardRef<
      */
     defaultContainerId?: string
     animation?: DialogAnimation
+    /**
+     * Ref to the inner content box — the actually-sized element (`max-w-*`),
+     * not the full-viewport `fixed inset-0` positioner the forwarded `ref`
+     * lands on. Lets a parent measure the visible panel's width.
+     */
+    contentBoxRef?: (el: HTMLDivElement | null) => void
   }
 >(
   (
@@ -50,12 +56,23 @@ export const DialogContent = forwardRef<
       children,
       container: propContainer,
       defaultContainerId = "content",
+      contentBoxRef,
       ...props
     },
     ref
   ) => {
     const [container, setContainer] = useState<HTMLElement | null>()
-    const contentRef = useRef<HTMLDivElement>(null)
+    // Mutable (not RefObject) because `setContentEl` assigns `.current` directly.
+    const contentRef = useRef<HTMLDivElement | null>(null)
+    // Keep `contentRef` (used by `shake`) and hand the same node to the optional
+    // `contentBoxRef` so a parent can measure the box.
+    const setContentEl = useCallback(
+      (el: HTMLDivElement | null) => {
+        contentRef.current = el
+        contentBoxRef?.(el)
+      },
+      [contentBoxRef]
+    )
 
     // Shake the content when the dialog is opened and clicked outside in modal mode
     const shake = useCallback(() => {
@@ -121,7 +138,7 @@ export const DialogContent = forwardRef<
           }}
         >
           <div
-            ref={contentRef}
+            ref={setContentEl}
             className={cn(
               "relative flex w-[90%] flex-col rounded-xl bg-f1-background shadow-lg pointer-events-auto",
               "group-data-[state=open]/dialog:animate-in group-data-[state=closed]/dialog:animate-out overflow-hidden",

--- a/packages/react/src/patterns/F0Graph/F0Graph.tsx
+++ b/packages/react/src/patterns/F0Graph/F0Graph.tsx
@@ -13,6 +13,7 @@ import type {
   GraphEdge,
   GraphNode,
   LayoutEngine,
+  ViewportInset,
   ZoomLevel,
   ZoomPreset,
   ZoomThresholds,
@@ -130,6 +131,40 @@ export interface F0GraphProps<T = unknown> {
    * still animate with the smooth pan.
    */
   initialFocusNodeId?: string
+  /**
+   * Whether clicking a node flies to it — centering and zooming in close on the
+   * clicked node. **Defaults to `true`**: every consumer gets the fly-to without
+   * wiring anything. Pass `false` to keep a static camera on click (selection
+   * still happens, the viewport just doesn't move). Keyboard navigation is never
+   * affected — it scrolls focus its own way and this only reacts to clicks.
+   *
+   * Re-fires on **every** click, including a click on the already-selected node,
+   * so a click after panning away always re-centers.
+   */
+  centerOnNodeClick?: boolean
+  /**
+   * Zoom level a node click lands on. Defaults to `NODE_CLICK_ZOOM` (`1.5`),
+   * clamped to `maxZoom`. A click is a deliberate "take me here", so it zooms in
+   * closer than the initial-focus frame regardless of the current zoom (clicking
+   * from far out still lands close; clicking from deep in doesn't stay deeper).
+   * Lower it for a dense graph where `1.5` feels too tight. Ignored when
+   * `centerOnNodeClick` is `false`.
+   */
+  nodeClickZoom?: number
+  /**
+   * Region of the canvas (in screen px) covered by external chrome — typically a
+   * side panel / drawer the consumer opens over the graph. Every fly-to path
+   * (click, `focusedNode`, `focusNode(id)`, "Find me", initial focus, fit-view)
+   * shifts its target so the node lands centered in the *free* area beside the
+   * panel instead of behind it. The side is encoded by which key is set (a
+   * right-hand drawer sets `right`; a left-hand one or RTL sets `left`).
+   *
+   * The consumer supplies the value — F0Graph has no notion of the panel. For a
+   * fixed-width drawer, pass its width while it's open (e.g. `{ right: 480 }`)
+   * and `undefined` / `{}` while it's closed. All-zero behaves exactly as if
+   * there were no inset.
+   */
+  viewportInset?: ViewportInset
 
   // ---- Layout ----
   /** Layout sizing hint passed to the built-in layout engine. Defaults to 256. Override for compact nodes (icons, file rows). */

--- a/packages/react/src/patterns/F0Graph/F0Graph.tsx
+++ b/packages/react/src/patterns/F0Graph/F0Graph.tsx
@@ -140,6 +140,11 @@ export interface F0GraphProps<T = unknown> {
    *
    * Re-fires on **every** click, including a click on the already-selected node,
    * so a click after panning away always re-centers.
+   *
+   * The fly starts a beat after the click (the same settle delay the reveal path
+   * uses) so it can see a `viewportInset` the click itself brought in — the usual
+   * case, where clicking a node is what opens the side panel. A second click
+   * within that window supersedes the first.
    */
   centerOnNodeClick?: boolean
   /**

--- a/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
@@ -43,6 +43,10 @@ const meta = {
     maxZoom: {
       control: { type: "number", min: 1, max: 4, step: 0.1 },
     },
+    centerOnNodeClick: { control: "boolean" },
+    nodeClickZoom: {
+      control: { type: "number", min: 0.1, max: 2, step: 0.1 },
+    },
 
     // ---- Hidden from controls ----
     nodes: { table: { disable: true } },
@@ -60,6 +64,7 @@ const meta = {
     onNodeSelect: { table: { disable: true } },
     focusedNode: { table: { disable: true } },
     highlightedNodes: { table: { disable: true } },
+    viewportInset: { table: { disable: true } },
     layoutEngine: { table: { disable: true } },
     controlLabels: { table: { disable: true } },
     onZoomLevelChange: { table: { disable: true } },
@@ -740,6 +745,77 @@ export const InitialFocus: Story = {
     defaultExpandDepth: 2,
     initialFocusNodeId: "dept-4-member-100",
   },
+}
+
+// ─── Click-to-focus + side-panel inset ─────────────────────────────
+
+/**
+ * Clicking a node flies to it (F0Graph's default `centerOnNodeClick`), zooming
+ * in close and centering it. This demo opens a fixed-width (480px) side panel on
+ * selection and passes `viewportInset={{ right: 480 }}` while it's open, so the
+ * clicked node lands centered in the free area beside the panel instead of behind
+ * it. Click nodes with the panel open vs. closed to see the offset; click the
+ * empty canvas to dismiss the panel.
+ */
+function ClickToFocusWithSidePanelDemo() {
+  const nodes = makeLargeTree(600)
+  const [selected, setSelected] = useState<GraphNode<Employee> | null>(null)
+  const PANEL_WIDTH = 480
+  const byId = useCallback(
+    (id: string) => nodes.find((n) => n.id === id) ?? null,
+    [nodes]
+  )
+
+  return (
+    <div className="relative h-full w-full overflow-hidden">
+      <F0Graph<Employee>
+        nodes={nodes}
+        renderNode={renderEmployee}
+        showControls
+        defaultExpandDepth={2}
+        selectionMode="single"
+        // The side panel is a fixed-width drawer; feed its width as the inset
+        // while it's open so every fly-to clears it. `0` while closed behaves
+        // exactly as if there were no inset.
+        viewportInset={{ right: selected ? PANEL_WIDTH : 0 }}
+        onSelectedNodesChange={(next) => {
+          const id = [...next][0]
+          setSelected(id ? byId(id) : null)
+        }}
+        onPaneClick={() => setSelected(null)}
+      />
+      {selected && (
+        <div
+          className="absolute right-0 top-0 z-20 flex h-full flex-col gap-2 border-l border-f1-border bg-f1-background p-6 shadow-lg"
+          style={{ width: PANEL_WIDTH }}
+        >
+          <div className="text-lg font-semibold text-f1-foreground">
+            {selected.data.name}
+          </div>
+          <div className="text-f1-foreground-secondary">
+            {selected.data.title}
+          </div>
+          <F0Button
+            variant="neutral"
+            label="Close"
+            onClick={() => setSelected(null)}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+export const ClickToFocusWithSidePanel: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Click a node to fly to it (default `centerOnNodeClick`). A fixed-width side panel opens on selection and `viewportInset={{ right: 480 }}` keeps the centered node in the visible area beside it. Click the canvas to dismiss.",
+      },
+    },
+  },
+  render: () => <ClickToFocusWithSidePanelDemo />,
 }
 
 // ─── Viewport virtualization (A0 harness + A1 windowing) ───────────

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
@@ -12,6 +12,7 @@ import {
 import { screen, zeroRender } from "@/testing/test-utils"
 
 import type { GraphNode } from "../types"
+import { FOCUS_SETTLE_DELAY_MS } from "../constants"
 import { F0Graph } from "../F0Graph"
 
 // Spy React Flow instance so we can observe the fly-to on click. Only the public
@@ -59,7 +60,7 @@ afterEach(() => vi.restoreAllMocks())
 // handler directly (it resolves `.react-flow__node[data-id]` under the pointer,
 // exactly as it does with a real node). This exercises the click → select + fly
 // wiring without depending on React Flow's DOM output.
-function clickNode(id: string) {
+function pressNode(id: string) {
   const tree = screen.getByRole("tree", { name: "Graph view" })
   const nodeEl = document.createElement("div")
   nodeEl.className = "react-flow__node"
@@ -74,6 +75,23 @@ function clickNode(id: string) {
   }
   fire("pointerdown")
   fire("pointerup")
+  return nodeEl
+}
+
+// The fly is deferred by FOCUS_SETTLE_DELAY_MS so it can see a side panel the
+// click opened, so tests must let that delay elapse before asserting.
+async function settleFly() {
+  await act(async () => {
+    await new Promise((resolve) =>
+      setTimeout(resolve, FOCUS_SETTLE_DELAY_MS + 20)
+    )
+  })
+}
+
+/** Press a node and wait for the deferred fly to run. */
+async function clickNode(id: string) {
+  const nodeEl = pressNode(id)
+  await settleFly()
   return nodeEl
 }
 
@@ -96,9 +114,9 @@ const mount = (props: Partial<React.ComponentProps<typeof F0Graph>> = {}) => {
 }
 
 describe("F0Graph — fly to node on click (default)", () => {
-  it("flies to the clicked node at NODE_CLICK_ZOOM (1.5) by default", () => {
+  it("flies to the clicked node at NODE_CLICK_ZOOM (1.5) by default", async () => {
     mount()
-    clickNode("root")
+    await clickNode("root")
     expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(1)
     expect(mockReactFlow.setCenter).toHaveBeenLastCalledWith(
       expect.any(Number),
@@ -107,16 +125,16 @@ describe("F0Graph — fly to node on click (default)", () => {
     )
   })
 
-  it("re-centers on every click, including a repeat click on the same node", () => {
+  it("re-centers on every click, including a repeat click on the same node", async () => {
     mount()
-    clickNode("root")
-    clickNode("root")
+    await clickNode("root")
+    await clickNode("root")
     expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(2)
   })
 
-  it("honors a custom nodeClickZoom, clamped to maxZoom", () => {
+  it("honors a custom nodeClickZoom, clamped to maxZoom", async () => {
     mount({ nodeClickZoom: 5, maxZoom: 2 })
-    clickNode("root")
+    await clickNode("root")
     expect(mockReactFlow.setCenter).toHaveBeenLastCalledWith(
       expect.any(Number),
       expect.any(Number),
@@ -124,24 +142,67 @@ describe("F0Graph — fly to node on click (default)", () => {
     )
   })
 
-  it("does not move the camera when centerOnNodeClick is false", () => {
+  it("does not move the camera when centerOnNodeClick is false", async () => {
     mount({ centerOnNodeClick: false })
-    clickNode("root")
+    await clickNode("root")
     expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
     expect(mockReactFlow.fitView).not.toHaveBeenCalled()
   })
 
-  it("offsets the center for a right-side viewportInset", () => {
+  it("offsets the center for a right-side viewportInset", async () => {
     const noInset = mount()
-    clickNode("root")
+    await clickNode("root")
     const noInsetX = mockReactFlow.setCenter.mock.calls[0][0]
     noInset.unmount()
 
     mount({ viewportInset: { right: 480 } })
-    clickNode("root")
+    await clickNode("root")
     const insetX = mockReactFlow.setCenter.mock.calls[0][0]
 
     // Right inset pushes the target to the right so the node clears the panel.
     expect(insetX).toBeGreaterThan(noInsetX)
+  })
+})
+
+describe("F0Graph — click fly waits for a panel the click opens", () => {
+  // The real consumer sequence: the click itself opens the side panel, so
+  // `viewportInset` only arrives on a later render. Flying synchronously would
+  // read no inset and center on the full canvas, leaving the node behind the
+  // panel that just opened — so the fly must see the inset that follows it.
+  it("uses an inset that only arrives after the click", async () => {
+    const baseline = mount()
+    await clickNode("root")
+    const noInsetX = mockReactFlow.setCenter.mock.calls[0][0]
+    baseline.unmount()
+
+    const { rerender } = mount()
+    const graph = (props: Partial<React.ComponentProps<typeof F0Graph>>) => (
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderNodeFn}
+          expandedNodes={new Set(["root"])}
+          {...props}
+        />
+      </div>
+    )
+
+    pressNode("root")
+    expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
+
+    // The panel opens as a result of the click and reports its width.
+    rerender(graph({ viewportInset: { right: 480 } }))
+    await settleFly()
+
+    expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(1)
+    expect(mockReactFlow.setCenter.mock.calls[0][0]).toBeGreaterThan(noInsetX)
+  })
+
+  it("a second click supersedes a still-pending fly instead of queueing both", async () => {
+    mount()
+    pressNode("root")
+    pressNode("a")
+    await settleFly()
+    expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
@@ -1,0 +1,147 @@
+import { act } from "react"
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import type { GraphNode } from "../types"
+import { F0Graph } from "../F0Graph"
+
+// Spy React Flow instance so we can observe the fly-to on click. Only the public
+// `useReactFlow` is mocked; the ReactFlow component itself renders normally.
+const mockReactFlow = {
+  fitView: vi.fn(),
+  setCenter: vi.fn(),
+  getZoom: () => 1,
+  getNode: vi.fn(),
+  fitBounds: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  setViewport: vi.fn(),
+  getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>()
+  return { ...actual, useReactFlow: () => mockReactFlow }
+})
+
+const NODES: GraphNode<string>[] = [
+  { id: "root", parentId: null, data: "Root", childrenCount: 1 },
+  { id: "a", parentId: "root", data: "A" },
+]
+
+const renderNodeFn = (node: GraphNode<string>) => (
+  <span data-testid={`node-${node.id}`}>{node.data}</span>
+)
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+beforeEach(() => {
+  mockReactFlow.setCenter.mockClear()
+  mockReactFlow.fitView.mockClear()
+})
+afterEach(() => vi.restoreAllMocks())
+
+// React Flow does not render `.react-flow__node` elements in jsdom, so we inject
+// a stand-in under the tree container and drive the real canvas `onPointerUp`
+// handler directly (it resolves `.react-flow__node[data-id]` under the pointer,
+// exactly as it does with a real node). This exercises the click → select + fly
+// wiring without depending on React Flow's DOM output.
+function clickNode(id: string) {
+  const tree = screen.getByRole("tree", { name: "Graph view" })
+  const nodeEl = document.createElement("div")
+  nodeEl.className = "react-flow__node"
+  nodeEl.setAttribute("data-id", id)
+  tree.appendChild(nodeEl)
+
+  const fire = (type: string) => {
+    const ev = new MouseEvent(type, { bubbles: true, clientX: 10, clientY: 10 })
+    act(() => {
+      nodeEl.dispatchEvent(ev)
+    })
+  }
+  fire("pointerdown")
+  fire("pointerup")
+  return nodeEl
+}
+
+// Mount, then clear the camera spies so only the click's calls are counted
+// (isolates the click behavior from any mount-time framing).
+const mount = (props: Partial<React.ComponentProps<typeof F0Graph>> = {}) => {
+  const view = zeroRender(
+    <div style={{ width: 800, height: 600 }}>
+      <F0Graph
+        nodes={NODES}
+        renderNode={renderNodeFn}
+        expandedNodes={new Set(["root"])}
+        {...props}
+      />
+    </div>
+  )
+  mockReactFlow.setCenter.mockClear()
+  mockReactFlow.fitView.mockClear()
+  return view
+}
+
+describe("F0Graph — fly to node on click (default)", () => {
+  it("flies to the clicked node at NODE_CLICK_ZOOM (1.5) by default", () => {
+    mount()
+    clickNode("root")
+    expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(1)
+    expect(mockReactFlow.setCenter).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      expect.objectContaining({ zoom: 1.5, duration: 300 })
+    )
+  })
+
+  it("re-centers on every click, including a repeat click on the same node", () => {
+    mount()
+    clickNode("root")
+    clickNode("root")
+    expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(2)
+  })
+
+  it("honors a custom nodeClickZoom, clamped to maxZoom", () => {
+    mount({ nodeClickZoom: 5, maxZoom: 2 })
+    clickNode("root")
+    expect(mockReactFlow.setCenter).toHaveBeenLastCalledWith(
+      expect.any(Number),
+      expect.any(Number),
+      expect.objectContaining({ zoom: 2 })
+    )
+  })
+
+  it("does not move the camera when centerOnNodeClick is false", () => {
+    mount({ centerOnNodeClick: false })
+    clickNode("root")
+    expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
+    expect(mockReactFlow.fitView).not.toHaveBeenCalled()
+  })
+
+  it("offsets the center for a right-side viewportInset", () => {
+    const noInset = mount()
+    clickNode("root")
+    const noInsetX = mockReactFlow.setCenter.mock.calls[0][0]
+    noInset.unmount()
+
+    mount({ viewportInset: { right: 480 } })
+    clickNode("root")
+    const insetX = mockReactFlow.setCenter.mock.calls[0][0]
+
+    // Right inset pushes the target to the right so the node clears the panel.
+    expect(insetX).toBeGreaterThan(noInsetX)
+  })
+})

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
@@ -149,6 +149,16 @@ describe("F0Graph — fly to node on click (default)", () => {
     expect(mockReactFlow.fitView).not.toHaveBeenCalled()
   })
 
+  // Regression: the canvas pointer-up also fires for the expander/collapser
+  // pseudo-nodes. Clicking one (to toggle) must not fly — it isn't a real node,
+  // so the camera would chase the toggle's shifting position.
+  it("does not fly when the expander/collapser pseudo-node is clicked", async () => {
+    mount()
+    await clickNode("expander-root")
+    expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
+    expect(mockReactFlow.fitView).not.toHaveBeenCalled()
+  })
+
   it("offsets the center for a right-side viewportInset", async () => {
     const noInset = mount()
     await clickNode("root")

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -403,11 +403,12 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
                 : { duration: 0.12, ease: [0.23, 1, 0.32, 1] }
             }
             className="max-w-[256px]"
-            // Tags are informational: clicking a tag must not select/center the
-            // node. Two paths select a node: the node-level `onClick` (centering
-            // + itemOnClick) — swallowed here via stopPropagation — and the
-            // canvas `onPointerUp` handler, which fires on pointerup regardless
-            // of this click handler. `data-no-node-select` tells that handler to
+            // Tags are informational: clicking a tag must not select the node.
+            // Two paths select a node: the node-level `onClick` (selection, plus
+            // any consumer `itemOnClick`) — swallowed here via stopPropagation —
+            // and the canvas `onPointerUp` handler, which selects and (by
+            // default) flies to the node, and fires on pointerup regardless of
+            // this click handler. `data-no-node-select` tells that handler to
             // skip selection when the pointer went down on a tag.
             data-no-node-select
             onClick={(e) => e.stopPropagation()}

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -603,7 +603,12 @@ export function F0GraphView<T = unknown>(
   const handleNodeClick = useCallback(
     (id: string) => {
       selectNode(id)
-      if (!centerOnNodeClick) return
+      // Fly only for real data nodes. The canvas pointer-up also fires for the
+      // expander/collapser pseudo-nodes (their `.react-flow__node` wrappers carry
+      // `expander-`/`collapser-` ids, absent from `nodeMap`); flying to one would
+      // chase the toggle's position as it shifts on expand/collapse. Gating on
+      // `nodeMap` leaves the toggle itself untouched.
+      if (!centerOnNodeClick || !nodeMap.has(id)) return
       // A second click supersedes a still-pending fly rather than queueing both.
       if (nodeClickFlyTimerRef.current) {
         clearTimeout(nodeClickFlyTimerRef.current)
@@ -613,7 +618,7 @@ export function F0GraphView<T = unknown>(
         FOCUS_SETTLE_DELAY_MS
       )
     },
-    [selectNode, centerOnNodeClick]
+    [selectNode, centerOnNodeClick, nodeMap]
   )
 
   useEffect(() => {

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -582,10 +582,36 @@ export function F0GraphView<T = unknown>(
   // Click handler shared by both selection paths: select the node, then (unless
   // opted out) fly to it. Kept out of `selectNode` itself so keyboard navigation
   // — which also calls `selectNode` — never moves the camera.
+  //
+  // The fly is deferred by the same settle delay the `focusedNode` path uses,
+  // because the consumer's side panel usually opens *as a result of* this click:
+  // its `viewportInset` only reaches us on a later render, so flying synchronously
+  // would read an empty inset and center on the full canvas — the very case the
+  // inset exists for — and the panel would then open over the node.
+  const nodeClickFlyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+  useEffect(
+    () => () => {
+      if (nodeClickFlyTimerRef.current) {
+        clearTimeout(nodeClickFlyTimerRef.current)
+      }
+    },
+    []
+  )
+
   const handleNodeClick = useCallback(
     (id: string) => {
       selectNode(id)
-      if (centerOnNodeClick) flyToNodeClickRef.current(id)
+      if (!centerOnNodeClick) return
+      // A second click supersedes a still-pending fly rather than queueing both.
+      if (nodeClickFlyTimerRef.current) {
+        clearTimeout(nodeClickFlyTimerRef.current)
+      }
+      nodeClickFlyTimerRef.current = setTimeout(
+        () => flyToNodeClickRef.current(id),
+        FOCUS_SETTLE_DELAY_MS
+      )
     },
     [selectNode, centerOnNodeClick]
   )

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -38,10 +38,12 @@ import {
   BACKGROUND_DOT_GAP,
   EMPTY_HIGHLIGHTED_NODES,
   FIT_VIEW_PADDING_LOOSE,
+  FIT_VIEW_PADDING_TIGHT,
   FOCUS_SETTLE_DELAY_MS,
   INITIAL_FOCUS_MAX_ZOOM,
   LARGE_GRAPH_SNAP_THRESHOLD,
   NODE_CLICK_DISTANCE_SQ,
+  NODE_CLICK_ZOOM,
 } from "../../constants"
 import {
   F0GraphActionsContext,
@@ -162,6 +164,9 @@ export function F0GraphView<T = unknown>(
     onPaneClick: onPaneClickProp,
     focusedNode,
     initialFocusNodeId,
+    centerOnNodeClick = true,
+    nodeClickZoom,
+    viewportInset,
     highlightedNodes: highlightedProp,
     nodeWidth: nodeWidthProp,
     nodeHeight: nodeHeightProp,
@@ -323,6 +328,8 @@ export function F0GraphView<T = unknown>(
     handleFitView,
     handleFocusUser,
     centerOnNode,
+    getFitPadding,
+    hasViewportInset,
   } = useGraphViewport({
     defaultZoom,
     zoomPreset,
@@ -333,6 +340,7 @@ export function F0GraphView<T = unknown>(
     nodeWindowingActive: enableNodeWindowing ?? false,
     getContentBounds,
     getNodePosition: getNodePositionStable,
+    viewportInset,
   })
 
   // Windowing only actually drives the render once the first viewport has settled
@@ -504,7 +512,21 @@ export function F0GraphView<T = unknown>(
   useEffect(() => {
     if (didInitialFitRef.current || renderedNodeIds.length === 0) return
     didInitialFitRef.current = true
-    reactFlow.fitView(initialFitViewOptions)
+    // Honor the inset on the first frame too, so an already-open panel never
+    // opens the graph with the focus target behind it. When there's no inset the
+    // options are passed through untouched (identical to before).
+    reactFlow.fitView(
+      hasViewportInset
+        ? {
+            ...initialFitViewOptions,
+            // Base matches React Flow's own default fitView padding (0.1), so
+            // with no inset this stays byte-identical to the untouched call.
+            padding: getFitPadding(FIT_VIEW_PADDING_TIGHT),
+          }
+        : initialFitViewOptions
+    )
+    // Guarded by `didInitialFitRef` so it runs once; `hasViewportInset` /
+    // `getFitPadding` are read fresh at that point and intentionally omitted.
   }, [renderedNodeIds.length, initialFitViewOptions, reactFlow])
 
   // ── Fly to the consumer-controlled focused node ──
@@ -531,10 +553,43 @@ export function F0GraphView<T = unknown>(
     reactFlow.fitView({
       nodes: framed ?? [{ id }],
       duration: 300,
-      padding: FIT_VIEW_PADDING_LOOSE,
+      padding: getFitPadding(FIT_VIEW_PADDING_LOOSE),
       maxZoom: Math.min(INITIAL_FOCUS_MAX_ZOOM, maxZoom),
     })
   }
+
+  // ── Fly to a clicked node ──
+  // Unlike `flyToFocusedRef` (which frames the node with its children at a capped
+  // zoom for context), a click is a deliberate "take me here", so it centers on
+  // the node alone and lands closer (`nodeClickZoom` / `NODE_CLICK_ZOOM`, clamped
+  // to `maxZoom`) regardless of the current zoom. Read via a ref so `handleNodeClick`
+  // stays stable and always sees the latest props. `centerOnNode` uses the node's
+  // layout position, so it works even for a node windowed out of the store and
+  // applies the `viewportInset` offset; the id-based fit is an unreachable
+  // fallback (a just-clicked node always has a position).
+  const flyToNodeClickRef = useRef<(id: string) => void>(() => {})
+  flyToNodeClickRef.current = (id: string) => {
+    const zoom = Math.min(nodeClickZoom ?? NODE_CLICK_ZOOM, maxZoom)
+    if (centerOnNode(id, 300, zoom)) return
+    reactFlow.fitView({
+      nodes: [{ id }],
+      duration: 300,
+      padding: getFitPadding(FIT_VIEW_PADDING_TIGHT),
+      maxZoom: zoom,
+    })
+  }
+
+  // Click handler shared by both selection paths: select the node, then (unless
+  // opted out) fly to it. Kept out of `selectNode` itself so keyboard navigation
+  // — which also calls `selectNode` — never moves the camera.
+  const handleNodeClick = useCallback(
+    (id: string) => {
+      selectNode(id)
+      if (centerOnNodeClick) flyToNodeClickRef.current(id)
+    },
+    [selectNode, centerOnNodeClick]
+  )
+
   useEffect(() => {
     if (!focusedNode) return
     // Fires only when `focusedNode` transitions to a new value (entry,
@@ -675,7 +730,10 @@ export function F0GraphView<T = unknown>(
                           target?.closest<HTMLElement>(".react-flow__node")
                         if (!nodeEl) return
                         const id = nodeEl.getAttribute("data-id")
-                        if (id) selectNode(id)
+                        // select + fly-to (the fly is opt-out via
+                        // `centerOnNodeClick`). This is the click-only path;
+                        // keyboard selection goes through `selectNode` directly.
+                        if (id) handleNodeClick(id)
                       }}
                       className="h-full w-full"
                     >

--- a/packages/react/src/patterns/F0Graph/constants.ts
+++ b/packages/react/src/patterns/F0Graph/constants.ts
@@ -73,3 +73,10 @@ export const LARGE_GRAPH_SNAP_THRESHOLD = 700
 // zoomed-in; capping lower opens the node with surrounding context (parent /
 // siblings / reports visible). The user can still zoom in further afterwards.
 export const INITIAL_FOCUS_MAX_ZOOM = 1
+
+// Zoom applied when a node is clicked. A click is a deliberate "take me to this
+// node", so it lands closer than the initial frame (`INITIAL_FOCUS_MAX_ZOOM`),
+// which deliberately opens wide with surrounding context. Centered on the node
+// alone via `setCenter`, clamped to the graph's `maxZoom` at the call site.
+// Overridable per graph via the `nodeClickZoom` prop.
+export const NODE_CLICK_ZOOM = 1.5

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphViewport.test.tsx
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphViewport.test.tsx
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRenderHook } from "@/testing/test-utils"
+
+import type { PositionedNode, ViewportInset } from "../../types"
+import { FIT_VIEW_PADDING_TIGHT } from "../../constants"
+import { useGraphViewport } from "../useGraphViewport"
+
+// Spy React Flow instance + store so we can assert on the camera calls without a
+// real canvas. (Names must start with `mock` for the hoisted vi.mock factory.)
+const mockReactFlow = {
+  fitView: vi.fn(),
+  setCenter: vi.fn(),
+  fitBounds: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  setViewport: vi.fn(),
+  getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}
+const mockStoreState = { width: 1200, height: 800 }
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>()
+  return {
+    ...actual,
+    useReactFlow: () => mockReactFlow,
+    useStoreApi: () => ({ getState: () => mockStoreState }),
+  }
+})
+
+const POS: PositionedNode = { id: "n", x: 100, y: 200, width: 256, height: 56 }
+// Center of POS: x = 100 + 256/2 = 228, y = 200 + 56/2 = 228.
+const CENTER_X = 228
+const CENTER_Y = 228
+
+const setup = (opts?: {
+  viewportInset?: ViewportInset
+  defaultZoom?: number
+}) =>
+  zeroRenderHook(
+    (props: { viewportInset?: ViewportInset; defaultZoom?: number }) =>
+      useGraphViewport({
+        defaultZoom: props.defaultZoom ?? 1,
+        getNodePosition: (id) => (id === "n" ? POS : undefined),
+        viewportInset: props.viewportInset,
+      }),
+    { initialProps: opts ?? {} }
+  )
+
+afterEach(() => {
+  mockReactFlow.setCenter.mockClear()
+  mockReactFlow.fitView.mockClear()
+})
+
+describe("useGraphViewport — centerOnNode zoom", () => {
+  it("centers on the node at defaultZoom when no zoom is passed", () => {
+    const { result } = setup({ defaultZoom: 1 })
+    expect(result.current.centerOnNode("n", 300)).toBe(true)
+    expect(mockReactFlow.setCenter).toHaveBeenCalledWith(CENTER_X, CENTER_Y, {
+      duration: 300,
+      zoom: 1,
+    })
+  })
+
+  it("centers at the explicit click zoom, independent of the current camera", () => {
+    const { result } = setup({ defaultZoom: 1 })
+    result.current.centerOnNode("n", 300, 1.5)
+    expect(mockReactFlow.setCenter).toHaveBeenCalledWith(CENTER_X, CENTER_Y, {
+      duration: 300,
+      zoom: 1.5,
+    })
+  })
+
+  it("returns false and does not move when the position is unknown", () => {
+    const { result } = setup()
+    expect(result.current.centerOnNode("missing", 300)).toBe(false)
+    expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
+  })
+})
+
+describe("useGraphViewport — centerOnNode viewportInset offset", () => {
+  it("shifts right by half the right inset (in flow units) so the node clears a right panel", () => {
+    const { result } = setup({ viewportInset: { right: 480 }, defaultZoom: 1 })
+    // shiftX = (480 - 0) / 2 / zoom(1.5) = 160
+    result.current.centerOnNode("n", 300, 1.5)
+    expect(mockReactFlow.setCenter).toHaveBeenCalledWith(
+      CENTER_X + 160,
+      CENTER_Y,
+      { duration: 300, zoom: 1.5 }
+    )
+  })
+
+  it("shifts left for a left inset (RTL / left-hand panel)", () => {
+    const { result } = setup({ viewportInset: { left: 480 }, defaultZoom: 1 })
+    // shiftX = (0 - 480) / 2 / zoom(1) = -240
+    result.current.centerOnNode("n", 300, 1)
+    expect(mockReactFlow.setCenter).toHaveBeenCalledWith(
+      CENTER_X - 240,
+      CENTER_Y,
+      { duration: 300, zoom: 1 }
+    )
+  })
+
+  it("shifts vertically for top/bottom insets", () => {
+    const { result } = setup({ viewportInset: { bottom: 200 }, defaultZoom: 1 })
+    // shiftY = (200 - 0) / 2 / zoom(1) = 100
+    result.current.centerOnNode("n", 300, 1)
+    expect(mockReactFlow.setCenter).toHaveBeenCalledWith(
+      CENTER_X,
+      CENTER_Y + 100,
+      { duration: 300, zoom: 1 }
+    )
+  })
+
+  it("with no inset behaves exactly as before (no shift)", () => {
+    const { result } = setup({ viewportInset: {}, defaultZoom: 1 })
+    result.current.centerOnNode("n", 300, 1)
+    expect(mockReactFlow.setCenter).toHaveBeenCalledWith(CENTER_X, CENTER_Y, {
+      duration: 300,
+      zoom: 1,
+    })
+  })
+})
+
+describe("useGraphViewport — getFitPadding / hasViewportInset", () => {
+  it("returns the plain base fraction when there is no inset", () => {
+    const { result } = setup()
+    expect(result.current.hasViewportInset).toBe(false)
+    expect(result.current.getFitPadding(FIT_VIEW_PADDING_TIGHT)).toBe(
+      FIT_VIEW_PADDING_TIGHT
+    )
+  })
+
+  it("layers the px inset onto the base as per-side fractions of the container", () => {
+    const { result } = setup({ viewportInset: { right: 480 } })
+    expect(result.current.hasViewportInset).toBe(true)
+    // right = base + 480/width(1200) = 0.1 + 0.4 = 0.5; others = base.
+    expect(result.current.getFitPadding(FIT_VIEW_PADDING_TIGHT)).toEqual({
+      top: FIT_VIEW_PADDING_TIGHT,
+      right: FIT_VIEW_PADDING_TIGHT + 480 / 1200,
+      bottom: FIT_VIEW_PADDING_TIGHT,
+      left: FIT_VIEW_PADDING_TIGHT,
+    })
+  })
+
+  it("handleFitView passes the inset-aware padding to fitView", () => {
+    const { result } = setup({ viewportInset: { right: 480 } })
+    result.current.handleFitView()
+    expect(mockReactFlow.fitView).toHaveBeenCalledWith(
+      expect.objectContaining({
+        padding: {
+          top: FIT_VIEW_PADDING_TIGHT,
+          right: FIT_VIEW_PADDING_TIGHT + 480 / 1200,
+          bottom: FIT_VIEW_PADDING_TIGHT,
+          left: FIT_VIEW_PADDING_TIGHT,
+        },
+      })
+    )
+  })
+})

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphViewport.test.tsx
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphViewport.test.tsx
@@ -1,3 +1,4 @@
+import type { Viewport } from "@xyflow/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { zeroRenderHook } from "@/testing/test-utils"
@@ -17,7 +18,9 @@ const mockReactFlow = {
   setViewport: vi.fn(),
   getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
 }
-const mockStoreState = { width: 1200, height: 800 }
+// `minZoom` / `maxZoom` are read by the real `getViewportForBounds` on the
+// windowing (bounds) fit path.
+const mockStoreState = { width: 1200, height: 800, minZoom: 0.05, maxZoom: 2 }
 vi.mock("@xyflow/react", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@xyflow/react")>()
   return {
@@ -46,9 +49,36 @@ const setup = (opts?: {
     { initialProps: opts ?? {} }
   )
 
+// The px React Flow derives from a numeric padding, mirroring its own formula.
+const basePx = (dimension: number, base: number) =>
+  (dimension - dimension / (1 + base)) / 2
+const BASE_PX_X = basePx(mockStoreState.width, FIT_VIEW_PADDING_TIGHT)
+const BASE_PX_Y = basePx(mockStoreState.height, FIT_VIEW_PADDING_TIGHT)
+
+/** Renders the hook on the windowing path (fit resolved from full-layout bounds). */
+const renderFitViewWithBounds = (
+  bounds: { x: number; y: number; width: number; height: number },
+  viewportInset?: ViewportInset
+) => {
+  const { result } = zeroRenderHook(
+    () =>
+      useGraphViewport({
+        defaultZoom: 1,
+        nodeWindowingActive: true,
+        getContentBounds: () => bounds,
+        viewportInset,
+      }),
+    { initialProps: {} }
+  )
+  result.current.handleFitView()
+  return mockReactFlow
+}
+
 afterEach(() => {
   mockReactFlow.setCenter.mockClear()
   mockReactFlow.fitView.mockClear()
+  mockReactFlow.fitBounds.mockClear()
+  mockReactFlow.setViewport.mockClear()
 })
 
 describe("useGraphViewport — centerOnNode zoom", () => {
@@ -130,15 +160,16 @@ describe("useGraphViewport — getFitPadding / hasViewportInset", () => {
     )
   })
 
-  it("layers the px inset onto the base as per-side fractions of the container", () => {
+  it("layers the px inset onto the base as per-side px", () => {
     const { result } = setup({ viewportInset: { right: 480 } })
     expect(result.current.hasViewportInset).toBe(true)
-    // right = base + 480/width(1200) = 0.1 + 0.4 = 0.5; others = base.
+    // The base fraction resolved to px the way React Flow does it:
+    // (dimension - dimension / (1 + base)) / 2 — then the inset added on `right`.
     expect(result.current.getFitPadding(FIT_VIEW_PADDING_TIGHT)).toEqual({
-      top: FIT_VIEW_PADDING_TIGHT,
-      right: FIT_VIEW_PADDING_TIGHT + 480 / 1200,
-      bottom: FIT_VIEW_PADDING_TIGHT,
-      left: FIT_VIEW_PADDING_TIGHT,
+      top: `${BASE_PX_Y}px`,
+      right: `${BASE_PX_X + 480}px`,
+      bottom: `${BASE_PX_Y}px`,
+      left: `${BASE_PX_X}px`,
     })
   })
 
@@ -148,12 +179,35 @@ describe("useGraphViewport — getFitPadding / hasViewportInset", () => {
     expect(mockReactFlow.fitView).toHaveBeenCalledWith(
       expect.objectContaining({
         padding: {
-          top: FIT_VIEW_PADDING_TIGHT,
-          right: FIT_VIEW_PADDING_TIGHT + 480 / 1200,
-          bottom: FIT_VIEW_PADDING_TIGHT,
-          left: FIT_VIEW_PADDING_TIGHT,
+          top: `${BASE_PX_Y}px`,
+          right: `${BASE_PX_X + 480}px`,
+          bottom: `${BASE_PX_Y}px`,
+          left: `${BASE_PX_X}px`,
         },
       })
     )
+  })
+
+  // The inset must move the fit by exactly the panel width. Asserting the px
+  // padding alone would not catch a wrong scale, so this pins the outcome: the
+  // content center must land in the middle of the region left of the panel.
+  it("frames the content in the free area when windowing uses the bounds path", () => {
+    const bounds = { x: 0, y: 0, width: 400, height: 300 }
+    const rf = renderFitViewWithBounds(bounds, { right: 480 })
+    expect(rf.setViewport).toHaveBeenCalledTimes(1)
+    const viewport = rf.setViewport.mock.calls[0]![0] as Viewport
+    const screenX = viewport.x + (bounds.x + bounds.width / 2) * viewport.zoom
+    // Free area is [0, 1200 - 480] → its center is 360.
+    expect(screenX).toBeCloseTo((mockStoreState.width - 480) / 2, 1)
+  })
+
+  it("keeps the plain fitBounds call on the windowing path with no inset", () => {
+    const bounds = { x: 0, y: 0, width: 400, height: 300 }
+    const rf = renderFitViewWithBounds(bounds)
+    expect(rf.setViewport).not.toHaveBeenCalled()
+    expect(rf.fitBounds).toHaveBeenCalledWith(bounds, {
+      duration: 400,
+      padding: FIT_VIEW_PADDING_TIGHT,
+    })
   })
 })

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphViewport.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphViewport.ts
@@ -1,4 +1,9 @@
-import { type Viewport, useReactFlow, useStoreApi } from "@xyflow/react"
+import {
+  type Viewport,
+  getViewportForBounds,
+  useReactFlow,
+  useStoreApi,
+} from "@xyflow/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { FIT_VIEW_PADDING_LOOSE, FIT_VIEW_PADDING_TIGHT } from "../constants"
@@ -69,20 +74,26 @@ export interface UseGraphViewportResult {
   centerOnNode: (nodeId: string, duration: number, zoom?: number) => boolean
   /**
    * Build a React Flow `fitView` padding that layers the current `viewportInset`
-   * on top of a symmetric base fraction, so id-based fits also clear the panel.
-   * Returns the plain `base` (identical to before) when there is no inset.
+   * on top of the symmetric `base`, so id-based fits also clear the panel. With
+   * an inset it returns per-side px; with none, the plain `base` fraction
+   * (identical to before).
    */
   getFitPadding: (base: number) => number | ViewportInsetPadding
   /** True when a non-zero `viewportInset` is currently set. */
   hasViewportInset: boolean
 }
 
-/** Per-side fitView padding (fractions), returned by {@link getFitPadding}. */
+/**
+ * Per-side fitView padding in px, returned by {@link getFitPadding}. Px (not
+ * fractions) because React Flow resolves a *numeric* padding non-linearly —
+ * `p` becomes `(dimension - dimension / (1 + p)) / 2` px per side — so a
+ * fraction cannot express "shift by exactly this many px".
+ */
 interface ViewportInsetPadding {
-  top: number
-  right: number
-  bottom: number
-  left: number
+  top: `${number}px`
+  right: `${number}px`
+  bottom: `${number}px`
+  left: `${number}px`
 }
 
 /** True when any side of the inset actually occludes part of the canvas. */
@@ -174,23 +185,27 @@ export function useGraphViewport({
     reactFlow.zoomOut({ duration: 300 })
   }, [reactFlow])
 
-  // Layer the current inset (screen px) onto a symmetric base fraction, so
+  // Layer the current inset onto the symmetric base, per side and in px, so
   // id-based fits frame their content in the free area rather than behind the
-  // panel. Each side's px is converted to a fraction of the container dimension
-  // it applies to (width for left/right, height for top/bottom) and added to the
-  // base. With no inset, returns the plain `base` — byte-for-byte the old call.
+  // panel. The base fraction is first resolved to the px React Flow would derive
+  // from it, then the inset px are added on the occluded sides — mixing the two
+  // scales instead (base + insetPx / dimension) lands far short of the panel
+  // edge, because a numeric padding is not linear in the dimension.
+  // With no inset, returns the plain `base` — byte-for-byte the old call.
   const getFitPadding = useCallback(
     (base: number): number | ViewportInsetPadding => {
       const inset = insetRef.current
       if (!insetOccludes(inset)) return base
       const { width, height } = storeApi.getState()
-      const fx = width > 0 ? width : 1
-      const fy = height > 0 ? height : 1
+      const basePx = (dimension: number) =>
+        (dimension - dimension / (1 + base)) / 2
+      const x = basePx(width)
+      const y = basePx(height)
       return {
-        top: base + (inset!.top ?? 0) / fy,
-        right: base + (inset!.right ?? 0) / fx,
-        bottom: base + (inset!.bottom ?? 0) / fy,
-        left: base + (inset!.left ?? 0) / fx,
+        top: `${y + (inset!.top ?? 0)}px`,
+        right: `${x + (inset!.right ?? 0)}px`,
+        bottom: `${y + (inset!.bottom ?? 0)}px`,
+        left: `${x + (inset!.left ?? 0)}px`,
       }
     },
     [storeApi]
@@ -201,17 +216,33 @@ export function useGraphViewport({
     // fit the window, not the graph. Fit the full layout bounds instead.
     const bounds = nodeWindowingActive ? getContentBounds?.() : null
     if (bounds) {
-      reactFlow.fitBounds(bounds, {
-        duration: 400,
-        padding: getFitPadding(FIT_VIEW_PADDING_TIGHT),
-      })
+      const padding = getFitPadding(FIT_VIEW_PADDING_TIGHT)
+      if (typeof padding === "number") {
+        reactFlow.fitBounds(bounds, { duration: 400, padding })
+        return
+      }
+      // `fitBounds`'s own `padding` is typed as a plain number, so a per-side
+      // inset cannot go through it. Resolve the viewport with the very helper
+      // `fitBounds` uses internally — that one does take per-side padding — and
+      // apply it directly, which is what `fitBounds` would have done.
+      const { width, height, minZoom, maxZoom } = storeApi.getState()
+      reactFlow.setViewport(
+        getViewportForBounds(bounds, width, height, minZoom, maxZoom, padding),
+        { duration: 400 }
+      )
       return
     }
     reactFlow.fitView({
       duration: 400,
       padding: getFitPadding(FIT_VIEW_PADDING_TIGHT),
     })
-  }, [reactFlow, nodeWindowingActive, getContentBounds, getFitPadding])
+  }, [
+    reactFlow,
+    storeApi,
+    nodeWindowingActive,
+    getContentBounds,
+    getFitPadding,
+  ])
 
   // Fly to a node by its full-layout position (works even when windowing has
   // dropped it from React Flow's store). Returns false when the position is

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphViewport.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphViewport.ts
@@ -1,9 +1,10 @@
-import { type Viewport, useReactFlow } from "@xyflow/react"
+import { type Viewport, useReactFlow, useStoreApi } from "@xyflow/react"
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { FIT_VIEW_PADDING_LOOSE, FIT_VIEW_PADDING_TIGHT } from "../constants"
 import type {
   PositionedNode,
+  ViewportInset,
   ZoomLevel,
   ZoomPreset,
   ZoomThresholds,
@@ -31,6 +32,12 @@ interface UseGraphViewportOptions {
     height: number
   } | null
   getNodePosition?: (id: string) => PositionedNode | undefined
+  /**
+   * Region of the canvas (screen px) occluded by external chrome (a side panel).
+   * All fly-to paths shift their target so the node lands in the free area. Read
+   * through a ref so it never changes the handlers' identity.
+   */
+  viewportInset?: ViewportInset
 }
 
 export interface UseGraphViewportResult {
@@ -54,10 +61,39 @@ export interface UseGraphViewportResult {
   handleFocusUser: () => void
   /**
    * Fly to a node using its full-layout position, so it works even when the
-   * node is windowed out of React Flow's store. Returns false if the position
-   * is unknown (caller should fall back to an id-based fit).
+   * node is windowed out of React Flow's store. Centers the node in the free
+   * region when a `viewportInset` is set. `zoom` defaults to the graph's
+   * `defaultZoom`. Returns false if the position is unknown (caller should fall
+   * back to an id-based fit).
    */
-  centerOnNode: (nodeId: string, duration: number) => boolean
+  centerOnNode: (nodeId: string, duration: number, zoom?: number) => boolean
+  /**
+   * Build a React Flow `fitView` padding that layers the current `viewportInset`
+   * on top of a symmetric base fraction, so id-based fits also clear the panel.
+   * Returns the plain `base` (identical to before) when there is no inset.
+   */
+  getFitPadding: (base: number) => number | ViewportInsetPadding
+  /** True when a non-zero `viewportInset` is currently set. */
+  hasViewportInset: boolean
+}
+
+/** Per-side fitView padding (fractions), returned by {@link getFitPadding}. */
+interface ViewportInsetPadding {
+  top: number
+  right: number
+  bottom: number
+  left: number
+}
+
+/** True when any side of the inset actually occludes part of the canvas. */
+function insetOccludes(inset?: ViewportInset): boolean {
+  return (
+    !!inset &&
+    ((inset.top ?? 0) > 0 ||
+      (inset.right ?? 0) > 0 ||
+      (inset.bottom ?? 0) > 0 ||
+      (inset.left ?? 0) > 0)
+  )
 }
 
 /**
@@ -75,8 +111,17 @@ export function useGraphViewport({
   nodeWindowingActive = false,
   getContentBounds,
   getNodePosition,
+  viewportInset,
 }: UseGraphViewportOptions): UseGraphViewportResult {
   const reactFlow = useReactFlow()
+  const storeApi = useStoreApi()
+
+  // Read the inset through a ref so the fly-to handlers keep a stable identity
+  // even when the consumer passes a fresh object every render (the careful
+  // `centerOnNode` identity guarantees the fly effects rely on must not churn).
+  const insetRef = useRef(viewportInset)
+  insetRef.current = viewportInset
+  const hasViewportInset = insetOccludes(viewportInset)
 
   // Viewport zoom (tracked via onViewportChange to avoid useViewport churn).
   const [currentZoom, setCurrentZoom] = useState(defaultZoom)
@@ -129,6 +174,28 @@ export function useGraphViewport({
     reactFlow.zoomOut({ duration: 300 })
   }, [reactFlow])
 
+  // Layer the current inset (screen px) onto a symmetric base fraction, so
+  // id-based fits frame their content in the free area rather than behind the
+  // panel. Each side's px is converted to a fraction of the container dimension
+  // it applies to (width for left/right, height for top/bottom) and added to the
+  // base. With no inset, returns the plain `base` — byte-for-byte the old call.
+  const getFitPadding = useCallback(
+    (base: number): number | ViewportInsetPadding => {
+      const inset = insetRef.current
+      if (!insetOccludes(inset)) return base
+      const { width, height } = storeApi.getState()
+      const fx = width > 0 ? width : 1
+      const fy = height > 0 ? height : 1
+      return {
+        top: base + (inset!.top ?? 0) / fy,
+        right: base + (inset!.right ?? 0) / fx,
+        bottom: base + (inset!.bottom ?? 0) / fy,
+        left: base + (inset!.left ?? 0) / fx,
+      }
+    },
+    [storeApi]
+  )
+
   const handleFitView = useCallback(() => {
     // Windowing: the store only holds on-screen nodes, so id-less fitView would
     // fit the window, not the graph. Fit the full layout bounds instead.
@@ -136,29 +203,42 @@ export function useGraphViewport({
     if (bounds) {
       reactFlow.fitBounds(bounds, {
         duration: 400,
-        padding: FIT_VIEW_PADDING_TIGHT,
+        padding: getFitPadding(FIT_VIEW_PADDING_TIGHT),
       })
       return
     }
-    reactFlow.fitView({ duration: 400, padding: FIT_VIEW_PADDING_TIGHT })
-  }, [reactFlow, nodeWindowingActive, getContentBounds])
+    reactFlow.fitView({
+      duration: 400,
+      padding: getFitPadding(FIT_VIEW_PADDING_TIGHT),
+    })
+  }, [reactFlow, nodeWindowingActive, getContentBounds, getFitPadding])
 
   // Fly to a node by its full-layout position (works even when windowing has
   // dropped it from React Flow's store). Returns false when the position is
   // unknown so callers can fall back to an id-based fitView.
   //
-  // Resets the zoom to `defaultZoom` (the graph's initial zoom) rather than
+  // `zoom` defaults to `defaultZoom` (the graph's initial zoom) rather than
   // keeping whatever the user had panned/zoomed to: navigating to a person
   // ("Find me" / search reveal) should land on the initial org-chart zoom state,
-  // not stay stuck at an arbitrary deep zoom.
+  // not stay stuck at an arbitrary deep zoom. The click path passes a closer zoom.
+  //
+  // When a `viewportInset` is set, the target is shifted so the node lands in the
+  // middle of the region NOT covered by the panel: a right-hand panel moves the
+  // target right by half its width (in flow units), so the node ends up centered
+  // in the visible area beside it. The side is encoded by the inset keys, so RTL
+  // is just a `left` inset — no extra direction handling here.
   const centerOnNode = useCallback(
-    (nodeId: string, duration: number): boolean => {
+    (nodeId: string, duration: number, zoom: number = defaultZoom): boolean => {
       const pos = getNodePosition?.(nodeId)
       if (!pos) return false
-      reactFlow.setCenter(pos.x + pos.width / 2, pos.y + pos.height / 2, {
-        duration,
-        zoom: defaultZoom,
-      })
+      const inset = insetRef.current
+      const shiftX = ((inset?.right ?? 0) - (inset?.left ?? 0)) / 2 / zoom
+      const shiftY = ((inset?.bottom ?? 0) - (inset?.top ?? 0)) / 2 / zoom
+      reactFlow.setCenter(
+        pos.x + pos.width / 2 + shiftX,
+        pos.y + pos.height / 2 + shiftY,
+        { duration, zoom }
+      )
       return true
     },
     [reactFlow, getNodePosition, defaultZoom]
@@ -172,9 +252,15 @@ export function useGraphViewport({
     reactFlow.fitView({
       nodes: [{ id: currentUserNodeId }],
       duration: 400,
-      padding: FIT_VIEW_PADDING_LOOSE,
+      padding: getFitPadding(FIT_VIEW_PADDING_LOOSE),
     })
-  }, [currentUserNodeId, reactFlow, nodeWindowingActive, centerOnNode])
+  }, [
+    currentUserNodeId,
+    reactFlow,
+    nodeWindowingActive,
+    centerOnNode,
+    getFitPadding,
+  ])
 
   return {
     zoomLevel,
@@ -185,5 +271,7 @@ export function useGraphViewport({
     handleFitView,
     handleFocusUser,
     centerOnNode,
+    getFitPadding,
+    hasViewportInset,
   }
 }

--- a/packages/react/src/patterns/F0Graph/index.tsx
+++ b/packages/react/src/patterns/F0Graph/index.tsx
@@ -24,6 +24,7 @@ export type {
   PositionedEdge,
   DeferredNodesPayload,
   DeferredStatus,
+  ViewportInset,
 } from "./types"
 
 // Sub-components

--- a/packages/react/src/patterns/F0Graph/types.ts
+++ b/packages/react/src/patterns/F0Graph/types.ts
@@ -90,6 +90,24 @@ export interface ZoomThresholds {
 export type LayoutDirection = "TB" | "LR" | "BT" | "RL"
 
 /**
+ * Region of the canvas (in screen px) covered by external chrome — typically a
+ * side panel / drawer opened over the graph. All fly-to paths shift their target
+ * so the node lands centered in the *free* area instead of behind the panel.
+ *
+ * The consumer measures / knows this (e.g. a fixed-width drawer) and passes it;
+ * F0Graph has no notion of the panel itself. The side is encoded by which key is
+ * set — a right-hand drawer sets `right`, a left-hand one (or RTL layout) sets
+ * `left` — so no separate direction handling is needed. Omitted / `0` on every
+ * side behaves exactly as if there were no inset.
+ */
+export interface ViewportInset {
+  top?: number
+  right?: number
+  bottom?: number
+  left?: number
+}
+
+/**
  * Layout engine interface (abstract — implementations can be swapped).
  *
  * The built-in implementation (`useLayoutEngine`) produces a deterministic

--- a/packages/react/src/patterns/OneDataCollection/exports.ts
+++ b/packages/react/src/patterns/OneDataCollection/exports.ts
@@ -24,3 +24,9 @@ export type {
   CustomVisualizationProps,
   VisualizationFilterOverrides,
 } from "./visualizations/collection/types"
+export type { GraphVisualizationOptions } from "./visualizations/collection/Graph/types"
+// The graph visualization's `viewportInset` field carries this type. It is
+// declared in the F0Graph pattern, which has no public barrel of its own, so
+// re-export it here (alongside the options that use it) to give consumers a
+// name to import instead of restructuring the shape by hand.
+export type { ViewportInset } from "@/patterns/F0Graph"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -77,6 +77,9 @@ export const GraphCollection = <
   zoomPreset,
   minZoom,
   maxZoom,
+  centerOnNodeClick,
+  nodeClickZoom,
+  viewportInset,
   showControls,
   canvasFooterActions,
   enableNodeWindowing,
@@ -256,6 +259,11 @@ export const GraphCollection = <
           zoomPreset={zoomPreset}
           minZoom={minZoom}
           maxZoom={maxZoom}
+          // Fly-to on click is F0Graph's default; centers + zooms in close on the
+          // clicked node and offsets for the side panel via `viewportInset`.
+          centerOnNodeClick={centerOnNodeClick}
+          nodeClickZoom={nodeClickZoom}
+          viewportInset={viewportInset}
           enableNodeWindowing={enableNodeWindowing}
           nodeWindowPadding={nodeWindowPadding}
           // The hook's own hydration loader (two-phase mode) wins; otherwise
@@ -291,10 +299,12 @@ export const GraphCollection = <
                 actions={nodeActions?.(node.data)}
                 hoverCard
                 onClick={() => {
+                  // Select + fly-to is handled by F0Graph's default
+                  // `centerOnNodeClick` (closer zoom, panel-aware offset), so we
+                  // no longer center imperatively here. `ctx.onClick()` keeps
+                  // keyboard (Enter) selection working, where there's no pointer
+                  // click for F0Graph's own click path to catch.
                   ctx.onClick()
-                  // Center on the node the user actually clicked (never fires on
-                  // an empty-canvas click); re-centers even on a repeat click.
-                  graphRef.current?.focusNode(ctx.nodeId)
                   itemOnClick?.()
                 }}
               />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -160,6 +160,8 @@ export type GraphVisualizationOptions<
    * Whether clicking a node flies to it (centers + zooms in close), passed
    * through to F0Graph. Defaults to `true` — pass `false` for a static camera on
    * click (selection still happens). Re-centers on every click, even a repeat.
+   * The fly starts a beat after the click so it picks up a `viewportInset` set in
+   * response to that same click (a side panel opening).
    */
   centerOnNodeClick?: boolean
   /**

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -6,6 +6,7 @@ import type { SortingsDefinition } from "@/hooks/datasource/types/sortings.typin
 import type {
   F0GraphNodeTag,
   F0GraphNodeTagColumn,
+  ViewportInset,
   ZoomPreset,
 } from "@/patterns/F0Graph"
 import type {
@@ -155,6 +156,25 @@ export type GraphVisualizationOptions<
   minZoom?: number
   /** Largest zoom the user can pan to (the zoom-in limit), passed through to F0Graph. */
   maxZoom?: number
+  /**
+   * Whether clicking a node flies to it (centers + zooms in close), passed
+   * through to F0Graph. Defaults to `true` — pass `false` for a static camera on
+   * click (selection still happens). Re-centers on every click, even a repeat.
+   */
+  centerOnNodeClick?: boolean
+  /**
+   * Zoom a node click lands on (pass-through). Defaults to F0Graph's
+   * `NODE_CLICK_ZOOM` (`1.5`), clamped to `maxZoom`. Lower it for a dense tree.
+   */
+  nodeClickZoom?: number
+  /**
+   * Region of the canvas (screen px) covered by a side panel / drawer the
+   * consumer opens over the graph (pass-through to F0Graph). Every fly-to path
+   * shifts its target so the clicked / revealed node lands centered in the free
+   * area beside the panel instead of behind it. For a fixed-width drawer, pass
+   * its width while open (e.g. `{ right: 480 }`) and omit it while closed.
+   */
+  viewportInset?: ViewportInset
   /** Whether to render the zoom/fit controls. Defaults to `true`. */
   showControls?: boolean
   /**


### PR DESCRIPTION
## Description

Clicking a node in F0Graph now flies to it — centering and zooming in close — by default, and every fly-to path can be offset for a side panel so the node lands in the visible area beside the panel instead of behind it. Previously a node click only updated selection; the viewport barely moved (the small nudge was just the browser's focus scroll), and OneDataCollection worked around it with an imperative `focusNode` that framed too wide and ignored the panel. Implements [FCT-60435](https://factorialmakers.atlassian.net/browse/FCT-60435).

> [!WARNING]
> **Behaviour change:** the fly-to is F0Graph's default (`centerOnNodeClick` defaults to `true`), so **every** existing consumer changes on upgrade — including the Org chart, Job Catalog and Teams graphs. Pass `centerOnNodeClick={false}` to restore today's static camera. Flagging for the release notes.

There's a `ClickToFocusWithSidePanel` Storybook story (Graph/F0Graph) that demonstrates the click fly-to plus a fixed-width drawer driving `viewportInset`.

## Implementation details

**F0Graph — fly to the clicked node**

- feat: fly to the clicked node by default (`centerOnNodeClick`, opt-out), centering on the node alone and re-firing on **every** click — including a repeat click after panning away
- feat: land closer than the initial-focus frame — `NODE_CLICK_ZOOM` (`1.5`, clamped to `maxZoom`), overridable per graph via `nodeClickZoom`; independent of the current zoom
- feat: the click fly is **deferred one settle tick**, so it picks up a `viewportInset` the click itself brought in — the usual case, where clicking a node is what opens the side panel (its width only reaches F0Graph on a later render); a second click supersedes a still-pending fly
- fix: **don't fly when the expand/collapse toggle is clicked** — the canvas pointer-up also fires for the expander/collapser pseudo-nodes; the fly is gated on the id being a real node (`nodeMap`), so the toggle is untouched and only real nodes fly
- fix(F0GraphNode): correct the stale comment claiming the node `onClick` does "centering" (it never did)

**F0Graph — panel-aware offset**

- feat: add `viewportInset` (px) honored by **all** fly-to paths (click, `focusedNode`, `focusNode`, "Find me", initial focus, fit-view) so nothing lands behind a side panel; the panel side is encoded by which inset key is set (so RTL is just a `left` inset)
- fix: the inset is layered onto the fit padding **in px, not as a fraction** — React Flow resolves a numeric padding non-linearly, so the fraction approach shifted far short of the panel edge; the windowing (`fitBounds`) path resolves the viewport via `getViewportForBounds` + `setViewport` since `fitBounds`' own `padding` is `number`-only

**F0Drawer — report its width**

- feat: `F0Drawer.onWidthChange(width)` — the drawer reports its content box's width on mount/resize and `0` on close, so a consumer (a graph offsetting a node) can reserve the right space **without hard-coding it**; measuring is reliable because the drawer slides in via a transform, not a width animation
- fix: measure the **inner content box** (`max-w-*`), not the `fixed inset-0` positioner the forwarded `ref` lands on — DialogContent hands its box to a `contentBoxRef`; measuring the positioner reported the full viewport width and flung an offset node off-screen

**OneDataCollection**

- feat: expose `centerOnNodeClick` / `nodeClickZoom` / `viewportInset` through `GraphVisualizationOptions`, and **export the `ViewportInset` type** (and `GraphVisualizationOptions`) so consumers can name it instead of restructuring the shape

  <details>
  <summary>Why drop the old imperative centering?</summary>

  OneDataCollection previously called `graphRef.current?.focusNode(id)` in the node's `onClick`, which framed the node with its children (capped at `1×`) and ignored any panel. F0Graph's new default replaces it with a closer, panel-aware fly, so the manual call is removed. `ctx.onClick()` stays for keyboard (Enter) selection, where there's no pointer click for F0Graph's own click path to catch.
  </details>

- test: `useGraphViewport` unit tests (zoom, inset px math, `fitView` padding + the windowing bounds path), `F0Graph.clickCenter` wiring tests (default fly, repeat-click re-centers, zoom clamp, opt-out, inset offset, deferred fly picking up a late inset, no fly on the expander pseudo-node), and `DialogWrapper.onWidthChange` tests (measures the inner box not the positioner, reports 0 on unmount)


https://github.com/user-attachments/assets/ecb7a406-5267-4dc0-9775-530db23c5c02



### Notes for reviewers

- Keyboard navigation is untouched: the fly-to lives at the click site (`onPointerUp`), not inside `selectNode` which keyboard also calls.
- Off-screen (windowed) nodes still fly via the layout-position `centerOnNode` path, so they remain reachable.
- Changelog / version bump are handled by release-please from these commits.
- The Org chart / Job Catalog / Teams **drawers** live in the monorepo, not this repo — those consumers inherit the new fly-to default and, once they pick up the release, can pass `viewportInset` fed by the drawer's `onWidthChange` (no hard-coded width) while their panel is open. Job Catalog's consumer PR: factorialco/factorial#108851.

[FCT-60435]: https://factorialmakers.atlassian.net/browse/FCT-60435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
