### PR TITLE
feat(BaseBanner): [FCT-60673] add vertical card variant

### DIFF
--- a/packages/react/src/kits/ai/Banners/BaseBanner/__tests__/BaseBanner.test.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/__tests__/BaseBanner.test.tsx
@@ -1,0 +1,106 @@
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
+
+import { BaseBanner } from "../index"
+
+const baseProps = {
+  title: "Submit expenses in seconds",
+  subtitle: "Upload receipts. One organizes everything for you.",
+  mediaUrl: "https://example.com/media.png",
+}
+
+/** The element carrying the layout classes is the banner root. */
+const getRoot = () => document.querySelector("div.shadow-md") as HTMLElement
+
+describe("BaseBanner", () => {
+  it("renders title, subtitle and media", () => {
+    render(<BaseBanner {...baseProps} />)
+
+    expect(screen.getByText(baseProps.title)).toBeVisible()
+    expect(screen.getByText(baseProps.subtitle)).toBeVisible()
+    expect(
+      screen.getByRole("presentation", { hidden: true })
+    ).toBeInTheDocument()
+  })
+
+  it("renders both actions and calls their handlers", async () => {
+    const onPrimary = vi.fn()
+    const onSecondary = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <BaseBanner
+        {...baseProps}
+        primaryAction={{
+          label: "Try it out",
+          onClick: onPrimary,
+          variant: "outline",
+        }}
+        secondaryAction={{
+          label: "Not now",
+          onClick: onSecondary,
+          variant: "ghost",
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Try it out" }))
+    await user.click(screen.getByRole("button", { name: "Not now" }))
+
+    expect(onPrimary).toHaveBeenCalledOnce()
+    expect(onSecondary).toHaveBeenCalledOnce()
+  })
+
+  it("calls onClose and removes itself when dismissed", async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    render(<BaseBanner {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "Close" }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(screen.queryByText(baseProps.title)).not.toBeInTheDocument()
+  })
+
+  it("renders no close button when onClose is omitted", () => {
+    render(<BaseBanner {...baseProps} />)
+
+    expect(
+      screen.queryByRole("button", { name: "Close" })
+    ).not.toBeInTheDocument()
+  })
+
+  describe('variant="card"', () => {
+    it("keeps the vertical stack at every viewport", () => {
+      render(<BaseBanner {...baseProps} variant="card" />)
+
+      // The horizontal variants opt into a row layout at the `sm` viewport
+      // breakpoint; the card variant must never do that, because it is used in
+      // narrow containers (popovers, side panels) on wide viewports.
+      expect(getRoot().className).not.toMatch(/sm:flex-row/)
+      expect(getRoot().className).toMatch(/flex-col/)
+    })
+
+    it("leaves the horizontal variants untouched", () => {
+      render(<BaseBanner {...baseProps} />)
+
+      expect(getRoot().className).toMatch(/sm:flex-row/)
+    })
+
+    it("clamps the subtitle to two lines", () => {
+      render(<BaseBanner {...baseProps} variant="card" />)
+
+      expect(screen.getByText(baseProps.subtitle).className).toMatch(
+        /line-clamp-2/
+      )
+    })
+
+    it("renders a skeleton while loading", () => {
+      render(<BaseBanner {...baseProps} variant="card" isLoading />)
+
+      expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true")
+      expect(screen.queryByText(baseProps.title)).not.toBeInTheDocument()
+    })
+  })
+})

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { expect, within } from "storybook/test"
 
 import { Download, Upsell } from "@/icons/app"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { BaseBanner } from "./index"
 
@@ -12,7 +13,7 @@ const meta = {
   parameters: {
     layout: "padded",
   },
-  tags: ["autodocs"],
+  tags: ["autodocs", "experimental"],
 } satisfies Meta<typeof BaseBanner>
 
 export default meta
@@ -132,6 +133,72 @@ export const FullWidthText: Story = {
     },
     onClose: () => alert("Banner closed"),
   },
+}
+
+export const Card: Story = {
+  args: {
+    variant: "card",
+    title: "Submit expenses in seconds",
+    subtitle:
+      "Upload receipts. One organizes everything for you. Just review and send.",
+    mediaUrl:
+      "https://images.unsplash.com/photo-1554224155-6726b3ff858f?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80",
+    primaryAction: {
+      label: "Try it out",
+      onClick: () => alert("Try it out clicked"),
+      variant: "outline",
+    },
+    secondaryAction: {
+      label: "Not now",
+      onClick: () => alert("Dismissed"),
+      variant: "ghost",
+    },
+    onClose: () => alert("Banner closed"),
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[308px]">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
+/** Single consolidated visual-regression story: both orientations side by side. */
+export const Snapshot: Story = {
+  args: Default.args,
+  parameters: withSnapshot({ layout: "padded" }),
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <BaseBanner
+        title="Boost your productivity"
+        subtitle="Discover new features that will help you work more efficiently"
+        mediaUrl={Default.args.mediaUrl}
+        primaryAction={{ label: "Get Started", onClick: () => {} }}
+        secondaryAction={{ label: "Learn More", onClick: () => {} }}
+        onClose={() => {}}
+      />
+      <div className="w-[308px]">
+        <BaseBanner
+          variant="card"
+          title="Submit expenses in seconds"
+          subtitle="Upload receipts. One organizes everything for you. Just review and send."
+          mediaUrl={Default.args.mediaUrl}
+          primaryAction={{
+            label: "Try it out",
+            onClick: () => {},
+            variant: "outline",
+          }}
+          secondaryAction={{
+            label: "Not now",
+            onClick: () => {},
+            variant: "ghost",
+          }}
+          onClose={() => {}}
+        />
+      </div>
+    </div>
+  ),
 }
 
 export const WithDataTestId: Story = {

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
@@ -162,20 +162,20 @@ export const Card: Story = {
       </div>
     ),
   ],
-  // The flow the card exists for: read it, take the action, or dismiss it.
+  // The flow the card exists for: read it, then take the action.
+  //
+  // Deliberately stops short of clicking Close. `play` runs on mount, so
+  // dismissing here would leave the story — and its autodocs entry — showing
+  // nothing but empty space. Dismissal is covered in the unit tests instead
+  // ("calls onClose and removes itself when dismissed").
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement)
 
     await expect(canvas.getByText("Submit expenses in seconds")).toBeVisible()
+    await expect(canvas.getByRole("button", { name: "Close" })).toBeVisible()
 
     await userEvent.click(canvas.getByRole("button", { name: "Try it out" }))
     await expect(args.primaryAction?.onClick).toHaveBeenCalledOnce()
-
-    await userEvent.click(canvas.getByRole("button", { name: "Close" }))
-    await expect(args.onClose).toHaveBeenCalledOnce()
-    await expect(
-      canvas.queryByText("Submit expenses in seconds")
-    ).not.toBeInTheDocument()
   },
 }
 

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
@@ -164,7 +164,11 @@ export const Card: Story = {
   ],
 }
 
-/** Single consolidated visual-regression story: both orientations side by side. */
+/**
+ * Single consolidated visual-regression story: every orientation in one
+ * snapshot (Chromatic bills per snapshot). Content is intentionally neutral —
+ * the illustrative copy lives in the individual stories.
+ */
 export const Snapshot: Story = {
   args: Default.args,
   parameters: withSnapshot({ layout: "padded" }),
@@ -181,16 +185,16 @@ export const Snapshot: Story = {
       <div className="w-[308px]">
         <BaseBanner
           variant="card"
-          title="Submit expenses in seconds"
-          subtitle="Upload receipts. One organizes everything for you. Just review and send."
+          title="Boost your productivity"
+          subtitle="Discover new features that will help you work more efficiently"
           mediaUrl={Default.args.mediaUrl}
           primaryAction={{
-            label: "Try it out",
+            label: "Get Started",
             onClick: () => {},
             variant: "outline",
           }}
           secondaryAction={{
-            label: "Not now",
+            label: "Learn More",
             onClick: () => {},
             variant: "ghost",
           }}

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { expect, within } from "storybook/test"
+import { expect, fn, userEvent, within } from "storybook/test"
 
 import { Download, Upsell } from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
@@ -145,15 +145,15 @@ export const Card: Story = {
       "https://images.unsplash.com/photo-1554224155-6726b3ff858f?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&q=80",
     primaryAction: {
       label: "Try it out",
-      onClick: () => alert("Try it out clicked"),
+      onClick: fn(),
       variant: "outline",
     },
     secondaryAction: {
       label: "Not now",
-      onClick: () => alert("Dismissed"),
+      onClick: fn(),
       variant: "ghost",
     },
-    onClose: () => alert("Banner closed"),
+    onClose: fn(),
   },
   decorators: [
     (Story) => (
@@ -162,6 +162,21 @@ export const Card: Story = {
       </div>
     ),
   ],
+  // The flow the card exists for: read it, take the action, or dismiss it.
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText("Submit expenses in seconds")).toBeVisible()
+
+    await userEvent.click(canvas.getByRole("button", { name: "Try it out" }))
+    await expect(args.primaryAction?.onClick).toHaveBeenCalledOnce()
+
+    await userEvent.click(canvas.getByRole("button", { name: "Close" }))
+    await expect(args.onClose).toHaveBeenCalledOnce()
+    await expect(
+      canvas.queryByText("Submit expenses in seconds")
+    ).not.toBeInTheDocument()
+  },
 }
 
 /**

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
@@ -24,7 +24,12 @@ export type BaseBannerProps = {
   onClose?: () => void
   isLoading?: boolean
   children?: React.ReactNode
-  variant?: "default" | "full-width"
+  /**
+   * `default` and `full-width` are horizontal banners (media beside the text on
+   * wider viewports). `card` keeps the vertical stack at every viewport — media
+   * on top, content below — for narrow surfaces such as popovers and side panels.
+   */
+  variant?: "default" | "full-width" | "card"
 }
 
 const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
@@ -43,6 +48,7 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
     ref
   ) {
     const isVideo = mediaUrl?.includes(".mp4")
+    const isCard = variant === "card"
     const [isDismissed, setIsDismissed] = useState(false)
 
     const handleClose = () => {
@@ -59,10 +65,22 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
     return !isDismissed ? (
       <div
         ref={ref}
-        className="bg-white relative flex w-full flex-col gap-4 rounded-xl border border-f1-border-secondary shadow-md sm:flex-row sm:gap-5"
+        className={cn(
+          "relative flex w-full flex-col rounded-xl border border-f1-border-secondary shadow-md",
+          isCard
+            ? // `bg-white` renders transparent and the border does not draw without
+              // an explicit style; scoped to `card` so existing banners are untouched.
+              "gap-0 border-solid bg-f1-background"
+            : "bg-white gap-4 sm:flex-row sm:gap-5"
+        )}
       >
         {/* Media 16:9 */}
-        <div className="aspect-video w-full flex-shrink-0 overflow-hidden rounded-xl px-1 pb-0 pt-1 sm:max-w-80 sm:py-1 sm:pl-1">
+        <div
+          className={cn(
+            "aspect-video w-full flex-shrink-0 overflow-hidden rounded-xl",
+            isCard ? "p-1" : "px-1 pb-0 pt-1 sm:max-w-80 sm:py-1 sm:pl-1"
+          )}
+        >
           {isVideo ? (
             <video
               src={mediaUrl}
@@ -81,23 +99,40 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
         </div>
 
         {/* Content */}
-        <div className="flex flex-col justify-center gap-5 px-3 pb-3 sm:py-3 sm:pl-0 sm:pr-3">
+        <div
+          className={cn(
+            "flex flex-col justify-center",
+            isCard ? "gap-2 p-3" : "gap-5 px-3 pb-3 sm:py-3 sm:pl-0 sm:pr-3"
+          )}
+        >
           <div
             className={cn(
               "flex w-full flex-col gap-1",
               variant === "default" ? "sm:max-w-lg" : undefined
             )}
           >
-            <h3 className="font-bold text-xl text-f1-foreground">{title}</h3>
+            <h3
+              className={cn(
+                "text-f1-foreground",
+                isCard ? "font-medium text-lg" : "font-bold text-xl"
+              )}
+            >
+              {title}
+            </h3>
             {subtitle && (
-              <p className="text-base text-f1-foreground-secondary">
+              <p
+                className={cn(
+                  "text-base text-f1-foreground-secondary",
+                  isCard && "line-clamp-2"
+                )}
+              >
                 {subtitle}
               </p>
             )}
           </div>
 
           {/* Actions */}
-          <div className="flex gap-3">
+          <div className={cn("flex", isCard ? "gap-2" : "gap-3")}>
             {primaryAction && (
               <F0Button
                 onClick={primaryAction.onClick}


### PR DESCRIPTION
## Description

Adds a `card` variant to `BaseBanner`: a vertical layout — media on top, content below — that keeps its stack at every viewport, for narrow surfaces such as popovers and side panels.

The existing `default` and `full-width` variants go horizontal at the `sm` breakpoint. Since that is a *viewport* breakpoint rather than a container query, they cannot be used in a narrow container on a wide screen — media and text end up crammed side by side. `card` is the same banner with that behaviour removed.

Driven by a concrete consumer: the `one_announcement` in-app communications widget ([factorial#108764](https://github.com/factorialco/factorial/pull/108764)), a 308px card announcing a One AI capability. It is an **extension of an existing component**, not a new one — per the contribution skill, "extend before you create".

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [x] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [ ] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor / internal change (no API or behavior change)
- [ ] Other:

## Lifecycle phase (if applicable)

Backward-compatible addition to an experimental component, so per the Definition of Done this is a light thread rather than an up-front design review. `BaseBanner` was previously untagged (`apiStatus: "unknown"`); this PR declares it `experimental`, which is what it has effectively always been.

- Linked #f0-support thread: [AiAnnouncementCard component](https://factorialteam.slack.com/archives/C082ZNKS403/p1786343125188429) — raised 10 Aug. This PR is **the alternative** in that thread; [#5038](https://github.com/factorialco/f0/pull/5038) is the same card as its own component and is the preferred route. One of the two gets closed once Foundations decides.
- Phase exit criteria met: story tagged `["autodocs", "experimental"]` ✅ · unit tests covering the public API ✅ (the component had none before) · play function on the primary flow ✅ · axe passes with no new skips ✅ · MDX documentation ❌ — see Known gaps

## Screenshots (if applicable)

[Link to Figma Design](https://www.figma.com/design/VTVKWL9OGmnTJDPOmQmVhI/One-AI-Kit?node-id=12559-19565) <!-- One AI Kit, frame 12559-19565 -->

The card at its designed width — 308px, media on top, actions in a row, dismiss in the corner:

<img width="308" alt="f0-card-CURRENT-default" src="https://github.com/user-attachments/assets/d523b816-897d-4ac2-9cf2-6ffe6840d66a" />

And in its first consumer ([factorial#108764](https://github.com/factorialco/factorial/pull/108764)) — floating below the One toggle while the panel is closed, and as the assistant overlay while it is open. These are the two narrow surfaces the variant exists for:

| One closed | One open |
| --- | --- |
| <img width="2880" height="1800" alt="in-situ-CURRENT-one-closed" src="https://github.com/user-attachments/assets/7d92293d-3f6f-4421-9a85-1e4cf972888b" /> | <img width="2880" height="1800" alt="in-situ-CURRENT-one-open" src="https://github.com/user-attachments/assets/58fbba7d-de9f-49bd-9a2c-cf84cf69b522" /> |

## Implementation details

One `isCard` flag gates every branch, so `default` and `full-width` emit exactly the class strings they did before — the diff is additive by construction.

- **Layout:** `gap-0` and no `sm:flex-row`, so the vertical stack survives every viewport.
- **Media:** uniform `p-1` instead of the horizontal variants' asymmetric padding.
- **Title:** `font-medium text-lg` — f0's `lg` token is `1rem / 1.5rem`, the 16/24 in the Figma frame.
- **Subtitle:** `line-clamp-2`, so a long CMS-authored description cannot unbalance the card.
- **Actions:** `gap-2`.

Consumers compose the actions through `children` rather than `primaryAction`/`secondaryAction` where they need a button variant outside `BannerAction`'s `default | outline | ghost` — factorial's announcement does this to keep its "open One" button on the `ai` variant.

### Testing

- **Unit (Vitest):** first tests for this component — render, both actions, close behaviour, and a two-sided assertion that `card` never gets `sm:flex-row` while `default` still does.
- **Play function:** the card's flow end to end — readable, primary action fires, close notifies and removes it.
- **Chromatic:** one consolidated `Snapshot` story covering both orientations, since Chromatic bills per snapshot.

### Known gaps

- **No MDX documentation.** `BaseBanner` has never had any, and the Definition of Done asks for at least the *Acceptable* tier at Phase 3. Not introduced by this PR, and not mechanically gated while the component is experimental (`check-stable-dod.ts` only enforces stable-tagged components), but it blocks promotion. Happy to add it here if reviewers would rather not carry it forward.
- **`bg-white` and the border are dead classes.** Worked around by scoping `bg-f1-background border-solid` to `card`, to avoid changing shipped visuals in this PR. Full explanation and the real fix in **#5022** (draft, stacked on this branch).


