### PR TITLE
fix(NewHomeLayout): size to its container, not the window

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -734,14 +734,33 @@ const Home = () => {
   )
 }
 
+/**
+ * The page-level strip the app puts above EVERYTHING — the frame's own `banner`
+ * row, over the sidebar and the content both, exactly where the
+ * "You are seeing X's company view" bar lives in production. Only the height
+ * probe below asks for it (`parameters.frameBanner`).
+ */
+const FrameBanner = () => (
+  <div className="flex h-12 flex-row items-center justify-between gap-4 bg-f1-background-info px-4 text-f1-foreground">
+    <span>You are seeing Factorial&apos;s company view.</span>
+    <span className="flex flex-row items-center gap-1.5 font-medium">
+      Factorial Professionals
+      <F0Icon icon={ExternalLink} size="sm" />
+    </span>
+  </div>
+)
+
 const meta = {
   title: "Home/NewHomeLayout",
   component: NewHomeLayout,
   tags: ["autodocs", "experimental"],
   parameters: { layout: "fullscreen", docsFullWidth: true },
   decorators: [
-    (Story) => (
+    (Story, { parameters }) => (
       <ApplicationFrame
+        // The frame's top row, outside the layout entirely: it takes real height
+        // off the content area, which is what the height probe is testing.
+        banner={parameters.frameBanner ? <FrameBanner /> : undefined}
         sidebar={
           <Sidebar
             header={<SidebarHeader {...SidebarHeaderStories.Default.args} />}
@@ -769,6 +788,27 @@ type Story = StoryObj<typeof meta>
  * toggles the per-widget remove chrome.
  */
 export const Default: Story = {
+  render: () => <Home />,
+}
+
+/**
+ * A HEIGHT PROBE, not a layout to copy: the same Home with a 48px banner in the
+ * frame's own top row — the production "company view" strip — above the sidebar
+ * and the content both, entirely outside `NewHomeLayout`.
+ *
+ * That banner takes its 48px off the content area, so the layout has that much
+ * LESS room than in `Default`. Nothing about the page should move: the banner
+ * stays put, the sidebar still ends at the window's bottom edge, and the
+ * layout's two columns absorb the loss by scrolling a little more inside
+ * themselves.
+ *
+ * If instead the layout keeps sizing itself to the WINDOW rather than to the box
+ * it was given, it overshoots by the banner's height, and you can see it: the
+ * page starts scrolling as a whole, and the rail's bottom widget, the
+ * "+ Add widget" placeholder and the bottom gutter fall past the window's edge.
+ */
+export const BannerAboveLayout: Story = {
+  parameters: { frameBanner: true },
   render: () => <Home />,
 }
 

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -112,7 +112,8 @@ export interface NewHomeLayoutProps {
   /**
    * How far the page surface reaches past this layout's box, in px — set it to
    * the page's own gutter so the gradient runs to the window's edges instead of
-   * stopping at that padding.
+   * stopping at that padding. The layout's HEIGHT is not its business: that
+   * comes from the box the page gives it.
    */
   bleed?: number
   /**
@@ -312,7 +313,20 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
         style={
           {
             "--home-aside-w": `${railWidth}px`,
-            height: `calc(100svh - ${2 * bleed}px)`,
+            // FILL THE BOX THE PAGE GIVES US, not the window. This used to be
+            // `calc(100svh - 2 * bleed)`, which assumed the layout's box WAS the
+            // viewport minus its own gutter — true only while nothing else is on
+            // the page. Put anything above it (the frame's banner row, a page
+            // header) and the layout still claimed the whole window: it overshot
+            // by exactly that element's height, so the page itself scrolled and
+            // the rail's bottom fell past the window's edge — the very overscroll
+            // the columns' own scrolling exists to avoid.
+            height: "100%",
+            // The guard for a page that hands us NO definite height: `100%` then
+            // resolves to auto, and without a cap the layout would grow with its
+            // content and the columns would never scroll. The window (less our
+            // gutter) is the most it can usefully be.
+            maxHeight: `calc(100svh - ${2 * bleed}px)`,
             // The column template lives HERE rather than in a class: it is the
             // same property Tailwind's `grid-cols-*` sets, so as a utility it
             // lost the specificity contest and the rail silently fell out of its


### PR DESCRIPTION
## Description

`NewHomeLayout` sized itself to the window rather than to the box the page gave it, so any page-level chrome above it pushed the layout past the viewport: the page itself scrolled and the rail's bottom fell off the screen — the very overscroll the columns' own internal scrolling exists to prevent. It now fills the box it's handed, and a new story reproduces the case that exposed it.
