### PR TITLE
fix(F0Graph): keep windowed-in nodes' edges from vanishing on pan

### DIFF
--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
@@ -169,7 +169,7 @@ describe("useGraphRenderModel — node windowing", () => {
     expect(result.current.renderedNodeCount).toBe(1)
   })
 
-  it("drops edges whose endpoints are not both windowed", () => {
+  it("pulls in an off-window child so a visible parent's edge still renders", () => {
     const child = treeNode("child", "root", 0, [], 1)
     const root = treeNode("root", null, 1, [child])
     // Rect covers root but not the far-away child.
@@ -182,15 +182,35 @@ describe("useGraphRenderModel — node windowing", () => {
         child: { x: 0, y: 5000 },
       }),
     })
-    expect(result.current.rfNodes.map((n) => n.id)).not.toContain("child")
-    // No surviving edge may reference the windowed-out child.
-    for (const edge of result.current.rfEdges) {
-      expect(edge.source).not.toBe("child")
-      expect(edge.target).not.toBe("child")
-    }
+    // The edge root→child passes through the viewport (root is inside it), so the
+    // child is materialized and the connecting line renders — a visible parent
+    // never looks connected only to the children that happen to stay on screen.
+    expect(result.current.rfNodes.map((n) => n.id)).toContain("child")
+    expect(
+      result.current.rfEdges.some(
+        (e) => e.source === "root" && e.target === "child"
+      )
+    ).toBe(true)
   })
 
-  it("trims aria-owns children that fall outside the window", () => {
+  it("keeps a lone off-window node dropped when no edge crosses the viewport", () => {
+    // Two unrelated roots (no edge between them): the far one is still culled —
+    // the frontier pull-in only materializes endpoints of edges touching the view.
+    const near = treeNode("near", null, 0)
+    const far = treeNode("far", null, 0)
+    mockViewportRect = { minX: -10, minY: -10, maxX: 200, maxY: 200 }
+    const { result } = renderModel({
+      ...baseOptions([near, far], []),
+      enableNodeWindowing: true,
+      layoutEngineProp: fixedLayout({
+        near: { x: 0, y: 0 },
+        far: { x: 5000, y: 5000 },
+      }),
+    })
+    expect(result.current.rfNodes.map((n) => n.id)).not.toContain("far")
+  })
+
+  it("keeps aria-owns to an off-window child once its edge pulls it in", () => {
     const child = treeNode("child", "root", 0, [], 1)
     const root = treeNode("root", null, 1, [child])
     mockViewportRect = { minX: -10, minY: -10, maxX: 200, maxY: 200 }
@@ -202,10 +222,11 @@ describe("useGraphRenderModel — node windowing", () => {
         child: { x: 0, y: 5000 },
       }),
     })
-    // `root` survives but its only child was windowed out → no dangling aria-owns.
+    // The off-window child is materialized to keep the parent's edge, so it is a
+    // valid aria-owns target (not a dangling ref).
     expect(
       graphNodeData(result.current.rfNodes, "root")?.visibleChildIds
-    ).toBeUndefined()
+    ).toEqual(["child"])
   })
 
   it("keeps aria-owns children that remain in the window", () => {

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -529,6 +529,16 @@ export function useGraphRenderModel<T>({
           y: (pos?.y ?? 0) * yStretch,
         },
         width: BASE_W,
+        height: BASE_H,
+        // Seed the measured size from the layout so React Flow can route this
+        // node's edges on the SAME commit it is added, instead of waiting for
+        // its ResizeObserver. Without it, a node that windowing pans into view
+        // is handed to React Flow un-measured for one commit; edges touching it
+        // resolve to a null position and are dropped from the DOM that frame, so
+        // connecting lines flicker/vanish while panning a large or deep tree
+        // (the on-screen node stays, its reporting line disappears). The real
+        // DOM measurement still runs and overwrites this with the exact size.
+        measured: { width: BASE_W, height: BASE_H },
         sourcePosition: sourcePos,
         targetPosition: targetPos,
         data: {

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -384,6 +384,11 @@ export function useGraphRenderModel<T>({
   ])
 
   // ── Node-array windowing ──
+  // Ids that have ever been materialized into React Flow. Once a node has been
+  // rendered (seen + hydrated), we keep it in the window so it never re-enters
+  // React Flow un-measured on a later pan — see the sticky union below.
+  const seenWindowedIdsRef = useRef<Set<string>>(new Set())
+
   // Ids of the LAYOUT nodes (graph pills + expanders) whose box intersects the
   // padded viewport. `null` means "no windowing" (feature off, or viewport not
   // yet measured) → render everything, which is also what the initial `fitView`
@@ -430,6 +435,25 @@ export function useGraphRenderModel<T>({
         parentId = nodeMap.get(parentId)?.parentId ?? null
       }
     }
+
+    // ── Sticky window ──
+    // Keep every node we have already materialized so it never re-enters React
+    // Flow un-measured on a later pan. When a node is re-added un-measured, React
+    // Flow can't resolve the endpoints of the edges touching it and drops them
+    // from the DOM for that commit — so a node you have ALREADY seen connected
+    // flickers/goes disconnected while panning (the "connections get lost"
+    // report). Only nodes actually seen are retained, so never-seen parts of a
+    // flat or deep tree stay windowed out and un-hydrated — the whole point of
+    // windowing. The set is pruned to ids still present in the current layout so
+    // it can't grow unbounded or resurrect collapsed nodes; it grows only with
+    // the region the user has actually looked at.
+    const layoutIds = new Set(layout.nodes.map((pn) => pn.id))
+    for (const seenId of seenWindowedIdsRef.current) {
+      if (layoutIds.has(seenId)) ids.add(seenId)
+      else seenWindowedIdsRef.current.delete(seenId)
+    }
+    for (const id of ids) seenWindowedIdsRef.current.add(id)
+
     return ids
   }, [
     enableNodeWindowing,
@@ -529,16 +553,6 @@ export function useGraphRenderModel<T>({
           y: (pos?.y ?? 0) * yStretch,
         },
         width: BASE_W,
-        height: BASE_H,
-        // Seed the measured size from the layout so React Flow can route this
-        // node's edges on the SAME commit it is added, instead of waiting for
-        // its ResizeObserver. Without it, a node that windowing pans into view
-        // is handed to React Flow un-measured for one commit; edges touching it
-        // resolve to a null position and are dropped from the DOM that frame, so
-        // connecting lines flicker/vanish while panning a large or deep tree
-        // (the on-screen node stays, its reporting line disappears). The real
-        // DOM measurement still runs and overwrites this with the exact size.
-        measured: { width: BASE_W, height: BASE_H },
         sourcePosition: sourcePos,
         targetPosition: targetPos,
         data: {

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -27,7 +27,6 @@ import type {
 import {
   BACKGROUND_DOT_GAP,
   COLLAPSER_OFFSET_ADJUSTMENT_BY_ZOOM,
-  DEFAULT_NODE_WINDOW_PADDING,
 } from "../constants"
 import {
   EXPANDER_Y_OFFSET_BY_ZOOM,
@@ -385,11 +384,6 @@ export function useGraphRenderModel<T>({
   ])
 
   // ── Node-array windowing ──
-  // The previous commit's windowed id set, used for the release hysteresis
-  // below (a node is only dropped once it leaves a margin larger than the one
-  // that added it).
-  const prevWindowedIdsRef = useRef<Set<string>>(new Set())
-
   // Ids of the LAYOUT nodes (graph pills + expanders) whose box intersects the
   // padded viewport. `null` means "no windowing" (feature off, or viewport not
   // yet measured) → render everything, which is also what the initial `fitView`
@@ -402,44 +396,19 @@ export function useGraphRenderModel<T>({
   // pan/zoom on large graphs: without it every pan cell-crossing and every
   // zoom-level change would rebuild an object per visible node.
   const windowedIds = useMemo((): Set<string> | null => {
-    if (!enableNodeWindowing || !viewportRect) {
-      prevWindowedIdsRef.current = new Set()
-      return null
-    }
+    if (!enableNodeWindowing || !viewportRect) return null
     const fallbackWidth = nodeWidthProp ?? 256
-
-    // Asymmetric release hysteresis. A node is ADDED as soon as it enters the
-    // padded viewport, but is only RELEASED once it leaves a larger margin
-    // (`viewportRect` grown by `release`). Without this, a node hovering on the
-    // window boundary flip-flops in/out on every pan cell-crossing; React Flow
-    // drops the edges touching any node re-added un-measured, so a node you can
-    // still see blinks disconnected ("connections get lost while panning"). The
-    // retained band is bounded (it never exceeds the release rect), so per-frame
-    // work stays ~O(on-screen) — FPS is preserved and never-seen parts of a flat
-    // or deep tree stay windowed out and un-hydrated. Nodes panned well past the
-    // release margin are dropped as before; a visible node's line to an
-    // off-window ancestor is instead guaranteed by the ancestry walk below.
-    const release = nodeWindowPadding ?? DEFAULT_NODE_WINDOW_PADDING
-    const keepRect = {
-      minX: viewportRect.minX - release,
-      minY: viewportRect.minY - release,
-      maxX: viewportRect.maxX + release,
-      maxY: viewportRect.maxY + release,
-    }
-    const prev = prevWindowedIdsRef.current
-
     const ids = new Set<string>()
     for (const pn of layout.nodes) {
-      const w = pn.width || fallbackWidth
-      const h = pn.height || effectiveNodeHeight
-      if (nodeIntersectsRect(pn.x, pn.y, w, h, viewportRect)) {
-        ids.add(pn.id)
-      } else if (
-        prev.has(pn.id) &&
-        nodeIntersectsRect(pn.x, pn.y, w, h, keepRect)
+      if (
+        nodeIntersectsRect(
+          pn.x,
+          pn.y,
+          pn.width || fallbackWidth,
+          pn.height || effectiveNodeHeight,
+          viewportRect
+        )
       ) {
-        // Retained: was in the window last commit and hasn't left the release
-        // margin yet — keep it (and its measurement) so its edges don't drop.
         ids.add(pn.id)
       }
     }
@@ -461,13 +430,10 @@ export function useGraphRenderModel<T>({
         parentId = nodeMap.get(parentId)?.parentId ?? null
       }
     }
-
-    prevWindowedIdsRef.current = ids
     return ids
   }, [
     enableNodeWindowing,
     viewportRect,
-    nodeWindowPadding,
     layout.nodes,
     nodeWidthProp,
     effectiveNodeHeight,
@@ -491,6 +457,14 @@ export function useGraphRenderModel<T>({
     const inWindow = (id: string): boolean =>
       !windowedIds || windowedIds.has(id)
 
+    // Whether windowing is actually driving this render (a viewport is measured
+    // and the feature is on). Only then do we seed `handles`/dimensions on the
+    // nodes — see the handle geometry below. With windowing off, React Flow's own
+    // `onlyRenderVisibleElements` is active, and marking nodes measured up front
+    // would let it cull them before their real size is known; leaving it as-is
+    // keeps the original non-windowed behavior untouched.
+    const windowingActive = windowedIds !== null
+
     // Direction-aware port positions for React Flow edge routing
     const isHorizontal = direction === "LR" || direction === "RL"
     const sourcePos =
@@ -509,6 +483,40 @@ export function useGraphRenderModel<T>({
           : direction === "LR"
             ? Position.Left
             : Position.Right
+
+    // Precomputed handle geometry so React Flow can route a node's edges on the
+    // very commit the node is added — before its DOM handles are measured.
+    // Without a `handles` array React Flow has no handle bounds for a freshly
+    // windowed-in node, so `getEdgePosition` returns null and every edge touching
+    // it is dropped from the DOM for that frame — connecting/reporting lines
+    // flicker or vanish while panning a large/flat/deep tree. Providing the port
+    // offsets lets React Flow derive the endpoint immediately; the real measured
+    // handle bounds take over once the node's DOM mounts. Node dimensions are
+    // supplied below (`width`/`height`) so the node also counts as "initialized".
+    const handleOffset = (p: Position): { x: number; y: number } =>
+      p === Position.Top
+        ? { x: BASE_W / 2, y: 0 }
+        : p === Position.Bottom
+          ? { x: BASE_W / 2, y: BASE_H }
+          : p === Position.Left
+            ? { x: 0, y: BASE_H / 2 }
+            : { x: BASE_W, y: BASE_H / 2 }
+    const graphNodeHandles = [
+      {
+        type: "source" as const,
+        position: sourcePos,
+        ...handleOffset(sourcePos),
+        width: 1,
+        height: 1,
+      },
+      {
+        type: "target" as const,
+        position: targetPos,
+        ...handleOffset(targetPos),
+        width: 1,
+        height: 1,
+      },
+    ] as RFNode["handles"]
 
     const nodes: RFNode[] = []
 
@@ -563,6 +571,14 @@ export function useGraphRenderModel<T>({
           y: (pos?.y ?? 0) * yStretch,
         },
         width: BASE_W,
+        // Only while windowing drives the render: seed the node's size and port
+        // handles so React Flow can route its edges on the commit it is added,
+        // before the DOM is measured (otherwise a freshly windowed-in node's
+        // connecting lines drop for that frame). Omitted when windowing is off so
+        // React Flow's own viewport culling keeps its original behavior.
+        ...(windowingActive
+          ? { height: BASE_H, handles: graphNodeHandles }
+          : null),
         sourcePosition: sourcePos,
         targetPosition: targetPos,
         data: {

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -27,6 +27,7 @@ import type {
 import {
   BACKGROUND_DOT_GAP,
   COLLAPSER_OFFSET_ADJUSTMENT_BY_ZOOM,
+  DEFAULT_NODE_WINDOW_PADDING,
 } from "../constants"
 import {
   EXPANDER_Y_OFFSET_BY_ZOOM,
@@ -384,10 +385,10 @@ export function useGraphRenderModel<T>({
   ])
 
   // ── Node-array windowing ──
-  // Ids that have ever been materialized into React Flow. Once a node has been
-  // rendered (seen + hydrated), we keep it in the window so it never re-enters
-  // React Flow un-measured on a later pan — see the sticky union below.
-  const seenWindowedIdsRef = useRef<Set<string>>(new Set())
+  // The previous commit's windowed id set, used for the release hysteresis
+  // below (a node is only dropped once it leaves a margin larger than the one
+  // that added it).
+  const prevWindowedIdsRef = useRef<Set<string>>(new Set())
 
   // Ids of the LAYOUT nodes (graph pills + expanders) whose box intersects the
   // padded viewport. `null` means "no windowing" (feature off, or viewport not
@@ -401,19 +402,44 @@ export function useGraphRenderModel<T>({
   // pan/zoom on large graphs: without it every pan cell-crossing and every
   // zoom-level change would rebuild an object per visible node.
   const windowedIds = useMemo((): Set<string> | null => {
-    if (!enableNodeWindowing || !viewportRect) return null
+    if (!enableNodeWindowing || !viewportRect) {
+      prevWindowedIdsRef.current = new Set()
+      return null
+    }
     const fallbackWidth = nodeWidthProp ?? 256
+
+    // Asymmetric release hysteresis. A node is ADDED as soon as it enters the
+    // padded viewport, but is only RELEASED once it leaves a larger margin
+    // (`viewportRect` grown by `release`). Without this, a node hovering on the
+    // window boundary flip-flops in/out on every pan cell-crossing; React Flow
+    // drops the edges touching any node re-added un-measured, so a node you can
+    // still see blinks disconnected ("connections get lost while panning"). The
+    // retained band is bounded (it never exceeds the release rect), so per-frame
+    // work stays ~O(on-screen) — FPS is preserved and never-seen parts of a flat
+    // or deep tree stay windowed out and un-hydrated. Nodes panned well past the
+    // release margin are dropped as before; a visible node's line to an
+    // off-window ancestor is instead guaranteed by the ancestry walk below.
+    const release = nodeWindowPadding ?? DEFAULT_NODE_WINDOW_PADDING
+    const keepRect = {
+      minX: viewportRect.minX - release,
+      minY: viewportRect.minY - release,
+      maxX: viewportRect.maxX + release,
+      maxY: viewportRect.maxY + release,
+    }
+    const prev = prevWindowedIdsRef.current
+
     const ids = new Set<string>()
     for (const pn of layout.nodes) {
-      if (
-        nodeIntersectsRect(
-          pn.x,
-          pn.y,
-          pn.width || fallbackWidth,
-          pn.height || effectiveNodeHeight,
-          viewportRect
-        )
+      const w = pn.width || fallbackWidth
+      const h = pn.height || effectiveNodeHeight
+      if (nodeIntersectsRect(pn.x, pn.y, w, h, viewportRect)) {
+        ids.add(pn.id)
+      } else if (
+        prev.has(pn.id) &&
+        nodeIntersectsRect(pn.x, pn.y, w, h, keepRect)
       ) {
+        // Retained: was in the window last commit and hasn't left the release
+        // margin yet — keep it (and its measurement) so its edges don't drop.
         ids.add(pn.id)
       }
     }
@@ -436,28 +462,12 @@ export function useGraphRenderModel<T>({
       }
     }
 
-    // ── Sticky window ──
-    // Keep every node we have already materialized so it never re-enters React
-    // Flow un-measured on a later pan. When a node is re-added un-measured, React
-    // Flow can't resolve the endpoints of the edges touching it and drops them
-    // from the DOM for that commit — so a node you have ALREADY seen connected
-    // flickers/goes disconnected while panning (the "connections get lost"
-    // report). Only nodes actually seen are retained, so never-seen parts of a
-    // flat or deep tree stay windowed out and un-hydrated — the whole point of
-    // windowing. The set is pruned to ids still present in the current layout so
-    // it can't grow unbounded or resurrect collapsed nodes; it grows only with
-    // the region the user has actually looked at.
-    const layoutIds = new Set(layout.nodes.map((pn) => pn.id))
-    for (const seenId of seenWindowedIdsRef.current) {
-      if (layoutIds.has(seenId)) ids.add(seenId)
-      else seenWindowedIdsRef.current.delete(seenId)
-    }
-    for (const id of ids) seenWindowedIdsRef.current.add(id)
-
+    prevWindowedIdsRef.current = ids
     return ids
   }, [
     enableNodeWindowing,
     viewportRect,
+    nodeWindowPadding,
     layout.nodes,
     nodeWidthProp,
     effectiveNodeHeight,

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -430,10 +430,34 @@ export function useGraphRenderModel<T>({
         parentId = nodeMap.get(parentId)?.parentId ?? null
       }
     }
+
+    // Draw every edge that passes through the window. An edge's path enters the
+    // viewport only when one of its endpoints sits inside it, so for each visible
+    // edge with exactly one endpoint IN THE VIEWPORT (not merely materialized via
+    // the ancestry spine), pull the other endpoint in too — React Flow can then
+    // route the edge even when the layout pushed that endpoint off-viewport. This
+    // keeps a visible parent's line to an off-screen child: expanding a wide node
+    // spreads its siblings past the screen edge, and without this the parent
+    // would look connected only to the child that stayed on screen. The reverse
+    // (a visible child's line up to an off-screen parent) is already covered by
+    // the ancestry walk above. Keyed on the VIEWPORT set — not `ids` — so an
+    // off-screen spine ancestor does not drag in all of its children at every
+    // level. A collapsed parent contributes only its expander-stub edge (its real
+    // children aren't in `visibleEdges`), so closed subtrees stay windowed out.
+    const viewportIds = new Set(base)
+    for (const edge of visibleEdges) {
+      const sourceIn = viewportIds.has(edge.source)
+      const targetIn = viewportIds.has(edge.target)
+      if (sourceIn !== targetIn) {
+        ids.add(edge.source)
+        ids.add(edge.target)
+      }
+    }
     return ids
   }, [
     enableNodeWindowing,
     viewportRect,
+    visibleEdges,
     layout.nodes,
     nodeWidthProp,
     effectiveNodeHeight,


### PR DESCRIPTION
## Problem

With `enableNodeWindowing` on, connecting/reporting lines vanish on a large, flat or deep org chart — the node stays on screen but its line disappears. This is the "las conexiones se pierden al abrir mucho el árbol" report, and it survives the earlier #4742 fix (which only stopped React Flow's own culling). Two triggers:

- **Panning** a large/deep tree: a node's line flickers and drops as the camera moves.
- **Expanding** a node: expanding a wide node spreads its siblings past the screen edge, so the parent ends up looking connected only to the child that stayed on screen — its reporting fan-out disappears.

<img width="2211" height="1186" alt="Screenshot 2026-08-05 at 16 10 07" src="https://github.com/user-attachments/assets/baf9796c-5cf7-4e5e-a9cf-901cfa3097ca" />


## Root cause

Two distinct issues in `useGraphRenderModel`, both coming from how viewport windowing feeds React Flow:

1. **Un-measured nodes drop their edges.** A node that windowing pans/expands into view is handed to React Flow with no measured handle bounds for the commit it is added. `getEdgePosition` returns `null` for any edge touching an un-measured node, so those edges are dropped from the DOM that frame — the line vanishes (and stays gone while panning, since every frame re-adds nodes un-measured).

2. **Off-viewport edge endpoints are culled.** Windowing materializes only the nodes intersecting the viewport (plus the ancestry spine). Expanding a wide node pushes its siblings off-screen, so the parent's edges to them are dropped even though the parent is on screen and those lines cross the viewport.

## Fix

1. **Seed port handles + size on each windowed graph node.** React Flow falls back to `toHandleBounds(node.handles)` when a node has no measured handle bounds, so providing the source/target port offsets (plus `width`/`height`) lets `getEdgePosition` resolve the endpoints on the very commit the node is added — the lines never drop, and the real measured bounds take over once the DOM mounts. Applied only while windowing actually drives the render, so React Flow's own `onlyRenderVisibleElements` path (windowing off) is left untouched.

2. **Frontier edge inclusion.** For every visible edge with exactly one endpoint inside the viewport, pull the other endpoint into the windowed set too, so React Flow can route the edge even when the layout pushed that endpoint off-screen. Keyed on the viewport set (not the ancestry spine), so an off-screen ancestor doesn't drag in all of its children at every level; a collapsed parent contributes only its expander-stub edge (its real children aren't in `visibleEdges`), so closed subtrees stay windowed out, and a lone far node with no edge crossing the view is still culled. The ancestry walk already covered the reverse (a visible child's line up to an off-screen parent).

Net effect: every edge whose path crosses the window is drawn — parent → off-screen child and child → off-screen ancestor — with **no sticky/unbounded retention across a session** (nodes panned away are released, and never-seen subtrees stay windowed out). `F0Graph` unit tests pass (250/250); typecheck/lint clean for the touched files.

## Performance trade-off

The frontier set is recomputed per frame and doesn't accumulate over time, but its size **grows with the child count of the visible nodes**: when a node with a very large fan-out is on screen and expanded, *all* of its children are materialized — including the ones the layout pushed off-screen — so their connecting lines can be drawn. For such **extreme fan-out, FPS preservation is not guaranteed**.

This is a deliberate, accepted trade-off: we sacrifice some performance on pathologically wide nodes in order to always show the complete set of paths from a node to its children — the exact pain this PR sets out to fix. For typical fan-out the extra cost is a handful of off-screen nodes and is negligible. If extreme fan-out becomes a problem in practice, a follow-up can cap the number of off-screen children materialized per parent (drawing the first N lines + an indicator).

<img width="2076" height="1148" alt="Screenshot 2026-08-05 at 18 09 15" src="https://github.com/user-attachments/assets/a8a30b87-38f5-4110-99b5-b29187873c6f" />


## How to test

- Storybook → `Graph/F0Graph/DeepTreeWindowing` (or `ViewportWindowing`): pan far from the initial frame with windowing on; the connecting lines stay attached under the camera.
- Local app: install this branch's alpha and open the org chart (v3) on a flat/deep tree. Expand a wide node and pan — the parent keeps its lines to **all** its children, including the ones pushed off-screen, and nothing drops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
