### PR TITLE
chore(storybook): cap docs pages to a readable measure

### DIFF
--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -1,6 +1,9 @@
 <style>
   :root {
     --storybook-docs-space-5: 20px;
+    /* Measure for docs pages. Keeps prose at a readable line length instead of
+       stretching to the full viewport on wide screens. */
+    --storybook-docs-content-width: 720px;
   }
 
   #storybook-docs h1:not(.docs-story *),
@@ -203,7 +206,36 @@
   }
 
   .sbdocs-content {
+    max-width: var(--storybook-docs-content-width) !important;
+    width: 100% !important;
+  }
+
+  /*
+   * Page shells are about the whole canvas, so the measure would squash them.
+   * A story opts in with `parameters: { docsFullWidth: true }` — the F0
+   * decorator in preview.tsx turns that into the marker below — and the column
+   * grows into the width left over by the table of contents.
+   */
+  .sbdocs-content:has([data-docs-full-width]) {
     max-width: 100% !important;
+  }
+
+  /*
+   * Only the canvas wants that width, though: the prose around it still reads
+   * better at the measure, so every other top-level block keeps it and stays
+   * centred over the canvas. Both selectors carry `#storybook-docs` to outrank
+   * the `#storybook-docs p { margin: 0 0 … !important }` rule above, which
+   * would otherwise pin paragraphs to the left edge.
+   */
+  #storybook-docs .sbdocs-content:has([data-docs-full-width]) > * {
+    max-width: var(--storybook-docs-content-width);
+    margin-inline: auto !important;
+  }
+
+  #storybook-docs
+    .sbdocs-content:has([data-docs-full-width])
+    > *:has(.sbdocs-preview) {
+    max-width: none;
   }
 
   input[type="radio"] {

--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -59,8 +59,15 @@ export const withTheme = () => {
   }
 }
 
-export const F0 = (Story: StoryFn, { parameters }: StoryContext) => {
+export const F0 = (Story: StoryFn, { parameters, viewMode }: StoryContext) => {
   const [currentPath, setCurrentPath] = useState(parameters.currentPath ?? "/")
+
+  // Docs pages are capped to a readable measure (see preview-head.html). Page
+  // shells — the Home layouts, ApplicationFrame — are about the whole canvas
+  // and have nothing to do with reading, so they opt out with
+  // `parameters: { docsFullWidth: true }` and the measure steps aside there.
+  const optOutOfDocsMeasure =
+    viewMode === "docs" && parameters.docsFullWidth === true
 
   return (
     <F0Provider
@@ -117,6 +124,13 @@ export const F0 = (Story: StoryFn, { parameters }: StoryContext) => {
       dataCollectionStorageHandler={dataCollectionLocalStorageHandler}
       renderDataTestIdAttribute={true}
     >
+      {optOutOfDocsMeasure && (
+        <span
+          data-docs-full-width
+          aria-hidden="true"
+          style={{ display: "none" }}
+        />
+      )}
       <Story />
     </F0Provider>
   )

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -539,6 +539,7 @@ const meta = {
   tags: ["autodocs", "experimental"],
   parameters: {
     layout: "fullscreen",
+    docsFullWidth: true,
   },
   args: {
     ai: {

--- a/packages/react/src/patterns/Navigation/Page/index.stories.tsx
+++ b/packages/react/src/patterns/Navigation/Page/index.stories.tsx
@@ -21,6 +21,7 @@ const meta: Meta<typeof Page> = {
   tags: ["autodocs", "experimental"],
   parameters: {
     layout: "fullscreen",
+    docsFullWidth: true,
   },
   decorators: [
     (Story) => (

--- a/packages/react/src/sds/Home/DaytimePage/index.stories.tsx
+++ b/packages/react/src/sds/Home/DaytimePage/index.stories.tsx
@@ -14,6 +14,7 @@ const meta: Meta<typeof DaytimePage> = {
   tags: ["autodocs", "experimental"],
   parameters: {
     layout: "fullscreen",
+    docsFullWidth: true,
   },
   decorators: [
     (Story) => (

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -680,7 +680,7 @@ const meta = {
   title: "Home/NewHomeLayout",
   component: NewHomeLayout,
   tags: ["autodocs", "experimental"],
-  parameters: { layout: "fullscreen" },
+  parameters: { layout: "fullscreen", docsFullWidth: true },
   decorators: [
     (Story) => (
       <ApplicationFrame


### PR DESCRIPTION
## Description

Docs pages stretched to the full viewport, so on wide screens prose ran to line lengths that are hard to read. This caps the docs column at a 720px measure and lets page-shell stories opt back out, since those are about the canvas rather than the reading.
