### PR TITLE
feat(F0RichTextEditor): add insertContent to the imperative handle

### DIFF
--- a/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
@@ -100,11 +100,6 @@ export type F0RichTextEditorHandle = {
   focus: () => void
   setError: (error: string | null) => void
   setContent: (content: string) => void
-  /**
-   * Inserts content at the current cursor position (restoring the last
-   * selection if the editor lost focus, e.g. to a dropdown). Falls back to
-   * the end of the document when the editor was never focused.
-   */
   insertContent: (content: string) => void
 }
 
@@ -243,9 +238,6 @@ const F0RichTextEditorComponent = forwardRef<
     ]
   )
 
-  // Whether the editor ever held focus: TipTap keeps the last selection after
-  // blur (so inserts can target it), but a never-focused editor's default
-  // selection is the document start — not a position the user ever chose.
   const hasEverBeenFocusedRef = useRef(false)
 
   const editor = useEditor({
@@ -360,8 +352,6 @@ const F0RichTextEditorComponent = forwardRef<
       }
     },
     focus: () => {
-      // Mark it here too: under jsdom (and if the DOM focus is swallowed)
-      // the editor's onFocus event never fires for programmatic focus.
       hasEverBeenFocusedRef.current = true
       editor?.commands.focus()
     },

--- a/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
@@ -100,6 +100,12 @@ export type F0RichTextEditorHandle = {
   focus: () => void
   setError: (error: string | null) => void
   setContent: (content: string) => void
+  /**
+   * Inserts content at the current cursor position (restoring the last
+   * selection if the editor lost focus, e.g. to a dropdown). Falls back to
+   * the end of the document when the editor was never focused.
+   */
+  insertContent: (content: string) => void
 }
 
 export interface F0RichTextEditorSkeletonProps {
@@ -237,11 +243,19 @@ const F0RichTextEditorComponent = forwardRef<
     ]
   )
 
+  // Whether the editor ever held focus: TipTap keeps the last selection after
+  // blur (so inserts can target it), but a never-focused editor's default
+  // selection is the document start — not a position the user ever chose.
+  const hasEverBeenFocusedRef = useRef(false)
+
   const editor = useEditor({
     extensions,
     content: initialEditorState?.content || "",
     editable: !disabled,
     onUpdate: onEditorUpdate,
+    onFocus: () => {
+      hasEverBeenFocusedRef.current = true
+    },
     // Give the contenteditable an explicit textbox role and an accessible name;
     // without this the editor is unnamed for screen readers and role+name queries.
     editorProps: {
@@ -345,12 +359,24 @@ const F0RichTextEditorComponent = forwardRef<
         filesConfig.onFiles([])
       }
     },
-    focus: () => editor?.commands.focus(),
+    focus: () => {
+      // Mark it here too: under jsdom (and if the DOM focus is swallowed)
+      // the editor's onFocus event never fires for programmatic focus.
+      hasEverBeenFocusedRef.current = true
+      editor?.commands.focus()
+    },
     setError: (errorMessage: string | null) => {
       enhance.setError(errorMessage)
     },
     setContent: (content: string) => {
       editor?.commands.setContent(content)
+    },
+    insertContent: (content: string) => {
+      editor
+        ?.chain()
+        .focus(hasEverBeenFocusedRef.current ? null : "end")
+        .insertContent(content)
+        .run()
     },
   }))
 

--- a/packages/react/src/components/RichText/F0RichTextEditor/__tests__/F0RichTextEditor.spec.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/__tests__/F0RichTextEditor.spec.tsx
@@ -79,8 +79,6 @@ test("insertContent inserts at the cursor position once the editor has been focu
   )
   await screen.findByRole("textbox", { name: "Title" })
 
-  // Focusing places the caret at the selection TipTap tracks (document start
-  // for a fresh editor). The insert must land there, not at the end.
   act(() => ref.current?.focus())
   act(() => ref.current?.insertContent("{{variable}}"))
 

--- a/packages/react/src/components/RichText/F0RichTextEditor/__tests__/F0RichTextEditor.spec.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/__tests__/F0RichTextEditor.spec.tsx
@@ -1,5 +1,6 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { act, render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { createRef } from "react"
 import { expect, test, vi } from "vitest"
 
 // TipTap's BubbleMenu relies on tippy, which doesn't work under jsdom: its
@@ -9,7 +10,7 @@ vi.mock("@/components/RichText/internal/BubbleMenu", () => ({
   EditorBubbleMenu: () => null,
 }))
 
-import { F0RichTextEditor } from ".."
+import { F0RichTextEditor, type F0RichTextEditorHandle } from ".."
 import { I18nProvider, defaultTranslations } from "@/lib/providers/i18n"
 import { UserPlatformProvider } from "@/lib/providers/user-platafform/UserPlatformProvider"
 
@@ -29,6 +30,65 @@ test("exposes the title as the accessible name of the editor textbox", async () 
   expect(
     await screen.findByRole("textbox", { name: "What was your main goal?" })
   ).toBeInTheDocument()
+})
+
+test("insertContent falls back to the end of the document when the editor was never focused", async () => {
+  const onChange = vi.fn()
+  const ref = createRef<F0RichTextEditorHandle>()
+
+  render(
+    <UserPlatformProvider platform="mac">
+      <I18nProvider translations={defaultTranslations}>
+        <F0RichTextEditor
+          ref={ref}
+          title="Title"
+          placeholder="Placeholder..."
+          onChange={onChange}
+          initialEditorState={{ content: "<p>Hello</p>" }}
+        />
+      </I18nProvider>
+    </UserPlatformProvider>
+  )
+  await screen.findByRole("textbox", { name: "Title" })
+
+  act(() => ref.current?.insertContent("{{variable}}"))
+
+  await waitFor(() =>
+    expect(onChange).toHaveBeenLastCalledWith({
+      value: "<p>Hello{{variable}}</p>",
+    })
+  )
+})
+
+test("insertContent inserts at the cursor position once the editor has been focused", async () => {
+  const onChange = vi.fn()
+  const ref = createRef<F0RichTextEditorHandle>()
+
+  render(
+    <UserPlatformProvider platform="mac">
+      <I18nProvider translations={defaultTranslations}>
+        <F0RichTextEditor
+          ref={ref}
+          title="Title"
+          placeholder="Placeholder..."
+          onChange={onChange}
+          initialEditorState={{ content: "<p>Hello</p>" }}
+        />
+      </I18nProvider>
+    </UserPlatformProvider>
+  )
+  await screen.findByRole("textbox", { name: "Title" })
+
+  // Focusing places the caret at the selection TipTap tracks (document start
+  // for a fresh editor). The insert must land there, not at the end.
+  act(() => ref.current?.focus())
+  act(() => ref.current?.insertContent("{{variable}}"))
+
+  await waitFor(() =>
+    expect(onChange).toHaveBeenLastCalledWith({
+      value: "<p>{{variable}}Hello</p>",
+    })
+  )
 })
 
 test("calls onFullscreenChange callback when fullscreen mode changes", async () => {


### PR DESCRIPTION
## Description

`F0RichTextEditorHandle` only exposes `setContent`, so consumers that insert variables into the body (e.g. ATS message templates in the monolith) have to append the variable to the full body and replace everything — which always inserts at the end instead of the cursor, and resets the selection and scroll position. This PR adds an `insertContent` method that inserts at the caret.

## Implementation details

- feat: add `insertContent(content)` to `F0RichTextEditorHandle`, inserting at the last known selection and falling back to the end of the document when the editor was never focused

  <details>
  <summary>Why the fallback?</summary>

  TipTap keeps the last selection when the editor loses focus (e.g. to a
  variables dropdown), so `focus()` restores it before inserting — exactly
  the interaction these consumers need. But a never-focused editor's
  default selection is the document start, which is not a position the
  user ever chose, so in that case the insert lands at the end instead.
  </details>

- test: cover both insert paths (caret insertion after focus, end-of-document fallback when never focused)

🤖 Generated with [Claude Code](https://claude.com/claude-code)