### PR TITLE
fix(NewHomeLayout): keep rail widgets mounted when collapsing

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -1,9 +1,11 @@
 import { beforeEach, describe, expect, test, vi } from "vitest"
 
-import { Calendar, Clock } from "@/icons/app"
-import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+import { useEffect, useState } from "react"
 
-import { type HomeWidgetItem } from "../slotRenderers"
+import { Calendar, Clock } from "@/icons/app"
+import { act, screen, userEvent, zeroRender } from "@/testing/test-utils"
+
+import { type HomeWidgetItem, type SlotRenderers } from "../slotRenderers"
 import { NewHomeLayout } from "./index"
 
 /**
@@ -12,6 +14,18 @@ import { NewHomeLayout } from "./index"
  * ResizeObserver reports back to it.
  */
 let layoutWidth = 1400
+
+/** Every live ResizeObserver callback, so a test can act like the box resized. */
+let resizeCallbacks: Array<() => void> = []
+
+/**
+ * Resizes the layout the way the window does: the new width is what
+ * `clientWidth` reports, and the observers are told to read it again.
+ */
+const resizeLayoutTo = (width: number) => {
+  layoutWidth = width
+  act(() => resizeCallbacks.forEach((notify) => notify()))
+}
 
 const widget = (
   id: string,
@@ -51,15 +65,82 @@ const renderLayout = (width: number, props = {}) => {
   )
 }
 
+/* ------------------- a widget whose render is not free ------------------- */
+
+/** How many times the clock-in tile has been built from scratch. */
+let clockMounts = 0
+
+/**
+ * The rail's clock-in tile as the real one behaves: it has NOTHING to show on
+ * its first frame and only settles once its deferred read lands (a running
+ * total, a fetch, a timer — anything a mount has to start over).
+ *
+ * That makes it the instrument for these tests: a remount both bumps
+ * `clockMounts` and drops the tile back to "clocking in…", so tearing the widget
+ * down and building it again is visible instead of silent.
+ */
+const DeferredClockIn = () => {
+  const [reading, setReading] = useState<string | null>(null)
+  useEffect(() => {
+    clockMounts += 1
+    const settle = setTimeout(() => setReading("08:00"), 0)
+    return () => clearTimeout(settle)
+  }, [])
+  return <span>{reading ?? "clocking in…"}</span>
+}
+
+const DEFERRED_RENDERERS: SlotRenderers = {
+  "clock-in": { render: () => <DeferredClockIn /> },
+}
+
+const DEFERRED_RAIL: HomeWidgetItem[] = [
+  {
+    id: "clock",
+    icon: Clock,
+    locked: true,
+    header: { title: "clock" },
+    slots: [{ visualization: "clock-in", params: {} }],
+  },
+  {
+    id: "events",
+    icon: Calendar,
+    header: { title: "events" },
+    // A label of its own, so a test can ask after THIS widget's body without
+    // matching the header that names it too.
+    slots: [
+      {
+        visualization: "indicators",
+        params: { items: [{ label: "requests", content: "1" }] },
+      },
+    ],
+  },
+]
+
+/** Renders the rail with the deferred tile in it, settled. */
+const renderDeferredRail = async (width: number) => {
+  const result = renderLayout(width, {
+    rightWidgets: DEFERRED_RAIL,
+    slotRenderers: DEFERRED_RENDERERS,
+  })
+  await screen.findByText("08:00")
+  return result
+}
+
 beforeEach(() => {
   Object.defineProperty(HTMLElement.prototype, "clientWidth", {
     configurable: true,
     get: () => layoutWidth,
   })
-  // jsdom has no ResizeObserver; the layout only needs the initial read.
+  resizeCallbacks = []
+  clockMounts = 0
+  // jsdom has no ResizeObserver. This one keeps its callback so a test can fire
+  // it (`resizeLayoutTo`) instead of only serving the initial read.
   vi.stubGlobal(
     "ResizeObserver",
     class {
+      constructor(callback: () => void) {
+        resizeCallbacks.push(callback)
+      }
       observe() {}
       disconnect() {}
     }
@@ -184,6 +265,73 @@ describe("NewHomeLayout", () => {
       const root = container.querySelector(".isolate") as HTMLElement
 
       expect(root.style.gridTemplateColumns).toBe("minmax(0, 1fr)")
+    })
+  })
+
+  /**
+   * ONE render per rail widget, whatever the rail is doing. Collapsing, hovering
+   * a glyph and expanding again are presentation changes — none of them may
+   * restart a widget's render, so a tile that had loaded stays loaded.
+   */
+  describe("the rail's widgets stay mounted", () => {
+    test("collapsing on resize keeps the same render, settled", async () => {
+      await renderDeferredRail(1400)
+      expect(clockMounts).toBe(1)
+
+      resizeLayoutTo(1000)
+
+      // Collapsed — and the tile is still the one that had already settled.
+      expect(screen.getByRole("button", { name: "clock" })).toBeInTheDocument()
+      expect(screen.getByText("08:00")).toBeInTheDocument()
+      expect(clockMounts).toBe(1)
+    })
+
+    test("keeps the collapsed rail out of sight until a glyph is hovered", async () => {
+      await renderDeferredRail(1000)
+
+      expect(screen.getByText("08:00")).not.toBeVisible()
+    })
+
+    test("hovering a glyph floats THAT widget, and only it", async () => {
+      await renderDeferredRail(1000)
+
+      await userEvent.hover(screen.getByRole("button", { name: "clock" }))
+
+      expect(screen.getByText("08:00")).toBeVisible()
+      // The rail's other widget is mounted beside it, not shown.
+      expect(screen.getByText("requests")).not.toBeVisible()
+      expect(clockMounts).toBe(1)
+    })
+
+    test("hovering does not rebuild the widget it floats", async () => {
+      await renderDeferredRail(1000)
+
+      await userEvent.hover(screen.getByRole("button", { name: "clock" }))
+
+      expect(screen.queryByText("clocking in…")).not.toBeInTheDocument()
+      expect(clockMounts).toBe(1)
+    })
+
+    test("expanding again keeps the render it had while collapsed", async () => {
+      await renderDeferredRail(1400)
+      resizeLayoutTo(1000)
+      resizeLayoutTo(1400)
+
+      expect(
+        screen.getByLabelText("Collapse widgets panel")
+      ).toBeInTheDocument()
+      expect(screen.getByText("08:00")).toBeVisible()
+      expect(clockMounts).toBe(1)
+    })
+
+    test("collapsing by hand keeps it mounted too", async () => {
+      await renderDeferredRail(1400)
+
+      await userEvent.click(screen.getByLabelText("Collapse widgets panel"))
+
+      expect(screen.getByLabelText("Expand widgets panel")).toBeInTheDocument()
+      expect(screen.getByText("08:00")).toBeInTheDocument()
+      expect(clockMounts).toBe(1)
     })
   })
 })

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -4,6 +4,7 @@ import {
   forwardRef,
   Fragment,
   ReactNode,
+  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -269,6 +270,13 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       ? rightWidgets.find((widget) => widget.id === openId)
       : undefined
 
+    // Nothing floats out of an EXPANDED rail, so the hover is dropped as soon as
+    // the rail opens up: kept, it would reopen whatever was last hovered the
+    // moment the layout narrowed again.
+    useEffect(() => {
+      if (!collapsed) setOpenId(null)
+    }, [collapsed])
+
     const cancelLeave = () => {
       if (leaveTimer.current) clearTimeout(leaveTimer.current)
       leaveTimer.current = null
@@ -442,121 +450,149 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             {stackedChildren}
           </WidgetContainer>
         </div>
-        {stacked ? null : hasSide ? (
-          collapsed ? (
-            // The collapsed strip: one avatar per widget, the widget's own
-            // catalog glyph. Hover/click floats the widget over the feed.
-            // NO FADE HERE: the strip is a short column of 40px glyphs, and a
-            // mask over those washes the glyphs themselves out rather than
-            // hinting at content past an edge. The fade belongs to the expanded
-            // rail, where the content is tall cards.
-            // `-m-1 p-1`: the hasUpdates dot pokes 2px past the 40px glyphs,
-            // and the scrollport would clip it — bleed the scrollport out by
-            // 4px (padding puts the glyphs back) so the dot stays inside it.
-            <aside
-              className={cn(
-                "-m-1 flex min-h-0 flex-col gap-2 overflow-y-auto p-1",
-                SCROLLBAR_HIDDEN
-              )}
-              onMouseLeave={scheduleLeave}
-              onMouseEnter={cancelLeave}
-            >
-              {rightWidgets.map((widget) => (
-                <button
-                  key={widget.id}
-                  type="button"
-                  aria-label={widget.header?.title ?? widget.id}
-                  aria-expanded={openId === widget.id}
-                  onMouseEnter={(event) =>
-                    openFromAnchor(widget.id, event.currentTarget)
-                  }
-                  onClick={(event) =>
-                    openId === widget.id
-                      ? setOpenId(null)
-                      : openFromAnchor(widget.id, event.currentTarget)
-                  }
-                  className="rounded-lg"
-                >
-                  {/* Same accent dot HomeListItem uses for unread rows. */}
-                  <span className="relative inline-flex">
-                    {widget.icon ? (
-                      <F0AvatarIcon icon={widget.icon} size="lg" />
-                    ) : (
-                      <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-solid border-f1-border-secondary bg-f1-background font-medium text-f1-foreground-secondary">
-                        {(widget.header?.title ?? widget.id).charAt(0)}
-                      </span>
-                    )}
-                    {widget.hasUpdates ? (
-                      // Same dot HomeListItem draws for unread rows — the ring
-                      // keeps it legible over any glyph.
-                      <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
-                    ) : null}
-                  </span>
-                </button>
-              ))}
-              {/* Always offered, not only in edit mode: collapsed, the strip has
+        {stacked || !hasSide || !collapsed ? null : (
+          // The collapsed strip: one avatar per widget, the widget's own
+          // catalog glyph. Hover/click floats the widget over the feed.
+          // NO FADE HERE: the strip is a short column of 40px glyphs, and a
+          // mask over those washes the glyphs themselves out rather than
+          // hinting at content past an edge. The fade belongs to the expanded
+          // rail, where the content is tall cards.
+          // `-m-1 p-1`: the hasUpdates dot pokes 2px past the 40px glyphs,
+          // and the scrollport would clip it — bleed the scrollport out by
+          // 4px (padding puts the glyphs back) so the dot stays inside it.
+          <aside
+            className={cn(
+              "-m-1 flex min-h-0 flex-col gap-2 overflow-y-auto p-1",
+              SCROLLBAR_HIDDEN
+            )}
+            onMouseLeave={scheduleLeave}
+            onMouseEnter={cancelLeave}
+          >
+            {rightWidgets.map((widget) => (
+              <button
+                key={widget.id}
+                type="button"
+                aria-label={widget.header?.title ?? widget.id}
+                aria-expanded={openId === widget.id}
+                onMouseEnter={(event) =>
+                  openFromAnchor(widget.id, event.currentTarget)
+                }
+                onClick={(event) =>
+                  openId === widget.id
+                    ? setOpenId(null)
+                    : openFromAnchor(widget.id, event.currentTarget)
+                }
+                className="rounded-lg"
+              >
+                {/* Same accent dot HomeListItem uses for unread rows. */}
+                <span className="relative inline-flex">
+                  {widget.icon ? (
+                    <F0AvatarIcon icon={widget.icon} size="lg" />
+                  ) : (
+                    <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-solid border-f1-border-secondary bg-f1-background font-medium text-f1-foreground-secondary">
+                      {(widget.header?.title ?? widget.id).charAt(0)}
+                    </span>
+                  )}
+                  {widget.hasUpdates ? (
+                    // Same dot HomeListItem draws for unread rows — the ring
+                    // keeps it legible over any glyph.
+                    <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
+                  ) : null}
+                </span>
+              </button>
+            ))}
+            {/* Always offered, not only in edit mode: collapsed, the strip has
                   no edit affordance of its own, and adding a widget is the one
                   thing you would still want from it. */}
-              {canEditSide("right") && onClickAddNewWidget ? (
-                <button
-                  type="button"
-                  aria-label="Add widget"
-                  onClick={() => onClickAddNewWidget("right")}
-                  className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:text-f1-foreground"
-                >
-                  +
-                </button>
-              ) : null}
-            </aside>
-          ) : (
-            <aside
-              ref={railFade.ref}
-              className={cn("min-h-0 overflow-y-auto", SCROLLBAR_HIDDEN)}
-              style={railFade.style}
-            >
-              <WidgetContainer
-                side="right"
-                widgets={rightWidgets}
-                slotRenderers={slotRenderers}
-                renderWidget={renderWidget}
-                ctx={ctx}
-                editing={isEditing}
-                disableEdition={!canEditSide("right")}
-                onReorder={
-                  onReorderWidgets
-                    ? (ids) => onReorderWidgets("right", ids)
-                    : undefined
-                }
-                onRemoveWidget={onRemoveWidget}
-                onClickAddNewWidget={
-                  onClickAddNewWidget
-                    ? () => onClickAddNewWidget("right")
-                    : undefined
-                }
+            {canEditSide("right") && onClickAddNewWidget ? (
+              <button
+                type="button"
+                aria-label="Add widget"
+                onClick={() => onClickAddNewWidget("right")}
+                className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:text-f1-foreground"
               >
-                {aside}
-              </WidgetContainer>
-            </aside>
-          )
-        ) : null}
-        {/* The floating panel: the SAME widget render the expanded rail makes,
-            at the expanded rail width, level with its avatar. */}
-        {openWidget ? (
-          <div className="pointer-events-none absolute inset-0">
-            <div
-              className="pointer-events-auto absolute rounded-xl bg-f1-background"
-              style={{
-                top: panelTop,
-                right: COLLAPSED_RAIL_WIDTH + 8,
-                width: asideWidth,
-              }}
-              onMouseEnter={cancelLeave}
-              onMouseLeave={scheduleLeave}
+                +
+              </button>
+            ) : null}
+          </aside>
+        )}
+        {/* THE RAIL BODY — one mount, whatever the rail is doing.
+
+            Expanded it is the rail's column. Collapsed it is the FLOATING PANEL:
+            the same element, taken out of the grid and put at the expanded rail
+            width level with the hovered glyph, showing that one widget while the
+            rest stay mounted beside it (`visibleWidgetId`).
+
+            This used to be two trees — a container for the column and a second
+            render of the open widget for the panel — and either one appearing or
+            disappearing tore down every widget in it. Crossing the collapse
+            threshold on a window resize, and every hover of a glyph, therefore
+            built the rail's widgets again from nothing: a tile that had loaded
+            went back to loading, a running clock restarted, an animation
+            replayed. Presentation changes now move ONE render around instead of
+            replacing it. (Stacked is the exception, and cannot be otherwise:
+            below `md` the rail's widgets belong to the main column's flow,
+            interleaved with content this layout doesn't own.) */}
+        {stacked || !hasSide ? null : (
+          <aside
+            ref={railFade.ref}
+            // With nothing hovered there is no panel to see or to read out — but
+            // its widgets stay mounted underneath, which is the whole point.
+            hidden={collapsed && !openWidget}
+            className={cn(
+              "min-h-0 overflow-y-auto",
+              SCROLLBAR_HIDDEN,
+              // Above the feed it floats over, and opaque: the widget behind it
+              // must not read through the card.
+              collapsed && "absolute z-10 rounded-xl bg-f1-background"
+            )}
+            style={
+              collapsed
+                ? {
+                    top: panelTop,
+                    right: COLLAPSED_RAIL_WIDTH + 8,
+                    width: asideWidth,
+                    // The panel grows to its widget, up to what is left below
+                    // its glyph, and scrolls past that.
+                    maxHeight: `calc(100% - ${panelTop}px)`,
+                  }
+                : railFade.style
+            }
+            onMouseEnter={collapsed ? cancelLeave : undefined}
+            onMouseLeave={collapsed ? scheduleLeave : undefined}
+          >
+            <WidgetContainer
+              side="right"
+              widgets={rightWidgets}
+              // Collapsed, this container IS the panel: one widget shown, the
+              // others hidden rather than dropped.
+              visibleWidgetId={collapsed ? openId : undefined}
+              slotRenderers={slotRenderers}
+              renderWidget={renderWidget}
+              ctx={ctx}
+              editing={isEditing}
+              disableEdition={!canEditSide("right")}
+              onReorder={
+                onReorderWidgets
+                  ? (ids) => onReorderWidgets("right", ids)
+                  : undefined
+              }
+              onRemoveWidget={onRemoveWidget}
+              // Not from the panel: collapsed, the strip carries the add
+              // affordance, and a placeholder under a single floating widget
+              // would be an offer in the wrong place.
+              onClickAddNewWidget={
+                onClickAddNewWidget && !collapsed
+                  ? () => onClickAddNewWidget("right")
+                  : undefined
+              }
             >
-              {render(openWidget)}
-            </div>
-          </div>
-        ) : null}
+              {/* The rail's freeform content belongs to the COLUMN, not to one
+                  widget floating out of it. */}
+              {collapsed ? null : aside}
+            </WidgetContainer>
+          </aside>
+        )}
       </div>
     )
   }

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, Fragment, ReactNode, useState } from "react"
+import { type CSSProperties, ReactNode, useState } from "react"
 
 import {
   closestCenter,
@@ -69,6 +69,34 @@ const widgetChrome = (widget: HomeWidgetItem) =>
 /** Which column a container is: the growing main one, or the fixed side rail. */
 export type WidgetContainerSide = "main" | "right"
 
+/**
+ * One widget's place in the column, and the only thing that decides whether it
+ * is SHOWN — never whether it exists.
+ *
+ * Shown, `display: contents` leaves no box behind, so the widget is the flex
+ * item it would have been without this wrapper: the column's gap, its own
+ * `fullHeight` and every child selector land on the card exactly as before.
+ * Hidden, plain `hidden` takes it out of sight AND out of the a11y tree — while
+ * its render stays MOUNTED.
+ *
+ * It wraps every widget whether or not anything is being hidden: a wrapper that
+ * came and went with the filtering would change the tree's shape, and changing
+ * shape is what unmounts a render.
+ */
+const WidgetSlot = ({
+  hidden,
+  children,
+}: {
+  hidden: boolean
+  children: ReactNode
+}) => (
+  // No `display` of its own while hidden: `hidden` only means `display: none`
+  // for as long as nothing else sets one.
+  <div hidden={hidden} style={{ display: hidden ? undefined : "contents" }}>
+    {children}
+  </div>
+)
+
 const AddWidgetPlaceholder = ({ onClick }: { onClick: () => void }) => (
   <button
     type="button"
@@ -107,6 +135,16 @@ export interface WidgetContainerProps {
    * it and the column is not draggable, even in edit mode.
    */
   onReorder?: (ids: string[]) => void
+  /**
+   * Shows ONE of the column's widgets and hides the rest — hides, not drops:
+   * every widget stays mounted, so what it had loaded, timed or animated
+   * survives. `undefined` (the default) shows them all; `null` shows none.
+   *
+   * For a container that is sometimes a whole column and sometimes a single
+   * floating widget — `NewHomeLayout`'s collapsed rail, which hovers one widget
+   * out over the feed from this same container rather than mounting a copy.
+   */
+  visibleWidgetId?: string | null
   /** Tooltip on a locked widget's lock icon. */
   lockedLabel?: string
   ctx?: HomeRenderCtx
@@ -139,12 +177,15 @@ export function WidgetContainer({
   onRemoveWidget,
   onClickAddNewWidget,
   onReorder,
+  visibleWidgetId,
   lockedLabel = "This widget is mandatory in your company.",
   ctx = {},
   className,
   style,
 }: WidgetContainerProps) {
   const canEdit = editing && !disableEdition
+  const isHidden = (widget: HomeWidgetItem) =>
+    visibleWidgetId !== undefined && widget.id !== visibleWidgetId
   const canDrag = canEdit && onReorder != null && widgets.length > 1
   // The widget being dragged: its in-list card hides while a clone rides the
   // pointer in the DragOverlay (see below).
@@ -295,13 +336,11 @@ export function WidgetContainer({
               )}
             >
               {widgets.map((widget) => (
-                <SortableWidget
-                  key={widget.id}
-                  id={widget.id}
-                  disabled={widget.locked}
-                >
-                  {(state) => render(widget, state)}
-                </SortableWidget>
+                <WidgetSlot key={widget.id} hidden={isHidden(widget)}>
+                  <SortableWidget id={widget.id} disabled={widget.locked}>
+                    {(state) => render(widget, state)}
+                  </SortableWidget>
+                </WidgetSlot>
               ))}
             </div>
           </SortableContext>
@@ -326,7 +365,9 @@ export function WidgetContainer({
         </DndContext>
       ) : (
         widgets.map((widget) => (
-          <Fragment key={widget.id}>{render(widget)}</Fragment>
+          <WidgetSlot key={widget.id} hidden={isHidden(widget)}>
+            {render(widget)}
+          </WidgetSlot>
         ))
       )}
       {/* NOT edit-gated: adding is always on offer — edit mode is for


### PR DESCRIPTION
## Description

The side rail's widgets were being torn down and rebuilt whenever the rail changed state: crossing the collapse threshold on a window resize unmounted them, and every hover of a collapsed glyph mounted a fresh copy. A custom `renderWidget`/slot renderer that loads, ticks or animates therefore started over from nothing each time — a tile that had finished loading went back to loading. The rail body is now one mount whose presentation changes instead of its identity.

## Implementation details

- fix: render the rail's widgets ONCE, in a single container that is the rail's column when expanded and the floating panel when collapsed — the same element, taken out of the grid and positioned level with the hovered glyph — instead of a container plus a second render of the open widget

  <details>
  <summary>Why the old shape remounted</summary>

  The expanded column and the collapsed strip's floating panel were two separate trees, each mounting its own render of the rail's widgets. Whichever one appeared or disappeared took its whole subtree with it, so `collapsed` flipping (on resize or the manual toggle) and `openId` changing (on hover) both counted as a fresh mount.
  </details>

- feat(WidgetContainer): add `visibleWidgetId` — shows one widget and HIDES the rest rather than dropping them, so the collapsed rail can float a single widget out of the same container it uses as a column

  <details>
  <summary>How the wrapper stays transparent</summary>

  Every widget is wrapped in a slot div whether or not anything is being filtered — a wrapper that came and went would itself change the tree's shape. Shown, it is `display: contents`, so it generates no box and the widget remains the flex item it was (gap, `fullHeight` and child selectors all land on the card as before). Hidden, it is plain `hidden`, which also takes it out of the a11y tree while its render stays mounted.
  </details>

- fix: clear the collapsed rail's hover when the rail expands, so re-collapsing doesn't reopen whatever was last hovered
- feat: cap the floating panel to the room left below its glyph and let it scroll, instead of letting a tall widget run off the page
- test: drive the layout's ResizeObserver from the spec, and add a deferred clock-in slot renderer (nothing to show until its first read lands, plus a mount counter) so a remount is observable — six tests covering resize-collapse, hover, expand and manual collapse

### Notes for the reviewer

- Verified in Storybook that the widget's DOM node is literally the same node across expand → collapse → hover → expand, and that the floating panel still shows one opaque widget at the rail's width, level with its glyph.
- While collapsed, the rail's widgets are mounted but hidden, so they keep doing their work. That is the point of the fix (hovering already mounted them all, one at a time), but it does mean a collapsed rail is no longer free.
- Below `md` the layout stacks and the rail's widgets fold into the main column's flow, interleaved with content the layout doesn't own. That transition still remounts them, and can't not — noted in the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)