### PR TITLE
refactor(BaseBanner): [FCT-60673] extract variants into cva

### DIFF
--- a/packages/react/src/kits/ai/Banners/BaseBanner/__tests__/BaseBanner.test.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/__tests__/BaseBanner.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
+
+import { BaseBanner } from "../index"
+
+const baseProps = {
+  title: "Submit expenses in seconds",
+  subtitle: "Upload receipts. One organizes everything for you.",
+  mediaUrl: "https://example.com/media.png",
+}
+
+/** The element carrying the layout classes is the banner root. */
+const getRoot = () => document.querySelector("div.shadow-md") as HTMLElement
+
+describe("BaseBanner", () => {
+  it("renders title, subtitle and media", () => {
+    render(<BaseBanner {...baseProps} />)
+
+    expect(screen.getByText(baseProps.title)).toBeVisible()
+    expect(screen.getByText(baseProps.subtitle)).toBeVisible()
+    expect(
+      screen.getByRole("presentation", { hidden: true })
+    ).toBeInTheDocument()
+  })
+
+  it("renders both actions and calls their handlers", async () => {
+    const onPrimary = vi.fn()
+    const onSecondary = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <BaseBanner
+        {...baseProps}
+        primaryAction={{
+          label: "Try it out",
+          onClick: onPrimary,
+          variant: "outline",
+        }}
+        secondaryAction={{
+          label: "Not now",
+          onClick: onSecondary,
+          variant: "ghost",
+        }}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: "Try it out" }))
+    await user.click(screen.getByRole("button", { name: "Not now" }))
+
+    expect(onPrimary).toHaveBeenCalledOnce()
+    expect(onSecondary).toHaveBeenCalledOnce()
+  })
+
+  it("calls onClose and removes itself when dismissed", async () => {
+    const onClose = vi.fn()
+    const user = userEvent.setup()
+
+    render(<BaseBanner {...baseProps} onClose={onClose} />)
+    await user.click(screen.getByRole("button", { name: "Close" }))
+
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(screen.queryByText(baseProps.title)).not.toBeInTheDocument()
+  })
+
+  it("renders no close button when onClose is omitted", () => {
+    render(<BaseBanner {...baseProps} />)
+
+    expect(
+      screen.queryByRole("button", { name: "Close" })
+    ).not.toBeInTheDocument()
+  })
+
+  // These pin the class strings the cva slots resolve to. They are what makes a
+  // "no behaviour change" refactor of this component checkable at all — the
+  // rendered classes *are* the behaviour.
+  describe("variants", () => {
+    it("lays both variants out as a horizontal banner at sm", () => {
+      render(<BaseBanner {...baseProps} />)
+      expect(getRoot().className).toMatch(/sm:flex-row/)
+      expect(getRoot().className).toMatch(/flex-col/)
+    })
+
+    it("caps the text column on default but not on full-width", () => {
+      const { unmount } = render(<BaseBanner {...baseProps} />)
+      expect(
+        screen.getByText(baseProps.title).parentElement?.className
+      ).toMatch(/sm:max-w-lg/)
+      unmount()
+
+      render(<BaseBanner {...baseProps} variant="full-width" />)
+      expect(
+        screen.getByText(baseProps.title).parentElement?.className
+      ).not.toMatch(/sm:max-w-lg/)
+    })
+
+    it("renders a skeleton while loading", () => {
+      render(<BaseBanner {...baseProps} isLoading />)
+
+      expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true")
+      expect(screen.queryByText(baseProps.title)).not.toBeInTheDocument()
+    })
+
+    // The skeleton is built from the same slots as the banner, so it cannot
+    // drift from the layout it stands in for.
+    it("gives the skeleton the same layout as the banner", () => {
+      render(<BaseBanner {...baseProps} isLoading />)
+
+      expect(getRoot().className).toMatch(/sm:flex-row/)
+      expect(getRoot().className).toMatch(/shadow-md/)
+    })
+  })
+})

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
@@ -5,8 +5,18 @@ import { IconType } from "@/components/F0Icon"
 import CrossIcon from "@/icons/app/Cross"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
-import { cn } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
+
+import {
+  actionsVariants,
+  bannerVariants,
+  contentVariants,
+  mediaVariants,
+  subtitleVariants,
+  textWrapperVariants,
+  titleVariants,
+  type BaseBannerVariant,
+} from "./variants"
 
 export type BannerAction = {
   label: string
@@ -24,7 +34,7 @@ export type BaseBannerProps = {
   onClose?: () => void
   isLoading?: boolean
   children?: React.ReactNode
-  variant?: "default" | "full-width"
+  variant?: BaseBannerVariant
 }
 
 const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
@@ -57,12 +67,9 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
     }
 
     return !isDismissed ? (
-      <div
-        ref={ref}
-        className="bg-white relative flex w-full flex-col gap-4 rounded-xl border border-f1-border-secondary shadow-md sm:flex-row sm:gap-5"
-      >
+      <div ref={ref} className={bannerVariants({ variant })}>
         {/* Media 16:9 */}
-        <div className="aspect-video w-full flex-shrink-0 overflow-hidden rounded-xl px-1 pb-0 pt-1 sm:max-w-80 sm:py-1 sm:pl-1">
+        <div className={mediaVariants({ variant })}>
           {isVideo ? (
             <video
               src={mediaUrl}
@@ -81,23 +88,16 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
         </div>
 
         {/* Content */}
-        <div className="flex flex-col justify-center gap-5 px-3 pb-3 sm:py-3 sm:pl-0 sm:pr-3">
-          <div
-            className={cn(
-              "flex w-full flex-col gap-1",
-              variant === "default" ? "sm:max-w-lg" : undefined
-            )}
-          >
-            <h3 className="font-bold text-xl text-f1-foreground">{title}</h3>
+        <div className={contentVariants({ variant })}>
+          <div className={textWrapperVariants({ variant })}>
+            <h3 className={titleVariants({ variant })}>{title}</h3>
             {subtitle && (
-              <p className="text-base text-f1-foreground-secondary">
-                {subtitle}
-              </p>
+              <p className={subtitleVariants({ variant })}>{subtitle}</p>
             )}
           </div>
 
           {/* Actions */}
-          <div className="flex gap-3">
+          <div className={actionsVariants({ variant })}>
             {primaryAction && (
               <F0Button
                 onClick={primaryAction.onClick}
@@ -138,28 +138,34 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
   }
 )
 
+// Built from the same slots as the banner itself, so the two cannot drift. The
+// variant is pinned to `default` for now, which is what the hard-coded classes
+// resolved to — making it follow the banner's own variant is a behaviour change,
+// not part of this refactor.
+const SKELETON_VARIANT = "default" satisfies BaseBannerVariant
+
 const BaseBannerSkeleton = forwardRef<HTMLDivElement>(
   function BaseBannerSkeleton(props, ref) {
     return (
       <div
         ref={ref}
-        className="bg-white relative flex w-full flex-col gap-4 rounded-xl border border-f1-border-secondary shadow-md sm:flex-row sm:gap-5"
+        className={bannerVariants({ variant: SKELETON_VARIANT })}
         role="status"
         aria-busy="true"
         aria-live="polite"
         {...props}
       >
-        <div className="aspect-video w-full flex-shrink-0 overflow-hidden rounded-xl px-1 pb-0 pt-1 sm:max-w-80 sm:py-1 sm:pl-1">
+        <div className={mediaVariants({ variant: SKELETON_VARIANT })}>
           <Skeleton className="h-full w-full rounded-lg" />
         </div>
 
-        <div className="flex flex-col justify-center gap-5 px-3 pb-3 sm:py-3 sm:pl-0 sm:pr-3">
-          <div className="flex w-full flex-col gap-1 sm:max-w-lg">
+        <div className={contentVariants({ variant: SKELETON_VARIANT })}>
+          <div className={textWrapperVariants({ variant: SKELETON_VARIANT })}>
             <Skeleton className="h-7 w-3/4" />
             <Skeleton className="h-4 w-full" />
             <Skeleton className="h-4 w-2/3" />
           </div>
-          <div className="flex gap-3">
+          <div className={actionsVariants({ variant: SKELETON_VARIANT })}>
             <Skeleton className="h-9 w-32" />
             <Skeleton className="h-9 w-24" />
           </div>

--- a/packages/react/src/kits/ai/Banners/BaseBanner/variants.ts
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/variants.ts
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "cva"
+
+/**
+ * Class variants for {@link BaseBanner}, one slot per element it styles.
+ *
+ * Both variants are horizontal banners: the media sits above the text on narrow
+ * viewports and moves beside it at `sm`. They differ in exactly one place — the
+ * text wrapper's max width — so most slots below carry identical values today.
+ * They are still written out per variant rather than collapsed into `base`,
+ * because the slots are the seam a new variant extends.
+ *
+ * Every generated class is a static string so Tailwind's JIT can see it.
+ */
+export const bannerVariants = cva({
+  base: "bg-white relative flex w-full flex-col rounded-xl border border-f1-border-secondary shadow-md",
+  variants: {
+    variant: {
+      default: "gap-4 sm:flex-row sm:gap-5",
+      "full-width": "gap-4 sm:flex-row sm:gap-5",
+    },
+  },
+  defaultVariants: { variant: "default" },
+})
+
+/** Media slot — fixed 16:9, capped beside the text once the row layout kicks in. */
+export const mediaVariants = cva({
+  base: "aspect-video w-full flex-shrink-0 overflow-hidden rounded-xl",
+  variants: {
+    variant: {
+      default: "px-1 pb-0 pt-1 sm:max-w-80 sm:py-1 sm:pl-1",
+      "full-width": "px-1 pb-0 pt-1 sm:max-w-80 sm:py-1 sm:pl-1",
+    },
+  },
+  defaultVariants: { variant: "default" },
+})
+
+/** Text + actions column. */
+export const contentVariants = cva({
+  base: "flex flex-col justify-center",
+  variants: {
+    variant: {
+      default: "gap-5 px-3 pb-3 sm:py-3 sm:pl-0 sm:pr-3",
+      "full-width": "gap-5 px-3 pb-3 sm:py-3 sm:pl-0 sm:pr-3",
+    },
+  },
+  defaultVariants: { variant: "default" },
+})
+
+/**
+ * Title + subtitle wrapper — the only slot where the two variants differ.
+ * `full-width` deliberately lets the copy run the full width of its column.
+ */
+export const textWrapperVariants = cva({
+  base: "flex w-full flex-col gap-1",
+  variants: {
+    variant: {
+      default: "sm:max-w-lg",
+      "full-width": "",
+    },
+  },
+  defaultVariants: { variant: "default" },
+})
+
+export const titleVariants = cva({
+  base: "text-f1-foreground",
+  variants: {
+    variant: {
+      default: "font-bold text-xl",
+      "full-width": "font-bold text-xl",
+    },
+  },
+  defaultVariants: { variant: "default" },
+})
+
+export const subtitleVariants = cva({
+  base: "text-base text-f1-foreground-secondary",
+  variants: {
+    variant: {
+      default: "",
+      "full-width": "",
+    },
+  },
+  defaultVariants: { variant: "default" },
+})
+
+export const actionsVariants = cva({
+  base: "flex",
+  variants: {
+    variant: {
+      default: "gap-3",
+      "full-width": "gap-3",
+    },
+  },
+  defaultVariants: { variant: "default" },
+})
+
+/**
+ * Extracted with `NonNullable` rather than used raw: `VariantProps` widens to
+ * `| null`, and `UpsellingBanner` passes `variant` straight through its rest
+ * props, so the raw type would leak `null` into that component's public API.
+ */
+export type BaseBannerVariant = NonNullable<
+  VariantProps<typeof bannerVariants>["variant"]
+>


### PR DESCRIPTION
## Description

`packages/react/AGENTS.md:194-203` prescribes cva for multi-variant components:

> - `cn()` from `@/lib/utils` for all className composition
> - **CVA from `"cva"` (not `"class-variance-authority"`) for multi-variant components**

That is what the rest of the library does — **55 files / 74 call sites**. `BaseBanner` instead picks classes with an inline ternary and long hard-coded strings, which does not extend: a third variant has to add a branch to every element it touches.

This extracts one cva slot per styled element into a sibling `variants.ts`, following [`kits/ai/F0AiInsightCard/variants.ts`](https://github.com/factorialco/f0/blob/main/packages/react/src/kits/ai/F0AiInsightCard/variants.ts) for the multi-slot layout and [`ui/ButtonGroup/variants.ts`](https://github.com/factorialco/f0/blob/main/packages/react/src/ui/ButtonGroup/variants.ts) for layout-affecting variants.

Groundwork for #4975 (`variant="card"`), which will retarget onto this branch. Landing the refactor first keeps that PR's diff to "add a `card` key to seven variant maps" — obviously inert for the shipped variants — instead of mixing a new variant with a restructuring of how the existing ones pick classes.

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [ ] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [ ] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [ ] Bug fix
- [ ] Documentation only
- [x] Refactor / internal change (no API or behavior change)
- [ ] Other:

## Lifecycle phase (if applicable)

Not a lifecycle change. No public API change, no behaviour change, no new surface. Per the `f0-pr` skill this is the `refactor(F0Name): extract variants into cva` shape — "existing tests must still pass unchanged".

- Linked #f0-support thread: n/a (internal refactor)
- Phase exit criteria met: n/a

## Screenshots (if applicable)

None — **nothing renders differently.** The proof is the absence of a Chromatic diff, not a screenshot.

## Implementation details

Seven slots, one `variant` axis each:

| Slot | Controls |
|---|---|
| `bannerVariants` | root layout, gap, background, border |
| `mediaVariants` | media padding, responsive max-width |
| `contentVariants` | content gap + padding |
| `textWrapperVariants` | **the only slot where the two variants differ** — `sm:max-w-lg` on `default`, nothing on `full-width` |
| `titleVariants` | weight + size |
| `subtitleVariants` | base only today |
| `actionsVariants` | actions gap |

Applied as `xVariants({ variant })`. Every generated class is a static literal so Tailwind's JIT can see it.

**Most slots carry identical values for both variants.** They are still written out per variant rather than folded into `base`, because the slots are the seam a new variant extends — collapsing them now just means un-collapsing them in #4975.

**The skeleton is rebuilt from the same slots** so the two cannot drift, with its variant pinned to `default` — that is what its hard-coded classes resolved to. Making it follow the banner's own variant is a behaviour change and is deliberately *not* in this PR. (It is a real bug once `card` exists: a card-variant skeleton would render horizontally and then pop into a vertical card. #4975 fixes it.)

**`BaseBannerVariant` is extracted with `NonNullable`** rather than using `VariantProps` raw, which widens to `| null`. `UpsellingBanner` — BaseBanner's only consumer in the repo — passes `variant` straight through its rest props, so the raw type would leak `null` into *its* public API. Same pattern as `ui/Text/variants.ts`.

### Verification

**Every rendered class set is byte-identical to `main`**, checked per slot by rendering both variants and the skeleton and comparing sorted class lists:

| Slot | default | full-width | skeleton |
|---|---|---|---|
| root | ✅ | ✅ | ✅ |
| media | ✅ | — | ✅ |
| content | ✅ | — | ✅ |
| text wrapper | ✅ | ✅ | ✅ |
| title / subtitle | ✅ | — | — |
| actions | ✅ | — | ✅ |

(cva emits classes in a different *order* than the old string literals; the sets are the same, and order is irrelevant to CSS here since none of them conflict.)

Adds the **first unit tests for this component** — 8 of them, pinning the class strings the slots resolve to. For a design-system component the rendered classes *are* the behaviour, so that is what makes a refactor like this checkable at all rather than taken on trust.

```
pnpm vitest run src/kits/ai/Banners/BaseBanner   → 8 passed
pnpm lint       src/kits/ai/Banners/BaseBanner   → 0 warnings, 0 errors
pnpm format     src/kits/ai/Banners/BaseBanner   → clean
```

> [!NOTE]
> **Chromatic should show no diff.** If it does, this PR is wrong — that is the whole contract.
