### PR TITLE
fix(F0AnalyticsDashboard): make exports complete and clear

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -445,8 +445,26 @@ export const defaultTranslations = {
     dataDownload: {
       title: "Download",
       download: "Download {{format}}",
+      downloadPreparing: "Preparing export",
+      downloadSuccess: "Download started",
+      downloadFailed: "Couldn't export data",
       exportDashboard: "Export dashboard as {{format}}",
       exporting: "Exporting…",
+      exportPreparing: "Preparing dashboard export",
+      exportSuccess: "Dashboard exported",
+      exportEmpty: "No data to export",
+      exportEmptyDescription: "Change your filters and try again",
+      exportTooLarge: "Too much data to export",
+      exportTooLargeDescription: "Narrow your filters and try again",
+      exportFailed: "Couldn't export dashboard",
+      exportFailedDescription: "Try again",
+      exportOverviewSheetName: "Dashboard overview",
+      exportOverviewDescription:
+        "Preview every dashboard widget here. Use each widget sheet for its full exported data.",
+      exportRowsExported: "{{amount}} rows exported",
+      exportPreviewTruncated:
+        "Showing the first {{amount}} rows here. Open the widget sheet for the full export.",
+      exportFullDataSheet: "Full data: {{sheetName}}",
     },
     dashboardItem: {
       chartType: "Chart type",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -158,6 +158,15 @@ The export control uses the applied report filter value for participating
 items. Items with `useDashboardFilters=false` are exported with an empty filter
 object, matching their on-screen fetch behavior.
 
+Dashboard export is all-or-nothing: every metric, chart, and collection must be
+fetched successfully before the workbook is downloaded. The control reports a
+preparing state, then a success, empty-data, too-large, or failure status. Empty
+dashboards do not download a blank workbook, and failures do not download a
+partial workbook. Collection exports are limited to 10,000 rows; when more data
+matches the current filters, the status asks the user to narrow those filters
+instead of silently truncating the file. The same status behavior applies to
+the Excel and CSV actions on individual collections and to chart downloads.
+
 <Canvas of={Stories.WithExport} />
 
 **With no report data**

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ExportDropdown.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ExportDropdown.test.tsx
@@ -1,12 +1,17 @@
 import userEvent from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
-import { zeroRender as render, screen } from "@/testing/test-utils"
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
 
 import { ExportDropdown } from "../components/ExportDropdown/ExportDropdown"
 
 describe("ExportDropdown", () => {
   it("renders the dropdown trigger button", () => {
-    render(<ExportDropdown onExportExcel={vi.fn()} isExporting={false} />)
+    render(
+      <ExportDropdown
+        onExportExcel={vi.fn().mockResolvedValue(undefined)}
+        isExporting={false}
+      />
+    )
 
     expect(
       screen.getByRole("button", { name: "Toggle dropdown menu" })
@@ -15,7 +20,12 @@ describe("ExportDropdown", () => {
 
   it("shows export label with format interpolation when opened", async () => {
     const user = userEvent.setup()
-    render(<ExportDropdown onExportExcel={vi.fn()} isExporting={false} />)
+    render(
+      <ExportDropdown
+        onExportExcel={vi.fn().mockResolvedValue(undefined)}
+        isExporting={false}
+      />
+    )
 
     await user.click(
       screen.getByRole("button", { name: "Toggle dropdown menu" })
@@ -28,16 +38,50 @@ describe("ExportDropdown", () => {
 
   it("shows exporting state when opened", async () => {
     const user = userEvent.setup()
-    render(<ExportDropdown onExportExcel={vi.fn()} isExporting={true} />)
+    render(
+      <ExportDropdown
+        onExportExcel={vi.fn().mockResolvedValue(undefined)}
+        isExporting
+      />
+    )
 
     await user.click(
       screen.getByRole("button", { name: "Toggle dropdown menu" })
     )
 
-    // While loading, the dropdown item swaps the label to "Exporting…" so
-    // users get clear in-progress feedback (dropdown items don't expose a
-    // built-in loading state). Re-clicking is a no-op until isExporting flips
-    // back to false.
-    expect(await screen.findByText("Exporting…")).toBeInTheDocument()
+    // While loading, the dropdown item swaps the label to "Exporting…" and is
+    // disabled until isExporting flips back to false.
+    const exportingItem = await screen.findByText("Exporting…")
+    expect(exportingItem).toBeInTheDocument()
+    expect(screen.getByRole("menuitem")).toHaveAttribute(
+      "aria-disabled",
+      "true"
+    )
+  })
+
+  it("starts the dashboard export from the menu", async () => {
+    const user = userEvent.setup()
+    const onExportExcel = vi.fn().mockResolvedValue(undefined)
+    render(<ExportDropdown onExportExcel={onExportExcel} isExporting={false} />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Toggle dropdown menu" })
+    )
+    await user.click(await screen.findByText("Export dashboard as Excel"))
+
+    await waitFor(() => expect(onExportExcel).toHaveBeenCalledTimes(1))
+  })
+
+  it("contains a rejected export without surfacing an unhandled rejection", async () => {
+    const user = userEvent.setup()
+    const onExportExcel = vi.fn().mockRejectedValue(new Error("Export failed"))
+    render(<ExportDropdown onExportExcel={onExportExcel} isExporting={false} />)
+
+    await user.click(
+      screen.getByRole("button", { name: "Toggle dropdown menu" })
+    )
+    await user.click(await screen.findByText("Export dashboard as Excel"))
+
+    await waitFor(() => expect(onExportExcel).toHaveBeenCalledTimes(1))
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartDataToTabular.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartDataToTabular.test.ts
@@ -23,6 +23,65 @@ const scatterData: DashboardChartData = {
   ],
 }
 
+describe("chartDataToTabular — numeric values", () => {
+  it("exports numeric measure strings as spreadsheet numbers", () => {
+    const data = {
+      categories: ["2026-01-01"],
+      series: [{ name: "Headcount", data: ["36"] }],
+    } as unknown as DashboardChartData
+
+    expect(chartDataToTabular({ type: "line" }, data).rows).toEqual([
+      { Category: "2026-01-01", Headcount: 36 },
+    ])
+  })
+
+  it.each([
+    [
+      { type: "funnel" } as const,
+      { series: { data: [{ name: "Qualified", value: "12" }] } },
+      [{ Stage: "Qualified", Value: 12 }],
+    ],
+    [
+      { type: "pie" } as const,
+      { series: { data: [{ name: "Permanent", value: "21" }] } },
+      [{ Name: "Permanent", Value: 21 }],
+    ],
+    [
+      { type: "radar" } as const,
+      { indicators: ["Quality"], series: [{ name: "Score", data: ["8"] }] },
+      [{ Indicator: "Quality", Score: 8 }],
+    ],
+    [
+      { type: "gauge" } as const,
+      { series: { name: "Progress", value: "75" } },
+      [{ Name: "Progress", Value: 75 }],
+    ],
+    [
+      { type: "heatmap" } as const,
+      { xCategories: ["April"], yCategories: ["Madrid"], data: [[0, 0, "5"]] },
+      [{ X: "April", Y: "Madrid", Value: 5 }],
+    ],
+  ])("normalizes numeric strings for $type charts", (config, data, rows) => {
+    expect(
+      chartDataToTabular(config, data as unknown as DashboardChartData).rows
+    ).toEqual(rows)
+  })
+
+  it("uses null for non-finite and invalid measure values", () => {
+    const data = {
+      categories: ["Invalid", "Infinite"],
+      series: [
+        { name: "Value", data: ["not-a-number", Number.POSITIVE_INFINITY] },
+      ],
+    } as unknown as DashboardChartData
+
+    expect(chartDataToTabular({ type: "bar" }, data).rows).toEqual([
+      { Category: "Invalid", Value: null },
+      { Category: "Infinite", Value: null },
+    ])
+  })
+})
+
 describe("chartDataToTabular — scatter", () => {
   it("emits one row per point across every series", () => {
     const { rows } = chartDataToTabular(scatterConfig, scatterData)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/collectionExport.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/collectionExport.test.ts
@@ -1,0 +1,259 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  ExportPaginationError,
+  ExportRowLimitExceededError,
+  fetchAllStateAwareRecords,
+} from "../utils/collectionExport"
+
+describe("fetchAllStateAwareRecords", () => {
+  it("prefers exportFetchData and preserves the active collection state", async () => {
+    const fetchData = vi.fn()
+    const exportFetchData = vi
+      .fn()
+      .mockResolvedValue({ records: [{ id: "1" }] })
+
+    await fetchAllStateAwareRecords({
+      dataAdapter: { fetchData, exportFetchData },
+      currentFilters: { team: ["Engineering"] },
+      currentSortings: { field: "name", order: "asc" },
+      currentGrouping: { field: "department", order: "desc" },
+      currentSearch: "Ada",
+      currentNavigationFilters: { date: "2026-08-06" },
+    })
+
+    expect(fetchData).not.toHaveBeenCalled()
+    expect(exportFetchData).toHaveBeenCalledWith({
+      filters: { team: ["Engineering"] },
+      sortings: [
+        { field: "name", order: "asc" },
+        { field: "department", order: "desc" },
+      ],
+      search: "Ada",
+      navigationFilters: { date: "2026-08-06" },
+    })
+  })
+
+  it("resolves observable-backed collection responses", async () => {
+    const unsubscribe = vi.fn()
+    const fetchData = vi.fn(() => ({
+      subscribe(observer: {
+        next: (state: unknown) => void
+        complete: () => void
+      }) {
+        queueMicrotask(() => {
+          observer.next({ loading: false, data: { records: [{ id: "1" }] } })
+        })
+        return { unsubscribe }
+      },
+    }))
+
+    await expect(
+      fetchAllStateAwareRecords({ dataAdapter: { fetchData } })
+    ).resolves.toEqual([{ id: "1" }])
+    expect(unsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    [
+      "an emitted error state",
+      (observer: {
+        next: (state: unknown) => void
+        error: (error: unknown) => void
+        complete: () => void
+      }) => observer.next({ loading: false, error: new Error("State failed") }),
+      "State failed",
+    ],
+    [
+      "an emitted state without data",
+      (observer: {
+        next: (state: unknown) => void
+        error: (error: unknown) => void
+        complete: () => void
+      }) => observer.next({ loading: false }),
+      "Observable resolved with no data",
+    ],
+    [
+      "a subscription error",
+      (observer: {
+        next: (state: unknown) => void
+        error: (error: unknown) => void
+        complete: () => void
+      }) => observer.error(new Error("Subscription failed")),
+      "Subscription failed",
+    ],
+    [
+      "completion without data",
+      (observer: {
+        next: (state: unknown) => void
+        error: (error: unknown) => void
+        complete: () => void
+      }) => observer.complete(),
+      "Observable completed without emitting data",
+    ],
+  ])("rejects observable responses with %s", async (_, emit, message) => {
+    const fetchData = vi.fn(() => ({
+      subscribe(observer: {
+        next: (state: unknown) => void
+        error: (error: unknown) => void
+        complete: () => void
+      }) {
+        emit(observer)
+        return { unsubscribe: vi.fn() }
+      },
+    }))
+
+    await expect(
+      fetchAllStateAwareRecords({ dataAdapter: { fetchData } })
+    ).rejects.toThrow(message)
+  })
+
+  it("treats explicit no-pagination adapters as unpaginated", async () => {
+    const fetchData = vi.fn().mockResolvedValue({ records: [{ id: "1" }] })
+
+    await fetchAllStateAwareRecords({
+      dataAdapter: { paginationType: "no-pagination", fetchData },
+    })
+
+    expect(fetchData).toHaveBeenCalledWith({
+      filters: undefined,
+      sortings: [],
+      search: undefined,
+      navigationFilters: undefined,
+    })
+  })
+
+  it("rejects an unpaginated export instead of silently truncating rows", async () => {
+    const records = Array.from({ length: 10_001 }, (_, index) => ({
+      id: index,
+    }))
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: {
+          fetchData: vi.fn().mockResolvedValue({ records }),
+        },
+      })
+    ).rejects.toBeInstanceOf(ExportRowLimitExceededError)
+  })
+
+  it("rejects infinite-scroll pagination when the backend repeats a cursor", async () => {
+    const fetchData = vi.fn().mockResolvedValue({
+      records: [{ id: "1" }],
+      hasMore: true,
+      cursor: "repeated-cursor",
+    })
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: { paginationType: "infinite-scroll", fetchData },
+      })
+    ).rejects.toBeInstanceOf(ExportPaginationError)
+    expect(fetchData).toHaveBeenCalledTimes(2)
+  })
+
+  it("exports every page from a valid infinite-scroll source", async () => {
+    const fetchData = vi
+      .fn()
+      .mockResolvedValueOnce({
+        records: [{ id: "1" }],
+        hasMore: true,
+        cursor: "next-page",
+      })
+      .mockResolvedValueOnce({
+        records: [{ id: "2" }],
+        hasMore: false,
+        cursor: null,
+      })
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: { paginationType: "infinite-scroll", fetchData },
+      })
+    ).resolves.toEqual([{ id: "1" }, { id: "2" }])
+    expect(fetchData).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        pagination: { cursor: "next-page", perPage: 100 },
+      })
+    )
+  })
+
+  it("rejects infinite-scroll pagination when more rows exist without a cursor", async () => {
+    const fetchData = vi.fn().mockResolvedValue({
+      records: [{ id: "1" }],
+      hasMore: true,
+    })
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: { paginationType: "infinite-scroll", fetchData },
+      })
+    ).rejects.toBeInstanceOf(ExportPaginationError)
+    expect(fetchData).toHaveBeenCalledTimes(1)
+  })
+
+  it("rejects a paginated export when more rows remain past the limit", async () => {
+    const page = Array.from({ length: 100 }, (_, index) => ({ id: index }))
+    const fetchData = vi.fn().mockResolvedValue({
+      records: page,
+      pagesCount: 101,
+    })
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: { paginationType: "pages", fetchData },
+      })
+    ).rejects.toBeInstanceOf(ExportRowLimitExceededError)
+    expect(fetchData).toHaveBeenCalledTimes(100)
+  })
+
+  it("rejects a paginated export when a page is missing before the declared end", async () => {
+    const fetchData = vi
+      .fn()
+      .mockResolvedValueOnce({ records: [{ id: "1" }], pagesCount: 3 })
+      .mockResolvedValueOnce({ records: [], pagesCount: 3 })
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: { paginationType: "pages", fetchData },
+      })
+    ).rejects.toBeInstanceOf(ExportPaginationError)
+    expect(fetchData).toHaveBeenCalledTimes(2)
+  })
+
+  it("rejects a final page that pushes the export above the row limit", async () => {
+    const page = Array.from({ length: 5_001 }, (_, index) => ({ id: index }))
+    const fetchData = vi.fn().mockResolvedValue({
+      records: page,
+      pagesCount: 2,
+    })
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: { paginationType: "pages", fetchData },
+      })
+    ).rejects.toBeInstanceOf(ExportRowLimitExceededError)
+    expect(fetchData).toHaveBeenCalledTimes(2)
+  })
+
+  it("rejects infinite scroll when more rows remain at the limit", async () => {
+    const page = Array.from({ length: 5_000 }, (_, index) => ({ id: index }))
+    let cursorIndex = 0
+    const fetchData = vi.fn().mockImplementation(() => {
+      cursorIndex += 1
+      return Promise.resolve({
+        records: page,
+        hasMore: true,
+        cursor: `cursor-${cursorIndex}`,
+      })
+    })
+
+    await expect(
+      fetchAllStateAwareRecords({
+        dataAdapter: { paginationType: "infinite-scroll", fetchData },
+      })
+    ).rejects.toBeInstanceOf(ExportRowLimitExceededError)
+    expect(fetchData).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/downloadHelpers.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/downloadHelpers.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import * as XLSX from "xlsx"
+
+import {
+  downloadAsCsv,
+  downloadMultiSheetExcel,
+  sanitizeDownloadFilename,
+  serializeValue,
+  uniqueExcelSheetName,
+} from "../utils/downloadHelpers"
+
+describe("downloadHelpers", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("preserves spreadsheet value types and neutralizes formulas", () => {
+    expect(serializeValue(42)).toBe(42)
+    expect(serializeValue(false)).toBe(false)
+    expect(serializeValue('=HYPERLINK("https://example.com")')).toBe(
+      '\'=HYPERLINK("https://example.com")'
+    )
+    expect(serializeValue("+44123456789")).toBe("'+44123456789")
+    expect(serializeValue(' \t=HYPERLINK("https://example.com")')).toBe(
+      '\' \t=HYPERLINK("https://example.com")'
+    )
+    expect(serializeValue("Headcount")).toBe("Headcount")
+  })
+
+  it("creates portable download filenames", () => {
+    expect(sanitizeDownloadFilename("  Workforce: GB/ES?*  ")).toBe(
+      "Workforce- GB-ES--"
+    )
+    expect(sanitizeDownloadFilename("CON")).toBe("_CON")
+    expect(sanitizeDownloadFilename("CON.txt")).toBe("_CON.txt")
+    expect(sanitizeDownloadFilename(" ... ")).toBe("download")
+  })
+
+  it("creates valid unique Excel sheet names after truncation", () => {
+    const usedNames = new Set<string>()
+    const longName = "Headcount by workplace and legal entity"
+
+    expect(uniqueExcelSheetName(longName, usedNames)).toBe(
+      "Headcount by workplace and lega"
+    )
+    expect(uniqueExcelSheetName(longName.toUpperCase(), usedNames)).toBe(
+      "HEADCOUNT BY WORKPLACE AND (2)"
+    )
+    expect(uniqueExcelSheetName("A/B:C*D?E[F]", usedNames)).toBe("A-B-C-D-E-F-")
+  })
+
+  it("keeps the Blob URL alive until after the download click", () => {
+    vi.useFakeTimers()
+    const createObjectURL = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:dashboard-export")
+    const revokeObjectURL = vi
+      .spyOn(URL, "revokeObjectURL")
+      .mockImplementation(() => {})
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {})
+
+    downloadAsCsv(["Name"], [{ Name: "Ada" }], "People/report")
+
+    expect(createObjectURL).toHaveBeenCalledTimes(1)
+    expect(click).toHaveBeenCalledTimes(1)
+    expect(revokeObjectURL).not.toHaveBeenCalled()
+    expect(document.querySelector('a[download="People-report.csv"]')).toBeNull()
+
+    vi.runAllTimers()
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:dashboard-export")
+  })
+
+  it("opens multi-widget workbooks with a useful dashboard overview", async () => {
+    let exportedBlob: Blob | undefined
+    vi.spyOn(URL, "createObjectURL").mockImplementation((blob) => {
+      exportedBlob = blob
+      return "blob:dashboard-export"
+    })
+    vi.spyOn(URL, "revokeObjectURL").mockImplementation(() => {})
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(() => {})
+
+    downloadMultiSheetExcel(
+      [
+        {
+          name: "Metrics",
+          columns: ["Metric", "Value"],
+          rows: [
+            { Metric: "Total headcount", Value: 34 },
+            { Metric: "Average tenure", Value: 3.5 },
+          ],
+        },
+        {
+          name: "Headcount by location",
+          columns: ["Location", "Headcount"],
+          rows: [
+            { Location: "Barcelona", Headcount: 20 },
+            { Location: "Madrid", Headcount: 14 },
+          ],
+        },
+      ],
+      "Workforce snapshot",
+      {
+        sheetName: "Dashboard overview",
+        description: "Every widget is previewed here.",
+        rowsExported: (amount) => `${amount} rows exported`,
+        previewTruncated: (amount) => `Showing the first ${amount} rows`,
+        fullDataSheet: (sheetName) => `Full data: ${sheetName}`,
+      }
+    )
+
+    expect(exportedBlob).toBeDefined()
+    const exportedBuffer = await new Promise<ArrayBuffer>((resolve, reject) => {
+      const reader = new FileReader()
+      reader.onload = () => resolve(reader.result as ArrayBuffer)
+      reader.onerror = () => reject(reader.error)
+      reader.readAsArrayBuffer(exportedBlob!)
+    })
+    const workbook = XLSX.read(exportedBuffer)
+    expect(workbook.SheetNames).toEqual([
+      "Dashboard overview",
+      "Metrics",
+      "Headcount by location",
+    ])
+
+    const overviewRows = XLSX.utils.sheet_to_json<unknown[]>(
+      workbook.Sheets["Dashboard overview"],
+      { header: 1, raw: true }
+    )
+    expect(overviewRows).toEqual(
+      expect.arrayContaining([
+        ["Workforce snapshot"],
+        ["Metrics", "2 rows exported"],
+        ["Total headcount", 34],
+        ["Headcount by location", "2 rows exported"],
+        ["Barcelona", 20],
+      ])
+    )
+    expect(workbook.Sheets["Dashboard overview"].A4.l?.Target).toBe(
+      "#'Metrics'!A1"
+    )
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useChartDownloadActions.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useChartDownloadActions.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { zeroRenderHook } from "@/testing/test-utils"
+import * as echarts from "echarts"
 
 import type { DashboardChartConfig, DashboardChartData } from "../types"
 
 import { useChartDownloadActions } from "../hooks/useChartDownloadActions"
+import * as downloadHelpers from "../utils/downloadHelpers"
+
+const { toastOpen } = vi.hoisted(() => ({ toastOpen: vi.fn() }))
+
+vi.mock("echarts", () => ({ getInstanceByDom: vi.fn() }))
+
+vi.mock("@/hooks/toast", () => ({
+  toasts: { open: toastOpen },
+}))
 
 const chartConfig: DashboardChartConfig = {
   type: "bar",
@@ -14,8 +24,10 @@ const chartData: DashboardChartData = {
   series: [{ name: "Revenue", data: [100, 200] }],
 }
 
-function renderHookWithData(data: DashboardChartData | undefined) {
-  const ref = { current: null } as React.RefObject<HTMLDivElement | null>
+function renderHookWithData(
+  data: DashboardChartData | undefined,
+  ref = { current: null } as React.RefObject<HTMLDivElement | null>
+) {
   return zeroRenderHook(() =>
     useChartDownloadActions({
       chartContainerRef: ref,
@@ -27,6 +39,19 @@ function renderHookWithData(data: DashboardChartData | undefined) {
 }
 
 describe("useChartDownloadActions", () => {
+  beforeEach(() => {
+    toastOpen.mockReset()
+    toastOpen.mockReturnValue("chart-export")
+    vi.spyOn(downloadHelpers, "downloadAsExcel").mockImplementation(() => {})
+    vi.spyOn(downloadHelpers, "downloadAsCsv").mockImplementation(() => {})
+    vi.spyOn(downloadHelpers, "downloadAsImage").mockImplementation(() => {})
+    vi.mocked(echarts.getInstanceByDom).mockReset()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   it("returns empty array when data is undefined", () => {
     const { result } = renderHookWithData(undefined)
     expect(result.current).toEqual([])
@@ -56,5 +81,124 @@ describe("useChartDownloadActions", () => {
     )
 
     expect(separators).toHaveLength(1)
+  })
+
+  it("reports success after downloading chart data", () => {
+    const { result } = renderHookWithData(chartData)
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => void }
+
+    excelAction.onClick()
+
+    expect(downloadHelpers.downloadAsExcel).toHaveBeenCalledTimes(1)
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "chart-export",
+      variant: "success",
+      title: "Download started",
+    })
+  })
+
+  it("downloads chart data as CSV and reports success", () => {
+    const { result } = renderHookWithData(chartData)
+    const csvAction = result.current.find(
+      (item) => "label" in item && item.label === "Download CSV"
+    ) as { onClick: () => void }
+
+    csvAction.onClick()
+
+    expect(downloadHelpers.downloadAsCsv).toHaveBeenCalledWith(
+      ["Category", "Revenue"],
+      [
+        { Category: "Q1", Revenue: 100 },
+        { Category: "Q2", Revenue: 200 },
+      ],
+      "Test Chart",
+      undefined
+    )
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "chart-export",
+      variant: "success",
+      title: "Download started",
+    })
+  })
+
+  it("reports failure when chart serialization fails", () => {
+    vi.mocked(downloadHelpers.downloadAsExcel).mockImplementation(() => {
+      throw new Error("Download failed")
+    })
+    const { result } = renderHookWithData(chartData)
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => void }
+
+    excelAction.onClick()
+
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "chart-export",
+      variant: "error",
+      title: "Couldn't export data",
+      description: "Try again",
+    })
+  })
+
+  it.each([
+    ["PNG", "png", "png", undefined],
+    ["JPG", "jpg", "jpeg", "#fff"],
+  ] as const)(
+    "downloads %s images and reports success",
+    (label, extension, echartsType, backgroundColor) => {
+      const inner = document.createElement("div")
+      const container = document.createElement("div")
+      container.appendChild(inner)
+      const getDataURL = vi.fn().mockReturnValue("data:image/test")
+      vi.mocked(echarts.getInstanceByDom).mockReturnValue({
+        getDataURL,
+      } as unknown as echarts.ECharts)
+      const { result } = renderHookWithData(chartData, {
+        current: container,
+      })
+      const imageAction = result.current.find(
+        (item) => "label" in item && item.label === `Download ${label}`
+      ) as { onClick: () => void }
+
+      imageAction.onClick()
+
+      expect(getDataURL).toHaveBeenCalledWith({
+        type: echartsType,
+        pixelRatio: 2,
+        ...(backgroundColor ? { backgroundColor } : {}),
+      })
+      expect(downloadHelpers.downloadAsImage).toHaveBeenCalledWith(
+        "data:image/test",
+        "Test Chart",
+        extension
+      )
+      expect(toastOpen).toHaveBeenLastCalledWith({
+        id: "chart-export",
+        variant: "success",
+        title: "Download started",
+      })
+    }
+  )
+
+  it("reports failure when the chart instance is not ready", () => {
+    const container = document.createElement("div")
+    container.appendChild(document.createElement("div"))
+    vi.mocked(echarts.getInstanceByDom).mockReturnValue(undefined)
+    const { result } = renderHookWithData(chartData, { current: container })
+    const pngAction = result.current.find(
+      (item) => "label" in item && item.label === "Download PNG"
+    ) as { onClick: () => void }
+
+    pngAction.onClick()
+
+    expect(downloadHelpers.downloadAsImage).not.toHaveBeenCalled()
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "chart-export",
+      variant: "error",
+      title: "Couldn't export data",
+      description: "Try again",
+    })
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useCollectionDownloadActions.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useCollectionDownloadActions.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { zeroRenderHook } from "@/testing/test-utils"
+import { act, zeroRenderHook } from "@/testing/test-utils"
 
 import { useCollectionDownloadActions } from "../hooks/useCollectionDownloadActions"
 import * as downloadHelpers from "../utils/downloadHelpers"
+
+const { toastOpen } = vi.hoisted(() => ({ toastOpen: vi.fn() }))
+
+vi.mock("@/hooks/toast", () => ({
+  toasts: { open: toastOpen },
+}))
 
 type Employee = {
   id: string
@@ -42,6 +48,8 @@ const columns = [
 
 describe("useCollectionDownloadActions", () => {
   beforeEach(() => {
+    toastOpen.mockReset()
+    toastOpen.mockReturnValue("collection-export")
     vi.spyOn(downloadHelpers, "downloadAsExcel").mockImplementation(() => {})
     vi.spyOn(downloadHelpers, "downloadAsCsv").mockImplementation(() => {})
   })
@@ -96,6 +104,11 @@ describe("useCollectionDownloadActions", () => {
     await excelAction.onClick()
 
     expect(downloadHelpers.downloadAsExcel).toHaveBeenCalledTimes(1)
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "collection-export",
+      variant: "success",
+      title: "Download started",
+    })
     const [headers, rows, filename, rowKeys] = (
       downloadHelpers.downloadAsExcel as unknown as {
         mock: { calls: unknown[][] }
@@ -172,5 +185,144 @@ describe("useCollectionDownloadActions", () => {
     await excelAction.onClick()
 
     expect(downloadHelpers.downloadAsExcel).not.toHaveBeenCalled()
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "collection-export",
+      variant: "default",
+      title: "No data to export",
+      description: "Change your filters and try again",
+    })
+  })
+
+  it("reports a failure when collection data cannot be fetched", async () => {
+    const source = makeSource()
+    source.dataAdapter.fetchData.mockRejectedValue(new Error("Request failed"))
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Employees",
+        columns,
+      })
+    )
+
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => Promise<void> }
+
+    await excelAction.onClick()
+
+    expect(downloadHelpers.downloadAsExcel).not.toHaveBeenCalled()
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "collection-export",
+      variant: "error",
+      title: "Couldn't export data",
+      description: "Try again",
+    })
+  })
+
+  it("reports when the collection exceeds the export limit", async () => {
+    const source = makeSource()
+    source.dataAdapter.fetchData.mockResolvedValue({
+      records: Array.from({ length: 10_001 }, (_, index) => ({ id: index })),
+    })
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Employees",
+        columns,
+      })
+    )
+
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => Promise<void> }
+
+    await excelAction.onClick()
+
+    expect(downloadHelpers.downloadAsExcel).not.toHaveBeenCalled()
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "collection-export",
+      variant: "default",
+      title: "Too much data to export",
+      description: "Narrow your filters and try again",
+    })
+  })
+
+  it("disables both download actions while an export is running", async () => {
+    let resolveFetch: ((value: { records: Employee[] }) => void) | undefined
+    const source = makeSource()
+    source.dataAdapter.fetchData.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+    )
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Employees",
+        columns,
+      })
+    )
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => Promise<void> }
+
+    let download: Promise<void> | undefined
+    act(() => {
+      download = excelAction.onClick()
+    })
+
+    expect(result.current).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ label: "Exporting…", disabled: true }),
+        expect.objectContaining({ label: "Exporting…", disabled: true }),
+      ])
+    )
+
+    await act(async () => {
+      resolveFetch?.({ records })
+      await download
+    })
+  })
+
+  it("coalesces concurrent collection export actions", async () => {
+    let resolveFetch: ((value: { records: Employee[] }) => void) | undefined
+    const source = makeSource()
+    source.dataAdapter.fetchData.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = resolve
+        })
+    )
+    const { result } = zeroRenderHook(() =>
+      useCollectionDownloadActions({
+        source,
+        title: "Employees",
+        columns,
+      })
+    )
+    const excelAction = result.current.find(
+      (item) => "label" in item && item.label === "Download Excel"
+    ) as { onClick: () => Promise<void> }
+    const csvAction = result.current.find(
+      (item) => "label" in item && item.label === "Download CSV"
+    ) as { onClick: () => Promise<void> }
+
+    let excelDownload: Promise<void> | undefined
+    let csvDownload: Promise<void> | undefined
+    act(() => {
+      excelDownload = excelAction.onClick()
+      csvDownload = csvAction.onClick()
+    })
+
+    expect(source.dataAdapter.fetchData).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      resolveFetch?.({ records })
+      await Promise.all([excelDownload, csvDownload])
+    })
+
+    expect(downloadHelpers.downloadAsExcel).toHaveBeenCalledTimes(1)
+    expect(downloadHelpers.downloadAsCsv).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
@@ -10,6 +10,12 @@ import { useDashboardExport } from "../hooks/useDashboardExport"
 import type { DashboardItem } from "../types"
 import * as downloadHelpers from "../utils/downloadHelpers"
 
+const { toastOpen } = vi.hoisted(() => ({ toastOpen: vi.fn() }))
+
+vi.mock("@/hooks/toast", () => ({
+  toasts: { open: toastOpen },
+}))
+
 const filtersDefinition = {
   department: {
     type: "in",
@@ -27,21 +33,27 @@ const activeFilters: TestFilters = {
 }
 
 async function runExport(items: DashboardItem<typeof filtersDefinition>[]) {
-  const { result } = zeroRenderHook(() =>
-    useDashboardExport({
-      items,
-      filters: activeFilters,
-      filename: "test-dashboard",
-    })
-  )
+  const { result } = renderExport(items)
 
   await act(async () => {
     await result.current.exportAsExcel()
   })
 }
 
+function renderExport(items: DashboardItem<typeof filtersDefinition>[]) {
+  return zeroRenderHook(() =>
+    useDashboardExport({
+      items,
+      filters: activeFilters,
+      filename: "test-dashboard",
+    })
+  )
+}
+
 describe("useDashboardExport", () => {
   beforeEach(() => {
+    toastOpen.mockReset()
+    toastOpen.mockReturnValue("dashboard-export")
     vi.spyOn(downloadHelpers, "downloadMultiSheetExcel").mockImplementation(
       () => {}
     )
@@ -143,5 +155,297 @@ describe("useDashboardExport", () => {
 
     expect(filteredCreateSource).toHaveBeenCalledWith(activeFilters)
     expect(unfilteredCreateSource).toHaveBeenCalledWith({})
+  })
+
+  it("exports paginated collections in bounded pages", async () => {
+    const fetchData = vi.fn(
+      ({ pagination }: { pagination: { currentPage: number } }) =>
+        Promise.resolve({
+          records:
+            pagination.currentPage === 1
+              ? [{ id: "1", name: "Ada" }]
+              : [{ id: "2", name: "Alan" }],
+          pagesCount: 2,
+        })
+    )
+
+    await runExport([
+      {
+        id: "people",
+        title: "People",
+        type: "collection",
+        createSource: () => ({
+          dataAdapter: { paginationType: "pages", fetchData },
+        }),
+        visualizations: [],
+      },
+    ])
+
+    expect(fetchData).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        pagination: { currentPage: 1, perPage: 100 },
+      })
+    )
+    expect(fetchData).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        pagination: { currentPage: 2, perPage: 100 },
+      })
+    )
+  })
+
+  it("reports preparing and success states for a complete export", async () => {
+    await runExport([
+      {
+        id: "headcount",
+        title: "Headcount",
+        type: "metric",
+        fetchData: vi.fn().mockResolvedValue({ value: 42 }),
+      },
+    ])
+
+    expect(toastOpen).toHaveBeenNthCalledWith(1, {
+      variant: "loading",
+      title: "Preparing dashboard export",
+      persistent: true,
+    })
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "dashboard-export",
+      variant: "success",
+      title: "Dashboard exported",
+    })
+  })
+
+  it("rejects the whole export when any dashboard item fails", async () => {
+    const { result } = renderExport([
+      {
+        id: "headcount",
+        title: "Headcount",
+        type: "metric",
+        fetchData: vi.fn().mockResolvedValue({ value: 42 }),
+      },
+      {
+        id: "failed-chart",
+        title: "Headcount over time",
+        type: "chart",
+        chart: { type: "line" },
+        fetchData: vi.fn().mockRejectedValue(new Error("Request failed")),
+      },
+    ])
+
+    await act(async () => {
+      await expect(result.current.exportAsExcel()).rejects.toThrow(
+        "Request failed"
+      )
+    })
+
+    expect(downloadHelpers.downloadMultiSheetExcel).not.toHaveBeenCalled()
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "dashboard-export",
+      variant: "error",
+      title: "Couldn't export dashboard",
+      description: "Try again",
+    })
+    expect(result.current.isExporting).toBe(false)
+  })
+
+  it("rejects the whole export when a chart type is unsupported", async () => {
+    const { result } = renderExport([
+      {
+        id: "unsupported-chart",
+        title: "Unsupported chart",
+        type: "chart",
+        chart: { type: "unsupported" } as never,
+        fetchData: vi.fn().mockResolvedValue({
+          categories: ["Engineering"],
+          series: [{ name: "Headcount", data: [42] }],
+        }),
+      },
+    ])
+
+    await act(async () => {
+      await expect(result.current.exportAsExcel()).rejects.toThrow(
+        'Chart "unsupported-chart" cannot be exported'
+      )
+    })
+    expect(downloadHelpers.downloadMultiSheetExcel).not.toHaveBeenCalled()
+  })
+
+  it("uses the displayed table labels and rendered values", async () => {
+    await runExport([
+      {
+        id: "people",
+        title: "People",
+        type: "collection",
+        createSource: () => ({
+          dataAdapter: {
+            fetchData: vi.fn().mockResolvedValue({
+              records: [{ name: "Ada", salary: 1000 }],
+            }),
+          },
+        }),
+        visualizations: [
+          {
+            type: "table",
+            options: {
+              columns: [
+                { id: "name", label: "Employee" },
+                {
+                  id: "salary",
+                  label: "Salary",
+                  render: (record: { salary: number }) => `$${record.salary}`,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    ])
+
+    expect(downloadHelpers.downloadMultiSheetExcel).toHaveBeenCalledWith(
+      [
+        {
+          name: "People",
+          columns: ["Employee", "Salary"],
+          keys: ["name", "salary"],
+          rows: [{ name: "Ada", salary: "$1000" }],
+        },
+      ],
+      "test-dashboard",
+      expect.objectContaining({
+        sheetName: "Dashboard overview",
+        description:
+          "Preview every dashboard widget here. Use each widget sheet for its full exported data.",
+        rowsExported: expect.any(Function),
+        previewTruncated: expect.any(Function),
+        fullDataSheet: expect.any(Function),
+      })
+    )
+  })
+
+  it("reports when a collection is too large instead of exporting partial data", async () => {
+    const records = Array.from({ length: 10_001 }, (_, index) => ({
+      id: index,
+    }))
+    const { result } = renderExport([
+      {
+        id: "people",
+        title: "People",
+        type: "collection",
+        createSource: () => ({
+          dataAdapter: {
+            fetchData: vi.fn().mockResolvedValue({ records }),
+          },
+        }),
+        visualizations: [],
+      },
+    ])
+
+    await act(async () => {
+      await expect(result.current.exportAsExcel()).rejects.toThrow(
+        "The export exceeds the 10000-row limit"
+      )
+    })
+
+    expect(downloadHelpers.downloadMultiSheetExcel).not.toHaveBeenCalled()
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "dashboard-export",
+      variant: "default",
+      title: "Too much data to export",
+      description: "Narrow your filters and try again",
+    })
+  })
+
+  it("reports an empty state when every dashboard item has no rows", async () => {
+    const { result } = renderExport([
+      {
+        id: "people",
+        title: "People",
+        type: "collection",
+        createSource: () => ({
+          dataAdapter: {
+            fetchData: vi.fn().mockResolvedValue({ records: [] }),
+          },
+        }),
+        visualizations: [],
+      },
+    ])
+
+    await act(async () => {
+      await expect(result.current.exportAsExcel()).rejects.toThrow(
+        "The dashboard has no data to export"
+      )
+    })
+
+    expect(downloadHelpers.downloadMultiSheetExcel).not.toHaveBeenCalled()
+    expect(toastOpen).toHaveBeenLastCalledWith({
+      id: "dashboard-export",
+      variant: "default",
+      title: "No data to export",
+      description: "Change your filters and try again",
+    })
+  })
+
+  it("keeps an empty item represented when another item has data", async () => {
+    await runExport([
+      {
+        id: "people",
+        title: "People",
+        type: "collection",
+        createSource: () => ({
+          dataAdapter: {
+            fetchData: vi.fn().mockResolvedValue({ records: [] }),
+          },
+        }),
+        visualizations: [],
+      },
+      {
+        id: "headcount",
+        title: "Headcount",
+        type: "metric",
+        fetchData: vi.fn().mockResolvedValue({ value: 42 }),
+      },
+    ])
+
+    expect(downloadHelpers.downloadMultiSheetExcel).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "Metrics", rows: expect.any(Array) }),
+        { name: "People", columns: [], rows: [] },
+      ]),
+      "test-dashboard",
+      expect.objectContaining({
+        sheetName: "Dashboard overview",
+        rowsExported: expect.any(Function),
+      })
+    )
+  })
+
+  it("coalesces concurrent export requests", async () => {
+    let resolveFetch: ((value: { value: number }) => void) | undefined
+    const fetchData = vi.fn(
+      () =>
+        new Promise<{ value: number }>((resolve) => {
+          resolveFetch = resolve
+        })
+    )
+    const { result } = renderExport([
+      {
+        id: "headcount",
+        title: "Headcount",
+        type: "metric",
+        fetchData,
+      },
+    ])
+
+    await act(async () => {
+      const first = result.current.exportAsExcel()
+      const second = result.current.exportAsExcel()
+      resolveFetch?.({ value: 42 })
+      await Promise.all([first, second])
+    })
+
+    expect(fetchData).toHaveBeenCalledTimes(1)
+    expect(downloadHelpers.downloadMultiSheetExcel).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -13,6 +13,7 @@ import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useD
 import type { DashboardCollectionItem } from "../../types"
 
 import { useCollectionDownloadActions } from "../../hooks/useCollectionDownloadActions"
+import { getDownloadableColumns } from "../../utils/collectionColumns"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
 
 interface CollectionItemProps<Filters extends FiltersDefinition> {
@@ -74,31 +75,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
   // `columns` list — the table viz is the source of truth, mirroring
   // OneDataCollection's own `extractColumns` flow.
   const downloadableColumns = useMemo(() => {
-    const tableViz = item.visualizations?.find(
-      (v) => (v as { type?: string })?.type === "table"
-    ) as
-      | {
-          options?: {
-            columns?: Array<{
-              id?: string
-              label?: string
-              render?: (item: RecordType) => unknown
-            }>
-          }
-        }
-      | undefined
-
-    return (tableViz?.options?.columns ?? [])
-      .filter(
-        (
-          c
-        ): c is {
-          id: string
-          label: string
-          render?: (i: RecordType) => unknown
-        } => typeof c?.id === "string" && typeof c?.label === "string"
-      )
-      .map((c) => ({ id: c.id, label: c.label, render: c.render }))
+    return getDownloadableColumns(item.visualizations)
   }, [item])
 
   const downloadActions = useCollectionDownloadActions({

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ExportDropdown/ExportDropdown.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ExportDropdown/ExportDropdown.tsx
@@ -3,7 +3,7 @@ import { Download, Ellipsis } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 
 interface ExportDropdownProps {
-  onExportExcel: () => void
+  onExportExcel: () => Promise<void>
   isExporting: boolean
 }
 
@@ -21,10 +21,10 @@ export function ExportDropdown({
             ? t("ai.dataDownload.exporting")
             : t("ai.dataDownload.exportDashboard", { format: "Excel" }),
           icon: Download,
-          // Dropdown items have no built-in disabled/loading state, so guard
-          // the click ourselves to avoid firing a second export while one is
-          // already in flight.
-          onClick: isExporting ? () => {} : onExportExcel,
+          onClick: () => {
+            void onExportExcel().catch(() => undefined)
+          },
+          disabled: isExporting,
         },
       ]}
       icon={Ellipsis}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useChartDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useChartDownloadActions.ts
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from "react"
 
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
 
+import { toasts } from "@/hooks/toast"
 import { Table, Image } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 
@@ -40,19 +41,47 @@ export function useChartDownloadActions({
 }: UseChartDownloadActionsOptions): DropdownItem[] {
   const { t } = useI18n()
 
+  const runDownload = useCallback(
+    (download: () => void) => {
+      const toastId = toasts.open({
+        variant: "loading",
+        title: t("ai.dataDownload.downloadPreparing"),
+        persistent: true,
+      })
+      try {
+        download()
+        toasts.open({
+          id: toastId,
+          variant: "success",
+          title: t("ai.dataDownload.downloadSuccess"),
+        })
+      } catch {
+        toasts.open({
+          id: toastId,
+          variant: "error",
+          title: t("ai.dataDownload.downloadFailed"),
+          description: t("ai.dataDownload.exportFailedDescription"),
+        })
+      }
+    },
+    [t]
+  )
+
   const handleImage = useCallback(
     (type: "png" | "jpg") => {
-      const instance = getEChartsInstance(chartContainerRef)
-      if (!instance) return
-      const echartsType = type === "jpg" ? "jpeg" : "png"
-      const dataUrl = instance.getDataURL({
-        type: echartsType,
-        pixelRatio: 2,
-        ...(type === "jpg" ? { backgroundColor: "#fff" } : {}),
+      runDownload(() => {
+        const instance = getEChartsInstance(chartContainerRef)
+        if (!instance) throw new Error("The chart is not ready to export")
+        const echartsType = type === "jpg" ? "jpeg" : "png"
+        const dataUrl = instance.getDataURL({
+          type: echartsType,
+          pixelRatio: 2,
+          ...(type === "jpg" ? { backgroundColor: "#fff" } : {}),
+        })
+        downloadAsImage(dataUrl, title, type)
       })
-      downloadAsImage(dataUrl, title, type)
     },
-    [chartContainerRef, title]
+    [chartContainerRef, title, runDownload]
   )
 
   const effectiveConfig = useMemo(() => {
@@ -65,15 +94,19 @@ export function useChartDownloadActions({
 
   const handleExcel = useCallback(() => {
     if (!data) return
-    const tabular = chartDataToTabular(effectiveConfig, data)
-    downloadAsExcel(tabular.columns, tabular.rows, title, tabular.keys)
-  }, [effectiveConfig, data, title])
+    runDownload(() => {
+      const tabular = chartDataToTabular(effectiveConfig, data)
+      downloadAsExcel(tabular.columns, tabular.rows, title, tabular.keys)
+    })
+  }, [effectiveConfig, data, title, runDownload])
 
   const handleCsv = useCallback(() => {
     if (!data) return
-    const tabular = chartDataToTabular(effectiveConfig, data)
-    downloadAsCsv(tabular.columns, tabular.rows, title, tabular.keys)
-  }, [effectiveConfig, data, title])
+    runDownload(() => {
+      const tabular = chartDataToTabular(effectiveConfig, data)
+      downloadAsCsv(tabular.columns, tabular.rows, title, tabular.keys)
+    })
+  }, [effectiveConfig, data, title, runDownload])
 
   return useMemo(() => {
     if (!data) return []

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
@@ -1,60 +1,27 @@
-import { useCallback, useMemo, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
 
+import { toasts } from "@/hooks/toast"
 import { Table } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 
-import type {
-  BaseResponse,
-  PaginatedResponse,
-  RecordType,
-  SortingsStateMultiple,
-} from "@/hooks/datasource"
-
-import { extractDisplayValue } from "@/patterns/OneDataCollection/utils/csvExport"
-
+import {
+  ExportRowLimitExceededError,
+  fetchAllStateAwareRecords,
+  type DownloadableSource,
+} from "../utils/collectionExport"
+import {
+  type DownloadableColumn,
+  transformCollectionRows,
+} from "../utils/collectionColumns"
 import { downloadAsCsv, downloadAsExcel } from "../utils/downloadHelpers"
-
-// Mirrors the caps used by OneDataCollection's own `useExportAction` so the
-// dashboard-item download has identical rollover behaviour (safety limit on
-// huge tables, modest page size while paginating).
-const MAX_EXPORT_ROWS = 10_000
-const EXPORT_PAGE_SIZE = 100
-
-/**
- * Minimum source shape we need to honour the view state at click-time.
- * Purposely loose (`unknown`) — this hook sits in dashboard land and must
- * accept any `DataCollectionSource` without dragging every generic
- * through the component tree.
- */
-type DownloadableSource = {
-  dataAdapter: {
-    paginationType?: "pages" | "infinite-scroll" | undefined
-    fetchData: (params: Record<string, unknown>) => unknown
-    exportFetchData?: (params: Record<string, unknown>) => unknown
-  }
-  currentFilters?: unknown
-  currentSortings?: { field: string; order: "asc" | "desc" } | null
-  currentGrouping?: { field: string; order?: "asc" | "desc" } | null
-  currentSearch?: string
-  currentNavigationFilters?: unknown
-}
 
 /**
  * Optional per-column metadata declared by the dashboard collection item.
  * Used to (a) produce human-readable headers and (b) anchor the export
  * column order when the user has not tweaked visualization settings.
  */
-export type DownloadableColumn = {
-  id: string
-  label: string
-  /** Optional renderer from the table visualization. When present, its output
-   *  is funneled through `extractDisplayValue` so typed cells (person, status,
-   *  tag, …) export as human-readable strings instead of raw objects. */
-  render?: (item: RecordType) => unknown
-}
-
 interface UseCollectionDownloadActionsOptions {
   /** Active data source — read at click-time to respect latest state. */
   source: DownloadableSource | null | undefined
@@ -69,97 +36,6 @@ interface UseCollectionDownloadActionsOptions {
    * `TableVisualizationSettings`.
    */
   tableSettings?: { hidden?: string[]; order?: string[] }
-}
-
-async function resolvePromiseLike<T>(value: T | Promise<T>): Promise<T> {
-  return value instanceof Promise ? await value : value
-}
-
-/**
- * Walk every page of the source using its declared pagination type and
- * the user's current filters/sortings/search. Mirrors the loop in
- * OneDataCollection's `useExportAction` so the dashboard-item download
- * returns the same full record set that the collection's built-in export
- * would return.
- */
-async function fetchAllStateAwareRecords(
-  source: DownloadableSource
-): Promise<RecordType[]> {
-  const { dataAdapter } = source
-
-  const sortings: SortingsStateMultiple = [
-    ...(source.currentSortings
-      ? [
-          {
-            field: source.currentSortings.field,
-            order: source.currentSortings.order,
-          },
-        ]
-      : []),
-    ...(source.currentGrouping
-      ? [
-          {
-            field: source.currentGrouping.field,
-            order: source.currentGrouping.order ?? "asc",
-          },
-        ]
-      : []),
-  ]
-
-  const baseParams = {
-    filters: source.currentFilters,
-    sortings,
-    search: source.currentSearch,
-    navigationFilters: source.currentNavigationFilters,
-  }
-
-  const fetchFn = dataAdapter.exportFetchData ?? dataAdapter.fetchData
-
-  if (!dataAdapter.paginationType) {
-    const response = (await resolvePromiseLike(
-      fetchFn(baseParams) as unknown
-    )) as BaseResponse<RecordType>
-    return (response.records ?? []).slice(0, MAX_EXPORT_ROWS)
-  }
-
-  if (dataAdapter.paginationType === "pages") {
-    const all: RecordType[] = []
-    let currentPage = 1
-    while (all.length < MAX_EXPORT_ROWS) {
-      const response = (await resolvePromiseLike(
-        fetchFn({
-          ...baseParams,
-          pagination: { currentPage, perPage: EXPORT_PAGE_SIZE },
-        }) as unknown
-      )) as PaginatedResponse<RecordType>
-      if (!response.records || response.records.length === 0) break
-      all.push(...response.records)
-      if ("pagesCount" in response && currentPage >= response.pagesCount) break
-      currentPage++
-    }
-    return all.slice(0, MAX_EXPORT_ROWS)
-  }
-
-  // infinite-scroll
-  const all: RecordType[] = []
-  let cursor: string | null = null
-  while (all.length < MAX_EXPORT_ROWS) {
-    const response = (await resolvePromiseLike(
-      fetchFn({
-        ...baseParams,
-        pagination: { cursor, perPage: EXPORT_PAGE_SIZE },
-      }) as unknown
-    )) as PaginatedResponse<RecordType>
-    if (!response.records || response.records.length === 0) break
-    all.push(...response.records)
-    if ("hasMore" in response && !response.hasMore) break
-    if ("cursor" in response) {
-      cursor = (response.cursor as string | null) ?? null
-    } else {
-      break
-    }
-  }
-  return all.slice(0, MAX_EXPORT_ROWS)
 }
 
 /**
@@ -210,44 +86,79 @@ export function useCollectionDownloadActions({
 }: UseCollectionDownloadActionsOptions): DropdownItem[] {
   const { t } = useI18n()
   const [isExporting, setIsExporting] = useState(false)
+  const exportPromiseRef = useRef<Promise<void> | null>(null)
 
   const runDownload = useCallback(
     async (fmt: "excel" | "csv") => {
-      if (!source || isExporting) return
-      setIsExporting(true)
-      try {
-        const records = await fetchAllStateAwareRecords(source)
-        const exportColumns = resolveExportColumns(columns, tableSettings)
-        if (exportColumns.length === 0 || records.length === 0) return
+      if (!source) return
+      if (exportPromiseRef.current) return exportPromiseRef.current
 
-        // Pass labels (header row) and ids (row lookup keys) separately so
-        // collections with two columns sharing the same label don't collide
-        // when re-shaping the row payload.
-        const headerLabels = exportColumns.map((c) => c.label)
-        const rowKeys = exportColumns.map((c) => c.id)
-
-        // Pre-resolve each cell: when the column has a renderer, use it (and
-        // extract the display value) so typed cells like `{ type: "person",
-        // value: { firstName, lastName } }` come out as plain text. Otherwise
-        // fall back to the raw field lookup keyed by column id.
-        const transformedRows = records.map((record) => {
-          const row: Record<string, unknown> = {}
-          for (const col of exportColumns) {
-            row[col.id] = col.render
-              ? extractDisplayValue(col.render(record))
-              : record[col.id]
-          }
-          return row
+      const exportPromise = (async () => {
+        setIsExporting(true)
+        const toastId = toasts.open({
+          variant: "loading",
+          title: t("ai.dataDownload.downloadPreparing"),
+          persistent: true,
         })
+        try {
+          const records = await fetchAllStateAwareRecords(source)
+          const exportColumns = resolveExportColumns(columns, tableSettings)
+          if (exportColumns.length === 0 || records.length === 0) {
+            toasts.open({
+              id: toastId,
+              variant: "default",
+              title: t("ai.dataDownload.exportEmpty"),
+              description: t("ai.dataDownload.exportEmptyDescription"),
+            })
+            return
+          }
 
-        if (fmt === "excel")
-          downloadAsExcel(headerLabels, transformedRows, title, rowKeys)
-        else downloadAsCsv(headerLabels, transformedRows, title, rowKeys)
+          const headerLabels = exportColumns.map((column) => column.label)
+          const rowKeys = exportColumns.map((column) => column.id)
+          const transformedRows = transformCollectionRows(
+            records,
+            exportColumns
+          )
+
+          if (fmt === "excel")
+            downloadAsExcel(headerLabels, transformedRows, title, rowKeys)
+          else downloadAsCsv(headerLabels, transformedRows, title, rowKeys)
+          toasts.open({
+            id: toastId,
+            variant: "success",
+            title: t("ai.dataDownload.downloadSuccess"),
+          })
+        } catch (error) {
+          const isTooLarge = error instanceof ExportRowLimitExceededError
+          toasts.open({
+            id: toastId,
+            variant: isTooLarge ? "default" : "error",
+            title: t(
+              isTooLarge
+                ? "ai.dataDownload.exportTooLarge"
+                : "ai.dataDownload.downloadFailed"
+            ),
+            description: t(
+              isTooLarge
+                ? "ai.dataDownload.exportTooLargeDescription"
+                : "ai.dataDownload.exportFailedDescription"
+            ),
+          })
+        } finally {
+          setIsExporting(false)
+        }
+      })()
+
+      exportPromiseRef.current = exportPromise
+      try {
+        await exportPromise
       } finally {
-        setIsExporting(false)
+        if (exportPromiseRef.current === exportPromise) {
+          exportPromiseRef.current = null
+        }
       }
     },
-    [source, columns, tableSettings, title, isExporting]
+    [source, columns, tableSettings, title, t]
   )
 
   const handleExcel = useCallback(() => runDownload("excel"), [runDownload])
@@ -257,15 +168,21 @@ export function useCollectionDownloadActions({
     if (!source) return []
     return [
       {
-        label: t("ai.dataDownload.download", { format: "Excel" }),
+        label: isExporting
+          ? t("ai.dataDownload.exporting")
+          : t("ai.dataDownload.download", { format: "Excel" }),
         icon: Table,
         onClick: handleExcel,
+        disabled: isExporting,
       },
       {
-        label: t("ai.dataDownload.download", { format: "CSV" }),
+        label: isExporting
+          ? t("ai.dataDownload.exporting")
+          : t("ai.dataDownload.download", { format: "CSV" }),
         icon: Table,
         onClick: handleCsv,
+        disabled: isExporting,
       },
     ]
-  }, [source, t, handleExcel, handleCsv])
+  }, [source, t, handleExcel, handleCsv, isExporting])
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
@@ -1,5 +1,7 @@
 import { useCallback, useRef, useState } from "react"
 
+import { toasts } from "@/hooks/toast"
+import { useI18n } from "@/lib/providers/i18n"
 import type {
   FiltersDefinition,
   FiltersState,
@@ -14,6 +16,14 @@ import type {
 
 import { isRenderableChart } from "../utils/chartDataAdapter"
 import { chartDataToTabular } from "../utils/chartDataToTabular"
+import {
+  getDownloadableColumns,
+  transformCollectionRows,
+} from "../utils/collectionColumns"
+import {
+  ExportRowLimitExceededError,
+  fetchAllStateAwareRecords,
+} from "../utils/collectionExport"
 import { downloadMultiSheetExcel } from "../utils/downloadHelpers"
 import { extractColumns } from "../utils/extractColumns"
 
@@ -36,6 +46,13 @@ interface UseDashboardExportResult {
   isExporting: boolean
 }
 
+class EmptyDashboardExportError extends Error {
+  constructor() {
+    super("The dashboard has no data to export")
+    this.name = "EmptyDashboardExportError"
+  }
+}
+
 function getItemFilters<Filters extends FiltersDefinition>(
   item: { useDashboardFilters?: boolean },
   filters: FiltersState<Filters>
@@ -55,28 +72,19 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
   let hasPrevious = false
 
   for (const item of metricItems) {
-    try {
-      const data: DashboardMetricData = await item.fetchData(
-        getItemFilters(item, filters)
-      )
-      const row: Record<string, unknown> = {
-        Metric: item.title,
-        Value: data.value,
-      }
-      if (data.previousValue !== undefined) {
-        row["Previous Value"] = data.previousValue
-        hasPrevious = true
-      }
-      rows.push(row)
-    } catch (err) {
-      console.warn(
-        `[useDashboardExport] Failed to export metric "${item.title}":`,
-        err
-      )
+    const data: DashboardMetricData = await item.fetchData(
+      getItemFilters(item, filters)
+    )
+    const row: Record<string, unknown> = {
+      Metric: item.title,
+      Value: data.value,
     }
+    if (data.previousValue !== undefined) {
+      row["Previous Value"] = data.previousValue
+      hasPrevious = true
+    }
+    rows.push(row)
   }
-
-  if (rows.length === 0) return null
 
   const columns = hasPrevious
     ? ["Metric", "Value", "Previous Value"]
@@ -103,57 +111,40 @@ async function buildAllSheets<Filters extends FiltersDefinition>(
   const sheetPromises = nonMetricItems.map(
     async (item): Promise<SheetData | null> => {
       if (item.type === "chart") {
-        try {
-          const data: DashboardChartData = await item.fetchData(
-            getItemFilters(item, filters)
+        const data: DashboardChartData = await item.fetchData(
+          getItemFilters(item, filters)
+        )
+        if (!isRenderableChart(item.chart)) {
+          throw new Error(
+            `[useDashboardExport] Chart "${item.id}" cannot be exported`
           )
-          // Same guard `ChartItem` applies when rendering: without it an
-          // unrenderable config throws inside the converter and the sheet is
-          // dropped by the catch below, which reads as a silent omission
-          // rather than a stated one.
-          if (!isRenderableChart(item.chart)) {
-            console.warn(
-              `[useDashboardExport] Skipped chart "${item.title}": unsupported chart type`
-            )
-            return null
-          }
-          const tabular = chartDataToTabular(item.chart, data)
-          return {
-            name: item.title,
-            columns: tabular.columns,
-            rows: tabular.rows,
-            keys: tabular.keys,
-          }
-        } catch (err) {
-          console.warn(
-            `[useDashboardExport] Failed to export chart "${item.title}":`,
-            err
-          )
-          return null
+        }
+        const tabular = chartDataToTabular(item.chart, data)
+        return {
+          name: item.title,
+          columns: tabular.columns,
+          rows: tabular.rows,
+          keys: tabular.keys,
         }
       }
 
       if (item.type === "collection") {
-        try {
-          const sourceDef = item.createSource(getItemFilters(item, filters))
-          const result = await sourceDef.dataAdapter.fetchData({
-            filters: {},
-            sortings: [],
-            pagination: { currentPage: 1, perPage: 100000 },
-          })
-          const records: Record<string, unknown>[] =
-            "records" in result
-              ? result.records
-              : (result as Record<string, unknown>[])
-          if (records.length === 0) return null
-          const columns = extractColumns(records)
-          return { name: item.title, columns, rows: records }
-        } catch (err) {
-          console.warn(
-            `[useDashboardExport] Failed to export collection "${item.title}":`,
-            err
-          )
-          return null
+        const sourceDef = item.createSource(getItemFilters(item, filters))
+        const records = await fetchAllStateAwareRecords(sourceDef)
+        const configuredColumns = getDownloadableColumns(item.visualizations)
+        if (configuredColumns.length > 0) {
+          return {
+            name: item.title,
+            columns: configuredColumns.map((column) => column.label),
+            keys: configuredColumns.map((column) => column.id),
+            rows: transformCollectionRows(records, configuredColumns),
+          }
+        }
+
+        return {
+          name: item.title,
+          columns: extractColumns(records),
+          rows: records,
         }
       }
 
@@ -174,6 +165,7 @@ export function useDashboardExport<Filters extends FiltersDefinition>({
   filters,
   filename = "dashboard",
 }: UseDashboardExportOptions<Filters>): UseDashboardExportResult {
+  const { t } = useI18n()
   const [isExporting, setIsExporting] = useState(false)
 
   // The export callback must keep a STABLE identity across renders. It is
@@ -187,16 +179,88 @@ export function useDashboardExport<Filters extends FiltersDefinition>({
   filtersRef.current = filters
   const filenameRef = useRef(filename)
   filenameRef.current = filename
+  const tRef = useRef(t)
+  tRef.current = t
+  const exportPromiseRef = useRef<Promise<void> | null>(null)
 
   const exportAsExcel = useCallback(async () => {
-    setIsExporting(true)
-    try {
-      const sheets = await buildAllSheets(itemsRef.current, filtersRef.current)
-      if (sheets.length > 0) {
-        downloadMultiSheetExcel(sheets, filenameRef.current)
+    if (exportPromiseRef.current) return exportPromiseRef.current
+
+    const exportPromise = (async () => {
+      setIsExporting(true)
+      const toastId = toasts.open({
+        variant: "loading",
+        title: tRef.current("ai.dataDownload.exportPreparing"),
+        persistent: true,
+      })
+
+      try {
+        const sheets = await buildAllSheets(
+          itemsRef.current,
+          filtersRef.current
+        )
+        if (
+          sheets.length === 0 ||
+          sheets.every((sheet) => sheet.rows.length === 0)
+        ) {
+          throw new EmptyDashboardExportError()
+        }
+
+        downloadMultiSheetExcel(sheets, filenameRef.current, {
+          sheetName: tRef.current("ai.dataDownload.exportOverviewSheetName"),
+          description: tRef.current(
+            "ai.dataDownload.exportOverviewDescription"
+          ),
+          rowsExported: (amount) =>
+            tRef.current("ai.dataDownload.exportRowsExported", { amount }),
+          previewTruncated: (amount) =>
+            tRef.current("ai.dataDownload.exportPreviewTruncated", {
+              amount,
+            }),
+          fullDataSheet: (sheetName) =>
+            tRef.current("ai.dataDownload.exportFullDataSheet", {
+              sheetName,
+            }),
+        })
+        toasts.open({
+          id: toastId,
+          variant: "success",
+          title: tRef.current("ai.dataDownload.exportSuccess"),
+        })
+      } catch (error) {
+        const isEmpty = error instanceof EmptyDashboardExportError
+        const isTooLarge = error instanceof ExportRowLimitExceededError
+        toasts.open({
+          id: toastId,
+          variant: isEmpty || isTooLarge ? "default" : "error",
+          title: tRef.current(
+            isEmpty
+              ? "ai.dataDownload.exportEmpty"
+              : isTooLarge
+                ? "ai.dataDownload.exportTooLarge"
+                : "ai.dataDownload.exportFailed"
+          ),
+          description: tRef.current(
+            isEmpty
+              ? "ai.dataDownload.exportEmptyDescription"
+              : isTooLarge
+                ? "ai.dataDownload.exportTooLargeDescription"
+                : "ai.dataDownload.exportFailedDescription"
+          ),
+        })
+        throw error
+      } finally {
+        setIsExporting(false)
       }
+    })()
+
+    exportPromiseRef.current = exportPromise
+    try {
+      await exportPromise
     } finally {
-      setIsExporting(false)
+      if (exportPromiseRef.current === exportPromise) {
+        exportPromiseRef.current = null
+      }
     }
   }, [])
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -487,7 +487,7 @@ export interface F0AnalyticsDashboardProps<
    */
   onLayoutChange?: (layout: DashboardItemLayout[]) => void
   /**
-   * Show a dashboard-level export button (PDF/Excel).
+   * Show a dashboard-level Excel export button.
    * @default false
    */
   enableExport?: boolean

--- a/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartDataToTabular.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartDataToTabular.ts
@@ -31,9 +31,13 @@ interface TabularResult {
  */
 function numericValue(point: unknown): number | null {
   if (point == null) return null
-  if (typeof point === "number") return point
+  if (typeof point === "number") return Number.isFinite(point) ? point : null
+  if (typeof point === "string" && point.trim() !== "") {
+    const parsed = Number(point)
+    return Number.isFinite(parsed) ? parsed : null
+  }
   if (typeof point === "object" && "value" in point) {
-    return (point as { value: number }).value
+    return numericValue((point as { value: unknown }).value)
   }
   return null
 }
@@ -97,7 +101,7 @@ function funnelToTabular(data: DashboardChartData): TabularResult {
     const categories = data.categories ?? []
     const rows = categories.map((cat, i) => ({
       Stage: cat,
-      Value: (firstSeries as { data: number[] }).data[i] ?? 0,
+      Value: numericValue((firstSeries as { data: unknown[] }).data[i]) ?? 0,
     }))
     return { columns: ["Stage", "Value"], rows }
   }
@@ -106,7 +110,7 @@ function funnelToTabular(data: DashboardChartData): TabularResult {
   const rows = (funnelSeries?.data ?? []).map(
     (d: { name: string; value: number }) => ({
       Stage: d.name,
-      Value: d.value,
+      Value: numericValue(d.value),
     })
   )
   return { columns: ["Stage", "Value"], rows }
@@ -117,7 +121,7 @@ function pieToTabular(data: DashboardChartData): TabularResult {
   const rows = (series?.data ?? []).map(
     (d: { name: string; value: number }) => ({
       Name: d.name,
-      Value: d.value,
+      Value: numericValue(d.value),
     })
   )
   return { columns: ["Name", "Value"], rows }
@@ -137,7 +141,7 @@ function radarToTabular(data: DashboardChartData): TabularResult {
       Indicator: typeof ind === "string" ? ind : ind.name,
     }
     for (const s of series) {
-      row[s.name] = s.data[i] ?? null
+      row[s.name] = numericValue(s.data[i])
     }
     return row
   })
@@ -149,7 +153,12 @@ function gaugeToTabular(data: DashboardChartData): TabularResult {
   const gauge = data.series as { value: number; name?: string }
   return {
     columns: ["Name", "Value"],
-    rows: [{ Name: gauge?.name ?? "Value", Value: gauge?.value ?? 0 }],
+    rows: [
+      {
+        Name: gauge?.name ?? "Value",
+        Value: numericValue(gauge?.value) ?? 0,
+      },
+    ],
   }
 }
 
@@ -161,7 +170,7 @@ function heatmapToTabular(data: DashboardChartData): TabularResult {
   const rows = points.map(([x, y, value]) => ({
     X: xCats[x] ?? x,
     Y: yCats[y] ?? y,
-    Value: value,
+    Value: numericValue(value),
   }))
 
   return { columns: ["X", "Y", "Value"], rows }
@@ -186,8 +195,8 @@ function scatterToTabular(
     series.data.map((point) => ({
       series: series.name,
       label: Array.isArray(point) ? "" : (point.label ?? ""),
-      x: Array.isArray(point) ? point[0] : point.x,
-      y: Array.isArray(point) ? point[1] : point.y,
+      x: numericValue(Array.isArray(point) ? point[0] : point.x),
+      y: numericValue(Array.isArray(point) ? point[1] : point.y),
     }))
   )
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/utils/collectionColumns.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/utils/collectionColumns.ts
@@ -1,0 +1,59 @@
+import type { RecordType } from "@/hooks/datasource"
+
+import { extractDisplayValue } from "@/patterns/OneDataCollection/utils/csvExport"
+
+export type DownloadableColumn = {
+  id: string
+  label: string
+  render?: (item: RecordType) => unknown
+}
+
+export function getDownloadableColumns(
+  visualizations: ReadonlyArray<unknown> | undefined
+): DownloadableColumn[] {
+  const tableVisualization = visualizations?.find(
+    (visualization) =>
+      (visualization as { type?: string } | undefined)?.type === "table"
+  ) as
+    | {
+        options?: {
+          columns?: Array<{
+            id?: string
+            label?: string
+            render?: (item: RecordType) => unknown
+          }>
+        }
+      }
+    | undefined
+
+  return (tableVisualization?.options?.columns ?? [])
+    .filter(
+      (
+        column
+      ): column is {
+        id: string
+        label: string
+        render?: (item: RecordType) => unknown
+      } => typeof column?.id === "string" && typeof column?.label === "string"
+    )
+    .map((column) => ({
+      id: column.id,
+      label: column.label,
+      render: column.render,
+    }))
+}
+
+export function transformCollectionRows(
+  records: RecordType[],
+  columns: DownloadableColumn[]
+): Record<string, unknown>[] {
+  return records.map((record) => {
+    const row: Record<string, unknown> = {}
+    for (const column of columns) {
+      row[column.id] = column.render
+        ? extractDisplayValue(column.render(record))
+        : record[column.id]
+    }
+    return row
+  })
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/utils/collectionExport.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/utils/collectionExport.ts
@@ -1,0 +1,205 @@
+import type {
+  BaseResponse,
+  PaginatedResponse,
+  RecordType,
+  SortingsStateMultiple,
+} from "@/hooks/datasource"
+import type { PromiseState } from "@/lib/promise-to-observable"
+
+// Mirrors OneDataCollection's export limits so table-only and multi-widget
+// dashboards have the same bounded behavior.
+const MAX_EXPORT_ROWS = 10_000
+const EXPORT_PAGE_SIZE = 100
+
+export class ExportRowLimitExceededError extends Error {
+  constructor() {
+    super(`The export exceeds the ${MAX_EXPORT_ROWS}-row limit`)
+    this.name = "ExportRowLimitExceededError"
+  }
+}
+
+export class ExportPaginationError extends Error {
+  constructor() {
+    super("The export could not retrieve every page")
+    this.name = "ExportPaginationError"
+  }
+}
+
+/** Minimum source state required to reproduce the collection visible at click-time. */
+export type DownloadableSource = {
+  dataAdapter: {
+    paginationType?: "pages" | "infinite-scroll" | "no-pagination" | undefined
+    fetchData: (params: Record<string, unknown>) => unknown
+    exportFetchData?: (params: Record<string, unknown>) => unknown
+  }
+  currentFilters?: unknown
+  currentSortings?: { field: string; order: "asc" | "desc" } | null
+  currentGrouping?: { field: string; order?: "asc" | "desc" } | null
+  currentSearch?: string
+  currentNavigationFilters?: unknown
+}
+
+async function resolvePromiseLike<T>(
+  value: T | Promise<T> | { subscribe?: unknown }
+): Promise<T> {
+  if (value && typeof (value as Promise<T>).then === "function") {
+    return value as Promise<T>
+  }
+
+  if (
+    value &&
+    typeof (value as { subscribe?: unknown }).subscribe === "function"
+  ) {
+    const observable = value as {
+      subscribe: (observer: {
+        next: (state: PromiseState<T>) => void
+        error: (error: unknown) => void
+        complete: () => void
+      }) => { unsubscribe: () => void }
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      let subscription: { unsubscribe: () => void } | undefined
+      let settled = false
+      subscription = observable.subscribe({
+        next(state) {
+          if (state.loading || settled) return
+          settled = true
+          subscription?.unsubscribe()
+          if (state.error) reject(state.error)
+          else if (state.data != null) resolve(state.data)
+          else reject(new Error("Observable resolved with no data"))
+        },
+        error(error) {
+          if (settled) return
+          settled = true
+          reject(error instanceof Error ? error : new Error(String(error)))
+        },
+        complete() {
+          if (settled) return
+          settled = true
+          reject(new Error("Observable completed without emitting data"))
+        },
+      })
+      if (settled) subscription.unsubscribe()
+    })
+  }
+
+  return value as T
+}
+
+/** Fetch the complete bounded collection using its filters and pagination contract. */
+export async function fetchAllStateAwareRecords(
+  source: DownloadableSource
+): Promise<RecordType[]> {
+  const { dataAdapter } = source
+  const sortings: SortingsStateMultiple = [
+    ...(source.currentSortings
+      ? [
+          {
+            field: source.currentSortings.field,
+            order: source.currentSortings.order,
+          },
+        ]
+      : []),
+    ...(source.currentGrouping
+      ? [
+          {
+            field: source.currentGrouping.field,
+            order: source.currentGrouping.order ?? "asc",
+          },
+        ]
+      : []),
+  ]
+  const baseParams = {
+    filters: source.currentFilters,
+    sortings,
+    search: source.currentSearch,
+    navigationFilters: source.currentNavigationFilters,
+  }
+  const fetchFn = dataAdapter.exportFetchData ?? dataAdapter.fetchData
+
+  if (
+    !dataAdapter.paginationType ||
+    dataAdapter.paginationType === "no-pagination"
+  ) {
+    const response = (await resolvePromiseLike(
+      fetchFn(baseParams) as unknown
+    )) as BaseResponse<RecordType>
+    const records = response.records ?? []
+    if (records.length > MAX_EXPORT_ROWS) {
+      throw new ExportRowLimitExceededError()
+    }
+    return records
+  }
+
+  if (dataAdapter.paginationType === "pages") {
+    const all: RecordType[] = []
+    let currentPage = 1
+    while (all.length < MAX_EXPORT_ROWS) {
+      const response = (await resolvePromiseLike(
+        fetchFn({
+          ...baseParams,
+          pagination: { currentPage, perPage: EXPORT_PAGE_SIZE },
+        }) as unknown
+      )) as PaginatedResponse<RecordType>
+      if (!response.records || response.records.length === 0) {
+        if ("pagesCount" in response && currentPage < response.pagesCount) {
+          throw new ExportPaginationError()
+        }
+        break
+      }
+      all.push(...response.records)
+      if (all.length > MAX_EXPORT_ROWS) {
+        throw new ExportRowLimitExceededError()
+      }
+      if (
+        all.length >= MAX_EXPORT_ROWS &&
+        (!("pagesCount" in response) || currentPage < response.pagesCount)
+      ) {
+        throw new ExportRowLimitExceededError()
+      }
+      if ("pagesCount" in response && currentPage >= response.pagesCount) break
+      currentPage += 1
+    }
+    return all
+  }
+
+  const all: RecordType[] = []
+  let cursor: string | null = null
+  while (all.length < MAX_EXPORT_ROWS) {
+    const response = (await resolvePromiseLike(
+      fetchFn({
+        ...baseParams,
+        pagination: { cursor, perPage: EXPORT_PAGE_SIZE },
+      }) as unknown
+    )) as PaginatedResponse<RecordType>
+    if (!response.records || response.records.length === 0) {
+      if ("hasMore" in response && response.hasMore) {
+        throw new ExportPaginationError()
+      }
+      break
+    }
+
+    const hasMore = "hasMore" in response && response.hasMore
+    const nextCursor = "cursor" in response ? (response.cursor ?? null) : null
+    if (hasMore && (!nextCursor || nextCursor === cursor)) {
+      throw new ExportPaginationError()
+    }
+
+    all.push(...response.records)
+    if (all.length > MAX_EXPORT_ROWS) {
+      throw new ExportRowLimitExceededError()
+    }
+    if (all.length >= MAX_EXPORT_ROWS && hasMore) {
+      throw new ExportRowLimitExceededError()
+    }
+    if ("hasMore" in response && !hasMore) break
+    if (!("cursor" in response)) break
+    if (!nextCursor || nextCursor === cursor) {
+      throw new ExportPaginationError()
+    }
+    cursor = nextCursor
+  }
+  return all
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/utils/downloadHelpers.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/utils/downloadHelpers.ts
@@ -1,18 +1,78 @@
 import * as XLSX from "xlsx"
 
+type SpreadsheetValue = string | number | boolean
+
+export interface DashboardOverviewCopy {
+  sheetName: string
+  description: string
+  rowsExported: (amount: number) => string
+  previewTruncated: (amount: number) => string
+  fullDataSheet: (sheetName: string) => string
+}
+
+const DASHBOARD_OVERVIEW_PREVIEW_ROWS = 50
+
 /**
- * Serialize a cell value to a string suitable for spreadsheet/CSV export.
+ * Serialize a cell value for spreadsheet/CSV export.
  * - null/undefined → ""
- * - booleans → "true"/"false"
+ * - numbers/booleans retain their native type for Excel
  * - Dates → ISO string
  * - objects/arrays → JSON string
+ * - user-authored strings that could execute as spreadsheet formulas are
+ *   prefixed with an apostrophe
  */
-function serializeValue(value: unknown): string {
+export function serializeValue(value: unknown): SpreadsheetValue {
   if (value == null) return ""
-  if (typeof value === "boolean") return String(value)
+  if (typeof value === "number" || typeof value === "boolean") return value
   if (value instanceof Date) return value.toISOString()
   if (typeof value === "object") return JSON.stringify(value)
-  return String(value)
+  const serialized = String(value)
+  return /^[\s\u0000-\u001F]*[=+\-@]/.test(serialized)
+    ? `'${serialized}`
+    : serialized
+}
+
+/**
+ * Keep downloads portable across Windows, macOS, mobile browsers, and shared
+ * drives. The browser may accept reserved characters that the destination
+ * filesystem cannot persist.
+ */
+export function sanitizeDownloadFilename(
+  filename: string,
+  fallback = "download"
+): string {
+  const sanitized = filename
+    .trim()
+    .replace(/[<>:"/\\|?*\u0000-\u001F]/g, "-")
+    .slice(0, 180)
+    .replace(/[. ]+$/g, "")
+
+  if (!sanitized) return fallback
+  const basename = sanitized.split(".", 1)[0]
+  if (/^(con|prn|aux|nul|com[1-9]|lpt[1-9])$/i.test(basename)) {
+    return `_${sanitized}`
+  }
+  return sanitized
+}
+
+/** Excel sheet names are case-insensitively unique and limited to 31 chars. */
+export function uniqueExcelSheetName(
+  requestedName: string,
+  usedNames: Set<string>
+): string {
+  const sanitized = requestedName.replace(/[\\/?*:[\]]/g, "-").trim()
+  const base = sanitized || "Sheet"
+  let candidate = base.slice(0, 31)
+  let suffixNumber = 2
+
+  while (usedNames.has(candidate.toLowerCase())) {
+    const suffix = ` (${suffixNumber})`
+    candidate = `${base.slice(0, 31 - suffix.length).trimEnd()}${suffix}`
+    suffixNumber += 1
+  }
+
+  usedNames.add(candidate.toLowerCase())
+  return candidate
 }
 
 /**
@@ -20,10 +80,19 @@ function serializeValue(value: unknown): string {
  */
 function triggerDownload(blob: Blob, filename: string): void {
   const link = document.createElement("a")
-  link.href = URL.createObjectURL(blob)
+  const objectUrl = URL.createObjectURL(blob)
+  link.href = objectUrl
   link.download = filename
-  link.click()
-  URL.revokeObjectURL(link.href)
+  link.style.display = "none"
+  document.body.appendChild(link)
+  try {
+    link.click()
+  } finally {
+    link.remove()
+    // Safari and Chromium can cancel the download if the Blob URL is revoked
+    // synchronously in the click stack.
+    setTimeout(() => URL.revokeObjectURL(objectUrl), 0)
+  }
 }
 
 /**
@@ -51,7 +120,7 @@ export function downloadAsExcel(
   const blob = new Blob([buffer], {
     type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   })
-  triggerDownload(blob, `${filename}.xlsx`)
+  triggerDownload(blob, `${sanitizeDownloadFilename(filename)}.xlsx`)
 }
 
 /**
@@ -66,7 +135,7 @@ export function downloadAsCsv(
 ): void {
   const rowKeys = keys ?? columns
   const escapeCsv = (value: unknown): string => {
-    const str = serializeValue(value)
+    const str = String(serializeValue(value))
     if (str.includes(",") || str.includes('"') || str.includes("\n")) {
       return `"${str.replace(/"/g, '""')}"`
     }
@@ -81,7 +150,7 @@ export function downloadAsCsv(
   const blob = new Blob([lines.join("\n")], {
     type: "text/csv;charset=utf-8;",
   })
-  triggerDownload(blob, `${filename}.csv`)
+  triggerDownload(blob, `${sanitizeDownloadFilename(filename)}.csv`)
 }
 
 /**
@@ -94,7 +163,7 @@ export function downloadAsImage(
 ): void {
   const link = document.createElement("a")
   link.href = dataUrl
-  link.download = `${filename}.${ext}`
+  link.download = `${sanitizeDownloadFilename(filename)}.${ext}`
   link.click()
 }
 
@@ -110,11 +179,76 @@ export function downloadMultiSheetExcel(
     /** Row-lookup keys parallel to `columns`; see {@link downloadAsExcel}. */
     keys?: string[]
   }[],
-  filename: string
+  filename: string,
+  overview?: DashboardOverviewCopy
 ): void {
   const workbook = XLSX.utils.book_new()
+  const usedSheetNames = new Set<string>()
 
-  for (const sheet of sheets) {
+  const overviewSheetName = overview
+    ? uniqueExcelSheetName(overview.sheetName, usedSheetNames)
+    : undefined
+  const namedSheets = sheets.map((sheet) => ({
+    ...sheet,
+    safeName: uniqueExcelSheetName(sheet.name, usedSheetNames),
+  }))
+
+  if (overview && overviewSheetName && namedSheets.length > 1) {
+    const overviewRows: SpreadsheetValue[][] = [
+      [serializeValue(filename)],
+      [overview.description],
+      [],
+    ]
+    const linkedRows: Array<{ row: number; sheetName: string }> = []
+
+    for (const sheet of namedSheets) {
+      const rowKeys = sheet.keys ?? sheet.columns
+      linkedRows.push({ row: overviewRows.length, sheetName: sheet.safeName })
+      overviewRows.push([
+        serializeValue(sheet.name),
+        overview.rowsExported(sheet.rows.length),
+      ])
+      overviewRows.push(sheet.columns.map(serializeValue))
+      overviewRows.push(
+        ...sheet.rows
+          .slice(0, DASHBOARD_OVERVIEW_PREVIEW_ROWS)
+          .map((row) => rowKeys.map((key) => serializeValue(row[key])))
+      )
+      if (sheet.rows.length > DASHBOARD_OVERVIEW_PREVIEW_ROWS) {
+        overviewRows.push([
+          overview.previewTruncated(DASHBOARD_OVERVIEW_PREVIEW_ROWS),
+        ])
+      }
+      overviewRows.push([overview.fullDataSheet(sheet.safeName)])
+      linkedRows.push({
+        row: overviewRows.length - 1,
+        sheetName: sheet.safeName,
+      })
+      overviewRows.push([])
+    }
+
+    const overviewWorksheet = XLSX.utils.aoa_to_sheet(overviewRows)
+    for (const link of linkedRows) {
+      const cell = overviewWorksheet[`A${link.row + 1}`]
+      if (cell) {
+        cell.l = {
+          Target: `#'${link.sheetName.replace(/'/g, "''")}'!A1`,
+        }
+      }
+    }
+    overviewWorksheet["!cols"] = Array.from(
+      {
+        length: Math.max(
+          2,
+          ...namedSheets.map((sheet) => sheet.columns.length)
+        ),
+      },
+      (_, index) => ({ wch: index === 0 ? 36 : 24 })
+    )
+    XLSX.utils.book_append_sheet(workbook, overviewWorksheet, overviewSheetName)
+  }
+
+  for (const sheet of namedSheets) {
     const rowKeys = sheet.keys ?? sheet.columns
     const wsData = [
       sheet.columns,
@@ -123,14 +257,12 @@ export function downloadMultiSheetExcel(
       ),
     ]
     const worksheet = XLSX.utils.aoa_to_sheet(wsData)
-    // Sheet names are limited to 31 chars in Excel
-    const safeName = sheet.name.slice(0, 31)
-    XLSX.utils.book_append_sheet(workbook, worksheet, safeName)
+    XLSX.utils.book_append_sheet(workbook, worksheet, sheet.safeName)
   }
 
   const buffer = XLSX.write(workbook, { type: "array", bookType: "xlsx" })
   const blob = new Blob([buffer], {
     type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   })
-  triggerDownload(blob, `${filename}.xlsx`)
+  triggerDownload(blob, `${sanitizeDownloadFilename(filename)}.xlsx`)
 }


### PR DESCRIPTION
## Designer handoff — 9 September 2026

**Dashboard exports.** Export a dashboard to Excel, open the Dashboard overview, then follow Full data to a widget worksheet. Review the preparing, success, empty, too-large, and failure feedback.

Factorial host feedback and translations: [factorial#109028](https://github.com/factorialco/factorial/pull/109028). The host adoption still needs the released F0 version and a combined application check.

**Preview:** [PR Storybook](https://66a7a8d7d124220c363457cc-bfwlohejyy.chromatic.com/?path=/story/patterns-analyticsdashboard--with-export&autoplay=false) (Chromatic sign-in required). For manual review, autoplay is disabled.

**Local review:** in a separate F0 checkout, run:

```sh
gh pr checkout 5028
pnpm install --frozen-lockfile
pnpm --filter @factorialco/f0-core build
pnpm --filter @factorialco/f0-react dev --no-open
```

Open [the local story](http://localhost:6006/?path=/story/patterns-analyticsdashboard--with-export&autoplay=false). These commands target the current PR branch; local startup was not rerun during this description refresh.

## Current status — 9 September 2026

- **Branch:** Open (non-draft); 360 commits behind main at this check. Integration with current main conflicts in 9 files; branch refresh and validation remain pending.
- **Source:** `b5f6a4c78c91452350a2674e201b12f93a7e09ab`.
- **Existing CI:** 32 successful check runs and 7 skipped, completed on 2026-08-06; no failing or running check runs returned for this source head. These are existing results, not validation against today's main.
- **Review:** the separate Review policy status remains pending.
- **Refresh scope:** PR description, dependency links, design walkthrough, and live status checked. Code rebases and new test runs remain pending.

<details>
<summary>Implementation details and earlier validation</summary>

The original implementation notes and validation below predate this status refresh. The current status above governs branch readiness.

## Description

Make AI Analytics exports complete, trustworthy, and understandable when opened. Multi-widget workbooks now start with a dashboard overview while retaining full per-widget data, and collection/chart exports preserve active state instead of silently producing partial or misleading files.

## Product story

| Before | After |
| --- | --- |
| Excel opened on a small `Metrics` tab, so a complete dashboard looked like it exported only 3–4 values. | Excel opens on `Dashboard overview`, where every widget is visible with its exported row count and a bounded data preview. |
| Reviewers had to discover and inspect every worksheet tab to know whether chart data existed. | Every overview section links directly to the widget's complete worksheet. |
| Collection exports used a generic fetch that could ignore the collection's active state or pagination contract. | Exports use the current filters, sorting, grouping, search, navigation filters, visible columns, and supported pagination. |
| A widget failure could be swallowed, creating a workbook that looked successful but was incomplete. | The whole dashboard export reports a clear failure instead of presenting partial data as complete. |

### Example users can verify

Exported examples
[Headcount & Org Movements.xlsx](https://github.com/user-attachments/files/30788897/Headcount.Org.Movements.xlsx)
[Latest main Chrome smoke test (10).xlsx](https://github.com/user-attachments/files/30788901/Latest.main.Chrome.smoke.test.10.xlsx)


- `Workforce snapshot`: 11 widgets → 76 overview rows + 8 complete data sheets.
- `Future analytics investigation demo`: 12 widgets → 137 overview rows + 10 complete data sheets.
- Opening either workbook immediately shows the whole report; following `Full data` opens the authoritative worksheet.

## Compatibility and non-regression contract

- No public `F0AnalyticsDashboard` prop or callback signature changes.
- Existing complete per-widget worksheets remain authoritative and keep their exported data; the overview is additive and only appears for multi-sheet workbooks.
- Existing per-chart PNG, JPG, Excel, and CSV actions remain available.
- Existing single-collection behavior remains unchanged.
- Overview duplication is bounded to 50 preview rows per widget; full data is not truncated.
- Collections above the existing 10,000-row safety limit fail explicitly rather than exporting a partial dataset.
- Every cell still passes through formula-injection protection, and dashboard failures do not expose exported data.

## Type of change

- [x] Bug fix
- [x] Variant or improvement of existing pattern

## Implementation details

- fix: open multi-widget Excel exports on a bounded dashboard overview with row counts, previews, and links to full sheets
- fix: fetch complete collection exports with active filters, sorting, grouping, search, navigation filters, pagination, and visible column configuration
- fix: fail explicitly when a widget cannot be exported or the bounded row limit is exceeded instead of silently dropping data
- fix: preserve numeric spreadsheet values and harden formulas, filenames, duplicate sheet names, scatter columns, and chart data formats
- fix: expose accurate preparing, success, empty, too-large, and failure states while coalescing concurrent export requests
- docs: document the dashboard export behavior and state contract

## Verification

- 71 focused unit tests passed across dashboard, collection, chart, CSV, Excel, pagination, concurrency, and failure-state behavior
- TypeScript, formatting, lint, production build, and the F0 quality gate passed
- Chrome: exported Workforce snapshot with 11 widgets into a 76-row overview plus 8 full-data sheets
- Chrome: exported Future analytics investigation demo with 12 widgets into a 137-row overview plus 10 full-data sheets

### Reviewer walkthrough

1. Open an AI Analytics dashboard containing metrics and multiple charts or collections.
2. Export the dashboard as Excel.
3. Confirm the workbook opens on `Dashboard overview` and lists every visible widget.
4. Follow a `Full data` link and confirm it opens the matching complete worksheet.
5. Compare the row count in the overview with the complete worksheet.

## Related PR

- [Factorial AI report integration](https://github.com/factorialco/factorial/pull/109028)


</details>
