### PR TITLE
fix(FiltersPresets): stop preset pill overlapping overflow indicator

### DIFF
--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersPresets.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersPresets.tsx
@@ -311,6 +311,10 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
       renderDropdownItem={renderDropdownItem}
       className="min-w-0 flex-1"
       min={1}
+      // Preset pills can ellipsize: with `min={1}` a pill wider than the space
+      // left by the overflow indicator stays in the row, so let it truncate
+      // rather than paint over the indicator.
+      fluidItems
     />
   )
 }

--- a/packages/react/src/ui/OnePreset/index.tsx
+++ b/packages/react/src/ui/OnePreset/index.tsx
@@ -54,7 +54,10 @@ const _Preset = ({
       onMouseEnter={hasActions ? () => setShowActions(true) : undefined}
       onMouseLeave={hasActions ? () => setShowActions(false) : undefined}
       className={cn(
-        "group flex cursor-default appearance-none items-center gap-2 rounded px-2.5 py-1.5 font-medium text-f1-foreground outline outline-1 outline-f1-border transition-all",
+        // `min-w-0` lets the pill shrink below its label when the row that
+        // holds it runs out of space, so the label ellipsizes instead of
+        // spilling out of the pill's box.
+        "group flex min-w-0 cursor-default appearance-none items-center gap-2 rounded px-2.5 py-1.5 font-medium text-f1-foreground outline outline-1 outline-f1-border transition-all",
         onClick &&
           "focus-within:ring-2 focus-within:ring-f1-border-selected focus-within:ring-offset-2",
         number && "pr-1.5",
@@ -69,7 +72,7 @@ const _Preset = ({
         checked={selected}
         onChange={() => onClick?.()}
       />
-      <span className="whitespace-nowrap">{label}</span>
+      <span className="min-w-0 truncate">{label}</span>
       {number !== undefined && (
         <Await resolve={number} fallback={<Skeleton className="h-4 w-4" />}>
           {(number) =>

--- a/packages/react/src/ui/OverflowList/index.test.tsx
+++ b/packages/react/src/ui/OverflowList/index.test.tsx
@@ -78,6 +78,37 @@ describe("OverflowList", () => {
     expect(screen.queryByText("skeleton-0")).not.toBeInTheDocument()
   })
 
+  it("only lets the visible items shrink when they are fluid", () => {
+    const rows: RowItem[] = [{ preset: { label: "First" } }]
+    const { rerender } = zeroRender(
+      <OverflowList
+        items={rows}
+        renderListItem={renderRow}
+        renderDropdownItem={renderRow}
+      />
+    )
+
+    // Fixed-size items keep their min-content floor: they have nothing to give.
+    expect(
+      screen.getByTestId("overflow-visible-container").className
+    ).not.toContain("[&>*]:min-w-0")
+
+    // Fluid items take the shrink pressure instead, so an item that `min` keeps
+    // visible without enough room truncates inside its own box rather than
+    // overflowing it and painting over the overflow indicator.
+    rerender(
+      <OverflowList
+        items={rows}
+        renderListItem={renderRow}
+        renderDropdownItem={renderRow}
+        fluidItems
+      />
+    )
+    expect(
+      screen.getByTestId("overflow-visible-container").className
+    ).toContain("[&>*]:min-w-0")
+  })
+
   it("renders nothing when items becomes empty", () => {
     const rows: RowItem[] = [{ preset: { label: "First" } }]
     const { rerender } = zeroRender(

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -66,7 +66,13 @@ interface OverflowListProps<T> {
   min?: number
 
   /**
-   * Whether the items can change their width dynamically, for example when they have ellipsis
+   * Whether the items can change their width dynamically, for example when they have ellipsis.
+   *
+   * Enable it for items that can ellipsize: the row then lets them shrink, so
+   * when `min` keeps an item visible that doesn't fit, it truncates inside its
+   * own box instead of painting over the overflow indicator. Leave it off for
+   * fixed-size items (avatars, chips), which have nothing to give and would
+   * only get squeezed.
    * @default false
    */
   fluidItems?: boolean
@@ -90,6 +96,7 @@ const OverflowList = function OverflowList<T>({
   gap = 8,
   max,
   min = 0,
+  fluidItems = false,
   itemsWidth,
 }: OverflowListProps<T>) {
   const [isOpen, setIsOpen] = useState(false)
@@ -152,7 +159,11 @@ const OverflowList = function OverflowList<T>({
           ref={measurementContainerRef}
           aria-hidden="true"
           className={cn(
-            "pointer-events-none invisible absolute left-0 top-0 opacity-0",
+            // `w-max` keeps this measuring at each item's natural width: it is
+            // absolutely positioned, so without it the container is shrink-to-fit
+            // against the row and items that can ellipsize would be measured
+            // squeezed.
+            "pointer-events-none invisible absolute left-0 top-0 w-max opacity-0",
             itemsWrapperClasses
           )}
           style={{ gap: gap > 0 ? `${gap}px` : undefined }}
@@ -171,7 +182,17 @@ const OverflowList = function OverflowList<T>({
       )}
 
       <div
-        className={itemsWrapperClasses}
+        className={cn(
+          itemsWrapperClasses,
+          // This container carries `min-w-0`, so it can end up narrower than its
+          // content: `min` keeps items in the row even when they don't fit (e.g.
+          // a single preset wider than the space the overflow indicator leaves).
+          // For fluid items, pass that pressure down so they truncate inside
+          // their own box instead of overflowing it and painting over the
+          // indicator. Fixed-size items keep their min-content floor — they have
+          // nothing to give, and squeezing them would only distort them.
+          fluidItems && "[&>*]:min-w-0"
+        )}
         style={{
           gap: gap > 0 ? `${gap}px` : undefined,
         }}


### PR DESCRIPTION
## Description

In the presets row, a preset pill wider than the space left by the "+N More" indicator was drawn on top of it — the story `patterns-filters-filterpicker--with-presets-overflow-counter-consistency` overlapped "Engineering Team 42" and "+4 More" by 20.6px. The count badge was never absolutely positioned; the visible-items container and the overflow indicator were simply laid out over one another, so this fixes the row's layout and lets a pill that can't fit truncate instead.

## Implementation details

- fix: let the presets row pass its shrink pressure down to the pills, so one that doesn't fit truncates rather than painting over the overflow indicator

  <details>
  <summary>Why?</summary>

  `OverflowList`'s row is a flex container: the visible-items wrapper carries `min-w-0` and the indicator button is `flex-shrink-0`. `FiltersPresets` passes `min={1}`, which keeps the first pill visible even when it doesn't fit — in the story the row is 243px, the indicator 101px, so the wrapper shrank to 134px while the pill held its 163px min-content floor and overflowed its own box.

  Two alternatives were tried and dropped: `overflow-hidden` on the container (clips the items' outlines and focus rings, and breaks the negative-gap avatar list), and a measured "is constrained" flag (goes stale, since the hook only recalculates on container resize, so a pre-font-load measurement sticks).
  </details>

- feat: wire up `OverflowList`'s `fluidItems` prop, which was declared with exactly this meaning ("items can change their width dynamically, for example when they have ellipsis") but never destructured or passed by any consumer

  <details>
  <summary>Why opt-in rather than applied to every list?</summary>

  `F0AvatarList` (`min={max}`) and `F0TagList` (`min={1}`) reach the same forced-overflow path with fixed-size items. Those have nothing to give, and squeezing them would only distort them, so they keep their min-content floor and are untouched by this PR.
  </details>

- fix: measure the hidden measurement container at `w-max`, since it is absolutely positioned and would otherwise be shrink-to-fit against the row — measuring ellipsizable items squeezed
- fix: let the preset pill's label ellipsize (`min-w-0` + `truncate`) instead of spilling out of the pill; the full label stays in the DOM
- test: cover that only fluid items take the shrink pressure

## Verified

- Swept 12 container widths from 220px to 900px: every one now sits at exactly the 8px gap, no overlap.
- The overflow dropdown's counters still match the visible pills (the invariant that story asserts).
- 195 tests pass across `OverflowList`, `OnePreset`, `OneFilterPicker`, `OneDataCollection` presets, `ButtonGroup`, and the avatar/tag/chip lists. Lint clean, no new type errors.

## Out of scope

`OverflowList` never re-splits when its container *grows* after mount — widening the presets row from 243px to 843px leaves it at one visible preset behind "+4 More". Confirmed pre-existing on an unmodified tree, affects every consumer, and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)