### PR TITLE
fix(F0Dialog): unify dialog overlay context

### DIFF
--- a/packages/react/src/components/dialog-alike/common/DialogWrapperProvider.tsx
+++ b/packages/react/src/components/dialog-alike/common/DialogWrapperProvider.tsx
@@ -1,19 +1,11 @@
-import { createContext, ReactNode, useContext } from "react"
+import { type ReactNode, useContext } from "react"
+
+import { F0DialogContext } from "@/patterns/F0Dialog/components/F0DialogProvider"
+import type { F0DialogContextType } from "@/patterns/F0Dialog/internal-types"
 
 import { DialogAlikePosition as Position } from "./types"
 
-export type DialogWrapperContextType = {
-  open: boolean
-  onClose: () => void
-  shownBottomSheet: boolean
-  position: Position
-  /**
-   * The dialog's content container element.
-   * Use this as the `portalContainer` prop for components like F0Select
-   * to ensure dropdowns render inside the dialog.
-   */
-  portalContainer: HTMLDivElement | null
-}
+export type DialogWrapperContextType = F0DialogContextType
 
 /**
  * The props for the F0DialogProvider component.
@@ -27,13 +19,9 @@ export type DialogWrapperProviderProps = {
   portalContainer: HTMLDivElement | null
 }
 
-export const DialogWrapperContext = createContext<DialogWrapperContextType>({
-  open: false,
-  onClose: () => {},
-  position: "center",
-  shownBottomSheet: false,
-  portalContainer: null,
-})
+// Dialog-alike components are being migrated to the stable dialog pattern.
+// Sharing its context keeps nested overlays in the same portal and focus scope.
+export const DialogWrapperContext = F0DialogContext
 
 export const DialogWrapperProvider = ({
   isOpen,

--- a/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupDialogPortal.test.tsx
+++ b/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupDialogPortal.test.tsx
@@ -1,7 +1,8 @@
 import { screen } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
+import { DialogWrapperProvider } from "@/components/dialog-alike/common/DialogWrapperProvider"
 import { DialogPosition, F0DialogContext } from "@/patterns/F0Dialog"
 import { zeroRender as render } from "@/testing/test-utils"
 
@@ -11,9 +12,17 @@ import { DatePickerPopup } from "../DatePickerPopup"
 // into the dialog's container. If the calendar itself stays in `document.body` it
 // sits after that container in document order and, at the shared z-index, paints
 // over the dropdowns it owns — leaving the year unpickable (FCT-59810).
-const renderInDialog = (position: DialogPosition) => {
+const portalContainers = new Set<HTMLDivElement>()
+
+const createPortalContainer = () => {
   const portalContainer = document.createElement("div")
   document.body.appendChild(portalContainer)
+  portalContainers.add(portalContainer)
+  return portalContainer
+}
+
+const renderInDialog = (position: DialogPosition) => {
+  const portalContainer = createPortalContainer()
 
   render(
     <F0DialogContext.Provider
@@ -35,6 +44,11 @@ const renderInDialog = (position: DialogPosition) => {
 }
 
 describe("DatePickerPopup portal container", () => {
+  afterEach(() => {
+    portalContainers.forEach((container) => container.remove())
+    portalContainers.clear()
+  })
+
   it.each(["center", "fullscreen"] as const)(
     "renders the calendar inside the dialog container for %s dialogs",
     async (position) => {
@@ -70,5 +84,36 @@ describe("DatePickerPopup portal container", () => {
     await user.click(screen.getByRole("button", { name: "Trigger" }))
 
     expect(screen.getByRole("dialog").closest("body")).toBe(document.body)
+  })
+
+  it("keeps dialog-alike calendar controls in one interactive portal", async () => {
+    const user = userEvent.setup()
+    const portalContainer = createPortalContainer()
+
+    render(
+      <DialogWrapperProvider
+        isOpen
+        onClose={vi.fn()}
+        position="center"
+        portalContainer={portalContainer}
+      >
+        <DatePickerPopup onSelect={vi.fn()} asChild>
+          <button>Trigger</button>
+        </DatePickerPopup>
+      </DialogWrapperProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }))
+
+    expect(portalContainer).toContainElement(screen.getByRole("dialog"))
+
+    const yearSelector = screen.getByRole("combobox", { name: "Select year" })
+    yearSelector.focus()
+    await user.keyboard("{Enter}")
+
+    const yearList = await screen.findByRole("listbox")
+    expect(portalContainer).toContainElement(yearList)
+    expect(yearSelector).toHaveAttribute("aria-expanded", "true")
+    expect(portalContainer).toContainElement(document.activeElement)
   })
 })


### PR DESCRIPTION
## Description

### Context

[FCT-59810](https://factorialmakers.atlassian.net/browse/FCT-59810) was reopened after a date field inside a Trainings modal could not switch month or year. The same failure was reported in Attendance's **Add employees** dialog after upgrading `@factorialco/f0-react` from 4.72.0 to 5.0.1.

The portal mismatch had two user-visible symptoms:

- Clicking the calendar's month or year selector could open its options behind the calendar, making the controls appear unresponsive.
- In the later Trainings recording, clicking either selector dismissed the entire calendar before an option could be chosen. Because the calendar was outside the dialog's portal and focus scope, opening its nested Select could be treated as an outside interaction and close the calendar popover.

The DOM and React provider investigation, including the suggested context-unification fix, is documented in this [Foundations channel message](https://factorialteam.slack.com/archives/C082ZNKS403/p1785939474795159).

### Root cause

F0 had two same-shaped but distinct React context instances:

- the stable `patterns/F0Dialog` exported `F0DialogContext`, which `DatePickerPopup` consumes
- the shipped dialog-alike implementation provided `DialogWrapperContext`, which it also re-exported under the name `F0DialogContext`

React matches contexts by identity, not by their type, shape, or exported name. The dialog-alike provider was therefore invisible to `DatePickerPopup`. The popup saw no dialog portal and rendered its calendar in `document.body`, while the calendar's month and year selects correctly rendered inside the dialog portal. At the same z-index, the later calendar layer painted over its own dropdowns.

This also explains why the existing portal regression test passed: its provider and consumer used the same stable context instance and never exercised the shipped dialog-alike provider.

### Solution

Make `DialogWrapperContext` reuse the canonical stable `F0DialogContext` instead of creating a second context instance. The dialog-alike provider and nested consumers now share the same portal container and focus scope.

This fixes the integration boundary for every nested overlay that consumes `F0DialogContext`. It does not add DatePicker-specific fallback logic, support two competing contexts, or rely on z-index adjustments.

The regression test renders `DatePickerPopup` through the real dialog-alike provider and verifies keyboard opening, calendar and listbox portal containment, expanded state, and focus containment. Manually created portal containers are cleaned after every case.

## Verification

- `pnpm --filter @factorialco/f0-react run format:check`
- `pnpm --filter @factorialco/f0-react run tsc`
- `pnpm --filter @factorialco/f0-react build`
- `pnpm --filter @factorialco/f0-react vitest:ci src/ui/DatePickerPopup/__tests__/DatePickerPopupDialogPortal.test.tsx src/components/dialog-alike/common/__tests__/Wrapper.test.tsx` (10 passed)
- pre-commit cycle-dependency, format, and lint hooks passed
- all applicable PR checks passed, including React unit tests, Storybook tests, Chromatic, accessibility, and public API surface checks

[FCT-59810]: https://factorialmakers.atlassian.net/browse/FCT-59810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ