### PR TITLE
fix(F0AiChatTextArea): anchor suggestions menu to the chips

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
@@ -172,6 +172,26 @@ describe("WelcomeScreenSuggestionsRow", () => {
     expect(item.closest("[data-side]")).toHaveAttribute("data-side", "top")
   })
 
+  // Regression: the row reserved two chip rows' worth of height (min-h) on the
+  // Radix anchor itself. Radix positions off the anchor's border box, so with a
+  // single row of chips the popover floated ~40px above them.
+  it("anchors the popover to the chips, not to the reserved-height box", () => {
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+      />
+    )
+
+    // The anchor Radix measures is the chips' own wrapper, so it must hug
+    // them; the reserved two-row height belongs to the box outside it.
+    const anchorRow = screen.getByRole("button", {
+      name: /analyze/i,
+    }).parentElement
+    expect(anchorRow?.className).not.toMatch(/min-h-/)
+    expect(anchorRow?.parentElement?.className).toMatch(/min-h-\[72px\]/)
+  })
+
   it("opens the popover below the trigger when side is bottom", async () => {
     const user = userEvent.setup()
     zeroRender(

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -79,38 +79,47 @@ export const WelcomeScreenSuggestionsRow = ({
         }
       }}
     >
-      <PopoverAnchor asChild>
-        {/* min-h reserves two chip rows (2 × h-8 + gap-2) so a suggestion-set
-            swap that wraps 1↔2 rows cannot shift the layout above it. */}
-        <div
-          ref={rowRef}
-          className="flex min-h-[72px] w-full flex-wrap content-end items-center gap-2"
-        >
-          {/* Plain buttons, NOT `PopoverTrigger`s: Radix registers a single
-              trigger per popover (the last one mounted), whose built-in toggle
-              fires after the button's own onClick and overwrites the group
-              selection — so switching to the last group closed the popover
-              instead. The buttons fully own the toggle/switch semantics. */}
-          {suggestions.map((group, index) => (
-            <ButtonInternal
-              key={`${group.label}-${index}`}
-              variant="outline"
-              label={group.label}
-              icon={group.icon}
-              pressed={activeIdx === index}
-              aria-haspopup="dialog"
-              aria-expanded={activeIdx === index}
-              aria-controls={activeIdx === index ? popoverContentId : undefined}
-              onClick={(event) => {
-                lastTriggerRef.current = event.currentTarget
-                shouldRestoreFocusRef.current = false
-                setActiveIdx((current) => (current === index ? null : index))
-                onItemHover?.(null)
-              }}
-            />
-          ))}
-        </div>
-      </PopoverAnchor>
+      {/* min-h reserves two chip rows (2 × h-8 + gap-2) so a suggestion-set
+          swap that wraps 1↔2 rows cannot shift the layout above it. The
+          reservation lives on this outer box and NOT on the anchor: Radix
+          positions the popover off the anchor's border box, so anchoring the
+          reserved height would float a single-row popover ~40px above the
+          chips it belongs to. */}
+      <div className="flex min-h-[72px] w-full items-end">
+        <PopoverAnchor asChild>
+          <div
+            ref={rowRef}
+            className="flex w-full flex-wrap items-center gap-2"
+          >
+            {/* Plain buttons, NOT `PopoverTrigger`s: Radix registers a single
+                trigger per popover (the last one mounted), whose built-in
+                toggle fires after the button's own onClick and overwrites the
+                group selection — so switching to the last group closed the
+                popover instead. The buttons fully own the toggle/switch
+                semantics. */}
+            {suggestions.map((group, index) => (
+              <ButtonInternal
+                key={`${group.label}-${index}`}
+                variant="outline"
+                label={group.label}
+                icon={group.icon}
+                pressed={activeIdx === index}
+                aria-haspopup="dialog"
+                aria-expanded={activeIdx === index}
+                aria-controls={
+                  activeIdx === index ? popoverContentId : undefined
+                }
+                onClick={(event) => {
+                  lastTriggerRef.current = event.currentTarget
+                  shouldRestoreFocusRef.current = false
+                  setActiveIdx((current) => (current === index ? null : index))
+                  onItemHover?.(null)
+                }}
+              />
+            ))}
+          </div>
+        </PopoverAnchor>
+      </div>
       {activeGroup && (
         <PopoverContent
           side={side}


### PR DESCRIPTION
## Description

On the AI chat welcome screen, the suggestions menu floated well above the chip that opened it, leaving a conspicuous gap between the chip (`Find`, `Analyze`, `Create`) and its menu. This anchors the menu to the chips so it sits at the intended 8px offset.

Only affects the single-chip-row case, which is the common one. Two rows were already correct and are untouched.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

**Before**
<img width="1264" height="746" alt="before-single-row" src="https://github.com/user-attachments/assets/a9f49650-d35e-4023-b88f-e819b51cb5e0" />

**After**
<img width="1264" height="746" alt="after-single-row" src="https://github.com/user-attachments/assets/81300b4d-972a-4add-8dad-fa5f945695ea" />
<img width="588" height="746" alt="after-two-rows" src="https://github.com/user-attachments/assets/765e3689-7dd3-4f05-9516-5c26aef44066" />


Measured on the `Kits/AI/F0AiChatTextArea` → `With Welcome Suggestions` story, gap from the menu's bottom edge to the top of the chip row:

| chip rows | before | after |
| --- | --- | --- |
| 1 (default) | **48px** | **8px** |
| 2 (wrapped) | 9px | 9px (unchanged) |

The 8/9px is the component's intended `sideOffset={8}`; the 9 is subpixel rounding.

## Implementation details

### Root cause

`WelcomeScreenSuggestionsRow` reserves two chip rows' worth of height (`min-h-[72px]`, i.e. 2 × `h-8` + `gap-2`) so that swapping a suggestion set that wraps 1↔2 rows cannot shift the composer above it. That reservation was on the element passed to `PopoverAnchor`, and the chips were pushed to the bottom of it with `content-end`.

Radix positions a popover off the anchor's **border box**, not off its visible content. With a single 32px row of chips, the anchor box was still 72px tall, so the menu was placed above the top of the reserved box — 40px above where the chips actually are — plus the intended 8px `sideOffset`. Hence 48px.

At two rows the chips measure exactly 72px and fill the reservation, so the anchor box and the chip block coincide and the position was already correct. That's why the bug only showed with one row.

### Fix

Split the two responsibilities across two elements:

- an **outer** box that keeps the `min-h-[72px]` reservation and bottom-aligns its content (`items-end`)
- an **inner** row — now the `PopoverAnchor` — that hugs the chips

`rowRef` stays on the chip row, so the `onPointerDownOutside` guard that lets chip clicks own the open/switch/close semantics is unaffected.

## ✅ Verification

### Tests

- New regression test: `packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx` — asserts the anchored row carries no height reservation and that the reservation lives on the box outside it. jsdom has no layout engine, so this guards the structural invariant rather than the pixel gap.
- All 50 tests in `src/kits/ai/F0AiChatTextArea/` pass; all 291 in `src/kits/ai/` pass.
- `pnpm tsc`, `oxlint`, and `oxfmt --check` clean.

### Manual verification

Measured live DOM geometry in Storybook on the `With Welcome Suggestions` story, stashing the change to capture each "before" number:

- **One chip row**: gap 48px → 8px. Anchor row 72px → 32px; outer reservation still 72px, so the anti-layout-shift behavior is preserved. Menu width still 608px (full composer width, from `--radix-popover-trigger-width`) and left edges still aligned.
- **Two chip rows** (narrowed the composer until `Analyze`/`Find` wrapped above `Create`): identical before and after — anchor 72px, gap 9px, width 228px, left edges aligned. The fix is a no-op here.
- Menu still opens above the **top** chip row and clears both rows when a bottom-row chip is clicked — pre-existing behavior of anchoring to the whole block, unchanged.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-pr
