### PR TITLE
fix(dialog): stop React propagation without stopping the DOM event

### DIFF
--- a/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.inner-click-propagation.test.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.inner-click-propagation.test.tsx
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0Dialog } from "../index"
+
+/**
+ * The dialog box stops propagation of clicks coming out of its contents, so they
+ * are not treated as outside-clicks and do not reach a clickable ancestor
+ * rendering the dialog (React propagates synthetic events along the component
+ * tree, so a portal does not isolate them).
+ *
+ * It must stop React's propagation ONLY. `e.stopPropagation()` forwards to
+ * `nativeEvent.stopPropagation()`, which halts the DOM event at React's root
+ * container — and anything delegating events at `document` then never observes
+ * the click. React 16 delegates every event there, so a widget embedded in a
+ * dialog that mounts its own React 16 root (e.g. the Cronofy Elements
+ * availability grid) becomes unusable: silently, with `mousedown` still flowing
+ * so its hover states look healthy.
+ */
+describe("dialog-alike F0Dialog inner click propagation", () => {
+  let overlayRoot: HTMLElement
+
+  beforeEach(() => {
+    overlayRoot = document.createElement("div")
+    overlayRoot.id = "f0-overlay-root"
+    document.body.appendChild(overlayRoot)
+  })
+
+  afterEach(() => {
+    overlayRoot.remove()
+    vi.clearAllMocks()
+  })
+
+  const clickInner = (
+    event = new MouseEvent("click", { bubbles: true, cancelable: true })
+  ) => {
+    screen.getByTestId("inner").dispatchEvent(event)
+    return event
+  }
+
+  it("does not reach a clickable ancestor rendering the dialog", () => {
+    const ancestorHandler = vi.fn()
+
+    render(
+      <div onClick={ancestorHandler}>
+        <F0Dialog
+          isOpen
+          modal
+          onClose={vi.fn()}
+          title="Modal inside a clickable row"
+        >
+          <button type="button" data-testid="inner" />
+        </F0Dialog>
+      </div>
+    )
+
+    clickInner()
+
+    expect(ancestorHandler).not.toHaveBeenCalled()
+  })
+
+  it("does not reach a clickable ancestor in non-modal mode either", () => {
+    const ancestorHandler = vi.fn()
+
+    render(
+      <div onClick={ancestorHandler}>
+        <F0Dialog
+          isOpen
+          onClose={vi.fn()}
+          title="Non-modal inside a clickable row"
+        >
+          <button type="button" data-testid="inner" />
+        </F0Dialog>
+      </div>
+    )
+
+    clickInner()
+
+    expect(ancestorHandler).not.toHaveBeenCalled()
+  })
+
+  it("never stops the DOM event, so embedded React roots still get the click", () => {
+    render(
+      <F0Dialog
+        isOpen
+        modal
+        onClose={vi.fn()}
+        title="Modal with an embedded React root"
+      >
+        <button type="button" data-testid="inner" />
+      </F0Dialog>
+    )
+
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true })
+    const stopNativePropagation = vi.fn()
+    const stopOriginal = event.stopPropagation.bind(event)
+    event.stopPropagation = () => {
+      stopNativePropagation()
+      stopOriginal()
+    }
+
+    clickInner(event)
+
+    expect(stopNativePropagation).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
@@ -129,14 +129,26 @@ export const DialogContent = forwardRef<
               className
             )}
             onClick={(e) => {
-              // Only stop propagation so clicks inside the dialog box are not
-              // treated as outside-clicks by the overlay handler above. Do NOT
-              // preventDefault: this handler runs for every click that bubbles
-              // up from the dialog's contents, and preventing the default would
-              // cancel default actions of inner controls — most visibly the
-              // native file picker, which opens via a programmatic
-              // `fileInputRef.click()` that bubbles through here.
-              e.stopPropagation()
+              // Stop propagation so clicks inside the dialog box are not treated as
+              // outside-clicks by the wrapper handler above, and do not reach a
+              // clickable ancestor rendering this dialog — React propagates
+              // synthetic events along the component tree, so a portal does not
+              // isolate them.
+              //
+              // Set React's own propagation flag rather than calling
+              // `e.stopPropagation()`: that forwards to
+              // `nativeEvent.stopPropagation()`, which halts the DOM event at
+              // React's root container. Widgets embedded in a dialog that mount
+              // their own React root need the DOM event to keep going — React 16
+              // delegates every event at `document`, so such a widget otherwise
+              // never observes its own clicks (silently, and with `mousedown` still
+              // flowing, so its hover states look healthy).
+              //
+              // Also never `preventDefault()` here: this runs for every click
+              // bubbling out of the dialog's contents, and it would cancel default
+              // actions of inner controls — most visibly the native file picker,
+              // opened by a programmatic `fileInputRef.click()` that passes through.
+              e.isPropagationStopped = () => true
             }}
           >
             {children}


### PR DESCRIPTION
## Problem

Any widget embedded inside an `F0Dialog` that mounts **its own React root** silently loses every click. No error, no warning — and because only `click` is affected, `mousedown`/`mouseover` keep flowing, so hover states, tooltips and internal rendering all look perfectly healthy. Only interaction is dead.

Hit in practice by the Cronofy availability grid in Factorial's ATS "Schedule an interview" wizard (which renders through `F0WizardForm` → `F0Dialog`): the grid drew correctly, hovered correctly, emitted its own `displayed_dates_changed`/`visible_slots` notifications — and clicking a slot did nothing at all.

## Root cause

The dialog content box called `e.stopPropagation()` on every bubbling click. That is wanted behaviour for the **React tree**: inner clicks must not be treated as outside-clicks by the wrapper handler above, and must not reach a clickable ancestor rendering the dialog (React propagates synthetic events along the component tree, so a portal does not isolate them).

But React's synthetic `stopPropagation` also calls `nativeEvent.stopPropagation()`, which halts the **DOM** event at React's root container. Anything delegating events at `document` then never observes the click — and **React 16 delegates every event at `document`**, so any embedded React 16 root is starved.

Traced in the browser from the consumer side:

```
reachedDocument: false
deepestReached: DIV#f0-overlay-root   ← last node to receive the click
blockedBy:      DIV#f0-layout         ← React's root container
```

Confirmed in a unit probe: on `main`, the native `stopPropagation` is invoked exactly once per inner click.

## Fix

Set React's own propagation flag instead of calling `stopPropagation()`:

```tsx
e.isPropagationStopped = () => true
```

React consults `event.isPropagationStopped()` while walking its dispatch queue, so React-tree propagation stops exactly as before — same semantics, including that listeners on the same instance still run — while the DOM event is left completely untouched.

`preventDefault()` is still never called here; see `F0Dialog.file-input-click.test.tsx`, which covers an earlier bug in this same handler where it cancelled the native file picker.

## Verification

New `F0Dialog.inner-click-propagation.test.tsx` — three tests, each verified to fail against the version it guards:

| Variant | Result |
| --- | --- |
| `main` (bug present) | **1 failed** — "never stops the DOM event" |
| stopping propagation in the wrapper by origin instead (my first attempt) | **2 failed** — both "clickable ancestor" tests |
| this fix | **3 passed** |

That middle row is worth calling out: my first attempt moved the check to the wrapper handler and dropped the box's `stopPropagation` entirely. It fixed the bug but **leaked inner clicks to clickable ancestors** — a data-collection row or card rendering a dialog would fire its handler when the user clicked inside. The tests here exist because of that near-miss.

Also: all 26 existing `dialog-alike` tests pass, `oxlint` clean, `pnpm build:types` clean.

### Automated cover is mechanism-level only

The original failure needs React's real root-container nesting (`#f0-layout` above `#f0-overlay-root`), which `zeroRender` does not reproduce — the unit tests above assert the *mechanism* (native `stopPropagation` never invoked), not the browser symptom.

The fix **has been verified end-to-end manually** in the consumer app running with this change applied: slot selection in the Cronofy grid works, clicks inside dialogs do not leak to clickable ancestors, dialog dismissal is unchanged, and `F0Drawer` and other dialog-alike components (which share this `DialogContent`) behave as before. Happy to add a Storybook interaction test if you want browser-level cover in CI.

## Consumer context

Consumer PR: factorialco/factorial#108845 — it carries **no workaround** and is blocked on this fix being merged, released, and the `@factorialco/f0-react` version bumped there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
