### PR TITLE
chore(storybook): add product-usage tag to component docs

### DIFF
--- a/packages/react/.storybook/ImportBanner.tsx
+++ b/packages/react/.storybook/ImportBanner.tsx
@@ -4,6 +4,7 @@ import { createPortal } from "react-dom"
 
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { Code } from "@/icons/app"
+import { ButtonCopy } from "@/ui/ButtonCopy"
 import {
   Tooltip,
   TooltipContent,
@@ -11,47 +12,29 @@ import {
   TooltipTrigger,
 } from "@/ui/tooltip"
 
-import { extractComponentName, resolveImportPath } from "./resolveImportPath.ts"
+import { ProductUsageTag } from "./ProductUsageTag.tsx"
+import {
+  extractComponentName,
+  resolveImportPath,
+  usageLookupNames,
+} from "./resolveImportPath.ts"
 
 /**
  * A single-line import statement with a copy button, styled for the dark
  * tooltip surface. Rendered directly (instead of Storybook's `Source` block)
  * so the padding stays tight and the text is readable regardless of the docs
  * page theme.
+ *
+ * The copy affordance is F0's own `ButtonCopy` — the docs should use the
+ * design system they document rather than a hand-rolled button.
  */
 function ImportSnippet({ code }: { code: string }) {
-  const [copied, setCopied] = useState(false)
-
-  const onCopy = () => {
-    try {
-      void navigator.clipboard?.writeText(code)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1500)
-    } catch {
-      // Clipboard may be unavailable (e.g. insecure context) — ignore.
-    }
-  }
-
   return (
-    <div className="sb-unstyled flex items-center gap-3 px-3 py-2 text-f1-foreground-inverse">
+    <div className="sb-unstyled flex items-center gap-2 py-2 pl-3 pr-2 text-f1-foreground-inverse">
       <div className="min-w-0 overflow-x-auto">
         <code className="whitespace-pre font-mono text-base">{code}</code>
       </div>
-      {/* Colors are inline (not Tailwind) because Storybook's Tailwind build
-          doesn't scan `.storybook/` for one-off utilities like `text-white`,
-          which would silently fall back to the default (black) text. */}
-      <button
-        type="button"
-        onClick={onCopy}
-        className="shrink-0 rounded-md px-2 py-1 text-sm font-medium transition-colors"
-        style={{
-          color: "#fff",
-          backgroundColor: "rgba(255,255,255,0.1)",
-          border: "1px solid rgba(255,255,255,0.25)",
-        }}
-      >
-        {copied ? "Copied" : "Copy"}
-      </button>
+      <ButtonCopy valueToCopy={code} />
     </div>
   )
 }
@@ -100,6 +83,11 @@ function usePortalInTitle() {
     if (!containerRef.current) {
       const el = document.createElement("span")
       el.style.whiteSpace = "nowrap"
+      // The h1's own flex gap only separates this container from the title —
+      // the tags inside it need their own row layout.
+      el.style.display = "inline-flex"
+      el.style.alignItems = "center"
+      el.style.gap = "0.5rem"
       containerRef.current = el
     }
     titleEl.append(containerRef.current)
@@ -184,6 +172,10 @@ export function ImportBanner() {
           )}
         </TooltipContent>
       </Tooltip>
+      {/* Shown for internal components too: several of them (Spinner, Select…)
+          are re-exported and used by product code, and for the rest "not used"
+          is still the answer people came for. */}
+      <ProductUsageTag names={usageLookupNames(fileName, title)} />
     </TooltipProvider>
   )
 

--- a/packages/react/.storybook/ImportBanner.tsx
+++ b/packages/react/.storybook/ImportBanner.tsx
@@ -16,6 +16,7 @@ import { ProductUsageTag } from "./ProductUsageTag.tsx"
 import {
   extractComponentName,
   resolveImportPath,
+  storyComponentPath,
   usageLookupNames,
 } from "./resolveImportPath.ts"
 
@@ -175,7 +176,10 @@ export function ImportBanner() {
       {/* Shown for internal components too: several of them (Spinner, Select…)
           are re-exported and used by product code, and for the rest "not used"
           is still the answer people came for. */}
-      <ProductUsageTag names={usageLookupNames(fileName, title)} />
+      <ProductUsageTag
+        names={usageLookupNames(fileName, title)}
+        componentPath={storyComponentPath(fileName)}
+      />
     </TooltipProvider>
   )
 

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -1,0 +1,313 @@
+import React, { useEffect, useState } from "react"
+
+import { F0TagRaw } from "@/components/tags/F0TagRaw"
+import { LayersFront } from "@/icons/app"
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/ui/tooltip"
+
+import type {
+  ComposerPrototype,
+  ProductUsageData,
+  ProductUsageEntry,
+  UsageResult,
+} from "../scripts/product-usage-scan.mjs"
+
+/**
+ * Served by the Storybook dev server (see scripts/product-usage-scan.mjs).
+ * Kept as a literal rather than imported from the scanner so this module never
+ * pulls Node built-ins into the browser bundle.
+ */
+const ENDPOINT = "/f0-product-usage.json"
+
+/** How many modules to list before collapsing the rest into a "+N more". */
+const MODULES_SHOWN = 8
+
+/** How many prototypes to name before collapsing the rest into a "+N more". */
+const PROTOTYPES_SHOWN = 6
+
+/** How many f0 components to name before collapsing the rest. */
+const INTERNAL_SHOWN = 6
+
+/**
+ * One fetch per Storybook session, shared by every docs page. Resolves to
+ * `null` when the data isn't available, in which case the tag stays hidden.
+ */
+let request: Promise<UsageResult | null> | undefined
+
+function fetchUsage(): Promise<UsageResult | null> {
+  // Local dev only. This data — product module names, internal prototype
+  // titles — must never reach the public Storybook at f0.factorial.dev, which
+  // anyone outside the company can read. `import.meta.env.DEV` is inlined at
+  // build time, so the static bundle drops the request entirely rather than
+  // relying on the endpoint 404ing.
+  if (!import.meta.env.DEV) return Promise.resolve(null)
+
+  request ??= fetch(ENDPOINT)
+    .then(async (response) => {
+      // A static build serves index.html for unknown paths, so a 200 alone
+      // isn't proof the endpoint exists — check what came back.
+      if (!response.ok) return null
+      const contentType = response.headers.get("content-type") ?? ""
+      if (!contentType.includes("application/json")) return null
+      return (await response.json()) as UsageResult
+    })
+    .catch(() => null)
+  return request
+}
+
+function useUsage() {
+  const [result, setResult] = useState<UsageResult | null>()
+
+  useEffect(() => {
+    let active = true
+    void fetchUsage().then((data) => {
+      if (active) setResult(data)
+    })
+    return () => {
+      active = false
+    }
+  }, [])
+
+  return result
+}
+
+/** Sums a component's usage across every name it is exported under. */
+function collectUsage(
+  data: ProductUsageData,
+  names: string[]
+): { entries: Array<[string, ProductUsageEntry]>; files: number } {
+  const entries = names
+    .map((name) => [name, data.components[name]] as const)
+    .filter((pair): pair is [string, ProductUsageEntry] => Boolean(pair[1]))
+
+  return {
+    entries: [...entries],
+    files: entries.reduce((total, [, entry]) => total + entry.files, 0),
+  }
+}
+
+/** Module → importing files, merged across aliases and sorted by weight. */
+function mergeModules(entries: Array<[string, ProductUsageEntry]>) {
+  const merged = new Map<string, number>()
+  for (const [, entry] of entries) {
+    for (const [module, files] of Object.entries(entry.modules)) {
+      merged.set(module, (merged.get(module) ?? 0) + files)
+    }
+  }
+  return [...merged.entries()].sort(
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0])
+  )
+}
+
+/** The prototypes using any of the names, deduped by project + slug. */
+function collectPrototypes(
+  byComponent: Record<string, ComposerPrototype[]>,
+  names: string[]
+): ComposerPrototype[] {
+  const seen = new Map<string, ComposerPrototype>()
+  for (const name of names) {
+    for (const prototype of byComponent[name] ?? []) {
+      seen.set(`${prototype.project}/${prototype.slug}`, prototype)
+    }
+  }
+  return [...seen.values()].sort((a, b) => a.title.localeCompare(b.title))
+}
+
+function plural(count: number, noun: string) {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`
+}
+
+/** The f0 components importing any of the names, deduped and sorted. */
+function collectInternal(
+  byComponent: Record<string, string[]>,
+  names: string[]
+): string[] {
+  const owners = new Set<string>()
+  for (const name of names) {
+    for (const owner of byComponent[name] ?? []) owners.add(owner)
+  }
+  // A component listing itself would be noise (its own docs page).
+  for (const name of names) owners.delete(name)
+  return [...owners].sort((a, b) => a.localeCompare(b))
+}
+
+/** A capped list of names under a heading, with a "+N more" tail. */
+function NameList({
+  heading,
+  items,
+  limit,
+  className,
+}: {
+  heading: string
+  items: string[]
+  limit: number
+  className?: string
+}) {
+  const shown = items.slice(0, limit)
+  const hidden = items.length - shown.length
+
+  return (
+    <div className={className}>
+      <p className="m-0 font-medium">{heading}</p>
+      <ul className="m-0 mt-2 list-none space-y-1 p-0">
+        {shown.map((item) => (
+          <li key={item} className="truncate">
+            {item}
+          </li>
+        ))}
+      </ul>
+      {hidden > 0 && <p className="m-0 mt-1 opacity-70">+{hidden} more</p>}
+    </div>
+  )
+}
+
+function ProductSection({
+  data,
+  names,
+}: {
+  data: ProductUsageData
+  names: string[]
+}) {
+  const { entries, files } = collectUsage(data, names)
+  const modules = mergeModules(entries)
+  const shown = modules.slice(0, MODULES_SHOWN)
+  const hidden = modules.length - shown.length
+
+  if (files === 0) {
+    return <p className="m-0">Not used anywhere in the product yet.</p>
+  }
+
+  return (
+    <>
+      <p className="m-0 font-medium">
+        Used in {plural(files, "file")} across{" "}
+        {plural(modules.length, "module")}
+      </p>
+      <ul className="m-0 mt-2 list-none space-y-1 p-0">
+        {shown.map(([module, count]) => (
+          <li key={module} className="flex justify-between gap-4">
+            <span className="truncate font-mono">{module}</span>
+            <span className="opacity-70">{count}</span>
+          </li>
+        ))}
+      </ul>
+      {hidden > 0 && <p className="m-0 mt-1 opacity-70">+{hidden} more</p>}
+      {entries.length > 1 && (
+        <p className="m-0 mt-2 opacity-70">
+          Counted across {entries.map(([name]) => name).join(", ")}.
+        </p>
+      )}
+    </>
+  )
+}
+
+/**
+ * Everything the tag needs about one component, resolved once so the trigger
+ * label and the tooltip can't disagree.
+ */
+function resolveUsage(result: UsageResult, names: string[]) {
+  const product = result.product.available ? result.product : null
+  const productFiles = product ? collectUsage(product, names).files : 0
+
+  const prototypes = result.composer.available
+    ? collectPrototypes(result.composer.prototypes, names)
+    : []
+
+  // Only worth surfacing when the component is absent from the product: it
+  // answers "is this dead, or just not shipped directly?".
+  const internal =
+    productFiles === 0 && result.internal.available
+      ? collectInternal(result.internal.components, names)
+      : []
+
+  return { product, productFiles, prototypes, internal }
+}
+
+function UsageDetails({
+  result,
+  names,
+}: {
+  result: UsageResult
+  names: string[]
+}) {
+  const { product, productFiles, prototypes, internal } = resolveUsage(
+    result,
+    names
+  )
+
+  return (
+    <div className="sb-unstyled max-w-xs p-3 text-base text-f1-foreground-inverse">
+      {product ? (
+        <ProductSection data={product} names={names} />
+      ) : (
+        <p className="m-0">
+          No local factorial checkout — product usage unavailable.
+        </p>
+      )}
+      {internal.length > 0 && (
+        <NameList
+          className="mt-3"
+          heading={`Used inside F0 by ${plural(internal.length, "component")}`}
+          items={internal}
+          limit={INTERNAL_SHOWN}
+        />
+      )}
+      {prototypes.length > 0 && (
+        <NameList
+          className={productFiles === 0 && internal.length === 0 ? "" : "mt-3"}
+          heading={`Used in ${plural(prototypes.length, "Composer prototype")}`}
+          items={prototypes.map((prototype) => prototype.title)}
+          limit={PROTOTYPES_SHOWN}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Renders a usage tag next to the docs title, revealing on hover how many
+ * product files import this component and which modules they belong to, plus —
+ * when it isn't in the product — which f0 components and Composer prototypes
+ * use it.
+ *
+ * The data comes from a dev-server scan of this package's `src/` and of local
+ * `factorialco/factorial` and `factorialco/factorial-composer` checkouts, so
+ * the tag renders nothing on the public Storybook.
+ *
+ * @see scripts/product-usage-scan.mjs
+ */
+export function ProductUsageTag({ names }: { names: string[] }) {
+  const result = useUsage()
+
+  // Undefined while in flight, null when there's no endpoint — i.e. the
+  // public static build, where this internal data must not appear at all.
+  if (!result) return null
+  if (names.length === 0) return null
+
+  const { productFiles, internal } = resolveUsage(result, names)
+
+  // "Not used" would be misleading for the building blocks other components
+  // are made of, so say which of the two it is.
+  const label =
+    productFiles > 0
+      ? "Where is this used in the product?"
+      : internal.length > 0
+        ? "Only used internally in F0"
+        : "Not used in the product"
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="sb-unstyled inline-flex cursor-help align-middle">
+          <F0TagRaw text={label} icon={LayersFront} />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent
+        side="bottom"
+        align="start"
+        className="w-max max-w-[min(90vw,42rem)] overflow-hidden !p-0"
+      >
+        <UsageDetails result={result} names={names} />
+      </TooltipContent>
+    </Tooltip>
+  )
+}

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -120,6 +120,24 @@ function plural(count: number, noun: string) {
   return `${count} ${noun}${count === 1 ? "" : "s"}`
 }
 
+/**
+ * The lookup names for a component: what the story path and title suggest,
+ * plus everything its folder's barrel exports.
+ *
+ * The second part is what makes `Toast` find `toasts` — a component is used
+ * under the name it exports, which often isn't the name of its folder.
+ */
+function withExportedNames(
+  result: UsageResult,
+  names: string[],
+  componentPath: string | null
+): string[] {
+  if (!componentPath || !result.internal.available) return names
+
+  const exported = result.internal.exports[componentPath] ?? []
+  return [...new Set([...names, ...exported])]
+}
+
 /** The f0 components importing any of the names, deduped and sorted. */
 function collectInternal(
   byComponent: Record<string, string[]>,
@@ -305,7 +323,14 @@ function UsageDetails({
  *
  * @see scripts/product-usage-scan.mjs
  */
-export function ProductUsageTag({ names }: { names: string[] }) {
+export function ProductUsageTag({
+  names,
+  componentPath,
+}: {
+  names: string[]
+  /** Folder relative to `src/`, used to look up what it exports. */
+  componentPath: string | null
+}) {
   const result = useUsage()
 
   // Before anything renders: the loading state would otherwise flash on the
@@ -339,7 +364,11 @@ export function ProductUsageTag({ names }: { names: string[] }) {
   // where this internal data must not appear at all.
   if (result === null) return null
 
-  const { productFiles, internal } = resolveUsage(result, names)
+  // Path/title candidates miss components whose export name differs from their
+  // folder (`hooks/toast` ships `toasts`), so fold in what the folder exports.
+  const lookup = withExportedNames(result, names, componentPath)
+
+  const { productFiles, internal } = resolveUsage(result, lookup)
 
   // "Not used" would be misleading for the building blocks other components
   // are made of, so say which of the two it is.
@@ -362,7 +391,7 @@ export function ProductUsageTag({ names }: { names: string[] }) {
         align="start"
         className="w-max max-w-[min(90vw,42rem)] overflow-hidden !p-0"
       >
-        <UsageDetails result={result} names={names} />
+        <UsageDetails result={result} names={lookup} />
       </TooltipContent>
     </Tooltip>
   )

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -10,6 +10,7 @@ import type {
   ProductUsageEntry,
   UsageResult,
 } from "../scripts/product-usage-scan.mjs"
+import { DIRTY_MESSAGE } from "./usage-contract.ts"
 import {
   ENABLED,
   rescan,
@@ -25,6 +26,9 @@ const PROTOTYPES_SHOWN = 6
 
 /** How many f0 components to name before collapsing the rest. */
 const INTERNAL_SHOWN = 6
+
+/** Pending-action key for the button that clones every missing repo. */
+const CLONE_ALL = "clone-all"
 
 /** Sums a component's usage across every name it is exported under. */
 function collectUsage(
@@ -180,12 +184,24 @@ function ProductSection({
  */
 function usePendingAction() {
   const [pending, setPending] = React.useState<string | null>(null)
+  const [failure, setFailure] = React.useState<string | null>(null)
 
   const run = React.useCallback(
-    async (name: string, work: () => Promise<unknown>) => {
+    async (
+      name: string,
+      work: () => Promise<{ ok: boolean; message?: string } | void>
+    ) => {
       setPending(name)
+      setFailure(null)
       try {
-        await work()
+        const result = await work()
+        // A request the server refused never reaches the actions payload, so
+        // this is the only place it can be reported.
+        if (result && !result.ok) {
+          setFailure(result.message ?? "Request failed")
+        }
+      } catch {
+        setFailure("Request failed")
       } finally {
         setPending(null)
       }
@@ -193,7 +209,7 @@ function usePendingAction() {
     []
   )
 
-  return { pending, run }
+  return { pending, failure, run }
 }
 
 /** A small button styled for the dark tooltip surface. */
@@ -241,9 +257,25 @@ function MissingRepos({
   missing: ProductUsageData["missing"]
   actions: UsageResult["actions"]
 }) {
-  const { pending, run } = usePendingAction()
+  const { pending, failure, run } = usePendingAction()
 
   if (missing.length === 0) return null
+
+  const label = missing.map((repo) => repo.id).join(" & ")
+  const cloningId = missing.find(
+    (repo) => actions?.[repo.id]?.state === "running"
+  )?.id
+  const cloning = pending === CLONE_ALL || Boolean(cloningId)
+
+  // Sequential: two clones of Factorial-sized repos at once help nobody.
+  const cloneAll = async () => {
+    let outcome: { ok: boolean; message?: string } = { ok: true }
+    for (const repo of missing) {
+      const result = await runRepoAction(repo.id, "clone")
+      if (!result.ok && outcome.ok) outcome = result
+    }
+    return outcome
+  }
 
   return (
     <div className="mt-2 text-sm opacity-70">
@@ -258,26 +290,27 @@ function MissingRepos({
         — no local checkout.
       </p>
       <div className="mt-2 flex flex-col gap-2">
+        <span className="flex items-center gap-2">
+          {/* One button for all of them: nobody wants to click Clone twice and
+              wait through two monorepos in sequence by hand. */}
+          <TooltipButton
+            onClick={() => void run(CLONE_ALL, cloneAll)}
+            disabled={cloning}
+          >
+            {cloning ? `Cloning ${cloningId ?? label}…` : `Clone ${label}`}
+          </TooltipButton>
+          <span className="opacity-80">
+            {cloning
+              ? "This takes a few minutes — the tag updates when it lands."
+              : failure}
+          </span>
+        </span>
         {missing.map((repo) => {
           const status = actions?.[repo.id]
-          const cloning = pending === repo.id || status?.state === "running"
+          if (!status || status.state === "running") return null
           return (
-            <span key={repo.id} className="flex items-center gap-2">
-              <TooltipButton
-                onClick={() =>
-                  void run(repo.id, () => runRepoAction(repo.id, "clone"))
-                }
-                disabled={cloning}
-              >
-                {cloning ? `Cloning ${repo.id}…` : `Clone ${repo.id}`}
-              </TooltipButton>
-              <span className="opacity-80">
-                {cloning
-                  ? "This takes a few minutes — the tag updates when it lands."
-                  : status && status.state !== "running"
-                    ? status.message
-                    : null}
-              </span>
+            <span key={repo.id} className="opacity-80">
+              <code className="font-mono">{repo.id}</code>: {status.message}
             </span>
           )
         })}
@@ -296,58 +329,112 @@ function MissingRepos({
 function RefreshActions({
   repos,
   actions,
+  stashes,
   generatedAt,
+  rescanning,
 }: {
   repos: ProductUsageData["repos"]
   actions: UsageResult["actions"]
+  stashes: UsageResult["stashes"]
   generatedAt: string
+  rescanning: boolean
 }) {
-  const { pending, run } = usePendingAction()
+  const { pending, failure, run } = usePendingAction()
 
-  // Either the button is mid-click, or the server still has git running from
-  // an earlier one (a pull outlives the request that started it).
-  const pullingOnServer = repos.some(
+  // Either a button is mid-click, or the server still has git running from an
+  // earlier one (a pull outlives the request that started it).
+  const runningOnServer = repos.some(
     (repo) => actions?.[repo.id]?.state === "running"
   )
-  const busy = pending !== null || pullingOnServer
+  const busy = pending !== null || runningOnServer || rescanning
+
+  // Repos a plain pull refused to touch. Offering "Pull latest" again would
+  // just reproduce the same refusal, so those get the stash route instead.
+  const blocked = repos.filter(
+    (repo) => actions?.[repo.id]?.message === DIRTY_MESSAGE
+  )
 
   const results = repos
     .map((repo) => [repo.id, actions?.[repo.id]] as const)
     .filter(([, status]) => status && status.state !== "running")
 
+  // Sequential: two gits writing at once, and the second failing on a lock,
+  // helps nobody. The first refusal is what gets reported.
+  const pullAll = async () => {
+    let outcome: { ok: boolean; message?: string } = { ok: true }
+    for (const repo of repos) {
+      const result = await runRepoAction(repo.id, "pull")
+      if (!result.ok && outcome.ok) outcome = result
+    }
+    return outcome
+  }
+
   return (
     <div className="mt-3 border-0 border-t border-solid border-f1-border-inverse pt-2 text-sm">
       <div className="flex flex-wrap items-center gap-2">
-        <TooltipButton
-          disabled={busy}
-          onClick={() =>
-            void run("pull", () =>
-              // Sequential: two gits writing at once, and the second failing
-              // on a lock, helps nobody.
-              repos.reduce(
-                (queue, repo) =>
-                  queue.then(() => runRepoAction(repo.id, "pull")),
-                Promise.resolve()
-              )
-            )
-          }
-        >
-          {pending === "pull" || pullingOnServer ? "Pulling…" : "Pull latest"}
-        </TooltipButton>
+        {blocked.length === 0 && (
+          <TooltipButton
+            disabled={busy}
+            onClick={() => void run("pull", pullAll)}
+          >
+            {pending === "pull" || runningOnServer ? "Pulling…" : "Pull latest"}
+          </TooltipButton>
+        )}
+        {blocked.map((repo) => (
+          <TooltipButton
+            key={repo.id}
+            disabled={busy}
+            onClick={() =>
+              void run(repo.id, () => runRepoAction(repo.id, "stash-pull"))
+            }
+          >
+            {pending === repo.id
+              ? `Stashing ${repo.id}…`
+              : `Stash & pull ${repo.id}`}
+          </TooltipButton>
+        ))}
         <TooltipButton
           disabled={busy}
           onClick={() => void run("rescan", rescan)}
         >
-          {pending === "rescan" ? "Rescanning…" : "Rescan"}
+          Rescan
         </TooltipButton>
         <span className="opacity-70">
-          {pending === "pull" || pullingOnServer
-            ? `Fetching ${plural(repos.length, "repo")}…`
-            : pending === "rescan"
-              ? "Reading the repos again…"
+          {rescanning
+            ? "Rescanning…"
+            : pending !== null || runningOnServer
+              ? "Running git…"
               : `Scanned at ${new Date(generatedAt).toLocaleTimeString()}`}
         </span>
       </div>
+      {blocked.length > 0 && (
+        <p className="m-0 mt-2 opacity-70">
+          Stashing keeps your work — restore it with{" "}
+          <code className="font-mono">git stash pop</code>. It also switches to
+          the default branch before pulling.
+        </p>
+      )}
+      {failure && <p className="m-0 mt-2 opacity-80">{failure}</p>}
+      {Object.entries(stashes ?? {}).map(([id, stash]) => (
+        // Someone's uncommitted work is sitting in a stash because of a click
+        // here. Say where it is, and how to get back to it, until Storybook
+        // restarts.
+        <p key={id} className="m-0 mt-2 opacity-80">
+          Stashed your <code className="font-mono">{id}</code> changes
+          {stash.branch ? (
+            <>
+              {" "}
+              from <code className="font-mono">{stash.branch}</code>
+            </>
+          ) : null}
+          . Restore with{" "}
+          <code className="font-mono">
+            git -C {id} {stash.branch ? `checkout ${stash.branch} && ` : ""}git
+            stash pop
+          </code>
+          .
+        </p>
+      ))}
       {results.length > 0 && (
         <ul className="m-0 mt-2 list-none space-y-1 p-0 opacity-70">
           {results.map(([id, status]) => (
@@ -386,9 +473,11 @@ function resolveUsage(result: UsageResult, names: string[]) {
 function UsageDetails({
   result,
   names,
+  rescanning,
 }: {
   result: UsageResult
   names: string[]
+  rescanning: boolean
 }) {
   const { product, productFiles, prototypes, internal } = resolveUsage(
     result,
@@ -434,7 +523,9 @@ function UsageDetails({
         <RefreshActions
           repos={product.repos}
           actions={result.actions}
+          stashes={result.stashes}
           generatedAt={result.generatedAt}
+          rescanning={rescanning}
         />
       )}
     </div>
@@ -461,7 +552,7 @@ export function ProductUsageTag({
   /** Folder relative to `src/`, used to look up what it exports. */
   componentPath: string | null
 }) {
-  const result = useProductUsage()
+  const { data: result, rescanning } = useProductUsage()
 
   // Before anything renders: the loading state would otherwise flash on the
   // public build for the frame between mount and the effect resolving to
@@ -541,7 +632,7 @@ export function ProductUsageTag({
         align="start"
         className="w-max max-w-[min(90vw,42rem)] overflow-hidden !p-0"
       >
-        <UsageDetails result={result} names={lookup} />
+        <UsageDetails result={result} names={lookup} rescanning={rescanning} />
       </TooltipContent>
     </Tooltip>
   )

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -174,6 +174,28 @@ function ProductSection({
   )
 }
 
+/**
+ * Runs one action at a time and reports which one is in flight, so a click
+ * can't be repeated while the work it started is still running.
+ */
+function usePendingAction() {
+  const [pending, setPending] = React.useState<string | null>(null)
+
+  const run = React.useCallback(
+    async (name: string, work: () => Promise<unknown>) => {
+      setPending(name)
+      try {
+        await work()
+      } finally {
+        setPending(null)
+      }
+    },
+    []
+  )
+
+  return { pending, run }
+}
+
 /** A small button styled for the dark tooltip surface. */
 function TooltipButton({
   onClick,
@@ -219,6 +241,8 @@ function MissingRepos({
   missing: ProductUsageData["missing"]
   actions: UsageResult["actions"]
 }) {
+  const { pending, run } = usePendingAction()
+
   if (missing.length === 0) return null
 
   return (
@@ -233,22 +257,27 @@ function MissingRepos({
         ))}{" "}
         — no local checkout.
       </p>
-      <div className="mt-2 flex flex-wrap items-center gap-2">
+      <div className="mt-2 flex flex-col gap-2">
         {missing.map((repo) => {
           const status = actions?.[repo.id]
+          const cloning = pending === repo.id || status?.state === "running"
           return (
             <span key={repo.id} className="flex items-center gap-2">
               <TooltipButton
-                onClick={() => void runRepoAction(repo.id, "clone")}
-                disabled={status?.state === "running"}
+                onClick={() =>
+                  void run(repo.id, () => runRepoAction(repo.id, "clone"))
+                }
+                disabled={cloning}
               >
-                {status?.state === "running"
-                  ? `Cloning ${repo.id}…`
-                  : `Clone ${repo.id}`}
+                {cloning ? `Cloning ${repo.id}…` : `Clone ${repo.id}`}
               </TooltipButton>
-              {status && status.state !== "running" && (
-                <span className="opacity-80">{status.message}</span>
-              )}
+              <span className="opacity-80">
+                {cloning
+                  ? "This takes a few minutes — the tag updates when it lands."
+                  : status && status.state !== "running"
+                    ? status.message
+                    : null}
+              </span>
             </span>
           )
         })}
@@ -267,11 +296,21 @@ function MissingRepos({
 function RefreshActions({
   repos,
   actions,
+  generatedAt,
 }: {
   repos: ProductUsageData["repos"]
   actions: UsageResult["actions"]
+  generatedAt: string
 }) {
-  const pulling = repos.some((repo) => actions?.[repo.id]?.state === "running")
+  const { pending, run } = usePendingAction()
+
+  // Either the button is mid-click, or the server still has git running from
+  // an earlier one (a pull outlives the request that started it).
+  const pullingOnServer = repos.some(
+    (repo) => actions?.[repo.id]?.state === "running"
+  )
+  const busy = pending !== null || pullingOnServer
+
   const results = repos
     .map((repo) => [repo.id, actions?.[repo.id]] as const)
     .filter(([, status]) => status && status.state !== "running")
@@ -280,14 +319,34 @@ function RefreshActions({
     <div className="mt-3 border-0 border-t border-solid border-f1-border-inverse pt-2 text-sm">
       <div className="flex flex-wrap items-center gap-2">
         <TooltipButton
-          onClick={() => {
-            for (const repo of repos) void runRepoAction(repo.id, "pull")
-          }}
-          disabled={pulling}
+          disabled={busy}
+          onClick={() =>
+            void run("pull", () =>
+              // Sequential: two gits writing at once, and the second failing
+              // on a lock, helps nobody.
+              repos.reduce(
+                (queue, repo) =>
+                  queue.then(() => runRepoAction(repo.id, "pull")),
+                Promise.resolve()
+              )
+            )
+          }
         >
-          {pulling ? "Pulling…" : "Pull latest"}
+          {pending === "pull" || pullingOnServer ? "Pulling…" : "Pull latest"}
         </TooltipButton>
-        <TooltipButton onClick={() => void rescan()}>Rescan</TooltipButton>
+        <TooltipButton
+          disabled={busy}
+          onClick={() => void run("rescan", rescan)}
+        >
+          {pending === "rescan" ? "Rescanning…" : "Rescan"}
+        </TooltipButton>
+        <span className="opacity-70">
+          {pending === "pull" || pullingOnServer
+            ? `Fetching ${plural(repos.length, "repo")}…`
+            : pending === "rescan"
+              ? "Reading the repos again…"
+              : `Scanned at ${new Date(generatedAt).toLocaleTimeString()}`}
+        </span>
       </div>
       {results.length > 0 && (
         <ul className="m-0 mt-2 list-none space-y-1 p-0 opacity-70">
@@ -372,7 +431,11 @@ function UsageDetails({
         />
       )}
       {product && (
-        <RefreshActions repos={product.repos} actions={result.actions} />
+        <RefreshActions
+          repos={product.repos}
+          actions={result.actions}
+          generatedAt={result.generatedAt}
+        />
       )}
     </div>
   )
@@ -450,11 +513,27 @@ export function ProductUsageTag({
         ? "Only used internally in F0"
         : "Not used in the product"
 
+  // A clone runs for minutes, and the tooltip is only open while you hover.
+  // Put it on the tag itself so starting one doesn't look like nothing
+  // happened.
+  const running = Object.entries(result.actions ?? {}).find(
+    ([, status]) => status.state === "running"
+  )
+
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <span className="sb-unstyled inline-flex cursor-help align-middle">
-          <F0TagRaw text={label} icon={LayersFront} />
+        <span
+          className={`sb-unstyled inline-flex align-middle ${running ? "cursor-progress" : "cursor-help"}`}
+        >
+          <F0TagRaw
+            text={
+              running
+                ? `${running[1].action === "clone" ? "Cloning" : "Pulling"} ${running[0]}…`
+                : label
+            }
+            icon={LayersFront}
+          />
         </span>
       </TooltipTrigger>
       <TooltipContent

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -213,21 +213,16 @@ function MissingRepos({ missing }: { missing: ProductUsageData["missing"] }) {
 
   return (
     <p className="m-0 mt-2 text-sm opacity-70">
-      Not checked:{" "}
+      Not counted:{" "}
       {missing.map((repo, index) => (
         <span key={repo.id}>
           {index > 0 && ", "}
           <code className="font-mono">{repo.id}</code>
         </span>
       ))}{" "}
-      — clone next to this repo or set{" "}
-      {missing.map((repo, index) => (
-        <span key={repo.id}>
-          {index > 0 && " / "}
-          <code className="font-mono">${repo.env}</code>
-        </span>
-      ))}
-      .
+      — no local checkout. Clone it anywhere usual (next to this repo,{" "}
+      <code className="font-mono">~/code</code>…) and it&apos;s picked up
+      automatically.
     </p>
   )
 }

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -33,13 +33,17 @@ const INTERNAL_SHOWN = 6
  */
 let request: Promise<UsageResult | null> | undefined
 
+/**
+ * Local dev only. This data — product module names, internal prototype titles
+ * — must never reach the public Storybook at f0.factorial.dev, which anyone
+ * outside the company can read. `import.meta.env.DEV` is inlined at build
+ * time, so the static bundle drops the tag and its request entirely rather
+ * than relying on the endpoint 404ing.
+ */
+const ENABLED = import.meta.env.DEV
+
 function fetchUsage(): Promise<UsageResult | null> {
-  // Local dev only. This data — product module names, internal prototype
-  // titles — must never reach the public Storybook at f0.factorial.dev, which
-  // anyone outside the company can read. `import.meta.env.DEV` is inlined at
-  // build time, so the static bundle drops the request entirely rather than
-  // relying on the endpoint 404ing.
-  if (!import.meta.env.DEV) return Promise.resolve(null)
+  if (!ENABLED) return Promise.resolve(null)
 
   request ??= fetch(ENDPOINT)
     .then(async (response) => {
@@ -309,10 +313,36 @@ function UsageDetails({
 export function ProductUsageTag({ names }: { names: string[] }) {
   const result = useUsage()
 
-  // Undefined while in flight, null when there's no endpoint — i.e. the
-  // public static build, where this internal data must not appear at all.
-  if (!result) return null
+  // Before anything renders: the loading state would otherwise flash on the
+  // public build for the frame between mount and the effect resolving to
+  // "unavailable", advertising internal tooling to the outside world.
+  if (!ENABLED) return null
   if (names.length === 0) return null
+
+  // The first docs page of a session pays for the scan (a second or two of
+  // walking three repos). Say so rather than leaving a gap where the tag will
+  // be — an absent tag is indistinguishable from a broken one.
+  if (result === undefined) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="sb-unstyled inline-flex cursor-progress align-middle opacity-60">
+            <F0TagRaw text="Checking usage…" icon={LayersFront} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" align="start">
+          <span className="sb-unstyled text-base text-f1-foreground-inverse">
+            Scanning the product, F0 and Composer prototypes for usages of this
+            component.
+          </span>
+        </TooltipContent>
+      </Tooltip>
+    )
+  }
+
+  // `null` means there's no endpoint to ask — i.e. the public static build,
+  // where this internal data must not appear at all.
+  if (result === null) return null
 
   const { productFiles, internal } = resolveUsage(result, names)
 

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react"
+import React from "react"
 
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { LayersFront } from "@/icons/app"
@@ -10,13 +10,12 @@ import type {
   ProductUsageEntry,
   UsageResult,
 } from "../scripts/product-usage-scan.mjs"
-
-/**
- * Served by the Storybook dev server (see scripts/product-usage-scan.mjs).
- * Kept as a literal rather than imported from the scanner so this module never
- * pulls Node built-ins into the browser bundle.
- */
-const ENDPOINT = "/f0-product-usage.json"
+import {
+  ENABLED,
+  rescan,
+  runRepoAction,
+  useProductUsage,
+} from "./useProductUsage.ts"
 
 /** How many modules to list before collapsing the rest into a "+N more". */
 const MODULES_SHOWN = 8
@@ -26,53 +25,6 @@ const PROTOTYPES_SHOWN = 6
 
 /** How many f0 components to name before collapsing the rest. */
 const INTERNAL_SHOWN = 6
-
-/**
- * One fetch per Storybook session, shared by every docs page. Resolves to
- * `null` when the data isn't available, in which case the tag stays hidden.
- */
-let request: Promise<UsageResult | null> | undefined
-
-/**
- * Local dev only. This data — product module names, internal prototype titles
- * — must never reach the public Storybook at f0.factorial.dev, which anyone
- * outside the company can read. `import.meta.env.DEV` is inlined at build
- * time, so the static bundle drops the tag and its request entirely rather
- * than relying on the endpoint 404ing.
- */
-const ENABLED = import.meta.env.DEV
-
-function fetchUsage(): Promise<UsageResult | null> {
-  if (!ENABLED) return Promise.resolve(null)
-
-  request ??= fetch(ENDPOINT)
-    .then(async (response) => {
-      // A static build serves index.html for unknown paths, so a 200 alone
-      // isn't proof the endpoint exists — check what came back.
-      if (!response.ok) return null
-      const contentType = response.headers.get("content-type") ?? ""
-      if (!contentType.includes("application/json")) return null
-      return (await response.json()) as UsageResult
-    })
-    .catch(() => null)
-  return request
-}
-
-function useUsage() {
-  const [result, setResult] = useState<UsageResult | null>()
-
-  useEffect(() => {
-    let active = true
-    void fetchUsage().then((data) => {
-      if (active) setResult(data)
-    })
-    return () => {
-      active = false
-    }
-  }, [])
-
-  return result
-}
 
 /** Sums a component's usage across every name it is exported under. */
 function collectUsage(
@@ -222,26 +174,131 @@ function ProductSection({
   )
 }
 
+/** A small button styled for the dark tooltip surface. */
+function TooltipButton({
+  onClick,
+  disabled,
+  children,
+}: {
+  onClick: () => void
+  disabled?: boolean
+  children: React.ReactNode
+}) {
+  return (
+    // Colors are inline because Storybook's Tailwind build doesn't scan
+    // `.storybook/`, so one-off utilities here silently fall back to defaults.
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="shrink-0 rounded-md px-2 py-1 text-sm font-medium transition-colors"
+      style={{
+        color: "#fff",
+        backgroundColor: "rgba(255,255,255,0.1)",
+        border: "1px solid rgba(255,255,255,0.25)",
+        cursor: disabled ? "default" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      {children}
+    </button>
+  )
+}
+
 /**
- * Names the product repos that weren't scanned. Without this the count reads
- * as the whole picture when a product surface is simply missing from disk.
+ * Names the product repos that weren't scanned, and offers to clone them.
+ *
+ * Without this the count reads as the whole picture when a product surface is
+ * simply missing from disk. The clone runs on the dev server against a fixed
+ * list of repos — see `KNOWN_REPOS` in the scanner.
  */
-function MissingRepos({ missing }: { missing: ProductUsageData["missing"] }) {
+function MissingRepos({
+  missing,
+  actions,
+}: {
+  missing: ProductUsageData["missing"]
+  actions: UsageResult["actions"]
+}) {
   if (missing.length === 0) return null
 
   return (
-    <p className="m-0 mt-2 text-sm opacity-70">
-      Not counted:{" "}
-      {missing.map((repo, index) => (
-        <span key={repo.id}>
-          {index > 0 && ", "}
-          <code className="font-mono">{repo.id}</code>
-        </span>
-      ))}{" "}
-      — no local checkout. Clone it anywhere usual (next to this repo,{" "}
-      <code className="font-mono">~/code</code>…) and it&apos;s picked up
-      automatically.
-    </p>
+    <div className="mt-2 text-sm opacity-70">
+      <p className="m-0">
+        Not counted:{" "}
+        {missing.map((repo, index) => (
+          <span key={repo.id}>
+            {index > 0 && ", "}
+            <code className="font-mono">{repo.id}</code>
+          </span>
+        ))}{" "}
+        — no local checkout.
+      </p>
+      <div className="mt-2 flex flex-wrap items-center gap-2">
+        {missing.map((repo) => {
+          const status = actions?.[repo.id]
+          return (
+            <span key={repo.id} className="flex items-center gap-2">
+              <TooltipButton
+                onClick={() => void runRepoAction(repo.id, "clone")}
+                disabled={status?.state === "running"}
+              >
+                {status?.state === "running"
+                  ? `Cloning ${repo.id}…`
+                  : `Clone ${repo.id}`}
+              </TooltipButton>
+              {status && status.state !== "running" && (
+                <span className="opacity-80">{status.message}</span>
+              )}
+            </span>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Fast-forwards the scanned checkouts and rescans, so the numbers reflect
+ * what's on main rather than whatever was last pulled.
+ *
+ * Pull is `--ff-only` and skips any repo with a dirty working tree — this runs
+ * against real checkouts people may be working in.
+ */
+function RefreshActions({
+  repos,
+  actions,
+}: {
+  repos: ProductUsageData["repos"]
+  actions: UsageResult["actions"]
+}) {
+  const pulling = repos.some((repo) => actions?.[repo.id]?.state === "running")
+  const results = repos
+    .map((repo) => [repo.id, actions?.[repo.id]] as const)
+    .filter(([, status]) => status && status.state !== "running")
+
+  return (
+    <div className="mt-3 border-0 border-t border-solid border-f1-border-inverse pt-2 text-sm">
+      <div className="flex flex-wrap items-center gap-2">
+        <TooltipButton
+          onClick={() => {
+            for (const repo of repos) void runRepoAction(repo.id, "pull")
+          }}
+          disabled={pulling}
+        >
+          {pulling ? "Pulling…" : "Pull latest"}
+        </TooltipButton>
+        <TooltipButton onClick={() => void rescan()}>Rescan</TooltipButton>
+      </div>
+      {results.length > 0 && (
+        <ul className="m-0 mt-2 list-none space-y-1 p-0 opacity-70">
+          {results.map(([id, status]) => (
+            <li key={id}>
+              <code className="font-mono">{id}</code>: {status?.message}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
   )
 }
 
@@ -284,12 +341,19 @@ function UsageDetails({
       {product ? (
         <>
           <ProductSection data={product} names={names} />
-          <MissingRepos missing={product.missing} />
+          <MissingRepos missing={product.missing} actions={result.actions} />
         </>
       ) : (
-        <p className="m-0">
-          No local factorial checkout — product usage unavailable.
-        </p>
+        <>
+          <p className="m-0">
+            No local factorial checkout — whether the product uses this is
+            unknown.
+          </p>
+          <MissingRepos
+            missing={result.product.missing ?? []}
+            actions={result.actions}
+          />
+        </>
       )}
       {internal.length > 0 && (
         <NameList
@@ -306,6 +370,9 @@ function UsageDetails({
           items={prototypes.map((prototype) => prototype.title)}
           limit={PROTOTYPES_SHOWN}
         />
+      )}
+      {product && (
+        <RefreshActions repos={product.repos} actions={result.actions} />
       )}
     </div>
   )
@@ -331,7 +398,7 @@ export function ProductUsageTag({
   /** Folder relative to `src/`, used to look up what it exports. */
   componentPath: string | null
 }) {
-  const result = useUsage()
+  const result = useProductUsage()
 
   // Before anything renders: the loading state would otherwise flash on the
   // public build for the frame between mount and the effect resolving to
@@ -368,14 +435,18 @@ export function ProductUsageTag({
   // folder (`hooks/toast` ships `toasts`), so fold in what the folder exports.
   const lookup = withExportedNames(result, names, componentPath)
 
-  const { productFiles, internal } = resolveUsage(result, lookup)
+  const { product, productFiles, internal } = resolveUsage(result, lookup)
 
-  // "Not used" would be misleading for the building blocks other components
-  // are made of, so say which of the two it is.
-  const label =
-    productFiles > 0
+  // Without a factorial checkout there is no product answer at all — claiming
+  // "not used" would be a confident lie about a component the product may
+  // depend on hundreds of times.
+  const label = !product
+    ? "Where is this used?"
+    : productFiles > 0
       ? "Where is this used in the product?"
-      : internal.length > 0
+      : // "Not used" would be misleading for the building blocks other
+        // components are made of, so say which of the two it is.
+        internal.length > 0
         ? "Only used internally in F0"
         : "Not used in the product"
 

--- a/packages/react/.storybook/ProductUsageTag.tsx
+++ b/packages/react/.storybook/ProductUsageTag.tsx
@@ -201,6 +201,34 @@ function ProductSection({
 }
 
 /**
+ * Names the product repos that weren't scanned. Without this the count reads
+ * as the whole picture when a product surface is simply missing from disk.
+ */
+function MissingRepos({ missing }: { missing: ProductUsageData["missing"] }) {
+  if (missing.length === 0) return null
+
+  return (
+    <p className="m-0 mt-2 text-sm opacity-70">
+      Not checked:{" "}
+      {missing.map((repo, index) => (
+        <span key={repo.id}>
+          {index > 0 && ", "}
+          <code className="font-mono">{repo.id}</code>
+        </span>
+      ))}{" "}
+      — clone next to this repo or set{" "}
+      {missing.map((repo, index) => (
+        <span key={repo.id}>
+          {index > 0 && " / "}
+          <code className="font-mono">${repo.env}</code>
+        </span>
+      ))}
+      .
+    </p>
+  )
+}
+
+/**
  * Everything the tag needs about one component, resolved once so the trigger
  * label and the tooltip can't disagree.
  */
@@ -237,7 +265,10 @@ function UsageDetails({
   return (
     <div className="sb-unstyled max-w-xs p-3 text-base text-f1-foreground-inverse">
       {product ? (
-        <ProductSection data={product} names={names} />
+        <>
+          <ProductSection data={product} names={names} />
+          <MissingRepos missing={product.missing} />
+        </>
       ) : (
         <p className="m-0">
           No local factorial checkout — product usage unavailable.

--- a/packages/react/.storybook/UnusedComponents.tsx
+++ b/packages/react/.storybook/UnusedComponents.tsx
@@ -28,6 +28,7 @@ interface Report {
   total: number
   rows: Row[]
   unused: Row[]
+  onlyInPrototypes: Row[]
   sources: {
     product:
       | { available: true; scope: string; importingFiles: number }
@@ -136,6 +137,8 @@ export function UnusedComponents() {
         {loading && <em>Rescanning…</em>}
       </p>
 
+      <h2>Used nowhere ({report.unused.length})</h2>
+
       {[...byZone]
         .sort((a, b) => b[1].length - a[1].length)
         .map(([zone, rows]) => (
@@ -169,6 +172,46 @@ export function UnusedComponents() {
             </table>
           </section>
         ))}
+
+      <h2>Only in prototypes ({report.onlyInPrototypes.length})</h2>
+      <p>
+        Built and prototyped, but no product code imports them yet. Unlike the
+        list above these aren&apos;t deprecation candidates — a Composer
+        prototype is usually where adoption starts, so expect them in{" "}
+        <code>factorial</code> or <code>factorial-it</code> next.
+      </p>
+
+      {report.onlyInPrototypes.length === 0 ? (
+        <p>
+          <em>
+            None right now — every component a prototype uses is already in the
+            product.
+          </em>
+        </p>
+      ) : (
+        <table>
+          <thead>
+            <tr>
+              <th>Component</th>
+              <th>Maturity</th>
+              <th>Prototypes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {report.onlyInPrototypes
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((row) => (
+                <tr key={row.name}>
+                  <td>
+                    <code>{row.name}</code>
+                  </td>
+                  <td>{row.status}</td>
+                  <td>{row.prototypes.join(", ")}</td>
+                </tr>
+              ))}
+          </tbody>
+        </table>
+      )}
 
       <p>
         <small>

--- a/packages/react/.storybook/UnusedComponents.tsx
+++ b/packages/react/.storybook/UnusedComponents.tsx
@@ -1,0 +1,182 @@
+import React, { useEffect, useState } from "react"
+
+/**
+ * The "Unused components" docs page: every documented component that nothing
+ * imports — not the product, not a Composer prototype, not another f0
+ * component.
+ *
+ * Same answer as `pnpm unused-components`; both call `computeUsageReport` on
+ * the dev server. Local only — the page isn't registered in public builds (see
+ * .storybook/main.ts) and the endpoint only exists on a dev server.
+ */
+
+const ENDPOINT = "/f0-unused-components.json"
+
+interface Row {
+  name: string
+  zone: string
+  status: string
+  storyFile: string | null
+  productFiles: number
+  prototypes: string[]
+  usedBy: string[]
+  unused: boolean
+}
+
+interface Report {
+  generatedAt: string
+  total: number
+  rows: Row[]
+  unused: Row[]
+  sources: {
+    product:
+      | { available: true; scope: string; importingFiles: number }
+      | { available: false; reason: string }
+    composer:
+      | { available: true; prototypes: number }
+      | { available: false; reason: string }
+    internal: { available: true; scope: string }
+  }
+}
+
+export function UnusedComponents() {
+  const [report, setReport] = useState<Report | null>()
+  const [full, setFull] = useState(false)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let active = true
+    setLoading(true)
+
+    fetch(`${ENDPOINT}${full ? "?full=1" : ""}`)
+      .then(async (response) => {
+        const type = response.headers.get("content-type") ?? ""
+        if (!response.ok || !type.includes("application/json")) return null
+        return (await response.json()) as Report
+      })
+      .catch(() => null)
+      .then((data) => {
+        if (!active) return
+        setReport(data)
+        setLoading(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [full])
+
+  if (loading && report === undefined) {
+    return <p>Scanning the product, F0 and Composer prototypes…</p>
+  }
+
+  if (!report) {
+    return (
+      <p>
+        This page needs the Storybook dev server — run{" "}
+        <code>pnpm --filter @factorialco/f0-react dev</code>.
+      </p>
+    )
+  }
+
+  const { sources } = report
+  const byZone = new Map<string, Row[]>()
+  for (const row of report.unused) {
+    if (!byZone.has(row.zone)) byZone.set(row.zone, [])
+    byZone.get(row.zone)?.push(row)
+  }
+
+  return (
+    <div>
+      <p>
+        <strong>
+          {report.unused.length} of {report.total} components are used nowhere
+        </strong>{" "}
+        — no product code, no Composer prototype, no other F0 component.
+      </p>
+
+      <ul>
+        <li>
+          <strong>Product:</strong>{" "}
+          {sources.product.available
+            ? `${sources.product.scope} (${sources.product.importingFiles} importing files)`
+            : sources.product.reason}
+        </li>
+        <li>
+          <strong>Composer:</strong>{" "}
+          {sources.composer.available
+            ? `${sources.composer.prototypes} prototypes`
+            : sources.composer.reason}
+        </li>
+        <li>
+          <strong>F0:</strong> {sources.internal.scope}
+        </li>
+      </ul>
+
+      {!sources.product.available && (
+        <p>
+          <strong>
+            Without a factorial checkout this list isn&apos;t trustworthy
+          </strong>{" "}
+          — every component looks unused in the product.
+        </p>
+      )}
+
+      <p>
+        <label>
+          <input
+            type="checkbox"
+            checked={full}
+            onChange={(event) => setFull(event.target.checked)}
+            disabled={loading}
+          />{" "}
+          Scan the whole factorial monorepo (slower — the default covers{" "}
+          <code>frontend/src/modules</code>)
+        </label>{" "}
+        {loading && <em>Rescanning…</em>}
+      </p>
+
+      {[...byZone]
+        .sort((a, b) => b[1].length - a[1].length)
+        .map(([zone, rows]) => (
+          <section key={zone}>
+            <h3>
+              {zone} ({rows.length})
+            </h3>
+            <table>
+              <thead>
+                <tr>
+                  <th>Component</th>
+                  <th>Maturity</th>
+                  <th>Source</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows
+                  .sort((a, b) => a.name.localeCompare(b.name))
+                  .map((row) => (
+                    <tr key={row.name}>
+                      <td>
+                        <code>{row.name}</code>
+                      </td>
+                      <td>{row.status}</td>
+                      <td>
+                        <code>{row.storyFile}</code>
+                      </td>
+                    </tr>
+                  ))}
+              </tbody>
+            </table>
+          </section>
+        ))}
+
+      <p>
+        <small>
+          Scanned at {new Date(report.generatedAt).toLocaleTimeString()}. Same
+          data as{" "}
+          <code>pnpm --filter @factorialco/f0-react unused-components</code>.
+        </small>
+      </p>
+    </div>
+  )
+}

--- a/packages/react/.storybook/local-docs/UnusedComponents.mdx
+++ b/packages/react/.storybook/local-docs/UnusedComponents.mdx
@@ -1,0 +1,22 @@
+import { Meta } from "@storybook/addon-docs/blocks"
+
+import { UnusedComponents } from "../UnusedComponents.tsx"
+
+{/*
+  Local-only page: it reports internal product and prototype usage, so it is
+  registered in `main.ts` for dev runs and left out of public builds.
+*/}
+
+<Meta title="Resources/Unused components" />
+
+# Unused components
+
+Components nothing imports — not `factorialco/factorial` (or `factorial-it`),
+not a Composer prototype, and not another F0 component. A candidate list for a
+deprecation round, or a prompt to ask why something never found an audience.
+
+Usage is matched on what each component's barrel actually **exports**, not its
+folder name, so a component shipped under a different name (`hooks/toast` →
+`toasts`) is counted correctly.
+
+<UnusedComponents />

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -179,7 +179,10 @@ const config: StorybookConfig = {
     { directory: "../src/ui/Lane", titlePrefix: "Patterns" },
     // Resources
     { directory: "../src/ui/OneRestrictComponent", titlePrefix: "Resources" },
-    ...(process.env.STORYBOOK_PUBLIC_BUILD ? [] : []),
+    // ── Local-only pages ────────────────────────────────────────
+    // "Unused components" reports internal product and prototype usage, so it
+    // is kept out of the public Storybook the same way the usage tag is.
+    ...(process.env.STORYBOOK_PUBLIC_BUILD ? [] : ["./local-docs/*.mdx"]),
   ],
   staticDirs: ["../public", "./static"],
   addons: [

--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -14,6 +14,7 @@ import {
   computeComponentStatusData,
   effectiveStatusByLeaf,
 } from "../scripts/component-status-build.mjs"
+import { productUsageVitePlugin } from "../scripts/product-usage-scan.mjs"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const require = createRequire(import.meta.url)
@@ -248,6 +249,15 @@ const config: StorybookConfig = {
     )
     if (!hasComponentStatus) {
       config.plugins.push(componentStatusVitePlugin())
+    }
+
+    // Serve usage data (scanned from local factorialco/factorial and
+    // factorial-composer checkouts) to the docs "Where is this used in the
+    // product?" tag. It only ever registers a dev-server route, and the tag
+    // itself is compiled out of production bundles — this data is internal and
+    // must not reach the public Storybook at f0.factorial.dev.
+    if (!process.env.STORYBOOK_PUBLIC_BUILD) {
+      config.plugins.push(productUsageVitePlugin())
     }
     // Ensure base is set to '/' to prevent absolute path issues in CI
     // This ensures paths are relative and work correctly when served

--- a/packages/react/.storybook/resolveImportPath.ts
+++ b/packages/react/.storybook/resolveImportPath.ts
@@ -80,26 +80,17 @@ export function resolveImportPath(fileName: string | undefined): string | null {
 }
 
 /**
- * Extracts the component export name from a story file path.
+ * Gathers the names a story file might correspond to, most reliable first:
+ * the impl filename, the story directory, the index-story directory, and the
+ * last segment of the Storybook title.
  *
- * Strategy:
- *   1. Gather candidate names from the file path (impl filename, story
- *      directory, index-story directory) and the Storybook title.
- *   2. First pass — prefer F0-prefixed exports: if any candidate has a
- *      matching `F0${name}` export, return that. This guarantees that when
- *      a component is renamed (e.g. `Input` -> `F0TextInput`) and the old
- *      name is kept as a `@deprecated` alias, the docs surface the new
- *      canonical name.
- *   3. Second pass — fall back to the raw candidate if it is itself an
- *      export (covers components that don't use the F0 prefix, like
- *      `F0Form` field renderers).
- *   4. If nothing matches, return the first candidate as-is.
+ * Callers resolve these against the package's export maps — a candidate that
+ * isn't an export is simply a miss, not an error.
  */
-export function extractComponentName(
+export function componentNameCandidates(
   fileName: string | undefined,
   title: string | undefined
-): string | null {
-  // Gather candidate names from path patterns and title
+): string[] {
   const candidates: string[] = []
 
   if (fileName) {
@@ -125,6 +116,31 @@ export function extractComponentName(
     if (last) candidates.push(last)
   }
 
+  return [...new Set(candidates)]
+}
+
+/**
+ * Extracts the component export name from a story file path.
+ *
+ * Strategy:
+ *   1. Gather candidate names from the file path (impl filename, story
+ *      directory, index-story directory) and the Storybook title.
+ *   2. First pass — prefer F0-prefixed exports: if any candidate has a
+ *      matching `F0${name}` export, return that. This guarantees that when
+ *      a component is renamed (e.g. `Input` -> `F0TextInput`) and the old
+ *      name is kept as a `@deprecated` alias, the docs surface the new
+ *      canonical name.
+ *   3. Second pass — fall back to the raw candidate if it is itself an
+ *      export (covers components that don't use the F0 prefix, like
+ *      `F0Form` field renderers).
+ *   4. If nothing matches, return the first candidate as-is.
+ */
+export function extractComponentName(
+  fileName: string | undefined,
+  title: string | undefined
+): string | null {
+  const candidates = componentNameCandidates(fileName, title)
+
   const exports = {
     ...mainExports,
     ...experimentalExports,
@@ -144,4 +160,43 @@ export function extractComponentName(
 
   // Fallback: return the first candidate as-is
   return candidates[0] ?? null
+}
+
+/**
+ * Every name this component might be imported under, most authoritative
+ * first: the canonical export, then aliases kept for backwards compatibility
+ * (e.g. `Input` alongside `F0TextInput`), then the remaining path/title
+ * candidates.
+ *
+ * Used to look the component up in consumer code. Names that aren't public
+ * exports are kept on purpose: a component missing from the public barrels
+ * (like `AIButton`) simply has no usage to find, and saying "not used" is more
+ * useful than showing nothing. They can't produce a false positive either — a
+ * name only shows up in a consumer scan if that consumer imported it from the
+ * package, which means it is exported after all.
+ */
+export function usageLookupNames(
+  fileName: string | undefined,
+  title: string | undefined
+): string[] {
+  const exports = {
+    ...mainExports,
+    ...experimentalExports,
+  } as Record<string, unknown>
+
+  const candidates = componentNameCandidates(fileName, title)
+  const names: string[] = []
+
+  const canonical = extractComponentName(fileName, title)
+  if (canonical) names.push(canonical)
+
+  for (const candidate of candidates) {
+    if (candidate in exports && !names.includes(candidate))
+      names.push(candidate)
+  }
+  for (const candidate of candidates) {
+    if (!names.includes(candidate)) names.push(candidate)
+  }
+
+  return names
 }

--- a/packages/react/.storybook/resolveImportPath.ts
+++ b/packages/react/.storybook/resolveImportPath.ts
@@ -163,6 +163,26 @@ export function extractComponentName(
 }
 
 /**
+ * The component folder a story belongs to, relative to `src/`
+ * (`./src/hooks/toast/__stories__/toast.stories.tsx` → `hooks/toast`).
+ *
+ * Used to look up what that folder actually exports — the docs tag can't read
+ * the filesystem, so the scanner ships an index keyed by this path.
+ */
+export function storyComponentPath(
+  fileName: string | undefined
+): string | null {
+  if (!fileName) return null
+
+  const normalized = fileName.replace(/^\.\//, "").replace(/^src\//, "")
+  const segments = normalized.split("/")
+  const storiesAt = segments.indexOf("__stories__")
+  const dirs = segments.slice(0, storiesAt === -1 ? -1 : storiesAt)
+
+  return dirs.length > 0 ? dirs.join("/") : null
+}
+
+/**
  * Every name this component might be imported under, most authoritative
  * first: the canonical export, then aliases kept for backwards compatibility
  * (e.g. `Input` alongside `F0TextInput`), then the remaining path/title

--- a/packages/react/.storybook/usage-contract.ts
+++ b/packages/react/.storybook/usage-contract.ts
@@ -1,0 +1,11 @@
+/**
+ * Strings the docs tag and the scanner both depend on.
+ *
+ * Deliberately its own file with no imports: the tag can't import anything
+ * from `scripts/product-usage-scan.mjs` at runtime — that module reaches for
+ * `node:child_process` and `node:fs`, which would blow up the browser bundle.
+ * The scanner keeps its own copy, and a unit test asserts the two match.
+ */
+
+/** Reported when a pull refuses to touch a checkout with uncommitted work. */
+export const DIRTY_MESSAGE = "Working tree is dirty — pull skipped"

--- a/packages/react/.storybook/useProductUsage.ts
+++ b/packages/react/.storybook/useProductUsage.ts
@@ -29,11 +29,25 @@ type State = UsageResult | null | undefined
 
 let state: State
 let inFlight: Promise<void> | undefined
-const listeners = new Set<(next: State) => void>()
+let rescanning = false
+const listeners = new Set<() => void>()
+
+function notify() {
+  for (const listener of listeners) listener()
+}
 
 function publish(next: State) {
+  const wasRunning = isRunning(state)
   state = next
-  for (const listener of listeners) listener(next)
+
+  // A clone or pull that just finished changed what's on disk, so the numbers
+  // on screen are stale the moment it lands. Refresh them without making
+  // anyone find the Rescan button.
+  if (wasRunning && !isRunning(next)) {
+    void rescan()
+  }
+
+  notify()
 }
 
 async function load(): Promise<void> {
@@ -73,39 +87,49 @@ function isRunning(value: State) {
 
 /**
  * The usage payload: `undefined` while loading, `null` when unavailable (no
- * endpoint — i.e. the public build), otherwise the scan result.
+ * endpoint — i.e. the public build), otherwise the scan result. `rescanning`
+ * covers both the manual button and the refresh that follows a clone or pull.
  */
 export function useProductUsage() {
-  const [value, setValue] = useState<State>(state)
+  const [, forceRender] = useState(0)
 
   useEffect(() => {
-    listeners.add(setValue)
+    const listener = () => forceRender((n) => n + 1)
+    listeners.add(listener)
     ensureLoaded()
     return () => {
-      listeners.delete(setValue)
+      listeners.delete(listener)
     }
   }, [])
 
   // A clone runs for minutes; keep re-reading so the tag shows the result
   // without anyone having to reload Storybook.
   useEffect(() => {
-    if (!isRunning(value)) return
+    if (!isRunning(state)) return
     const timer = setInterval(() => ensureLoaded(true), POLL_MS)
     return () => clearInterval(timer)
-  }, [value])
+  })
 
-  return value
+  return { data: state, rescanning }
 }
 
 /** Re-runs the scan (bypassing the server's cache) and republishes it. */
 export async function rescan() {
   if (!ENABLED) return
+
+  rescanning = true
+  notify()
   try {
     const response = await fetch(`${ENDPOINT}?refresh=1`)
-    if (response.ok) publish((await response.json()) as UsageResult)
+    if (response.ok) {
+      state = (await response.json()) as UsageResult
+    }
   } catch {
     // Leave the previous data in place — a failed refresh isn't worth blanking
     // the tag for.
+  } finally {
+    rescanning = false
+    notify()
   }
 }
 
@@ -114,15 +138,37 @@ export async function rescan() {
  * there. Returns as soon as the work has started; progress arrives through the
  * usual payload (see `actions`).
  */
-export async function runRepoAction(repo: string, action: "clone" | "pull") {
-  if (!ENABLED) return
+export async function runRepoAction(
+  repo: string,
+  action: "clone" | "pull" | "stash-pull"
+): Promise<{ ok: boolean; message?: string }> {
+  if (!ENABLED) return { ok: false, message: "Disabled outside dev" }
+
+  let outcome: { ok: boolean; message?: string }
   try {
-    await fetch(`${ACTION_ENDPOINT}?repo=${repo}&action=${action}`, {
-      method: "POST",
-    })
-  } catch {
-    // The server reports failures through the payload; a network error here
-    // just means nothing started.
+    const response = await fetch(
+      `${ACTION_ENDPOINT}?repo=${repo}&action=${action}`,
+      { method: "POST" }
+    )
+    // A refusal here (stale dev server that doesn't know this action, wrong
+    // method, cross-origin) is silent otherwise, and silence is exactly what
+    // makes a button feel broken.
+    outcome = response.ok
+      ? { ok: true }
+      : {
+          ok: false,
+          message:
+            (
+              (await response.json().catch(() => null)) as {
+                message?: string
+              } | null
+            )?.message ?? `Request failed (${response.status})`,
+        }
+  } catch (error) {
+    outcome = { ok: false, message: `Could not reach the dev server` }
+    void error
   }
+
   await ensureLoaded(true)
+  return outcome
 }

--- a/packages/react/.storybook/useProductUsage.ts
+++ b/packages/react/.storybook/useProductUsage.ts
@@ -1,0 +1,128 @@
+import { useEffect, useState } from "react"
+
+import type { UsageResult } from "../scripts/product-usage-scan.mjs"
+
+/**
+ * Data layer for the docs usage tag: one fetch shared by every docs page, plus
+ * the clone/pull actions the tag can trigger.
+ *
+ * Served by the Storybook dev server (see scripts/product-usage-scan.mjs).
+ * Endpoints are literals rather than imports so this module never pulls Node
+ * built-ins into the browser bundle.
+ */
+const ENDPOINT = "/f0-product-usage.json"
+const ACTION_ENDPOINT = "/f0-usage-repo-action"
+
+/** How often to re-read the payload while a clone or pull is running. */
+const POLL_MS = 2000
+
+/**
+ * Local dev only. This data — product module names, internal prototype titles
+ * — must never reach the public Storybook at f0.factorial.dev, which anyone
+ * outside the company can read. `import.meta.env.DEV` is inlined at build
+ * time, so the static bundle drops the tag and its requests entirely rather
+ * than relying on the endpoints 404ing.
+ */
+export const ENABLED = import.meta.env.DEV
+
+type State = UsageResult | null | undefined
+
+let state: State
+let inFlight: Promise<void> | undefined
+const listeners = new Set<(next: State) => void>()
+
+function publish(next: State) {
+  state = next
+  for (const listener of listeners) listener(next)
+}
+
+async function load(): Promise<void> {
+  if (!ENABLED) return publish(null)
+
+  try {
+    const response = await fetch(ENDPOINT)
+    // A static build serves index.html for unknown paths, so a 200 alone isn't
+    // proof the endpoint exists — check what came back.
+    const contentType = response.headers.get("content-type") ?? ""
+    if (!response.ok || !contentType.includes("application/json")) {
+      return publish(null)
+    }
+    publish((await response.json()) as UsageResult)
+  } catch {
+    publish(null)
+  }
+}
+
+/** Fetches once per session; later calls re-read the (possibly changed) data. */
+function ensureLoaded(force = false) {
+  if (!force && (state !== undefined || inFlight)) return
+  inFlight = load().finally(() => {
+    inFlight = undefined
+  })
+}
+
+/** Any clone or pull still in progress? Drives the poll. */
+function isRunning(value: State) {
+  return Boolean(
+    value &&
+    Object.values(value.actions ?? {}).some(
+      (action) => action.state === "running"
+    )
+  )
+}
+
+/**
+ * The usage payload: `undefined` while loading, `null` when unavailable (no
+ * endpoint — i.e. the public build), otherwise the scan result.
+ */
+export function useProductUsage() {
+  const [value, setValue] = useState<State>(state)
+
+  useEffect(() => {
+    listeners.add(setValue)
+    ensureLoaded()
+    return () => {
+      listeners.delete(setValue)
+    }
+  }, [])
+
+  // A clone runs for minutes; keep re-reading so the tag shows the result
+  // without anyone having to reload Storybook.
+  useEffect(() => {
+    if (!isRunning(value)) return
+    const timer = setInterval(() => ensureLoaded(true), POLL_MS)
+    return () => clearInterval(timer)
+  }, [value])
+
+  return value
+}
+
+/** Re-runs the scan (bypassing the server's cache) and republishes it. */
+export async function rescan() {
+  if (!ENABLED) return
+  try {
+    const response = await fetch(`${ENDPOINT}?refresh=1`)
+    if (response.ok) publish((await response.json()) as UsageResult)
+  } catch {
+    // Leave the previous data in place — a failed refresh isn't worth blanking
+    // the tag for.
+  }
+}
+
+/**
+ * Asks the dev server to clone a repo, or fast-forward it if it's already
+ * there. Returns as soon as the work has started; progress arrives through the
+ * usual payload (see `actions`).
+ */
+export async function runRepoAction(repo: string, action: "clone" | "pull") {
+  if (!ENABLED) return
+  try {
+    await fetch(`${ACTION_ENDPOINT}?repo=${repo}&action=${action}`, {
+      method: "POST",
+    })
+  } catch {
+    // The server reports failures through the payload; a network error here
+    // just means nothing started.
+  }
+  await ensureLoaded(true)
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -43,6 +43,7 @@
     "build-api": "pnpm --dir api install --ignore-workspace && pnpm --dir api run build",
     "serve-storybook": "http-server storybook-static",
     "test-storybook": "test-storybook --testTimeout=60000",
+    "unused-components": "node scripts/unused-components.mjs",
     "format": "sh -c 'oxfmt \"${@:-src/}\"' --",
     "format:check": "sh -c 'oxfmt --check \"${@:-src/}\"' --",
     "tsc": "tsc --noEmit",

--- a/packages/react/scripts/component-usage-report.mjs
+++ b/packages/react/scripts/component-usage-report.mjs
@@ -1,0 +1,169 @@
+/**
+ * component-usage-report.mjs
+ *
+ * Joins the documented components (from the component-status scan) to the
+ * usage scans, so both the CLI (`pnpm unused-components`) and the Storybook
+ * "Unused components" page answer from one implementation.
+ *
+ * A component counts as USED if any of its candidate names turns up in:
+ *   - product   — `factorialco/factorial` (+ `factorialco/factorial-it`)
+ *   - composer  — `factorialco/factorial-composer` prototypes
+ *   - f0        — another component in this package's `src/`
+ */
+
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { computeComponentStatusData } from "./component-status-build.mjs"
+import {
+  exportedNamesOf,
+  scanComposerUsage,
+  scanInternalUsage,
+  scanProductUsage,
+} from "./product-usage-scan.mjs"
+
+const SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../src")
+
+/** Last segment of a grouped component name ("Avatars/Avatar" → "Avatar"). */
+function leafName(name) {
+  const parts = name.split("/")
+  return parts[parts.length - 1] ?? name
+}
+
+/**
+ * The implementation folder a story belongs to — the deepest capitalised
+ * directory on its path. Several story files share one folder
+ * (`OneDataCollection/__stories__/grouping.stories.tsx`,
+ * `…/url-params.stories.tsx`), and it's the folder, not each story page, that
+ * is the unit people mean by "component".
+ */
+function componentDirOf(storyFile) {
+  if (!storyFile) return null
+  const segments = storyFile.split("/").slice(0, -1)
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (/^[A-Z]/.test(segments[i])) return segments[i]
+  }
+  return null
+}
+
+/** The directory a story file lives in, as an absolute path. */
+function componentPathOf(storyFile) {
+  if (!storyFile) return null
+  const segments = storyFile.split("/")
+  const storiesAt = segments.indexOf("__stories__")
+  const dirs = segments.slice(0, storiesAt === -1 ? -1 : storiesAt)
+  return dirs.length > 0 ? join(SRC_DIR, ...dirs) : null
+}
+
+/**
+ * The names a component might be imported under: its folder and title, their
+ * `F0`-prefixed forms, and whatever its barrel actually exports.
+ */
+function candidateNames(component) {
+  const candidates = []
+  for (const base of [
+    componentDirOf(component.storyFile),
+    leafName(component.name),
+  ]) {
+    if (!base) continue
+    candidates.push(base)
+    if (!base.startsWith("F0")) candidates.push(`F0${base}`)
+  }
+  candidates.push(...exportedNamesOf(componentPathOf(component.storyFile)))
+  return [...new Set(candidates)]
+}
+
+/**
+ * Every documented component with where it's used, plus the subset used
+ * nowhere. `full` widens the product scan to the whole factorial monorepo.
+ */
+export function computeUsageReport({ full = false } = {}) {
+  const { components } = computeComponentStatusData()
+  const product = scanProductUsage({ full })
+  const internal = scanInternalUsage()
+  const composer = scanComposerUsage()
+
+  // One row per implementation folder: the docs list a component several times
+  // (one story file per facet), but it is used or unused as a whole.
+  const merged = new Map()
+  for (const component of components) {
+    const key = componentDirOf(component.storyFile) ?? leafName(component.name)
+    const existing = merged.get(key)
+    if (existing) {
+      existing.titles.push(component.name)
+      for (const name of candidateNames(component)) {
+        if (!existing.names.includes(name)) existing.names.push(name)
+      }
+      continue
+    }
+    merged.set(key, {
+      key,
+      titles: [component.name],
+      zone: component.zone,
+      apiStatus: component.apiStatus,
+      storyFile: component.storyFile,
+      names: candidateNames(component),
+    })
+  }
+
+  const rows = [...merged.values()].map((component) => {
+    const names = component.names
+
+    const productFiles = product.available
+      ? names.reduce(
+          (total, name) => total + (product.components[name]?.files ?? 0),
+          0
+        )
+      : 0
+
+    const prototypes = composer.available
+      ? [
+          ...new Set(
+            names.flatMap((name) =>
+              (composer.prototypes[name] ?? []).map((p) => p.title)
+            )
+          ),
+        ]
+      : []
+
+    const usedBy = internal.available
+      ? [
+          ...new Set(names.flatMap((name) => internal.components[name] ?? [])),
+        ].filter((owner) => !names.includes(owner))
+      : []
+
+    return {
+      name: component.key,
+      titles: component.titles,
+      zone: component.zone,
+      status: component.apiStatus,
+      storyFile: component.storyFile,
+      productFiles,
+      prototypes,
+      usedBy,
+      unused:
+        productFiles === 0 && prototypes.length === 0 && usedBy.length === 0,
+    }
+  })
+
+  return {
+    generatedAt: new Date().toISOString(),
+    sources: {
+      product: product.available
+        ? {
+            available: true,
+            scope: product.scope,
+            importingFiles: product.totals.importingFiles,
+            missing: product.missing,
+          }
+        : { available: false, reason: product.reason },
+      composer: composer.available
+        ? { available: true, prototypes: composer.totals.prototypes }
+        : { available: false, reason: composer.reason },
+      internal: { available: true, scope: internal.scope },
+    },
+    total: rows.length,
+    rows,
+    unused: rows.filter((row) => row.unused),
+  }
+}

--- a/packages/react/scripts/component-usage-report.mjs
+++ b/packages/react/scripts/component-usage-report.mjs
@@ -165,5 +165,13 @@ export function computeUsageReport({ full = false } = {}) {
     total: rows.length,
     rows,
     unused: rows.filter((row) => row.unused),
+    /**
+     * Built, prototyped, not shipped. A different signal from "unused": the
+     * product hasn't adopted it *yet*, and a prototype is usually where
+     * adoption starts — so these are worth watching rather than deprecating.
+     */
+    onlyInPrototypes: rows.filter(
+      (row) => row.productFiles === 0 && row.prototypes.length > 0
+    ),
   }
 }

--- a/packages/react/scripts/product-usage-scan.d.mts
+++ b/packages/react/scripts/product-usage-scan.d.mts
@@ -34,6 +34,11 @@ export interface ProductUsageData {
     modules: number
     importingFiles: number
   }>
+  /**
+   * Consumer repos that weren't checked out, with the env var that would point
+   * at them. Their absence makes the counts partial, so the docs tag says so.
+   */
+  missing: Array<{ id: string; env: string }>
   totals: {
     modules: number
     scannedFiles: number

--- a/packages/react/scripts/product-usage-scan.d.mts
+++ b/packages/react/scripts/product-usage-scan.d.mts
@@ -4,6 +4,8 @@
 export interface UsageUnavailable {
   available: false
   reason: string
+  /** Repos that could have been scanned, so the tag can offer to clone them. */
+  missing?: Array<{ id: string; env: string }>
 }
 
 /** Per-component usage across the product's feature modules. */
@@ -99,16 +101,37 @@ export interface ComposerUsageData {
 
 export type ComposerUsageResult = ComposerUsageData | UsageUnavailable
 
+/** Progress of a clone or fast-forward the docs tag asked for. */
+export interface RepoActionState {
+  state: "running" | "done" | "error"
+  action: string
+  message: string
+}
+
 /** The endpoint payload: every scan, each with its own availability. */
 export interface UsageResult {
   generatedAt: string
   product: ProductUsageResult
   internal: InternalUsageResult
   composer: ComposerUsageResult
+  /** Repo id → progress of the clone/pull started from the docs tag. */
+  actions: Record<string, RepoActionState>
 }
 
 /** The dev-server route serving the scan result. */
 export const PRODUCT_USAGE_ENDPOINT: string
+
+/** The dev-server route that clones or fast-forwards a scanned repo. */
+export const REPO_ACTION_ENDPOINT: string
+
+/** Repos the docs tag can offer to clone, keyed by id. */
+export const KNOWN_REPOS: Record<string, { url: string }>
+
+/** Clones a known repo, or fast-forwards it when it's already checked out. */
+export function runRepoAction(
+  id: string,
+  action: "clone" | "pull"
+): Promise<RepoActionState | { ok: false; message: string }>
 
 /** Path, relative to the product repo root, that we scan. */
 export const PRODUCT_SCOPE: string

--- a/packages/react/scripts/product-usage-scan.d.mts
+++ b/packages/react/scripts/product-usage-scan.d.mts
@@ -116,6 +116,14 @@ export interface UsageResult {
   composer: ComposerUsageResult
   /** Repo id → progress of the clone/pull started from the docs tag. */
   actions: Record<string, RepoActionState>
+  /**
+   * Repo id → uncommitted work this tool stashed, and the branch it was on.
+   * Separate from `actions` so the note outlives the next click.
+   */
+  stashes: Record<
+    string,
+    { label: string; branch: string | null; at: string }
+  >
 }
 
 /** The dev-server route serving the scan result. */

--- a/packages/react/scripts/product-usage-scan.d.mts
+++ b/packages/react/scripts/product-usage-scan.d.mts
@@ -1,0 +1,155 @@
+/** Type declarations for the JS build helper (see product-usage-scan.mjs). */
+
+/** No checkout was found for a source (or its scan failed). */
+export interface UsageUnavailable {
+  available: false
+  reason: string
+}
+
+/** Per-component usage across the product's feature modules. */
+export interface ProductUsageEntry {
+  /** Number of product files importing this export. */
+  files: number
+  /** Module name → number of importing files in that module. */
+  modules: Record<string, number>
+}
+
+/** A successful scan of a local `factorialco/factorial` checkout. */
+export interface ProductUsageData {
+  available: true
+  generatedAt: string
+  repo: {
+    root: string
+    /** The `@factorialco/f0-react` range in the product's frontend package.json. */
+    f0Version: string | null
+    lastModified: string | null
+  }
+  /** Human-readable summary of what was scanned across repos. */
+  scope: string
+  /** One entry per consumer repo that was found and scanned. */
+  repos: Array<{
+    id: string
+    root: string
+    scope: string
+    modules: number
+    importingFiles: number
+  }>
+  totals: {
+    modules: number
+    scannedFiles: number
+    importingFiles: number
+    components: number
+  }
+  /** Exported name → usage. Names absent from the map are unused. */
+  components: Record<string, ProductUsageEntry>
+}
+
+export type ProductUsageResult = ProductUsageData | UsageUnavailable
+
+/** A scan of f0's own `src/` — always available, no checkout needed. */
+export interface InternalUsageData {
+  available: true
+  /** Path that was scanned, relative to this package (`src`). */
+  scope: string
+  /**
+   * Imported name → the f0 components importing it (deepest capitalised
+   * directory on the importing file's path), sorted. Self-imports from a
+   * component's own internals are excluded.
+   */
+  components: Record<string, string[]>
+}
+
+export type InternalUsageResult = InternalUsageData | UsageUnavailable
+
+/** A Composer prototype (`src/projects/<project>/<slug>`). */
+export interface ComposerPrototype {
+  /** Project folder the prototype belongs to. */
+  project: string
+  /** kebab-case id, also its route (`/p/<slug>`). */
+  slug: string
+  title: string
+  /** `published` / `internal-draft` / `archived`, when declared. */
+  status: string | null
+}
+
+/** A successful scan of a local `factorialco/factorial-composer` checkout. */
+export interface ComposerUsageData {
+  available: true
+  repo: { root: string }
+  /** Repo-relative path that was scanned (`src/projects`). */
+  scope: string
+  totals: { prototypes: number }
+  /**
+   * Exported name → the prototypes importing it. Deliberately a list, not a
+   * count: prototype files must never inflate the product usage numbers.
+   */
+  prototypes: Record<string, ComposerPrototype[]>
+}
+
+export type ComposerUsageResult = ComposerUsageData | UsageUnavailable
+
+/** The endpoint payload: every scan, each with its own availability. */
+export interface UsageResult {
+  generatedAt: string
+  product: ProductUsageResult
+  internal: InternalUsageResult
+  composer: ComposerUsageResult
+}
+
+/** The dev-server route serving the scan result. */
+export const PRODUCT_USAGE_ENDPOINT: string
+
+/** Path, relative to the product repo root, that we scan. */
+export const PRODUCT_SCOPE: string
+
+/** Path, relative to the Composer repo root, holding the prototypes. */
+export const COMPOSER_SCOPE: string
+
+/** Extracts the names a source file imports from `@factorialco/f0-react`. */
+export function parseF0Imports(source: string): string[]
+
+/** Locates a local `factorialco/factorial` checkout, or `null`. */
+export function resolveProductRepoRoot(
+  env?: Record<string, string | undefined>
+): string | null
+
+/** Locates a local `factorialco/factorial-it` checkout, or `null`. */
+export function resolveItRepoRoot(
+  env?: Record<string, string | undefined>
+): string | null
+
+/** Locates a local `factorialco/factorial-composer` checkout, or `null`. */
+export function resolveComposerRepoRoot(
+  env?: Record<string, string | undefined>
+): string | null
+
+/**
+ * Scans the product repos for `@factorialco/f0-react` imports.
+ *
+ * `full` widens the factorial monorepo from `frontend/src/modules` to
+ * everything, grouped by top-level directory.
+ */
+export function scanProductUsage(options?: {
+  repoRoot?: string | null
+  itRepoRoot?: string | null
+  full?: boolean
+}): ProductUsageResult
+
+/** Scans f0's own `src/` for components importing each other. */
+export function scanInternalUsage(options?: {
+  srcDir?: string
+}): InternalUsageResult
+
+/** Scans the Composer repo for the prototypes using each component. */
+export function scanComposerUsage(options?: {
+  repoRoot?: string | null
+}): ComposerUsageResult
+
+/** Runs both scans — the payload the endpoint serves. */
+export function scanUsage(): UsageResult
+
+/** Vite plugin serving the scan result from the Storybook dev server. */
+export function productUsageVitePlugin(): {
+  name: string
+  configureServer(server: unknown): void
+}

--- a/packages/react/scripts/product-usage-scan.d.mts
+++ b/packages/react/scripts/product-usage-scan.d.mts
@@ -62,6 +62,12 @@ export interface InternalUsageData {
    * component's own internals are excluded.
    */
   components: Record<string, string[]>
+  /**
+   * Component folder (relative to `src/`) → the names its barrel exports.
+   * Lets the docs tag look a component up under the name it actually ships
+   * (`hooks/toast` → `toasts`), which its folder name rarely matches.
+   */
+  exports: Record<string, string[]>
 }
 
 export type InternalUsageResult = InternalUsageData | UsageUnavailable
@@ -139,6 +145,14 @@ export function scanProductUsage(options?: {
   itRepoRoot?: string | null
   full?: boolean
 }): ProductUsageResult
+
+/** The names a component folder's barrel exports. */
+export function exportedNamesOf(componentPath: string | null): string[]
+
+/** Component folder (relative to `src/`) → the names it exports. */
+export function scanComponentExports(options?: {
+  srcDir?: string
+}): Record<string, string[]>
 
 /** Scans f0's own `src/` for components importing each other. */
 export function scanInternalUsage(options?: {

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -52,6 +52,9 @@ export const PRODUCT_USAGE_ENDPOINT = "/f0-product-usage.json"
 /** The dev-server route that clones or fast-forwards a scanned repo. */
 export const REPO_ACTION_ENDPOINT = "/f0-usage-repo-action"
 
+/** The dev-server route behind the "Unused components" docs page. */
+export const UNUSED_COMPONENTS_ENDPOINT = "/f0-unused-components.json"
+
 /** Path, relative to the product repo root, that we scan. */
 export const PRODUCT_SCOPE = join("frontend", "src", "modules")
 
@@ -923,6 +926,9 @@ async function defaultBranchOf(root) {
 /** In-process cache so page views don't each trigger a filesystem walk. */
 let cache = null
 
+/** Same, for the heavier report behind the Unused components page. */
+const reportCache = Object.create(null)
+
 function getUsage({ refresh = false } = {}) {
   const now = Date.now()
   if (!refresh && cache && now - cache.at < CACHE_TTL_MS) return cache.data
@@ -959,6 +965,26 @@ export function productUsageVitePlugin() {
         res.setHeader("Content-Type", "application/json; charset=utf-8")
         res.setHeader("Cache-Control", "no-store")
         res.end(body)
+      })
+
+      server.middlewares.use(UNUSED_COMPONENTS_ENDPOINT, async (req, res) => {
+        // Imported lazily: it pulls in the component-status scan, which the
+        // usage endpoint doesn't need.
+        const { computeUsageReport } = await import(
+          "./component-usage-report.mjs"
+        )
+        const full = (req.url ?? "").includes("full=1")
+        const refresh = (req.url ?? "").includes("refresh=1")
+
+        const key = full ? "full" : "scoped"
+        const now = Date.now()
+        if (refresh || !reportCache[key] || now - reportCache[key].at > CACHE_TTL_MS) {
+          reportCache[key] = { at: now, data: computeUsageReport({ full }) }
+        }
+
+        res.setHeader("Content-Type", "application/json; charset=utf-8")
+        res.setHeader("Cache-Control", "no-store")
+        res.end(JSON.stringify(reportCache[key].data))
       })
 
       server.middlewares.use(REPO_ACTION_ENDPOINT, (req, res) => {

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -131,10 +131,33 @@ export function parseF0Imports(source) {
 }
 
 /**
- * Locates a sibling checkout named `repoName`, in order of preference:
- *   1. `envPath` (explicit opt-in / non-standard layouts)
+ * Where people keep their checkouts, relative to `~`. Ordered by how common
+ * they are; each is a single `existsSync` so the whole list is free.
+ *
+ * The point is that nobody should have to configure anything: if the repo is
+ * cloned anywhere conventional, it's found. `$F0_*_REPO` stays as the escape
+ * hatch for layouts this can't guess (an external drive, a nested workspace).
+ */
+const COMMON_CHECKOUT_PARENTS = [
+  "code",
+  "dev",
+  "src",
+  "repos",
+  "projects",
+  "work",
+  "workspace",
+  "Developer",
+  "Projects",
+  "Code",
+  join("Documents", "GitHub"),
+  join("Documents", "code"),
+]
+
+/**
+ * Locates a checkout named `repoName`, in order of preference:
+ *   1. `envPath` (explicit opt-in / unguessable layouts)
  *   2. a sibling of this repo (`../<repoName>`)
- *   3. `~/code/<repoName>`
+ *   3. `~/<common parent>/<repoName>` (see COMMON_CHECKOUT_PARENTS)
  *
  * A candidate only counts when it contains `marker`, so an unrelated directory
  * of the same name can't be mistaken for the repo. Note that this package may
@@ -154,7 +177,9 @@ function resolveSiblingRepo(repoName, marker, envPath) {
     dir = parent
   }
 
-  candidates.push(join(homedir(), "code", repoName))
+  for (const parent of COMMON_CHECKOUT_PARENTS) {
+    candidates.push(join(homedir(), parent, repoName))
+  }
 
   for (const candidate of candidates) {
     if (existsSync(join(candidate, marker))) return candidate

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -712,6 +712,8 @@ export function scanUsage() {
     composer: scanComposerUsage(),
     // Progress of any clone/pull the tag started, so it can report back.
     actions: { ...actions },
+    // Uncommitted work this tool set aside, kept until Storybook restarts.
+    stashes: { ...stashes },
   }
 }
 
@@ -756,6 +758,21 @@ function checkoutParent() {
  */
 const actions = Object.create(null)
 
+/**
+ * Exact wording the tag matches on to offer the stash-and-pull escape hatch.
+ * Shared so the two sides can't drift apart.
+ */
+export const DIRTY_MESSAGE = "Working tree is dirty — pull skipped"
+
+/**
+ * Work this tool moved aside, by repo id.
+ *
+ * Kept apart from `actions` because that entry is overwritten by whatever runs
+ * next: the note saying where somebody's uncommitted work went must outlive
+ * the next click on "Pull latest".
+ */
+const stashes = Object.create(null)
+
 function runGit(args, options = {}) {
   return new Promise((resolvePromise) => {
     execFile("git", args, { maxBuffer: 1024 * 1024, ...options }, (error, stdout, stderr) => {
@@ -772,7 +789,7 @@ function runGit(args, options = {}) {
  * there. Never merges or rebases, and refuses to touch a dirty working tree —
  * this runs against somebody's real checkout, possibly mid-task.
  */
-export async function runRepoAction(id, action) {
+export async function runRepoAction(id, action, options = {}) {
   const repo = KNOWN_REPOS[id]
   if (!repo) return { ok: false, message: `Unknown repo: ${id}` }
   if (actions[id]?.state === "running") return actions[id]
@@ -786,7 +803,9 @@ export async function runRepoAction(id, action) {
     return actions[id]
   }
 
-  const existing = repo.resolve()
+  // `root` is a test seam only — the HTTP handler passes an id and an action
+  // and nothing else, so a request can never point git at a path.
+  const existing = options.root ?? repo.resolve()
 
   if (action === "clone") {
     if (existing) return finish("done", `Already cloned at ${existing}`)
@@ -817,21 +836,88 @@ export async function runRepoAction(id, action) {
       : finish("error", result.output.trim().split("\n").slice(-3).join(" "))
   }
 
-  if (action === "pull") {
+  if (action === "pull" || action === "stash-pull") {
     if (!existing) return finish("error", "Nothing to pull — not cloned yet")
 
     const status = await runGit(["-C", existing, "status", "--porcelain"])
-    if (status.output.trim()) {
-      return finish("error", "Working tree is dirty — pull skipped")
+    const dirty = Boolean(status.output.trim())
+
+    if (dirty && action === "pull") {
+      return finish("error", DIRTY_MESSAGE)
+    }
+
+    const notes = []
+
+    if (dirty) {
+      // Named and timestamped: whatever this moves aside has to be findable
+      // afterwards, because it's somebody's unfinished work.
+      const label = `f0 usage tag: auto-stash ${new Date().toISOString()}`
+      const stash = await runGit([
+        "-C",
+        existing,
+        "stash",
+        "push",
+        "--include-untracked",
+        "-m",
+        label,
+      ])
+      if (!stash.ok) {
+        return finish("error", `Could not stash: ${lastLines(stash.output, 2)}`)
+      }
+      notes.push("stashed your changes")
+      stashes[id] = { label, branch: null, at: new Date().toISOString() }
+    }
+
+    const branch = (
+      await runGit(["-C", existing, "rev-parse", "--abbrev-ref", "HEAD"])
+    ).output.trim()
+    const target = await defaultBranchOf(existing)
+
+    // Recorded so the note can say which branch to go back to, not just that
+    // something was stashed.
+    if (stashes[id] && !stashes[id].branch) stashes[id].branch = branch
+
+    if (branch && branch !== target) {
+      const checkout = await runGit(["-C", existing, "checkout", target])
+      if (!checkout.ok) {
+        return finish(
+          "error",
+          `Stashed, but could not switch to ${target}: ${lastLines(checkout.output, 2)}`
+        )
+      }
+      notes.push(`switched ${branch} → ${target}`)
     }
 
     const result = await runGit(["-C", existing, "pull", "--ff-only"])
-    return result.ok
-      ? finish("done", "Up to date")
-      : finish("error", result.output.trim().split("\n").slice(-2).join(" "))
+    if (!result.ok) {
+      return finish(
+        "error",
+        [...notes, `pull failed: ${lastLines(result.output, 2)}`].join("; ")
+      )
+    }
+
+    return finish("done", [...notes, "up to date"].join("; "))
   }
 
   return finish("error", `Unknown action: ${action}`)
+}
+
+/** The last `count` lines of git output, for messages that stay readable. */
+function lastLines(output, count) {
+  return output.trim().split("\n").slice(-count).join(" ")
+}
+
+/** The remote's default branch (`origin/HEAD`), falling back to `main`. */
+async function defaultBranchOf(root) {
+  const head = await runGit([
+    "-C",
+    root,
+    "symbolic-ref",
+    "--short",
+    "refs/remotes/origin/HEAD",
+  ])
+  const name = head.output.trim().replace(/^origin\//, "")
+  return head.ok && name ? name : "main"
 }
 
 /** In-process cache so page views don't each trigger a filesystem walk. */
@@ -899,7 +985,10 @@ export function productUsageVitePlugin() {
         const id = params.get("repo") ?? ""
         const action = params.get("action") ?? ""
 
-        if (!(id in KNOWN_REPOS) || !["clone", "pull"].includes(action)) {
+        if (
+          !(id in KNOWN_REPOS) ||
+          !["clone", "pull", "stash-pull"].includes(action)
+        ) {
           return json(400, { ok: false, message: "Unknown repo or action" })
         }
 

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -268,27 +268,31 @@ function f0ImportsOf(path) {
  * called `frontend` can't be confused with a factorial feature module.
  */
 function consumerSources({ repoRoot, itRepoRoot, full }) {
-  const sources = []
-
-  if (repoRoot) {
-    sources.push({
+  const configured = [
+    {
       id: "factorial",
+      env: "F0_PRODUCT_REPO",
       root: repoRoot,
       scope: full ? "." : PRODUCT_SCOPE,
       prefix: "",
-    })
-  }
-
-  if (itRepoRoot) {
-    sources.push({
+    },
+    {
       id: "factorial-it",
+      env: "F0_IT_REPO",
       root: itRepoRoot,
       scope: ".",
       prefix: "factorial-it/",
-    })
-  }
+    },
+  ]
 
-  return sources
+  return {
+    sources: configured.filter((source) => source.root),
+    // Reported so the docs tag can say the numbers are partial rather than
+    // presenting a count that silently excludes a whole product surface.
+    missing: configured
+      .filter((source) => !source.root)
+      .map(({ id, env }) => ({ id, env })),
+  }
 }
 
 /**
@@ -303,7 +307,7 @@ export function scanProductUsage({
   itRepoRoot = resolveItRepoRoot(),
   full = false,
 } = {}) {
-  const sources = consumerSources({ repoRoot, itRepoRoot, full })
+  const { sources, missing } = consumerSources({ repoRoot, itRepoRoot, full })
 
   if (sources.length === 0) {
     return {
@@ -361,6 +365,7 @@ export function scanProductUsage({
     },
     scope: sources.map((source) => join(source.id, source.scope)).join(", "),
     repos,
+    missing,
     totals: {
       modules: moduleCount,
       scannedFiles,

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -1,0 +1,604 @@
+/**
+ * product-usage-scan.mjs
+ *
+ * Answers "where is this component used?" by scanning local checkouts of
+ * `factorialco/factorial` (the product) and `factorialco/factorial-composer`
+ * (prototypes) for imports of `@factorialco/f0-react`.
+ *
+ * Storybook runs in a browser and can't read the filesystem, so the scan runs
+ * in the Storybook dev server (Node) and is exposed over a small JSON endpoint
+ * (`/f0-product-usage.json`) that the docs page fetches at runtime. The result
+ * is cached in-process with a short TTL, so a long Storybook session picks up
+ * changes without rescanning on every page view.
+ *
+ * There is deliberately NO committed snapshot: the numbers are only shown to
+ * people who have those repos checked out locally, and are computed from
+ * whatever is on their disk right now. On the public (static) Storybook build
+ * the endpoint doesn't exist and the docs tag hides itself.
+ *
+ * Two independent sources, each reporting its own availability:
+ *
+ * - product  — `factorialco/factorial`, scanning `frontend/src/modules` (the
+ *              130-odd feature modules). Reports the number of files that
+ *              IMPORT the component and how many modules they span. Counting
+ *              imports rather than JSX occurrences means hooks, types and
+ *              other non-JSX exports are counted too.
+ * - composer — `factorialco/factorial-composer`, scanning `src/projects`.
+ *              Reports only WHICH prototypes use the component: prototypes are
+ *              throwaway explorations, so their files must never inflate the
+ *              product usage numbers.
+ *
+ * Test, story and mock files are excluded from both.
+ *
+ * Consumed by:
+ * - .storybook/main.ts        → productUsageVitePlugin()
+ * - .storybook/ProductUsageTag.tsx → fetch(PRODUCT_USAGE_ENDPOINT)
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
+import { homedir } from "node:os"
+import { dirname, join, resolve, sep } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url))
+
+/** f0's own source tree — the third usage source (see scanInternalUsage). */
+const SRC_DIR = resolve(scriptsDir, "../src")
+
+/** The dev-server route serving the scan result. */
+export const PRODUCT_USAGE_ENDPOINT = "/f0-product-usage.json"
+
+/** Path, relative to the product repo root, that we scan. */
+export const PRODUCT_SCOPE = join("frontend", "src", "modules")
+
+/** Path, relative to the Composer repo root, holding the prototypes. */
+export const COMPOSER_SCOPE = join("src", "projects")
+
+/** How long a scan result is reused before the next request recomputes it. */
+const CACHE_TTL_MS = 5 * 60 * 1000
+
+/**
+ * Directories never worth walking into. `.claude` matters for the whole-repo
+ * scan in particular: it holds git worktrees, i.e. entire second copies of the
+ * repo that would double every count.
+ */
+const SKIP_DIRS = new Set([
+  ".cache",
+  ".claude",
+  ".git",
+  ".next",
+  ".pnpm-store",
+  ".turbo",
+  "__mocks__",
+  "__snapshots__",
+  "__stories__",
+  "__tests__",
+  "build",
+  "coverage",
+  "dist",
+  "node_modules",
+  "storybook-static",
+  "tmp",
+  "vendor",
+])
+
+/** Files that aren't product code (their imports don't count as usage). */
+const NON_PRODUCT_FILE = /\.(test|spec|stories|mock|mocks)\.[jt]sx?$/
+
+const SOURCE_FILE = /\.[jt]sx?$/
+
+/**
+ * Matches an `import`/`export … from "@factorialco/f0-react[/dist/<entry>]"`
+ * statement and captures the clause.
+ *
+ * The clause pattern excludes quotes and semicolons on purpose: an import
+ * clause never contains either, so the lazy match can't run backwards past a
+ * preceding statement and swallow it (which `[\s\S]*?` would happily do). It
+ * does allow newlines, so multi-line `{ … }` blocks are matched.
+ *
+ * Every `dist/` entry counts (experimental, ai, sds…), but the asset entries
+ * (`/icons/app`, `/flags`) don't — they export SVGs, not documented components.
+ */
+const F0_IMPORT_RE =
+  /\b(?:import|export)\s+([^;'"`]*?)\s*from\s*['"]@factorialco\/f0-react(?:\/dist\/[a-z-]+)?['"]/g
+
+/**
+ * Extracts the exported names a source file pulls in from `@factorialco/f0-react`.
+ *
+ * Handles multi-line clauses, `type` modifiers and `as` aliases (the exported
+ * name is kept, not the local alias). Default and namespace imports are
+ * ignored — the package has no default export.
+ */
+export function parseF0Imports(source) {
+  const names = new Set()
+
+  for (const match of source.matchAll(F0_IMPORT_RE)) {
+    const clause = match[1]
+    const braced = clause.match(/\{([^}]*)\}/)
+    if (!braced) continue
+
+    for (const raw of braced[1].split(",")) {
+      const specifier = raw
+        .trim()
+        .replace(/^type\s+/, "")
+        .split(/\s+as\s+/)[0]
+        .trim()
+      if (specifier) names.add(specifier)
+    }
+  }
+
+  return [...names]
+}
+
+/**
+ * Locates a sibling checkout named `repoName`, in order of preference:
+ *   1. `envPath` (explicit opt-in / non-standard layouts)
+ *   2. a sibling of this repo (`../<repoName>`)
+ *   3. `~/code/<repoName>`
+ *
+ * A candidate only counts when it contains `marker`, so an unrelated directory
+ * of the same name can't be mistaken for the repo. Note that this package may
+ * live in a git worktree (`.claude/worktrees/…`), so the sibling candidate is
+ * derived from a few levels up rather than assumed.
+ */
+function resolveSiblingRepo(repoName, marker, envPath) {
+  const candidates = []
+
+  if (envPath) candidates.push(resolve(envPath))
+
+  let dir = scriptsDir
+  for (let i = 0; i < 8; i++) {
+    candidates.push(join(dirname(dir), repoName))
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+
+  candidates.push(join(homedir(), "code", repoName))
+
+  for (const candidate of candidates) {
+    if (existsSync(join(candidate, marker))) return candidate
+  }
+
+  return null
+}
+
+/** Locates a checkout of `factorialco/factorial`, or `null`. */
+export function resolveProductRepoRoot(env = process.env) {
+  return resolveSiblingRepo("factorial", PRODUCT_SCOPE, env.F0_PRODUCT_REPO)
+}
+
+/**
+ * Locates a checkout of `factorialco/factorial-it`, or `null`. It ships its
+ * own frontend against f0, so its imports count as product usage too.
+ */
+export function resolveItRepoRoot(env = process.env) {
+  return resolveSiblingRepo("factorial-it", "package.json", env.F0_IT_REPO)
+}
+
+/** Locates a checkout of `factorialco/factorial-composer`, or `null`. */
+export function resolveComposerRepoRoot(env = process.env) {
+  return resolveSiblingRepo(
+    "factorial-composer",
+    COMPOSER_SCOPE,
+    env.F0_COMPOSER_REPO
+  )
+}
+
+/** The `@factorialco/f0-react` version the product is currently on, if readable. */
+function readProductF0Version(repoRoot) {
+  try {
+    const pkg = JSON.parse(
+      readFileSync(join(repoRoot, "frontend", "package.json"), "utf8")
+    )
+    return (
+      pkg.dependencies?.["@factorialco/f0-react"] ??
+      pkg.devDependencies?.["@factorialco/f0-react"] ??
+      null
+    )
+  } catch {
+    return null
+  }
+}
+
+/** Immediate subdirectory names of `dir`, skipping the noise ones. */
+function subdirectories(dir) {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !SKIP_DIRS.has(entry.name))
+      .map((entry) => entry.name)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Calls `onFile(absolutePath)` for every product source file under `root`,
+ * skipping tests, stories, mocks and vendored directories.
+ */
+function walkSourceFiles(root, onFile) {
+  const stack = [root]
+  while (stack.length > 0) {
+    const dir = stack.pop()
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      continue
+    }
+    for (const entry of entries) {
+      const path = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        if (!SKIP_DIRS.has(entry.name)) stack.push(path)
+        continue
+      }
+      if (!SOURCE_FILE.test(entry.name)) continue
+      if (NON_PRODUCT_FILE.test(entry.name)) continue
+      onFile(path)
+    }
+  }
+}
+
+/** The names a source file imports from f0, or `null` when it imports none. */
+function f0ImportsOf(path) {
+  let source
+  try {
+    source = readFileSync(path, "utf8")
+  } catch {
+    return null
+  }
+  // Cheap pre-filter: the regex is only worth running on files that mention
+  // the package at all (roughly 1 in 5).
+  if (!source.includes("@factorialco/f0-react")) return null
+
+  const names = parseF0Imports(source)
+  return names.length > 0 ? names : null
+}
+
+/**
+ * The product code to scan: `factorialco/factorial` plus the standalone
+ * `factorialco/factorial-it` frontend, whichever are checked out.
+ *
+ * Only the feature modules are scanned by default — that's where product UI
+ * lives, and it gives the module names the docs tag reports. `full` widens the
+ * factorial monorepo to everything (backstage, webpage, mobile…), grouped by
+ * top-level directory instead.
+ *
+ * Groups from secondary repos are prefixed with the repo name so a module
+ * called `frontend` can't be confused with a factorial feature module.
+ */
+function consumerSources({ repoRoot, itRepoRoot, full }) {
+  const sources = []
+
+  if (repoRoot) {
+    sources.push({
+      id: "factorial",
+      root: repoRoot,
+      scope: full ? "." : PRODUCT_SCOPE,
+      prefix: "",
+    })
+  }
+
+  if (itRepoRoot) {
+    sources.push({
+      id: "factorial-it",
+      root: itRepoRoot,
+      scope: ".",
+      prefix: "factorial-it/",
+    })
+  }
+
+  return sources
+}
+
+/**
+ * Scans the product repos and returns, per exported name, how many product
+ * files import it and which modules those files belong to.
+ *
+ * Returns `{ available: false, reason }` when no checkout was found, so the
+ * caller can tell "no data" apart from "used nowhere".
+ */
+export function scanProductUsage({
+  repoRoot = resolveProductRepoRoot(),
+  itRepoRoot = resolveItRepoRoot(),
+  full = false,
+} = {}) {
+  const sources = consumerSources({ repoRoot, itRepoRoot, full })
+
+  if (sources.length === 0) {
+    return {
+      available: false,
+      reason:
+        "No factorialco/factorial checkout found. Clone it next to this repo, " +
+        "or point $F0_PRODUCT_REPO at it, then restart Storybook.",
+    }
+  }
+
+  const components = Object.create(null)
+  const repos = []
+  let scannedFiles = 0
+  let importingFiles = 0
+  let moduleCount = 0
+
+  for (const source of sources) {
+    const scopeDir = join(source.root, source.scope)
+    const groups = subdirectories(scopeDir)
+    moduleCount += groups.length
+
+    const before = importingFiles
+    for (const group of groups) {
+      const moduleName = `${source.prefix}${group}`
+      walkSourceFiles(join(scopeDir, group), (path) => {
+        scannedFiles++
+        const names = f0ImportsOf(path)
+        if (!names) return
+        importingFiles++
+
+        for (const name of names) {
+          const entry = (components[name] ??= { files: 0, modules: {} })
+          entry.files++
+          entry.modules[moduleName] = (entry.modules[moduleName] ?? 0) + 1
+        }
+      })
+    }
+
+    repos.push({
+      id: source.id,
+      root: source.root,
+      scope: source.scope,
+      modules: groups.length,
+      importingFiles: importingFiles - before,
+    })
+  }
+
+  return {
+    available: true,
+    generatedAt: new Date().toISOString(),
+    repo: {
+      root: repoRoot,
+      f0Version: repoRoot ? readProductF0Version(repoRoot) : null,
+      lastModified: repoRoot ? safeMtime(join(repoRoot, PRODUCT_SCOPE)) : null,
+    },
+    scope: sources.map((source) => join(source.id, source.scope)).join(", "),
+    repos,
+    totals: {
+      modules: moduleCount,
+      scannedFiles,
+      importingFiles,
+      components: Object.keys(components).length,
+    },
+    components,
+  }
+}
+
+function safeMtime(path) {
+  try {
+    return statSync(path).mtime.toISOString()
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Reads a prototype's `meta` (see the Composer's `PrototypeMeta`) from its
+ * `index.ts`. Regex rather than a parse: the file is generated from a fixed
+ * template, and the scanner can't import TypeScript. Falls back to the folder
+ * name when the file is missing or shaped unexpectedly.
+ */
+function readPrototypeMeta(prototypeDir, folderName) {
+  let source = ""
+  try {
+    source = readFileSync(join(prototypeDir, "index.ts"), "utf8")
+  } catch {
+    // Older or in-progress prototypes may not have one yet.
+  }
+
+  const title = source.match(/\btitle:\s*["'](.+?)["']/)?.[1]
+  const slug = source.match(/\bslug:\s*["']([\w-]+)["']/)?.[1]
+  const status = source.match(/\bstatus:\s*["']([\w-]+)["']/)?.[1]
+
+  return {
+    slug: slug ?? folderName,
+    title: title ?? folderName,
+    status: status ?? null,
+  }
+}
+
+/**
+ * Matches an `import`/`export … from "<local module>"` statement — the `@/`,
+ * `~/` and relative specifiers f0 components use to pull in one another.
+ * Package imports (react, motion…) don't match. Clause rules as above.
+ */
+const LOCAL_IMPORT_RE =
+  /\b(?:import|export)\s+([^;'"`]*?)\s*from\s*['"](?:@\/|~\/|\.\.?\/)[^'"]*['"]/g
+
+/** The names a source file imports from other f0 modules. */
+function parseLocalImports(source) {
+  const names = new Set()
+
+  for (const match of source.matchAll(LOCAL_IMPORT_RE)) {
+    const braced = match[1].match(/\{([^}]*)\}/)
+    if (!braced) continue
+
+    for (const raw of braced[1].split(",")) {
+      const specifier = raw
+        .trim()
+        .replace(/^type\s+/, "")
+        .split(/\s+as\s+/)[0]
+        .trim()
+      if (specifier) names.add(specifier)
+    }
+  }
+
+  return [...names]
+}
+
+/**
+ * The component a source file belongs to: the deepest capitalised directory
+ * on its path (`src/experimental/Forms/F0PhoneInput/components/Foo.tsx` →
+ * `F0PhoneInput`). Returns `null` for files that sit outside any component
+ * folder, like the `exports.ts` barrels.
+ */
+function owningComponent(relativePath) {
+  const segments = relativePath.split(sep).slice(0, -1)
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (/^[A-Z]/.test(segments[i])) return segments[i]
+  }
+  return null
+}
+
+/**
+ * Scans f0's own `src/` for components that import each other.
+ *
+ * Unlike the other two sources this needs no external checkout — it reads the
+ * package this Storybook documents — so it answers "is this used anywhere at
+ * all?" even for someone with neither factorial nor Composer cloned.
+ */
+export function scanInternalUsage({ srcDir = SRC_DIR } = {}) {
+  /** imported name → Set of component folders importing it. */
+  const byComponent = Object.create(null)
+
+  walkSourceFiles(srcDir, (path) => {
+    const owner = owningComponent(path.slice(srcDir.length + 1))
+    if (!owner) return
+
+    let source
+    try {
+      source = readFileSync(path, "utf8")
+    } catch {
+      return
+    }
+
+    for (const name of parseLocalImports(source)) {
+      // A component's own internals importing it isn't "used by".
+      if (name === owner) continue
+      ;(byComponent[name] ??= new Set()).add(owner)
+    }
+  })
+
+  const components = Object.create(null)
+  for (const [name, owners] of Object.entries(byComponent)) {
+    components[name] = [...owners].sort((a, b) => a.localeCompare(b))
+  }
+
+  return { available: true, scope: "src", components }
+}
+
+/**
+ * Scans a `factorialco/factorial-composer` checkout for the prototypes that
+ * use each component.
+ *
+ * Prototypes are throwaway explorations, not product code, so this deliberately
+ * reports only WHICH prototypes touch a component — never a file count that
+ * could inflate the product usage numbers.
+ *
+ * Layout (enforced by the Composer's own `pnpm validate`):
+ *   src/projects/<project>/<prototype>/v<N>/…
+ */
+export function scanComposerUsage({
+  repoRoot = resolveComposerRepoRoot(),
+} = {}) {
+  if (!repoRoot) {
+    return {
+      available: false,
+      reason:
+        "No factorialco/factorial-composer checkout found. Clone it next to " +
+        "this repo, or point $F0_COMPOSER_REPO at it, then restart Storybook.",
+    }
+  }
+
+  const projectsDir = join(repoRoot, COMPOSER_SCOPE)
+  /** component name → Map of "<project>/<prototype>" → prototype descriptor. */
+  const byComponent = Object.create(null)
+  let prototypeCount = 0
+
+  for (const project of subdirectories(projectsDir)) {
+    for (const folder of subdirectories(join(projectsDir, project))) {
+      const prototypeDir = join(projectsDir, project, folder)
+      const meta = readPrototypeMeta(prototypeDir, folder)
+      const prototype = { project, ...meta }
+      prototypeCount++
+
+      const used = new Set()
+      walkSourceFiles(prototypeDir, (path) => {
+        const names = f0ImportsOf(path)
+        if (names) for (const name of names) used.add(name)
+      })
+
+      for (const name of used) {
+        ;(byComponent[name] ??= []).push(prototype)
+      }
+    }
+  }
+
+  for (const prototypes of Object.values(byComponent)) {
+    prototypes.sort((a, b) => a.title.localeCompare(b.title))
+  }
+
+  return {
+    available: true,
+    repo: { root: repoRoot },
+    scope: COMPOSER_SCOPE,
+    totals: { prototypes: prototypeCount },
+    /** component name → the prototypes that import it. */
+    prototypes: byComponent,
+  }
+}
+
+/**
+ * Both scans, as served by the endpoint. The two repos are independent: having
+ * one checked out and not the other is normal, so each side reports its own
+ * availability.
+ */
+export function scanUsage() {
+  return {
+    generatedAt: new Date().toISOString(),
+    product: scanProductUsage(),
+    internal: scanInternalUsage(),
+    composer: scanComposerUsage(),
+  }
+}
+
+/** In-process cache so page views don't each trigger a filesystem walk. */
+let cache = null
+
+function getUsage({ refresh = false } = {}) {
+  const now = Date.now()
+  if (!refresh && cache && now - cache.at < CACHE_TTL_MS) return cache.data
+
+  const data = scanUsage()
+  cache = { at: now, data }
+  return data
+}
+
+/**
+ * Vite plugin serving {@link PRODUCT_USAGE_ENDPOINT} from the dev server.
+ *
+ * Dev-only by design: a static Storybook build has no server to scan with, and
+ * the numbers are meaningless without a local product checkout anyway.
+ */
+export function productUsageVitePlugin() {
+  return {
+    name: "f0-product-usage",
+    configureServer(server) {
+      server.middlewares.use(PRODUCT_USAGE_ENDPOINT, (req, res) => {
+        const refresh = (req.url ?? "").includes("refresh=1")
+        const failed = (reason) => ({ available: false, reason })
+        let body
+        try {
+          body = JSON.stringify(getUsage({ refresh }))
+        } catch (error) {
+          const reason = `Usage scan failed: ${String(error)}`
+          body = JSON.stringify({
+            product: failed(reason),
+            internal: failed(reason),
+            composer: failed(reason),
+          })
+        }
+        res.setHeader("Content-Type", "application/json; charset=utf-8")
+        res.setHeader("Cache-Control", "no-store")
+        res.end(body)
+      })
+    },
+  }
+}

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -35,6 +35,7 @@
  * - .storybook/ProductUsageTag.tsx → fetch(PRODUCT_USAGE_ENDPOINT)
  */
 
+import { execFile } from "node:child_process"
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
 import { homedir } from "node:os"
 import { dirname, join, resolve, sep } from "node:path"
@@ -47,6 +48,9 @@ const SRC_DIR = resolve(scriptsDir, "../src")
 
 /** The dev-server route serving the scan result. */
 export const PRODUCT_USAGE_ENDPOINT = "/f0-product-usage.json"
+
+/** The dev-server route that clones or fast-forwards a scanned repo. */
+export const REPO_ACTION_ENDPOINT = "/f0-usage-repo-action"
 
 /** Path, relative to the product repo root, that we scan. */
 export const PRODUCT_SCOPE = join("frontend", "src", "modules")
@@ -339,7 +343,10 @@ export function scanProductUsage({
       available: false,
       reason:
         "No factorialco/factorial checkout found. Clone it next to this repo, " +
-        "or point $F0_PRODUCT_REPO at it, then restart Storybook.",
+        "or point $F0_PRODUCT_REPO at it.",
+      // Carried even when nothing could be scanned, so the tag can offer to
+      // clone the repos rather than just naming them.
+      missing,
     }
   }
 
@@ -698,7 +705,116 @@ export function scanUsage() {
     product: scanProductUsage(),
     internal: scanInternalUsage(),
     composer: scanComposerUsage(),
+    // Progress of any clone/pull the tag started, so it can report back.
+    actions: { ...actions },
   }
+}
+
+/**
+ * Repos the docs tag can offer to clone, and where each one is scanned from.
+ *
+ * A fixed map on purpose: the endpoint that runs `git` must never take a URL
+ * or a path from the request, or a page open in the browser could make the dev
+ * server clone anything anywhere.
+ */
+export const KNOWN_REPOS = {
+  factorial: {
+    url: "git@github.com:factorialco/factorial.git",
+    resolve: resolveProductRepoRoot,
+  },
+  "factorial-it": {
+    url: "git@github.com:factorialco/factorial-it.git",
+    resolve: resolveItRepoRoot,
+  },
+  "factorial-composer": {
+    url: "git@github.com:factorialco/factorial-composer.git",
+    resolve: resolveComposerRepoRoot,
+  },
+}
+
+/**
+ * Where a new checkout should land: next to a repo we already found, so it
+ * joins whatever convention this machine already uses. Falls back to `~/code`.
+ */
+function checkoutParent() {
+  for (const { resolve: resolveRoot } of Object.values(KNOWN_REPOS)) {
+    const root = resolveRoot()
+    if (root) return dirname(root)
+  }
+  return join(homedir(), "code")
+}
+
+/**
+ * State of the clone/pull the docs tag kicked off, by repo id. Actions run
+ * detached — a monorepo clone takes minutes, far longer than a request should
+ * hang — and the tag polls this through the usual payload.
+ */
+const actions = Object.create(null)
+
+function runGit(args, options = {}) {
+  return new Promise((resolvePromise) => {
+    execFile("git", args, { maxBuffer: 1024 * 1024, ...options }, (error, stdout, stderr) => {
+      resolvePromise({
+        ok: !error,
+        output: (stdout || "") + (stderr || ""),
+      })
+    })
+  })
+}
+
+/**
+ * Clones a known repo next to the others, or fast-forwards it if it's already
+ * there. Never merges or rebases, and refuses to touch a dirty working tree —
+ * this runs against somebody's real checkout, possibly mid-task.
+ */
+export async function runRepoAction(id, action) {
+  const repo = KNOWN_REPOS[id]
+  if (!repo) return { ok: false, message: `Unknown repo: ${id}` }
+  if (actions[id]?.state === "running") return actions[id]
+
+  actions[id] = { state: "running", action, message: `${action} in progress…` }
+
+  const finish = (state, message) => {
+    actions[id] = { state, action, message }
+    // The next request should see the new checkout, not the cached answer.
+    cache = null
+    return actions[id]
+  }
+
+  const existing = repo.resolve()
+
+  if (action === "clone") {
+    if (existing) return finish("done", `Already cloned at ${existing}`)
+
+    const target = join(checkoutParent(), id)
+    // Blobless clone: full history for tooling, without paying for every blob
+    // ever committed. Still a normal checkout to work in afterwards.
+    const result = await runGit([
+      "clone",
+      "--filter=blob:none",
+      repo.url,
+      target,
+    ])
+    return result.ok
+      ? finish("done", `Cloned into ${target}`)
+      : finish("error", result.output.trim().split("\n").slice(-3).join(" "))
+  }
+
+  if (action === "pull") {
+    if (!existing) return finish("error", "Nothing to pull — not cloned yet")
+
+    const status = await runGit(["-C", existing, "status", "--porcelain"])
+    if (status.output.trim()) {
+      return finish("error", "Working tree is dirty — pull skipped")
+    }
+
+    const result = await runGit(["-C", existing, "pull", "--ff-only"])
+    return result.ok
+      ? finish("done", "Up to date")
+      : finish("error", result.output.trim().split("\n").slice(-2).join(" "))
+  }
+
+  return finish("error", `Unknown action: ${action}`)
 }
 
 /** In-process cache so page views don't each trigger a filesystem walk. */
@@ -740,6 +856,40 @@ export function productUsageVitePlugin() {
         res.setHeader("Content-Type", "application/json; charset=utf-8")
         res.setHeader("Cache-Control", "no-store")
         res.end(body)
+      })
+
+      server.middlewares.use(REPO_ACTION_ENDPOINT, (req, res) => {
+        const json = (status, payload) => {
+          res.statusCode = status
+          res.setHeader("Content-Type", "application/json; charset=utf-8")
+          res.setHeader("Cache-Control", "no-store")
+          res.end(JSON.stringify(payload))
+        }
+
+        // This route runs `git` on the developer's machine, so it has to be
+        // unreachable from anything but the Storybook page itself. A POST from
+        // another site always carries an Origin header; the docs page's own
+        // fetch carries this server's origin (or none at all).
+        const origin = req.headers.origin
+        if (req.method !== "POST") {
+          return json(405, { ok: false, message: "POST only" })
+        }
+        if (origin && !/^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?$/.test(origin)) {
+          return json(403, { ok: false, message: "Cross-origin request refused" })
+        }
+
+        const params = new URLSearchParams((req.url ?? "").split("?")[1] ?? "")
+        const id = params.get("repo") ?? ""
+        const action = params.get("action") ?? ""
+
+        if (!(id in KNOWN_REPOS) || !["clone", "pull"].includes(action)) {
+          return json(400, { ok: false, message: "Unknown repo or action" })
+        }
+
+        // Detached on purpose: a monorepo clone runs for minutes. The tag polls
+        // the usage payload for the outcome.
+        void runRepoAction(id, action)
+        json(202, { ok: true, state: "running", repo: id, action })
       })
     },
   }

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -478,6 +478,117 @@ function owningComponent(relativePath) {
 }
 
 /**
+ * The identifiers a component folder exports, read from its public surface
+ * (`index.ts(x)` / `exports.ts(x)`) only.
+ *
+ * Folder and story names are a poor proxy for import names — `hooks/toast`
+ * ships `toasts`, `hooks/datasource` ships `useDataSource` — so without this a
+ * component looks unused when the product imports it every day. Deliberately
+ * shallow: pulling in every internal helper name would collide with unrelated
+ * exports and make dead components look alive.
+ */
+export function exportedNamesOf(componentPath) {
+  if (!componentPath) return []
+
+  const names = new Set()
+
+  const collect = (file, followStars) => {
+    let source
+    try {
+      source = readFileSync(file, "utf8")
+    } catch {
+      return
+    }
+
+    for (const match of source.matchAll(
+      /export\s+(?:declare\s+)?(?:const|function|class|type|interface)\s+([A-Za-z0-9_]+)/g
+    )) {
+      names.add(match[1])
+    }
+    for (const match of source.matchAll(/export\s*\{([^}]*)\}/g)) {
+      for (const raw of match[1].split(",")) {
+        const specifier = raw
+          .trim()
+          .replace(/^type\s+/, "")
+          .split(/\s+as\s+/)
+        const exported = (specifier[1] ?? specifier[0])?.trim()
+        if (exported) names.add(exported)
+      }
+    }
+
+    if (!followStars) return
+
+    // `export * from "./ToastProvider"` hides the real export names (`toasts`)
+    // one file away, so follow the star exactly one hop.
+    for (const match of source.matchAll(
+      /export\s+\*\s+from\s*["']\.\/([A-Za-z0-9_/]+)["']/g
+    )) {
+      const target = match[1]
+      // The file name is only a plausible export name when it's capitalised
+      // (`./F0Toast`); `./types` and `./imperative` are just module names and
+      // would sit in the candidate list as noise.
+      const fileName = target.split("/").pop()
+      if (/^[A-Z]/.test(fileName)) names.add(fileName)
+      const dir = dirname(file)
+      for (const suffix of [
+        `${target}.ts`,
+        `${target}.tsx`,
+        join(target, "index.ts"),
+        join(target, "index.tsx"),
+      ]) {
+        collect(join(dir, suffix), false)
+      }
+    }
+  }
+
+  for (const barrel of BARREL_FILES) {
+    collect(join(componentPath, barrel), true)
+  }
+
+  return [...names]
+}
+
+const BARREL_FILES = ["index.ts", "index.tsx", "exports.ts", "exports.tsx"]
+
+/**
+ * Maps every component folder under `src/` to the names it exports, keyed by
+ * its path relative to `src/` (`hooks/toast` → `["toasts", …]`).
+ *
+ * The docs tag can't read the filesystem, and the export maps it imports at
+ * runtime say nothing about which file a name came from — so the association
+ * has to be built here and shipped with the payload.
+ */
+export function scanComponentExports({ srcDir = SRC_DIR } = {}) {
+  const byPath = Object.create(null)
+
+  const walk = (dir) => {
+    let entries
+    try {
+      entries = readdirSync(dir, { withFileTypes: true })
+    } catch {
+      return
+    }
+
+    if (entries.some((entry) => entry.isFile() && BARREL_FILES.includes(entry.name))) {
+      const names = exportedNamesOf(dir)
+      if (names.length > 0) {
+        byPath[dir.slice(srcDir.length + 1).split(sep).join("/")] = names
+      }
+    }
+
+    for (const entry of entries) {
+      if (entry.isDirectory() && !SKIP_DIRS.has(entry.name)) {
+        walk(join(dir, entry.name))
+      }
+    }
+  }
+
+  walk(srcDir)
+
+  return byPath
+}
+
+/**
  * Scans f0's own `src/` for components that import each other.
  *
  * Unlike the other two sources this needs no external checkout — it reads the
@@ -487,6 +598,7 @@ function owningComponent(relativePath) {
 export function scanInternalUsage({ srcDir = SRC_DIR } = {}) {
   /** imported name → Set of component folders importing it. */
   const byComponent = Object.create(null)
+  const exports = scanComponentExports({ srcDir })
 
   walkSourceFiles(srcDir, (path) => {
     const owner = owningComponent(path.slice(srcDir.length + 1))
@@ -511,7 +623,7 @@ export function scanInternalUsage({ srcDir = SRC_DIR } = {}) {
     components[name] = [...owners].sort((a, b) => a.localeCompare(b))
   }
 
-  return { available: true, scope: "src", components }
+  return { available: true, scope: "src", components, exports }
 }
 
 /**

--- a/packages/react/scripts/product-usage-scan.mjs
+++ b/packages/react/scripts/product-usage-scan.mjs
@@ -200,9 +200,14 @@ export function resolveProductRepoRoot(env = process.env) {
 /**
  * Locates a checkout of `factorialco/factorial-it`, or `null`. It ships its
  * own frontend against f0, so its imports count as product usage too.
+ *
+ * Recognised by `.git` rather than a manifest: unlike factorial it has no
+ * root `package.json` (its frontend lives under `frontend/`), and a marker
+ * that isn't there means a perfectly good checkout reads as missing — and
+ * every "Clone" click then fails on the directory it already cloned.
  */
 export function resolveItRepoRoot(env = process.env) {
-  return resolveSiblingRepo("factorial-it", "package.json", env.F0_IT_REPO)
+  return resolveSiblingRepo("factorial-it", ".git", env.F0_IT_REPO)
 }
 
 /** Locates a checkout of `factorialco/factorial-composer`, or `null`. */
@@ -787,6 +792,18 @@ export async function runRepoAction(id, action) {
     if (existing) return finish("done", `Already cloned at ${existing}`)
 
     const target = join(checkoutParent(), id)
+
+    // A directory can be there without the resolver recognising it: an
+    // interrupted clone, or a checkout this scanner doesn't know how to spot.
+    // Either way `git clone` would fail with a fatal nobody can act on.
+    if (existsSync(target)) {
+      return existsSync(join(target, ".git"))
+        ? finish("done", `Already cloned at ${target}`)
+        : finish(
+            "error",
+            `${target} already exists and isn't a checkout — remove it, then clone again`
+          )
+    }
     // Blobless clone: full history for tooling, without paying for every blob
     // ever committed. Still a normal checkout to work in afterwards.
     const result = await runGit([

--- a/packages/react/scripts/product-usage-scan.test.ts
+++ b/packages/react/scripts/product-usage-scan.test.ts
@@ -5,12 +5,14 @@ import { dirname, join } from "node:path"
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 
 import {
+  KNOWN_REPOS,
   parseF0Imports,
   resolveComposerRepoRoot,
   resolveProductRepoRoot,
   scanComposerUsage,
   scanInternalUsage,
   scanProductUsage,
+  runRepoAction,
 } from "./product-usage-scan.mjs"
 
 describe("parseF0Imports", () => {
@@ -333,6 +335,34 @@ export const meta: PrototypeMeta = {
     expect(resolveComposerRepoRoot({ F0_COMPOSER_REPO: repoRoot })).toBe(
       repoRoot
     )
+  })
+})
+
+describe("runRepoAction", () => {
+  test("only knows the repos it ships with", () => {
+    // The endpoint takes a repo id from the browser, so the id must never be
+    // able to become an arbitrary path or URL passed to git.
+    expect(Object.keys(KNOWN_REPOS).sort()).toEqual([
+      "factorial",
+      "factorial-composer",
+      "factorial-it",
+    ])
+    for (const repo of Object.values(KNOWN_REPOS)) {
+      expect(repo.url).toMatch(/^git@github\.com:factorialco\//)
+    }
+  })
+
+  test("refuses an unknown repo", async () => {
+    await expect(runRepoAction("../../etc/passwd", "clone")).resolves.toEqual({
+      ok: false,
+      message: "Unknown repo: ../../etc/passwd",
+    })
+  })
+
+  test("refuses an unknown action", async () => {
+    const result = await runRepoAction("factorial", "rm -rf" as "pull")
+
+    expect(result).toMatchObject({ state: "error" })
   })
 })
 

--- a/packages/react/scripts/product-usage-scan.test.ts
+++ b/packages/react/scripts/product-usage-scan.test.ts
@@ -1,10 +1,19 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { execFileSync } from "node:child_process"
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 
+import { DIRTY_MESSAGE as TAG_DIRTY_MESSAGE } from "../.storybook/usage-contract.ts"
 import {
+  DIRTY_MESSAGE,
   KNOWN_REPOS,
   parseF0Imports,
   resolveComposerRepoRoot,
@@ -365,6 +374,76 @@ describe("runRepoAction", () => {
     const result = await runRepoAction("factorial", "rm -rf" as "pull")
 
     expect(result).toMatchObject({ state: "error" })
+  })
+
+  test("the tag and the scanner agree on the dirty message", () => {
+    // The tag can't import the scanner (Node built-ins), so it keeps its own
+    // copy — and matches on it to decide whether to offer "Stash & pull".
+    // Drift here silently removes that button.
+    expect(TAG_DIRTY_MESSAGE).toBe(DIRTY_MESSAGE)
+  })
+})
+
+describe("stash-pull", () => {
+  let repoRoot: string
+
+  const git = (args: string[], cwd = repoRoot) =>
+    execFileSync("git", args, { cwd, stdio: "pipe" }).toString()
+
+  beforeAll(() => {
+    // A real repo with an origin, so pull/checkout behave like they do on a
+    // developer's machine rather than against a mock.
+    const base = mkdtempSync(join(tmpdir(), "f0-stash-pull-"))
+    const origin = join(base, "origin")
+    repoRoot = join(base, "clone")
+
+    mkdirSync(origin, { recursive: true })
+    git(["init", "--bare", "--initial-branch=main", origin], base)
+
+    const seed = join(base, "seed")
+    mkdirSync(seed, { recursive: true })
+    git(["init", "--initial-branch=main"], seed)
+    git(["config", "user.email", "test@example.com"], seed)
+    git(["config", "user.name", "Test"], seed)
+    writeFileSync(join(seed, "README.md"), "one\n")
+    git(["add", "."], seed)
+    git(["commit", "-m", "first"], seed)
+    git(["remote", "add", "origin", origin], seed)
+    git(["push", "-u", "origin", "main"], seed)
+
+    git(["clone", origin, repoRoot], base)
+    git(["config", "user.email", "test@example.com"])
+    git(["config", "user.name", "Test"])
+
+    // Somebody mid-task: on a feature branch, with uncommitted work.
+    git(["checkout", "-b", "feature/wip"])
+    writeFileSync(join(repoRoot, "README.md"), "local edit\n")
+
+    // Meanwhile main moved on.
+    writeFileSync(join(seed, "README.md"), "two\n")
+    git(["commit", "-am", "second"], seed)
+    git(["push"], seed)
+  })
+
+  afterAll(() => rmSync(dirname(repoRoot), { recursive: true, force: true }))
+
+  test("stashes, switches to the default branch and fast-forwards", async () => {
+    const result = await runRepoAction("factorial", "stash-pull", {
+      root: repoRoot,
+    })
+
+    expect(result).toMatchObject({ state: "done" })
+    expect(git(["rev-parse", "--abbrev-ref", "HEAD"]).trim()).toBe("main")
+    expect(readFileSync(join(repoRoot, "README.md"), "utf8")).toBe("two\n")
+  })
+
+  test("keeps the stashed work recoverable", () => {
+    // The whole promise of the button: nothing of theirs is lost. Note this
+    // asserts the stash holds their edit, not that `git stash pop` applies
+    // cleanly — once main has moved under the same file, popping conflicts,
+    // and that's ordinary git rather than something to paper over.
+    expect(git(["stash", "list"])).toContain("f0 usage tag: auto-stash")
+    expect(git(["stash", "show", "-p", "stash@{0}"])).toContain("local edit")
   })
 })
 

--- a/packages/react/scripts/product-usage-scan.test.ts
+++ b/packages/react/scripts/product-usage-scan.test.ts
@@ -137,7 +137,9 @@ describe("scanProductUsage", () => {
   })
 
   test("degrades gracefully without a product checkout", () => {
-    const result = scanProductUsage({ repoRoot: null })
+    // Both roots pinned to null: whether this machine happens to have the
+    // repos checked out must not change the result.
+    const result = scanProductUsage({ repoRoot: null, itRepoRoot: null })
 
     expect(result.available).toBe(false)
     if (result.available) throw new Error("expected an unavailable result")

--- a/packages/react/scripts/product-usage-scan.test.ts
+++ b/packages/react/scripts/product-usage-scan.test.ts
@@ -383,6 +383,30 @@ describe("scanInternalUsage", () => {
     expect(result.components.useState).toBeUndefined()
   })
 
+  test("indexes what each component folder exports", () => {
+    // The whole point: `hooks/toast` is imported as `toasts`, a name nothing
+    // about its folder or story title reveals.
+    write(
+      "hooks/toast/index.ts",
+      `export * from "./types"
+       export * from "./ToastProvider"`
+    )
+    write(
+      "hooks/toast/ToastProvider.tsx",
+      `export const toasts = {}
+       export const ToastProvider = () => null`
+    )
+
+    const result = scanInternalUsage({ srcDir })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.exports["hooks/toast"]).toEqual(
+      expect.arrayContaining(["toasts", "ToastProvider"])
+    )
+    // Lowercase module names behind `export *` are not export names.
+    expect(result.exports["hooks/toast"]).not.toContain("types")
+  })
+
   test("records type-only imports under their exported name", () => {
     const result = scanInternalUsage({ srcDir })
     if (!result.available) throw new Error(result.reason)

--- a/packages/react/scripts/product-usage-scan.test.ts
+++ b/packages/react/scripts/product-usage-scan.test.ts
@@ -208,6 +208,16 @@ describe("scanProductUsage across repos", () => {
       "factorial",
       "factorial-it",
     ])
+    expect(result.missing).toEqual([])
+  })
+
+  test("reports a repo that wasn't checked out", () => {
+    const result = scanProductUsage({ repoRoot, itRepoRoot: null })
+    if (!result.available) throw new Error(result.reason)
+
+    // The docs tag turns this into "Not checked: factorial-it", so a partial
+    // count never reads as the whole picture.
+    expect(result.missing).toEqual([{ id: "factorial-it", env: "F0_IT_REPO" }])
   })
 })
 

--- a/packages/react/scripts/product-usage-scan.test.ts
+++ b/packages/react/scripts/product-usage-scan.test.ts
@@ -1,0 +1,382 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import {
+  parseF0Imports,
+  resolveComposerRepoRoot,
+  resolveProductRepoRoot,
+  scanComposerUsage,
+  scanInternalUsage,
+  scanProductUsage,
+} from "./product-usage-scan.mjs"
+
+describe("parseF0Imports", () => {
+  test("reads single-line and multi-line named imports", () => {
+    expect(
+      parseF0Imports(`import { F0Button } from '@factorialco/f0-react'`)
+    ).toEqual(["F0Button"])
+
+    expect(
+      parseF0Imports(`import {
+        F0Box,
+        F0Text,
+      } from "@factorialco/f0-react"`)
+    ).toEqual(["F0Box", "F0Text"])
+  })
+
+  test("keeps the exported name for aliased and type imports", () => {
+    expect(
+      parseF0Imports(
+        `import { F0Button as Button, type F0ButtonProps } from '@factorialco/f0-react'`
+      )
+    ).toEqual(["F0Button", "F0ButtonProps"])
+  })
+
+  test("covers the experimental entry and re-exports", () => {
+    expect(
+      parseF0Imports(
+        `import { OneDataCollection } from '@factorialco/f0-react/dist/experimental'
+         export { F0Alert } from '@factorialco/f0-react'`
+      )
+    ).toEqual(["OneDataCollection", "F0Alert"])
+  })
+
+  test("ignores other entry points and non-import references", () => {
+    expect(
+      parseF0Imports(
+        `import { Add } from '@factorialco/f0-react/icons/app'
+         jest.mock('@factorialco/f0-react', () => ({}))
+         const pkg = '@factorialco/f0-react'`
+      )
+    ).toEqual([])
+  })
+
+  test("does not swallow a preceding import statement", () => {
+    // A lazy `[\s\S]*?` clause would match from the first `import` all the way
+    // to the f0 specifier, picking up `useState` as an f0 export.
+    expect(
+      parseF0Imports(
+        `import { useState } from 'react'
+         import { F0Card } from '@factorialco/f0-react'`
+      )
+    ).toEqual(["F0Card"])
+  })
+})
+
+describe("scanProductUsage", () => {
+  let repoRoot: string
+
+  const write = (relativePath: string, contents: string) => {
+    const path = join(repoRoot, "frontend", "src", "modules", relativePath)
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, contents)
+  }
+
+  beforeAll(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), "f0-product-usage-"))
+
+    const importsButton = `import { F0Button } from '@factorialco/f0-react'`
+
+    write("ats/Candidate.tsx", importsButton)
+    write(
+      "ats/nested/List.tsx",
+      `import { F0Button, F0Box } from "@factorialco/f0-react"`
+    )
+    write("payroll/Payslip.tsx", importsButton)
+    write("payroll/Untouched.tsx", `export const x = 1`)
+
+    // Not product code — must not count.
+    write("ats/Candidate.test.tsx", importsButton)
+    write("ats/Candidate.stories.tsx", importsButton)
+    write("ats/__tests__/helpers.tsx", importsButton)
+    write("ats/node_modules/pkg/index.tsx", importsButton)
+
+    writeFileSync(
+      join(repoRoot, "frontend", "package.json"),
+      JSON.stringify({ dependencies: { "@factorialco/f0-react": "4.72.0" } })
+    )
+  })
+
+  afterAll(() => rmSync(repoRoot, { recursive: true, force: true }))
+
+  test("counts importing product files per component and module", () => {
+    const result = scanProductUsage({ repoRoot, itRepoRoot: null })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.components.F0Button).toEqual({
+      files: 3,
+      modules: { ats: 2, payroll: 1 },
+    })
+    expect(result.components.F0Box).toEqual({
+      files: 1,
+      modules: { ats: 1 },
+    })
+  })
+
+  test("excludes tests, stories and vendored code", () => {
+    const result = scanProductUsage({ repoRoot, itRepoRoot: null })
+    if (!result.available) throw new Error(result.reason)
+
+    // 4 product files walked (the 4 test/story/vendor ones are skipped), 3 of
+    // which import from the package.
+    expect(result.totals.scannedFiles).toBe(4)
+    expect(result.totals.importingFiles).toBe(3)
+    expect(result.totals.modules).toBe(2)
+  })
+
+  test("reports the product's f0-react version", () => {
+    const result = scanProductUsage({ repoRoot, itRepoRoot: null })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.repo.f0Version).toBe("4.72.0")
+  })
+
+  test("degrades gracefully without a product checkout", () => {
+    const result = scanProductUsage({ repoRoot: null })
+
+    expect(result.available).toBe(false)
+    if (result.available) throw new Error("expected an unavailable result")
+    expect(result.reason).toMatch(/factorial/i)
+  })
+
+  test("resolves the repo root from $F0_PRODUCT_REPO", () => {
+    expect(resolveProductRepoRoot({ F0_PRODUCT_REPO: repoRoot })).toBe(repoRoot)
+  })
+
+  test("`full` widens the monorepo beyond frontend/src/modules", () => {
+    // `backstage/` is invisible to the default scope and shows up as its own
+    // group once the whole monorepo is in play.
+    mkdirSync(join(repoRoot, "backstage"), { recursive: true })
+    writeFileSync(
+      join(repoRoot, "backstage", "Admin.tsx"),
+      `import { F0Table } from '@factorialco/f0-react'`
+    )
+
+    const scoped = scanProductUsage({ repoRoot, itRepoRoot: null })
+    expect(scoped.available && scoped.components.F0Table).toBeUndefined()
+
+    const full = scanProductUsage({ repoRoot, itRepoRoot: null, full: true })
+    if (!full.available) throw new Error(full.reason)
+    expect(full.components.F0Table).toEqual({
+      files: 1,
+      modules: { backstage: 1 },
+    })
+  })
+})
+
+describe("scanProductUsage across repos", () => {
+  let repoRoot: string
+  let itRepoRoot: string
+
+  beforeAll(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), "f0-product-"))
+    const modules = join(repoRoot, "frontend", "src", "modules", "ats")
+    mkdirSync(modules, { recursive: true })
+    writeFileSync(
+      join(modules, "Candidate.tsx"),
+      `import { F0Button } from '@factorialco/f0-react'`
+    )
+
+    itRepoRoot = mkdtempSync(join(tmpdir(), "f0-it-"))
+    const itFrontend = join(itRepoRoot, "frontend", "devices")
+    mkdirSync(itFrontend, { recursive: true })
+    writeFileSync(
+      join(itFrontend, "DeviceList.tsx"),
+      `import { F0Button } from '@factorialco/f0-react'`
+    )
+  })
+
+  afterAll(() => {
+    rmSync(repoRoot, { recursive: true, force: true })
+    rmSync(itRepoRoot, { recursive: true, force: true })
+  })
+
+  test("counts factorial-it alongside factorial, namespacing its groups", () => {
+    const result = scanProductUsage({ repoRoot, itRepoRoot })
+    if (!result.available) throw new Error(result.reason)
+
+    // The `factorial-it/` prefix keeps its top-level dirs from colliding with
+    // factorial feature module names.
+    expect(result.components.F0Button).toEqual({
+      files: 2,
+      modules: { ats: 1, "factorial-it/frontend": 1 },
+    })
+    expect(result.repos.map((repo) => repo.id)).toEqual([
+      "factorial",
+      "factorial-it",
+    ])
+  })
+})
+
+describe("scanComposerUsage", () => {
+  let repoRoot: string
+
+  const write = (relativePath: string, contents: string) => {
+    const path = join(repoRoot, "src", "projects", relativePath)
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, contents)
+  }
+
+  const prototypeIndex = (slug: string, title: string) =>
+    `import type { PrototypeMeta } from "@/prototypes/types"
+
+export const meta: PrototypeMeta = {
+  slug: "${slug}",
+  title: "${title}",
+  domain: "talent",
+  status: "published",
+}`
+
+  beforeAll(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), "f0-composer-usage-"))
+
+    write(
+      "training/ai-mentor/index.ts",
+      prototypeIndex("ai-mentor", "AI Mentor")
+    )
+    write(
+      "training/ai-mentor/v1/Page.tsx",
+      `import { F0Button, F0Box } from "@factorialco/f0-react"`
+    )
+    // A second file in the same prototype must not list it twice.
+    write(
+      "training/ai-mentor/v2/Page.tsx",
+      `import { F0Button } from "@factorialco/f0-react"`
+    )
+
+    write(
+      "expense-management/expenses/index.ts",
+      prototypeIndex("expenses", "Expenses")
+    )
+    write(
+      "expense-management/expenses/v1/Page.tsx",
+      `import { F0Button } from "@factorialco/f0-react/dist/experimental"`
+    )
+
+    // A prototype with no meta file falls back to its folder name.
+    write(
+      "retake-flow/untitled/v1/Page.tsx",
+      `import { F0Box } from "@factorialco/f0-react"`
+    )
+  })
+
+  afterAll(() => rmSync(repoRoot, { recursive: true, force: true }))
+
+  test("lists each prototype using a component, once, sorted by title", () => {
+    const result = scanComposerUsage({ repoRoot })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.prototypes.F0Button).toEqual([
+      {
+        project: "training",
+        slug: "ai-mentor",
+        title: "AI Mentor",
+        status: "published",
+      },
+      {
+        project: "expense-management",
+        slug: "expenses",
+        title: "Expenses",
+        status: "published",
+      },
+    ])
+  })
+
+  test("never reports prototype file counts", () => {
+    const result = scanComposerUsage({ repoRoot })
+    if (!result.available) throw new Error(result.reason)
+
+    // Prototypes are explorations: the payload names them, and nothing about
+    // it can be summed into the product usage numbers.
+    expect(result.totals).toEqual({ prototypes: 3 })
+    for (const prototypes of Object.values(result.prototypes)) {
+      for (const prototype of prototypes) {
+        expect(prototype).not.toHaveProperty("files")
+      }
+    }
+  })
+
+  test("falls back to the folder name when a prototype has no meta", () => {
+    const result = scanComposerUsage({ repoRoot })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.prototypes.F0Box).toContainEqual({
+      project: "retake-flow",
+      slug: "untitled",
+      title: "untitled",
+      status: null,
+    })
+  })
+
+  test("degrades gracefully without a Composer checkout", () => {
+    const result = scanComposerUsage({ repoRoot: null })
+
+    expect(result.available).toBe(false)
+    if (result.available) throw new Error("expected an unavailable result")
+    expect(result.reason).toMatch(/composer/i)
+  })
+
+  test("resolves the repo root from $F0_COMPOSER_REPO", () => {
+    expect(resolveComposerRepoRoot({ F0_COMPOSER_REPO: repoRoot })).toBe(
+      repoRoot
+    )
+  })
+})
+
+describe("scanInternalUsage", () => {
+  let srcDir: string
+
+  const write = (relativePath: string, contents: string) => {
+    const path = join(srcDir, relativePath)
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, contents)
+  }
+
+  beforeAll(() => {
+    srcDir = join(mkdtempSync(join(tmpdir(), "f0-internal-usage-")), "src")
+
+    write(
+      "components/F0Dialog/F0Dialog.tsx",
+      `import { F0Button } from "@/components/F0Button"
+       import { useState } from "react"`
+    )
+    // Nested folders resolve to the deepest capitalised directory.
+    write(
+      "experimental/Forms/F0PhoneInput/components/CountrySelect.tsx",
+      `import { F0Button as Button, type F0IconProps } from "../../../../components/F0Button"`
+    )
+    // A component's own internals don't count as a user of it.
+    write(
+      "components/F0Button/internal/Label.tsx",
+      `import { F0Button } from "@/components/F0Button"`
+    )
+    // Files outside any component folder (barrels) are ignored.
+    write("components/exports.ts", `export * from "./F0Button"`)
+  })
+
+  afterAll(() => rmSync(dirname(srcDir), { recursive: true, force: true }))
+
+  test("lists the f0 components importing a component", () => {
+    const result = scanInternalUsage({ srcDir })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.components.F0Button).toEqual(["F0Dialog", "F0PhoneInput"])
+  })
+
+  test("ignores package imports", () => {
+    const result = scanInternalUsage({ srcDir })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.components.useState).toBeUndefined()
+  })
+
+  test("records type-only imports under their exported name", () => {
+    const result = scanInternalUsage({ srcDir })
+    if (!result.available) throw new Error(result.reason)
+
+    expect(result.components.F0IconProps).toEqual(["F0PhoneInput"])
+  })
+})

--- a/packages/react/scripts/unused-components.mjs
+++ b/packages/react/scripts/unused-components.mjs
@@ -21,12 +21,12 @@
  *   pnpm unused-components --used        # invert: show where each one IS used
  */
 
-import { readFileSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { computeComponentStatusData } from "./component-status-build.mjs"
 import {
+  exportedNamesOf,
   scanComposerUsage,
   scanInternalUsage,
   scanProductUsage,
@@ -68,74 +68,6 @@ function componentPathOf(storyFile) {
   const storiesAt = segments.indexOf("__stories__")
   const dirs = segments.slice(0, storiesAt === -1 ? -1 : storiesAt)
   return dirs.length > 0 ? join(SRC_DIR, ...dirs) : null
-}
-
-/**
- * The identifiers a component folder actually exports, read from its public
- * surface (`index.ts(x)` / `exports.ts(x)`) only.
- *
- * Folder names are a poor proxy for import names — `hooks/toast` ships
- * `toasts`, `hooks/datasource` ships `useDataSource` — and without this the
- * component looks dead when the product uses it every day. Deliberately not
- * recursive: internal helper names would collide with unrelated exports and
- * mark genuinely dead components as used.
- */
-function exportedNamesOf(componentPath) {
-  if (!componentPath) return []
-
-  const names = new Set()
-
-  /** Collects the identifiers a single file exports directly. */
-  const collect = (file, followStars) => {
-    let source
-    try {
-      source = readFileSync(file, "utf8")
-    } catch {
-      return
-    }
-
-    for (const match of source.matchAll(
-      /export\s+(?:declare\s+)?(?:const|function|class|type|interface)\s+([A-Za-z0-9_]+)/g
-    )) {
-      names.add(match[1])
-    }
-    for (const match of source.matchAll(/export\s*\{([^}]*)\}/g)) {
-      for (const raw of match[1].split(",")) {
-        const specifier = raw
-          .trim()
-          .replace(/^type\s+/, "")
-          .split(/\s+as\s+/)
-        const exported = (specifier[1] ?? specifier[0])?.trim()
-        if (exported) names.add(exported)
-      }
-    }
-
-    if (!followStars) return
-
-    // `export * from "./ToastProvider"` hides the real export names (`toasts`)
-    // one file away, so follow the star exactly one hop.
-    for (const match of source.matchAll(
-      /export\s+\*\s+from\s*["']\.\/([A-Za-z0-9_/]+)["']/g
-    )) {
-      const target = match[1]
-      names.add(target.split("/").pop())
-      const dir = dirname(file)
-      for (const suffix of [
-        `${target}.ts`,
-        `${target}.tsx`,
-        join(target, "index.ts"),
-        join(target, "index.tsx"),
-      ]) {
-        collect(join(dir, suffix), false)
-      }
-    }
-  }
-
-  for (const barrel of ["index.ts", "index.tsx", "exports.ts", "exports.tsx"]) {
-    collect(join(componentPath, barrel), true)
-  }
-
-  return [...names]
 }
 
 /**

--- a/packages/react/scripts/unused-components.mjs
+++ b/packages/react/scripts/unused-components.mjs
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/**
+ * unused-components.mjs
+ *
+ * Lists the documented components that nothing uses — not the product, not a
+ * Composer prototype, and not another f0 component. Useful before a deprecation
+ * round, or to see what never found an audience after being built.
+ *
+ * A component counts as USED if any of its candidate names turns up in:
+ *   - product   — `factorialco/factorial` (+ `factorialco/factorial-it`)
+ *   - composer  — `factorialco/factorial-composer` prototypes
+ *   - f0        — another component in this package's `src/`
+ *
+ * Missing checkouts are reported (and, for the product, make the answer
+ * unreliable) rather than silently treated as "no usage".
+ *
+ * Usage:
+ *   pnpm unused-components               # frontend/src/modules only (fast)
+ *   pnpm unused-components --all         # whole factorial monorepo
+ *   pnpm unused-components --json        # machine-readable
+ *   pnpm unused-components --used        # invert: show where each one IS used
+ */
+
+import { readFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import { computeComponentStatusData } from "./component-status-build.mjs"
+import {
+  scanComposerUsage,
+  scanInternalUsage,
+  scanProductUsage,
+} from "./product-usage-scan.mjs"
+
+const SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../src")
+
+const args = new Set(process.argv.slice(2))
+const full = args.has("--all")
+const asJson = args.has("--json")
+const showUsed = args.has("--used")
+
+/** Last segment of a grouped component name ("Avatars/Avatar" → "Avatar"). */
+function leafName(name) {
+  const parts = name.split("/")
+  return parts[parts.length - 1] ?? name
+}
+
+/**
+ * The implementation folder a story belongs to — the deepest capitalised
+ * directory on its path. Several story files share one folder
+ * (`OneDataCollection/__stories__/grouping.stories.tsx`,
+ * `…/url-params.stories.tsx`), and it's the folder, not each story page, that
+ * is the unit people mean by "component".
+ */
+function componentDirOf(storyFile) {
+  if (!storyFile) return null
+  const segments = storyFile.split("/").slice(0, -1)
+  for (let i = segments.length - 1; i >= 0; i--) {
+    if (/^[A-Z]/.test(segments[i])) return segments[i]
+  }
+  return null
+}
+
+/** The directory a story file lives in, relative to `src/`. */
+function componentPathOf(storyFile) {
+  if (!storyFile) return null
+  const segments = storyFile.split("/")
+  const storiesAt = segments.indexOf("__stories__")
+  const dirs = segments.slice(0, storiesAt === -1 ? -1 : storiesAt)
+  return dirs.length > 0 ? join(SRC_DIR, ...dirs) : null
+}
+
+/**
+ * The identifiers a component folder actually exports, read from its public
+ * surface (`index.ts(x)` / `exports.ts(x)`) only.
+ *
+ * Folder names are a poor proxy for import names — `hooks/toast` ships
+ * `toasts`, `hooks/datasource` ships `useDataSource` — and without this the
+ * component looks dead when the product uses it every day. Deliberately not
+ * recursive: internal helper names would collide with unrelated exports and
+ * mark genuinely dead components as used.
+ */
+function exportedNamesOf(componentPath) {
+  if (!componentPath) return []
+
+  const names = new Set()
+
+  /** Collects the identifiers a single file exports directly. */
+  const collect = (file, followStars) => {
+    let source
+    try {
+      source = readFileSync(file, "utf8")
+    } catch {
+      return
+    }
+
+    for (const match of source.matchAll(
+      /export\s+(?:declare\s+)?(?:const|function|class|type|interface)\s+([A-Za-z0-9_]+)/g
+    )) {
+      names.add(match[1])
+    }
+    for (const match of source.matchAll(/export\s*\{([^}]*)\}/g)) {
+      for (const raw of match[1].split(",")) {
+        const specifier = raw
+          .trim()
+          .replace(/^type\s+/, "")
+          .split(/\s+as\s+/)
+        const exported = (specifier[1] ?? specifier[0])?.trim()
+        if (exported) names.add(exported)
+      }
+    }
+
+    if (!followStars) return
+
+    // `export * from "./ToastProvider"` hides the real export names (`toasts`)
+    // one file away, so follow the star exactly one hop.
+    for (const match of source.matchAll(
+      /export\s+\*\s+from\s*["']\.\/([A-Za-z0-9_/]+)["']/g
+    )) {
+      const target = match[1]
+      names.add(target.split("/").pop())
+      const dir = dirname(file)
+      for (const suffix of [
+        `${target}.ts`,
+        `${target}.tsx`,
+        join(target, "index.ts"),
+        join(target, "index.tsx"),
+      ]) {
+        collect(join(dir, suffix), false)
+      }
+    }
+  }
+
+  for (const barrel of ["index.ts", "index.tsx", "exports.ts", "exports.tsx"]) {
+    collect(join(componentPath, barrel), true)
+  }
+
+  return [...names]
+}
+
+/**
+ * The names a component might be imported under: its folder and title, their
+ * `F0`-prefixed forms, and whatever its barrel actually exports.
+ */
+function candidateNames(component) {
+  const candidates = []
+  for (const base of [
+    componentDirOf(component.storyFile),
+    leafName(component.name),
+  ]) {
+    if (!base) continue
+    candidates.push(base)
+    if (!base.startsWith("F0")) candidates.push(`F0${base}`)
+  }
+  candidates.push(...exportedNamesOf(componentPathOf(component.storyFile)))
+  return [...new Set(candidates)]
+}
+
+const { components } = computeComponentStatusData()
+const product = scanProductUsage({ full })
+const internal = scanInternalUsage()
+const composer = scanComposerUsage()
+
+/**
+ * One row per implementation folder: the docs list a component several times
+ * (one story file per facet), but it is used or unused as a whole.
+ */
+const merged = new Map()
+for (const component of components) {
+  const key = componentDirOf(component.storyFile) ?? leafName(component.name)
+  const existing = merged.get(key)
+  if (existing) {
+    existing.titles.push(component.name)
+    for (const name of candidateNames(component)) {
+      if (!existing.names.includes(name)) existing.names.push(name)
+    }
+    continue
+  }
+  merged.set(key, {
+    key,
+    titles: [component.name],
+    zone: component.zone,
+    apiStatus: component.apiStatus,
+    storyFile: component.storyFile,
+    names: candidateNames(component),
+  })
+}
+
+const rows = [...merged.values()].map((component) => {
+  const names = component.names
+
+  const productFiles = product.available
+    ? names.reduce(
+        (total, name) => total + (product.components[name]?.files ?? 0),
+        0
+      )
+    : 0
+
+  const prototypes = composer.available
+    ? [
+        ...new Set(
+          names.flatMap((name) =>
+            (composer.prototypes[name] ?? []).map((p) => p.title)
+          )
+        ),
+      ]
+    : []
+
+  const usedBy = internal.available
+    ? [
+        ...new Set(names.flatMap((name) => internal.components[name] ?? [])),
+      ].filter((owner) => !names.includes(owner))
+    : []
+
+  return {
+    name: component.key,
+    titles: component.titles,
+    zone: component.zone,
+    status: component.apiStatus,
+    storyFile: component.storyFile,
+    productFiles,
+    prototypes,
+    usedBy,
+    unused:
+      productFiles === 0 && prototypes.length === 0 && usedBy.length === 0,
+  }
+})
+
+const unused = rows.filter((row) => row.unused)
+
+if (asJson) {
+  console.log(
+    JSON.stringify(
+      {
+        sources: {
+          product: product.available
+            ? { scope: product.scope, repos: product.repos }
+            : { unavailable: product.reason },
+          composer: composer.available
+            ? { prototypes: composer.totals.prototypes }
+            : { unavailable: composer.reason },
+          internal: { scope: internal.scope },
+        },
+        total: rows.length,
+        unused: showUsed ? undefined : unused,
+        components: showUsed ? rows : undefined,
+      },
+      null,
+      2
+    )
+  )
+  process.exit(0)
+}
+
+const bold = (text) => `[1m${text}[0m`
+const dim = (text) => `[2m${text}[0m`
+
+console.log("")
+console.log(bold("Sources"))
+console.log(
+  `  product   ${product.available ? `${product.scope} ${dim(`(${product.totals.importingFiles} importing files)`)}` : dim(product.reason)}`
+)
+console.log(
+  `  composer  ${composer.available ? `${composer.totals.prototypes} prototypes` : dim(composer.reason)}`
+)
+console.log(`  f0        ${internal.scope}`)
+console.log("")
+
+if (showUsed) {
+  for (const row of rows) {
+    const where = [
+      row.productFiles > 0 ? `product:${row.productFiles}` : null,
+      row.usedBy.length > 0 ? `f0:${row.usedBy.length}` : null,
+      row.prototypes.length > 0 ? `prototypes:${row.prototypes.length}` : null,
+    ].filter(Boolean)
+    console.log(
+      `${row.name.padEnd(38)} ${where.length > 0 ? where.join(" · ") : dim("unused")}`
+    )
+  }
+  process.exit(0)
+}
+
+if (!product.available) {
+  console.log(
+    dim(
+      "! Without a factorial checkout this list is not trustworthy — every " +
+        "component looks unused in the product.\n"
+    )
+  )
+}
+
+console.log(
+  bold(
+    `${unused.length} of ${rows.length} components are used nowhere` +
+      ` ${dim("(product · composer · f0)")}`
+  )
+)
+
+const byZone = new Map()
+for (const row of unused) {
+  if (!byZone.has(row.zone)) byZone.set(row.zone, [])
+  byZone.get(row.zone).push(row)
+}
+
+for (const [zone, zoneRows] of [...byZone].sort(
+  (a, b) => b[1].length - a[1].length
+)) {
+  console.log("")
+  console.log(`  ${bold(zone)} ${dim(`(${zoneRows.length})`)}`)
+  for (const row of zoneRows.sort((a, b) => a.name.localeCompare(b.name))) {
+    console.log(`    ${row.name.padEnd(36)} ${dim(row.storyFile ?? "")}`)
+  }
+}
+
+console.log("")

--- a/packages/react/scripts/unused-components.mjs
+++ b/packages/react/scripts/unused-components.mjs
@@ -6,13 +6,8 @@
  * Composer prototype, and not another f0 component. Useful before a deprecation
  * round, or to see what never found an audience after being built.
  *
- * A component counts as USED if any of its candidate names turns up in:
- *   - product   — `factorialco/factorial` (+ `factorialco/factorial-it`)
- *   - composer  — `factorialco/factorial-composer` prototypes
- *   - f0        — another component in this package's `src/`
- *
- * Missing checkouts are reported (and, for the product, make the answer
- * unreliable) rather than silently treated as "no usage".
+ * The same answer is available in Storybook (Resources → Unused components)
+ * when running locally; both read `computeUsageReport`.
  *
  * Usage:
  *   pnpm unused-components               # frontend/src/modules only (fast)
@@ -21,159 +16,22 @@
  *   pnpm unused-components --used        # invert: show where each one IS used
  */
 
-import { dirname, join, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
-
-import { computeComponentStatusData } from "./component-status-build.mjs"
-import {
-  exportedNamesOf,
-  scanComposerUsage,
-  scanInternalUsage,
-  scanProductUsage,
-} from "./product-usage-scan.mjs"
-
-const SRC_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../src")
+import { computeUsageReport } from "./component-usage-report.mjs"
 
 const args = new Set(process.argv.slice(2))
 const full = args.has("--all")
 const asJson = args.has("--json")
 const showUsed = args.has("--used")
 
-/** Last segment of a grouped component name ("Avatars/Avatar" → "Avatar"). */
-function leafName(name) {
-  const parts = name.split("/")
-  return parts[parts.length - 1] ?? name
-}
-
-/**
- * The implementation folder a story belongs to — the deepest capitalised
- * directory on its path. Several story files share one folder
- * (`OneDataCollection/__stories__/grouping.stories.tsx`,
- * `…/url-params.stories.tsx`), and it's the folder, not each story page, that
- * is the unit people mean by "component".
- */
-function componentDirOf(storyFile) {
-  if (!storyFile) return null
-  const segments = storyFile.split("/").slice(0, -1)
-  for (let i = segments.length - 1; i >= 0; i--) {
-    if (/^[A-Z]/.test(segments[i])) return segments[i]
-  }
-  return null
-}
-
-/** The directory a story file lives in, relative to `src/`. */
-function componentPathOf(storyFile) {
-  if (!storyFile) return null
-  const segments = storyFile.split("/")
-  const storiesAt = segments.indexOf("__stories__")
-  const dirs = segments.slice(0, storiesAt === -1 ? -1 : storiesAt)
-  return dirs.length > 0 ? join(SRC_DIR, ...dirs) : null
-}
-
-/**
- * The names a component might be imported under: its folder and title, their
- * `F0`-prefixed forms, and whatever its barrel actually exports.
- */
-function candidateNames(component) {
-  const candidates = []
-  for (const base of [
-    componentDirOf(component.storyFile),
-    leafName(component.name),
-  ]) {
-    if (!base) continue
-    candidates.push(base)
-    if (!base.startsWith("F0")) candidates.push(`F0${base}`)
-  }
-  candidates.push(...exportedNamesOf(componentPathOf(component.storyFile)))
-  return [...new Set(candidates)]
-}
-
-const { components } = computeComponentStatusData()
-const product = scanProductUsage({ full })
-const internal = scanInternalUsage()
-const composer = scanComposerUsage()
-
-/**
- * One row per implementation folder: the docs list a component several times
- * (one story file per facet), but it is used or unused as a whole.
- */
-const merged = new Map()
-for (const component of components) {
-  const key = componentDirOf(component.storyFile) ?? leafName(component.name)
-  const existing = merged.get(key)
-  if (existing) {
-    existing.titles.push(component.name)
-    for (const name of candidateNames(component)) {
-      if (!existing.names.includes(name)) existing.names.push(name)
-    }
-    continue
-  }
-  merged.set(key, {
-    key,
-    titles: [component.name],
-    zone: component.zone,
-    apiStatus: component.apiStatus,
-    storyFile: component.storyFile,
-    names: candidateNames(component),
-  })
-}
-
-const rows = [...merged.values()].map((component) => {
-  const names = component.names
-
-  const productFiles = product.available
-    ? names.reduce(
-        (total, name) => total + (product.components[name]?.files ?? 0),
-        0
-      )
-    : 0
-
-  const prototypes = composer.available
-    ? [
-        ...new Set(
-          names.flatMap((name) =>
-            (composer.prototypes[name] ?? []).map((p) => p.title)
-          )
-        ),
-      ]
-    : []
-
-  const usedBy = internal.available
-    ? [
-        ...new Set(names.flatMap((name) => internal.components[name] ?? [])),
-      ].filter((owner) => !names.includes(owner))
-    : []
-
-  return {
-    name: component.key,
-    titles: component.titles,
-    zone: component.zone,
-    status: component.apiStatus,
-    storyFile: component.storyFile,
-    productFiles,
-    prototypes,
-    usedBy,
-    unused:
-      productFiles === 0 && prototypes.length === 0 && usedBy.length === 0,
-  }
-})
-
-const unused = rows.filter((row) => row.unused)
+const report = computeUsageReport({ full })
+const { rows, unused, sources } = report
 
 if (asJson) {
   console.log(
     JSON.stringify(
       {
-        sources: {
-          product: product.available
-            ? { scope: product.scope, repos: product.repos }
-            : { unavailable: product.reason },
-          composer: composer.available
-            ? { prototypes: composer.totals.prototypes }
-            : { unavailable: composer.reason },
-          internal: { scope: internal.scope },
-        },
-        total: rows.length,
+        sources,
+        total: report.total,
         unused: showUsed ? undefined : unused,
         components: showUsed ? rows : undefined,
       },
@@ -190,12 +48,20 @@ const dim = (text) => `[2m${text}[0m`
 console.log("")
 console.log(bold("Sources"))
 console.log(
-  `  product   ${product.available ? `${product.scope} ${dim(`(${product.totals.importingFiles} importing files)`)}` : dim(product.reason)}`
+  `  product   ${
+    sources.product.available
+      ? `${sources.product.scope} ${dim(`(${sources.product.importingFiles} importing files)`)}`
+      : dim(sources.product.reason)
+  }`
 )
 console.log(
-  `  composer  ${composer.available ? `${composer.totals.prototypes} prototypes` : dim(composer.reason)}`
+  `  composer  ${
+    sources.composer.available
+      ? `${sources.composer.prototypes} prototypes`
+      : dim(sources.composer.reason)
+  }`
 )
-console.log(`  f0        ${internal.scope}`)
+console.log(`  f0        ${sources.internal.scope}`)
 console.log("")
 
 if (showUsed) {
@@ -212,7 +78,7 @@ if (showUsed) {
   process.exit(0)
 }
 
-if (!product.available) {
+if (!sources.product.available) {
   console.log(
     dim(
       "! Without a factorial checkout this list is not trustworthy — every " +
@@ -223,7 +89,7 @@ if (!product.available) {
 
 console.log(
   bold(
-    `${unused.length} of ${rows.length} components are used nowhere` +
+    `${unused.length} of ${report.total} components are used nowhere` +
       ` ${dim("(product · composer · f0)")}`
   )
 )

--- a/packages/react/scripts/unused-components.mjs
+++ b/packages/react/scripts/unused-components.mjs
@@ -24,7 +24,7 @@ const asJson = args.has("--json")
 const showUsed = args.has("--used")
 
 const report = computeUsageReport({ full })
-const { rows, unused, sources } = report
+const { rows, unused, onlyInPrototypes, sources } = report
 
 if (asJson) {
   console.log(
@@ -33,6 +33,7 @@ if (asJson) {
         sources,
         total: report.total,
         unused: showUsed ? undefined : unused,
+        onlyInPrototypes: showUsed ? undefined : onlyInPrototypes,
         components: showUsed ? rows : undefined,
       },
       null,
@@ -108,6 +109,18 @@ for (const [zone, zoneRows] of [...byZone].sort(
   for (const row of zoneRows.sort((a, b) => a.name.localeCompare(b.name))) {
     console.log(`    ${row.name.padEnd(36)} ${dim(row.storyFile ?? "")}`)
   }
+}
+
+// Prototyped but not shipped: worth watching, not deprecating.
+console.log("")
+console.log(
+  bold(`${onlyInPrototypes.length} are used only in Composer prototypes`) +
+    ` ${dim("(no product code imports them yet)")}`
+)
+for (const row of onlyInPrototypes.sort((a, b) =>
+  a.name.localeCompare(b.name)
+)) {
+  console.log(`    ${row.name.padEnd(36)} ${dim(row.prototypes.join(", "))}`)
 }
 
 console.log("")


### PR DESCRIPTION
## Description

Every component docs page now carries a "Where is this used in the product?" tag next to "How to import this?", answering the question people currently answer by grepping the product repo. Hovering it shows how many product files import the component and which modules they belong to, and — for components the product doesn't use — which other F0 components and which Composer prototypes do. Data is scanned at runtime by the Storybook dev server from local checkouts, so it is never stale and never leaves your machine.

<img width="885" height="386" alt="Screenshot 2026-08-10 at 12 28 27" src="https://github.com/user-attachments/assets/d017d426-f6ae-481b-8151-d17763e3c6ce" />

<img width="885" height="386" alt="Screenshot 2026-08-10 at 12 28 51" src="https://github.com/user-attachments/assets/f8321f90-6b3e-4081-acdf-64f3d995199e" />

## Type of change

- [x] Other: Storybook docs tooling (no `src/` component changes)

## Screenshots (if applicable)

Chip states, next to the existing import tag:

- `Where is this used in the product?` → e.g. F0Button: "Used in 422 files across 66 modules" + top modules with counts + "Used in 7 Composer prototypes"
- `Only used internally in F0` → e.g. AIButton: "Not used anywhere in the product yet." + "Used inside F0 by 2 components" (F0AiInsightCard, Widget)
- `Not used in the product` → nothing uses it anywhere

## Implementation details

- feat: scan the product for component usage and serve it to the docs page

  <details>
  <summary>Why a dev-server endpoint?</summary>

  Storybook runs in a browser and can't read the filesystem, so the scan runs in Node (`scripts/product-usage-scan.mjs`) behind a dev-server route the docs page fetches. The result is cached in-process for 5 minutes, so a long session picks up product changes without rescanning per page view. A full scan of `frontend/src/modules` (14.5k files) takes ~1.9s.

  There is deliberately no committed snapshot: numbers are computed from whatever is on your disk right now, and people without the repo simply see less.
  </details>

- feat: count `factorial-it` alongside `factorial` as product usage — its groups are namespaced `factorial-it/<dir>` so they can't collide with feature module names
- feat: list the Composer prototypes using a component, by name only

  <details>
  <summary>Why no counts?</summary>

  Prototypes are throwaway explorations. Letting their files into the usage count would inflate the number that people use to judge whether a component is load-bearing in the product, so the payload names them and nothing more.
  </details>

- feat: scan F0's own `src/` so "not used in the product" can distinguish dead components from building blocks other components are made of
- feat: add `pnpm unused-components` to list components nothing uses

  <details>
  <summary>Flags and current output</summary>

  `--all` widens from `frontend/src/modules` to the whole factorial monorepo, `--json` for machine-readable output, `--used` inverts it to show where each component *is* used.

  It currently reports 12 of 216 components used nowhere. Matching is on what each component's barrel actually exports, not its folder name — otherwise `hooks/toast` (ships `toasts`, 6 product files), `hooks/datasource` (`useDataSource`, 4) and `layouts/Layout` (`StandardLayout`/`TwoColumnLayout`, 28) all report as dead.
  </details>

- chore: keep this data off the public Storybook

  <details>
  <summary>How</summary>

  Three layers: the route only exists on a dev server, it isn't registered for `STORYBOOK_PUBLIC_BUILD`, and the fetch sits behind `import.meta.env.DEV` so the static bundle drops it at build time rather than relying on a 404. Product module names and internal prototype titles must not reach f0.factorial.dev.
  </details>

- refactor: replace the hand-rolled copy button in the import tooltip with F0's own `ButtonCopy` — also removes an inline-color workaround for Storybook's Tailwind scan
- test: cover the three scanners against synthetic trees (20 tests)

## Notes for reviewers

- Repos are found via `$F0_PRODUCT_REPO` / `$F0_IT_REPO` / `$F0_COMPOSER_REPO`, a sibling checkout, or `~/code/<repo>`. Any that are missing degrade gracefully — no checkout means no tag, not a wrong tag.
- `factorial-it` is wired in but was not checked out locally, so that path is untested against real code.
- The whole-repo scan skips `.claude/`: git worktrees in there are full second copies of the repo and double every count.