### PR TITLE
chore(F0Icon): meet the stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -25,7 +25,6 @@
     "Graph/F0GraphEdge",
     "Graph/F0GraphNode",
     "Heading",
-    "Icon",
     "Image",
     "Inputs/Duration input",
     "Inputs/Number input",

--- a/packages/react/src/components/F0Icon/__stories__/F0Icon.mdx
+++ b/packages/react/src/components/F0Icon/__stories__/F0Icon.mdx
@@ -1,65 +1,302 @@
-import { Meta, Canvas, Controls } from "@storybook/addon-docs/blocks"
-import LinkTo from "@storybook/addon-links/react"
-import * as IconStories from "./F0Icon.stories"
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0Icon.stories"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
-<Meta title="Icon" />
+<Meta of={Stories} />
 
-# Icon
+# F0Icon
 
-The Icon component is used to display an icon from the
-[Icons library](/docs/foundations-icons--documentation).
+Renders an icon from the F0 [icon library](/docs/foundations-icons--documentation)
+with consistent sizing and color. It supports app, module, AI, special, and
+animated icon sets through the same API.
 
 ## Anatomy
 
-<Canvas of={IconStories.App} />
-<Controls of={IconStories.App} />
+<Canvas of={Stories.App} />
 
-## Usage
+<Controls of={Stories.App} />
 
-### Import
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>icon</code>
+        </td>
+        <td>
+          <code>IconType</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>The generated F0 icon component to render.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>size</code>
+        </td>
+        <td>
+          <code>"xs" | "sm" | "md" | "lg"</code>
+        </td>
+        <td>
+          <code>"md"</code>
+        </td>
+        <td>—</td>
+        <td>
+          Sets the icon width to 12, 16, 20, or 24 pixels and applies the
+          matching F0 stroke width to paths, circles, and rectangles.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>color</code>
+        </td>
+        <td>
+          <code>
+            {'"default" | "currentColor" | `#${string}` | IconColorToken'}
+          </code>
+        </td>
+        <td>
+          <code>"currentColor"</code>
+        </td>
+        <td>—</td>
+        <td>
+          Inherits the surrounding text color, uses the default F0 icon color,
+          resolves an F0 icon color token, or applies a hexadecimal color.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>state</code>
+        </td>
+        <td>
+          <code>"normal" | "animate"</code>
+        </td>
+        <td>
+          <code>"normal"</code>
+        </td>
+        <td>—</td>
+        <td>
+          Selects the motion state for generated animated icons. It has no
+          effect on static icons.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>dataTestId</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Adds a test selector through the shared F0 test-id wrapper when test
+          IDs are enabled by the platform provider.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>ref</code>
+        </td>
+        <td>
+          <code>Ref&lt;SVGSVGElement&gt;</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Forwards a ref to the rendered SVG element.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>...SVG props</code>
+        </td>
+        <td>
+          <code>SVGProps&lt;SVGSVGElement&gt;</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Forwards native SVG attributes such as <code>aria-label</code>,{" "}
+          <code>aria-hidden</code>, and <code>role</code>. Use an interactive
+          component such as <code>F0Button</code> or <code>F0Link</code> instead
+          of attaching interaction to the SVG. F0Icon supplies its own{" "}
+          <code>className</code> and <code>style</code>, so caller-provided
+          values for those two props are replaced.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
 
-Import the Icon component and the icon you want to display. Then, pass the icon
-to the Icon component as a prop.
+### Sizes and colors
 
-{/* prettier-ignore */}
-```jsx
-import { Icon } from "@/components/Utilities/Icon"
-import { Archive } from "@/icons/app"
+The matrix shows every supported size with the icon color tokens covered by the
+visual snapshot story.
 
-<F0Icon icon={Archive} size="md" />
-```
+<Canvas of={Stories.Snapshot} />
+
+## Guidelines
+
+### Design best practices
+
+**When to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0Icon when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Rendering an icon exported by an F0 icon set</td>
+        <td>
+          The icon needs the standard F0 sizes, stroke widths, and color tokens
+        </td>
+      </tr>
+      <tr>
+        <td>Matching an icon to surrounding text</td>
+        <td>
+          The icon should inherit the parent's text color through the default{" "}
+          <code>currentColor</code> value
+        </td>
+      </tr>
+      <tr>
+        <td>Controlling a generated animated icon</td>
+        <td>
+          The icon should switch between its <code>normal</code> and{" "}
+          <code>animate</code> states
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>The icon triggers an action when clicked</td>
+        <td>
+          An accessible control such as <code>F0Button</code>, with the icon
+          passed to that component
+        </td>
+      </tr>
+      <tr>
+        <td>The graphic is an illustration or other non-icon asset</td>
+        <td>
+          A dedicated illustration component or a native{" "}
+          <code>&lt;img&gt;</code>
+          element
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do's and don'ts**
 
 <DoDonts
   do={{
-    description: "Use the Icon component to display an icon.",
+    description: "Render generated F0 icons through F0Icon.",
+    guidelines: [
+      "Pass the generated component through the icon prop",
+      "Use an F0 icon color token or inherit the surrounding color",
+      "Add SVG accessibility attributes that match the icon's meaning",
+    ],
   }}
   dont={{
-    description: "Use the icon directly, without the Icon component.",
+    description: "Don't bypass the wrapper for standard interface icons.",
+    guidelines: [
+      "Don't render a generated icon component directly to set its size or color",
+      "Don't make the SVG itself the interactive control",
+      "Don't rely on color or the icon shape as the only accessible label",
+    ],
   }}
 />
 
-### Color
+### Behavior
 
-The Icon component supports different color options through the `color` prop:
+- WHEN <code>color="currentColor"</code> or <code>color</code> is omitted → THEN
+  the icon inherits the current text color.
+- WHEN <code>color="default"</code> → THEN the icon uses the default F0 icon
+  token.
+- WHEN an F0 icon color token is provided → THEN F0Icon applies the matching
+  <code>text-f1-icon-*</code> class.
+- WHEN a hexadecimal color is provided → THEN F0Icon applies it as the SVG's
+  inline color.
+- WHEN the icon component's display name contains <code>Animated</code> → THEN
+  F0Icon forwards <code>state</code> as the icon's animation state.
+- WHEN a static icon is provided → THEN <code>state</code> is ignored.
 
-- **Token colors**: Use predefined icon color tokens like `secondary`, `accent`
-  or `critical`.
-  [Here is the full list of icon tokens](/docs/foundations-colors--documentation&globals=#icon).
-- **Hex colors**: Pass any hex color value like `#ff0000`
-- **Current color**: Default behavior that inherits the parent's text color
+### Usage examples
 
-```jsx
-// Using token colors
-<F0Icon icon={Archive} color="secondary" />
-<F0Icon icon={Alert} color="critical" />
+**Module navigation icon**
 
-// Using hex colors
-<F0Icon icon={Star} color="#ff0000" />
+Module icons use the same sizing and color API as app icons.
 
-// Using current color (default)
-<F0Icon icon={Home} />
-```
+<Canvas of={Stories.Module} />
 
-Please, use the token colors unless you have a specific reason to use a hex
-color.
+**Animated icon state**
+
+The animated story switches the icon to <code>animate</code> while its preview
+area is hovered.
+
+<Canvas of={Stories.Animated} />
+
+**Special multicolor icon**
+
+The special <code>One</code> icon shown here preserves its built-in color
+treatment when the default <code>currentColor</code> value is used. Setting the
+color prop replaces that treatment with the selected color.
+
+<Canvas of={Stories.Special} />
+
+**AI icon**
+
+AI icons are selected from the dedicated AI icon set and rendered through the
+same F0Icon API.
+
+<Canvas of={Stories.AI} />
+
+**Test selector**
+
+Use <code>dataTestId</code> when a stable test selector is required and the
+platform provider enables test-id rendering.
+
+<Canvas of={Stories.WithDataTestId} />
+
+## Accessibility
+
+- F0Icon does not add a role, accessible name, or hidden state. WHEN an icon is
+  decorative → THEN pass <code>aria-hidden="true"</code>.
+- WHEN an icon communicates meaning without visible text → THEN pass
+  <code>role="img"</code> and a concise <code>aria-label</code> through the
+  native SVG props.
+- WHEN an icon appears inside a labeled interactive control → THEN keep the
+  control's accessible name on the control and hide the icon from assistive
+  technology.
+- F0Icon does not make itself focusable or interactive. Use an appropriate
+  button or link component for actions and navigation.
+- Animation state and color changes are visual only and are not announced to
+  assistive technology. Do not use either as the only way to communicate state.
+- When a custom hexadecimal color carries meaning, ensure the icon maintains at
+  least 3:1 contrast against adjacent colors.

--- a/packages/react/src/components/F0Icon/__stories__/F0Icon.stories.tsx
+++ b/packages/react/src/components/F0Icon/__stories__/F0Icon.stories.tsx
@@ -10,6 +10,7 @@ import * as Icons from "@/icons/app"
 import * as ModuleIcons from "@/icons/modules"
 import * as SpecialIcons from "@/icons/special"
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { snapshotMatrix } from "@/lib/storybook-utils/snapshotMatrix"
 
 import { F0Icon } from "../index"
@@ -33,8 +34,14 @@ const meta = {
   },
   parameters: {
     layout: "centered",
+    a11y: {
+      test: "error",
+    },
   },
-  tags: ["autodocs", "stable"],
+  tags: ["!autodocs", "stable"],
+  args: {
+    "aria-hidden": true,
+  },
 } satisfies Meta<ComponentProps<typeof F0Icon>>
 
 export default meta
@@ -104,6 +111,7 @@ export const Animated: Story = {
           icon={icon}
           state={isHovered ? "animate" : "normal"}
           size={size}
+          aria-hidden="true"
         />
       </div>
     )
@@ -141,19 +149,23 @@ export const AI: Story = {
   },
 }
 
-export const Snapshot = snapshotMatrix(F0Icon, {
-  baseArgs: { icon: Icons.ChartLine },
-  rows: { arg: "size", values: ["xs", "sm", "md", "lg"] },
-  cols: {
-    arg: "color",
-    values: [
-      "default",
-      "bold",
-      "accent",
-      "info",
-      "warning",
-      "positive",
-      "critical",
-    ],
-  },
-})
+export const Snapshot: Story = {
+  ...snapshotMatrix(F0Icon, {
+    baseArgs: { icon: Icons.ChartLine, "aria-hidden": true },
+    rows: { arg: "size", values: ["xs", "sm", "md", "lg"] },
+    cols: {
+      arg: "color",
+      values: [
+        "default",
+        "bold",
+        "accent",
+        "info",
+        "warning",
+        "positive",
+        "critical",
+      ],
+    },
+  }),
+  args: { icon: Icons.ChartLine },
+  parameters: withSnapshot({}),
+}

--- a/packages/react/src/components/F0Icon/__tests__/F0Icon.test.tsx
+++ b/packages/react/src/components/F0Icon/__tests__/F0Icon.test.tsx
@@ -1,0 +1,148 @@
+import { createRef, forwardRef, type SVGProps } from "react"
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0Icon, type IconType } from "../index"
+
+interface TestIconProps extends SVGProps<SVGSVGElement> {
+  animate?: "normal" | "animate"
+}
+
+const StaticIcon: IconType = forwardRef<SVGSVGElement, TestIconProps>(
+  function StaticIcon(props, ref) {
+    return (
+      <svg ref={ref} role="img" {...props}>
+        <path d="M0 0h10v10H0z" />
+      </svg>
+    )
+  }
+)
+
+const AnimatedIcon: IconType = forwardRef<SVGSVGElement, TestIconProps>(
+  function TestAnimatedIcon({ animate, ...props }, ref) {
+    return (
+      <svg ref={ref} role="img" data-animation-state={animate} {...props}>
+        <path d="M0 0h10v10H0z" />
+      </svg>
+    )
+  }
+)
+AnimatedIcon.displayName = "TestAnimatedIcon"
+
+describe("F0Icon", () => {
+  it("uses the medium size and current text color by default", () => {
+    render(<F0Icon icon={StaticIcon} aria-label="Default icon" />)
+
+    const icon = screen.getByLabelText("Default icon")
+    expect(icon).toHaveClass("aspect-square", "inline-block", "shrink-0", "w-5")
+    expect(icon).toHaveClass("text-current")
+    expect(icon).not.toHaveAttribute("data-has-color")
+  })
+
+  it.each([
+    ["xs", "w-3", "[&_path]:stroke-xs"],
+    ["sm", "w-4", "[&_path]:stroke-sm"],
+    ["md", "w-5", "[&_path]:stroke-md"],
+    ["lg", "w-6", "[&_path]:stroke-lg"],
+  ] as const)(
+    "applies the %s size classes",
+    (size, widthClass, strokeClass) => {
+      render(
+        <F0Icon icon={StaticIcon} size={size} aria-label={`${size} icon`} />
+      )
+
+      expect(screen.getByLabelText(`${size} icon`)).toHaveClass(
+        widthClass,
+        strokeClass
+      )
+    }
+  )
+
+  it.each([
+    ["currentColor", "text-current", false],
+    ["default", "text-f1-icon", true],
+    ["critical", "text-f1-icon-critical", true],
+  ] as const)(
+    "maps the %s color to its token class",
+    (color, colorClass, hasColor) => {
+      render(
+        <F0Icon icon={StaticIcon} color={color} aria-label={`${color} icon`} />
+      )
+
+      const icon = screen.getByLabelText(`${color} icon`)
+      expect(icon).toHaveClass(colorClass)
+      if (hasColor) {
+        expect(icon).toHaveAttribute("data-has-color", "true")
+      } else {
+        expect(icon).not.toHaveAttribute("data-has-color")
+      }
+    }
+  )
+
+  it("applies a hex color directly to the SVG", () => {
+    render(
+      <F0Icon
+        icon={StaticIcon}
+        color="#123456"
+        aria-label="Custom color icon"
+      />
+    )
+
+    const icon = screen.getByLabelText("Custom color icon")
+    expect(icon).toHaveStyle({ color: "#123456" })
+    expect(icon).toHaveAttribute("data-has-color", "true")
+  })
+
+  it("uses the static icon path without forwarding animation state", () => {
+    render(
+      <F0Icon icon={StaticIcon} state="animate" aria-label="Static icon" />
+    )
+
+    const icon = screen.getByLabelText("Static icon")
+    expect(icon).toHaveClass("aspect-square")
+    expect(icon).not.toHaveClass("select-none")
+    expect(icon).not.toHaveAttribute("animate")
+    expect(icon).not.toHaveAttribute("data-animation-state")
+  })
+
+  it.each([
+    ["default", undefined, "normal"],
+    ["animate", "animate", "animate"],
+  ] as const)(
+    "forwards the %s state to animated icons",
+    (name, state, expectedState) => {
+      render(
+        <F0Icon
+          icon={AnimatedIcon}
+          state={state}
+          aria-label={`${name} animated icon`}
+        />
+      )
+
+      const icon = screen.getByLabelText(`${name} animated icon`)
+      expect(icon).toHaveAttribute("data-animation-state", expectedState)
+      expect(icon).toHaveClass("select-none")
+      expect(icon).not.toHaveClass("aspect-square")
+    }
+  )
+
+  it("forwards SVG attributes, refs, and the public data test id", () => {
+    const ref = createRef<SVGSVGElement>()
+
+    render(
+      <F0Icon
+        ref={ref}
+        icon={StaticIcon}
+        aria-label="Referenced icon"
+        focusable="false"
+        dataTestId="interactive-icon"
+      />
+    )
+
+    const icon = screen.getByLabelText("Referenced icon")
+    expect(icon).toHaveAttribute("focusable", "false")
+    expect(ref.current).toBe(icon)
+    expect(screen.getByTestId("interactive-icon")).toContainElement(icon)
+  })
+})


### PR DESCRIPTION
## Description

Brings F0Icon up to the Stable definition of done: adds behavioral test coverage for sizing, color tokens, animation state, ref/attribute forwarding, and the `dataTestId`; enables Storybook a11y checks (`error` level) on the component's stories; and replaces the F0Icon.mdx stub with a full props reference plus usage and accessibility guidance. The component's runtime behavior and public API are unchanged.

## Type of change
- [x] Refactor / internal change (no API or behavior change)

## Implementation details

- test: cover default size/color, all size variants, color token mapping, hex colors, static vs. animated icon state, and ref/attribute/`dataTestId` forwarding
- test: enable Storybook `a11y: { test: "error" }` on F0Icon stories and wrap the color/size matrix in `snapshotMatrix` via `withSnapshot`
- docs: rewrite `F0Icon.mdx` with a full anatomy section, a props reference table (`icon`, `size`, `color`, `state`), and usage/accessibility guidance
- chore: remove `Icon` from `stable-dod-debt.json` now that the Stable DoD ratchet passes
