### PR TITLE
feat(OneDataCollection): add defaultExpanded to nested tables

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/default-expanded.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/default-expanded.stories.tsx
@@ -128,7 +128,9 @@ export const All: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     // Depth 3 proves the cascade: each level opened because its parent did.
-    await canvas.findByText("Senior")
+    // Both roles carry a "Senior", as levels repeat across roles, so this also
+    // pins that the cascade reached BOTH branches and not just the first.
+    expect(await canvas.findAllByText("Senior")).toHaveLength(2)
   },
 }
 
@@ -151,6 +153,9 @@ export const StopAtRoles: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await canvas.findByText("Backend Engineer")
-    expect(canvas.queryByText("Junior")).toBeNull()
+    // `queryAllBy`, not `queryBy`: "Junior" exists under both roles, so if the
+    // levels ever did render, `queryByText` would throw on the duplicate rather
+    // than report the real failure.
+    expect(canvas.queryAllByText("Junior")).toHaveLength(0)
   },
 }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/default-expanded.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/default-expanded.stories.tsx
@@ -1,0 +1,156 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, within } from "storybook/test"
+
+import { useDataCollectionSource } from "../../../hooks/useDataCollectionSource"
+import { OneDataCollection } from "../../../index"
+
+/**
+ * `defaultExpanded` decides which rows of a nested table start out open before
+ * the user touches anything. It is evaluated per row as rows mount, so an
+ * opened row's children evaluate it in turn and the cascade needs no
+ * consumer-side traversal of the tree.
+ */
+const meta = {
+  title: "Data Collection/Visualizations/Table/Default expanded",
+  parameters: { layout: "padded" },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+type Node = {
+  id: string
+  name: string
+  kind: "category" | "role" | "level"
+  children?: Node[]
+}
+
+const TREE: Node[] = [
+  {
+    id: "engineering",
+    name: "Engineering",
+    kind: "category",
+    children: [
+      {
+        id: "backend",
+        name: "Backend",
+        kind: "category",
+        children: [
+          {
+            id: "backend-engineer",
+            name: "Backend Engineer",
+            kind: "role",
+            children: [
+              { id: "be-junior", name: "Junior", kind: "level" },
+              { id: "be-senior", name: "Senior", kind: "level" },
+            ],
+          },
+        ],
+      },
+      {
+        id: "frontend",
+        name: "Frontend",
+        kind: "category",
+        children: [
+          {
+            id: "frontend-engineer",
+            name: "Frontend Engineer",
+            kind: "role",
+            children: [
+              { id: "fe-junior", name: "Junior", kind: "level" },
+              { id: "fe-senior", name: "Senior", kind: "level" },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+const byId = new Map<string, Node>()
+const indexTree = (nodes: Node[]) =>
+  nodes.forEach((node) => {
+    byId.set(node.id, node)
+    if (node.children) indexTree(node.children)
+  })
+indexTree(TREE)
+
+const columns = [
+  { id: "name", label: "Name", render: (node: Node) => node.name },
+  { id: "kind", label: "Kind", width: 140, render: (node: Node) => node.kind },
+] as const
+
+const useTreeSource = () =>
+  useDataCollectionSource({
+    dataAdapter: { fetchData: async () => ({ records: TREE }) },
+    itemsWithChildren: (node: Node) => !!byId.get(node.id)?.children?.length,
+    fetchChildren: async ({ item }: { item: Node }) => ({
+      records: byId.get(item.id)?.children ?? [],
+      type: "basic" as const,
+    }),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any)
+
+const Tree = ({
+  defaultExpanded,
+}: {
+  defaultExpanded: boolean | number | ((node: Node) => boolean)
+}) => {
+  const source = useTreeSource()
+  return (
+    <OneDataCollection
+      /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+      source={source as any}
+      visualizations={[
+        {
+          type: "table",
+          options: { columns, defaultExpanded },
+          /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        } as any,
+      ]}
+    />
+  )
+}
+
+/** Nothing starts open — the behaviour before `defaultExpanded` existed. */
+export const Collapsed: Story = {
+  render: () => <Tree defaultExpanded={false} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText("Engineering")
+    expect(canvas.queryByText("Backend")).toBeNull()
+  },
+}
+
+/** `true` — the whole tree, levels included. */
+export const All: Story = {
+  render: () => <Tree defaultExpanded={true} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // Depth 3 proves the cascade: each level opened because its parent did.
+    await canvas.findByText("Senior")
+  },
+}
+
+/** A depth — `1` opens the top-level rows and reveals depth 1. */
+export const ToDepth: Story = {
+  render: () => <Tree defaultExpanded={1} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText("Backend")
+    expect(canvas.queryByText("Backend Engineer")).toBeNull()
+  },
+}
+
+/**
+ * A predicate — everything opens except roles, so roles are visible and their
+ * levels stay closed. This is the Job Catalog case.
+ */
+export const StopAtRoles: Story = {
+  render: () => <Tree defaultExpanded={(node) => node.kind !== "role"} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await canvas.findByText("Backend Engineer")
+    expect(canvas.queryByText("Junior")).toBeNull()
+  },
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -104,6 +104,7 @@ export const TableCollection = <
   columns: originalColumns,
   source,
   frozenColumns = 0,
+  defaultExpanded,
   onSelectItems,
   onLoadData,
   onLoadError,
@@ -427,11 +428,14 @@ export const TableCollection = <
       ? i18n.status.selected.singular
       : i18n.status.selected.plural
 
-  const TableWrapper = tableWithChildren ? NestedDataProvider : Fragment
-
+  // Mounted unconditionally rather than swapped for a `Fragment` on flat
+  // tables: it only holds nested state that flat tables never read, and
+  // choosing the wrapper by branch made it impossible to pass it props without
+  // rebuilding the component type — which would remount the whole table
+  // whenever a consumer passed an inline `defaultExpanded` predicate.
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
-      <TableWrapper>
+      <NestedDataProvider defaultExpanded={defaultExpanded}>
         <div
           ref={tableContainerRef}
           className={cn(
@@ -1127,7 +1131,7 @@ export const TableCollection = <
           setPage={setPage}
           className="pb-4"
         />
-      </TableWrapper>
+      </NestedDataProvider>
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/defaultExpanded.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/defaultExpanded.test.tsx
@@ -1,0 +1,396 @@
+import { waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  FiltersDefinition,
+  GroupingDefinition,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+
+import { screen, zeroRender as render } from "@/testing/test-utils"
+import { TextCell } from "@/ui/value-display/types/text"
+
+import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { SummariesDefinition } from "../../../../summary"
+import { TableCollection } from "../index"
+
+vi.mock("../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+class MockIntersectionObserver implements IntersectionObserver {
+  root: Document | Element | null = null
+  rootMargin = ""
+  thresholds: readonly number[] = []
+  disconnect = vi.fn()
+  observe = vi.fn()
+  takeRecords = vi.fn()
+  unobserve = vi.fn()
+}
+window.IntersectionObserver = MockIntersectionObserver
+
+type Node = {
+  id: string
+  name: string
+  kind: "category" | "role" | "level"
+  children?: Node[]
+}
+
+/**
+ * Engineering (0) > Backend (1) > Backend Engineer (2) > Junior/Senior (3).
+ *
+ * Four levels on purpose: depth 3 can only be reached by a row that the policy
+ * opened, whose children the policy opened in turn, so it is what proves the
+ * cascade rather than a single hard-coded level.
+ */
+const TREE: Node[] = [
+  {
+    id: "engineering",
+    name: "Engineering",
+    kind: "category",
+    children: [
+      {
+        id: "backend",
+        name: "Backend",
+        kind: "category",
+        children: [
+          {
+            id: "backend-engineer",
+            name: "Backend Engineer",
+            kind: "role",
+            children: [
+              { id: "be-junior", name: "Junior", kind: "level" },
+              { id: "be-senior", name: "Senior", kind: "level" },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+]
+
+const indexTree = (nodes: Node[], into = new Map<string, Node>()) => {
+  nodes.forEach((node) => {
+    into.set(node.id, node)
+    if (node.children) indexTree(node.children, into)
+  })
+  return into
+}
+
+const columns = [{ label: "name", render: (item: Node) => item.name }]
+
+type TestSource = DataCollectionSource<
+  Node,
+  FiltersDefinition,
+  SortingsDefinition,
+  SummariesDefinition,
+  ItemActionsDefinition<Node>,
+  NavigationFiltersDefinition,
+  GroupingDefinition<Node>
+>
+
+const createSource = (
+  tree: Node[] = TREE,
+  fetchChildren?: (args: { item: Node }) => { records: Node[] }
+): TestSource => {
+  const byId = indexTree(tree)
+
+  return {
+    currentFilters: {},
+    setCurrentFilters: vi.fn(),
+    currentSortings: null,
+    setCurrentSortings: vi.fn(),
+    currentNavigationFilters: {},
+    setCurrentNavigationFilters: vi.fn(),
+    navigationFilters: undefined,
+    currentSearch: undefined,
+    debouncedCurrentSearch: undefined,
+    setCurrentSearch: vi.fn(),
+    isLoading: false,
+    setIsLoading: vi.fn(),
+    currentGrouping: undefined,
+    setCurrentGrouping: vi.fn(),
+    itemsWithChildren: (item: Node) => !!byId.get(item.id)?.children?.length,
+    fetchChildren:
+      fetchChildren ??
+      (({ item }: { item: Node }) => ({
+        records: byId.get(item.id)?.children ?? [],
+      })),
+    dataAdapter: {
+      paginationType: "pages",
+      fetchData: async () => ({
+        records: tree,
+        type: "pages",
+        total: tree.length,
+        perPage: 20,
+        currentPage: 1,
+        pagesCount: 1,
+      }),
+    },
+  } as unknown as TestSource
+}
+
+const renderTable = (
+  props: {
+    source?: TestSource
+    defaultExpanded?: boolean | number | ((node: Node) => boolean)
+  } = {}
+) =>
+  render(
+    <TableCollection<
+      Node,
+      FiltersDefinition,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Node>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<Node>
+    >
+      columns={columns}
+      source={props.source ?? createSource()}
+      defaultExpanded={props.defaultExpanded}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+
+/**
+ * Clicks the chevron of the row showing `name`. The icon carries
+ * `pointer-events-none` and the handler sits on its wrapper, but the click
+ * bubbles, which is what the other nested-table tests rely on too.
+ */
+const toggleRow = async (
+  user: ReturnType<typeof userEvent.setup>,
+  name: string
+) => {
+  const row = screen.getByText(name).closest("tr")
+  expect(row).not.toBeNull()
+
+  const chevron = row?.querySelector(
+    ".lucide-chevron-right, .lucide-chevron-down"
+  )
+  expect(chevron).not.toBeNull()
+
+  await user.click(chevron as Element)
+}
+
+describe("TableCollection defaultExpanded", () => {
+  describe("policy", () => {
+    it("keeps every row collapsed when no policy is passed", async () => {
+      renderTable()
+
+      await waitFor(() =>
+        expect(screen.getByText("Engineering")).toBeInTheDocument()
+      )
+      expect(screen.queryByText("Backend")).toBeNull()
+    })
+
+    it("opens the whole tree with `true`, cascading down to depth 3", async () => {
+      renderTable({ defaultExpanded: true })
+
+      // A row opened by the policy never goes through the expand handler, so
+      // reaching "Junior" also proves each opened row fetched its own children.
+      await waitFor(() =>
+        expect(screen.getByText("Junior")).toBeInTheDocument()
+      )
+      expect(screen.getByText("Senior")).toBeInTheDocument()
+    })
+
+    it("opens rows shallower than the given depth with a number", async () => {
+      renderTable({ defaultExpanded: 1 })
+
+      // depth 0 < 1 opens, revealing depth 1; depth 1 is not < 1 so it stays shut.
+      await waitFor(() =>
+        expect(screen.getByText("Backend")).toBeInTheDocument()
+      )
+      expect(screen.queryByText("Backend Engineer")).toBeNull()
+    })
+
+    it("lets a predicate stop the cascade at a kind of row", async () => {
+      renderTable({ defaultExpanded: (node) => node.kind !== "role" })
+
+      await waitFor(() =>
+        expect(screen.getByText("Backend Engineer")).toBeInTheDocument()
+      )
+      expect(screen.queryByText("Junior")).toBeNull()
+    })
+
+    it("passes the row depth to the predicate", async () => {
+      const policy = vi.fn(() => false)
+
+      renderTable({
+        defaultExpanded: policy as unknown as (node: Node) => boolean,
+      })
+
+      await waitFor(() =>
+        expect(screen.getByText("Engineering")).toBeInTheDocument()
+      )
+      expect(policy).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "engineering" }),
+        { depth: 0 }
+      )
+    })
+  })
+
+  /**
+   * The provider used to DELETE the entry on collapse, which made "never seen"
+   * and "the user closed it" the same state. Harmless while nothing opened rows
+   * on its own; with a policy in play it means an opening policy reopens a row
+   * the instant the user closes it. These are the cases that regress if the
+   * tri-state goes back to a two-state map.
+   */
+  describe("a user decision wins over the policy", () => {
+    it("does not reopen a row the user collapsed under an opening policy", async () => {
+      const user = userEvent.setup()
+      renderTable({ defaultExpanded: true })
+
+      await waitFor(() =>
+        expect(screen.getByText("Backend")).toBeInTheDocument()
+      )
+
+      await toggleRow(user, "Engineering")
+
+      await waitFor(() => expect(screen.queryByText("Backend")).toBeNull())
+      // Still closed after the tree has had a chance to re-render and
+      // re-evaluate the policy for that row.
+      await new Promise((resolve) => setTimeout(resolve, 50))
+      expect(screen.queryByText("Backend")).toBeNull()
+    })
+
+    it("keeps a collapse recorded while its row is unmounted", async () => {
+      const user = userEvent.setup()
+      renderTable({ defaultExpanded: true })
+
+      await waitFor(() =>
+        expect(screen.getByText("Junior")).toBeInTheDocument()
+      )
+
+      // Close the grandchild, then close its parent so the grandchild unmounts.
+      await toggleRow(user, "Backend Engineer")
+      await waitFor(() => expect(screen.queryByText("Junior")).toBeNull())
+
+      await toggleRow(user, "Backend")
+      await waitFor(() =>
+        expect(screen.queryByText("Backend Engineer")).toBeNull()
+      )
+
+      // Reopening the parent brings the row back visible but still closed: its
+      // `false` outlived the unmount because it lives in the provider.
+      await toggleRow(user, "Backend")
+      await waitFor(() =>
+        expect(screen.getByText("Backend Engineer")).toBeInTheDocument()
+      )
+      expect(screen.queryByText("Junior")).toBeNull()
+    })
+
+    it("still lets the user open a row the policy left closed", async () => {
+      const user = userEvent.setup()
+      renderTable({ defaultExpanded: false })
+
+      await waitFor(() =>
+        expect(screen.getByText("Engineering")).toBeInTheDocument()
+      )
+
+      await toggleRow(user, "Engineering")
+
+      await waitFor(() =>
+        expect(screen.getByText("Backend")).toBeInTheDocument()
+      )
+    })
+  })
+
+  describe("children of policy-opened rows", () => {
+    it("fetches an opened row's children exactly once", async () => {
+      const byId = indexTree(TREE)
+      const fetchChildren = vi.fn(({ item }: { item: Node }) => ({
+        records: byId.get(item.id)?.children ?? [],
+      }))
+
+      renderTable({
+        source: createSource(TREE, fetchChildren),
+        defaultExpanded: true,
+      })
+
+      await waitFor(() =>
+        expect(screen.getByText("Junior")).toBeInTheDocument()
+      )
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      // One call per parent (Engineering, Backend, Backend Engineer), no repeats.
+      expect(fetchChildren).toHaveBeenCalledTimes(3)
+    })
+
+    it("does not re-request a parent whose children come back empty", async () => {
+      // `itemsWithChildren` says yes but the fetch returns nothing — the case
+      // where `children.length` stays 0 forever. Guarding the request on it
+      // instead of on a ref re-fires on every render, and since each response
+      // sets a fresh `children` array the effect re-runs itself in a loop.
+      const empty: Node[] = [
+        {
+          id: "engineering",
+          name: "Engineering",
+          kind: "category",
+          children: [],
+        },
+      ]
+      const fetchChildren = vi.fn(() => ({ records: [] as Node[] }))
+      const source = {
+        ...createSource(empty, fetchChildren),
+        itemsWithChildren: () => true,
+      } as unknown as TestSource
+
+      renderTable({ source, defaultExpanded: true })
+
+      await waitFor(() =>
+        expect(screen.getByText("Engineering")).toBeInTheDocument()
+      )
+      await new Promise((resolve) => setTimeout(resolve, 100))
+
+      expect(fetchChildren).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  /**
+   * The provider used to be swapped for a `Fragment` on flat tables; it is now
+   * mounted unconditionally so it can take the policy as a prop.
+   */
+  describe("flat tables", () => {
+    it("renders a table with no nesting at all", async () => {
+      const flat = {
+        currentFilters: {},
+        setCurrentFilters: vi.fn(),
+        currentSortings: null,
+        setCurrentSortings: vi.fn(),
+        currentNavigationFilters: {},
+        setCurrentNavigationFilters: vi.fn(),
+        navigationFilters: undefined,
+        currentSearch: undefined,
+        debouncedCurrentSearch: undefined,
+        setCurrentSearch: vi.fn(),
+        isLoading: false,
+        setIsLoading: vi.fn(),
+        currentGrouping: undefined,
+        setCurrentGrouping: vi.fn(),
+        dataAdapter: {
+          fetchData: async () => ({
+            records: [{ id: "a", name: "Alone", kind: "category" as const }],
+          }),
+        },
+      } as unknown as TestSource
+
+      renderTable({ source: flat })
+
+      await waitFor(() => expect(screen.getByText("Alone")).toBeInTheDocument())
+      expect(
+        document.querySelector(".lucide-chevron-right, .lucide-chevron-down")
+      ).toBeNull()
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -16,7 +16,7 @@
  *
  */
 
-import { forwardRef, useCallback, useRef } from "react"
+import { forwardRef, useCallback, useEffect, useRef } from "react"
 
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
 
@@ -135,8 +135,14 @@ const NestedRowContent = <
 
   const rowId = `${props.nestedRowProps?.depth ?? 0}-${"id" in props.item ? props.item.id + "-" + props.index : props.index}`
 
-  const { expandedRowIds, setRowExpanded } = useNestedDataContext()
-  const open = expandedRowIds[rowId] ?? false
+  const { expandedRowIds, setRowExpanded, isExpandedByDefault } =
+    useNestedDataContext()
+  // An absent entry means the user has not decided for this row, and only then
+  // does the default policy apply. `??` is deliberate over `||`: a recorded
+  // `false` is a deliberate collapse and must win over an opening policy.
+  const open =
+    expandedRowIds[rowId] ??
+    isExpandedByDefault(props.item, props.nestedRowProps?.depth ?? 0)
 
   /**
    * useLoadChildren hook manages:
@@ -212,6 +218,17 @@ const NestedRowContent = <
       loadChildren()
     }
   }
+
+  // A row the default policy opens never went through `handleExpand`, so it has
+  // to ask for its children itself. Guarded by a ref rather than by
+  // `children.length`, which stays 0 for a parent whose fetch comes back empty
+  // and would otherwise re-request on every render.
+  const requestedDefaultChildrenRef = useRef(false)
+  useEffect(() => {
+    if (!open || requestedDefaultChildrenRef.current || children.length) return
+    requestedDefaultChildrenRef.current = true
+    loadChildren()
+  }, [open, children.length, loadChildren])
 
   const sharedNestedRowProps = {
     depth: props.nestedRowProps?.depth ?? 0,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -9,13 +9,41 @@ import {
 import { RecordType } from "@/hooks/datasource"
 import { ChildrenResponse } from "@/hooks/datasource/types/nested.typings"
 
+/**
+ * How rows start out when the user has not touched them yet.
+ *
+ * - `true` / `false` — every row, or none (the default).
+ * - a number — expand rows shallower than that depth, so `1` opens the
+ *   top-level rows and reveals depth 1.
+ * - a predicate — anything else, e.g. `(node) => node.type !== "role"`.
+ *
+ * The policy is re-evaluated per row rather than resolved into a set of ids up
+ * front: rows evaluate it as they mount, so an expanded row's children evaluate
+ * it in turn and the cascade falls out of the component tree. That works the
+ * same whether the tree is already in memory or fetched lazily.
+ */
+export type DefaultExpandedPolicy<R extends RecordType> =
+  | boolean
+  | number
+  | ((record: R, context: { depth: number }) => boolean)
+
 interface NestedDataContextValue<R extends RecordType> {
   fetchedData: Record<string, ChildrenResponse<R>>
   updateFetchedData: (rowId: string, data: ChildrenResponse<R>) => void
   clearFetchedData: () => void
-  /** Persisted expansion state so rows stay open across parent re-renders (e.g. GraphQL refetch) */
+  /**
+   * Rows the user has explicitly opened or closed, persisted here so they
+   * survive a row unmounting (collapsing a parent) or the parent re-rendering
+   * (e.g. a GraphQL refetch).
+   *
+   * Tri-state on purpose: an ABSENT entry means "the user has not decided", and
+   * only then does `isExpandedByDefault` get a say. Recording the `false`
+   * instead of deleting the entry is what keeps a deliberate collapse from
+   * being immediately undone by the default policy.
+   */
   expandedRowIds: Record<string, boolean>
   setRowExpanded: (rowId: string, expanded: boolean) => void
+  isExpandedByDefault: (record: R, depth: number) => boolean
 }
 
 const NestedDataContext = createContext<
@@ -24,8 +52,10 @@ const NestedDataContext = createContext<
 
 export const NestedDataProvider = <R extends RecordType>({
   children,
+  defaultExpanded = false,
 }: {
   children: ReactNode
+  defaultExpanded?: DefaultExpandedPolicy<R>
 }) => {
   const [fetchedData, setFetchedData] = useState<
     Record<string, ChildrenResponse<R>>
@@ -50,14 +80,20 @@ export const NestedDataProvider = <R extends RecordType>({
     setExpandedRowIdsState({})
   }, [])
 
+  // Records the `false` rather than dropping the entry — see `expandedRowIds`.
   const setRowExpanded = useCallback((rowId: string, expanded: boolean) => {
-    setExpandedRowIdsState((prev) => {
-      if (expanded) return { ...prev, [rowId]: true }
-      const next = { ...prev }
-      delete next[rowId]
-      return next
-    })
+    setExpandedRowIdsState((prev) => ({ ...prev, [rowId]: expanded }))
   }, [])
+
+  const isExpandedByDefault = useCallback(
+    (record: R, depth: number) => {
+      if (typeof defaultExpanded === "function")
+        return defaultExpanded(record, { depth })
+      if (typeof defaultExpanded === "number") return depth < defaultExpanded
+      return defaultExpanded
+    },
+    [defaultExpanded]
+  )
 
   return (
     <NestedDataContext.Provider
@@ -68,6 +104,7 @@ export const NestedDataProvider = <R extends RecordType>({
           clearFetchedData,
           expandedRowIds,
           setRowExpanded,
+          isExpandedByDefault,
         } as NestedDataContextValue<RecordType>
       }
     >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -14,6 +14,7 @@ import { NavigationFiltersDefinition } from "../../../navigationFilters/types"
 import { PropertyDefinition } from "../../../property-render"
 import { SummariesDefinition, SummaryKey } from "../../../summary"
 import { CollectionProps } from "../../../types"
+import { DefaultExpandedPolicy } from "./providers/NestedProvider"
 
 export type TableVisualizationSettings = {
   order?: ColId[]
@@ -174,6 +175,29 @@ export type TableVisualizationOptions<
    * The number of columns to freeze on the left
    */
   frozenColumns?: 0 | 1 | 2
+
+  /**
+   * For nested tables, which rows start out expanded before the user touches
+   * anything. Pass `true` for the whole tree, a depth, or a predicate:
+   *
+   * ```ts
+   * defaultExpanded: true                            // everything
+   * defaultExpanded: 2                               // down to depth 2
+   * defaultExpanded: (node) => node.type !== "role"  // stop at roles
+   * ```
+   *
+   * Once the user expands or collapses a row their choice wins for that row and
+   * the policy no longer applies to it. Changing filters, sortings or
+   * navigation filters resets the tree, so the policy applies again and a
+   * filtered view comes back expanded.
+   *
+   * Expanding a row loads its children, so a policy that opens a large tree
+   * costs one `fetchChildren` per opened row on first paint.
+   *
+   * @default false
+   */
+  defaultExpanded?: DefaultExpandedPolicy<R>
+
   /**
    * Allow users to reorder columns (you can only reorder columns that are not frozen) (check cols props to define the order)
    */


### PR DESCRIPTION
## Description

Nested tables always start fully collapsed, and today there is no way to ask for anything else — the expansion state lives in a private `useState` inside `NestedDataProvider`, with no prop, callback or handle to seed it.

This adds a `defaultExpanded` option to the table visualization. Two products need it with *different* policies: Teams wants the whole tree open, Job Catalog wants it open down to roles but not into their levels. So the option is a policy, not a flag.

```ts
defaultExpanded: true                            // everything
defaultExpanded: 2                               // down to depth 2
defaultExpanded: (node) => node.type !== "role"  // stop at roles
```

## Screenshots 

### Expanded until a certain level based on policies

https://github.com/user-attachments/assets/8b99b6fe-4ddf-4f19-967a-630a1d58b78e

### Expanded completely

https://github.com/user-attachments/assets/df5270f2-f7ed-4b02-b26a-4bcf3ae8f9d8




## Implementation details

### Why a per-row policy and not a list of ids

Two reasons, and both rule out an `expandedIds` style API:

1. **A consumer cannot build the keys.** The row key is `` `${depth}-${item.id}-${index}` `` — it embeds the depth and the index within the parent's children, neither of which the consumer controls.
2. **The cascade is free.** A row that opens mounts its children, and those children evaluate the policy themselves. Recursion falls out of the component tree, so there is no traversal on the consumer side and the same code works whether the tree is already in memory or fetched lazily one level at a time.

A row opened by the policy never goes through `handleExpand`, so it requests its own children from an effect. That is guarded by a ref rather than by `children.length`, which stays `0` for a parent whose fetch comes back empty and would otherwise re-request on every render.

### The tri-state, and why it is load-bearing

Collapsing used to **delete** the entry:

```ts
if (expanded) return { ...prev, [rowId]: true }
const next = { ...prev }
delete next[rowId]      // ← "never seen" and "user closed it" became the same state
return next
```

With a default-expanded policy that is a bug generator: the two states are indistinguishable, so an opening policy reopens a row the instant the user collapses it. Recording the `false` gives three states — absent means "the user has not decided", and only then does the policy get a say.

It also makes a deliberate collapse survive the row unmounting. Collapse a grandchild, collapse its parent (the grandchild unmounts), reopen the parent: the grandchild comes back visible but still closed, because its `false` lives in the provider above the rows.

### `NestedDataProvider` is now mounted unconditionally

It used to be swapped for a `Fragment` on flat tables. Choosing the wrapper by branch makes it impossible to pass it props without rebuilding the component type on every render — which would remount the entire table whenever a consumer passed an inline `defaultExpanded` predicate. The provider only holds nested state that flat tables never read, so mounting it always is both cheaper and simpler than the alternatives.

### Interaction with filters

`clearFetchedData()` already resets the tree when filters, sortings or navigation filters change. With a policy in play that means a filtered view comes back expanded, which is the behaviour the consuming teams asked for. It also means manual collapses are discarded on a filter change — deliberate, and documented on the option.

### Cost

Opening a row loads its children, so a policy that opens a large tree costs one `fetchChildren` per opened row on first paint. Documented on the option. For the two consumers driving this the tree structure is already in memory, so the cost is per-node data hydration rather than structure fetching.

## Verification

Four stories with `play` assertions: collapsed, all, to-depth, and stop-at-roles.

Plus 11 unit tests in `Table/__tests__/defaultExpanded.test.tsx`, covering the policy (no policy, `true` cascading to depth 3, a depth, a predicate, and the `{ depth }` it receives), the two behaviours the feature leans on, and the flat table now that the provider is always mounted.

Every test was checked against the pre-fix code rather than only against the fix:

| Revert to the old code | What fails |
| --- | --- |
| `delete next[rowId]` on collapse | the two tri-state tests — the policy reopens the row the user just closed, and the collapse is lost when the row unmounts |
| guard the request on `children.length` instead of the ref | the empty-children test — 1 expected `fetchChildren` becomes **1145** |
| drop the self-fetch effect | 7 tests — a policy-opened row renders open with no children |
| ignore `isExpandedByDefault` in `open` | 8 tests |

Also manually verified in Storybook that the cascade reaches depth 3, that a manual collapse is not undone by the policy, and that a collapse survives its row unmounting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

