### PR TITLE
chore(F0GraphControls): meet stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -21,7 +21,6 @@
     "EmptyState",
     "Filters/FilterPicker",
     "Graph/F0Graph",
-    "Graph/F0GraphControls",
     "Graph/F0GraphEdge",
     "Graph/F0GraphNode",
     "Heading",

--- a/packages/react/src/patterns/F0Graph/components/F0GraphControls/__stories__/F0GraphControls.mdx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphControls/__stories__/F0GraphControls.mdx
@@ -1,90 +1,249 @@
-import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
-
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
 import * as Stories from "./F0GraphControls.stories"
 
 <Meta of={Stories} />
 
 # F0GraphControls
 
-A floating toolbar that provides zoom and viewport controls for the graph
-canvas, plus an optional "Find me" shortcut for centering on the current
-user's node and a metadata-visibility popover for toggling node tag
-types.
+Provides a compact toolbar for graph viewport navigation. It is rendered automatically by `F0Graph` when `showControls` is enabled and can also support custom graph canvases.
 
----
-
-## Overview
-
-F0GraphControls is rendered automatically by `<F0Graph>` when
-`showControls={true}`. It can also be used standalone for custom graph
-implementations that need a consistent control surface.
-
-The story below renders `<F0Graph>` with every available control
-enabled — Find me, fit-to-view, and the metadata-visibility popover —
-so the toolbar is shown in its fully-loaded state.
+## Anatomy
 
 <Canvas of={Stories.Default} />
+
 <Controls of={Stories.Default} />
 
----
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>onZoomIn</code>
+        </td>
+        <td>
+          <code>{`() => void`}</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Runs when the Zoom in button is activated.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onZoomOut</code>
+        </td>
+        <td>
+          <code>{`() => void`}</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Runs when the Zoom out button is activated.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onFitView</code>
+        </td>
+        <td>
+          <code>{`() => void`}</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Runs when the Fit to view button is activated.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onFocusUser</code>
+        </td>
+        <td>
+          <code>{`() => void | Promise<void>`}</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Shows the Find me button and runs when it is activated. A returned
+          promise drives the button loading state.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>labels</code>
+        </td>
+        <td>
+          <code>F0GraphControlLabels</code>
+        </td>
+        <td>Localized F0 defaults</td>
+        <td>—</td>
+        <td>
+          Overrides the accessible names for <code>zoomIn</code>,{" "}
+          <code>zoomOut</code>, <code>fitView</code>, and <code>findMe</code>.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
 
-## Behavior
+The toolbar contains Fit to view, Zoom in, and Zoom out controls separated into viewport and zoom groups. Find me appears first when `onFocusUser` is available.
 
-- **Find me** — appears when `onFocusUser` is provided. Pass
-  `currentUserNodeId` to `<F0Graph>` to enable this button automatically.
-- **Fit to view** — always rendered.
-- **Metadata visibility** — appears when `tagTypes.length > 0` and
-  `onToggleTagType` is provided. The popover lists each tag type with a
-  toggle switch bound to `visibleTagTypes`. If `tagTypes` is empty (or
-  omitted), or `onToggleTagType` is not provided, the metadata popover
-  button is hidden.
+## Guidelines
 
----
+### Design best practices
 
-## Props
+**When to use**
 
-| Prop              | Type                                          | Default | Description                                                                                                          |
-| ----------------- | --------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------- |
-| `onZoomIn`        | `() => void`                                  | —       | Callback for zoom-in button                                                                                          |
-| `onZoomOut`       | `() => void`                                  | —       | Callback for zoom-out button                                                                                         |
-| `onFitView`       | `() => void`                                  | —       | Callback for fit-to-view button                                                                                      |
-| `onFocusUser`     | `() => void`                                  | —       | Callback for the Find me button. Button is hidden if omitted.                                                        |
-| `tagTypes`        | `ReadonlyArray<F0GraphNodeTagType>`           | —       | Tag types to expose in the metadata-visibility popover. When omitted (or empty), the popover button is not rendered. |
-| `visibleTagTypes` | `ReadonlySet<F0GraphNodeTagType>`             | —       | Currently visible tag types (set form). Required when `tagTypes` is set.                                             |
-| `onToggleTagType` | `(type: F0GraphNodeTagType) => void`          | —       | Callback when the user toggles a tag type in the popover.                                                            |
-| `tagTypeLabels`   | `Partial<Record<F0GraphNodeTagType, string>>` | —       | Friendly labels per tag type for the popover.                                                                        |
-| `labels`          | `F0GraphControlLabels`                        | —       | Override default English labels for controls (`zoomIn`, `zoomOut`, `fitView`, `findMe`, `metadataSettings`).         |
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0GraphControls when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Standard F0 graph</td>
+        <td>
+          Viewport controls should be added through{" "}
+          <code>F0Graph showControls</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>Custom graph canvas</td>
+        <td>
+          The canvas needs the same compact viewport-navigation surface as{" "}
+          <code>F0Graph</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>Person-centered graph</td>
+        <td>
+          A current-person node can be revealed and centered through{" "}
+          <code>onFocusUser</code>.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
 
-#### F0GraphControlLabels
+**When not to use**
 
-| Key                | Type     | Description                                                    |
-| ------------------ | -------- | -------------------------------------------------------------- |
-| `zoomIn`           | `string` | Label for zoom-in button                                       |
-| `zoomOut`          | `string` | Label for zoom-out button                                      |
-| `fitView`          | `string` | Label for fit-to-view button                                   |
-| `findMe`           | `string` | Label for the Find me button                                   |
-| `metadataSettings` | `string` | Aria label for the metadata-visibility popover trigger button. |
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          An <code>F0Graph</code> already renders its controls
+        </td>
+        <td>
+          Use the existing <code>showControls</code> toolbar instead of mounting
+          a duplicate.
+        </td>
+      </tr>
+      <tr>
+        <td>Actions modify graph data rather than the viewport</td>
+        <td>
+          Use <code>canvasActions</code> or <code>canvasFooterActions</code> on{" "}
+          <code>F0Graph</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>Navigation outside a graph canvas</td>
+        <td>
+          Use <code>F0Link</code> for navigation or <code>F0Button</code> for an
+          action.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
 
----
+**Do's and don'ts**
 
-## Usage
+<DoDonts
+  do={{
+    description:
+      "Let F0Graph own one consistent viewport toolbar through showControls.",
+  }}
+  dont={{
+    description:
+      "Don't add a second set of zoom controls beside an existing graph toolbar.",
+  }}
+/>
 
-Most consumers never render `F0GraphControls` directly — pass
-`showControls` (and optionally `currentUserNodeId`) to `<F0Graph>`
-instead. Use standalone only when building a custom graph canvas
-that needs the same control toolbar.
+### Behavior
 
-```tsx
-import { F0GraphControls } from "@factorialco/f0-react"
+- WHEN `onFocusUser` is provided → THEN Find me appears before the other controls.
+- WHEN `onFocusUser` is omitted → THEN the toolbar contains only Fit to view, Zoom in, and Zoom out.
+- WHEN `onFocusUser` returns a promise → THEN Find me shows its loading state until the promise settles.
+- WHEN a value is provided in `labels` → THEN it replaces the matching localized accessible name.
 
-function Example() {
-  return (
-    <F0GraphControls
-      onZoomIn={handleZoomIn}
-      onZoomOut={handleZoomOut}
-      onFitView={handleFitView}
-      onFocusUser={handleFocusUser}
-    />
-  )
-}
-```
+**Asynchronous person focus**
+
+Find me blocks repeated activation while an asynchronous focus action is pending.
+
+<Canvas of={Stories.AsyncFindMe} />
+
+### Usage examples
+
+**Viewport controls without person focus**
+
+Use three controls when the graph has no current-person concept.
+
+<Canvas of={Stories.WithoutFindMe} />
+
+**Product-specific accessible names**
+
+Override labels when the surrounding graph terminology needs more specific button names.
+
+<Canvas of={Stories.CustomLabels} />
+
+## Accessibility
+
+The container uses `role="toolbar"` with the localized accessible name “Graph navigation.” Each icon-only button exposes its label as an accessible name, and the divider is not focusable.
+
+### Keyboard interaction
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Key</th>
+        <th className="text-left">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Tab</kbd> / <kbd>Shift</kbd> + <kbd>Tab</kbd>
+        </td>
+        <td>Move focus through the toolbar buttons in visual order.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Enter</kbd> / <kbd>Space</kbd>
+        </td>
+        <td>Activate the focused graph control.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Screen reader behavior
+
+- The toolbar is announced as “Graph navigation.”
+- Controls are announced by their localized or overridden labels rather than by icon names.
+- Custom labels must describe the action and remain distinct from one another.

--- a/packages/react/src/patterns/F0Graph/components/F0GraphControls/__stories__/F0GraphControls.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphControls/__stories__/F0GraphControls.stories.tsx
@@ -1,43 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, fn, userEvent, waitFor, within } from "storybook/test"
 
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
-import type { GraphNode } from "../../../types"
-
-import { F0Graph, type F0GraphNodeRenderContext } from "../../../F0Graph"
-import { F0GraphNode } from "../../F0GraphNode"
 import { F0GraphControls } from "../F0GraphControls"
-
-interface Person {
-  name: string
-  title: string
-}
-
-const NODES: GraphNode<Person>[] = [
-  {
-    id: "a",
-    parentId: null,
-    data: { name: "Alice Moreno", title: "Manager" },
-    childrenCount: 1,
-  },
-  {
-    id: "b",
-    parentId: "a",
-    data: { name: "Bob Smith", title: "Engineer" },
-  },
-]
-
-function renderPerson(node: GraphNode<Person>, ctx: F0GraphNodeRenderContext) {
-  const [firstName = "", lastName = ""] = node.data.name.split(" ")
-  return (
-    <F0GraphNode
-      {...ctx}
-      avatar={{ type: "person", firstName, lastName }}
-      title={node.data.name}
-      subtitle={node.data.title}
-    />
-  )
-}
 
 const meta = {
   component: F0GraphControls,
@@ -45,6 +11,9 @@ const meta = {
   tags: ["stable", "!autodocs"],
   parameters: {
     layout: "centered",
+    a11y: {
+      test: "error",
+    },
   },
 } satisfies Meta<typeof F0GraphControls>
 
@@ -52,44 +21,137 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
+  args: {
+    onZoomIn: fn(),
+    onZoomOut: fn(),
+    onFitView: fn(),
+    onFocusUser: fn(),
+  },
   parameters: {
     docs: {
       description: {
         story:
-          "Shows the toolbar with every available control enabled — Find me, fit-to-view, and the metadata-visibility popover — rendered inside a real `<F0Graph>`.",
+          "Shows the complete graph navigation toolbar with Find me, Fit to view, Zoom in, and Zoom out controls.",
       },
     },
   },
-  render: () => (
-    <div style={{ width: 480, height: 320 }} className="bg-f1-background">
-      <F0Graph
-        nodes={NODES}
-        edges={[]}
-        renderNode={renderPerson}
-        defaultExpandDepth={1}
-        showControls
-        currentUserNodeId="a"
-        nodeTagTypes={["person", "team", "status"]}
-        defaultVisibleTagTypes={["person", "team", "status"]}
-      />
-    </div>
-  ),
+  play: async ({ canvasElement, args, step }) => {
+    const canvas = within(canvasElement)
+
+    await step("Expose the toolbar and its accessible name", async () => {
+      await expect(
+        canvas.getByRole("toolbar", { name: "Graph navigation" })
+      ).toBeInTheDocument()
+    })
+
+    await step("Run the first action from the keyboard", async () => {
+      const findMe = canvas.getByRole("button", { name: "Find me" })
+
+      await userEvent.tab()
+      await expect(findMe).toHaveFocus()
+      await userEvent.keyboard("{Enter}")
+      await expect(args.onFocusUser).toHaveBeenCalledTimes(1)
+    })
+
+    await step("Run the remaining graph navigation actions", async () => {
+      await userEvent.click(canvas.getByRole("button", { name: "Fit to view" }))
+      await expect(args.onFitView).toHaveBeenCalledTimes(1)
+
+      await userEvent.click(canvas.getByRole("button", { name: "Zoom in" }))
+      await expect(args.onZoomIn).toHaveBeenCalledTimes(1)
+
+      await userEvent.click(canvas.getByRole("button", { name: "Zoom out" }))
+      await expect(args.onZoomOut).toHaveBeenCalledTimes(1)
+    })
+  },
+}
+
+export const WithoutFindMe: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    onZoomIn: fn(),
+    onZoomOut: fn(),
+    onFitView: fn(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(
+      canvas.queryByRole("button", { name: "Find me" })
+    ).not.toBeInTheDocument()
+    await expect(canvas.getAllByRole("button")).toHaveLength(3)
+  },
+}
+
+export const CustomLabels: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    onZoomIn: fn(),
+    onZoomOut: fn(),
+    onFitView: fn(),
+    onFocusUser: fn(),
+    labels: {
+      findMe: "Center on my node",
+      fitView: "Show every node",
+      zoomIn: "Increase graph zoom",
+      zoomOut: "Decrease graph zoom",
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(
+      canvas.getByRole("button", { name: "Center on my node" })
+    ).toBeInTheDocument()
+    await expect(
+      canvas.getByRole("button", { name: "Show every node" })
+    ).toBeInTheDocument()
+    await expect(
+      canvas.getByRole("button", { name: "Increase graph zoom" })
+    ).toBeInTheDocument()
+    await expect(
+      canvas.getByRole("button", { name: "Decrease graph zoom" })
+    ).toBeInTheDocument()
+  },
+}
+
+export const AsyncFindMe: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    onZoomIn: fn(),
+    onZoomOut: fn(),
+    onFitView: fn(),
+    onFocusUser: fn(
+      () => new Promise<void>((resolve) => window.setTimeout(resolve, 200))
+    ),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement)
+    const findMe = canvas.getByRole("button", { name: "Find me" })
+
+    await userEvent.click(findMe)
+    await expect(args.onFocusUser).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(findMe).toBeDisabled())
+    await waitFor(() => expect(findMe).toBeEnabled())
+  },
 }
 
 export const Snapshot: Story = {
   tags: ["no-sidebar"],
+  args: {
+    onZoomIn: fn(),
+    onZoomOut: fn(),
+    onFitView: fn(),
+    onFocusUser: fn(),
+  },
   parameters: withSnapshot({}),
-  render: () => (
-    <div style={{ width: 480, height: 320 }} className="bg-f1-background">
-      <F0Graph
-        nodes={NODES}
-        edges={[]}
-        renderNode={renderPerson}
-        defaultExpandDepth={1}
-        showControls
-        currentUserNodeId="a"
-        nodeTagTypes={["person", "team", "status"]}
-        defaultVisibleTagTypes={["person", "team", "status"]}
+  render: (args) => (
+    <div className="flex items-start gap-8 bg-f1-background p-4">
+      <F0GraphControls {...args} />
+      <F0GraphControls
+        onZoomIn={args.onZoomIn}
+        onZoomOut={args.onZoomOut}
+        onFitView={args.onFitView}
       />
     </div>
   ),

--- a/packages/react/src/patterns/F0Graph/components/F0GraphControls/__tests__/F0GraphControls.test.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphControls/__tests__/F0GraphControls.test.tsx
@@ -1,7 +1,13 @@
 import { userEvent } from "@testing-library/user-event"
+import { createRef } from "react"
 import { describe, expect, it, vi } from "vitest"
 
-import { screen, zeroRender as render } from "@/testing/test-utils"
+import {
+  act,
+  screen,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
 
 import { F0GraphControls } from "../F0GraphControls"
 
@@ -52,10 +58,12 @@ describe("F0GraphControls", () => {
     expect(screen.queryByLabelText("Find me")).not.toBeInTheDocument()
   })
 
-  it("has ARIA toolbar role", () => {
+  it("exposes its toolbar role with an accessible name", () => {
     render(<F0GraphControls />)
 
-    expect(screen.getByRole("toolbar")).toBeInTheDocument()
+    expect(
+      screen.getByRole("toolbar", { name: "Graph navigation" })
+    ).toBeInTheDocument()
   })
 
   it("all buttons have aria-labels", () => {
@@ -65,5 +73,69 @@ describe("F0GraphControls", () => {
     buttons.forEach((button) => {
       expect(button).toHaveAttribute("aria-label")
     })
+  })
+
+  it("uses custom labels as the button accessible names", () => {
+    render(
+      <F0GraphControls
+        onFocusUser={vi.fn()}
+        labels={{
+          findMe: "Center on my node",
+          fitView: "Show every node",
+          zoomIn: "Increase graph zoom",
+          zoomOut: "Decrease graph zoom",
+        }}
+      />
+    )
+
+    expect(screen.getByLabelText("Center on my node")).toBeInTheDocument()
+    expect(screen.getByLabelText("Show every node")).toBeInTheDocument()
+    expect(screen.getByLabelText("Increase graph zoom")).toBeInTheDocument()
+    expect(screen.getByLabelText("Decrease graph zoom")).toBeInTheDocument()
+  })
+
+  it("keeps localized defaults for labels that are not overridden", () => {
+    render(<F0GraphControls labels={{ zoomIn: "Increase scale" }} />)
+
+    expect(screen.getByLabelText("Fit to view")).toBeInTheDocument()
+    expect(screen.getByLabelText("Increase scale")).toBeInTheDocument()
+    expect(screen.getByLabelText("Zoom out")).toBeInTheDocument()
+  })
+
+  it("renders Find me first when it is available", () => {
+    render(<F0GraphControls onFocusUser={vi.fn()} />)
+
+    expect(
+      screen
+        .getAllByRole("button")
+        .map((button) => button.getAttribute("aria-label"))
+    ).toEqual(["Find me", "Fit to view", "Zoom in", "Zoom out"])
+  })
+
+  it("forwards its ref to the toolbar", () => {
+    const ref = createRef<HTMLDivElement>()
+
+    render(<F0GraphControls ref={ref} />)
+
+    expect(ref.current).toBe(screen.getByRole("toolbar"))
+  })
+
+  it("shows and clears the Find me loading state for async actions", async () => {
+    let resolveAction: () => void = () => {}
+    const pendingAction = new Promise<void>((resolve) => {
+      resolveAction = resolve
+    })
+    const onFocusUser = vi.fn(() => pendingAction)
+
+    render(<F0GraphControls onFocusUser={onFocusUser} />)
+
+    const findMe = screen.getByRole("button", { name: "Find me" })
+    await userEvent.click(findMe)
+
+    expect(onFocusUser).toHaveBeenCalledTimes(1)
+    await waitFor(() => expect(findMe).toBeDisabled())
+
+    act(() => resolveAction())
+    await waitFor(() => expect(findMe).toBeEnabled())
   })
 })


### PR DESCRIPTION
## Description

Makes F0GraphControls genuinely satisfy the Stable Definition of Done. The stories now isolate the toolbar from F0Graph's separate ARIA tree debt, the documentation matches the component's real five-prop API, accessibility is enforced, and the Stable DoD debt entry is removed.

## Implementation details

- docs: replace the inaccurate metadata-popover documentation with anatomy, usage, behavior, and accessibility guidance
- test: cover keyboard activation, every action, optional Find me behavior, custom and fallback labels, async loading, accessible naming, control order, and ref forwarding
- chore: enforce Storybook axe failures and remove F0GraphControls from the Stable DoD debt ratchet

## Validation

- `pnpm --filter @factorialco/f0-react check:stable-dod --verbose` reports F0GraphControls as truly stable
- full unit suite passed; focused F0GraphControls suite passed 13/13
- stable-tagged Storybook suite passed 43/43 suites and 434/434 tests, including enforced axe for F0GraphControls
- TypeScript, formatting, direct changed-file lint, and `git diff --check` passed
- Chrome verified the restarted Storybook badge, rendered documentation, accessible toolbar name, and all four controls
