### PR TITLE
fix(F0Wizard): reset step content scroll on step change

### DIFF
--- a/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
+++ b/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
@@ -996,7 +996,14 @@ export const ScrollResetOnStepChange: Story = {
   render: () => <ManyFieldsStory extraDefaultValues={{ gender: "female" }} />,
   play: async ({ canvasElement, step }) => {
     const page = within(canvasElement.closest("body")!)
-    const content = getStepContent(canvasElement)
+
+    // The wizard dialog mounts through a portal and animates in, so the pane is
+    // not in the DOM yet when the play function starts.
+    const content = await page.findByTestId(
+      "wizard-step-content",
+      {},
+      { timeout: 10000 }
+    )
 
     await step("The step content pane actually overflows", async () => {
       await waitFor(() =>
@@ -1008,7 +1015,11 @@ export const ScrollResetOnStepChange: Story = {
       content.scrollTop = content.scrollHeight
       await waitFor(() => expect(content.scrollTop).toBeGreaterThan(0))
 
-      await userEvent.click(page.getByRole("button", { name: /Continue/ }))
+      // Continue starts disabled until the section's validation settles, and
+      // userEvent.click on a disabled button is a silent no-op.
+      const nextButton = page.getByRole("button", { name: /Continue/ })
+      await waitFor(() => expect(nextButton).toBeEnabled(), { timeout: 10000 })
+      await userEvent.click(nextButton)
       // "Job title" only exists in the employment step. Advancing runs the
       // section's async validation, so this needs more than the 1s default.
       await waitFor(
@@ -1026,7 +1037,11 @@ export const ScrollResetOnStepChange: Story = {
       content.scrollTop = content.scrollHeight
       await waitFor(() => expect(content.scrollTop).toBeGreaterThan(0))
 
-      await userEvent.click(page.getByRole("button", { name: /Previous/ }))
+      const previousButton = page.getByRole("button", { name: /Previous/ })
+      await waitFor(() => expect(previousButton).toBeEnabled(), {
+        timeout: 10000,
+      })
+      await userEvent.click(previousButton)
       // "Emergency contact name" only exists in the personal step.
       await waitFor(
         () =>

--- a/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
+++ b/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
@@ -8,6 +8,7 @@ import { f0FormField } from "@/patterns/F0Form/f0Schema"
 import { ApplicationFrame } from "@/patterns/ApplicationFrame"
 import ApplicationFrameStoryMeta from "@/patterns/ApplicationFrame/index.stories"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import { forms } from "@/patterns/forms"
 
@@ -905,7 +906,11 @@ const manyFieldsSchema = z.object({
   }),
 })
 
-function ManyFieldsStory() {
+function ManyFieldsStory({
+  extraDefaultValues,
+}: {
+  extraDefaultValues?: Partial<z.input<typeof manyFieldsSchema>>
+} = {}) {
   const [open, setOpen] = useState(true)
 
   const definition = useF0FormDefinition({
@@ -917,6 +922,7 @@ function ManyFieldsStory() {
       healthInsurance: true,
       mealAllowance: true,
       accessCard: true,
+      ...extraDefaultValues,
     },
     sections: {
       personal: {
@@ -967,6 +973,72 @@ function ManyFieldsStory() {
 
 export const ManyFieldsPerSection: Story = {
   render: () => <ManyFieldsStory />,
+}
+
+// =============================================================================
+// Scroll reset on step change
+//
+// The step-content pane is one DOM node reused across every step, so scrollTop
+// survives the children swap unless F0Wizard resets it. This needs real layout
+// (jsdom reports zero heights and nothing is scrollable), hence a play test.
+// =============================================================================
+
+const getStepContent = (canvasElement: HTMLElement): HTMLElement => {
+  const content = canvasElement.ownerDocument.body.querySelector<HTMLElement>(
+    '[data-testid="wizard-step-content"]'
+  )
+  if (!content) throw new Error("Wizard step content pane not found")
+  return content
+}
+
+export const ScrollResetOnStepChange: Story = {
+  // The personal section must be valid up front so "Continue" actually advances.
+  render: () => <ManyFieldsStory extraDefaultValues={{ gender: "female" }} />,
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+    const content = getStepContent(canvasElement)
+
+    await step("The step content pane actually overflows", async () => {
+      await waitFor(() =>
+        expect(content.scrollHeight).toBeGreaterThan(content.clientHeight)
+      )
+    })
+
+    await step("Forward: scroll to the bottom, then Continue", async () => {
+      content.scrollTop = content.scrollHeight
+      await waitFor(() => expect(content.scrollTop).toBeGreaterThan(0))
+
+      await userEvent.click(page.getByRole("button", { name: /Continue/ }))
+      // "Job title" only exists in the employment step. Advancing runs the
+      // section's async validation, so this needs more than the 1s default.
+      await waitFor(
+        () =>
+          expect(within(content).getByText("Job title")).toBeInTheDocument(),
+        { timeout: 10000 }
+      )
+
+      // Same DOM node across the step change, and back at the top.
+      expect(getStepContent(canvasElement)).toBe(content)
+      await waitFor(() => expect(content.scrollTop).toBe(0))
+    })
+
+    await step("Backward: scroll to the bottom, then Previous", async () => {
+      content.scrollTop = content.scrollHeight
+      await waitFor(() => expect(content.scrollTop).toBeGreaterThan(0))
+
+      await userEvent.click(page.getByRole("button", { name: /Previous/ }))
+      // "Emergency contact name" only exists in the personal step.
+      await waitFor(
+        () =>
+          expect(
+            within(content).getByText("Emergency contact name")
+          ).toBeInTheDocument(),
+        { timeout: 10000 }
+      )
+
+      await waitFor(() => expect(content.scrollTop).toBe(0))
+    })
+  },
 }
 
 // =============================================================================

--- a/packages/react/src/ui/F0Wizard/F0Wizard.tsx
+++ b/packages/react/src/ui/F0Wizard/F0Wizard.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo } from "react"
+import { FC, useLayoutEffect, useMemo, useRef } from "react"
 
 import type { F0DialogAction } from "@/components/dialog-alike/F0Dialog"
 // Import the unwrapped component directly to avoid the experimental-usage
@@ -59,6 +59,25 @@ export const F0Wizard: FC<F0WizardProps> = ({
   })
 
   const i18n = useI18n()
+
+  // The step-content pane is a single DOM node reused across every step, so its
+  // scrollTop survives the children swap. Without this, a step taller than the
+  // pane opens part-way down (the user had to scroll to reach "Next"). Layout
+  // effect so the reset lands before paint, and instant so it never animates.
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  useLayoutEffect(() => {
+    const content = contentRef.current
+    if (!content) return
+    // `behavior: "instant"` keeps it immune to a `scroll-behavior: smooth` on
+    // the element; jsdom (consumer unit tests) has no `scrollTo`, hence the
+    // `scrollTop` fallback.
+    if (typeof content.scrollTo === "function") {
+      content.scrollTo({ top: 0, behavior: "instant" })
+    } else {
+      content.scrollTop = 0
+    }
+  }, [navigation.currentStep])
 
   const currentStepDef = steps[navigation.currentStep]
   const isFirstStep = navigation.currentStep === 0
@@ -122,7 +141,11 @@ export const F0Wizard: FC<F0WizardProps> = ({
           <div className="w-1/3 shrink-0 overflow-y-auto border-x-0 border-b-0 border-r border-t-0 border-dashed border-f1-border-secondary p-2">
             <WizardSteps />
           </div>
-          <div className="flex-1 overflow-y-auto px-8">
+          <div
+            ref={contentRef}
+            data-testid="wizard-step-content"
+            className="flex-1 overflow-y-auto px-8"
+          >
             {children({
               currentStep: navigation.currentStep,
               goToStep: navigation.goToStep,

--- a/packages/react/src/ui/F0Wizard/__tests__/F0Wizard.test.tsx
+++ b/packages/react/src/ui/F0Wizard/__tests__/F0Wizard.test.tsx
@@ -587,6 +587,151 @@ describe("F0Wizard", () => {
   })
 
   // ---------------------------------------------------------------------------
+  // scroll reset on step change
+  //
+  // jsdom does no layout, so the pane is never actually scrollable here. These
+  // tests assert the reset call reaches the content container; the visible
+  // behaviour is covered by the `ScrollResetOnStepChange` play test in
+  // patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx.
+  // ---------------------------------------------------------------------------
+
+  const stubContentScroll = () => {
+    const content = screen.getByTestId("wizard-step-content")
+    const scrollTo = vi.fn()
+    // jsdom does not implement Element.prototype.scrollTo at all.
+    Object.defineProperty(content, "scrollTo", {
+      value: scrollTo,
+      configurable: true,
+    })
+    content.scrollTop = 300
+    return { content, scrollTo }
+  }
+
+  it("resets the step content scroll when moving to the next step", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <F0Wizard isOpen={true} onClose={() => {}} steps={makeSteps(3)}>
+        {({ currentStep }) => (
+          <div data-testid="step-content">Step {currentStep}</div>
+        )}
+      </F0Wizard>
+    )
+
+    const { scrollTo } = stubContentScroll()
+
+    await user.click(screen.getByText("Continue"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-content")).toHaveTextContent("Step 1")
+    })
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "instant" })
+  })
+
+  it("resets the step content scroll when going back to the previous step", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <F0Wizard
+        isOpen={true}
+        onClose={() => {}}
+        steps={makeSteps(3)}
+        defaultStepIndex={1}
+      >
+        {({ currentStep }) => (
+          <div data-testid="step-content">Step {currentStep}</div>
+        )}
+      </F0Wizard>
+    )
+
+    const { scrollTo } = stubContentScroll()
+
+    await user.click(screen.getByText("Previous"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-content")).toHaveTextContent("Step 0")
+    })
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "instant" })
+  })
+
+  it("resets the step content scroll when jumping via the sidebar", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <F0Wizard
+        isOpen={true}
+        onClose={() => {}}
+        steps={makeSteps(3)}
+        defaultStepIndex={1}
+      >
+        {({ currentStep }) => (
+          <div data-testid="step-content">Step {currentStep}</div>
+        )}
+      </F0Wizard>
+    )
+
+    const { scrollTo } = stubContentScroll()
+
+    const nav = screen.getByRole("navigation", { name: "Wizard steps" })
+    await user.click(nav.querySelectorAll("button")[0])
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-content")).toHaveTextContent("Step 0")
+    })
+    expect(scrollTo).toHaveBeenCalledWith({ top: 0, behavior: "instant" })
+  })
+
+  it("does not reset the step content scroll when navigation is blocked", async () => {
+    const user = userEvent.setup()
+    const onNext = vi.fn().mockRejectedValue(new Error("Validation failed"))
+
+    render(
+      <F0Wizard
+        isOpen={true}
+        onClose={() => {}}
+        steps={[{ title: "Step 1", onNext }, { title: "Step 2" }]}
+      >
+        {({ currentStep }) => (
+          <div data-testid="step-content">Step {currentStep}</div>
+        )}
+      </F0Wizard>
+    )
+
+    const { scrollTo } = stubContentScroll()
+
+    await user.click(screen.getByText("Continue"))
+
+    await waitFor(() => {
+      expect(onNext).toHaveBeenCalledOnce()
+    })
+    expect(screen.getByTestId("step-content")).toHaveTextContent("Step 0")
+    expect(scrollTo).not.toHaveBeenCalled()
+  })
+
+  it("falls back to scrollTop when the environment has no scrollTo", async () => {
+    const user = userEvent.setup()
+
+    render(
+      <F0Wizard isOpen={true} onClose={() => {}} steps={makeSteps(3)}>
+        {({ currentStep }) => (
+          <div data-testid="step-content">Step {currentStep}</div>
+        )}
+      </F0Wizard>
+    )
+
+    const content = screen.getByTestId("wizard-step-content")
+    expect(content.scrollTo).toBeUndefined()
+    content.scrollTop = 300
+
+    await user.click(screen.getByText("Continue"))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("step-content")).toHaveTextContent("Step 1")
+    })
+    expect(content.scrollTop).toBe(0)
+  })
+
+  // ---------------------------------------------------------------------------
   // autoCloseOnLastStepSubmit
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Description

The wizard's step-content pane is a single DOM node reused across every step, so its `scrollTop` survived the children swap and a step taller than the pane opened part-way down — guaranteed whenever the user had to scroll to reach "Continue". This resets the pane to the top on every step change, which covers all three navigation paths (next, previous, sidebar `goToStep`) since they all funnel through `currentStep`. Reported from the course-creation wizard migration in the product monorepo ([factorial#101686](https://github.com/factorialco/factorial/pull/101686)); consumers cannot fix it themselves because the container is created inside `F0Wizard` and no prop exposes it:

https://github.com/user-attachments/assets/365aa780-b40c-4056-ab92-e8187bfbeee7


## Implementation details

- fix: reset the step-content pane to the top whenever `currentStep` changes

  <details>
  <summary>Why a layout effect, and why "instant"</summary>

  `useLayoutEffect` runs after the new step is in the DOM but before paint, so
  the reset never flashes. `behavior: "instant"` keeps it immune to a
  `scroll-behavior: smooth` on the element — a smooth scroll on step change
  reads as a glitch. jsdom implements no `Element.scrollTo` at all, so there is
  a `scrollTop` fallback to avoid crashing consumers' unit tests.
  </details>

- test: unit tests for forward, backward, sidebar and blocked navigation, plus the `scrollTop` fallback path
- test: `ScrollResetOnStepChange` play test on `F0WizardForm`, which scrolls the pane to the bottom, advances, and asserts the same node is back at 0

  <details>
  <summary>Why a play test too</summary>

  jsdom does no layout, so `scrollHeight`/`clientHeight` are 0 and nothing is
  ever scrollable there — the unit tests can only assert the reset call reaches
  the container. The play test is what actually proves the visible behavior.
  Verified both ways: green with the fix, red with the effect disabled.
  </details>