### PR TITLE
fix(F0AvatarList): deprecate layout, correct max docs

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -34,13 +34,20 @@ export const F0AvatarList = ({
   remainingCount: initialRemainingCount,
   max,
   // Deprecated and intentionally ignored — see `F0AvatarListProps`. Kept in the
-  // destructuring, under this exact name, because the pattern is emitted
+  // destructuring, under these exact names, because the pattern is emitted
   // verbatim into the public .d.ts signature of `F0AvatarList`: dropping or
-  // renaming it reads as a breaking public API change for a prop that still
-  // exists and still typechecks. `void` below satisfies `noUnusedLocals`.
+  // renaming them reads as a breaking public API change for props that still
+  // exist and still typecheck. `void` below satisfies `noUnusedLocals`.
+  //
+  // `layout` is listed here rather than left out of the destructuring so the
+  // ignore is deliberate in the code, not an omission a reader has to infer:
+  // it was documented for long enough that both of its values already have a
+  // home on `max` (unset = the old `"fill"`, a number = the old `"compact"`).
   tooltipScroll,
+  layout,
 }: F0AvatarListProps) => {
   void tooltipScroll
+  void layout
 
   // Check legacy size
   if (size && !avatarListSizes.includes(size)) {
@@ -80,6 +87,13 @@ export const F0AvatarList = ({
       // the cluster is rendered inside narrow columns (e.g. OneDataCollection
       // list fields). Without this, a configured `max: 3` could still render
       // as `1 avatar + "+N"` if the column was tight.
+      //
+      // This is also why the deprecated `layout` prop needs no implementation:
+      // `max` unset leaves both bounds open and the row fills its container
+      // (the old `"fill"`), while any `max` pins both bounds to a fixed
+      // footprint (the old `"compact"`). Do not give `max` a numeric default —
+      // that would take the fill behaviour away from every consumer that omits
+      // it, including OneDataCollection list fields.
       min={max}
       items={avatars.map((avatar) => ({ type, ...avatar }) as AvatarVariant)}
       gap={gap}

--- a/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.mdx
+++ b/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.mdx
@@ -26,9 +26,10 @@ members of a project or the attendees of an event.
 ### Anatomy
 
 The list renders each entity through the matching `F0Avatar*` component, stacks
-them with a slight overlap, and — when there are more than `max` — collapses the
-extras into a `+N` counter. Every avatar carries a tooltip with its name, and
-can show a secondary line (`tooltipDescription`) such as an email or role.
+them with a slight overlap, and — when more entries arrive than there is room
+for, or than `max` allows — collapses the extras into a `+N` counter. Every
+avatar carries a tooltip with its name, and can show a secondary line
+(`tooltipDescription`) such as an email or role.
 
 <Canvas of={ListStories.Default} />
 
@@ -46,10 +47,21 @@ for each entry.
 
 #### Overflow
 
-Use `max` to cap how many avatars are visible; the rest collapse into a `+N`
-counter. `remainingCount` adds to that number rather than replacing it — the
-counter renders `remainingCount` plus whatever `max` collapsed
-(`F0AvatarList.tsx:134`), so it is for entities that are not in `avatars` at all.
+Use `max` to fix how many avatars are visible; the rest collapse into a `+N`
+counter. It is an exact count, not a cap: `max` is also passed as the list's
+`min`, so a `max={3}` cluster still renders three avatars in a container too
+narrow to fit them, rather than degrading to `1 avatar + "+N"`.
+
+`max` has no numeric default. Omit it and the visible count is container-driven
+instead — the row measures the space it has and shows as many avatars as fit.
+That is the right choice when the cluster sits somewhere elastic; pass a `max`
+when you need a predictable footprint, such as a narrow column or rail. (The
+deprecated `layout` prop was meant to be this switch, but was never implemented
+and never had an effect — `max` is the switch.)
+
+`remainingCount` adds to the `+N` number rather than replacing it — the counter
+renders `remainingCount` plus whatever `max` collapsed (`F0AvatarList.tsx:155`),
+so it is for entities that are not in `avatars` at all.
 
 <Canvas of={ListStories.WithRemainingCount} />
 

--- a/packages/react/src/components/avatars/F0AvatarList/__tests__/F0AvatarList.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/__tests__/F0AvatarList.test.tsx
@@ -67,6 +67,55 @@ describe("F0AvatarList", () => {
     expect(screen.getByText("+7")).toBeInTheDocument()
   })
 
+  it("ignores the deprecated `layout` prop, whose two values are `max`", () => {
+    // `layout` was documented (`"fill"` vs `"compact"`, default `"compact"`)
+    // but never read. It stays deprecated rather than getting an
+    // implementation because `max` already covers both: unset fills the
+    // container, a number pins the count. This asserts the inertness both
+    // ways round — a future "implementation" of `layout` would have to make
+    // these two trees differ, and would fail here.
+    const avatars = [
+      { firstName: "Ada", lastName: "Lovelace" },
+      { firstName: "Alan", lastName: "Turing" },
+      { firstName: "Grace", lastName: "Hopper" },
+      { firstName: "Marie", lastName: "Curie" },
+      { firstName: "Lionel", lastName: "Messi" },
+    ]
+
+    // Radix hands the counter's popover a per-instance id (`radix-:r1:`,
+    // `radix-:r2:`, …) that increments across renders in a file, so the raw
+    // markup can never match twice. Normalising it is the whole allowance —
+    // everything else is compared byte for byte.
+    const stripReactIds = (html: string) =>
+      html.replace(/radix-:r[^:]*:/g, "radix-:id:")
+
+    const fill = render(
+      <F0AvatarList
+        type="person"
+        avatars={avatars}
+        max={3}
+        layout="fill"
+        noTooltip
+      />
+    )
+    const fillHtml = stripReactIds(fill.container.innerHTML)
+    fill.unmount()
+
+    const compact = render(
+      <F0AvatarList
+        type="person"
+        avatars={avatars}
+        max={3}
+        layout="compact"
+        noTooltip
+      />
+    )
+
+    expect(stripReactIds(compact.container.innerHTML)).toBe(fillHtml)
+    // And the tree is the one `max` dictates, not a `layout`-specific one.
+    expect(compact.getByText("+2")).toBeInTheDocument()
+  })
+
   it("renders tooltipDescription inside the overflow popover", async () => {
     const user = userEvent.setup()
     render(

--- a/packages/react/src/components/avatars/F0AvatarList/types.ts
+++ b/packages/react/src/components/avatars/F0AvatarList/types.ts
@@ -66,8 +66,16 @@ export type F0AvatarListProps = {
   noTooltip?: boolean
 
   /**
-   * The maximum number of avatars to display.
-   * @default 3
+   * The exact number of avatars to keep visible; the rest collapse into the
+   * `+N` counter. Not a soft cap — a provided `max` is forwarded as
+   * `OverflowList`'s `min` as well, so exactly this many avatars render even in
+   * a container too narrow to fit them (see `F0AvatarList.tsx`).
+   *
+   * There is no numeric default. Left unset, the visible count is
+   * container-driven: `OverflowList` measures the available width and shows as
+   * many avatars as fit, collapsing the remainder into the counter. So passing
+   * a number opts into a fixed footprint, and omitting it opts into filling
+   * the row.
    */
   max?: number
 
@@ -77,10 +85,17 @@ export type F0AvatarListProps = {
   remainingCount?: number
 
   /**
-   * The layout of the avatar list.
-   * - "fill" - Avatars will expand to fill the available width, with overflow items shown in a counter
-   * - "compact" - Avatars will be stacked tightly together up to the max limit, with remaining shown in counter
-   * @default "compact"
+   * @deprecated Never implemented — `F0AvatarList` has always ignored this
+   * prop — and not needed, because `max` already selects between the two
+   * layouts it described. Omit `max` for what this called `"fill"`:
+   * `OverflowList` measures the row and shows as many avatars as fit. Pass a
+   * `max` for `"compact"`: it doubles as `min`, so exactly that many stay
+   * visible. A separate switch could only contradict `max` — `layout="fill"`
+   * with `max={3}` has no coherent meaning — which is why this is going rather
+   * than getting an implementation.
+   * @removeIn 7.0.0
+   * @migration Remove the prop. If you were passing `layout="compact"` to cap
+   * the row, add `max={n}`: `"compact"` never capped anything.
    */
   layout?: "fill" | "compact"
 

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -359,7 +359,11 @@ const listRight = (
       <F0AvatarList
         type={right.slice(0, -"-list".length) as F0AvatarListProps["type"]}
         size="sm"
-        layout="compact"
+        // Explicit, because it is the prop that actually produces the compact
+        // strip this slot documents. The deprecated `layout="compact"` that
+        // used to sit here was inert, so the strip was really sized by the
+        // rail's width — which in a narrow rail collapsed it to a bare `+N`.
+        max={3}
         avatars={row.avatars as never}
         remainingCount={row.remainingCount}
       />


### PR DESCRIPTION
## Description

`F0AvatarList/types.ts` documented two things `F0AvatarList.tsx` never implemented: a `layout?: "fill" | "compact"` prop that was never destructured and silently ignored, and `max` as `@default 3` when no default was ever applied. This deprecates `layout` instead of implementing it, corrects the `max` documentation to describe what the component actually does, and fixes the one call site that was relying on the inert prop.

## Type of change

- [x] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [x] Bug fix
- [x] Documentation only

## Lifecycle phase (if applicable)

Not a lifecycle transition — `F0AvatarList` is already stable (promoted in #4416). This is a prop-level deprecation under the [Release & Versioning](https://github.com/factorialco/f0/blob/main/packages/react/docs/development/release-and-versioning.mdx) policy: `@deprecated` + `@removeIn` + `@migration`, removal no sooner than 90 days.

## Implementation details

- chore: deprecate `layout` with `@deprecated` / `@removeIn 7.0.0` / `@migration`, matching the `tooltipScroll` precedent already in this file

  <details>
  <summary>Why deprecate rather than implement?</summary>

  `max` already **is** the switch `layout` described, because a provided `max` is forwarded as `OverflowList`'s `min` as well:

  | | `F0ChipList` | `F0AvatarList` today |
  |---|---|---|
  | fill | `layout="fill"` → container-measured | omit `max` → `min=0`, `max=items.length` |
  | compact | `layout="compact"` → hard slice at `max` | pass `max` → `min=max=max`, exact count |

  So implementing `layout` could only add a knob that contradicts `max` — `layout="fill"` with `max={3}` has no coherent meaning. `F0ChipList`, the reference implementation, shows the footgun: its `"fill"` branch silently drops `max`, so `layout="fill" max={4}` ignores the cap with no warning.
  </details>

- docs: replace `max`'s `@default 3` with its real contract — an exact count when passed, container-driven when omitted

  <details>
  <summary>Why not add the documented default?</summary>

  Because `max` also feeds `min`, a default of `3` would not cap but **pin**. Every consumer that currently fills its container would go from "as many avatars as fit" to "exactly 3 + `+N`", including in wide containers: OneDataCollection list fields (`ui/value-display/types/avatarList`, which passes `args.max` and may pass `undefined`), `MeetingAttendees`, `ChatTypingBubble`, `ApprovalStep`, `WidgetAvatarsListItem`, `MetadataValue`. That is a broad silent regression to satisfy a docstring no code ever honored.
  </details>

- fix: pass `max={3}` instead of the inert `layout="compact"` in the Home list slot, so the "compact strip" it documents is actually capped rather than sized by the rail's width (which collapsed it to a bare `+N` in a narrow rail)
- refactor: destructure `layout` alongside `tooltipScroll` with `void`, so the ignore is deliberate in the code rather than an omission a reader has to infer — that invisibility is what let the drift go unnoticed
- docs: record on the `min={max}` line why `layout` needs no implementation, and why `max` must not be given a numeric default
- docs: update the MDX overflow section — `max` is an exact count with no default, with guidance on elastic vs. fixed footprint
- test: pin `layout` as inert (`"fill"` and `"compact"` render byte-identical markup, modulo Radix's incrementing popover id), so a future silent implementation fails

## Verification

- `vitest`: 15/15 in `F0AvatarList`, plus 201/201 across `sds/Home`, `ui/OverflowList` and `ui/value-display`
- `oxlint` and `oxfmt`: clean
- `tsc --noEmit`: 36 errors, identical before and after (confirmed by stashing) — all pre-existing, in story/pattern files plus an unbuilt `@factorialco/f0-core`, none in touched files

## Follow-ups noted, not changed here

- `@removeIn 5.0` is already in the past — the package is at 6.16.2 and the policy requires a future major, which is why this PR uses `7.0.0`. But `tooltipScroll` in this same file and `ui/value-display/types/avatarList/avatarList.tsx:31` both say `5.0`, so quarterly cleanup should already have deleted them. Worth a sweep.
- `packages/react-native/.../F0AvatarList.tsx` defaults `max = 3` and has no `layout` at all. Defensible — RN has no `OverflowList` width measurement, so it needs a numeric default — but the two platforms now document `max` differently.