### PR TITLE
fix(F0Graph): let tags shorten the connecting line instead of moving the nodes

### DIFF
--- a/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
@@ -6,6 +6,7 @@ import { F0Button } from "@/components/F0Button"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import type { DeferredNodesPayload, GraphNode } from "../types"
+import type { F0GraphNodeTag } from "../components/F0GraphNode"
 
 import {
   F0Graph,
@@ -1322,6 +1323,120 @@ export const StagedLoadingError: Story = {
       console.error("[StagedLoadingError] Deferred load failed:", error.message)
     },
   },
+}
+
+// ─── Tag row reservation (repro) ───────────────────────────────
+
+/**
+ * Mirrors the org chart: four toggleable tag columns with realistic, long
+ * labels. Use the metadata popover to hide them all (dead space below the
+ * card?) and to toggle combinations that wrap to two rows (does the outgoing
+ * edge start above the last row?).
+ */
+const TAG_REPRO_NODES: GraphNode<Employee>[] = [
+  {
+    id: "tr-1",
+    parentId: null,
+    data: { name: "Fidel Johnson", title: "People Director, CPO" },
+    childrenCount: 2,
+  },
+  {
+    id: "tr-2",
+    parentId: "tr-1",
+    data: { name: "Nina Volkov", title: "Frontend Lead" },
+    childrenCount: 0,
+  },
+  {
+    id: "tr-3",
+    parentId: "tr-1",
+    data: { name: "Diego Martín", title: "Backend Lead" },
+    childrenCount: 0,
+  },
+]
+
+const TAG_REPRO_COLUMNS = [
+  "workplace",
+  "reports",
+  "hired",
+  "legalEntity",
+] as const
+
+const tagReproTags = (node: GraphNode<Employee>): F0GraphNodeTag[] => [
+  { type: "raw", column: "workplace", text: "Tokyo office 11" },
+  { type: "raw", column: "reports", text: "20 reports" },
+  { type: "raw", column: "hired", text: "May 2025" },
+  { type: "raw", column: "legalEntity", text: `${node.data.name} SL` },
+]
+
+const TagRowReproDemo = () => {
+  const [visible, setVisible] = useState<string[]>([...TAG_REPRO_COLUMNS])
+  const toggle = (c: string) =>
+    setVisible((prev) =>
+      prev.includes(c) ? prev.filter((x) => x !== c) : [...prev, c]
+    )
+
+  return (
+    <div className="flex h-full w-full flex-col">
+      <div
+        className="flex flex-wrap items-center gap-2 p-2"
+        data-testid="tag-controls"
+      >
+        {TAG_REPRO_COLUMNS.map((c) => (
+          <F0Button
+            key={c}
+            size="sm"
+            variant={visible.includes(c) ? "default" : "outline"}
+            label={c}
+            onClick={() => toggle(c)}
+          />
+        ))}
+        <F0Button
+          size="sm"
+          variant="outline"
+          label="Hide all"
+          onClick={() => setVisible([])}
+        />
+        <F0Button
+          size="sm"
+          variant="outline"
+          label="Show all"
+          onClick={() => setVisible([...TAG_REPRO_COLUMNS])}
+        />
+      </div>
+      <div className="min-h-0 flex-1">
+        <F0Graph<Employee>
+          nodes={TAG_REPRO_NODES}
+          defaultExpandDepth={2}
+          nodeTagTypes={TAG_REPRO_COLUMNS}
+          visibleTagTypes={visible}
+          renderNode={(node, ctx) => {
+            const [firstName = "", lastName = ""] = node.data.name.split(" ")
+            return (
+              <F0GraphNode
+                {...ctx}
+                avatar={{ type: "person", firstName, lastName }}
+                title={node.data.name}
+                subtitle={node.data.title}
+                tags={tagReproTags(node)}
+              />
+            )
+          }}
+        />
+      </div>
+    </div>
+  )
+}
+
+export const TagRowReservation: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Repro for the tag-row reservation: the layout reserves a block below every card, estimated from the visible tag COUNT rather than what the tags actually render. Hide every column (dead space should collapse) and pick combinations that wrap to two rows (the edge should still start below the last row).",
+      },
+    },
+  },
+  render: () => <TagRowReproDemo />,
 }
 
 export const Snapshot: Story = {

--- a/packages/react/src/patterns/F0Graph/components/F0GraphEdge/F0GraphEdge.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphEdge/F0GraphEdge.tsx
@@ -10,6 +10,7 @@ import { memo } from "react"
 import type { EdgeVariant, F0GraphEdgeProps } from "./types"
 
 import { useF0GraphZoomInternal } from "../../contexts"
+import { EDGE_BUS_OFFSET, EDGE_MIN_STEM } from "../../constants"
 
 // Semantic edge stroke colors. Defined as CSS vars on .f0-graph in
 // F0Graph.css so they flip automatically in dark mode and stay aligned
@@ -77,6 +78,25 @@ export function F0GraphEdgeBase({
   const getPath = usesStraightSnap
     ? getStraightPath
     : (pathGetters[pathType] ?? pathGetters.smoothstep)
+
+  // Where the connector makes its horizontal run. Smoothstep defaults to the
+  // midpoint between the two nodes, which drags the run around with the SOURCE:
+  // a parent showing three chip rows starts lower and pushes its bus down, one
+  // showing none lifts it. Sibling branches then never line up.
+  //
+  // Anchoring it a fixed distance above the target instead puts every bus into
+  // the same band — targets in a rank share a y — so the horizontals read as a
+  // grid regardless of how much metadata each parent happens to show. Clamped
+  // so a short connector keeps a bit of vertical stem instead of the run
+  // colliding with the node it just left.
+  const busY =
+    isVertical && edgeProps.targetY > edgeProps.sourceY
+      ? Math.max(
+          edgeProps.sourceY + EDGE_MIN_STEM,
+          edgeProps.targetY - EDGE_BUS_OFFSET
+        )
+      : undefined
+
   const [edgePath] = getPath({
     sourceX: edgeProps.sourceX,
     sourceY: edgeProps.sourceY,
@@ -85,6 +105,7 @@ export function F0GraphEdgeBase({
     sourcePosition: edgeProps.sourcePosition,
     targetPosition: edgeProps.targetPosition,
     borderRadius: 10,
+    ...(busY !== undefined ? { centerY: busY } : null),
   })
 
   const color = strokeColors[variant]

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -134,27 +134,34 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
       : undefined
     const tagsVisible = isDetail && !!filteredTags && filteredTags.length > 0
 
-    // Measure the tag block and report it so the graph can reserve exactly the
-    // room it takes. The number of rows depends on each node's label widths, so
-    // counting tags cannot predict it — a two-tag node wraps to two rows when
-    // its labels are long, and the layout would then place the next rank inside
-    // this node, leaving the outgoing edge crossing the tags.
+    // Two measurements, for two different jobs.
+    //
+    // `full` is what the block would take with EVERY column shown. The layout
+    // reserves that, so the rank pitch is the "all open" one and stays put
+    // whatever the user toggles — nodes never shuffle. It cannot be computed:
+    // rows come from wrapping inside a fixed max-width, so they depend on this
+    // node's label widths. Hence the hidden mirror further down, which renders
+    // the unfiltered set for no reason other than to be measured.
+    //
+    // `visible` is what is on screen right now. Everything hanging below the
+    // card — the outgoing edge, the expander — anchors to that, so hiding
+    // columns lengthens the connector instead of leaving a blank band.
     const tagsRef = useRef<HTMLDivElement | null>(null)
+    const fullTagsRef = useRef<HTMLDivElement | null>(null)
     const reportTagRowHeight = renderCfg?.reportTagRowHeight
     useEffect(() => {
       if (!reportTagRowHeight || !nodeId) return
-      const el = tagsRef.current
-      if (!el) {
-        reportTagRowHeight(nodeId, 0)
-        return
-      }
       const report = () =>
-        reportTagRowHeight(nodeId, el.getBoundingClientRect().height)
+        reportTagRowHeight(nodeId, {
+          visible: tagsRef.current?.getBoundingClientRect().height ?? 0,
+          full: fullTagsRef.current?.getBoundingClientRect().height ?? 0,
+        })
       report()
       const observer = new ResizeObserver(report)
-      observer.observe(el)
+      if (tagsRef.current) observer.observe(tagsRef.current)
+      if (fullTagsRef.current) observer.observe(fullTagsRef.current)
       return () => observer.disconnect()
-    }, [reportTagRowHeight, nodeId, tagsVisible, filteredTags])
+    }, [reportTagRowHeight, nodeId, tagsVisible, filteredTags, tags])
 
     // The hover card only makes sense in the compacted modes, where part of the
     // node's info is not on screen. In detail everything is already visible, so
@@ -438,6 +445,25 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
           >
             <F0GraphNodeTags tags={filteredTags!} />
           </motion.div>
+        )}
+
+        {/* Hidden mirror of the UNFILTERED tag set, rendered only to be
+            measured (see the two-measurement note above). The layout reserves
+            the "all columns open" height so toggling metadata never moves a
+            node, and that height is unknowable without laying the full set out
+            at the real width — wrapping depends on the label text.
+
+            Taken out of flow and left unpainted, so it costs a layout pass and
+            nothing else: no paint, no hit-testing, and `aria-hidden` keeps the
+            duplicate labels out of the accessibility tree. */}
+        {isDetail && reportTagRowHeight && tags && tags.length > 0 && (
+          <div
+            aria-hidden
+            className="pointer-events-none invisible absolute max-w-[256px]"
+            ref={fullTagsRef}
+          >
+            <F0GraphNodeTags tags={tags} />
+          </div>
         )}
       </div>
     )

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -135,40 +135,32 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
       : undefined
     const tagsVisible = isDetail && !!filteredTags && filteredTags.length > 0
 
-    // Two measurements, for two different jobs.
+    // Reports how tall this node's tag block is RIGHT NOW. Everything hanging
+    // below the card — the outgoing edge, the expander — anchors to it, so
+    // hiding columns lengthens the connector instead of leaving a blank band.
     //
-    // `full` is what the block would take with EVERY column shown. The layout
-    // reserves that, so the rank pitch is the "all open" one and stays put
-    // whatever the user toggles — nodes never shuffle. It cannot be computed:
-    // rows come from wrapping inside a fixed max-width, so they depend on this
-    // node's label widths. Hence the hidden mirror further down, which renders
-    // the unfiltered set for no reason other than to be measured.
-    //
-    // `visible` is what is on screen right now. Everything hanging below the
-    // card — the outgoing edge, the expander — anchors to that, so hiding
-    // columns lengthens the connector instead of leaving a blank band.
+    // Strictly a per-node number. The rank pitch is NOT derived from it: with
+    // windowing and lazy hydration only a slice of the graph is ever measured,
+    // so any cross-node maximum taken from these reports would keep rising as
+    // the user pans and drag the whole layout with it. The reservation is
+    // counted from the declared columns instead (see `useGraphRenderModel`).
     const tagsRef = useRef<HTMLDivElement | null>(null)
-    const fullTagsRef = useRef<HTMLDivElement | null>(null)
     const reportTagRowHeight = renderCfg?.reportTagRowHeight
     useEffect(() => {
       if (!reportTagRowHeight || !nodeId) return
       // `offsetHeight`, never `getBoundingClientRect`: nodes live inside React
       // Flow's viewport, which is CSS-transformed by the current zoom. A rect
       // reports the SCALED height, so at any zoom but 1 the reported block —
-      // and with it the reserved box and the connector anchor — comes out
-      // multiplied by the zoom factor. `offsetHeight` is layout px, immune to
-      // the transform, which is the number the layout actually works in.
+      // and with it the connector anchor — comes out multiplied by the zoom
+      // factor. `offsetHeight` is layout px, immune to the transform, which is
+      // the number the layout actually works in.
       const report = () =>
-        reportTagRowHeight(nodeId, {
-          visible: tagsRef.current?.offsetHeight ?? 0,
-          full: fullTagsRef.current?.offsetHeight ?? 0,
-        })
+        reportTagRowHeight(nodeId, tagsRef.current?.offsetHeight ?? 0)
       report()
       const observer = new ResizeObserver(report)
       if (tagsRef.current) observer.observe(tagsRef.current)
-      if (fullTagsRef.current) observer.observe(fullTagsRef.current)
       return () => observer.disconnect()
-    }, [reportTagRowHeight, nodeId, tagsVisible, filteredTags, tags])
+    }, [reportTagRowHeight, nodeId, tagsVisible, filteredTags])
 
     // The hover card only makes sense in the compacted modes, where part of the
     // node's info is not on screen. In detail everything is already visible, so
@@ -462,25 +454,6 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
           >
             <F0GraphNodeTags tags={filteredTags!} />
           </motion.div>
-        )}
-
-        {/* Hidden mirror of the UNFILTERED tag set, rendered only to be
-            measured (see the two-measurement note above). The layout reserves
-            the "all columns open" height so toggling metadata never moves a
-            node, and that height is unknowable without laying the full set out
-            at the real width — wrapping depends on the label text.
-
-            Taken out of flow and left unpainted, so it costs a layout pass and
-            nothing else: no paint, no hit-testing, and `aria-hidden` keeps the
-            duplicate labels out of the accessibility tree. */}
-        {isDetail && reportTagRowHeight && tags && tags.length > 0 && (
-          <div
-            aria-hidden
-            className="pointer-events-none invisible absolute max-w-[256px]"
-            ref={fullTagsRef}
-          >
-            <F0GraphNodeTags tags={tags} />
-          </div>
         )}
       </div>
     )

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -134,6 +134,28 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
       : undefined
     const tagsVisible = isDetail && !!filteredTags && filteredTags.length > 0
 
+    // Measure the tag block and report it so the graph can reserve exactly the
+    // room it takes. The number of rows depends on each node's label widths, so
+    // counting tags cannot predict it — a two-tag node wraps to two rows when
+    // its labels are long, and the layout would then place the next rank inside
+    // this node, leaving the outgoing edge crossing the tags.
+    const tagsRef = useRef<HTMLDivElement | null>(null)
+    const reportTagRowHeight = renderCfg?.reportTagRowHeight
+    useEffect(() => {
+      if (!reportTagRowHeight || !nodeId) return
+      const el = tagsRef.current
+      if (!el) {
+        reportTagRowHeight(nodeId, 0)
+        return
+      }
+      const report = () =>
+        reportTagRowHeight(nodeId, el.getBoundingClientRect().height)
+      report()
+      const observer = new ResizeObserver(report)
+      observer.observe(el)
+      return () => observer.disconnect()
+    }, [reportTagRowHeight, nodeId, tagsVisible, filteredTags])
+
     // The hover card only makes sense in the compacted modes, where part of the
     // node's info is not on screen. In detail everything is already visible, so
     // there's nothing to reveal. Only the non-hidden tags (`filteredTags`,
@@ -402,6 +424,7 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
                 ? { duration: 0 }
                 : { duration: 0.12, ease: [0.23, 1, 0.32, 1] }
             }
+            ref={tagsRef}
             className="max-w-[256px]"
             // Tags are informational: clicking a tag must not select the node.
             // Two paths select a node: the node-level `onClick` (selection, plus

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -152,10 +152,16 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
     const reportTagRowHeight = renderCfg?.reportTagRowHeight
     useEffect(() => {
       if (!reportTagRowHeight || !nodeId) return
+      // `offsetHeight`, never `getBoundingClientRect`: nodes live inside React
+      // Flow's viewport, which is CSS-transformed by the current zoom. A rect
+      // reports the SCALED height, so at any zoom but 1 the reported block —
+      // and with it the reserved box and the connector anchor — comes out
+      // multiplied by the zoom factor. `offsetHeight` is layout px, immune to
+      // the transform, which is the number the layout actually works in.
       const report = () =>
         reportTagRowHeight(nodeId, {
-          visible: tagsRef.current?.getBoundingClientRect().height ?? 0,
-          full: fullTagsRef.current?.getBoundingClientRect().height ?? 0,
+          visible: tagsRef.current?.offsetHeight ?? 0,
+          full: fullTagsRef.current?.offsetHeight ?? 0,
         })
       report()
       const observer = new ResizeObserver(report)

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -15,6 +15,7 @@ import { Skeleton } from "@/ui/skeleton"
 
 import type { F0GraphNodeProps } from "./types"
 
+import { TAG_BLOCK_CLEARANCE } from "../../constants"
 import { useF0GraphRenderConfigInternal } from "../../contexts"
 import { F0GraphNodeHoverCard } from "./F0GraphNodeHoverCard"
 import { F0GraphNodeTags } from "./F0GraphNodeTags"
@@ -433,6 +434,16 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
             }
             ref={tagsRef}
             className="max-w-[256px]"
+            // Clearance below the last chip row, carried by the DOM rather than
+            // only by the layout maths. React Flow puts the source handle at the
+            // node element's bottom edge whenever it measures the node itself
+            // (everything except the windowed path, which is seeded with the
+            // same offset) — so without this the outgoing edge leaves flush with
+            // the chips and reads as running behind them.
+            //
+            // Margin, not padding: `getBoundingClientRect` excludes it, so the
+            // reported block height stays the height of the chips alone.
+            style={{ marginBottom: TAG_BLOCK_CLEARANCE }}
             // Tags are informational: clicking a tag must not select the node.
             // Two paths select a node: the node-level `onClick` (selection, plus
             // any consumer `itemOnClick`) — swallowed here via stopPropagation —

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -395,47 +395,25 @@ export function F0GraphView<T = unknown>(
   )
 
   // ── Measured tag block ──
-  // Nodes report what their tags occupy: `full` (every column shown) drives the
-  // reservation, `visible` places what hangs below each card.
+  // Each node reports what its tag block currently occupies, which places what
+  // hangs below THAT card (its connector and expander).
   //
-  // The reservation only ever GROWS. It sets the rank pitch, and every rank in
-  // the graph has to sit on one fixed line — so it cannot depend on which nodes
-  // happen to be rendered. With windowing it otherwise does: panning swaps the
-  // rendered set, a taller node leaves it, the max drops, and the entire layout
-  // slides under the user. Worse, that shift changes which nodes are windowed,
-  // so the two feed each other.
-  //
-  // Ratcheting up is the price. It converges after the tallest node has been
-  // seen once and never oscillates, which is what "each generation on its own
-  // line" needs. It resets when the graph is remounted for a new dataset.
-  const tagHeightsRef = useRef(
-    new Map<string, { visible: number; full: number }>()
-  )
-  const maxFullRef = useRef(0)
-  const [measuredTagRowHeight, setMeasuredTagRowHeight] = useState<
-    number | undefined
-  >(undefined)
+  // Nothing here feeds the rank pitch. That is deliberate: these reports only
+  // ever cover the nodes React Flow has rendered, and with windowing plus lazy
+  // hydration that is a moving slice of the graph. A maximum taken across them
+  // would climb every time a pan revealed a taller node, shifting every rank —
+  // and the shift changes which nodes are windowed, so the two feed each other.
+  // The reservation is counted from the declared tag columns instead.
+  const tagHeightsRef = useRef(new Map<string, number>())
   const [visibleTagHeights, setVisibleTagHeights] = useState<
     ReadonlyMap<string, number>
   >(new Map())
-  const reportTagRowHeight = useCallback(
-    (id: string, heights: { visible: number; full: number }) => {
-      const store = tagHeightsRef.current
-      const prev = store.get(id)
-      if (prev?.visible === heights.visible && prev?.full === heights.full)
-        return
-      store.set(id, heights)
-
-      if (heights.full > maxFullRef.current) {
-        maxFullRef.current = heights.full
-        setMeasuredTagRowHeight(heights.full)
-      }
-      const visible = new Map<string, number>()
-      for (const [key, value] of store) visible.set(key, value.visible)
-      setVisibleTagHeights(visible)
-    },
-    []
-  )
+  const reportTagRowHeight = useCallback((id: string, height: number) => {
+    const store = tagHeightsRef.current
+    if (store.get(id) === height) return
+    store.set(id, height)
+    setVisibleTagHeights(new Map(store))
+  }, [])
 
   // ── React Flow render model (layout + anchor + rf nodes/edges) ──
   const {
@@ -456,9 +434,7 @@ export function F0GraphView<T = unknown>(
     resolvedEdgesProp,
     stableRenderNode,
     nodeTagTypes,
-    visibleTagTypesSet,
     reserveTagRow,
-    measuredTagRowHeight,
     visibleTagHeights,
     nodeWidthProp,
     nodeHeightProp,

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -399,18 +399,33 @@ export function F0GraphView<T = unknown>(
   // across every node, so the tallest report is what has to be reserved. Kept
   // per node so a node shrinking its tags (or leaving the window) releases the
   // room again, rather than the max ratcheting up for the session.
-  const tagHeightsRef = useRef(new Map<string, number>())
+  const tagHeightsRef = useRef(
+    new Map<string, { visible: number; full: number }>()
+  )
   const [measuredTagRowHeight, setMeasuredTagRowHeight] = useState<
     number | undefined
   >(undefined)
-  const reportTagRowHeight = useCallback((id: string, height: number) => {
-    const heights = tagHeightsRef.current
-    if (heights.get(id) === height) return
-    heights.set(id, height)
-    let max = 0
-    for (const h of heights.values()) if (h > max) max = h
-    setMeasuredTagRowHeight(max)
-  }, [])
+  const [visibleTagHeights, setVisibleTagHeights] = useState<
+    ReadonlyMap<string, number>
+  >(new Map())
+  const reportTagRowHeight = useCallback(
+    (id: string, heights: { visible: number; full: number }) => {
+      const store = tagHeightsRef.current
+      const prev = store.get(id)
+      if (prev?.visible === heights.visible && prev?.full === heights.full)
+        return
+      store.set(id, heights)
+      let maxFull = 0
+      const visible = new Map<string, number>()
+      for (const [key, value] of store) {
+        if (value.full > maxFull) maxFull = value.full
+        visible.set(key, value.visible)
+      }
+      setMeasuredTagRowHeight(maxFull)
+      setVisibleTagHeights(visible)
+    },
+    []
+  )
 
   // ── React Flow render model (layout + anchor + rf nodes/edges) ──
   const {
@@ -434,6 +449,7 @@ export function F0GraphView<T = unknown>(
     visibleTagTypesSet,
     reserveTagRow,
     measuredTagRowHeight,
+    visibleTagHeights,
     nodeWidthProp,
     nodeHeightProp,
     layoutEngineProp,

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -394,6 +394,24 @@ export function F0GraphView<T = unknown>(
     [reactFlow]
   )
 
+  // ── Measured tag block ──
+  // Nodes report what their tags actually occupy; the layout shares one height
+  // across every node, so the tallest report is what has to be reserved. Kept
+  // per node so a node shrinking its tags (or leaving the window) releases the
+  // room again, rather than the max ratcheting up for the session.
+  const tagHeightsRef = useRef(new Map<string, number>())
+  const [measuredTagRowHeight, setMeasuredTagRowHeight] = useState<
+    number | undefined
+  >(undefined)
+  const reportTagRowHeight = useCallback((id: string, height: number) => {
+    const heights = tagHeightsRef.current
+    if (heights.get(id) === height) return
+    heights.set(id, height)
+    let max = 0
+    for (const h of heights.values()) if (h > max) max = h
+    setMeasuredTagRowHeight(max)
+  }, [])
+
   // ── React Flow render model (layout + anchor + rf nodes/edges) ──
   const {
     visibleTreeNodes,
@@ -415,6 +433,7 @@ export function F0GraphView<T = unknown>(
     nodeTagTypes,
     visibleTagTypesSet,
     reserveTagRow,
+    measuredTagRowHeight,
     nodeWidthProp,
     nodeHeightProp,
     layoutEngineProp,
@@ -689,6 +708,7 @@ export function F0GraphView<T = unknown>(
       deferredLoading: isDeferredLoading || undefined,
       dataLoadingEnabled: loadVisibleNodeData !== undefined || undefined,
       tagRowHeight: reservedTagHeight,
+      reportTagRowHeight,
       largeGraph: isLargeGraph,
     }),
     [
@@ -699,6 +719,7 @@ export function F0GraphView<T = unknown>(
       loadVisibleNodeData,
       isLargeGraph,
       reservedTagHeight,
+      reportTagRowHeight,
     ]
   )
 

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -395,13 +395,23 @@ export function F0GraphView<T = unknown>(
   )
 
   // ── Measured tag block ──
-  // Nodes report what their tags actually occupy; the layout shares one height
-  // across every node, so the tallest report is what has to be reserved. Kept
-  // per node so a node shrinking its tags (or leaving the window) releases the
-  // room again, rather than the max ratcheting up for the session.
+  // Nodes report what their tags occupy: `full` (every column shown) drives the
+  // reservation, `visible` places what hangs below each card.
+  //
+  // The reservation only ever GROWS. It sets the rank pitch, and every rank in
+  // the graph has to sit on one fixed line — so it cannot depend on which nodes
+  // happen to be rendered. With windowing it otherwise does: panning swaps the
+  // rendered set, a taller node leaves it, the max drops, and the entire layout
+  // slides under the user. Worse, that shift changes which nodes are windowed,
+  // so the two feed each other.
+  //
+  // Ratcheting up is the price. It converges after the tallest node has been
+  // seen once and never oscillates, which is what "each generation on its own
+  // line" needs. It resets when the graph is remounted for a new dataset.
   const tagHeightsRef = useRef(
     new Map<string, { visible: number; full: number }>()
   )
+  const maxFullRef = useRef(0)
   const [measuredTagRowHeight, setMeasuredTagRowHeight] = useState<
     number | undefined
   >(undefined)
@@ -415,13 +425,13 @@ export function F0GraphView<T = unknown>(
       if (prev?.visible === heights.visible && prev?.full === heights.full)
         return
       store.set(id, heights)
-      let maxFull = 0
-      const visible = new Map<string, number>()
-      for (const [key, value] of store) {
-        if (value.full > maxFull) maxFull = value.full
-        visible.set(key, value.visible)
+
+      if (heights.full > maxFullRef.current) {
+        maxFullRef.current = heights.full
+        setMeasuredTagRowHeight(heights.full)
       }
-      setMeasuredTagRowHeight(maxFull)
+      const visible = new Map<string, number>()
+      for (const [key, value] of store) visible.set(key, value.visible)
       setVisibleTagHeights(visible)
     },
     []

--- a/packages/react/src/patterns/F0Graph/constants.ts
+++ b/packages/react/src/patterns/F0Graph/constants.ts
@@ -15,6 +15,13 @@ export const COLLAPSER_OFFSET_ADJUSTMENT_BY_ZOOM: Record<ZoomLevel, number> = {
   dot: 0,
 }
 
+// Clearance between a node's last chip row and whatever hangs below it — the
+// outgoing edge and the expander pill. Applied in two places that must agree:
+// F0GraphNode carries it as margin below the tag block (React Flow reads the
+// node's DOM bottom for the source handle), and the render model adds it to the
+// reserved box and to the connector anchor.
+export const TAG_BLOCK_CLEARANCE = 32
+
 // Canvas background dot spacing. Shared with the layout engine so node
 // columns/rows snap onto the dot grid (nodes "squared" with the dots).
 export const BACKGROUND_DOT_GAP = 32

--- a/packages/react/src/patterns/F0Graph/constants.ts
+++ b/packages/react/src/patterns/F0Graph/constants.ts
@@ -22,6 +22,15 @@ export const COLLAPSER_OFFSET_ADJUSTMENT_BY_ZOOM: Record<ZoomLevel, number> = {
 // reserved box and to the connector anchor.
 export const TAG_BLOCK_CLEARANCE = 32
 
+// Where a connector makes its horizontal run, measured UP from the target rank.
+// Fixed rather than the midpoint between the two nodes, so every bus in a rank
+// lands in the same band no matter how tall each parent is — a parent showing
+// three chip rows would otherwise push its own bus down and break the grid.
+export const EDGE_BUS_OFFSET = 48
+// Vertical stem kept below the source before the run turns, so a short
+// connector does not corner straight out of the node it just left.
+export const EDGE_MIN_STEM = 16
+
 // Canvas background dot spacing. Shared with the layout engine so node
 // columns/rows snap onto the dot grid (nodes "squared" with the dots).
 export const BACKGROUND_DOT_GAP = 32

--- a/packages/react/src/patterns/F0Graph/contexts.ts
+++ b/packages/react/src/patterns/F0Graph/contexts.ts
@@ -175,15 +175,21 @@ export interface F0GraphRenderConfigContextValue {
    */
   tagRowHeight?: number
   /**
-   * Reports the height a node's rendered tag block actually occupies (`0` when
-   * it renders none). The graph keeps the tallest report and reserves that,
-   * instead of guessing rows from the tag count — the real row count depends on
-   * each node's label widths, which only the DOM knows.
+   * Reports what a node's tag block measures — `visible` for the columns
+   * currently shown, `full` for the whole set (measured off-screen). The layout
+   * reserves the tallest `full`, so the rank pitch is the "all open" one and
+   * never moves as columns are toggled; `visible` places what hangs below the
+   * card, so hiding columns lengthens the connector instead of leaving a gap.
    *
-   * Safe against feedback: the tag block wraps inside a fixed max-width, so the
-   * reservation never changes what is being measured.
+   * Neither can be derived from the tag count: rows come from wrapping inside a
+   * fixed max-width, so they depend on each node's label widths. Safe against
+   * feedback for the same reason — that width does not depend on the
+   * reservation, so measuring never changes what is measured.
    */
-  reportTagRowHeight?: (nodeId: string, height: number) => void
+  reportTagRowHeight?: (
+    nodeId: string,
+    heights: { visible: number; full: number }
+  ) => void
   /**
    * `true` when the graph has more rendered nodes than the snap threshold.
    * F0GraphNode uses this to disable variant transitions (chrome opacity,

--- a/packages/react/src/patterns/F0Graph/contexts.ts
+++ b/packages/react/src/patterns/F0Graph/contexts.ts
@@ -175,6 +175,16 @@ export interface F0GraphRenderConfigContextValue {
    */
   tagRowHeight?: number
   /**
+   * Reports the height a node's rendered tag block actually occupies (`0` when
+   * it renders none). The graph keeps the tallest report and reserves that,
+   * instead of guessing rows from the tag count — the real row count depends on
+   * each node's label widths, which only the DOM knows.
+   *
+   * Safe against feedback: the tag block wraps inside a fixed max-width, so the
+   * reservation never changes what is being measured.
+   */
+  reportTagRowHeight?: (nodeId: string, height: number) => void
+  /**
    * `true` when the graph has more rendered nodes than the snap threshold.
    * F0GraphNode uses this to disable variant transitions (chrome opacity,
    * avatar transform, text reveal) so changing zoomLevel snaps instantly

--- a/packages/react/src/patterns/F0Graph/contexts.ts
+++ b/packages/react/src/patterns/F0Graph/contexts.ts
@@ -175,21 +175,16 @@ export interface F0GraphRenderConfigContextValue {
    */
   tagRowHeight?: number
   /**
-   * Reports what a node's tag block measures — `visible` for the columns
-   * currently shown, `full` for the whole set (measured off-screen). The layout
-   * reserves the tallest `full`, so the rank pitch is the "all open" one and
-   * never moves as columns are toggled; `visible` places what hangs below the
-   * card, so hiding columns lengthens the connector instead of leaving a gap.
+   * Reports how tall a node's currently shown tag block measures, in layout px.
+   * Places what hangs below that card, so hiding columns lengthens its
+   * connector instead of leaving a gap.
    *
-   * Neither can be derived from the tag count: rows come from wrapping inside a
-   * fixed max-width, so they depend on each node's label widths. Safe against
-   * feedback for the same reason — that width does not depend on the
-   * reservation, so measuring never changes what is measured.
+   * Per-node only. The rank pitch must not be derived from these reports —
+   * windowing and lazy hydration mean they cover a moving slice of the graph,
+   * so any cross-node maximum climbs as the user pans and drags the layout with
+   * it. The reservation is counted from the declared tag columns instead.
    */
-  reportTagRowHeight?: (
-    nodeId: string,
-    heights: { visible: number; full: number }
-  ) => void
+  reportTagRowHeight?: (nodeId: string, height: number) => void
   /**
    * `true` when the graph has more rendered nodes than the snap threshold.
    * F0GraphNode uses this to disable variant transitions (chrome opacity,

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
@@ -27,11 +27,11 @@ const treeNode = (
 })
 
 /**
- * The reserved tag block is not returned directly in a comparable form, so it
- * is read off the layout: the child rank sits `nodeHeight + reservedTagHeight +
- * rankSep` below the parent, and the parent's own box carries the reservation.
+ * Room the tags add to the node's layout box. Tags normally hang into the lane
+ * that already sits between a node and its children, so this is `0` for any
+ * block that fits — the rank pitch must not move when metadata is toggled.
  */
-const parentBoxHeight = (
+const reserved = (
   options: Partial<Parameters<typeof useGraphRenderModel>[0]> = {}
 ) => {
   const child = treeNode("child", "root")
@@ -60,73 +60,56 @@ const parentBoxHeight = (
   return result.current.reservedTagHeight
 }
 
+const withTags = (over: Record<string, unknown> = {}) => ({
+  nodeTagTypes: ["workplace", "reports"],
+  visibleTagTypesSet: new Set(["workplace", "reports"]),
+  ...over,
+})
+
 describe("useGraphRenderModel — tag row reservation", () => {
   it("reserves nothing when no tag columns are declared", () => {
-    expect(parentBoxHeight()).toBe(0)
+    expect(reserved()).toBe(0)
+  })
+
+  it("keeps the rank pitch fixed for a tag block that fits the lane", () => {
+    // The whole point: tags hang into the 130px lane that already exists
+    // between a node and its children, so the node box does not grow and
+    // nothing moves. What shrinks is the connecting line.
+    expect(reserved(withTags({ measuredTagRowHeight: 26 }))).toBe(0)
+    expect(reserved(withTags({ measuredTagRowHeight: 56 }))).toBe(0)
   })
 
   it("collapses when every declared column is toggled off", () => {
-    // The regression: the Data Collection graph hard-codes `reserveTagRow`
-    // whenever a `tags` mapper exists, so "hide all" used to leave the block of
-    // empty canvas the tags had occupied. The visible-count gate has to win.
+    // The Data Collection graph hard-codes `reserveTagRow` whenever a `tags`
+    // mapper exists, so "hide all" used to leave the empty block the tags had
+    // occupied. The visible-count gate has to win over that flag.
     expect(
-      parentBoxHeight({
+      reserved({
         nodeTagTypes: ["workplace", "reports"],
         visibleTagTypesSet: new Set<string>(),
         reserveTagRow: true,
-      })
-    ).toBe(0)
-  })
-
-  it("falls back to the count estimate before any node has measured", () => {
-    expect(
-      parentBoxHeight({
-        nodeTagTypes: ["workplace", "reports"],
-        visibleTagTypesSet: new Set(["workplace", "reports"]),
-      })
-    ).toBeGreaterThan(0)
-  })
-
-  it("prefers a measured height over the count estimate", () => {
-    // Two columns estimate one 36px row. A node whose labels wrap to two rows
-    // reports 56, and that — plus the pill/tags gap — is what gets reserved,
-    // instead of the estimate that would put the next rank inside the node.
-    const measured = parentBoxHeight({
-      nodeTagTypes: ["workplace", "reports"],
-      visibleTagTypesSet: new Set(["workplace", "reports"]),
-      measuredTagRowHeight: 56,
-    })
-    const estimated = parentBoxHeight({
-      nodeTagTypes: ["workplace", "reports"],
-      visibleTagTypesSet: new Set(["workplace", "reports"]),
-    })
-
-    expect(measured).toBeGreaterThan(estimated)
-    expect(measured).toBe(56 + 6)
-  })
-
-  it("shrinks the reservation when the measurement shrinks", () => {
-    const tall = parentBoxHeight({
-      nodeTagTypes: ["workplace"],
-      visibleTagTypesSet: new Set(["workplace"]),
-      measuredTagRowHeight: 56,
-    })
-    const short = parentBoxHeight({
-      nodeTagTypes: ["workplace"],
-      visibleTagTypesSet: new Set(["workplace"]),
-      measuredTagRowHeight: 26,
-    })
-
-    expect(short).toBeLessThan(tall)
-  })
-
-  it("ignores a measurement once the columns are all hidden", () => {
-    expect(
-      parentBoxHeight({
-        nodeTagTypes: ["workplace"],
-        visibleTagTypesSet: new Set<string>(),
         measuredTagRowHeight: 56,
       })
     ).toBe(0)
+  })
+
+  it("grows the box only for a block that would eat the whole lane", () => {
+    // 130 lane, 24px of line kept visible: a block over ~100px has to push the
+    // next rank down, or the tags would run into it.
+    expect(reserved(withTags({ measuredTagRowHeight: 120 }))).toBe(20)
+    expect(reserved(withTags({ measuredTagRowHeight: 200 }))).toBe(100)
+  })
+
+  it("uses the measured height, not the tag count, to decide the overflow", () => {
+    // Two columns estimate a single 36px row. A node whose labels wrap far
+    // enough reports the real height, and only that can tell whether the block
+    // still fits the lane.
+    expect(reserved(withTags())).toBe(0)
+    expect(reserved(withTags({ measuredTagRowHeight: 160 }))).toBe(60)
+  })
+
+  it("releases the extra room when the measurement shrinks again", () => {
+    expect(reserved(withTags({ measuredTagRowHeight: 160 }))).toBeGreaterThan(0)
+    expect(reserved(withTags({ measuredTagRowHeight: 40 }))).toBe(0)
   })
 })

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
@@ -1,0 +1,132 @@
+import { ReactFlowProvider } from "@xyflow/react"
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import { createElement, type MutableRefObject, type ReactNode } from "react"
+
+import type { TreeNode } from "../../types"
+import { useGraphRenderModel } from "../useGraphRenderModel"
+
+vi.mock("../useViewportGeometry", () => ({ useViewportGeometry: () => null }))
+
+const wrapper = ({ children }: { children: ReactNode }) =>
+  createElement(ReactFlowProvider, null, children)
+
+const treeNode = (
+  id: string,
+  parentId: string | null,
+  children: TreeNode<null>[] = []
+): TreeNode<null> => ({
+  id,
+  parentId,
+  data: null,
+  children,
+  depth: parentId === null ? 0 : 1,
+  childrenCount: children.length,
+  childrenLoaded: true,
+})
+
+/**
+ * The reserved tag block is not returned directly in a comparable form, so it
+ * is read off the layout: the child rank sits `nodeHeight + reservedTagHeight +
+ * rankSep` below the parent, and the parent's own box carries the reservation.
+ */
+const parentBoxHeight = (
+  options: Partial<Parameters<typeof useGraphRenderModel>[0]> = {}
+) => {
+  const child = treeNode("child", "root")
+  const root = treeNode("root", null, [child])
+  const nodeMap = new Map<string, TreeNode<null>>([
+    ["root", root],
+    ["child", child],
+  ])
+
+  const { result } = renderHook(
+    () =>
+      useGraphRenderModel({
+        roots: [root],
+        nodeMap,
+        expandedNodes: new Set(["root"]),
+        anchorNodeRef: { current: null } as MutableRefObject<string | null>,
+        stableRenderNode: () => null,
+        visibleTagTypesSet: new Set<string>(),
+        zoomLevel: "detail" as const,
+        direction: "TB" as const,
+        hoveredEdgeId: null,
+        ...options,
+      } as Parameters<typeof useGraphRenderModel>[0]),
+    { wrapper }
+  )
+  return result.current.reservedTagHeight
+}
+
+describe("useGraphRenderModel — tag row reservation", () => {
+  it("reserves nothing when no tag columns are declared", () => {
+    expect(parentBoxHeight()).toBe(0)
+  })
+
+  it("collapses when every declared column is toggled off", () => {
+    // The regression: the Data Collection graph hard-codes `reserveTagRow`
+    // whenever a `tags` mapper exists, so "hide all" used to leave the block of
+    // empty canvas the tags had occupied. The visible-count gate has to win.
+    expect(
+      parentBoxHeight({
+        nodeTagTypes: ["workplace", "reports"],
+        visibleTagTypesSet: new Set<string>(),
+        reserveTagRow: true,
+      })
+    ).toBe(0)
+  })
+
+  it("falls back to the count estimate before any node has measured", () => {
+    expect(
+      parentBoxHeight({
+        nodeTagTypes: ["workplace", "reports"],
+        visibleTagTypesSet: new Set(["workplace", "reports"]),
+      })
+    ).toBeGreaterThan(0)
+  })
+
+  it("prefers a measured height over the count estimate", () => {
+    // Two columns estimate one 36px row. A node whose labels wrap to two rows
+    // reports 56, and that — plus the pill/tags gap — is what gets reserved,
+    // instead of the estimate that would put the next rank inside the node.
+    const measured = parentBoxHeight({
+      nodeTagTypes: ["workplace", "reports"],
+      visibleTagTypesSet: new Set(["workplace", "reports"]),
+      measuredTagRowHeight: 56,
+    })
+    const estimated = parentBoxHeight({
+      nodeTagTypes: ["workplace", "reports"],
+      visibleTagTypesSet: new Set(["workplace", "reports"]),
+    })
+
+    expect(measured).toBeGreaterThan(estimated)
+    expect(measured).toBe(56 + 6)
+  })
+
+  it("shrinks the reservation when the measurement shrinks", () => {
+    const tall = parentBoxHeight({
+      nodeTagTypes: ["workplace"],
+      visibleTagTypesSet: new Set(["workplace"]),
+      measuredTagRowHeight: 56,
+    })
+    const short = parentBoxHeight({
+      nodeTagTypes: ["workplace"],
+      visibleTagTypesSet: new Set(["workplace"]),
+      measuredTagRowHeight: 26,
+    })
+
+    expect(short).toBeLessThan(tall)
+  })
+
+  it("ignores a measurement once the columns are all hidden", () => {
+    expect(
+      parentBoxHeight({
+        nodeTagTypes: ["workplace"],
+        visibleTagTypesSet: new Set<string>(),
+        measuredTagRowHeight: 56,
+      })
+    ).toBe(0)
+  })
+})

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
@@ -26,11 +26,11 @@ const treeNode = (
   childrenLoaded: true,
 })
 
-/**
- * Room the tags add to the node's layout box. Tags normally hang into the lane
- * that already sits between a node and its children, so this is `0` for any
- * block that fits — the rank pitch must not move when metadata is toggled.
- */
+/** Gap between the pill and the tag block, added to every measured height. */
+const PILL_GAP = 6
+/** Clearance kept below the fully-open block. */
+const MARGIN = 32
+
 const reserved = (
   options: Partial<Parameters<typeof useGraphRenderModel>[0]> = {}
 ) => {
@@ -60,56 +60,83 @@ const reserved = (
   return result.current.reservedTagHeight
 }
 
-const withTags = (over: Record<string, unknown> = {}) => ({
-  nodeTagTypes: ["workplace", "reports"],
-  visibleTagTypesSet: new Set(["workplace", "reports"]),
-  ...over,
-})
+const columns = ["workplace", "reports"]
 
 describe("useGraphRenderModel — tag row reservation", () => {
   it("reserves nothing when no tag columns are declared", () => {
     expect(reserved()).toBe(0)
   })
 
-  it("keeps the rank pitch fixed for a tag block that fits the lane", () => {
-    // The whole point: tags hang into the 130px lane that already exists
-    // between a node and its children, so the node box does not grow and
-    // nothing moves. What shrinks is the connecting line.
-    expect(reserved(withTags({ measuredTagRowHeight: 26 }))).toBe(0)
-    expect(reserved(withTags({ measuredTagRowHeight: 56 }))).toBe(0)
-  })
-
-  it("collapses when every declared column is toggled off", () => {
-    // The Data Collection graph hard-codes `reserveTagRow` whenever a `tags`
-    // mapper exists, so "hide all" used to leave the empty block the tags had
-    // occupied. The visible-count gate has to win over that flag.
+  it("reserves the fully-open block plus its clearance", () => {
     expect(
       reserved({
-        nodeTagTypes: ["workplace", "reports"],
-        visibleTagTypesSet: new Set<string>(),
-        reserveTagRow: true,
+        nodeTagTypes: columns,
+        visibleTagTypesSet: new Set(columns),
         measuredTagRowHeight: 56,
       })
-    ).toBe(0)
+    ).toBe(56 + PILL_GAP + MARGIN)
   })
 
-  it("grows the box only for a block that would eat the whole lane", () => {
-    // 130 lane, 24px of line kept visible: a block over ~100px has to push the
-    // next rank down, or the tags would run into it.
-    expect(reserved(withTags({ measuredTagRowHeight: 120 }))).toBe(20)
-    expect(reserved(withTags({ measuredTagRowHeight: 200 }))).toBe(100)
+  it("reserves the same whatever is toggled on", () => {
+    // The point of the whole change: the box is sized for "all columns open",
+    // so the rank pitch is constant and toggling metadata cannot move a node.
+    // The hidden rows turn into connector length instead.
+    const all = reserved({
+      nodeTagTypes: columns,
+      visibleTagTypesSet: new Set(columns),
+      measuredTagRowHeight: 56,
+    })
+    const one = reserved({
+      nodeTagTypes: columns,
+      visibleTagTypesSet: new Set(["workplace"]),
+      measuredTagRowHeight: 56,
+    })
+    const none = reserved({
+      nodeTagTypes: columns,
+      visibleTagTypesSet: new Set<string>(),
+      measuredTagRowHeight: 56,
+    })
+
+    expect(one).toBe(all)
+    expect(none).toBe(all)
   })
 
-  it("uses the measured height, not the tag count, to decide the overflow", () => {
-    // Two columns estimate a single 36px row. A node whose labels wrap far
-    // enough reports the real height, and only that can tell whether the block
-    // still fits the lane.
-    expect(reserved(withTags())).toBe(0)
-    expect(reserved(withTags({ measuredTagRowHeight: 160 }))).toBe(60)
+  it("tracks the fully-open measurement, not the tag count", () => {
+    // Two columns estimate a single 36px row; a node whose labels wrap to two
+    // reports 56, and only the measurement can know that.
+    const estimated = reserved({
+      nodeTagTypes: columns,
+      visibleTagTypesSet: new Set(columns),
+    })
+    const measured = reserved({
+      nodeTagTypes: columns,
+      visibleTagTypesSet: new Set(columns),
+      measuredTagRowHeight: 56,
+    })
+
+    expect(estimated).toBe(36 + PILL_GAP + MARGIN)
+    expect(measured).toBeGreaterThan(estimated)
   })
 
-  it("releases the extra room when the measurement shrinks again", () => {
-    expect(reserved(withTags({ measuredTagRowHeight: 160 }))).toBeGreaterThan(0)
-    expect(reserved(withTags({ measuredTagRowHeight: 40 }))).toBe(0)
+  it("still honours reserveTagRow when no columns are declared", () => {
+    // Tags rendered straight from `renderNode`, with no popover to toggle.
+    expect(reserved({ reserveTagRow: true })).toBeGreaterThan(0)
+    expect(reserved({ reserveTagRow: false })).toBe(0)
+  })
+
+  it("follows the measurement back down when it shrinks", () => {
+    const tall = reserved({
+      nodeTagTypes: columns,
+      visibleTagTypesSet: new Set(columns),
+      measuredTagRowHeight: 86,
+    })
+    const short = reserved({
+      nodeTagTypes: columns,
+      visibleTagTypesSet: new Set(columns),
+      measuredTagRowHeight: 26,
+    })
+
+    expect(short).toBeLessThan(tall)
+    expect(short).toBe(26 + PILL_GAP + MARGIN)
   })
 })

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.tagRow.test.ts
@@ -7,7 +7,13 @@ import { createElement, type MutableRefObject, type ReactNode } from "react"
 import type { TreeNode } from "../../types"
 import { useGraphRenderModel } from "../useGraphRenderModel"
 
-vi.mock("../useViewportGeometry", () => ({ useViewportGeometry: () => null }))
+// A viewport big enough to contain the whole fixture. React Flow is only handed
+// an explicit node height while windowing drives the render, so the painted-box
+// assertions below need geometry to exist.
+vi.mock("../useViewportGeometry", () => ({
+  useViewportGeometry: ({ enabled }: { enabled?: boolean }) =>
+    enabled ? { minX: -1e4, minY: -1e4, maxX: 1e4, maxY: 1e4 } : null,
+}))
 
 const wrapper = ({ children }: { children: ReactNode }) =>
   createElement(ReactFlowProvider, null, children)
@@ -26,12 +32,14 @@ const treeNode = (
   childrenLoaded: true,
 })
 
-/** Gap between the pill and the tag block, added to every measured height. */
+/** Height of one row of tag pills. */
+const ROW = 36
+/** Gap between the pill and the tag block. */
 const PILL_GAP = 6
 /** Clearance kept below the fully-open block. */
 const MARGIN = 32
 
-const reserved = (
+const render = (
   options: Partial<Parameters<typeof useGraphRenderModel>[0]> = {}
 ) => {
   const child = treeNode("child", "root")
@@ -49,7 +57,6 @@ const reserved = (
         expandedNodes: new Set(["root"]),
         anchorNodeRef: { current: null } as MutableRefObject<string | null>,
         stableRenderNode: () => null,
-        visibleTagTypesSet: new Set<string>(),
         zoomLevel: "detail" as const,
         direction: "TB" as const,
         hoveredEdgeId: null,
@@ -57,8 +64,17 @@ const reserved = (
       } as Parameters<typeof useGraphRenderModel>[0]),
     { wrapper }
   )
-  return result.current.reservedTagHeight
+  return result.current
 }
+
+const reserved = (
+  options: Partial<Parameters<typeof useGraphRenderModel>[0]> = {}
+) => render(options).reservedTagHeight
+
+const heightOf = (
+  id: string,
+  options: Partial<Parameters<typeof useGraphRenderModel>[0]> = {}
+) => render(options).rfNodes.find((n) => n.id === id)?.height
 
 const columns = ["workplace", "reports"]
 
@@ -67,55 +83,42 @@ describe("useGraphRenderModel — tag row reservation", () => {
     expect(reserved()).toBe(0)
   })
 
-  it("reserves the fully-open block plus its clearance", () => {
+  it("counts the declared columns, never the DOM", () => {
+    // The reservation sets the rank pitch, so it has to be knowable before a
+    // single node renders. Measuring instead would tie it to whichever nodes
+    // are currently windowed and hydrated.
+    expect(reserved({ nodeTagTypes: columns })).toBe(ROW + PILL_GAP + MARGIN)
     expect(
-      reserved({
-        nodeTagTypes: columns,
-        visibleTagTypesSet: new Set(columns),
-        measuredTagRowHeight: 56,
-      })
-    ).toBe(56 + PILL_GAP + MARGIN)
+      reserved({ nodeTagTypes: [...columns, "hireDate", "company"] })
+    ).toBe(2 * ROW + PILL_GAP + MARGIN)
+  })
+
+  it("reserves the same whatever the rendered nodes report", () => {
+    // The pitch must not move as the user pans: with windowing, panning swaps
+    // the measured set, and any cross-node maximum taken from it would climb
+    // and slide every rank off its line.
+    const none = reserved({ nodeTagTypes: columns })
+    const someReported = reserved({
+      nodeTagTypes: columns,
+      visibleTagHeights: new Map([["root", 86]]),
+    })
+
+    expect(someReported).toBe(none)
   })
 
   it("reserves the same whatever is toggled on", () => {
-    // The point of the whole change: the box is sized for "all columns open",
-    // so the rank pitch is constant and toggling metadata cannot move a node.
-    // The hidden rows turn into connector length instead.
+    // The box is sized for "all columns open", so toggling metadata cannot move
+    // a node. The hidden rows turn into connector length instead.
     const all = reserved({
       nodeTagTypes: columns,
-      visibleTagTypesSet: new Set(columns),
-      measuredTagRowHeight: 56,
-    })
-    const one = reserved({
-      nodeTagTypes: columns,
-      visibleTagTypesSet: new Set(["workplace"]),
-      measuredTagRowHeight: 56,
+      visibleTagHeights: new Map([["root", 56]]),
     })
     const none = reserved({
       nodeTagTypes: columns,
-      visibleTagTypesSet: new Set<string>(),
-      measuredTagRowHeight: 56,
+      visibleTagHeights: new Map(),
     })
 
-    expect(one).toBe(all)
     expect(none).toBe(all)
-  })
-
-  it("tracks the fully-open measurement, not the tag count", () => {
-    // Two columns estimate a single 36px row; a node whose labels wrap to two
-    // reports 56, and only the measurement can know that.
-    const estimated = reserved({
-      nodeTagTypes: columns,
-      visibleTagTypesSet: new Set(columns),
-    })
-    const measured = reserved({
-      nodeTagTypes: columns,
-      visibleTagTypesSet: new Set(columns),
-      measuredTagRowHeight: 56,
-    })
-
-    expect(estimated).toBe(36 + PILL_GAP + MARGIN)
-    expect(measured).toBeGreaterThan(estimated)
   })
 
   it("still honours reserveTagRow when no columns are declared", () => {
@@ -123,20 +126,93 @@ describe("useGraphRenderModel — tag row reservation", () => {
     expect(reserved({ reserveTagRow: true })).toBeGreaterThan(0)
     expect(reserved({ reserveTagRow: false })).toBe(0)
   })
+})
 
-  it("follows the measurement back down when it shrinks", () => {
-    const tall = reserved({
+describe("useGraphRenderModel — painted node height", () => {
+  const base = 56
+
+  it("shrinks to the pill when a node shows no tags", () => {
+    // The freed room becomes connector length rather than a blank band.
+    expect(
+      heightOf("root", {
+        nodeTagTypes: columns,
+        nodeHeightProp: base,
+        enableNodeWindowing: true,
+        visibleTagHeights: new Map(),
+      })
+    ).toBe(base)
+  })
+
+  it("grows with what that node currently shows", () => {
+    expect(
+      heightOf("root", {
+        nodeTagTypes: columns,
+        nodeHeightProp: base,
+        enableNodeWindowing: true,
+        visibleTagHeights: new Map([["root", 20]]),
+      })
+    ).toBe(base + 20 + PILL_GAP + MARGIN)
+  })
+
+  it("never grows past its reserved lane", () => {
+    // The reservation estimates how the chips wrap, so an outlier whose labels
+    // wrap onto an extra row must be clipped rather than allowed to anchor its
+    // connector into the next rank.
+    const reservation = reserved({ nodeTagTypes: columns })
+    expect(
+      heightOf("root", {
+        nodeTagTypes: columns,
+        nodeHeightProp: base,
+        enableNodeWindowing: true,
+        visibleTagHeights: new Map([["root", 500]]),
+      })
+    ).toBe(base + reservation)
+  })
+
+  it("sizes each node independently", () => {
+    const model = render({
       nodeTagTypes: columns,
-      visibleTagTypesSet: new Set(columns),
-      measuredTagRowHeight: 86,
-    })
-    const short = reserved({
-      nodeTagTypes: columns,
-      visibleTagTypesSet: new Set(columns),
-      measuredTagRowHeight: 26,
+      nodeHeightProp: base,
+      enableNodeWindowing: true,
+      visibleTagHeights: new Map([["root", 20]]),
     })
 
-    expect(short).toBeLessThan(tall)
-    expect(short).toBe(26 + PILL_GAP + MARGIN)
+    expect(model.rfNodes.find((n) => n.id === "root")?.height).toBe(
+      base + 20 + PILL_GAP + MARGIN
+    )
+    expect(model.rfNodes.find((n) => n.id === "child")?.height).toBe(base)
+  })
+})
+
+describe("useGraphRenderModel — rank pitch", () => {
+  it("puts every generation on a line the reservation fixes", () => {
+    const model = render({
+      nodeTagTypes: columns,
+      nodeHeightProp: 56,
+      visibleTagHeights: new Map([["root", 20]]),
+    })
+
+    const root = model.rfNodes.find((n) => n.id === "root")
+    const child = model.rfNodes.find((n) => n.id === "child")
+    const pitch = (child?.position.y ?? 0) - (root?.position.y ?? 0)
+
+    // Whatever the nodes report, the gap between ranks is the reserved box plus
+    // the engine's rank separation — the same for every generation.
+    expect(pitch).toBe(56 + model.reservedTagHeight + 130)
+  })
+
+  it("holds that pitch when the reported heights change", () => {
+    const pitchWith = (heights: ReadonlyMap<string, number>) => {
+      const model = render({
+        nodeTagTypes: columns,
+        nodeHeightProp: 56,
+        visibleTagHeights: heights,
+      })
+      const root = model.rfNodes.find((n) => n.id === "root")
+      const child = model.rfNodes.find((n) => n.id === "child")
+      return (child?.position.y ?? 0) - (root?.position.y ?? 0)
+    }
+
+    expect(pitchWith(new Map([["root", 86]]))).toBe(pitchWith(new Map()))
   })
 })

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -52,13 +52,10 @@ const ESTIMATED_TAGS_PER_ROW = 2
 // Gap between the pill and the tag block (`gap-1.5` on the node's column).
 // Added to the measured tag height so the reservation covers the whole stack.
 const TAG_ROW_GAP = 6
-// The lane the layout engine already leaves between a node and its children
-// (`DEFAULT_RANK_SEP`). Tags hang into it rather than extending the node box.
-const NODE_RANK_SEP = 130
-// Line still visible below the tags when a tag block is long enough to need
-// room of its own. Without it a very tall block would butt straight into the
-// next rank.
-const MIN_EDGE_LENGTH = 24
+// Clearance between the last chip row and whatever hangs below it (the
+// connector, the expander pill). Applied to the fully-open block, so it is the
+// minimum gap in the tightest state a node can reach.
+const TAG_BLOCK_MARGIN = 32
 
 interface UseGraphRenderModelOptions<T> {
   roots: TreeNode<T>[]
@@ -80,10 +77,12 @@ interface UseGraphRenderModelOptions<T> {
   visibleTagTypesSet: Set<F0GraphNodeTagColumn>
   reserveTagRow?: boolean
   /**
-   * Tallest tag block reported by the rendered nodes, in px. Replaces the
-   * count-based estimate once the first measurement lands.
+   * Tallest "all columns open" tag block reported by the rendered nodes, in px.
+   * Drives the reservation, so the rank pitch never moves as columns toggle.
    */
   measuredTagRowHeight?: number
+  /** Per-node height of the tag block CURRENTLY on screen, in px. */
+  visibleTagHeights?: ReadonlyMap<string, number>
   nodeWidthProp?: number
   nodeHeightProp?: number
   layoutEngineProp?: LayoutEngine
@@ -140,6 +139,7 @@ export function useGraphRenderModel<T>({
   visibleTagTypesSet,
   reserveTagRow,
   measuredTagRowHeight,
+  visibleTagHeights,
   nodeWidthProp,
   nodeHeightProp,
   layoutEngineProp,
@@ -294,9 +294,12 @@ export function useGraphRenderModel<T>({
   // is toggled off — otherwise hiding them all leaves the block of empty canvas
   // the tags used to occupy. So the visible-count gate wins whenever the toggle
   // UI exists; `reserveTagRow` only decides the case with no columns declared.
-  const tagsAffectLayout = nodeTagTypes
-    ? visibleTagTypesSet.size > 0
-    : (reserveTagRow ?? false)
+  // Declaring tag columns is what reserves the room — not how many are visible
+  // right now. The box is sized for the fully-open block so the rank pitch is
+  // constant and toggling metadata cannot move a node; the currently hidden
+  // rows simply become connector length (see `contentHeightOf`).
+  const tagsAffectLayout =
+    nodeTagTypes && nodeTagTypes.length > 0 ? true : (reserveTagRow ?? false)
   // How much room the tags take is a DOM question, not an arithmetic one: rows
   // come from wrapping, which depends on each node's label widths. The nodes
   // measure themselves and report (see `reportTagRowHeight`); the tallest wins,
@@ -311,20 +314,25 @@ export function useGraphRenderModel<T>({
     ? 0
     : (measuredTagRowHeight ?? estimatedTagHeight) + TAG_ROW_GAP
 
-  // Rank pitch is a fixed design constant: a node's children always sit the
-  // same distance below it, tags or no tags. So tags are NOT added to the node
-  // box — they hang into the lane that already exists between a node and its
-  // children, and what changes is how much of that lane is left for the
-  // connecting line. Toggling metadata then never moves a single node.
-  //
-  // The one case that does need room is a tag block long enough to eat the
-  // whole lane: past that the tags would run into the next rank, so reserve
-  // just the overflow, keeping `MIN_EDGE_LENGTH` of line visible.
-  const reservedTagHeight = Math.max(
-    0,
-    tagBlockHeight + MIN_EDGE_LENGTH - NODE_RANK_SEP
-  )
+  // Reserve the "all columns open" block, never the currently visible one. The
+  // rank pitch is then the widest case the graph can ever need, so toggling
+  // metadata cannot move a single node — what changes is how much of the lane
+  // is left for the connector (see `contentHeightOf`). `TAG_BLOCK_MARGIN` is
+  // the clearance kept between the last chip row and the expander pill.
+  const reservedTagHeight =
+    tagBlockHeight > 0 ? tagBlockHeight + TAG_BLOCK_MARGIN : 0
   const effectiveNodeHeight = (nodeHeightProp ?? 56) + reservedTagHeight
+
+  // What a given node actually paints right now: the card plus whichever chip
+  // rows survive the current column toggles. The box above is the same for
+  // every node; this is not, and it is what the connector and the expander hang
+  // from — so hiding a column lengthens the line rather than stranding it below
+  // a band of empty canvas.
+  const contentHeightOf = (id: string): number => {
+    const base = nodeHeightProp ?? 56
+    const visible = visibleTagHeights?.get(id) ?? 0
+    return visible > 0 ? base + visible + TAG_ROW_GAP : base
+  }
 
   const builtInEngine = useLayoutEngine({
     nodeWidth: nodeWidthProp,
@@ -560,30 +568,38 @@ export function useGraphRenderModel<T>({
     // offsets lets React Flow derive the endpoint immediately; the real measured
     // handle bounds take over once the node's DOM mounts. Node dimensions are
     // supplied below (`width`/`height`) so the node also counts as "initialized".
-    const handleOffset = (p: Position): { x: number; y: number } =>
-      p === Position.Top
-        ? { x: BASE_W / 2, y: 0 }
-        : p === Position.Bottom
-          ? { x: BASE_W / 2, y: BASE_H }
-          : p === Position.Left
-            ? { x: 0, y: BASE_H / 2 }
-            : { x: BASE_W, y: BASE_H / 2 }
-    const graphNodeHandles = [
-      {
-        type: "source" as const,
-        position: sourcePos,
-        ...handleOffset(sourcePos),
-        width: 1,
-        height: 1,
-      },
-      {
-        type: "target" as const,
-        position: targetPos,
-        ...handleOffset(targetPos),
-        width: 1,
-        height: 1,
-      },
-    ] as RFNode["handles"]
+    //
+    // Built per box because the source handle follows a node's PAINTED bottom,
+    // not the shared layout box: a node showing fewer chip rows than the
+    // reserved "all open" block anchors its edge higher, so the connector
+    // lengthens instead of starting inside the empty part of the box.
+    const handlesForBox = (w: number, h: number): RFNode["handles"] => {
+      const handleOffset = (p: Position): { x: number; y: number } =>
+        p === Position.Top
+          ? { x: w / 2, y: 0 }
+          : p === Position.Bottom
+            ? { x: w / 2, y: h }
+            : p === Position.Left
+              ? { x: 0, y: h / 2 }
+              : { x: w, y: h / 2 }
+      return [
+        {
+          type: "source" as const,
+          position: sourcePos,
+          ...handleOffset(sourcePos),
+          width: 1,
+          height: 1,
+        },
+        {
+          type: "target" as const,
+          position: targetPos,
+          ...handleOffset(targetPos),
+          width: 1,
+          height: 1,
+        },
+      ] as RFNode["handles"]
+    }
+    const graphNodeHandles = handlesForBox(BASE_W, BASE_H)
 
     const nodes: RFNode[] = []
 
@@ -643,8 +659,17 @@ export function useGraphRenderModel<T>({
         // before the DOM is measured (otherwise a freshly windowed-in node's
         // connecting lines drop for that frame). Omitted when windowing is off so
         // React Flow's own viewport culling keeps its original behavior.
+        // The source handle is where the edge leaves from, so it belongs at
+        // this node's painted bottom — seeding it at the shared box height is
+        // what made the line start between the chips and run behind them.
         ...(windowingActive
-          ? { height: BASE_H, handles: graphNodeHandles }
+          ? {
+              height: BASE_H,
+              handles:
+                contentHeightOf(treeNode.id) === BASE_H
+                  ? graphNodeHandles
+                  : handlesForBox(BASE_W, contentHeightOf(treeNode.id)),
+            }
           : null),
         sourcePosition: sourcePos,
         targetPosition: targetPos,
@@ -672,6 +697,10 @@ export function useGraphRenderModel<T>({
       }
       const pw = parentNode.width ?? BASE_W
       const ph = parentNode.height ?? BASE_H
+      // Hang from what the parent paints, then re-centre in the (now longer)
+      // lane below it. With no tags this is exactly the old offset.
+      const pContent = contentHeightOf(exp.parentId)
+      const laneShift = (ph - pContent) / 2
       const expX = isHorizontal
         ? direction === "LR"
           ? parentNode.x + pw + EXPANDER_Y_OFFSET
@@ -680,7 +709,7 @@ export function useGraphRenderModel<T>({
       const expY = isHorizontal
         ? parentNode.y * yStretch
         : direction === "TB"
-          ? parentNode.y * yStretch + ph + EXPANDER_Y_OFFSET
+          ? parentNode.y * yStretch + pContent + EXPANDER_Y_OFFSET + laneShift
           : parentNode.y * yStretch - ph
       nodes.push({
         id: exp.id,
@@ -709,6 +738,8 @@ export function useGraphRenderModel<T>({
       const py = parentPos?.y ?? 0
       const pw = parentPos?.width ?? BASE_W
       const ph = parentPos?.height ?? BASE_H
+      const pContent = contentHeightOf(parent.id)
+      const laneShift = (ph - pContent) / 2
       const colX = isHorizontal
         ? direction === "LR"
           ? px + pw + EXPANDER_Y_OFFSET + COLLAPSER_OFFSET_ADJUSTMENT
@@ -717,7 +748,11 @@ export function useGraphRenderModel<T>({
       const colY = isHorizontal
         ? py * yStretch
         : direction === "TB"
-          ? py * yStretch + ph + EXPANDER_Y_OFFSET + COLLAPSER_OFFSET_ADJUSTMENT
+          ? py * yStretch +
+            pContent +
+            EXPANDER_Y_OFFSET +
+            COLLAPSER_OFFSET_ADJUSTMENT +
+            laneShift
           : py * yStretch - ph
       nodes.push({
         id: `collapser-${parent.id}`,

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -52,6 +52,13 @@ const ESTIMATED_TAGS_PER_ROW = 2
 // Gap between the pill and the tag block (`gap-1.5` on the node's column).
 // Added to the measured tag height so the reservation covers the whole stack.
 const TAG_ROW_GAP = 6
+// The lane the layout engine already leaves between a node and its children
+// (`DEFAULT_RANK_SEP`). Tags hang into it rather than extending the node box.
+const NODE_RANK_SEP = 130
+// Line still visible below the tags when a tag block is long enough to need
+// room of its own. Without it a very tall block would butt straight into the
+// next rank.
+const MIN_EDGE_LENGTH = 24
 
 interface UseGraphRenderModelOptions<T> {
   roots: TreeNode<T>[]
@@ -300,11 +307,23 @@ export function useGraphRenderModel<T>({
   const estimatedTagHeight =
     Math.max(1, Math.ceil(visibleTagCount / ESTIMATED_TAGS_PER_ROW)) *
     TAG_ROW_HEIGHT
-  const reservedTagHeight = !tagsAffectLayout
+  const tagBlockHeight = !tagsAffectLayout
     ? 0
-    : measuredTagRowHeight !== undefined
-      ? measuredTagRowHeight + TAG_ROW_GAP
-      : estimatedTagHeight
+    : (measuredTagRowHeight ?? estimatedTagHeight) + TAG_ROW_GAP
+
+  // Rank pitch is a fixed design constant: a node's children always sit the
+  // same distance below it, tags or no tags. So tags are NOT added to the node
+  // box — they hang into the lane that already exists between a node and its
+  // children, and what changes is how much of that lane is left for the
+  // connecting line. Toggling metadata then never moves a single node.
+  //
+  // The one case that does need room is a tag block long enough to eat the
+  // whole lane: past that the tags would run into the next rank, so reserve
+  // just the overflow, keeping `MIN_EDGE_LENGTH` of line visible.
+  const reservedTagHeight = Math.max(
+    0,
+    tagBlockHeight + MIN_EDGE_LENGTH - NODE_RANK_SEP
+  )
   const effectiveNodeHeight = (nodeHeightProp ?? 56) + reservedTagHeight
 
   const builtInEngine = useLayoutEngine({

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -49,6 +49,9 @@ import { useViewportGeometry } from "./useViewportGeometry"
 // (and the next rank) below the metadata instead of overlapping it.
 const TAG_ROW_HEIGHT = 36
 const ESTIMATED_TAGS_PER_ROW = 2
+// Gap between the pill and the tag block (`gap-1.5` on the node's column).
+// Added to the measured tag height so the reservation covers the whole stack.
+const TAG_ROW_GAP = 6
 
 interface UseGraphRenderModelOptions<T> {
   roots: TreeNode<T>[]
@@ -69,6 +72,11 @@ interface UseGraphRenderModelOptions<T> {
   nodeTagTypes?: ReadonlyArray<F0GraphNodeTagColumn>
   visibleTagTypesSet: Set<F0GraphNodeTagColumn>
   reserveTagRow?: boolean
+  /**
+   * Tallest tag block reported by the rendered nodes, in px. Replaces the
+   * count-based estimate once the first measurement lands.
+   */
+  measuredTagRowHeight?: number
   nodeWidthProp?: number
   nodeHeightProp?: number
   layoutEngineProp?: LayoutEngine
@@ -124,6 +132,7 @@ export function useGraphRenderModel<T>({
   nodeTagTypes,
   visibleTagTypesSet,
   reserveTagRow,
+  measuredTagRowHeight,
   nodeWidthProp,
   nodeHeightProp,
   layoutEngineProp,
@@ -272,15 +281,30 @@ export function useGraphRenderModel<T>({
   // when `reserveTagRow` is explicitly set (e.g. tags rendered via
   // `renderNode` without using the popover). Inflating the box otherwise
   // would push the source handle and the expander below the pill.
-  const tagsAffectLayout =
-    reserveTagRow ?? (nodeTagTypes ? visibleTagTypesSet.size > 0 : false)
-  // Same-type tags collapse to a single pill, so the visible tag-type count is
-  // a good proxy for how many pills (and therefore rows) are rendered.
+  //
+  // A consumer that hard-codes `reserveTagRow` (as the Data Collection graph
+  // does whenever a `tags` mapper exists) must still collapse when every column
+  // is toggled off — otherwise hiding them all leaves the block of empty canvas
+  // the tags used to occupy. So the visible-count gate wins whenever the toggle
+  // UI exists; `reserveTagRow` only decides the case with no columns declared.
+  const tagsAffectLayout = nodeTagTypes
+    ? visibleTagTypesSet.size > 0
+    : (reserveTagRow ?? false)
+  // How much room the tags take is a DOM question, not an arithmetic one: rows
+  // come from wrapping, which depends on each node's label widths. The nodes
+  // measure themselves and report (see `reportTagRowHeight`); the tallest wins,
+  // since one layout height is shared by every node. Until the first report
+  // lands, fall back to the old count-based estimate so the first paint is not
+  // visibly wrong.
   const visibleTagCount = nodeTagTypes ? visibleTagTypesSet.size : 1
-  const tagRowCount = tagsAffectLayout
-    ? Math.max(1, Math.ceil(visibleTagCount / ESTIMATED_TAGS_PER_ROW))
-    : 0
-  const reservedTagHeight = tagRowCount * TAG_ROW_HEIGHT
+  const estimatedTagHeight =
+    Math.max(1, Math.ceil(visibleTagCount / ESTIMATED_TAGS_PER_ROW)) *
+    TAG_ROW_HEIGHT
+  const reservedTagHeight = !tagsAffectLayout
+    ? 0
+    : measuredTagRowHeight !== undefined
+      ? measuredTagRowHeight + TAG_ROW_GAP
+      : estimatedTagHeight
   const effectiveNodeHeight = (nodeHeightProp ?? 56) + reservedTagHeight
 
   const builtInEngine = useLayoutEngine({

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -792,6 +792,12 @@ export function useGraphRenderModel<T>({
     COLLAPSER_OFFSET_ADJUSTMENT,
     nodeWidthProp,
     effectiveNodeHeight,
+    // The seeded node height and the expander/collapser offsets are all derived
+    // from `contentHeightOf`, which reads this map. Leaving it out froze them at
+    // whatever the first render measured: toggling a column re-measured the
+    // chips and updated the map, but the nodes kept their old height, so the
+    // connector never grew back or shrank.
+    visibleTagHeights,
     direction,
     ariaTreeInfo,
     controlLabels?.collapseChildren,

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -323,15 +323,22 @@ export function useGraphRenderModel<T>({
     tagBlockHeight > 0 ? tagBlockHeight + TAG_BLOCK_MARGIN : 0
   const effectiveNodeHeight = (nodeHeightProp ?? 56) + reservedTagHeight
 
-  // What a given node actually paints right now: the card plus whichever chip
-  // rows survive the current column toggles. The box above is the same for
-  // every node; this is not, and it is what the connector and the expander hang
-  // from — so hiding a column lengthens the line rather than stranding it below
-  // a band of empty canvas.
+  // Where a node's connector and expander hang from: below whichever chip rows
+  // survive the current toggles, plus the same clearance the box reserves. The
+  // box above is identical for every node; this is not, so hiding a column
+  // lengthens the line instead of stranding it under a band of empty canvas.
+  //
+  // The clearance has to be applied here too, not only to the box: reserving it
+  // inside the box sets the rank pitch, but the edge still left from the exact
+  // bottom of the tags and read as touching the last chip.
+  //
+  // Bounded by the box by construction — the visible block is never taller than
+  // the fully-open one it was reserved from — so the anchor lands at the box
+  // bottom at most, never past the next rank.
   const contentHeightOf = (id: string): number => {
     const base = nodeHeightProp ?? 56
     const visible = visibleTagHeights?.get(id) ?? 0
-    return visible > 0 ? base + visible + TAG_ROW_GAP : base
+    return visible > 0 ? base + visible + TAG_ROW_GAP + TAG_BLOCK_MARGIN : base
   }
 
   const builtInEngine = useLayoutEngine({

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -665,12 +665,17 @@ export function useGraphRenderModel<T>({
         // before the DOM is measured (otherwise a freshly windowed-in node's
         // connecting lines drop for that frame). Omitted when windowing is off so
         // React Flow's own viewport culling keeps its original behavior.
-        // The source handle is where the edge leaves from, so it belongs at
-        // this node's painted bottom — seeding it at the shared box height is
-        // what made the line start between the chips and run behind them.
+        //
+        // The height is this node's PAINTED height, not the reserved box. React
+        // Flow stretches the node element to whatever `height` says and pins the
+        // bottom handle to that element's edge — hand it the reservation and the
+        // edge leaves from the bottom of the empty band instead of from under
+        // the chips, which is the blank gap a node with few chips would show.
+        // The reservation stays where it belongs: in the layout, setting the
+        // rank pitch. React Flow never needs to know about it.
         ...(windowingActive
           ? {
-              height: BASE_H,
+              height: contentHeightOf(treeNode.id),
               handles:
                 contentHeightOf(treeNode.id) === BASE_H
                   ? graphNodeHandles

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -27,6 +27,7 @@ import type {
 import {
   BACKGROUND_DOT_GAP,
   COLLAPSER_OFFSET_ADJUSTMENT_BY_ZOOM,
+  TAG_BLOCK_CLEARANCE,
 } from "../constants"
 import {
   EXPANDER_Y_OFFSET_BY_ZOOM,
@@ -52,10 +53,6 @@ const ESTIMATED_TAGS_PER_ROW = 2
 // Gap between the pill and the tag block (`gap-1.5` on the node's column).
 // Added to the measured tag height so the reservation covers the whole stack.
 const TAG_ROW_GAP = 6
-// Clearance between the last chip row and whatever hangs below it (the
-// connector, the expander pill). Applied to the fully-open block, so it is the
-// minimum gap in the tightest state a node can reach.
-const TAG_BLOCK_MARGIN = 32
 
 interface UseGraphRenderModelOptions<T> {
   roots: TreeNode<T>[]
@@ -317,10 +314,10 @@ export function useGraphRenderModel<T>({
   // Reserve the "all columns open" block, never the currently visible one. The
   // rank pitch is then the widest case the graph can ever need, so toggling
   // metadata cannot move a single node — what changes is how much of the lane
-  // is left for the connector (see `contentHeightOf`). `TAG_BLOCK_MARGIN` is
+  // is left for the connector (see `contentHeightOf`). `TAG_BLOCK_CLEARANCE` is
   // the clearance kept between the last chip row and the expander pill.
   const reservedTagHeight =
-    tagBlockHeight > 0 ? tagBlockHeight + TAG_BLOCK_MARGIN : 0
+    tagBlockHeight > 0 ? tagBlockHeight + TAG_BLOCK_CLEARANCE : 0
   const effectiveNodeHeight = (nodeHeightProp ?? 56) + reservedTagHeight
 
   // Where a node's connector and expander hang from: below whichever chip rows
@@ -338,7 +335,9 @@ export function useGraphRenderModel<T>({
   const contentHeightOf = (id: string): number => {
     const base = nodeHeightProp ?? 56
     const visible = visibleTagHeights?.get(id) ?? 0
-    return visible > 0 ? base + visible + TAG_ROW_GAP + TAG_BLOCK_MARGIN : base
+    return visible > 0
+      ? base + visible + TAG_ROW_GAP + TAG_BLOCK_CLEARANCE
+      : base
   }
 
   const builtInEngine = useLayoutEngine({

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -71,13 +71,7 @@ interface UseGraphRenderModelOptions<T> {
     ctx: F0GraphNodeRenderContext
   ) => ReactNode
   nodeTagTypes?: ReadonlyArray<F0GraphNodeTagColumn>
-  visibleTagTypesSet: Set<F0GraphNodeTagColumn>
   reserveTagRow?: boolean
-  /**
-   * Tallest "all columns open" tag block reported by the rendered nodes, in px.
-   * Drives the reservation, so the rank pitch never moves as columns toggle.
-   */
-  measuredTagRowHeight?: number
   /** Per-node height of the tag block CURRENTLY on screen, in px. */
   visibleTagHeights?: ReadonlyMap<string, number>
   nodeWidthProp?: number
@@ -133,9 +127,7 @@ export function useGraphRenderModel<T>({
   resolvedEdgesProp,
   stableRenderNode,
   nodeTagTypes,
-  visibleTagTypesSet,
   reserveTagRow,
-  measuredTagRowHeight,
   visibleTagHeights,
   nodeWidthProp,
   nodeHeightProp,
@@ -280,36 +272,37 @@ export function useGraphRenderModel<T>({
   // ── Layout edges: include expander edges so the engine sees the full graph ──
   const layoutEdges = useMemo(() => visibleEdges, [visibleEdges])
 
-  // The tag row only contributes to layout when the consumer opts into the
-  // popover (`nodeTagTypes`) and at least one type is currently visible, or
-  // when `reserveTagRow` is explicitly set (e.g. tags rendered via
-  // `renderNode` without using the popover). Inflating the box otherwise
-  // would push the source handle and the expander below the pill.
+  // The tag row only contributes to layout when the consumer declares columns
+  // (`nodeTagTypes`), or when `reserveTagRow` is explicitly set (e.g. tags
+  // rendered via `renderNode` without using the popover). Inflating the box
+  // otherwise would push the source handle and the expander below the pill.
   //
-  // A consumer that hard-codes `reserveTagRow` (as the Data Collection graph
-  // does whenever a `tags` mapper exists) must still collapse when every column
-  // is toggled off — otherwise hiding them all leaves the block of empty canvas
-  // the tags used to occupy. So the visible-count gate wins whenever the toggle
-  // UI exists; `reserveTagRow` only decides the case with no columns declared.
-  // Declaring tag columns is what reserves the room — not how many are visible
-  // right now. The box is sized for the fully-open block so the rank pitch is
-  // constant and toggling metadata cannot move a node; the currently hidden
-  // rows simply become connector length (see `contentHeightOf`).
+  // Declaring the columns is what reserves the room — not how many happen to be
+  // visible right now. The box is sized for the fully-open block so the rank
+  // pitch is constant and toggling metadata cannot move a node; the currently
+  // hidden rows simply become connector length (see `contentHeightOf`).
   const tagsAffectLayout =
     nodeTagTypes && nodeTagTypes.length > 0 ? true : (reserveTagRow ?? false)
-  // How much room the tags take is a DOM question, not an arithmetic one: rows
-  // come from wrapping, which depends on each node's label widths. The nodes
-  // measure themselves and report (see `reportTagRowHeight`); the tallest wins,
-  // since one layout height is shared by every node. Until the first report
-  // lands, fall back to the old count-based estimate so the first paint is not
-  // visibly wrong.
-  const visibleTagCount = nodeTagTypes ? visibleTagTypesSet.size : 1
-  const estimatedTagHeight =
-    Math.max(1, Math.ceil(visibleTagCount / ESTIMATED_TAGS_PER_ROW)) *
-    TAG_ROW_HEIGHT
+  // The reservation is arithmetic — derived from how many tag columns the
+  // consumer DECLARED — and deliberately never measured from the DOM.
+  //
+  // Measuring the tallest rendered node looks correct and is not: a graph with
+  // node windowing only ever renders a slice, and a graph with lazy hydration
+  // only knows a node's labels once it has been fetched. The true tallest node
+  // is therefore undiscoverable at first paint, and every pan that reveals a
+  // taller one raises the reservation, which changes the rank pitch, which
+  // slides every generation off its line. Ratcheting the max only converts that
+  // oscillation into a one-way creep; it does not make the pitch fixed.
+  //
+  // Counting declared columns is knowable before a single node renders, so the
+  // pitch is final on frame one and identical for every viewport, hydration
+  // state and toggle combination.
+  const declaredTagCount = nodeTagTypes ? nodeTagTypes.length : 1
   const tagBlockHeight = !tagsAffectLayout
     ? 0
-    : (measuredTagRowHeight ?? estimatedTagHeight) + TAG_ROW_GAP
+    : Math.max(1, Math.ceil(declaredTagCount / ESTIMATED_TAGS_PER_ROW)) *
+        TAG_ROW_HEIGHT +
+      TAG_ROW_GAP
 
   // Reserve the "all columns open" block, never the currently visible one. The
   // rank pitch is then the widest case the graph can ever need, so toggling
@@ -329,15 +322,20 @@ export function useGraphRenderModel<T>({
   // inside the box sets the rank pitch, but the edge still left from the exact
   // bottom of the tags and read as touching the last chip.
   //
-  // Bounded by the box by construction — the visible block is never taller than
-  // the fully-open one it was reserved from — so the anchor lands at the box
-  // bottom at most, never past the next rank.
+  // Clamped to the box: the reservation is an estimate of how the chips wrap,
+  // so a node whose labels wrap onto an extra row would otherwise anchor its
+  // connector past the next rank. Clamping keeps the invariant that a node
+  // never grows beyond its lane — that node's last chip row sits closer to the
+  // connector than the clearance would like, which is a cosmetic cost paid by
+  // the outlier instead of a layout shift paid by every node.
   const contentHeightOf = (id: string): number => {
     const base = nodeHeightProp ?? 56
     const visible = visibleTagHeights?.get(id) ?? 0
-    return visible > 0
-      ? base + visible + TAG_ROW_GAP + TAG_BLOCK_CLEARANCE
-      : base
+    if (visible <= 0) return base
+    return Math.min(
+      base + visible + TAG_ROW_GAP + TAG_BLOCK_CLEARANCE,
+      effectiveNodeHeight
+    )
   }
 
   const builtInEngine = useLayoutEngine({


### PR DESCRIPTION
## Description

Two org-chart symptoms with a single cause.

1. **Hiding every metadata column left dead space.** The block the tags used to occupy stayed reserved, so the node looked like it still had them.
2. **The connecting edge sometimes crossed the tags** instead of starting below them — and only sometimes, which is what made it look random.

The layout reserved room for the tags from the *number* of visible columns (`ceil(count / 2)` rows of 36px). But how many rows the tags actually take is a DOM question: `F0GraphNodeTags` is a `flex-wrap` row inside a fixed `max-w-[256px]`, so the row count depends on each node's **label widths**, not on how many tags there are.

Two tags with long labels wrap to two rows while the estimate reserved one — the next rank then lands 26px *inside* the node, which is the edge crossing the chips. The same arithmetic over-reserved by 4–10px in the combinations that did fit on one row.

## Measured

New `TagRowReservation` story, toggling the same four columns as the org chart. `pitch` is a node's top to its child's top — it must not move. `line` is the visible connector — it absorbs the difference.

| Visible columns | Rows rendered | pitch | line |
| --- | --- | --- | --- |
| none | 0 | **186** | 130 |
| `workplace` | 1 | **186** | 98 |
| `workplace + reports` | 1 | **186** | 98 |
| `workplace + legalEntity` | 2 | **186** | 68 |
| all four | 2 | **186** | 68 |

Before the fix the pitch moved with the tags (and, in the `workplace + legalEntity` case, the estimate came up 26px short and the edge crossed the chips).

## Implementation

**Rank pitch is fixed; tags hang into the lane.** The layout no longer adds the tag block to the node box, so toggling a column moves nothing. Tags occupy part of the 130px lane that already exists between a node and its children, and the connecting line takes whatever is left. The only case that still grows the box is a block long enough to eat the whole lane, where just the overflow is reserved so `MIN_EDGE_LENGTH` of line stays visible.

**Block height is measured, not counted.** It used to be estimated from the number of visible columns (`ceil(count / 2)` rows of 36px), but `F0GraphNodeTags` is a `flex-wrap` row inside a fixed `max-w-[256px]` — the row count comes from each node's **label widths**. Two tags with long labels wrap to two rows where the estimate saw one. Nodes now report their measured block height (`reportTagRowHeight`, driven by a `ResizeObserver`) and the tallest report drives the overflow check.

Safe against feedback: the block wraps inside a fixed max-width, so the reservation never changes what is being measured. Reports are kept per node id rather than as a running max, so a node that sheds tags — or leaves the viewport window — releases the room instead of the max ratcheting up for the session. The count estimate remains as the value used before the first measurement lands.

**The gate itself was broken too.** `reserveTagRow` short-circuited the "collapse when nothing is visible" branch:

```ts
// before — an explicit `reserveTagRow` skips the whole gate
reserveTagRow ?? (nodeTagTypes ? visibleTagTypesSet.size > 0 : false)
```

…and the Data Collection graph hard-codes `reserveTagRow={tags !== undefined}`, so for every consumer with a `tags` mapper the collapse could never happen. The visible-count gate now wins whenever tag columns are declared; `reserveTagRow` only decides the case with no columns at all (tags rendered straight from `renderNode`).

## Type of change

- [x] Bug fix

## Implementation details

- `contexts.ts` — `reportTagRowHeight` on the internal render config.
- `F0GraphNode.tsx` — `ResizeObserver` on the tag block, reports height (`0` when it renders none).
- `F0GraphView.tsx` — collects reports per node id, keeps the max in state.
- `useGraphRenderModel.ts` — reservation precedence, and measured height over estimate.
- 6 new unit tests covering the precedence, the estimate fallback, measured-over-estimate, shrinking, and hidden-wins-over-measurement.
- `TagRowReservation` story with per-column toggles for manual checking.

Full `F0Graph` + Data Collection graph suites green (305 tests).
