### PR TITLE
fix(BaseBanner): paint the background and border on every variant

### DIFF
--- a/packages/react/src/kits/ai/Banners/BaseBanner/__tests__/BaseBanner.test.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/__tests__/BaseBanner.test.tsx
@@ -103,4 +103,30 @@ describe("BaseBanner", () => {
       expect(screen.queryByText(baseProps.title)).not.toBeInTheDocument()
     })
   })
+
+  // `bg-white` is not a class f0 emits: the palette defines `white` as numeric
+  // steps (`white-3` … `white-100`) with no `DEFAULT` key, so it produced
+  // nothing at all. And preflight is disabled repo-wide, so `border` sets a
+  // width with no style and never draws. Every variant needs the real
+  // background token and an explicit border style.
+  describe("surface", () => {
+    it.each(["default", "full-width", "card"] as const)(
+      "paints a background and a drawable border in the %s variant",
+      (variant) => {
+        render(<BaseBanner {...baseProps} variant={variant} />)
+
+        expect(getRoot().className).toMatch(/bg-f1-background/)
+        expect(getRoot().className).toMatch(/border-solid/)
+        expect(getRoot().className.split(" ")).not.toContain("bg-white")
+      }
+    )
+
+    it("paints the same surface while loading", () => {
+      render(<BaseBanner {...baseProps} isLoading />)
+
+      expect(getRoot().className).toMatch(/bg-f1-background/)
+      expect(getRoot().className).toMatch(/border-solid/)
+      expect(getRoot().className.split(" ")).not.toContain("bg-white")
+    })
+  })
 })

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
@@ -66,12 +66,8 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
       <div
         ref={ref}
         className={cn(
-          "relative flex w-full flex-col rounded-xl border border-f1-border-secondary shadow-md",
-          isCard
-            ? // `bg-white` renders transparent and the border does not draw without
-              // an explicit style; scoped to `card` so existing banners are untouched.
-              "gap-0 border-solid bg-f1-background"
-            : "bg-white gap-4 sm:flex-row sm:gap-5"
+          "relative flex w-full flex-col rounded-xl border border-solid border-f1-border-secondary bg-f1-background shadow-md",
+          isCard ? "gap-0" : "gap-4 sm:flex-row sm:gap-5"
         )}
       >
         {/* Media 16:9 */}
@@ -178,7 +174,7 @@ const BaseBannerSkeleton = forwardRef<HTMLDivElement>(
     return (
       <div
         ref={ref}
-        className="bg-white relative flex w-full flex-col gap-4 rounded-xl border border-f1-border-secondary shadow-md sm:flex-row sm:gap-5"
+        className="relative flex w-full flex-col gap-4 rounded-xl border border-solid border-f1-border-secondary bg-f1-background shadow-md sm:flex-row sm:gap-5"
         role="status"
         aria-busy="true"
         aria-live="polite"


### PR DESCRIPTION
> [!NOTE]
> Stacked on #4975 — base branch is `feat/base-banner-card-variant`, so the diff here is just this fix. Merge #4975 first, or retarget this to `main` if that one is going to sit.

## Description

Two class names on `BaseBanner` have never done anything. This makes the background and border actually render, on every variant.

**`bg-white` is not a class f0 emits.** The palette defines `white` as numeric steps with no `DEFAULT` key:

```ts
// packages/core/src/tokens/colors.ts
white: { 3: "…", 5: "…", …, 100: "0 0% 100%" },
```

Tailwind generates `bg-white-3` … `bg-white-100` from that, but never a bare `bg-white`. The banner has had **no background** for as long as the class has been there.

**The border fails from the other direction.** `corePlugins.preflight` is `false` in `packages/core/tailwind.ts`, so Tailwind's base reset — the rule that sets `border-style: solid` on every element — never lands. `border` sets a width, the browser default `border-style: none` stands, and nothing draws.

#4975 hit both while building the `card` variant and worked around them by scoping `bg-f1-background border-solid` to `card` alone, specifically to avoid changing shipped visuals. This is the real fix.

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [ ] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [ ] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [x] Bug fix
- [ ] Documentation only
- [ ] Refactor / internal change (no API or behavior change)
- [ ] Other:

## Lifecycle phase (if applicable)

Not a lifecycle change — no API change, no new surface. `BaseBanner` stays `experimental`. It does change rendered output on shipped components, so it wants a designer's eye rather than a design review.

- Linked #f0-support thread: n/a — a bug fix, independent of the card decision being taken in [this thread](https://factorialteam.slack.com/archives/C082ZNKS403/p1786343125188429). It stands whichever route wins.
- Phase exit criteria met: n/a (bug fix)

## Screenshots (if applicable)

<!-- TODO: attach before/after of the default variant — the "before" is the point here, since the banner currently renders with no background and no border. The Chromatic diff on this PR is the clearest artefact. -->

## Implementation details

```diff
-  "relative flex w-full flex-col rounded-xl border border-f1-border-secondary shadow-md",
-  isCard
-    ? "gap-0 border-solid bg-f1-background"
-    : "bg-white gap-4 sm:flex-row sm:gap-5"
+  "relative flex w-full flex-col rounded-xl border border-solid border-f1-border-secondary bg-f1-background shadow-md",
+  isCard ? "gap-0" : "gap-4 sm:flex-row sm:gap-5"
```

- `bg-f1-background` and `border-solid` move onto the shared root class, so the remaining conditional carries only the layout difference it is actually about.
- Same fix for `BaseBannerSkeleton`, which had the identical class string.
- Tests asserting every variant — and the loading state — paints a background and a drawable border, and that `bg-white` is gone.

> [!WARNING]
> **`default` and `full-width` will render differently.** They gain the background and border they were always meant to have, so **Chromatic will show a diff and it should be accepted.** These components have been shipping transparent, so this is what they were specified as, not what people are used to seeing.

### Out of scope

`bg-white` appears in four other places with the same dead-class problem. They belong to other owners, so they are not touched here:

- `sds/UpsellingKit/ProductBlankslate/index.tsx`
- `experimental/AiPromotionChat/components/ChatTextarea.tsx` (twice)
- `lib/xray.tsx` — already pairs it with an explicit `border-solid`, which is supporting evidence for the preflight diagnosis
- `ui/Kanban/__stories__/Kanban.stories.tsx` (story only)

`ui/.../Table/components/Row.tsx` uses `after:bg-white-100`, which is a real class and fine.

Worth considering separately: either add a `DEFAULT` to the `white` palette entry so `bg-white` resolves, or lint against it. Right now it fails silently everywhere it is used.

