### PR TITLE
fix(F0Graph): keep the node border visible on hover

### DIFF
--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -230,7 +230,7 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
               state !== "selected" &&
                 state !== "highlighted" &&
                 !isDot &&
-                "group-hover/pill:border-transparent group-hover/pill:bg-f1-background-hover",
+                "group-hover/pill:bg-f1-background-hover",
               (state === "selected" || state === "highlighted") &&
                 "border-f1-border-selected-bold"
             )}


### PR DESCRIPTION
## Description

In the Job Catalog **Graph** view (and any F0Graph consumer), hovering a node made its border disappear. The node's "chrome layer" applied `group-hover/pill:border-transparent` together with the hover background, so on hover the resting `border-f1-border` was overridden to transparent and the node lost its edge until the pointer left.

This removes only the transparent-border override. The hover background (`bg-f1-background-hover`) and all other hover behaviour are unchanged; the resting border now stays visible on hover, consistent with the at-rest state.

Jira: FCT-60738

## Type of change

- [x] Bug fix

## Implementation details

`packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx` — the chrome-layer class list:

```diff
-  "group-hover/pill:border-transparent group-hover/pill:bg-f1-background-hover",
+  "group-hover/pill:bg-f1-background-hover",
```

- The base border `border-f1-border` (non-`dot`) is now preserved through the hover instead of being overridden to transparent.
- `selected` / `highlighted` keep their own `border-f1-border-selected-bold` branch — untouched.
- `dot` variant is excluded by the existing `!isDot` guard — untouched.
- Applies to all node types (root / family / function / role / level), which all share this chrome layer.

## Screenshots

### Before

<img width="493" height="443" alt="Screenshot 2026-08-06 at 08 59 49" src="https://github.com/user-attachments/assets/8e77b907-e994-41f1-b117-8a097e3779e6" />

### After

<img width="493" height="443" alt="Screenshot 2026-08-06 at 09 12 08" src="https://github.com/user-attachments/assets/7b8cade6-02c9-4522-8da9-dbc91f86fa2e" />
