### PR TITLE
fix(storybook): show internal tag for unexported components

### DIFF
--- a/packages/react/.storybook/ImportBanner.tsx
+++ b/packages/react/.storybook/ImportBanner.tsx
@@ -138,6 +138,10 @@ export function ImportBanner() {
 
   const importPath = resolveImportPath(fileName)
   const componentName = extractComponentName(fileName, title)
+  // Both checks matter: the path tells us which entry point *would* serve the
+  // component, but a component can sit under an exported prefix and still be
+  // absent from its group's `exports.ts`. Only when we resolved a real export
+  // name do we render a copyable import.
   const isInternal = !importPath || !componentName
 
   if (!portalTarget) {

--- a/packages/react/.storybook/resolveImportPath.ts
+++ b/packages/react/.storybook/resolveImportPath.ts
@@ -80,6 +80,27 @@ export function resolveImportPath(fileName: string | undefined): string | null {
 }
 
 /**
+ * Every name reachable from the package's public entry points, merged across
+ * the main and experimental barrels.
+ *
+ * This is the source of truth for "is this component actually importable?".
+ * A path prefix alone isn't enough: a component can live under
+ * `src/components/` (a main-entry prefix) and still be missing from its
+ * group's `exports.ts`, in which case no import statement would resolve.
+ */
+let exportedNamesCache: Set<string> | null = null
+
+export function exportedComponentNames(): Set<string> {
+  if (!exportedNamesCache) {
+    exportedNamesCache = new Set([
+      ...Object.keys(mainExports),
+      ...Object.keys(experimentalExports),
+    ])
+  }
+  return exportedNamesCache
+}
+
+/**
  * Gathers the names a story file might correspond to, most reliable first:
  * the impl filename, the story directory, the index-story directory, and the
  * last segment of the Storybook title.
@@ -133,7 +154,11 @@ export function componentNameCandidates(
  *   3. Second pass — fall back to the raw candidate if it is itself an
  *      export (covers components that don't use the F0 prefix, like
  *      `F0Form` field renderers).
- *   4. If nothing matches, return the first candidate as-is.
+ *   4. If nothing matches, return `null` — the component isn't exported, so
+ *      any import statement we rendered would be a broken copy-paste. Callers
+ *      treat `null` as "internal". (Notably NOT "first candidate as-is": that
+ *      produced import snippets for components under `src/components/` that
+ *      their group barrel never re-exported.)
  */
 export function extractComponentName(
   fileName: string | undefined,
@@ -141,25 +166,22 @@ export function extractComponentName(
 ): string | null {
   const candidates = componentNameCandidates(fileName, title)
 
-  const exports = {
-    ...mainExports,
-    ...experimentalExports,
-  } as Record<string, unknown>
+  const exports = exportedComponentNames()
 
   // Pass 1: prefer the F0-prefixed variant of any candidate.
   for (const name of candidates) {
-    if (name.startsWith("F0") && name in exports) return name
+    if (name.startsWith("F0") && exports.has(name)) return name
     const f0Name = `F0${name}`
-    if (f0Name in exports) return f0Name
+    if (exports.has(f0Name)) return f0Name
   }
 
   // Pass 2: fall back to the raw candidate.
   for (const name of candidates) {
-    if (name in exports) return name
+    if (exports.has(name)) return name
   }
 
-  // Fallback: return the first candidate as-is
-  return candidates[0] ?? null
+  // Nothing matched a real export — the component is internal.
+  return null
 }
 
 /**
@@ -199,10 +221,7 @@ export function usageLookupNames(
   fileName: string | undefined,
   title: string | undefined
 ): string[] {
-  const exports = {
-    ...mainExports,
-    ...experimentalExports,
-  } as Record<string, unknown>
+  const exports = exportedComponentNames()
 
   const candidates = componentNameCandidates(fileName, title)
   const names: string[] = []
@@ -211,7 +230,7 @@ export function usageLookupNames(
   if (canonical) names.push(canonical)
 
   for (const candidate of candidates) {
-    if (candidate in exports && !names.includes(candidate))
+    if (exports.has(candidate) && !names.includes(candidate))
       names.push(candidate)
   }
   for (const candidate of candidates) {


### PR DESCRIPTION
## Description

Storybook docs pages for components that live under an exported path prefix but are missing from their group's `exports.ts` were rendering a "How to import this?" tag with an import statement that doesn't resolve. `extractComponentName` ended with an unconditional `return candidates[0] ?? null`, so it returned a name it had never verified was actually exported by the package. Those pages now correctly show the "Internal component" tag instead of a broken copy-paste.

## Type of change

- [x] Bug fix

## Repro

Open `Components/Avatars/AvatarFlag`. Before this change it offered `import { F0AvatarFlag } from "@factorialco/f0-react"`, but `packages/react/src/components/avatars/exports.ts` does not re-export `./F0AvatarFlag`, so that import fails.

## Follow-ups (not in this PR)

Auditing all 62 stories under `src/components/` surfaced three more components with docs pages but no public export. They render correctly as "Internal component" after this fix; whether they *should* be exported is a separate public-API decision:

| Component | Missing from | Note |
|---|---|---|
| `F0AvatarFlag` | `components/avatars/exports.ts` | All 11 siblings listed — looks like a plain omission |
| `F0ButtonToggleGroup` | `components/exports.ts` | Already wrapped in `experimentalComponent(...)`, i.e. authored to ship |
| `F0InputField` | `components/exports.ts` | Two deprecation shims tell users to import it, but it's unreachable from `f0.ts` |
| `F0Dialog` (dialog-alike) | `components/exports.ts` | Likely superseded by `patterns/F0Dialog`; both stories declare `title: "Dialog"` and collide in the sidebar |