### PR TITLE
chore(react): make Resource header truly stable

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -33,7 +33,6 @@
     "Inputs/Search input",
     "Inputs/Text area input",
     "Inputs/Text input",
-    "Primitives/F0InputField",
-    "Resource header"
+    "Primitives/F0InputField"
   ]
 }

--- a/packages/react/src/patterns/ResourceHeader/index.mdx
+++ b/packages/react/src/patterns/ResourceHeader/index.mdx
@@ -61,6 +61,28 @@ Designed to display information about a team.
   (e.g., "Add to Factorial")
 - Ensure metadata labels are clear and consistent across the application
 
+## When to use
+
+Reach for Resource header on a page whose subject is one identifiable resource,
+where the user needs to recognize it and act on it without scrolling.
+
+- Display key information about a specific resource (employee, project,
+  document, course, job post, expense, performance review, etc.)
+- Provide quick access to common actions related to the resource
+- Show the current status and important metadata of a resource
+- Create consistent navigation patterns across resource detail pages
+
+## When not to use
+
+- You're displaying a data collection. Index and list pages are about many
+  records, so the title belongs to the collection, not to a resource: use the
+  module header instead
+- The page doesn't represent a specific resource
+- You need minimal identification without actions or metadata. Resource header
+  reserves space for the action row and the metadata row, and both read as empty
+  when unused
+- You're creating a dashboard overview
+
 ## Design best practices
 
 <DoDonts
@@ -132,6 +154,53 @@ Designed to display information about a team.
   src="docs/headers/resource-header-layout.png"
   alt="Layout structure with mandatory and optional components"
 />
+
+## Accessibility
+
+### The title is not a heading
+
+`title` renders as a styled `<span>`, not an `<h1>`–`<h6>`
+(`BaseHeader/index.tsx`: a `<span className="text-2xl font-semibold">` wrapping
+`{title}`, with no `role="heading"` and no `aria-level`). It looks like a page
+title and it is not one.
+
+What that means for you as a consumer:
+
+- **You own the page `<h1>`.** Resource header does not contribute a level to
+  the document outline, so a page that renders only a Resource header at the top
+  has no `<h1>`. Render your own heading in the page shell, or the page is
+  unreachable by heading navigation in a screen reader
+- **Don't rely on it for outline or landmark structure.** The component renders a
+  plain `<div>` wrapper: no `<header>` element, no `role="banner"`, no
+  `aria-label`. If the region needs to be announced or skipped, wrap it yourself
+- **Avoid duplicating the same string twice.** If you add an `<h1>` with the same
+  text as `title`, a screen reader user hears it twice. Prefer a visually hidden
+  `<h1>`, or place the visible heading where Resource header's title would
+  otherwise sit
+
+This is a known gap, not a design decision to copy. Treat the title as
+decorative text and put the semantics in your page.
+
+### State must not depend on color alone
+
+`deactivated` only dims the title (`text-f1-foreground/[0.61]`). It adds no text,
+no icon, and no ARIA state, so the distinction disappears for anyone who can't
+compare two shades of the same color. When a resource is deactivated, also pass
+the state as content, typically a `Status` metadata item or a tag, so it is
+announced and readable.
+
+### Actions
+
+- Every action needs a meaningful `label`. `hideLabel` only hides it visually:
+  the string still becomes the button's `aria-label` and its tooltip, so an empty
+  or vague label leaves the control unnamed for everyone who can't see the icon
+- On desktop the actions are laid out and tabbed in the same order (overflow
+  menu, then secondary actions, then the primary action on the far right), so
+  focus order matches reading order. Keep it that way: don't reorder actions with
+  CSS
+- Pair a destructive action with a confirmation dialog. It is the recoverable
+  step before an irreversible one, and it is a convention here, not something the
+  component enforces for you
 
 ---
 

--- a/packages/react/src/patterns/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { ComponentProps } from "react"
-import { fn } from "storybook/test"
+import { expect, fn, userEvent, within } from "storybook/test"
 
-import { withSnapshot } from "@/lib/storybook-utils/parameters"
-
+import { PrimaryDropdownAction } from "@/experimental/Information/utils"
 import * as Icon from "@/icons/app"
 import { Archive, Comment, Download, ExternalLink, Pencil } from "@/icons/app"
-import { PrimaryDropdownAction } from "@/experimental/Information/utils"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
 import { ResourceHeader } from "./index"
 
 const meta: Meta<typeof ResourceHeader> = {
@@ -16,6 +16,7 @@ const meta: Meta<typeof ResourceHeader> = {
   tags: ["stable"],
   parameters: {
     layout: "padded",
+    a11y: { test: "error" },
   },
   argTypes: {
     title: {
@@ -50,6 +51,10 @@ export default meta
 
 type Story = StoryObj<typeof ResourceHeader>
 
+// Hoisted so the play function has a type-safe handle on the spy: `args.primaryAction`
+// is a union (PrimaryActionButton | PrimaryDropdownAction) and has no `onClick` in common.
+const publishAction = { label: "Publish", icon: Icon.ArrowUp, onClick: fn() }
+
 export const Default: Story = {
   tags: ["!dev"],
   args: {
@@ -69,11 +74,7 @@ export const Default: Story = {
       ],
     },
 
-    primaryAction: {
-      label: "Publish",
-      icon: Icon.ArrowUp,
-      onClick: fn(),
-    },
+    primaryAction: publishAction,
     secondaryActions: [
       {
         label: "Edit",
@@ -130,6 +131,13 @@ export const Default: Story = {
         },
       },
     ],
+  },
+  // BaseHeader renders the action row twice (mobile + desktop); only CSS hides one,
+  // so both matches exist in the DOM. Click the first.
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getAllByRole("button", { name: "Publish" })[0])
+    await expect(publishAction.onClick).toHaveBeenCalledOnce()
   },
 }
 

--- a/packages/react/src/patterns/ResourceHeader/index.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.tsx
@@ -1,7 +1,5 @@
 import { ComponentProps } from "react"
 
-import { experimentalComponent } from "@/lib/experimental"
-
 import { BaseHeader } from "@/experimental/Information/Headers/BaseHeader"
 
 type BaseHeaderProps = ComponentProps<typeof BaseHeader>
@@ -22,7 +20,11 @@ type Props = {} & Pick<
   | "onClose"
 >
 
-const _ResourceHeader = ({
+/**
+ * Header for a resource detail page: avatar, title, description, status,
+ * metadata and its primary, secondary and overflow actions.
+ */
+export const ResourceHeader = ({
   avatar,
   title,
   description,
@@ -55,11 +57,3 @@ const _ResourceHeader = ({
 }
 
 export type ResourceHeaderProps = Props
-
-/**
- * @experimental This is an experimental component use it at your own risk
- */
-export const ResourceHeader = experimentalComponent(
-  "ResourceHeader",
-  _ResourceHeader
-)


### PR DESCRIPTION
## Description

`Resource header` was tagged `stable` while sitting on the Definition of Done debt list, so it rendered no `Stable` badge and counted as experimental. This closes its three remaining mechanical gaps — no play function, docs at `acceptable`, axe at `todo` — and removes its entry from `.scripts/stable-dod-debt.json`, which is required rather than optional because the ratchet in `.scripts/check-stable-dod.ts` fails once a listed component starts meeting the bar. Truly stable goes from 6 to 7 and the debt list from 35 to 34.

## Implementation details

- test: add a play function to `Default` that clicks the primary action and asserts the handler fired

  <details>
  <summary>Why the spy is hoisted, and why <code>getAllByRole</code></summary>

  `args.primaryAction` is typed as `PrimaryActionButton | PrimaryDropdownAction`, which have no `onClick` in common, so `args.primaryAction.onClick` does not typecheck. The inline object moves to a `publishAction` const to give the assertion a typed handle on the spy.

  `getAllByRole(...)[0]` rather than `getByRole`: `BaseHeader` renders the action row twice, once for mobile and once for desktop, and only CSS (`md:hidden` / `hidden md:block`) hides one — both matches exist in the DOM. The existing unit test already asserts 2 matches in jsdom.

  The play deliberately does not hover a metadata item or open a dropdown. axe runs in `postVisit`, after play, so a left-open hover state would expose an unrelated `nested-interactive` candidate and turn the suite red for a reason this PR did not introduce.
  </details>

- docs: add `When to use`, `When not to use` and `Accessibility` sections, taking doc quality from `acceptable` to `gold`

  <details>
  <summary>What the Accessibility section documents</summary>

  Real gaps, not checkbox filler. `title` renders as a plain `<span>` with no `role="heading"` and no `aria-level`, so it looks like a page title and is not one — consumers own the page `<h1>`, and a page rendering only a Resource header has none. `deactivated` signals state through colour alone (`text-f1-foreground/[0.61]`), with no text, icon or ARIA state, so it needs to be paired with content. And `hideLabel` only hides a label visually — the string still becomes the button's accessible name, so it cannot be vague.
  </details>

- chore: enforce axe with a meta-level `a11y: { test: "error" }`

  <details>
  <summary>Measured, not assumed</summary>

  15/15 stories pass under CI's rule scope. The run was sensitivity-checked before being believed: an injected violation did fail the suite, and was then fully reverted.

  `CompanyHeader` passes, which was the open question. #4866 deleted that story's `color-contrast` rule disable without any accompanying style fix while the file still sat at `test: "todo"`, so nothing had verified it since — this is the first real measurement. It is clean.

  A meta-level key is load-bearing here: `.storybook/preview.tsx` sets a repo-wide `a11y: { test: "todo" }` and the test runner reads the merged parameters, so a story file with no `a11y` key is not gated at all.
  </details>

- chore: drop the `experimentalComponent` wrapper and its `@experimental` JSDoc

  <details>
  <summary>Why</summary>

  The wrapper emits a runtime `console.warn` telling every consumer the component is experimental, which contradicts the `stable` tag. Checked first that no test asserts the warning and that nothing imports the unwrapped component directly.
  </details>

- chore: remove `Resource header` from the stable DoD debt list

- refactor: sort the story file's `@/` imports to match the convention in the components that already meet the DoD (`F0Alert`, `F0Link`) — alphabetical by path, relative imports last. oxfmt does not enforce this, hence the otherwise unrelated hunk.

## Verification

- `pnpm tsc`, `npx oxfmt --check src/` — clean
- `pnpm vitest --project=unit run src/patterns/ResourceHeader src/lib/storybook-utils/a11yRuleSuppression.test.ts` — 20/20 pass
- `pnpm check:stable-dod --verbose` — ratchet holds; `Resource header` now listed under truly stable
- Full Storybook suite against a static build on a dedicated port; `Default` runs as `play-test`

Pre-existing and unrelated to this diff, called out so review is not surprised by red:

- 4 `F0Chat` attachment fullscreen-viewer unit timeouts under full-suite load. Reproduced identically on clean `main` at `fd81aea02` with none of these changes; each test runs 4.83–4.96s against the 5000ms default timeout, so they blow the budget only under load.
- `ApplicationFrame › CommunicationsComposerAttachmentPreviews` and `F0Chat › Snapshot`, the two known static-build-only Storybook failures.

## Out of scope

The `role="button"` + `MobileDropdown` nesting in `experimental/Information/Headers/Metadata` is a genuine `nested-interactive` (SC 4.1.2) defect at narrow viewports. It is pre-existing library code and is currently unreachable by the test setup — no story sets a viewport, so axe always runs at desktop width where the wrapper is `display: none`. Fixing it means either changing a component shared well beyond ResourceHeader or adding a mobile-viewport story that makes it measurable; both belong in their own PR.

Separately: `packages/react`'s `lint` script is effectively a no-op. `sh -c 'oxlint "${@:-src/**/*}" --max-warnings 0'` passes the glob as a quoted literal, so a bare `pnpm lint` scans 0 files. Running `npx oxlint src` scans 3135 files and surfaces 3 pre-existing `react(display-name)` errors in `src/lib/data-testid/__tests__/withDataTestId.test.tsx`. Untouched by this branch, worth its own fix.