### PR TITLE
fix(F0Form): export f0FormField.phone types from the public rollup

### DIFF
--- a/packages/react/src/patterns/F0Form/f0Schema.ts
+++ b/packages/react/src/patterns/F0Form/f0Schema.ts
@@ -1290,15 +1290,16 @@ export namespace f0FormField {
 
   // ---- phone ---------------------------------------------------------------
 
-  /** @internal */
-  type PhoneObjectSchema = z.ZodEffects<
+  export type PhoneObjectSchema = z.ZodEffects<
     z.ZodObject<{
       prefix: z.ZodOptional<z.ZodString>
       number: z.ZodString
     }>
   >
-  /** @internal */
-  type PhoneFieldShortcutConfig = Omit<F0PhoneFieldConfig, "fieldType"> & {
+  export type PhoneFieldShortcutConfig = Omit<
+    F0PhoneFieldConfig,
+    "fieldType"
+  > & {
     optional?: boolean
     /**
      * Validation strictness against libphonenumber metadata: "valid" checks


### PR DESCRIPTION
## Description

Fixes the published types of `f0FormField.phone` for external consumers. Its two type aliases (`PhoneObjectSchema`, `PhoneFieldShortcutConfig`) were non-exported and tagged `@internal`, so API Extractor strips their declarations from the rolled-up `dist/f0.d.ts` while the public `phone()` signature keeps referencing them. Under `skipLibCheck` (how consumers compile), both references degrade to error types: the config object passed to `f0FormField.phone(...)` is not typechecked at all, and `z.infer` through the returned schema collapses to `unknown` — forcing consumers to hand-write the `{ prefix, number }` value type and cast submit data (hit while migrating Factorial's ATS `EditPhoneModal` to `F0PhoneInput`

## Type of change

- [x] Bug fix

## Implementation details

- fix: export `PhoneObjectSchema` and `PhoneFieldShortcutConfig` from the `f0FormField` namespace — they stay namespace-scoped (`f0FormField.PhoneObjectSchema`), so the top-level API surface is unchanged, and every type they reference (`F0PhoneFieldConfig`, zod) is already public in the rollup. Types-only change; the emitted JavaScript is untouched.

  <details>
  <summary>Verification</summary>

  Rebuilt the types rollup and compiled a consumer-style snippet against `dist/f0.d.ts` with `skipLibCheck` (mirroring the monorepo setup):

  - `z.infer` through a schema containing `f0FormField.phone(...)` now resolves to `{ phone: { prefix?: string; number: string } }` (previously `{ phone?: unknown }`).
  - An unknown config option (`bogusOption: true`) is now a compile error (previously accepted silently).
  - The `f0FormField` namespace section of the rollup no longer contains `Excluded from this release type` markers for the phone aliases.
  - `tsc`, oxlint, oxfmt clean; all 11 `f0FormFieldPhone` tests and the full F0Form suite (532 tests) pass.
  </details>

- note: every other `f0FormField.*` shortcut shares the same `@internal` alias pattern, so their config params are equally unchecked for consumers (and `richText`/`period`/`dateRange`/`entitiesList` have the same `z.infer` breakage). Deliberately left out of this PR — exporting those ~30 aliases promotes them to supported public API, which deserves its own alignment. Happy to open a follow-up if Foundations agrees.

🤖 Generated with [Claude Code](https://claude.com/claude-code)