### PR TITLE
fix: centre UpsellRequestResponseDialog instead of double-offsetting it

### DIFF
--- a/packages/react/src/sds/UpsellingKit/UpsellRequestResponseDialog/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellRequestResponseDialog/index.tsx
@@ -168,7 +168,16 @@ const _UpsellRequestResponseDialog = forwardRef<
       >
         <DialogContent
           ref={ref}
-          className="bottom-3 top-auto max-w-[400px] translate-y-0 sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%]"
+          // Alignment belongs to the WRAPPER, which is the flex container
+          // (`fixed inset-0 flex items-center justify-center`). The card itself is
+          // `relative`, so offsetting it with `top-[50%] translate-y-[-50%]` — the
+          // centring trick for an ABSOLUTE element — stacked a second centring on
+          // top of the flex one: a percentage `top` resolves against the
+          // full-viewport wrapper, so the card was pushed half a viewport down and
+          // only pulled back half its own height, landing it near the bottom of the
+          // screen on desktop.
+          wrapperClassName="items-end sm:items-center"
+          className="mb-3 max-w-[400px] sm:mb-0"
           container={portalContainer}
         >
           <DialogHeader


### PR DESCRIPTION
## Description

`UpsellRequestResponseDialog` renders near the **bottom edge** of the viewport on desktop instead of centred. It is centred twice: once by `DialogContent`'s flex wrapper, and again by offset utilities on the card itself.

Reported from the Factorial marketplace module detail page, where it is used for the "Request a meeting" confirmation.

## Screenshots (if applicable)

Before — the success dialog sits flush against the bottom of the window:

<img width="1309" height="919" alt="Screenshot 2026-08-05 at 10 01 22 AM" src="https://github.com/user-attachments/assets/5eef38b2-6c15-4a7f-861d-3795574ac4fc" />


## Implementation details

`DialogContent` already positions its card by flex-centring inside a full-viewport wrapper:

```tsx
// ui/Dialog/components/DialogContent.tsx
<DialogPrimitive.Content className="fixed inset-0 z-50 flex items-center justify-center …">
  <div className={cn("relative flex w-[90%] flex-col …", className)}>
```

This component was passing:

```
bottom-3 top-auto translate-y-0 sm:bottom-auto sm:top-[50%] sm:translate-y-[-50%]
```

`top-[50%] translate-y-[-50%]` is the centring idiom for an **absolutely** positioned element. Here the card is `relative` and its parent already centres it, so the offset stacks on top of the flex centring. A percentage `top` on a relative element resolves against its containing block — the full-viewport wrapper — so the card is pushed down half the viewport and pulled back up only half its own height.

Concretely, on a 922px viewport with a ~200px card:

| step | card top |
|---|---|
| flex centring | 361px |
| `+ top: 50%` (461px) | 822px |
| `+ translateY(-50%)` (−100px) | **722px** |

Card top 722, bottom 922 — flush with the bottom edge, exactly as reported.

The mobile branch has the same root cause: `bottom-3` on a flex-centred `relative` element nudges the card 12px *above* centre, rather than pinning it near the bottom as a sheet.

**Fix:** express alignment once, on the flex wrapper, and use margin for the mobile gap:

```tsx
wrapperClassName="items-end sm:items-center"
className="mb-3 max-w-[400px] sm:mb-0"
```

Intent is preserved — sheet-style on mobile, centred on desktop — with no competing offsets. `cn` uses `tailwind-merge`, so `items-end` correctly overrides the wrapper's base `items-center` while `sm:items-center` restores centring at ≥640px.

This is the only component in the package passing that offset pattern to `DialogContent`, so no other consumers are affected:

```
$ grep -rn "translate-y-\[-50%\]\|top-\[50%\]" --include="*.tsx" packages/react/src | grep -v ui/Dialog
packages/react/src/sds/UpsellingKit/UpsellRequestResponseDialog/index.tsx:171
```

### Verification

- `pnpm lint` and `pnpm format` clean on the touched file
- `pnpm tsc` error count unchanged vs `main` (74 pre-existing, none in this file)
- No unit tests exist for this component; the change is visual and covered by its stories

Please sanity-check the rendered result at both breakpoints — I could not run Storybook in my environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)