### PR TITLE
feat(SlotWidget): add per-slot loading skeletons

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
@@ -3,7 +3,7 @@ import { Fragment } from "react"
 import { expect, test } from "vitest"
 
 /* eslint-disable no-constant-binary-expression */
-import { zeroRender } from "@/testing/test-utils"
+import { userEvent, zeroRender } from "@/testing/test-utils"
 
 import { Widget } from "./index"
 
@@ -39,4 +39,25 @@ test("there is one separator between each valid element", async () => {
 
   const separators = screen.queryAllByRole("separator")
   expect(separators).toHaveLength(2)
+})
+
+test("the header link names itself: its title is the accessible name AND the tooltip", async () => {
+  zeroRender(
+    <Widget
+      header={{
+        title: "Communications",
+        link: { title: "Go to Communications", onClick: () => {} },
+      }}
+    >
+      <p>body</p>
+    </Widget>
+  )
+
+  // Icon-only, so the title is all a screen reader has to go on.
+  const link = screen.getByRole("button", { name: "Go to Communications" })
+
+  await userEvent.hover(link)
+  expect(
+    await screen.findByRole("tooltip", { name: /Go to Communications/ })
+  ).toBeInTheDocument()
 })

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -16,7 +16,13 @@ import { useI18n } from "@/lib/providers/i18n"
 import { Counter } from "@/ui/Counter"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { PrivateBox } from "@/sds/Profile/PrivateBox"
-import { EyeInvisible, EyeVisible, Handle, InfoCircleLine } from "@/icons/app"
+import {
+  ExternalLink,
+  EyeInvisible,
+  EyeVisible,
+  Handle,
+  InfoCircleLine,
+} from "@/icons/app"
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { usePrivacyMode } from "@/lib/privacyMode"
@@ -43,9 +49,16 @@ export interface WidgetProps {
     info?: string
     canBeBlurred?: boolean
     link?: {
+      /**
+       * What following the link DOES, in words — "Go to Communities". The
+       * control is icon-only, so this is the only thing that says where it
+       * goes: it is its tooltip and its accessible name, and it is required
+       * for exactly that reason.
+       */
       title: string
       url?: string
       onClick?: () => void
+      /** Defaults to the external-link glyph. */
       icon?: IconType
     }
     count?: number
@@ -220,12 +233,16 @@ const Container = forwardRef<
                   </DropdownInternal>
                 )}
                 {header.link && (
-                  <CardLink
-                    onClick={handleLinkClick}
-                    href={header.link.url}
-                    title={header.link.title}
-                    icon={header.link.icon}
-                  />
+                  // The glyph alone can't say where it goes, so `title` is
+                  // shown as a tooltip as well as being the accessible name.
+                  <Tooltip label={header.link.title}>
+                    <CardLink
+                      onClick={handleLinkClick}
+                      href={header.link.url}
+                      title={header.link.title}
+                      icon={header.link.icon ?? ExternalLink}
+                    />
+                  </Tooltip>
                 )}
               </div>
             </div>

--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -60,7 +60,7 @@ describe("HomeListItem", () => {
     expect(screen.getByText("trailing")).toBeInTheDocument()
   })
 
-  test("is a REAL link with a chevron when it has an href, inert otherwise", () => {
+  test("is a REAL link when it has an href, inert otherwise", () => {
     const { rerender } = zeroRender(<HomeListItem title="row" href="/x" />)
 
     expect(screen.getByRole("link", { name: "row" })).toHaveAttribute(
@@ -70,6 +70,18 @@ describe("HomeListItem", () => {
 
     rerender(<HomeListItem title="row" />)
     expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+
+  test("draws no trailing chevron, even as a link, unless asked for one", () => {
+    // No avatar, no right slot: the chevron would be the row's only glyph.
+    const { container, rerender } = zeroRender(
+      <HomeListItem title="row" href="/x" />
+    )
+
+    expect(container.querySelector("svg")).toBeNull()
+
+    rerender(<HomeListItem title="row" href="/x" showChevron />)
+    expect(container.querySelector("svg")).not.toBeNull()
   })
 
   test("relative and # hrefs stay in this tab; other domains open a new one", () => {

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -8,8 +8,10 @@ import { Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
 
 /**
- * The BASE row every Home list draws: a LEFT slot, a text stack, a RIGHT slot,
- * and a chevron when the row goes somewhere.
+ * The BASE row every Home list draws: a LEFT slot, a text stack and a RIGHT
+ * slot. A row that goes somewhere says so by being a link — hover state and
+ * all — not with a trailing chevron: a column of arrows repeating "clickable"
+ * on every row is noise in a widget this dense. `showChevron` opts one in.
  *
  * The left slot is data first — `avatar` takes any of F0Avatar's types (person,
  * team, company, file, flag, emoji, icon), so a slot's params stay serializable —
@@ -34,7 +36,7 @@ export interface HomeListItemProps {
   subtitle?: string
   /** The second line. */
   description?: string
-  /** Trailing slot, before the chevron: a tag, a counter, people. */
+  /** Trailing slot: a tag, a counter, people. */
   right?: ReactNode
   /** An accent dot on the left slot's corner — unseen/pending. */
   unread?: boolean
@@ -45,7 +47,7 @@ export interface HomeListItemProps {
    * tab, hrefs to other domains open in a new one.
    */
   href?: string
-  /** Defaults to whether the row is clickable. */
+  /** A trailing chevron. Off — the row's link affordance is the row itself. */
   showChevron?: boolean
 }
 
@@ -75,7 +77,7 @@ export function HomeListItem({
   right,
   unread = false,
   href,
-  showChevron = href != null,
+  showChevron = false,
 }: HomeListItemProps) {
   const leading =
     left ?? (avatar ? <F0Avatar avatar={avatar} size={avatarSize} /> : null)

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -27,8 +27,15 @@ import {
   Target,
 } from "@/icons/app"
 
+import { Skeleton } from "@/ui/skeleton"
+
 import { SlotWidget } from "../SlotWidget"
-import { homeSlot, type HomeWidgetItem, listSlot } from "../slotRenderers"
+import {
+  homeSlot,
+  type HomeWidgetItem,
+  listSlot,
+  type SlotRenderers,
+} from "../slotRenderers"
 import { type WidgetContainerSide } from "../WidgetContainer"
 import { WidgetCatalog } from "../WidgetCatalog"
 import { ApplicationFrame } from "@/patterns/ApplicationFrame"
@@ -418,10 +425,61 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
 ]
 
 /**
- * The bespoke slot renderers this Home supplies — only `clock-in` here; every
- * other slot the rail and the feed use is a kit default.
+ * The `clock-in` tile's PLACEHOLDER: the same four lines the real tile has —
+ * state + total, the day's bar, started/left, then the two controls.
  */
-const SLOT_RENDERERS = { "clock-in": () => <ClockInBody /> }
+const ClockInSkeleton = () => (
+  <div className="flex flex-col gap-2">
+    <div className="flex items-end justify-between">
+      <Skeleton className="h-6 w-28" />
+      <Skeleton className="h-6 w-12" />
+    </div>
+    <Skeleton className="h-1.5 rounded-full" />
+    <div className="flex justify-between">
+      <Skeleton className="h-5 w-12" />
+      <Skeleton className="h-5 w-20" />
+    </div>
+    <div className="flex items-center justify-between pt-1">
+      <Skeleton className="h-8 w-24 rounded-md" />
+      <Skeleton className="h-8 w-24 rounded-md" />
+    </div>
+  </div>
+)
+
+/**
+ * The bespoke slot renderers this Home supplies — only `clock-in` here; every
+ * other slot the rail and the feed use is a kit default. It declares its own
+ * `skeleton` beside its `render`, so the tile has a placeholder shaped like
+ * itself while the rail loads.
+ */
+const SLOT_RENDERERS: SlotRenderers = {
+  "clock-in": {
+    render: () => <ClockInBody />,
+    skeleton: () => <ClockInSkeleton />,
+  },
+}
+
+/**
+ * The rail's widgets BEFORE their data lands: same widgets, same slots (a
+ * `list` keeps its schema — that's what shapes its placeholder rows), no items,
+ * and each slot declaring how many are coming so the loading rail stands as
+ * tall as the loaded one.
+ */
+const LOADING_RIGHT_WIDGETS: HomeWidgetItem[] = RIGHT_WIDGETS.map((widget) => ({
+  ...widget,
+  loading: true,
+  slots: widget.slots.map((slot) => {
+    const params = slot.params as { items?: unknown[]; events?: unknown[] }
+    const items = params.items ?? params.events
+    return {
+      ...slot,
+      expectedItemsCount: items?.length,
+      params: params.events
+        ? { ...params, events: [] }
+        : { ...params, items: [] },
+    }
+  }),
+}))
 
 /* ============================ add-widget catalog ============================ */
 
@@ -712,4 +770,31 @@ type Story = StoryObj<typeof meta>
  */
 export const Default: Story = {
   render: () => <Home />,
+}
+
+/**
+ * The same Home while the rail waits on its data. A widget declares
+ * `loading: true` and every one of its slots draws that visualization's
+ * SKELETON instead of its content — the frame, the header and the seams stay,
+ * so the card fills in rather than changing shape.
+ *
+ * How many placeholder items a slot draws is its own `expectedItemsCount`
+ * (Communications expects 5 rows, Events 4), which is what keeps the loading
+ * rail as tall as the loaded one. `clock-in` is bespoke, so its renderer brings
+ * its own skeleton — see `SLOT_RENDERERS` above.
+ *
+ * The main column is freeform content rather than widgets, so it isn't part of
+ * this: only what the layout renders as widgets has a loading state.
+ */
+export const Loading: Story = {
+  render: () => (
+    <div className="h-full w-full p-6">
+      <NewHomeLayout
+        rightWidgets={LOADING_RIGHT_WIDGETS}
+        slotRenderers={SLOT_RENDERERS}
+      >
+        {mainColumnBlocks()}
+      </NewHomeLayout>
+    </div>
+  ),
 }

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -337,7 +337,7 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
     locked: true,
     header: {
       title: "Clock in",
-      link: { title: "Time tracking", onClick: () => {} },
+      link: { title: "Go to Time tracking", onClick: () => {} },
     },
     slots: [{ visualization: "clock-in", params: {} }],
   },
@@ -348,7 +348,7 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
     hasUpdates: true,
     header: {
       title: "Communications",
-      link: { title: "Open", onClick: () => {} },
+      link: { title: "Go to Communications", onClick: () => {} },
     },
     slots: [
       listSlot(
@@ -369,7 +369,7 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
     header: {
       title: "Events",
       count: 8,
-      link: { title: "Calendar", onClick: () => {} },
+      link: { title: "Go to Calendar", onClick: () => {} },
     },
     slots: [
       homeSlot("event-list", { showAllItems: true, events: RAIL_EVENTS }),
@@ -384,7 +384,7 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
     icon: Globe,
     header: {
       title: "Resources",
-      link: { title: "factorial.co", url: "https://factorial.co" },
+      link: { title: "Go to factorial.co", url: "https://factorial.co" },
     },
     slots: [
       // `compact` keeps the rows one-line even with 3 items — every row's

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -208,6 +208,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           header={widget.header}
           fullHeight={widget.fullHeight}
           slots={widget.slots}
+          loading={widget.loading}
           slotRenderers={slotRenderers}
           ctx={ctx}
         />

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -24,6 +24,80 @@ instead of crashing.
 <Canvas of={SlotWidgetStories.AllSlots} />
 <Controls of={SlotWidgetStories.AllSlots} />
 
+## Loading
+
+`loading` swaps every slot's content for that visualization's **skeleton**,
+keeping the frame, the chrome and the seams — the card fills in rather than
+changing shape when the data lands.
+
+How many placeholder items a slot draws is its own **`expectedItemsCount`**:
+the widget declares its loading height instead of guessing at one. Both slot
+builders take it as a third argument, and it defaults to
+`DEFAULT_EXPECTED_ITEMS_COUNT` (3).
+
+```tsx
+<SlotWidget
+  header={{ title: "Team" }}
+  loading={isLoading}
+  slots={[
+    // The schema is static config, so it is known before the items are —
+    // that's what shapes the placeholder rows.
+    listSlot({ left: "person", descriptionRequired: true }, items, {
+      expectedItemsCount: 4,
+    }),
+    homeSlot("event-list", { events }, { expectedItemsCount: 2 }),
+  ]}
+/>
+```
+
+Each placeholder is drawn from what the slot already knows. A `list`'s schema
+decides whether its rows carry a left glyph (round for a person, square
+otherwise), whether they trail something, and — through the same prescriptive
+sizing the real rows use — whether they are one line or two. `maxVisibleItems`
+caps the placeholder the way it caps the list, and when more items are expected
+than it will show, the "View more" button is placed too.
+
+The widget is marked `aria-busy` while it loads, and the placeholders
+themselves are hidden from assistive tech — there is nothing in them to read.
+
+<Canvas of={SlotWidgetStories.AllLoadingSlots} />
+
+### Defining a widget's loading state
+
+The slots you pass while loading are the **same slots**, minus the data: keep
+each one's static config (a `list`'s schema), leave its items empty, and say
+how many are coming.
+
+```tsx
+const teamWidget = (people: Person[] | undefined): HomeWidgetItem => ({
+  id: "team",
+  header: { title: "Team" },
+  // The widget knows it is waiting; every slot draws its skeleton.
+  loading: people == null,
+  slots: [
+    listSlot({ left: "person", descriptionRequired: true }, people ?? [], {
+      // What the widget will hold — the page size, the API's count, or just
+      // what this widget always shows. It only decides the loading height.
+      expectedItemsCount: 5,
+    }),
+  ],
+})
+```
+
+`loading` lives on `HomeWidgetItem` as well as on `SlotWidget`, so a Home built
+from data gets it for free: `NewHomeLayout` and `WidgetContainer` pass it
+through to each widget they render. That means a rail can load widget by
+widget — each one flips as its own request lands — rather than all at once.
+
+```tsx
+<NewHomeLayout
+  rightWidgets={[teamWidget(people), eventsWidget(events)]}
+  slotRenderers={slotRenderers}
+/>
+```
+
+See `NewHomeLayout`'s **Loading** story for the whole rail in that state.
+
 ## `list` — schema-driven rows
 
 Every row-based slot is a `list`. Its params are a **schema plus items**: the
@@ -213,3 +287,24 @@ visualization, using a plain `{ visualization, params }` literal for the slot.
 A consumer renderer also **overrides** a built-in one for the same key.
 
 <Canvas of={SlotWidgetStories.BespokeAndFallback} />
+
+### A bespoke slot's skeleton
+
+An entry is either the render function on its own or that function **paired
+with its skeleton**, so a visualization's loading state lives beside the thing
+that draws it:
+
+```tsx
+slotRenderers={{
+  "clock-in": {
+    render: (params) => <ClockInTracker {...params} />,
+    skeleton: () => <Skeleton className="h-[52px] w-full rounded-md" />,
+  },
+}}
+```
+
+A visualization with no skeleton of its own — a bespoke renderer passed as a
+bare function, or one nobody registered — still gets a placeholder while
+loading (`expectedItemsCount` plain bars) rather than the dashed notice.
+
+<Canvas of={SlotWidgetStories.BespokeLoadingSlots} />

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -24,6 +24,27 @@ instead of crashing.
 <Canvas of={SlotWidgetStories.AllSlots} />
 <Controls of={SlotWidgetStories.AllSlots} />
 
+## The header link
+
+`header.link` is the widget's way out — an icon-only control in the header's
+top-right, drawn with the **external-link** glyph (pass `icon` to override it).
+Being icon-only, it carries nothing that says where it goes, so its `title` is
+**required** and does that job twice: it is the control's **tooltip** and its
+accessible name.
+
+Write it as the action, naming the destination — the user should know where
+they are about to land before they click:
+
+```tsx
+header={{
+  title: "Communications",
+  link: { title: "Go to Communications", onClick: openCommunications },
+}}
+```
+
+Not `"Open"`, `"View"`, or the destination on its own: with several widgets on
+a Home, a column of identical "Open" tooltips says nothing.
+
 ## Loading
 
 `loading` swaps every slot's content for that visualization's **skeleton**,

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -156,7 +156,12 @@ cmd-click, and copy-address all behave). Where the anchor goes:
 - **Other domains** (`https://developer.mozilla.org`) open in a **new tab**
   (`target="_blank"` with `rel="noreferrer"`), always as a native anchor.
 
-Rows without `clickBehavior` are inert — no hover state, no chevron.
+Rows without `clickBehavior` are inert — no hover state.
+
+A clickable row carries **no trailing chevron**: the row itself is the
+affordance (it highlights on hover, focuses, and is a real link), and a column
+of arrows repeating "clickable" on every row is noise in a widget this dense.
+The row's right-hand side belongs to the schema's `right` instead.
 
 ### Prescriptive sizing
 

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -2,7 +2,12 @@ import { describe, expect, test } from "vitest"
 
 import { screen, userEvent, zeroRender } from "@/testing/test-utils"
 
-import { LIST_COMPACT_AFTER, listSlot } from "../slotRenderers"
+import {
+  DEFAULT_EXPECTED_ITEMS_COUNT,
+  LIST_COMPACT_AFTER,
+  listSlot,
+  SLOT_SKELETON_ITEM_TESTID,
+} from "../slotRenderers"
 import { SlotWidget } from "./index"
 
 describe("SlotWidget", () => {
@@ -305,6 +310,131 @@ describe("list slot schema", () => {
     )
 
     expect(screen.getByText("3")).toBeInTheDocument()
+  })
+})
+
+describe("SlotWidget loading", () => {
+  const placeholders = () => screen.queryAllByTestId(SLOT_SKELETON_ITEM_TESTID)
+
+  test("draws each slot's skeleton instead of its content, keeping the frame and the seams", () => {
+    const { container } = zeroRender(
+      <SlotWidget
+        header={{ title: "Team" }}
+        loading
+        slots={[
+          { visualization: "indicators", params: { items: [] } },
+          listSlot({ left: "person" }, []),
+        ]}
+      />
+    )
+
+    // The chrome is real while the slots are placeholders.
+    expect(screen.getByText("Team")).toBeInTheDocument()
+    expect(container.querySelectorAll('[role="separator"]')).toHaveLength(1)
+    expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0)
+  })
+
+  test("draws as many placeholder items as the slot expects", () => {
+    zeroRender(
+      <SlotWidget
+        loading
+        slots={[listSlot({ left: "person" }, [], { expectedItemsCount: 5 })]}
+      />
+    )
+
+    expect(placeholders()).toHaveLength(5)
+  })
+
+  test(`a slot that doesn't say expects ${DEFAULT_EXPECTED_ITEMS_COUNT}`, () => {
+    zeroRender(<SlotWidget loading slots={[listSlot({}, [])]} />)
+
+    expect(placeholders()).toHaveLength(DEFAULT_EXPECTED_ITEMS_COUNT)
+  })
+
+  test("a list never places more rows than maxVisibleItems will show", () => {
+    zeroRender(
+      <SlotWidget
+        loading
+        slots={[
+          listSlot({ left: "person", maxVisibleItems: 2 }, [], {
+            expectedItemsCount: 7,
+          }),
+        ]}
+      />
+    )
+
+    expect(placeholders()).toHaveLength(2)
+  })
+
+  test("the list placeholder follows the schema: a left glyph only where one is declared, md for two-line rows", () => {
+    const { container, rerender } = zeroRender(
+      <SlotWidget
+        loading
+        slots={[
+          listSlot({ left: "person", descriptionRequired: true }, [], {
+            expectedItemsCount: 1,
+          }),
+        ]}
+      />
+    )
+
+    // Two-line rows draw the md glyph, exactly as the loaded rows do.
+    expect(container.querySelector(".size-8")).not.toBeNull()
+
+    rerender(
+      <SlotWidget
+        loading
+        slots={[listSlot({}, [], { expectedItemsCount: 1 })]}
+      />
+    )
+    // No left declared, no glyph.
+    expect(container.querySelector(".size-8")).toBeNull()
+    expect(container.querySelector(".size-6")).toBeNull()
+  })
+
+  test("a bespoke renderer's own skeleton wins, and one without falls back to the generic placeholder", () => {
+    zeroRender(
+      <SlotWidget
+        loading
+        slots={[
+          { visualization: "clock-in", params: {} },
+          { visualization: "carousel", params: {}, expectedItemsCount: 2 },
+        ]}
+        slotRenderers={{
+          "clock-in": {
+            render: () => <span>clock</span>,
+            skeleton: () => <span>clock placeholder</span>,
+          },
+          // A bare function: no skeleton of its own.
+          carousel: () => <span>carousel</span>,
+        }}
+      />
+    )
+
+    expect(screen.getByText("clock placeholder")).toBeInTheDocument()
+    expect(screen.queryByText("clock")).not.toBeInTheDocument()
+    expect(placeholders()).toHaveLength(2)
+  })
+
+  test("an unregistered visualization gets a placeholder, not the dashed notice", () => {
+    zeroRender(
+      <SlotWidget
+        loading
+        slots={[{ visualization: "not-registered", params: {} }]}
+      />
+    )
+
+    expect(screen.queryByText(/No renderer for slot/)).not.toBeInTheDocument()
+    expect(placeholders()).toHaveLength(DEFAULT_EXPECTED_ITEMS_COUNT)
+  })
+
+  test("no placeholders once the widget is not loading", () => {
+    zeroRender(
+      <SlotWidget slots={[listSlot({}, [{ id: "1", title: "Barcelona" }])]} />
+    )
+
+    expect(placeholders()).toHaveLength(0)
+    expect(screen.getByText("Barcelona")).toBeInTheDocument()
   })
 })
 

--- a/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
@@ -284,7 +284,7 @@ export const AllSlots: Story = {
     header: {
       title: "Team",
       count: 7,
-      link: { title: "Open", onClick: () => {} },
+      link: { title: "Go to Team", onClick: () => {} },
     },
     slots: teamSlots,
   },
@@ -325,7 +325,7 @@ export const AllLoadingSlots: Story = {
   args: {
     // No `count` in the header: the frame's chrome is real while the slots are
     // placeholders, so it should only say what is actually known yet.
-    header: { title: "Team", link: { title: "Open", onClick: () => {} } },
+    header: { title: "Team", link: { title: "Go to Team", onClick: () => {} } },
     loading: true,
     slots: teamSlots.map(beforeItemsLand),
   },

--- a/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
@@ -1,8 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Comment, PalmTree } from "@/icons/app"
+import { Skeleton } from "@/ui/skeleton"
 
-import { homeSlot, listSlot } from "../slotRenderers"
+import {
+  homeSlot,
+  listSlot,
+  type HomeWidgetSlot,
+  type SlotRenderers,
+} from "../slotRenderers"
 import { SlotWidget } from "./index"
 
 const meta = {
@@ -20,6 +26,246 @@ const meta = {
 
 export default meta
 type Story = StoryObj<typeof meta>
+
+/**
+ * The slot stack both the loaded and the loading story draw — one is the other
+ * with its items taken away (see {@link beforeItemsLand}).
+ */
+const teamSlots: HomeWidgetSlot[] = [
+  homeSlot("indicators", {
+    items: [
+      { label: "On holidays", content: "6" },
+      { label: "Remote", content: "3" },
+    ],
+  }),
+  // Alert left + faces right: two-line rows (md glyphs), every row a link.
+  listSlot(
+    {
+      left: "alert",
+      right: "person-list",
+      descriptionRequired: true,
+      clickBehavior: "link",
+    },
+    [
+      {
+        id: "in",
+        title: "Clocked in",
+        description: "4 people",
+        alert: "positive",
+        avatars: [
+          { firstName: "Ada", lastName: "Lovelace" },
+          { firstName: "Alan", lastName: "Turing" },
+        ],
+        remainingCount: 2,
+        href: "/attendance",
+      },
+      {
+        id: "away",
+        title: "Away",
+        description: "2 people",
+        alert: "warning",
+        avatars: [{ firstName: "Grace", lastName: "Hopper" }],
+        href: "/attendance/away",
+      },
+    ]
+  ),
+  // Icon left + counter right: one-line rows (sm glyphs).
+  listSlot({ left: "icon", right: "counter", clickBehavior: "link" }, [
+    {
+      id: "bcn",
+      title: "Barcelona",
+      avatar: { icon: PalmTree },
+      count: 3,
+      href: "/positions/bcn",
+    },
+    {
+      id: "mad",
+      title: "Madrid",
+      avatar: { icon: Comment },
+      count: 2,
+      href: "/positions/mad",
+    },
+  ]),
+  // Person left with BOTH text voices: inline subtitle + second line (md).
+  listSlot(
+    {
+      left: "person",
+      subtitleRequired: true,
+      descriptionRequired: true,
+      clickBehavior: "link",
+    },
+    [
+      {
+        id: "ada",
+        title: "Ada Lovelace",
+        subtitle: "Engineering",
+        description: "Out until Friday",
+        avatar: { firstName: "Ada", lastName: "Lovelace" },
+        href: "/employees/ada",
+      },
+    ]
+  ),
+  // Module left + sender right, with the unread dot: an inbox.
+  listSlot(
+    {
+      left: "module",
+      right: "person",
+      descriptionRequired: true,
+      clickBehavior: "link",
+    },
+    [
+      {
+        id: "deploy",
+        title: "Deploy 2026.7.3 is live 🚀",
+        description: "8:47",
+        module: "communities",
+        unread: true,
+        rightAvatar: { firstName: "Leo", lastName: "Costa" },
+        href: "/posts/1",
+      },
+      {
+        id: "summer",
+        title: "Summer office hours ☀️",
+        description: "Jul 18",
+        module: "communities",
+        rightAvatar: { firstName: "Mia", lastName: "Ruiz" },
+        href: "/posts/2",
+      },
+    ]
+  ),
+  // One-line rows over the remaining avatar kinds, one slot each.
+  listSlot({ left: "team", subtitleRequired: true, clickBehavior: "link" }, [
+    {
+      id: "payroll",
+      title: "Payroll",
+      subtitle: "12 members",
+      avatar: { name: "Payroll" },
+      href: "/teams/payroll",
+    },
+  ]),
+  listSlot({ left: "company", subtitleRequired: true, clickBehavior: "link" }, [
+    {
+      id: "office",
+      title: "Barcelona office",
+      subtitle: "18 people",
+      avatar: { name: "Factorial" },
+      href: "/offices/bcn",
+    },
+  ]),
+  listSlot({ left: "file", descriptionRequired: true, clickBehavior: "link" }, [
+    {
+      id: "contract",
+      title: "Contract.pdf",
+      description: "Needs your signature",
+      avatar: { file: { name: "contract.pdf", type: "application/pdf" } },
+      href: "/documents/1",
+    },
+  ]),
+  listSlot({ left: "flag", right: "counter", clickBehavior: "link" }, [
+    {
+      id: "es",
+      title: "Spain",
+      avatar: { flag: "es" },
+      count: 24,
+      href: "/offices/es",
+    },
+  ]),
+  listSlot({ left: "emoji", subtitleRequired: true, clickBehavior: "link" }, [
+    {
+      id: "pto",
+      title: "Time off",
+      subtitle: "12 days left",
+      avatar: { emoji: "🌴" },
+      href: "/time-off",
+    },
+  ]),
+  // No left, no right: plain text rows. An external href opens in a new
+  // tab; relative ones stay in this one.
+  listSlot({ clickBehavior: "link" }, [
+    {
+      id: "requests",
+      title: "Review pending requests",
+      href: "/requests",
+    },
+    {
+      id: "help",
+      title: "Help center",
+      href: "https://help.factorial.co",
+    },
+  ]),
+  // compact: true — the second line folds into a tooltip even under the
+  // threshold (hover the row for it), and the glyph draws sm.
+  listSlot(
+    {
+      left: "icon",
+      descriptionRequired: true,
+      compact: true,
+      clickBehavior: "link",
+    },
+    [
+      {
+        id: "faq",
+        title: "FAQs",
+        description: "Answers to the most common questions",
+        avatar: { icon: Comment },
+        href: "/faq",
+      },
+    ]
+  ),
+  // maxVisibleItems: 3 of 7 rows show, the rest behind "View more (4)" at
+  // the bottom (then "View less"). Expanded, the list passes
+  // LIST_COMPACT_AFTER and auto-compacts — the second line folds into a
+  // tooltip and the glyphs drop to sm.
+  listSlot(
+    {
+      left: "person",
+      descriptionRequired: true,
+      clickBehavior: "link",
+      maxVisibleItems: 3,
+    },
+    [
+      "Ada Lovelace",
+      "Alan Turing",
+      "Grace Hopper",
+      "Katherine Johnson",
+      "Margaret Hamilton",
+      "Annie Easley",
+      "Mary Jackson",
+    ].map((name, index) => ({
+      id: String(index),
+      title: name,
+      description: `Joined in 20${10 + index}`,
+      avatar: {
+        firstName: name.split(" ")[0],
+        lastName: name.split(" ")[1],
+      },
+      href: `/employees/${index}`,
+    }))
+  ),
+  homeSlot("event-list", {
+    events: [
+      // A date range.
+      {
+        title: "Company holiday",
+        subtitle: "2 days off",
+        description: "Offices closed Thursday and Friday for the summer break.",
+        isPending: false,
+        color: "#10B981",
+        fromDate: new Date(2026, 6, 30),
+        toDate: new Date(2026, 6, 31),
+      },
+      // A single day, still pending.
+      {
+        title: "Monthly all-hands",
+        subtitle: "Q3 roadmap update",
+        description: "Q3 roadmap and hiring update — bring questions.",
+        isPending: true,
+        color: "#6366F1",
+        fromDate: new Date(2026, 7, 7),
+      },
+    ],
+  }),
+]
 
 /**
  * Every DEFAULT slot, stacked in one widget with the dashed divider between
@@ -40,256 +286,96 @@ export const AllSlots: Story = {
       count: 7,
       link: { title: "Open", onClick: () => {} },
     },
-    slots: [
-      homeSlot("indicators", {
-        items: [
-          { label: "On holidays", content: "6" },
-          { label: "Remote", content: "3" },
-        ],
-      }),
-      // Alert left + faces right: two-line rows (md glyphs), every row a link.
-      listSlot(
-        {
-          left: "alert",
-          right: "person-list",
-          descriptionRequired: true,
-          clickBehavior: "link",
-        },
-        [
-          {
-            id: "in",
-            title: "Clocked in",
-            description: "4 people",
-            alert: "positive",
-            avatars: [
-              { firstName: "Ada", lastName: "Lovelace" },
-              { firstName: "Alan", lastName: "Turing" },
-            ],
-            remainingCount: 2,
-            href: "/attendance",
-          },
-          {
-            id: "away",
-            title: "Away",
-            description: "2 people",
-            alert: "warning",
-            avatars: [{ firstName: "Grace", lastName: "Hopper" }],
-            href: "/attendance/away",
-          },
-        ]
-      ),
-      // Icon left + counter right: one-line rows (sm glyphs).
-      listSlot({ left: "icon", right: "counter", clickBehavior: "link" }, [
-        {
-          id: "bcn",
-          title: "Barcelona",
-          avatar: { icon: PalmTree },
-          count: 3,
-          href: "/positions/bcn",
-        },
-        {
-          id: "mad",
-          title: "Madrid",
-          avatar: { icon: Comment },
-          count: 2,
-          href: "/positions/mad",
-        },
-      ]),
-      // Person left with BOTH text voices: inline subtitle + second line (md).
-      listSlot(
-        {
-          left: "person",
-          subtitleRequired: true,
-          descriptionRequired: true,
-          clickBehavior: "link",
-        },
-        [
-          {
-            id: "ada",
-            title: "Ada Lovelace",
-            subtitle: "Engineering",
-            description: "Out until Friday",
-            avatar: { firstName: "Ada", lastName: "Lovelace" },
-            href: "/employees/ada",
-          },
-        ]
-      ),
-      // Module left + sender right, with the unread dot: an inbox.
-      listSlot(
-        {
-          left: "module",
-          right: "person",
-          descriptionRequired: true,
-          clickBehavior: "link",
-        },
-        [
-          {
-            id: "deploy",
-            title: "Deploy 2026.7.3 is live 🚀",
-            description: "8:47",
-            module: "communities",
-            unread: true,
-            rightAvatar: { firstName: "Leo", lastName: "Costa" },
-            href: "/posts/1",
-          },
-          {
-            id: "summer",
-            title: "Summer office hours ☀️",
-            description: "Jul 18",
-            module: "communities",
-            rightAvatar: { firstName: "Mia", lastName: "Ruiz" },
-            href: "/posts/2",
-          },
-        ]
-      ),
-      // One-line rows over the remaining avatar kinds, one slot each.
-      listSlot(
-        { left: "team", subtitleRequired: true, clickBehavior: "link" },
-        [
-          {
-            id: "payroll",
-            title: "Payroll",
-            subtitle: "12 members",
-            avatar: { name: "Payroll" },
-            href: "/teams/payroll",
-          },
-        ]
-      ),
-      listSlot(
-        { left: "company", subtitleRequired: true, clickBehavior: "link" },
-        [
-          {
-            id: "office",
-            title: "Barcelona office",
-            subtitle: "18 people",
-            avatar: { name: "Factorial" },
-            href: "/offices/bcn",
-          },
-        ]
-      ),
-      listSlot(
-        { left: "file", descriptionRequired: true, clickBehavior: "link" },
-        [
-          {
-            id: "contract",
-            title: "Contract.pdf",
-            description: "Needs your signature",
-            avatar: { file: { name: "contract.pdf", type: "application/pdf" } },
-            href: "/documents/1",
-          },
-        ]
-      ),
-      listSlot({ left: "flag", right: "counter", clickBehavior: "link" }, [
-        {
-          id: "es",
-          title: "Spain",
-          avatar: { flag: "es" },
-          count: 24,
-          href: "/offices/es",
-        },
-      ]),
-      listSlot(
-        { left: "emoji", subtitleRequired: true, clickBehavior: "link" },
-        [
-          {
-            id: "pto",
-            title: "Time off",
-            subtitle: "12 days left",
-            avatar: { emoji: "🌴" },
-            href: "/time-off",
-          },
-        ]
-      ),
-      // No left, no right: plain text rows. An external href opens in a new
-      // tab; relative ones stay in this one.
-      listSlot({ clickBehavior: "link" }, [
-        {
-          id: "requests",
-          title: "Review pending requests",
-          href: "/requests",
-        },
-        {
-          id: "help",
-          title: "Help center",
-          href: "https://help.factorial.co",
-        },
-      ]),
-      // compact: true — the second line folds into a tooltip even under the
-      // threshold (hover the row for it), and the glyph draws sm.
-      listSlot(
-        {
-          left: "icon",
-          descriptionRequired: true,
-          compact: true,
-          clickBehavior: "link",
-        },
-        [
-          {
-            id: "faq",
-            title: "FAQs",
-            description: "Answers to the most common questions",
-            avatar: { icon: Comment },
-            href: "/faq",
-          },
-        ]
-      ),
-      // maxVisibleItems: 3 of 7 rows show, the rest behind "View more (4)" at
-      // the bottom (then "View less"). Expanded, the list passes
-      // LIST_COMPACT_AFTER and auto-compacts — the second line folds into a
-      // tooltip and the glyphs drop to sm.
-      listSlot(
-        {
-          left: "person",
-          descriptionRequired: true,
-          clickBehavior: "link",
-          maxVisibleItems: 3,
-        },
-        [
-          "Ada Lovelace",
-          "Alan Turing",
-          "Grace Hopper",
-          "Katherine Johnson",
-          "Margaret Hamilton",
-          "Annie Easley",
-          "Mary Jackson",
-        ].map((name, index) => ({
-          id: String(index),
-          title: name,
-          description: `Joined in 20${10 + index}`,
-          avatar: {
-            firstName: name.split(" ")[0],
-            lastName: name.split(" ")[1],
-          },
-          href: `/employees/${index}`,
-        }))
-      ),
-      homeSlot("event-list", {
-        events: [
-          // A date range.
-          {
-            title: "Company holiday",
-            subtitle: "2 days off",
-            description:
-              "Offices closed Thursday and Friday for the summer break.",
-            isPending: false,
-            color: "#10B981",
-            fromDate: new Date(2026, 6, 30),
-            toDate: new Date(2026, 6, 31),
-          },
-          // A single day, still pending.
-          {
-            title: "Monthly all-hands",
-            subtitle: "Q3 roadmap update",
-            description: "Q3 roadmap and hiring update — bring questions.",
-            isPending: true,
-            color: "#6366F1",
-            fromDate: new Date(2026, 7, 7),
-          },
-        ],
-      }),
-    ],
+    slots: teamSlots,
   },
 }
+
+/**
+ * A slot as it looks BEFORE its data arrives: same visualization, same static
+ * config (a `list` keeps its schema — that's what shapes the placeholder), no
+ * items yet, and `expectedItemsCount` set to however many are coming, taken
+ * here from what the loaded slot holds.
+ */
+const beforeItemsLand = (slot: HomeWidgetSlot): HomeWidgetSlot => {
+  const params = slot.params as { items?: unknown[]; events?: unknown[] }
+  const items = params.items ?? params.events ?? []
+  return {
+    ...slot,
+    expectedItemsCount: items.length,
+    params: params.events
+      ? { ...params, events: [] }
+      : { ...params, items: [] },
+  }
+}
+
+/**
+ * The SAME widget as `AllSlots`, waiting on its data: `loading` swaps every
+ * slot's content for that visualization's skeleton, keeping the frame, the
+ * header and the seams — the card fills in rather than changing shape.
+ *
+ * Each placeholder is drawn from what the slot already knows. A `list`'s schema
+ * decides whether its rows carry a left glyph (round for a person, square
+ * otherwise), whether they trail something, and — through the same prescriptive
+ * sizing the real rows use — whether they are one line or two. `maxVisibleItems`
+ * caps the placeholder the way it caps the list. How MANY items each slot draws
+ * is its own `expectedItemsCount`, so a widget declares its loading height
+ * instead of guessing at one.
+ */
+export const AllLoadingSlots: Story = {
+  args: {
+    // No `count` in the header: the frame's chrome is real while the slots are
+    // placeholders, so it should only say what is actually known yet.
+    header: { title: "Team", link: { title: "Open", onClick: () => {} } },
+    loading: true,
+    slots: teamSlots.map(beforeItemsLand),
+  },
+}
+
+const bespokeSlots: HomeWidgetSlot[] = [
+  { visualization: "clock-in", params: { variant: "tracker" } },
+  {
+    visualization: "carousel",
+    params: { kind: "celebrations" },
+    expectedItemsCount: 3,
+  },
+  { visualization: "not-registered", params: {} },
+]
+
+/**
+ * A bespoke renderer brings its OWN skeleton by declaring the entry as
+ * `{ render, skeleton }` instead of a bare function — `clock-in` does.
+ * `carousel` stays a bare function, so it falls back to the generic
+ * placeholder while loading.
+ */
+const bespokeRenderers = {
+  "clock-in": {
+    render: (params: unknown) => (
+      <div className="rounded-md bg-f1-background-secondary p-3 text-f1-foreground-secondary">
+        {`Clock-in (${(params as { variant: string }).variant}) — bespoke renderer, owns its data`}
+      </div>
+    ),
+    skeleton: () => <Skeleton className="h-[52px] w-full rounded-md" />,
+  },
+  carousel: () => (
+    // Focusable: a scrollable region whose content isn't must be keyboard
+    // reachable (axe: scrollable-region-focusable).
+    <div
+      className="flex gap-3 overflow-x-auto"
+      role="region"
+      aria-label="Celebrations"
+      tabIndex={0}
+    >
+      {["🎂 Ada — birthday", "🎉 Alan — 2y", "👋 Grace — 1st day"].map((c) => (
+        <div
+          key={c}
+          className="shrink-0 rounded-lg border border-solid border-f1-border p-3 text-f1-foreground"
+        >
+          {c}
+        </div>
+      ))}
+    </div>
+  ),
+} satisfies SlotRenderers
 
 /**
  * The BESPOKE slots the Home uses (no default renderer ships for them — they
@@ -300,38 +386,22 @@ export const AllSlots: Story = {
 export const BespokeAndFallback: Story = {
   args: {
     header: { title: "Attendance" },
-    slots: [
-      { visualization: "clock-in", params: { variant: "tracker" } },
-      { visualization: "carousel", params: { kind: "celebrations" } },
-      { visualization: "not-registered", params: {} },
-    ],
-    slotRenderers: {
-      "clock-in": (params) => (
-        <div className="rounded-md bg-f1-background-secondary p-3 text-f1-foreground-secondary">
-          {`Clock-in (${(params as { variant: string }).variant}) — bespoke renderer, owns its data`}
-        </div>
-      ),
-      carousel: () => (
-        // Focusable: a scrollable region whose content isn't must be keyboard
-        // reachable (axe: scrollable-region-focusable).
-        <div
-          className="flex gap-3 overflow-x-auto"
-          role="region"
-          aria-label="Celebrations"
-          tabIndex={0}
-        >
-          {["🎂 Ada — birthday", "🎉 Alan — 2y", "👋 Grace — 1st day"].map(
-            (c) => (
-              <div
-                key={c}
-                className="shrink-0 rounded-lg border border-solid border-f1-border p-3 text-f1-foreground"
-              >
-                {c}
-              </div>
-            )
-          )}
-        </div>
-      ),
-    },
+    slots: bespokeSlots,
+    slotRenderers: bespokeRenderers,
+  },
+}
+
+/**
+ * The same bespoke widget, loading. `clock-in` draws the skeleton it declared
+ * beside its renderer; `carousel` and the unregistered visualization have none,
+ * so they get the generic placeholder — `expectedItemsCount` bars — rather than
+ * nothing or the dashed notice.
+ */
+export const BespokeLoadingSlots: Story = {
+  args: {
+    header: { title: "Attendance" },
+    loading: true,
+    slots: bespokeSlots,
+    slotRenderers: bespokeRenderers,
   },
 }

--- a/packages/react/src/sds/Home/SlotWidget/index.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.tsx
@@ -6,6 +6,9 @@ import { Widget, WidgetProps } from "@/experimental/Widgets/Widget"
 
 import {
   defaultSlotRenderers,
+  defaultSlotSkeleton,
+  DEFAULT_EXPECTED_ITEMS_COUNT,
+  resolveSlotRenderer,
   type HomeWidgetChrome,
   type HomeRenderCtx,
   type HomeWidgetSlot,
@@ -21,11 +24,20 @@ import {
  * from the merged renderer map (`defaultSlotRenderers` + the `slotRenderers`
  * prop). Bespoke visualizations (e.g. `clock-in`) have no default and must be
  * supplied via `slotRenderers`.
+ *
+ * `loading` swaps every slot's content for that visualization's SKELETON,
+ * keeping the frame, the chrome and the seams — the card doesn't change shape
+ * when the data lands, it fills in.
  */
 export type SlotWidgetProps = HomeWidgetChrome & {
   header?: WidgetProps["header"]
   fullHeight?: boolean
   slots: HomeWidgetSlot[]
+  /**
+   * Draws each slot's SKELETON instead of its content. How many placeholder
+   * items each one draws is the slot's own `expectedItemsCount`.
+   */
+  loading?: boolean
   /** Per-visualization renderers, MERGED OVER `defaultSlotRenderers`. */
   slotRenderers?: SlotRenderers
   /** Forwarded to the f0 `Widget`: its own drag handle and dragging state. */
@@ -43,6 +55,7 @@ export function SlotWidget({
   alert,
   status,
   slots,
+  loading = false,
   slotRenderers,
   draggable,
   onDragStart,
@@ -66,9 +79,18 @@ export function SlotWidget({
     >
       {/* ONE child, so the Widget frame's internal `gap-4` applies once to the
           whole slot stack instead of around every slot AND every divider. */}
-      <div className="flex flex-col">
+      <div
+        className="flex flex-col"
+        {...(loading
+          ? { "aria-busy": true, "aria-live": "polite" as const }
+          : {})}
+      >
         {slots.map((slot, index) => {
-          const renderer = renderers[slot.visualization]
+          const entry = resolveSlotRenderer(renderers[slot.visualization])
+          const slotCtx = {
+            ...ctx,
+            isLastSlot: index === slots.length - 1,
+          }
           return (
             <Fragment key={index}>
               {/* Wrapped rather than passing className: Separator spreads its
@@ -79,11 +101,21 @@ export function SlotWidget({
                   <Separator bare />
                 </div>
               ) : null}
-              {renderer ? (
-                renderer(slot.params, {
-                  ...ctx,
-                  isLastSlot: index === slots.length - 1,
-                })
+              {loading ? (
+                // A placeholder says nothing worth reading out — the stack
+                // above already announces that the widget is busy.
+                <div aria-hidden="true">
+                  {/* A visualization with no skeleton of its own (a bespoke
+                      renderer passed as a bare function, an unregistered one)
+                      still gets a placeholder rather than the dashed notice. */}
+                  {(entry?.skeleton ?? defaultSlotSkeleton)(slot.params, {
+                    ...slotCtx,
+                    expectedItemsCount:
+                      slot.expectedItemsCount ?? DEFAULT_EXPECTED_ITEMS_COUNT,
+                  })}
+                </div>
+              ) : entry ? (
+                entry.render(slot.params, slotCtx)
               ) : (
                 <div className="rounded-md border border-dashed border-f1-border p-2 text-f1-foreground-secondary">
                   {`No renderer for slot "${slot.visualization}"`}

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -9,7 +9,7 @@ import { WidgetContainer } from "./index"
 const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) => ({
   id,
   icon: id === "clock" ? Clock : Calendar,
-  header: { title: id, link: { title: "Open", onClick: () => {} } },
+  header: { title: id, link: { title: `Go to ${id}`, onClick: () => {} } },
   slots: [
     {
       visualization: "indicators",

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -198,6 +198,7 @@ export function WidgetContainer({
         }
         fullHeight={widget.fullHeight}
         slots={widget.slots}
+        loading={widget.loading}
         slotRenderers={slotRenderers}
         ctx={ctx}
         draggable={drag?.draggable}
@@ -218,6 +219,7 @@ export function WidgetContainer({
               header={{ ...widget.header, link: undefined }}
               fullHeight={widget.fullHeight}
               slots={widget.slots}
+              loading={widget.loading}
               slotRenderers={slotRenderers}
               ctx={ctx}
             />

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -15,6 +15,7 @@ import { F0Button } from "@/components/F0Button"
 import { type IconType } from "@/components/F0Icon"
 import { cn } from "@/lib/utils"
 import { Counter } from "@/ui/Counter"
+import { Skeleton } from "@/ui/skeleton"
 import {
   CalendarEvent,
   type CalendarEventProps,
@@ -49,7 +50,43 @@ export type SlotRenderer<P = unknown> = (
   params: P,
   ctx: HomeRenderCtx
 ) => ReactNode
-export type SlotRenderers = Record<string, SlotRenderer>
+
+/**
+ * The ctx a SKELETON is drawn with: the render ctx plus how many placeholder
+ * items to draw — the slot's `expectedItemsCount`, already defaulted.
+ */
+export type HomeSkeletonCtx = HomeRenderCtx & { expectedItemsCount: number }
+
+/**
+ * Draws the slot's PLACEHOLDER, before its data lands. It gets the same params
+ * the renderer will get — a loading slot still carries its static config (a
+ * `list`'s schema, say), just no items — so the placeholder can be shaped like
+ * what is coming.
+ */
+export type SlotSkeletonRenderer<P = unknown> = (
+  params: P,
+  ctx: HomeSkeletonCtx
+) => ReactNode
+
+/**
+ * How a visualization is drawn: the render function on its own, or that
+ * function PAIRED with the skeleton to draw while the slot loads.
+ */
+export type SlotRendererEntry<P = unknown> =
+  | SlotRenderer<P>
+  | { render: SlotRenderer<P>; skeleton?: SlotSkeletonRenderer<P> }
+
+export type SlotRenderers = Record<string, SlotRendererEntry>
+
+/** A renderer entry in its full form — a bare function is just its `render`. */
+export const resolveSlotRenderer = (
+  entry: SlotRendererEntry | undefined
+): { render: SlotRenderer; skeleton?: SlotSkeletonRenderer } | undefined =>
+  entry == null
+    ? undefined
+    : typeof entry === "function"
+      ? { render: entry }
+      : entry
 
 /* ------------------------------ list schema ------------------------------ */
 
@@ -167,7 +204,17 @@ export interface EventListParams {
 export interface HomeWidgetSlot {
   visualization: string
   params: unknown
+  /**
+   * How many items this slot expects to hold — the number of PLACEHOLDER items
+   * its skeleton draws while the widget is `loading`, so the loading card is
+   * about as tall as the one that replaces it. Defaults to
+   * {@link DEFAULT_EXPECTED_ITEMS_COUNT}.
+   */
+  expectedItemsCount?: number
 }
+
+/** What a slot carries beyond its params. Taken by both slot builders. */
+export type SlotOptions = Pick<HomeWidgetSlot, "expectedItemsCount">
 
 /** The built-in slot vocabulary: each visualization and its params shape. */
 export interface HomeSlotParamsMap {
@@ -184,8 +231,9 @@ export interface HomeSlotParamsMap {
  */
 export const homeSlot = <V extends keyof HomeSlotParamsMap>(
   visualization: V,
-  params: HomeSlotParamsMap[V]
-): HomeWidgetSlot => ({ visualization, params })
+  params: HomeSlotParamsMap[V],
+  options?: SlotOptions
+): HomeWidgetSlot => ({ visualization, params, ...options })
 
 /**
  * Builds a `list` slot: the schema is declared once, and the items' shape is
@@ -194,8 +242,13 @@ export const homeSlot = <V extends keyof HomeSlotParamsMap>(
  */
 export const listSlot = <const S extends ListSchema>(
   schema: S,
-  items: Array<ListItem<S>>
-): HomeWidgetSlot => ({ visualization: "list", params: { schema, items } })
+  items: Array<ListItem<S>>,
+  options?: SlotOptions
+): HomeWidgetSlot => ({
+  visualization: "list",
+  params: { schema, items },
+  ...options,
+})
 
 /**
  * The `Widget` chrome a Home widget may carry beyond its header, passed straight
@@ -232,6 +285,11 @@ export type HomeWidgetItem = HomeWidgetChrome & {
    */
   hasUpdates?: boolean
   slots: HomeWidgetSlot[]
+  /**
+   * The widget is waiting on its data: every slot draws its skeleton instead of
+   * its content (see `SlotWidget`'s `loading`).
+   */
+  loading?: boolean
 }
 
 /**
@@ -376,30 +434,203 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
   )
 }
 
+/* ------------------------------- skeletons ------------------------------- */
+
+/**
+ * How many placeholder items a slot draws when it doesn't say (its
+ * `expectedItemsCount`). Three: enough to read as a list, short enough that a
+ * widget which turns out to hold one item barely jumps.
+ */
+export const DEFAULT_EXPECTED_ITEMS_COUNT = 3
+
+/**
+ * Marks ONE placeholder item, whatever the visualization draws as an item — a
+ * list row, an event, an indicator. `expectedItemsCount` of these appear.
+ */
+export const SLOT_SKELETON_ITEM_TESTID = "slot-skeleton-item"
+
+/**
+ * Cycled title widths: a column of identical bars reads as a pattern rather
+ * than as items, so the placeholder titles vary the way real ones do.
+ */
+const SKELETON_TITLE_WIDTHS = ["w-1/2", "w-2/3", "w-2/5", "w-3/5"]
+
+const skeletonTitleWidth = (index: number) =>
+  SKELETON_TITLE_WIDTHS[index % SKELETON_TITLE_WIDTHS.length]
+
+/**
+ * One line of placeholder text: a thin bar centred in the 20px LINE BOX a real
+ * line of text occupies. Lines, not bars, are what make a placeholder row as
+ * tall as the row that replaces it — so the card fills in without jumping.
+ */
+const SkeletonLine = ({ className }: { className?: string }) => (
+  <div className="flex h-5 items-center">
+    <Skeleton className={cn("h-3", className)} />
+  </div>
+)
+
+/**
+ * The `list` slot's placeholder, drawn from the SCHEMA alone — which is static
+ * config, so it is known before the items land. It follows the same rules the
+ * real list follows: a left glyph only where the schema declares one (round for
+ * a person, square for everything else), a trailing block only where it
+ * declares a right, and the same prescriptive sizing — two-line rows draw `md`
+ * glyphs, one-line rows `sm`.
+ */
+const ListSlotSkeleton = ({
+  params,
+  ctx,
+}: {
+  params: Partial<ListParams>
+  ctx: HomeSkeletonCtx
+}) => {
+  const schema = params.schema ?? {}
+  // Rows past `maxVisibleItems` fold behind "View more", so the loaded list
+  // never shows more than that — nor should the placeholder.
+  const count = Math.max(
+    0,
+    Math.min(ctx.expectedItemsCount, schema.maxVisibleItems ?? Infinity)
+  )
+  const compact = Boolean(schema.compact) || count > LIST_COMPACT_AFTER
+  const twoLine = Boolean(schema.descriptionRequired) && !compact
+  // More items than the list will show means the loaded list carries the "View
+  // more" button at its bottom — so the placeholder leaves room for it.
+  const overflows = ctx.expectedItemsCount > count
+
+  return (
+    <div className={cn(slotRowBleed(ctx), "flex flex-col")}>
+      {Array.from({ length: count }, (_, index) => (
+        // The row's own geometry (see `HomeListItem`): p-2, gap-3, centered.
+        <div
+          key={index}
+          data-testid={SLOT_SKELETON_ITEM_TESTID}
+          className="flex w-full items-center gap-3 p-2"
+        >
+          {schema.left ? (
+            <Skeleton
+              className={cn(
+                "shrink-0",
+                twoLine ? "size-8" : "size-6",
+                schema.left === "person" ? "rounded-full" : "rounded-sm"
+              )}
+            />
+          ) : null}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <SkeletonLine className={skeletonTitleWidth(index)} />
+            {twoLine ? <SkeletonLine className="w-1/4" /> : null}
+          </div>
+          {schema.right ? (
+            <Skeleton className="h-4 w-10 shrink-0 rounded-sm" />
+          ) : null}
+        </div>
+      ))}
+      {overflows ? (
+        <div className="mt-1 self-start">
+          {/* An `sm` ghost button — what "View more (n)" will be. */}
+          <Skeleton className="h-6 w-24 rounded-sm" />
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+/** The `event-list` placeholder: the colour band, two lines, the date avatar. */
+const EventListSlotSkeleton = ({ ctx }: { ctx: HomeSkeletonCtx }) => (
+  <div className={cn(slotRowBleed(ctx), "flex flex-col", EVENT_LIST_GAP)}>
+    {Array.from({ length: ctx.expectedItemsCount }, (_, index) => (
+      <div
+        key={index}
+        data-testid={SLOT_SKELETON_ITEM_TESTID}
+        className="flex flex-row items-stretch gap-2.5 rounded-sm p-2"
+      >
+        <Skeleton className="min-h-10 w-1 shrink-0 rounded-2xs" />
+        <div className="flex flex-1 flex-col justify-center">
+          <SkeletonLine className={skeletonTitleWidth(index)} />
+          <SkeletonLine className="w-1/3" />
+        </div>
+        {/* `F0AvatarDate` is a fixed 40px square. */}
+        <Skeleton className="size-10 shrink-0 rounded-md" />
+      </div>
+    ))}
+  </div>
+)
+
+/** The `indicators` placeholder: a big number over its label, per indicator. */
+const IndicatorsSlotSkeleton = ({ ctx }: { ctx: HomeSkeletonCtx }) => (
+  <div className="grid auto-cols-fr grid-flow-col items-end gap-x-3">
+    {Array.from({ length: ctx.expectedItemsCount }, (_, index) => (
+      <div
+        key={index}
+        data-testid={SLOT_SKELETON_ITEM_TESTID}
+        className="flex flex-col gap-1"
+      >
+        {/* The big number's own line box, then the label's. */}
+        <div className="flex h-8 items-center">
+          <Skeleton className="h-6 w-10" />
+        </div>
+        <SkeletonLine className="w-3/4" />
+      </div>
+    ))}
+  </div>
+)
+
+/**
+ * What a slot draws while loading when its visualization brings no skeleton of
+ * its own — an unregistered one, or a bespoke renderer passed as a bare
+ * function. Deliberately shapeless: one bar per expected item.
+ */
+export const defaultSlotSkeleton: SlotSkeletonRenderer = (_params, ctx) => (
+  <div className="flex flex-col gap-2">
+    {Array.from({ length: ctx.expectedItemsCount }, (_, index) => (
+      <div key={index} data-testid={SLOT_SKELETON_ITEM_TESTID}>
+        <Skeleton className={cn("h-6", skeletonTitleWidth(index))} />
+      </div>
+    ))}
+  </div>
+)
+
 /**
  * Built-in renderers for the standard visualizations. `list` covers every
  * row-based slot through its schema; `event-list` and `indicators` spread
  * their params onto the matching f0 content component. Bespoke visualizations
  * (e.g. `clock-in`, `carousel`) are intentionally absent — supply them via
  * `slotRenderers`.
+ *
+ * Each ships its own `skeleton` beside its `render`, so a widget's loading
+ * state is drawn by the same thing that draws its content.
  */
 export const defaultSlotRenderers: SlotRenderers = {
-  list: (params, ctx) => <ListSlot params={params as ListParams} ctx={ctx} />,
+  list: {
+    render: (params, ctx) => (
+      <ListSlot params={params as ListParams} ctx={ctx} />
+    ),
+    skeleton: (params, ctx) => (
+      // Partial: a loading `list` carries its schema but not yet its items.
+      <ListSlotSkeleton
+        params={(params ?? {}) as Partial<ListParams>}
+        ctx={ctx}
+      />
+    ),
+  },
   // The events are rendered here rather than through `CalendarEventList` for one
   // reason: that component's `showAllItems` container has no gap, and its `gap`
   // prop only reaches the overflow path — so `EVENT_LIST_GAP` has to sit on the
   // DIRECT parent of the event items, which is this container.
-  "event-list": (params, ctx) => {
-    const { events } = params as EventListParams
-    return (
-      <div className={cn(slotRowBleed(ctx), "flex flex-col", EVENT_LIST_GAP)}>
-        {events.map((event) => (
-          <CalendarEvent key={event.title} {...event} />
-        ))}
-      </div>
-    )
+  "event-list": {
+    render: (params, ctx) => {
+      const { events } = params as EventListParams
+      return (
+        <div className={cn(slotRowBleed(ctx), "flex flex-col", EVENT_LIST_GAP)}>
+          {events.map((event) => (
+            <CalendarEvent key={event.title} {...event} />
+          ))}
+        </div>
+      )
+    },
+    skeleton: (_params, ctx) => <EventListSlotSkeleton ctx={ctx} />,
   },
-  indicators: (params) => (
-    <IndicatorsList {...(params as IndicatorsListProps)} />
-  ),
+  indicators: {
+    render: (params) => <IndicatorsList {...(params as IndicatorsListProps)} />,
+    skeleton: (_params, ctx) => <IndicatorsSlotSkeleton ctx={ctx} />,
+  },
 }


### PR DESCRIPTION
## Description

Home widgets had no loading state of their own: a widget waiting on its data either rendered an empty frame or was replaced wholesale by `Widget.Skeleton`, whose generic bars look nothing like the rows that follow and change the card's height when the data lands. This gives every slot visualization its own minimal skeleton, drawn from the static config the slot already carries, and lets each slot declare how many items it expects — so the loading card is the same shape as the loaded one and simply fills in.

## Screenshots (if applicable)

Storybook: **Home/SlotWidget → All Loading Slots**, **Home/SlotWidget → Bespoke Loading Slots**, and **Home/NewHomeLayout → Loading**.

Slot-for-slot height parity with the loaded widget, measured in the browser (`All Slots` vs `All Loading Slots`):

```
loaded    [56, 112, 80, 56, 112, 40, 40, 56, 45, 40, 72, 40, 196, 164]
loading   [56, 112, 80, 56, 112, 40, 40, 56, 40, 40, 72, 40, 196, 112]
```

Only two differ: the flag row (5px, a quirk of that glyph) and `event-list`, whose real rows grow with wrapped descriptions.

## Implementation details

- feat: add `loading` to `SlotWidget` — every slot draws its visualization's skeleton while the frame, chrome and dashed seams stay put. The stack is marked `aria-busy` and the placeholders are `aria-hidden`.
- feat: add `expectedItemsCount` to `HomeWidgetSlot`, taken as a third argument by `homeSlot` and `listSlot`, defaulting to `DEFAULT_EXPECTED_ITEMS_COUNT` (3) — a widget declares its loading height instead of the kit guessing at one.
- feat: ship a skeleton with each built-in visualization (`list`, `event-list`, `indicators`)

  <details>
  <summary>How the <code>list</code> placeholder is shaped</summary>

  A `list`'s schema is static config, so it is known before the items are. The placeholder reads it the way the real list does: a left glyph only where one is declared (round for a person, square otherwise), a trailing block only where the schema declares a `right`, and the same prescriptive sizing — two-line rows draw `md` glyphs, one-line rows `sm`. `maxVisibleItems` caps the placeholder the way it caps the list, and when more items are expected than it will show, the "View more" button is placed too.

  Placeholder bars sit in the same 20px line boxes real text occupies, which is what buys the height parity above.
  </details>

- feat: let a renderer entry be `{ render, skeleton }` as well as a bare function, so a bespoke visualization's loading state lives beside the thing that draws it. Existing bare-function maps keep working; a visualization with no skeleton (bespoke or unregistered) gets a generic placeholder rather than the dashed "no renderer" notice.
- feat: add `loading` to `HomeWidgetItem`, threaded through `WidgetContainer` and `NewHomeLayout`, so a rail can load widget by widget as each request lands.
- docs: document how to define a widget's loading state in the SlotWidget MDX — the loading slots are the same slots minus their data, plus `expectedItemsCount`.
- test: add 12 unit tests covering the expected count, the `maxVisibleItems` cap, schema-driven row shape, a bespoke renderer's own skeleton, and the generic fallback.
- refactor: drop the trailing chevron from Home list rows

  <details>
  <summary>Why?</summary>

  A row that goes somewhere already says so by being a link — it highlights on hover, focuses, and behaves as a real anchor. A column of arrows repeating "clickable" on every row is noise in a widget this dense, and it competed with the schema's `right` (counters, avatar strips) for the row's right-hand side. `HomeListItem`'s `showChevron` keeps it available as an opt-in; it just no longer defaults to on for link rows. Row heights are unchanged, so the parity figures above still hold.
  </details>
- feat: draw the widget header's link with the **external-link** glyph and show its `title` as a tooltip

  <details>
  <summary>Why?</summary>

  The header link is an icon-only control, so nothing on screen said where it went — the chevron read as "more of this widget" rather than "leave for Communications". It now uses the external-link glyph (`icon` still overrides it) and shows its `title` in a tooltip as well as using it for the accessible name. `title` was already required by the type; this makes it earn that, so the labels are written as the action — "Go to Communications", not "Open". Applies to every f0 `Widget`, not just Home's.
  </details>
