### PR TITLE
fix(react): keep the locked sidebar above the main content

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -153,7 +153,7 @@ export function TableCell({
         // its content never blends into whatever is to its left.
         isStickyLeft &&
           stickyLeft === 0 &&
-          "border-l border-f1-border-secondary",
+          "border-l border-solid border-f1-border-secondary",
         isStickyRight && stickyScrollClasses[referenceRowType],
         href && "cursor-pointer",
         className

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -148,6 +148,12 @@ export function TableCell({
         firstCell && "peer font-medium",
         isSticky && isScrolled && stickyScrollClasses[referenceRowType],
         isSticky && "sticky z-10",
+        // The left-frozen first column can sit flush against an outer surface
+        // (e.g. the app sidebar). A left border keeps it visually separated so
+        // its content never blends into whatever is to its left.
+        isStickyLeft &&
+          stickyLeft === 0 &&
+          "border-l border-f1-border-secondary",
         isStickyRight && stickyScrollClasses[referenceRowType],
         href && "cursor-pointer",
         className

--- a/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
@@ -176,3 +176,46 @@ describe("TableHead rich header info", () => {
     ).not.toBeInTheDocument()
   })
 })
+
+describe("left-frozen column border", () => {
+  // Only the left-frozen FIRST column (left === 0) gets a left border, so it
+  // stays separated from whatever sits to its left (e.g. the app sidebar).
+  // Inner frozen columns (left > 0) and non-frozen columns do not. FCT-60739.
+  const renderFrozenTable = () =>
+    zeroRender(
+      <OneTable>
+        <TableHeader>
+          <TableRow>
+            <TableHead sticky={{ left: 0 }}>Name</TableHead>
+            <TableHead sticky={{ left: 120 }}>Team</TableHead>
+            <TableHead>Role</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell sticky={{ left: 0 }}>Ada</TableCell>
+            <TableCell sticky={{ left: 120 }}>Platform</TableCell>
+            <TableCell>Engineer</TableCell>
+          </TableRow>
+        </TableBody>
+      </OneTable>
+    )
+
+  it("borders only the left-frozen first header cell", () => {
+    renderFrozenTable()
+    const [name, team, role] = screen.getAllByRole("columnheader")
+
+    expect(name).toHaveClass("border-l", "border-f1-border-secondary")
+    expect(team).not.toHaveClass("border-l")
+    expect(role).not.toHaveClass("border-l")
+  })
+
+  it("borders only the left-frozen first body cell", () => {
+    renderFrozenTable()
+    const [name, team, role] = screen.getAllByRole("cell")
+
+    expect(name).toHaveClass("border-l", "border-f1-border-secondary")
+    expect(team).not.toHaveClass("border-l")
+    expect(role).not.toHaveClass("border-l")
+  })
+})

--- a/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
@@ -205,7 +205,13 @@ describe("left-frozen column border", () => {
     renderFrozenTable()
     const [name, team, role] = screen.getAllByRole("columnheader")
 
-    expect(name).toHaveClass("border-l", "border-f1-border-secondary")
+    // border-solid is required: F0 disables Tailwind preflight, so a border-*
+    // width utility without an explicit style renders at 0px (invisible).
+    expect(name).toHaveClass(
+      "border-l",
+      "border-solid",
+      "border-f1-border-secondary"
+    )
     expect(team).not.toHaveClass("border-l")
     expect(role).not.toHaveClass("border-l")
   })
@@ -214,7 +220,13 @@ describe("left-frozen column border", () => {
     renderFrozenTable()
     const [name, team, role] = screen.getAllByRole("cell")
 
-    expect(name).toHaveClass("border-l", "border-f1-border-secondary")
+    // border-solid is required: F0 disables Tailwind preflight, so a border-*
+    // width utility without an explicit style renders at 0px (invisible).
+    expect(name).toHaveClass(
+      "border-l",
+      "border-solid",
+      "border-f1-border-secondary"
+    )
     expect(team).not.toHaveClass("border-l")
     expect(role).not.toHaveClass("border-l")
   })

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -321,7 +321,7 @@ export function TableHead({
         // sits to its left (e.g. the app sidebar).
         isStickyLeft &&
           stickyLeft === 0 &&
-          "border-l border-f1-border-secondary",
+          "border-l border-solid border-f1-border-secondary",
         hidden && "after:hidden",
         handleCellClick && "cursor-pointer",
         className

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -316,6 +316,12 @@ export function TableHead({
           (isScrolled || isScrolledRight) &&
           "relative bg-f1-background z-10 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:w-full before:bg-f1-border-secondary before:content-['']",
         isSticky && "sticky",
+        // Match TableCell: the left-frozen first column keeps a left border so
+        // the header lines up with the body and stays separated from whatever
+        // sits to its left (e.g. the app sidebar).
+        isStickyLeft &&
+          stickyLeft === 0 &&
+          "border-l border-f1-border-secondary",
         hidden && "after:hidden",
         handleCellClick && "cursor-pointer",
         className

--- a/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.sidebarLayer.test.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.sidebarLayer.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { ApplicationFrame } from ".."
+
+// Regression: with the sidebar locked (docked open), its stacking wrapper must
+// sit ABOVE the main content. A sticky first table column pins its left border
+// to the content's left edge at the sidebar seam; if the sidebar stacks below
+// the content, that border paints over the sidebar during horizontal scroll.
+// The bug was the locked wrapper at `z-0`, below the content's `z-10`. FCT-60739.
+describe("ApplicationFrame sidebar stacking (locked)", () => {
+  it("stacks the locked sidebar above the main content", () => {
+    render(
+      <ApplicationFrame sidebar={<div>SIDEBAR</div>}>
+        <div>PAGE CONTENT</div>
+      </ApplicationFrame>
+    )
+
+    // The locked sidebar's wrapper is z-20 (above the content), never the old z-0.
+    expect(screen.getByText("SIDEBAR").closest(".z-20")).not.toBeNull()
+    expect(screen.getByText("SIDEBAR").closest(".z-0")).toBeNull()
+
+    // The main content stays at z-10, so z-20 > z-10 keeps the sidebar on top.
+    const main = screen.getByText("PAGE CONTENT").closest("main")
+    expect(main).not.toBeNull()
+    expect(main).toHaveClass("z-10")
+  })
+})

--- a/packages/react/src/patterns/ApplicationFrame/index.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.tsx
@@ -164,12 +164,17 @@ function useAutoCloseSidebar(
 
 /**
  * Z-index layers (within the isolate stacking context):
- *   z-5   Sidebar
+ *   z-0   Chat (normal)
  *   z-10  Main content
  *   z-15  Canvas dashboard panel
- *   z-20  Sidebar backdrop / Chat (fullscreen)
+ *   z-20  Locked sidebar · Sidebar backdrop · Chat (fullscreen)
  *   z-30  Sidebar (unlocked/floating)
- *   z-0   Chat (normal)
+ *
+ * The locked sidebar sits above the main content (z-20 > z-10) so a sticky
+ * first table column — whose left border pins to the content's left edge at the
+ * sidebar seam — cannot paint over the sidebar during horizontal scroll. Sharing
+ * z-20 with the backdrop and fullscreen chat is safe: both only appear while the
+ * sidebar is floating (z-30) or hidden, never while it is locked.
  */
 function ApplicationFrameContent({
   ai,
@@ -298,7 +303,7 @@ function ApplicationFrameContent({
             {/* Sidebar */}
             <div
               className={cn(
-                sidebarState !== "locked" ? "z-30" : "z-0",
+                sidebarState !== "locked" ? "z-30" : "z-20",
                 !shouldReduceMotion && "transition-all",
                 sidebarState === "locked" ? "w-[240px] shrink-0 pl-3" : "w-0"
               )}


### PR DESCRIPTION
## Description

Fix the seam between the app **left sidebar** and a `OneDataCollection`/`OneTable` with a **frozen first column** (`frozenColumns: 1`). Reported from Factorial's **Job Catalog → Table (Roles)** view: the frozen "Name" column painted over the sidebar on horizontal scroll, and — sharing the sidebar's white background — blended into it with no visible separator.

Fixes [FCT-60739](https://factorialmakers.atlassian.net/browse/FCT-60739).

## Type of change

- [x] Bug fix

## Changes

**1. Stacking — locked sidebar above the content** (`patterns/ApplicationFrame`)
- The locked (docked) sidebar's stacking wrapper was `z-0`, below the main content's `z-10`, so a sticky column pinned at the sidebar seam painted over the sidebar. Raise the locked wrapper to `z-20` (above content, below the floating sidebar `z-30`) and fix the stale z-index legend. `z-20` is shared only with layers that never coexist with a locked sidebar (backdrop, fullscreen chat).

**2. Separator — border the left-frozen first column** (`experimental/OneTable`)
- The left-frozen first column (`sticky left === 0`) now has a gray `border-l` (`border-f1-border-secondary`) in both the header (`TableHead`) and body (`TableCell`) cells, so it stays visually separated from whatever sits to its left (the sidebar) instead of blending into it. Inner frozen columns (`left > 0`) and non-frozen columns are unchanged.

## Tests

- `ApplicationFrame.sidebarLayer.test.tsx` — locked sidebar wrapper stacks at `z-20`, above the `z-10` content (never the old `z-0`).
- `TableHead.test.tsx` — only the left-frozen first header/body cell gets `border-l border-f1-border-secondary`; inner frozen (`left > 0`) and non-frozen columns do not.
- `ApplicationFrame` + `OneTable/TableHead` suites green (16 tests); `oxfmt` + `oxlint` clean.

## Screenshots (if applicable)

Verified live against the Job Catalog Table in a local slot running this branch's alpha.

## Follow-up

After merge + release, bump `@factorialco/f0-react` in the `factorial` monorepo to pick up the fix.


[FCT-60739]: https://factorialmakers.atlassian.net/browse/FCT-60739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ