### PR TITLE
fix(Page): draw the page frame above content so flush children can't cover it

### DIFF
--- a/packages/react/src/patterns/Navigation/Page/__tests__/Page.test.tsx
+++ b/packages/react/src/patterns/Navigation/Page/__tests__/Page.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { Page } from "../index"
+
+/**
+ * The page frame used to be a `ring-inset` on the page element itself. An inset
+ * ring is a box-shadow, painted in the element's own background layer and
+ * therefore *underneath* every descendant, so any full-bleed child reaching the
+ * edge with an opaque background erased it — a table's header cells and its
+ * sticky rows do exactly that.
+ *
+ * jsdom does not paint, so no test can observe the erased border directly.
+ * These pin the structural property that makes the paint order right instead:
+ * the frame is an overlay stacked above the content, and the page itself no
+ * longer carries a ring for content to cover.
+ */
+describe("Page frame", () => {
+  const renderPage = () => {
+    render(
+      <Page>
+        <div data-testid="content">Content</div>
+      </Page>
+    )
+    const contentWrapper = screen.getByTestId("content").parentElement!
+    const page = contentWrapper.parentElement!
+    const frame = page.querySelector<HTMLElement>(":scope > [aria-hidden]")
+    return { page, contentWrapper, frame }
+  }
+
+  it("does not paint the frame on the page element, where content covers it", () => {
+    const { page } = renderPage()
+
+    expect(page.className).not.toMatch(/\bring-1\b/)
+    expect(page.className).not.toMatch(/\bring-inset\b/)
+  })
+
+  it("paints the frame in a dedicated overlay", () => {
+    const { frame } = renderPage()
+
+    expect(frame).not.toBeNull()
+    expect(frame!.className).toMatch(/\bring-1\b/)
+    expect(frame!.className).toMatch(/\bring-inset\b/)
+    expect(frame!.className).toMatch(/\babsolute\b/)
+    expect(frame!.className).toMatch(/\binset-0\b/)
+  })
+
+  it("stacks the overlay above the content so a flush child cannot cover it", () => {
+    const { page, contentWrapper, frame } = renderPage()
+
+    // Both halves matter: a later sibling loses to an earlier one that raises
+    // itself, and a z-index resolves against nothing without a positioned page.
+    expect(page.className).toMatch(/\brelative\b/)
+    expect(frame!.className).toMatch(/\bz-10\b/)
+
+    const order = [...page.children]
+    expect(order.indexOf(frame!)).toBeGreaterThan(order.indexOf(contentWrapper))
+  })
+
+  it("keeps the overlay inert so it cannot swallow clicks on the content", () => {
+    const { frame } = renderPage()
+
+    expect(frame!.className).toMatch(/\bpointer-events-none\b/)
+  })
+
+  it("follows the page's rounded corners", () => {
+    const { frame } = renderPage()
+
+    expect(frame!.className).toContain("rounded-[inherit]")
+  })
+})

--- a/packages/react/src/patterns/Navigation/Page/index.tsx
+++ b/packages/react/src/patterns/Navigation/Page/index.tsx
@@ -12,7 +12,7 @@ function _Page({ children, header, embedded = false }: PageProps) {
   return (
     <div
       className={cn(
-        "flex min-h-full w-full flex-col overflow-hidden bg-f1-special-page ring-1 ring-inset ring-f1-border-secondary",
+        "relative flex min-h-full w-full flex-col overflow-hidden bg-f1-special-page",
         !embedded && "xs:rounded-xl"
       )}
     >
@@ -20,6 +20,14 @@ function _Page({ children, header, embedded = false }: PageProps) {
       <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">
         {children}
       </div>
+      {/* The frame is an overlay rather than a `ring-inset` on the page itself:
+          an inset ring is painted underneath descendants, so any full-bleed
+          child that reaches the edge with an opaque background covers it — a
+          table's header cells and its sticky rows do exactly that. */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 z-10 rounded-[inherit] ring-1 ring-inset ring-f1-border-secondary"
+      />
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/inside-page.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/inside-page.stories.tsx
@@ -1,0 +1,78 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+
+import { Page } from "@/patterns/Navigation/Page"
+
+import { ExampleComponent, getMockVisualizations } from "./mockData"
+
+/**
+ * A collection mounted flush inside `Page`, the way a full-bleed product page
+ * does it (no layout gutter between the page frame and the table). The page
+ * frame has to stay visible along the table's edge: a table paints opaque
+ * layers right up to it — header cells always, sticky parent rows once a nested
+ * row is expanded, and frozen columns once the table is scrolled sideways.
+ */
+const meta = {
+  title: "Data Collection/Inside Page",
+  parameters: {
+    layout: "fullscreen",
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// `frozenColumns` has to go in the visualization options: the `ExampleComponent`
+// prop of the same name is only read when the component builds its own
+// visualizations, so an explicit `visualizations` array would freeze nothing.
+const nestedFrozenTable = () =>
+  getMockVisualizations({
+    table: {
+      frozenColumns: 2,
+      noSorting: true,
+      allowColumnHiding: true,
+      allowColumnReordering: true,
+      nestedRecords: true,
+      applyLongText: false,
+    },
+  }).table
+
+const Collection = () => (
+  <ExampleComponent
+    frozenColumns={2}
+    tableAllowColumnReordering
+    tableAllowColumnHiding
+    noSorting
+    storage={false}
+    visualizations={[nestedFrozenTable()]}
+    id="employees/inside-page"
+    nestedRecords
+    fullHeight
+  />
+)
+
+/**
+ * Expand a row and scroll sideways: the page frame must remain visible on all
+ * four edges.
+ */
+export const NestedFrozenTableInsidePage: Story = {
+  render: () => (
+    <div className="h-screen w-screen p-4">
+      <Page>
+        <Collection />
+      </Page>
+    </div>
+  ),
+}
+
+/** The same collection with a header, so the frame is checked below it too. */
+export const NestedFrozenTableInsidePageWithHeader: Story = {
+  render: () => (
+    <div className="h-screen w-screen p-4">
+      <Page
+        header={<div className="px-6 py-4 text-lg font-semibold">Roles</div>}
+      >
+        <Collection />
+      </Page>
+    </div>
+  ),
+}


### PR DESCRIPTION
## Description

`Page` drew its 1px frame as a `ring-inset` on the page element itself. An inset ring is a `box-shadow`, and the browser paints it in the element's own background layer — **underneath every descendant**. So any full-bleed child that reaches the page edge with an opaque background silently erases the frame.

A `OneDataCollection` table mounted flush inside `Page` does exactly that, which is how this surfaced: on a full-bleed product page the frame vanished along the table, but only in some states, which made it look like a table bug.

This PR moves the frame to a `pointer-events-none` overlay stacked above the content wrapper. No API change; consumers need no changes.

## Type of change

- [x] Bug fix


## Screenshots (if applicable)

### Before
<img width="794" height="643" alt="Screenshot 2026-08-07 at 12 44 55" src="https://github.com/user-attachments/assets/8748d9c4-e6ea-4f03-836f-293e879aebf6" />

### After
<img width="376" height="617" alt="Screenshot 2026-08-07 at 13 11 03" src="https://github.com/user-attachments/assets/28567b3b-9f3d-4945-9b7b-5c99cdfd92b5" />

## Implementation details

### Root cause

Three layers a table paints are opaque and reach the page edge, so each one erases the part of the frame it covers:

| Layer | Style | Erases the frame |
|---|---|---|
| `<th>` header cells | `bg-f1-background`, unconditional | always |
| sticky parent `<tr>` | `sticky z-20 bg-f1-background` | once a nested row is expanded |
| frozen `<td>` | opaque once `isScrolled` | once the table is scrolled sideways |
| child `<tr>` | transparent | no |

That table is also why the symptom looked erratic: collapsed + unscrolled hides two of the three, so the frame looks almost fine and then degrades as you interact.

Pages that go through a layout with a gutter never showed it, because their content never overlaps the 1px. Measured on two real pages at the same viewport:

| | page card left | table left | gutter | frame survives |
|---|---|---|---|---|
| gutter page (`StandardLayout`) | 240 | 265 | 25px | yes |
| full-bleed page | 240 | **240** | **0** | no |

### Why an overlay

There are only three ways out, and the other two are worse:

- **`border` on the card** — changes layout (the content box shrinks by 1px per side). Avoiding that is precisely why the design system uses `ring` here.
- **Force a gutter on the content** — defeats the purpose of a full-bleed page.
- **Paint the frame above the content** — what this PR does.

The overlay is also the idiom already used in this codebase for exactly this problem: `TableHead` draws its top border as `<div className="absolute inset-x-0 top-0 z-[1] h-px w-full bg-f1-border-secondary" />`, and the sticky cells rebuild their separators with `before:` / `after:` layers, both because a 1px line has to survive opaque content on top of it.

The content wrapper already carries `isolate`, so it forms a stacking context with `z-index: auto` and a sibling at `z-10` reliably paints above it no matter what the children do.

### Behavior note for the reviewer

The frame now wins over any page content with a stacking position below `z-10`. Nothing should legitimately paint over the page frame, and the overlay is `pointer-events-none` so it cannot intercept interaction — but it is a real change and worth a look if you know of a consumer that deliberately paints over the page edge.

### Verification

New story `Data Collection/Inside Page` mounts a nested, frozen-column collection flush inside `Page` — the configuration that reproduces it. There was no story combining `Page` with a collection before, which is why this never showed up in Storybook or Chromatic.

Validated end to end on a real full-bleed product page via the PR alpha.

### Out of scope

Two unrelated fragilities found while tracking this down, not touched here:

- `useSticky` derives sticky offsets from *declared* column widths, so a frozen column without an explicit `width` silently mis-offsets any frozen column after it.
- `isScrolled` / `isScrolledRight` are computed on mount and on `scroll` only — there is no `ResizeObserver`, so a table that becomes wider after mount keeps stale flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
