### PR TITLE
feat(ClockInControls): add horizontal-bar variant

### DIFF
--- a/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
@@ -163,7 +163,8 @@ const SplitMode = ({
           aria-label={selectedItem.label}
           prepend={selectedItem.icon && <F0Icon icon={selectedItem.icon} />}
           className="rounded-r-none after:rounded-r-none disabled:opacity-100"
-          tooltip={tooltip}
+          // Same as dropdown mode: what this control is, then what is chosen.
+          tooltip={{ label: tooltip, description: selectedItem.label }}
           appendOutside={
             <DropdownInternal
               items={dropdownItems}
@@ -215,6 +216,7 @@ const SplitMode = ({
 const DropdownMode = ({
   onClick,
   trigger,
+  value,
   items: rawItems,
   size,
   variant,
@@ -224,6 +226,7 @@ const DropdownMode = ({
 }: {
   onClick: (value: string, item: ButtonDropdownItem<string>) => void
   trigger?: string
+  value?: string
   items:
     | ButtonDropdownItem<string>[]
     | ButtonDropdownGroup<string>[]
@@ -245,7 +248,26 @@ const DropdownMode = ({
     return items.flatMap((item) => item.items)
   }, [items])
 
-  const triggerLabel = trigger || flattenedItems[0]?.label
+  // What `value` names, if anything — the trigger then shows that item, exactly
+  // as split mode's main button does.
+  const selectedItem = useMemo(
+    () => flattenedItems.find((item) => item.value === value),
+    [value, flattenedItems]
+  )
+
+  const triggerLabel =
+    trigger || selectedItem?.label || flattenedItems[0]?.label
+
+  /**
+   * On hover: which control this is, then what is chosen in it — the same
+   * two-line shape `F0Select`'s trigger tooltip has (`tooltip` bold on top, the
+   * selection under it). Either half alone is fine: with nothing selected the
+   * tooltip stays what the consumer passed, and without a `tooltip` the selection
+   * speaks for itself.
+   */
+  const triggerTooltip = selectedItem
+    ? { label: tooltip, description: selectedItem.label }
+    : tooltip
 
   const dropdownItems = useMemo(
     () =>
@@ -288,11 +310,12 @@ const DropdownMode = ({
         loading={loading}
         data-testid="button-dropdown-trigger"
         aria-label={triggerLabel}
+        prepend={selectedItem?.icon && <F0Icon icon={selectedItem.icon} />}
         append={
           <F0Icon icon={ChevronDown} size={size === "sm" ? "sm" : "md"} />
         }
         pressed={isOpen && !disabled}
-        tooltip={tooltip}
+        tooltip={triggerTooltip}
       >
         {triggerLabel}
       </Action>
@@ -308,6 +331,7 @@ const _F0ButtonDropdown = (props: F0ButtonDropdownProps) => {
       <DropdownMode
         onClick={props.onClick}
         trigger={"trigger" in props ? props.trigger : undefined}
+        value={"value" in props ? props.value : undefined}
         items={props.items}
         size={props.size}
         variant={props.variant}

--- a/packages/react/src/components/F0ButtonDropdown/__tests__/F0ButtonDropdown.test.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/__tests__/F0ButtonDropdown.test.tsx
@@ -16,6 +16,7 @@ vi.mock("@/ui/Action", () => ({
     appendOutside,
     disabled,
     pressed,
+    tooltip,
     ...props
   }) => (
     <>
@@ -23,6 +24,9 @@ vi.mock("@/ui/Action", () => ({
         onClick={onClick}
         disabled={disabled}
         data-pressed={pressed}
+        // Serialized so a test can assert the two-line (label + description)
+        // shape, not just that some tooltip was passed.
+        data-tooltip={tooltip ? JSON.stringify(tooltip) : undefined}
         {...props}
       >
         {prepend && <div data-testid="action-prepend">{prepend}</div>}
@@ -329,6 +333,83 @@ describe("F0ButtonDropdown", () => {
       expect(screen.getByTestId("action-label").textContent).toBe(
         "Regular expense"
       )
+    })
+
+    it("shows the selected item on the trigger — its label AND its icon", () => {
+      render(
+        <F0ButtonDropdown
+          mode="dropdown"
+          value="mileage"
+          items={mockItemsWithDescriptions}
+          onClick={mockOnClick}
+        />
+      )
+
+      expect(screen.getByTestId("action-label").textContent).toBe("Mileage")
+      // The icon is what makes the trigger read as the option you picked, the
+      // same way split mode's main button does.
+      expect(screen.getByTestId("action-prepend")).toBeInTheDocument()
+    })
+
+    it("lets an explicit trigger label win over the selected item's", () => {
+      render(
+        <F0ButtonDropdown
+          mode="dropdown"
+          value="mileage"
+          trigger="New expense"
+          items={mockItemsWithDescriptions}
+          onClick={mockOnClick}
+        />
+      )
+
+      expect(screen.getByTestId("action-label").textContent).toBe("New expense")
+      // …while the selected item's icon still shows what is chosen.
+      expect(screen.getByTestId("action-prepend")).toBeInTheDocument()
+    })
+
+    it("tooltips the control's name over the selection, in two lines", () => {
+      render(
+        <F0ButtonDropdown
+          mode="dropdown"
+          value="mileage"
+          tooltip="Expense type"
+          items={mockItemsWithDescriptions}
+          onClick={mockOnClick}
+        />
+      )
+
+      expect(screen.getByTestId("button-dropdown-trigger")).toHaveAttribute(
+        "data-tooltip",
+        JSON.stringify({ label: "Expense type", description: "Mileage" })
+      )
+    })
+
+    it("leaves the tooltip as given when nothing is selected", () => {
+      render(
+        <F0ButtonDropdown
+          mode="dropdown"
+          tooltip="Expense type"
+          items={mockItemsWithDescriptions}
+          onClick={mockOnClick}
+        />
+      )
+
+      expect(screen.getByTestId("button-dropdown-trigger")).toHaveAttribute(
+        "data-tooltip",
+        JSON.stringify("Expense type")
+      )
+    })
+
+    it("has no icon on the trigger when nothing is selected", () => {
+      render(
+        <F0ButtonDropdown
+          mode="dropdown"
+          items={mockItemsWithDescriptions}
+          onClick={mockOnClick}
+        />
+      )
+
+      expect(screen.queryByTestId("action-prepend")).not.toBeInTheDocument()
     })
 
     it("renders nothing when no items are provided", () => {

--- a/packages/react/src/components/F0ButtonDropdown/types.ts
+++ b/packages/react/src/components/F0ButtonDropdown/types.ts
@@ -113,9 +113,15 @@ type F0ButtonDropdownDropdownProps<T = string> =
      */
     mode: "dropdown"
     /**
+     * The currently selected value. When it names an item, the trigger becomes
+     * that item — its label and its icon — the same way split mode's main button
+     * shows what is selected. Without it the trigger is just an opener.
+     */
+    value?: T
+    /**
      * Optional trigger button label. Customize the label shown on the
      * trigger button independently from the dropdown items.
-     * Falls back to the first item's label if not provided.
+     * Falls back to the selected item's label, then to the first item's.
      */
     trigger?: string
     /**

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -53,6 +53,8 @@ import type {
 } from "./types"
 
 import { Arrow } from "./components/Arrow"
+import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
+
 import { SelectAll } from "./components/SelectAll"
 import { SelectBottomActions } from "./components/SelectBottomActions"
 import { SelectedItems } from "./components/SelectedItems"
@@ -1165,6 +1167,51 @@ const F0SelectComponent = forwardRef(function Select<
     />
   )
 
+  /**
+   * The trigger's hover tooltip: WHAT IS SELECTED, spelled out.
+   *
+   * The field is a single line that truncates, and with `hideLabel` it doesn't
+   * even say which field it is — so on hover it says both: the selection as its
+   * own line, and the field's label above it ONLY when that label isn't already
+   * rendered beside the field (repeating what is on screen is noise). Multiple
+   * selection lists what is chosen, which is what the trigger's "N selected"
+   * cannot.
+   *
+   * Nothing selected, nothing to explain: no tooltip at all.
+   */
+  const selectedTooltipText = getDisplayItemsForSelection
+    .map((item) => item.selectedLabel ?? item.label)
+    .filter(Boolean)
+    .join(", ")
+
+  const withTriggerTooltip = (trigger: React.ReactNode) => {
+    /**
+     * The tooltip needs ONE DOM element to hang its handlers on, and the real
+     * trigger is Radix's own `asChild` target inside — wrapping that would strip
+     * its props. So the box is always here, tooltip or not: when it came and went
+     * with the selection, the field's width came and went with it too — clearing
+     * a select dropped the box and the field contracted to its content.
+     *
+     * NOT a flex box either: as a flex container it made the field a flex item
+     * with the default `min-width: auto`, and the field then neither shrank (it
+     * overflowed a narrow column) nor stretched (it left a gap inside it). A plain
+     * full-width block passes the width straight through, which is all this
+     * wrapper is for.
+     */
+    const box = <div className="w-full min-w-0">{trigger}</div>
+
+    return selectedTooltipText ? (
+      <TooltipInternal
+        label={hideLabel ? label : undefined}
+        description={selectedTooltipText}
+      >
+        {box}
+      </TooltipInternal>
+    ) : (
+      box
+    )
+  }
+
   if (asList) {
     return (
       <DataTestIdWrapper dataTestId={dataTestId}>
@@ -1207,107 +1254,110 @@ const F0SelectComponent = forwardRef(function Select<
     )
   }
 
-  return (
-    <DataTestIdWrapper dataTestId={dataTestId}>
-      <SelectPrimitive {...selectPrimitiveProps}>
-        <SelectTrigger ref={ref} asChild>
-          {children ? (
-            <div
+  const triggerWithContent = (
+    <SelectPrimitive {...selectPrimitiveProps}>
+      <SelectTrigger ref={ref} asChild>
+        {children ? (
+          <div
+            className="flex w-full items-center justify-between"
+            aria-label={label || placeholder}
+          >
+            {children}
+          </div>
+        ) : (
+          <F0InputField
+            label={label}
+            error={error}
+            required={required}
+            status={status}
+            hint={hint}
+            icon={icon}
+            labelIcon={labelIcon}
+            hideLabel={hideLabel}
+            value={
+              multiple
+                ? // For multiple: use count of selected items
+                  Math.max(
+                    localValue.length,
+                    selectionMeta.selectedItemsCount
+                  ).toString()
+                : // For single: use the selected value directly
+                  (localValue[0] ?? undefined)
+            }
+            isEmpty={(value) =>
+              multiple ? !value || +(value ?? 0) === 0 : !value
+            }
+            onClear={() => {
+              hasUserInteracted.current = true
+              clearSelection()
+              // Clear the cache when clearing selection
+              selectedItemsCache.current.clear()
+              // Call with undefined to indicate no item is selected
+              ;(
+                onChangeSelectedOption as (
+                  option: undefined,
+                  checked: boolean
+                ) => void
+              )?.(undefined, false)
+            }}
+            placeholder={placeholder || ""}
+            disabled={disabled}
+            clearable={clearable}
+            size={effectiveSize}
+            loadingIndicator={{
+              asOverlay: true,
+              offset: 34,
+            }}
+            loading={isInitialLoading || loading || isLoading}
+            name={name}
+            onClickContent={() => {
+              handleChangeOpenLocal(!openLocal)
+            }}
+            append={
+              <Arrow
+                open={openLocal}
+                disabled={disabled}
+                size={effectiveSize}
+              />
+            }
+          >
+            <button
               className="flex w-full items-center justify-between"
               aria-label={label || placeholder}
+              onClick={(e) => {
+                e.preventDefault()
+              }}
             >
-              {children}
-            </div>
-          ) : (
-            <F0InputField
-              label={label}
-              error={error}
-              required={required}
-              status={status}
-              hint={hint}
-              icon={icon}
-              labelIcon={labelIcon}
-              hideLabel={hideLabel}
-              value={
-                multiple
-                  ? // For multiple: use count of selected items
-                    Math.max(
-                      localValue.length,
-                      selectionMeta.selectedItemsCount
-                    ).toString()
-                  : // For single: use the selected value directly
-                    (localValue[0] ?? undefined)
-              }
-              isEmpty={(value) =>
-                multiple ? !value || +(value ?? 0) === 0 : !value
-              }
-              onClear={() => {
-                hasUserInteracted.current = true
-                clearSelection()
-                // Clear the cache when clearing selection
-                selectedItemsCache.current.clear()
-                // Call with undefined to indicate no item is selected
-                ;(
-                  onChangeSelectedOption as (
-                    option: undefined,
-                    checked: boolean
-                  ) => void
-                )?.(undefined, false)
-              }}
-              placeholder={placeholder || ""}
-              disabled={disabled}
-              clearable={clearable}
-              size={effectiveSize}
-              loadingIndicator={{
-                asOverlay: true,
-                offset: 34,
-              }}
-              loading={isInitialLoading || loading || isLoading}
-              name={name}
-              onClickContent={() => {
-                handleChangeOpenLocal(!openLocal)
-              }}
-              append={
-                <Arrow
-                  open={openLocal}
-                  disabled={disabled}
-                  size={effectiveSize}
+              {(multiple
+                ? localValue.length > 0 || selectionMeta.selectedItemsCount > 0
+                : !!localValue[0]) && (
+                <SelectedItems
+                  multiple={multiple}
+                  totalSelectedCount={
+                    multiple
+                      ? Math.max(
+                          localValue.length,
+                          selectionMeta.selectedItemsCount
+                        )
+                      : localValue[0]
+                        ? 1
+                        : 0
+                  }
+                  allSelected={selectedState.allSelected}
+                  selection={getDisplayItemsForSelection}
                 />
-              }
-            >
-              <button
-                className="flex w-full items-center justify-between"
-                aria-label={label || placeholder}
-                onClick={(e) => {
-                  e.preventDefault()
-                }}
-              >
-                {(multiple
-                  ? localValue.length > 0 ||
-                    selectionMeta.selectedItemsCount > 0
-                  : !!localValue[0]) && (
-                  <SelectedItems
-                    multiple={multiple}
-                    totalSelectedCount={
-                      multiple
-                        ? Math.max(
-                            localValue.length,
-                            selectionMeta.selectedItemsCount
-                          )
-                        : localValue[0]
-                          ? 1
-                          : 0
-                    }
-                    allSelected={selectedState.allSelected}
-                    selection={getDisplayItemsForSelection}
-                  />
-                )}
-              </button>
-            </F0InputField>
-          )}
-        </SelectTrigger>
-        {openLocal && selectContent}
-      </SelectPrimitive>
+              )}
+            </button>
+          </F0InputField>
+        )}
+      </SelectTrigger>
+      {openLocal && selectContent}
+    </SelectPrimitive>
+  )
+
+  return (
+    <DataTestIdWrapper dataTestId={dataTestId}>
+      {withTriggerTooltip(triggerWithContent)}
     </DataTestIdWrapper>
   )
 })

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -1345,6 +1345,11 @@ const F0SelectComponent = forwardRef(function Select<
                   }
                   allSelected={selectedState.allSelected}
                   selection={getDisplayItemsForSelection}
+                  // The field's own icon already occupies the trigger's glyph
+                  // slot, and the two are drawn in different places — showing
+                  // both put two icons 4px apart on one trigger. Options keep
+                  // their icons for the rows regardless.
+                  hideItemIcon={!!icon}
                 />
               )}
             </button>

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -909,6 +909,34 @@ describe("Select", () => {
       expect(screen.getByText("Tokens")).toBeInTheDocument()
     })
 
+    it("draws ONE glyph on the trigger when the field and the option both have an icon", async () => {
+      const user = userEvent.setup()
+      const { container } = render(
+        <F0Select
+          {...defaultSelectProps}
+          icon={Search}
+          value="option1"
+          options={mockOptions}
+          onChange={() => {}}
+        />
+      )
+
+      // The field's icon owns the trigger's glyph slot; the selected option's is
+      // left out, because the two are drawn in different places and would sit 4px
+      // apart. `mockOptions[0]` carries an icon of its own.
+      const trigger = screen.getByRole("combobox")
+      expect(trigger.querySelectorAll("svg")).toHaveLength(0)
+      expect(container.querySelectorAll("svg").length).toBeGreaterThan(0)
+
+      // …while the ROW keeps its icon. Scoped to the list: the trigger shows the
+      // same label, so an unscoped query finds both.
+      await openSelect(user)
+      const row = within(screen.getByRole("listbox"))
+        .getByText("Option 1")
+        .closest("[role='option']")
+      expect(row?.querySelectorAll("svg").length).toBeGreaterThan(0)
+    })
+
     describe("hover tooltip", () => {
       /**
        * The trigger is WIRED as a tooltip trigger: Radix marks its (asChild)

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -881,6 +881,77 @@ describe("Select", () => {
     ).not.toBeInTheDocument()
   })
 
+  describe("selected item's display", () => {
+    it("shows `selectedLabel` on the trigger while the row keeps its `label`", async () => {
+      const user = userEvent.setup()
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          value="option1"
+          options={[
+            {
+              value: "option1",
+              label: "Tokens",
+              selectedLabel: "Tokens — Design system",
+            },
+            { value: "option2", label: "Components" },
+          ]}
+          onChange={() => {}}
+        />
+      )
+
+      // The trigger has no group header or siblings to read "Tokens" against.
+      expect(screen.getByText("Tokens — Design system")).toBeInTheDocument()
+
+      await openSelect(user)
+
+      // The row does, so it stays short.
+      expect(screen.getByText("Tokens")).toBeInTheDocument()
+    })
+
+    describe("hover tooltip", () => {
+      /**
+       * The trigger is WIRED as a tooltip trigger: Radix marks its (asChild)
+       * trigger with `data-state`, and renders the content lazily — so this is
+       * what "there is a tooltip here" looks like before anyone hovers. Opening
+       * it for real needs Radix's 700ms timer, which deadlocks `user.hover`
+       * under fake timers and does not resolve under real ones in jsdom; what the
+       * tooltip SAYS is asserted in `F0Select.triggerTooltip.test.tsx`, against a
+       * stubbed tooltip.
+       */
+      const tooltipWrapper = () =>
+        screen.getByRole("combobox").closest("div[data-state]")
+
+      it("is wired on the trigger when an item is selected", () => {
+        render(
+          <F0Select
+            {...defaultSelectProps}
+            hideLabel
+            value="option1"
+            options={mockOptions}
+            onChange={() => {}}
+          />
+        )
+
+        expect(tooltipWrapper()).toHaveAttribute("data-state", "closed")
+      })
+
+      it("is not wired at all when nothing is selected", () => {
+        render(
+          <F0Select
+            {...defaultSelectProps}
+            hideLabel
+            options={mockOptions}
+            onChange={() => {}}
+          />
+        )
+
+        // Nothing selected, nothing to explain.
+        expect(tooltipWrapper()).toBeNull()
+      })
+    })
+  })
+
   describe("asList mode", () => {
     it("preserves selection after searching and clicking an item", async () => {
       const handleChange = vi.fn()

--- a/packages/react/src/components/F0Select/__tests__/F0Select.triggerTooltip.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.triggerTooltip.test.tsx
@@ -1,0 +1,100 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, zeroRender as render } from "@/testing/test-utils"
+
+import { F0Select } from "../index"
+
+/**
+ * The tooltip, STUBBED — its real content lives behind Radix's 700ms open timer
+ * and a portal, which jsdom will not open (fake timers deadlock `user.hover`,
+ * real ones never settle). The wiring is covered in `F0Select.test.tsx`; what is
+ * worth pinning here is the CONTENT DECISION: which of `label` / `description`
+ * F0Select hands the tooltip, and when. So the stub renders both eagerly.
+ */
+vi.mock("@/experimental/Overlays/Tooltip", () => ({
+  TooltipInternal: ({
+    label,
+    description,
+    children,
+  }: {
+    label?: string
+    description?: string
+    children: React.ReactNode
+  }) => (
+    <div>
+      <span data-testid="tooltip-label">{label ?? ""}</span>
+      <span data-testid="tooltip-description">{description ?? ""}</span>
+      {children}
+    </div>
+  ),
+}))
+
+const OPTIONS = [
+  { value: "tokens", label: "Tokens", selectedLabel: "Tokens — Design system" },
+  { value: "flows", label: "Flows" },
+]
+
+describe("F0Select trigger tooltip content", () => {
+  it("names the field and the selection when the label is hidden", () => {
+    render(
+      <F0Select
+        label="Select project"
+        hideLabel
+        value="tokens"
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    expect(screen.getByTestId("tooltip-label")).toHaveTextContent(
+      "Select project"
+    )
+    expect(screen.getByTestId("tooltip-description")).toHaveTextContent(
+      "Tokens — Design system"
+    )
+  })
+
+  it("drops the label when it is already rendered beside the field", () => {
+    render(
+      <F0Select
+        label="Select project"
+        value="tokens"
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    // Repeating what is on screen would be noise.
+    expect(screen.getByTestId("tooltip-label")).toHaveTextContent("")
+    expect(screen.getByTestId("tooltip-description")).toHaveTextContent(
+      "Tokens — Design system"
+    )
+  })
+
+  it("uses the plain label when the item has no `selectedLabel`", () => {
+    render(
+      <F0Select
+        label="Select project"
+        hideLabel
+        value="flows"
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    expect(screen.getByTestId("tooltip-description")).toHaveTextContent("Flows")
+  })
+
+  it("wires no tooltip when nothing is selected", () => {
+    render(
+      <F0Select
+        label="Select project"
+        hideLabel
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    expect(screen.queryByTestId("tooltip-description")).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/F0Select/components/SelectedItems.tsx
+++ b/packages/react/src/components/F0Select/components/SelectedItems.tsx
@@ -36,7 +36,7 @@ function MultiSelectDisplay({
   selection: F0SelectItemObject<string>[]
   totalSelectedCount: number
 }) {
-  const labels = selection.map((item) => item.label)
+  const labels = selection.map((item) => item.selectedLabel ?? item.label)
   const { allFit, containerRef } = useLabelsOverflow(labels)
 
   if (!allFit) {
@@ -145,7 +145,9 @@ export const SelectedItems = forwardRef<HTMLDivElement, SelectValueProps>(
           </div>
         )}
         <OneEllipsis tag="span" className="text-left text-f1-foreground">
-          {selectedItem.label}
+          {/* `selectedLabel` when the item carries one: out here there is no
+              group header or sibling to read the row's short label against. */}
+          {selectedItem.selectedLabel ?? selectedItem.label}
         </OneEllipsis>
       </div>
     )

--- a/packages/react/src/components/F0Select/components/SelectedItems.tsx
+++ b/packages/react/src/components/F0Select/components/SelectedItems.tsx
@@ -16,6 +16,15 @@ type SelectValueProps = {
   totalSelectedCount?: number
   /** Whether all items are selected */
   allSelected?: boolean | "indeterminate"
+  /**
+   * Whether to leave the selected item's icon out.
+   *
+   * Set when the FIELD already carries an `icon`: the two are drawn in different
+   * places — the field's is absolutely placed at `left-2`, this one sits inside
+   * the value area's `px-3` — so showing both puts two glyphs 4px apart on one
+   * trigger. Options keep their icons for the rows either way.
+   */
+  hideItemIcon?: boolean
 }
 
 function SelectedCount({ count }: { count: number }) {
@@ -64,7 +73,7 @@ function MultiSelectDisplay({
  */
 export const SelectedItems = forwardRef<HTMLDivElement, SelectValueProps>(
   function SelectValue(
-    { selection, multiple, totalSelectedCount, allSelected },
+    { selection, multiple, totalSelectedCount, allSelected, hideItemIcon },
     ref
   ) {
     const i18n = useI18n()
@@ -139,7 +148,7 @@ export const SelectedItems = forwardRef<HTMLDivElement, SelectValueProps>(
             <F0Avatar avatar={selectedItem.avatar} size="xs" />
           </div>
         )}
-        {selectedItem.icon && (
+        {selectedItem.icon && !hideItemIcon && (
           <div className="h-5 shrink-0 text-f1-icon">
             <F0Icon icon={selectedItem.icon} />
           </div>

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -94,10 +94,19 @@ type F0SelectBaseProps<T extends string, R = unknown> = {
 export type F0SelectProps<T extends string, R = unknown> = F0SelectBaseProps<
   T,
   R
-> & // Single select not clearable
+> &
   (
-    | {
-        clearable?: false
+  /**
+   * Single select, then multiple.
+   *
+   * `clearable` is a plain boolean on the single-select member. It used to be two
+   * members here — `clearable?: false` and `clearable: true` — that were
+   * otherwise IDENTICAL, so a computed `clearable={!required}` matched neither
+   * and every such call site had to cast. Nothing else about single select
+   * changes with it, so there was nothing for a second member to say.
+   */
+  | {
+        clearable?: boolean
         multiple?: false
         value?: T
         defaultItem?: F0SelectItemObject<T, ResolvedRecordType<R>>
@@ -107,19 +116,6 @@ export type F0SelectProps<T extends string, R = unknown> = F0SelectBaseProps<
           option?: F0SelectItemObject<T, ResolvedRecordType<R>>
         ) => void
         /** Callback for selection changes - provides full selection state for advanced use cases (e.g., "Select All" with exclusions) */
-        onSelectItems?: never
-      }
-    // Single select clearable
-    | {
-        clearable: true
-        multiple?: false
-        value?: T
-        defaultItem?: F0SelectItemObject<T, ResolvedRecordType<R>>
-        onChange?: (
-          value: T,
-          originalItem?: ResolvedRecordType<R> | undefined,
-          option?: F0SelectItemObject<T, ResolvedRecordType<R>>
-        ) => void
         onSelectItems?: never
       }
     // Multiple select
@@ -218,6 +214,15 @@ export type F0SelectItemObject<T, R = unknown> = {
   type?: "item"
   value: T
   label: string
+  /**
+   * What the TRIGGER shows once this item is selected, when that has to differ
+   * from the row's own `label`. The row is read in the context the list gives it
+   * — under a group header, beside its siblings — and the trigger has none of
+   * that, so a label that is clear in the list can be ambiguous on its own
+   * ("Tokens", once the "Design system" header is gone). Give the trigger the
+   * full path there and leave the row short. Defaults to `label`.
+   */
+  selectedLabel?: string
   description?: string
   /** Short token shown next to the label (e.g. a dial code) */
   metadata?: F0SelectItemMetadata

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -94,19 +94,10 @@ type F0SelectBaseProps<T extends string, R = unknown> = {
 export type F0SelectProps<T extends string, R = unknown> = F0SelectBaseProps<
   T,
   R
-> &
+> & // Single select not clearable
   (
-  /**
-   * Single select, then multiple.
-   *
-   * `clearable` is a plain boolean on the single-select member. It used to be two
-   * members here — `clearable?: false` and `clearable: true` — that were
-   * otherwise IDENTICAL, so a computed `clearable={!required}` matched neither
-   * and every such call site had to cast. Nothing else about single select
-   * changes with it, so there was nothing for a second member to say.
-   */
-  | {
-        clearable?: boolean
+    | {
+        clearable?: false
         multiple?: false
         value?: T
         defaultItem?: F0SelectItemObject<T, ResolvedRecordType<R>>
@@ -116,6 +107,19 @@ export type F0SelectProps<T extends string, R = unknown> = F0SelectBaseProps<
           option?: F0SelectItemObject<T, ResolvedRecordType<R>>
         ) => void
         /** Callback for selection changes - provides full selection state for advanced use cases (e.g., "Select All" with exclusions) */
+        onSelectItems?: never
+      }
+    // Single select clearable
+    | {
+        clearable: true
+        multiple?: false
+        value?: T
+        defaultItem?: F0SelectItemObject<T, ResolvedRecordType<R>>
+        onChange?: (
+          value: T,
+          originalItem?: ResolvedRecordType<R> | undefined,
+          option?: F0SelectItemObject<T, ResolvedRecordType<R>>
+        ) => void
         onSelectItems?: never
       }
     // Multiple select

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.spec.tsx
@@ -1,0 +1,193 @@
+import { fireEvent, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { Office as OfficeIcon } from "@/icons/app"
+import { screen, zeroRender as render } from "@/testing/test-utils"
+
+import { type ClockInLocation, LocationSelector } from "./LocationSelector"
+import { flattenTree } from "./TreeSelector"
+import { toLocationTree } from "./LocationSelector"
+
+/** Three levels: type → city → work area, plus one type with nothing below it. */
+const NESTED: ClockInLocation[] = [
+  {
+    id: "office",
+    name: "Office",
+    icon: OfficeIcon,
+    sublocations: [
+      {
+        id: "bcn",
+        name: "Barcelona",
+        sublocations: [
+          { id: "llucuna", name: "Llucuna A-3" },
+          { id: "tanger", name: "Tànger 98" },
+        ],
+      },
+    ],
+  },
+  { id: "trip", name: "Business trip", icon: OfficeIcon },
+]
+
+const openPicker = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("combobox", { name: "Select location" }))
+  await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+  // F0Select only fills its list once the popover's open animation starts.
+  fireEvent.animationStart(screen.getByRole("listbox"))
+}
+
+describe("flattenTree", () => {
+  it("keeps only leaves, and gives each one its ancestor chain", () => {
+    const leaves = flattenTree(toLocationTree(NESTED))
+
+    expect(leaves.map((leaf) => leaf.id)).toEqual(["llucuna", "tanger", "trip"])
+    // Three levels: the two above the leaf head its group…
+    expect(leaves[0].group).toBe("Office · Barcelona")
+    // …and the trigger gets the whole path, leaf first.
+    expect(leaves[0].path).toBe("Llucuna A-3 — Office · Barcelona")
+  })
+
+  it("lets a top-level leaf head its own group, having no ancestors", () => {
+    const trip = flattenTree(toLocationTree(NESTED))[2]
+
+    expect(trip.group).toBe("Business trip")
+    expect(trip.path).toBe("Business trip")
+  })
+
+  it("inherits the nearest ancestor's icon, since deep levels rarely carry one", () => {
+    const [llucuna] = flattenTree(toLocationTree(NESTED))
+
+    // Set on `Office`, two levels up.
+    expect(llucuna.icon).toBe(OfficeIcon)
+  })
+
+  it("searches on the leaf AND every ancestor", () => {
+    const [llucuna] = flattenTree(toLocationTree(NESTED))
+
+    expect(llucuna.haystack).toContain("barcelona")
+    expect(llucuna.haystack).toContain("office")
+    expect(llucuna.haystack).toContain("llucuna a-3")
+  })
+})
+
+describe("LocationSelector", () => {
+  // F0Select's list is VIRTUALIZED: with jsdom's zero-height boxes it decides
+  // nothing is on screen and renders no options.
+  global.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+  } as typeof ResizeObserver
+
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", { value: 800 })
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", { value: 800 })
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        width: 120,
+        height: 120,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      })
+    )
+  })
+
+  it("shows the selected leaf's whole path on the trigger", () => {
+    render(
+      <LocationSelector
+        locations={NESTED}
+        locationId="llucuna"
+        onChangeLocationId={() => {}}
+        label="Select location"
+      />
+    )
+
+    expect(
+      screen.getByText("Llucuna A-3 — Office · Barcelona")
+    ).toBeInTheDocument()
+  })
+
+  it("groups work areas under the chain above them", async () => {
+    const user = userEvent.setup()
+    render(
+      <LocationSelector
+        locations={NESTED}
+        onChangeLocationId={() => {}}
+        label="Select location"
+      />
+    )
+
+    await openPicker(user)
+
+    await waitFor(() =>
+      expect(screen.getByText("Office · Barcelona")).toBeInTheDocument()
+    )
+    // The rows stay short — the heading carries the context.
+    expect(screen.getByText("Llucuna A-3")).toBeInTheDocument()
+    expect(screen.getByText("Tànger 98")).toBeInTheDocument()
+  })
+
+  it("reports the selected leaf's id, not its parent's", async () => {
+    const user = userEvent.setup()
+    const onChangeLocationId = vi.fn()
+    render(
+      <LocationSelector
+        locations={NESTED}
+        onChangeLocationId={onChangeLocationId}
+        label="Select location"
+      />
+    )
+
+    await openPicker(user)
+    await waitFor(() =>
+      expect(screen.getByText("Tànger 98")).toBeInTheDocument()
+    )
+    await user.click(screen.getByText("Tànger 98"))
+
+    expect(onChangeLocationId).toHaveBeenCalledWith(
+      "tanger",
+      expect.anything(),
+      expect.anything()
+    )
+  })
+
+  it("finds work areas by their city, which names none of them", async () => {
+    const user = userEvent.setup()
+    render(
+      <LocationSelector
+        locations={NESTED}
+        onChangeLocationId={() => {}}
+        label="Select location"
+      />
+    )
+
+    await openPicker(user)
+    // Twice: a top-level leaf heads its own group AND is the row under it.
+    await waitFor(() =>
+      expect(screen.getAllByText("Business trip")).toHaveLength(2)
+    )
+
+    // `fireEvent.change`, not `user.type`: the search box is controlled and
+    // re-renders per keystroke, which drops characters here — "Barcelona" reached
+    // the adapter as "brcelona", and the search then correctly found nothing.
+    fireEvent.change(screen.getByRole("searchbox"), {
+      target: { value: "Barcelona" },
+    })
+
+    await waitFor(() =>
+      expect(screen.queryAllByText("Business trip")).toHaveLength(0)
+    )
+    // The virtualized list re-measures on the refetched page, and jsdom needs the
+    // open animation nudged again before it renders rows.
+    fireEvent.animationStart(screen.getByRole("listbox"))
+
+    await waitFor(() =>
+      expect(screen.getByText("Llucuna A-3")).toBeInTheDocument()
+    )
+  })
+})

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react"
+
+import type { IconType } from "@/components/F0Icon"
+
+import { TreeSelector, type TreeSelectorItem } from "./TreeSelector"
+
+/**
+ * A place you can clock in from, and — optionally — the places INSIDE it.
+ *
+ * Up to two or three levels is what this is for: location → workplace → work
+ * area (Office → Barcelona → Llucuna A-3). Selection is always a LEAF: a location
+ * with `sublocations` is clocked into through one of them, one without is clocked
+ * into directly. The icon is usually only worth setting at the top (Office, Home,
+ * Business trip) — deeper levels inherit the nearest one above them.
+ */
+export type ClockInLocation = {
+  id: string
+  name: string
+  icon?: IconType
+  /** The level below. When present, this location itself is not selectable. */
+  sublocations?: ClockInLocation[]
+}
+
+export interface LocationSelectorProps {
+  locations: ClockInLocation[]
+  locationId?: string
+  onChangeLocationId: (locationId: string) => void
+  /** The picker's label, also the empty trigger's placeholder. */
+  label: string
+  /** Placeholder for the search box. Falls back to F0Select's own wording. */
+  searchPlaceholder?: string
+  /** When false the picker offers a clear affordance. */
+  required?: boolean
+  disabled?: boolean
+}
+
+/** `sublocations` is this domain's word for the tree's `children`. */
+export const toLocationTree = (
+  locations: ClockInLocation[]
+): TreeSelectorItem[] =>
+  locations.map((location) => ({
+    id: location.id,
+    name: location.name,
+    icon: location.icon,
+    children: location.sublocations?.length
+      ? toLocationTree(location.sublocations)
+      : undefined,
+  }))
+
+/**
+ * The `horizontal-bar` variant's location control: a `TreeSelector` over
+ * `locations`, so a Home tile can't be handed a node that breaks the controls
+ * line — and so a nested location list is picked the same way a nested project
+ * list is.
+ *
+ * A select rather than the `F0ButtonDropdown` this started as: a select already
+ * carries everything this control needs and a button dropdown carries none of it
+ * — the location's own icon on the trigger, a clear affordance when the location
+ * isn't required, the "label + selection" hover tooltip, and the group headings a
+ * two- or three-level list needs.
+ *
+ * No field icon of its own: each location brings one, and `F0Select` shows the
+ * selected option's icon on the trigger.
+ */
+export function LocationSelector({
+  locations,
+  locationId,
+  onChangeLocationId,
+  label,
+  searchPlaceholder,
+  required = true,
+  disabled,
+}: LocationSelectorProps) {
+  const items = useMemo(() => toLocationTree(locations), [locations])
+
+  return (
+    <TreeSelector
+      items={items}
+      value={locationId}
+      onChange={onChangeLocationId}
+      label={label}
+      searchPlaceholder={searchPlaceholder}
+      required={required}
+      disabled={disabled}
+    />
+  )
+}

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from "react"
 
 import type { IconType } from "@/components/F0Icon"
+import { Pin } from "@/icons/app"
 
 import { TreeSelector, type TreeSelectorItem } from "./TreeSelector"
 
@@ -59,8 +60,9 @@ export const toLocationTree = (
  * isn't required, the "label + selection" hover tooltip, and the group headings a
  * two- or three-level list needs.
  *
- * No field icon of its own: each location brings one, and `F0Select` shows the
- * selected option's icon on the trigger.
+ * The trigger shows the selected location's own glyph, and a pin until there is
+ * one — through the field's icon slot, the same one the project picker uses, so
+ * the two sit at the same offset beside each other.
  */
 export function LocationSelector({
   locations,
@@ -80,6 +82,9 @@ export function LocationSelector({
       onChange={onChangeLocationId}
       label={label}
       searchPlaceholder={searchPlaceholder}
+      // Stands in until a location is picked; after that the location's own glyph
+      // takes the slot.
+      fieldIcon={Pin}
       required={required}
       disabled={disabled}
     />

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/ProjectSelector.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/ProjectSelector.spec.tsx
@@ -1,0 +1,168 @@
+import { fireEvent, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { screen, zeroRender as render } from "@/testing/test-utils"
+
+import { type ClockInProject, ProjectSelector } from "./ProjectSelector"
+
+const NESTED: ClockInProject[] = [
+  {
+    id: "design-system",
+    name: "Design system",
+    subprojects: [
+      { id: "ds-components", name: "Components" },
+      { id: "ds-tokens", name: "Tokens" },
+    ],
+  },
+  { id: "internal", name: "Internal tooling" },
+]
+
+const FLAT: ClockInProject[] = [
+  { id: "internal", name: "Internal tooling" },
+  { id: "support", name: "Customer support" },
+]
+
+/** 11 projects × 5 subprojects = 55 leaves, past the picker's 20-per-page window. */
+const MANY: ClockInProject[] = [
+  "Alpha",
+  "Bravo",
+  "Charlie",
+  "Delta",
+  "Echo",
+  "Foxtrot",
+  "Golf",
+  "Hotel",
+  "India",
+  "Juliett",
+  "Kilo",
+].map((name) => ({
+  id: name.toLowerCase(),
+  name,
+  subprojects: [1, 2, 3, 4, 5].map((n) => ({
+    id: `${name.toLowerCase()}-${n}`,
+    name: `${name} ${n}`,
+  })),
+}))
+
+/** F0Select only fills its list once the popover's open animation starts. */
+const openPicker = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("combobox", { name: "Select project" }))
+  await waitFor(() => expect(screen.getByRole("listbox")).toBeInTheDocument())
+  fireEvent.animationStart(screen.getByRole("listbox"))
+}
+
+describe("ProjectSelector", () => {
+  // F0Select's list is VIRTUALIZED: with jsdom's zero-height boxes it decides
+  // nothing is on screen and renders no options. Same measurements F0Select's own
+  // tests fake, for the same reason.
+  global.ResizeObserver = class MockResizeObserver {
+    observe = vi.fn()
+    unobserve = vi.fn()
+    disconnect = vi.fn()
+  } as typeof ResizeObserver
+
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, "offsetHeight", { value: 800 })
+    Object.defineProperty(HTMLElement.prototype, "offsetWidth", { value: 800 })
+    vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(
+      () => ({
+        width: 120,
+        height: 120,
+        top: 0,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      })
+    )
+  })
+
+  it("exposes a focusable combobox named by the label", () => {
+    render(<ProjectSelector projects={FLAT} label="Select project" />)
+
+    const trigger = screen.getByRole("combobox", { name: "Select project" })
+    // A keyboard has to reach it — the trigger is a real control, not the `div`
+    // F0Select renders when it is handed a custom child.
+    trigger.focus()
+    expect(trigger).toHaveFocus()
+  })
+
+  it("groups subprojects under their parent, and leaves a flat project as its own option", async () => {
+    const user = userEvent.setup()
+    render(<ProjectSelector projects={NESTED} label="Select project" />)
+
+    await openPicker(user)
+
+    // The parent names a group; its subprojects are what you can pick under it.
+    await waitFor(() =>
+      expect(screen.getByText("Design system")).toBeInTheDocument()
+    )
+    expect(screen.getByText("Components")).toBeInTheDocument()
+    expect(screen.getByText("Tokens")).toBeInTheDocument()
+    // A project with no subprojects IS the leaf, so in a nested list it appears
+    // twice: as its own group heading and as the one option under it.
+    expect(screen.getAllByText("Internal tooling")).toHaveLength(2)
+  })
+
+  it("offers a flat list without group headers when nothing is nested", async () => {
+    const user = userEvent.setup()
+    render(<ProjectSelector projects={FLAT} label="Select project" />)
+
+    await openPicker(user)
+
+    await waitFor(() =>
+      expect(screen.getByText("Customer support")).toBeInTheDocument()
+    )
+    expect(screen.getByText("Internal tooling")).toBeInTheDocument()
+  })
+
+  it("pages a long list instead of rendering all of it", async () => {
+    const user = userEvent.setup()
+    render(<ProjectSelector projects={MANY} label="Select project" />)
+
+    await openPicker(user)
+
+    // 55 leaves, 20 per page: the first page lands, the rest waits on a scroll.
+    await waitFor(() => expect(screen.getByText("Alpha 1")).toBeInTheDocument())
+    expect(screen.queryByText("Kilo 1")).not.toBeInTheDocument()
+  })
+
+  it("searches by the parent project's name as well as the leaf's", async () => {
+    const user = userEvent.setup()
+    render(<ProjectSelector projects={MANY} label="Select project" />)
+
+    await openPicker(user)
+    await waitFor(() => expect(screen.getByText("Alpha 1")).toBeInTheDocument())
+
+    // "Kilo" names no leaf — only a parent — and its children must still show.
+    await user.type(screen.getByRole("searchbox"), "Kilo")
+
+    await waitFor(() => expect(screen.getByText("Kilo 1")).toBeInTheDocument())
+    expect(screen.queryByText("Alpha 1")).not.toBeInTheDocument()
+  })
+
+  it("reports the selected leaf's id", async () => {
+    const user = userEvent.setup()
+    const onChangeProjectId = vi.fn()
+    render(
+      <ProjectSelector
+        projects={NESTED}
+        label="Select project"
+        onChangeProjectId={onChangeProjectId}
+      />
+    )
+
+    await openPicker(user)
+    await waitFor(() => expect(screen.getByText("Tokens")).toBeInTheDocument())
+    await user.click(screen.getByText("Tokens"))
+
+    expect(onChangeProjectId).toHaveBeenCalledWith(
+      "ds-tokens",
+      expect.anything(),
+      expect.anything()
+    )
+  })
+})

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/ProjectSelector.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/ProjectSelector.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from "react"
+
+import { Suitcase } from "@/icons/app"
+
+import { TreeSelector, type TreeSelectorItem } from "./TreeSelector"
+
+/**
+ * A project as the `horizontal-bar` variant takes it, and — optionally — the work
+ * inside it.
+ *
+ * Selection is always a LEAF: a project with `subprojects` is booked through one
+ * of them, a project without them is booked directly. That rule is what lets the
+ * picker show the hierarchy with F0Select's own group headings rather than an
+ * invented indent — a parent is a heading, not an option.
+ */
+export type ClockInProject = {
+  id: string
+  name: string
+  /** The level below. When present, the parent itself is not selectable. */
+  subprojects?: ClockInProject[]
+}
+
+export interface ProjectSelectorProps {
+  projects: ClockInProject[]
+  projectId?: string
+  onChangeProjectId?: (projectId: string) => void
+  /** The picker's label, also the empty trigger's placeholder. */
+  label: string
+  /** Placeholder for the search box. Falls back to F0Select's own wording. */
+  searchPlaceholder?: string
+  /** When false the picker offers a clear affordance. */
+  required?: boolean
+  disabled?: boolean
+}
+
+/** `subprojects` is this domain's word for the tree's `children`. */
+export const toProjectTree = (projects: ClockInProject[]): TreeSelectorItem[] =>
+  projects.map((project) => ({
+    id: project.id,
+    name: project.name,
+    children: project.subprojects?.length
+      ? toProjectTree(project.subprojects)
+      : undefined,
+  }))
+
+/**
+ * The `horizontal-bar` variant's project control: a `TreeSelector` over
+ * `projects` — no consumer-supplied node, so every Home renders the same picker.
+ *
+ * A suitcase marks the field as the project one at a glance, the way the location
+ * picker carries the chosen location's own glyph. Fixed rather than a prop: the
+ * control means one thing here.
+ */
+export function ProjectSelector({
+  projects,
+  projectId,
+  onChangeProjectId,
+  label,
+  searchPlaceholder,
+  required = true,
+  disabled,
+}: ProjectSelectorProps) {
+  const items = useMemo(() => toProjectTree(projects), [projects])
+
+  return (
+    <TreeSelector
+      items={items}
+      value={projectId}
+      onChange={onChangeProjectId}
+      label={label}
+      searchPlaceholder={searchPlaceholder}
+      fieldIcon={Suitcase}
+      required={required}
+      disabled={disabled}
+    />
+  )
+}

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/Skeleton.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/Skeleton.tsx
@@ -1,0 +1,95 @@
+import { Skeleton } from "@/ui/skeleton"
+
+import type { ClockInControlsVariant } from "./index"
+
+type ClockInControlsSkeletonProps = {
+  variant?: ClockInControlsVariant
+  canSeeGraph?: boolean
+  canShowLocation?: boolean
+  /** Whether a project picker is coming — not merely allowed. */
+  canShowProject?: boolean
+}
+
+/**
+ * The placeholder `ClockInControls` draws while `loading`.
+ *
+ * It is shaped like the variant it stands in for — same rows, same heights, the
+ * ring's 160px box or the rail's 6px line — so the tile fills in with its data
+ * instead of changing shape under it. Which controls are coming is honoured for
+ * the same reason: a placeholder for a graph or a picker that will never arrive
+ * is a placeholder that lies about the height.
+ */
+export function ClockInControlsSkeleton({
+  variant = "default",
+  canSeeGraph = true,
+  canShowLocation = true,
+  canShowProject = false,
+}: ClockInControlsSkeletonProps) {
+  if (variant === "horizontal-bar") {
+    return (
+      <div
+        role="status"
+        aria-busy="true"
+        aria-live="polite"
+        className="flex flex-col gap-2"
+      >
+        {/* `h-7` is `text-xl`'s line box and `h-5` the `body` one below the bar,
+            so these rows measure what the loaded tile's do: 114px with one
+            picker, 154px with both. Measured, not guessed — the rail must not
+            shift when the day lands. */}
+        <div className="flex flex-row items-end justify-between gap-2">
+          <Skeleton className="h-7 w-28" />
+          <Skeleton className="h-7 w-12" />
+        </div>
+        {canSeeGraph && <Skeleton className="h-1.5 w-full rounded-full" />}
+        <div className="flex flex-row justify-between gap-2">
+          <Skeleton className="h-5 w-12" />
+          <Skeleton className="h-5 w-24" />
+        </div>
+        {/* The loaded footer's own rule: one picker on the actions' line, and a
+            second one on a line above it. Same fields at the same widths, so the
+            tile does not resize when the day lands. */}
+        <div className="flex flex-col gap-2 pt-1">
+          {canShowLocation && canShowProject ? (
+            <Skeleton className="h-8 w-full rounded-md" />
+          ) : null}
+          <div className="flex flex-row items-center gap-2">
+            {(canShowLocation || canShowProject) && (
+              <Skeleton className="h-8 min-w-0 flex-1 rounded-md" />
+            )}
+            <Skeleton className="ml-auto h-8 w-24 shrink-0 rounded-md" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      role="status"
+      aria-busy="true"
+      aria-live="polite"
+      className="@container"
+    >
+      <div className="flex flex-grow flex-col">
+        <div className="flex flex-col-reverse items-center gap-2 @xs:flex-row">
+          <div className="flex-1 space-y-4">
+            <div className="flex flex-col items-center gap-1.5 @xs:items-start">
+              <Skeleton className="h-7 w-32" />
+              <Skeleton className="h-5 w-40" />
+            </div>
+            <div className="flex flex-row justify-center gap-2 @xs:justify-start">
+              <Skeleton className="h-8 w-28 rounded-md" />
+            </div>
+          </div>
+          {canSeeGraph && (
+            <Skeleton className="h-40 w-40 shrink-0 rounded-full" />
+          )}
+        </div>
+        <div className="mt-6 flex flex-row justify-center @xs:justify-start">
+          {canShowLocation && <Skeleton className="h-6 w-32 rounded-md" />}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
@@ -196,7 +196,14 @@ export function TreeSelector({
     size: "sm" as const,
     showSearchBox: true,
     searchBoxPlaceholder: searchPlaceholder,
-    clearable: !required,
+    // `F0Select` splits `clearable` across two union members (`?: false` and
+    // `: true`), so a computed boolean matches neither and the call site needs a
+    // literal. Asserted here on purpose: collapsing that public type would have
+    // rippled through every export built on select props — `SelectProps`,
+    // `BreadcrumbSelect`, `Breadcrumbs`, `PageHeader` — and widening a shared
+    // type to spare one line here is the wrong trade. Only truthiness is read
+    // downstream, so the runtime value is exactly what it says it is.
+    clearable: !required as true,
     value,
     onChange,
     // Clearing goes through `onChangeSelectedOption`, not `onChange` — the empty

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
@@ -1,0 +1,236 @@
+import { useMemo } from "react"
+
+import type { IconType } from "@/components/F0Icon"
+import { F0Select } from "@/components/F0Select"
+import type { DataSourceDefinition } from "@/hooks/datasource"
+
+/**
+ * A node in one of the tile's pickers — a location, a project, anything you pick
+ * by drilling down. `children` nests it, and a node WITHOUT children is a LEAF:
+ * only leaves are selectable, which is what lets the hierarchy show as F0Select
+ * group headings instead of an invented indent.
+ *
+ * Two or three levels is what reads well — location → workplace → work area,
+ * project → subproject: the leaf names the row and its ancestors name the group
+ * above it. Deeper nests still work; the heading just carries a longer chain.
+ */
+export type TreeSelectorItem = {
+  id: string
+  name: string
+  icon?: IconType
+  children?: TreeSelectorItem[]
+}
+
+/** One selectable leaf, flattened: what it is, what it sits under, how to find it. */
+type LeafRecord = {
+  id: string
+  name: string
+  /** The ancestor chain, which becomes the group heading. */
+  group: string
+  /** Leaf + ancestors, for the trigger — out there a leaf name can be ambiguous. */
+  path: string
+  /** Leaf AND every ancestor: searching "Barcelona" must find its work areas. */
+  haystack: string
+  icon?: IconType
+}
+
+/** Ancestors read as a trail; the leaf is set apart from them. */
+const ANCESTOR_SEPARATOR = " · "
+const PATH_SEPARATOR = " — "
+
+/**
+ * How many leaves a page of the dropdown holds. Small enough that a real book of
+ * work or a real building list actually pages rather than arriving in one go.
+ */
+const PER_PAGE = 20
+
+/**
+ * Every leaf of the tree, in order, each carrying the context its row and trigger
+ * need.
+ *
+ * A TOP-LEVEL leaf heads a group of its own — F0Select's grouping is
+ * all-or-nothing (a group per record, or no groups), so there is no ungrouped
+ * tail to put it in. In a list that nests nowhere the caller skips grouping
+ * entirely, so this only shows up in mixed lists.
+ */
+export function flattenTree(items: TreeSelectorItem[]): LeafRecord[] {
+  const leaves: LeafRecord[] = []
+
+  const walk = (node: TreeSelectorItem, ancestors: TreeSelectorItem[]) => {
+    if (node.children?.length) {
+      node.children.forEach((child) => walk(child, [...ancestors, node]))
+      return
+    }
+
+    const names = ancestors.map((ancestor) => ancestor.name)
+    const trail = names.join(ANCESTOR_SEPARATOR)
+
+    leaves.push({
+      id: node.id,
+      name: node.name,
+      group: names.length ? trail : node.name,
+      path: names.length ? `${node.name}${PATH_SEPARATOR}${trail}` : node.name,
+      haystack: [node.name, ...names].join(" ").toLowerCase(),
+      // The glyph that means something is usually the ROOT's (Office, Home,
+      // Business trip) — a work area rarely has its own, so the nearest one up
+      // the chain stands in for it.
+      icon:
+        node.icon ??
+        [...ancestors].reverse().find((ancestor) => ancestor.icon)?.icon,
+    })
+  }
+
+  items.forEach((item) => walk(item, []))
+  return leaves
+}
+
+/** The selected leaf, wherever it sits in the tree. */
+export const findLeaf = (
+  items: TreeSelectorItem[],
+  id: string | undefined
+): TreeSelectorItem | undefined =>
+  id ? flattenTreeNodes(items).find((node) => node.id === id) : undefined
+
+const flattenTreeNodes = (items: TreeSelectorItem[]): TreeSelectorItem[] =>
+  items.flatMap((item) => [item, ...flattenTreeNodes(item.children ?? [])])
+
+export interface TreeSelectorProps {
+  items: TreeSelectorItem[]
+  value?: string
+  onChange?: (value: string) => void
+  /** The picker's label, also the empty trigger's placeholder. */
+  label: string
+  /** Placeholder for the search box. Falls back to F0Select's own wording. */
+  searchPlaceholder?: string
+  /** A fixed glyph for the field, when the items don't carry their own. */
+  fieldIcon?: IconType
+  /** When false the picker offers a clear affordance. */
+  required?: boolean
+  disabled?: boolean
+}
+
+/**
+ * The tile's picker for a tree of options: an `F0Select` the component owns and
+ * builds from data, so a Home tile can't be handed a node that breaks its layout.
+ *
+ * Nesting arrives as F0Select GROUPS — the ancestor chain heads the group, its
+ * leaves are the options under it. Grouping only kicks in when something actually
+ * nests; in a flat list a heading per option would just repeat it.
+ *
+ * SEARCH AND PAGING are on, because these lists grow to hundreds and scrolling a
+ * nested one to find a single work area is not a way to book time. The nested path
+ * fetches through an infinite-scroll adapter and matches search against the leaf
+ * AND its ancestors; the flat path leaves search to F0Select over `options`.
+ *
+ * It uses F0Select's OWN trigger rather than a `children` one: that path renders
+ * the trigger as a `div`, which a keyboard can't reach (`SelectTrigger asChild`
+ * over a plain element). The field is a real, focusable trigger, at `sm` because
+ * it sits inside a widget.
+ */
+export function TreeSelector({
+  items,
+  value,
+  onChange,
+  label,
+  searchPlaceholder,
+  fieldIcon,
+  required = true,
+  disabled,
+}: TreeSelectorProps) {
+  const leaves = useMemo(() => flattenTree(items), [items])
+  const nested = useMemo(
+    () => items.some((item) => !!item.children?.length),
+    [items]
+  )
+
+  // A definition, not a `useDataSource` result: `F0Select` builds the source
+  // itself. Memoized because its identity is what would otherwise refetch.
+  const source = useMemo<DataSourceDefinition<LeafRecord>>(
+    () => ({
+      grouping: {
+        mandatory: true,
+        hideSelector: true,
+        collapsible: true,
+        defaultOpenGroups: true,
+        groupBy: {
+          group: { name: label, label: (groupId) => String(groupId) },
+        },
+      },
+      dataAdapter: {
+        paginationType: "infinite-scroll",
+        perPage: PER_PAGE,
+        // Synchronous: the records are already here. This is the shape a real
+        // consumer's endpoint would fill in — search in, one page out — so the
+        // dropdown pages and searches the same way either side of the wire.
+        fetchData: ({ search, pagination }) => {
+          const term = search?.trim().toLowerCase()
+          const matching = term
+            ? leaves.filter((leaf) => leaf.haystack.includes(term))
+            : leaves
+
+          const perPage = pagination.perPage ?? PER_PAGE
+          const cursor = Number(
+            ("cursor" in pagination ? pagination.cursor : null) ?? 0
+          )
+          const nextCursor = cursor + perPage
+
+          return {
+            type: "infinite-scroll" as const,
+            records: matching.slice(cursor, nextCursor),
+            total: matching.length,
+            perPage,
+            cursor: String(nextCursor),
+            hasMore: nextCursor < matching.length,
+          }
+        },
+      },
+    }),
+    [leaves, label]
+  )
+
+  const shared = {
+    label,
+    hideLabel: true,
+    placeholder: label,
+    icon: fieldIcon,
+    size: "sm" as const,
+    showSearchBox: true,
+    searchBoxPlaceholder: searchPlaceholder,
+    clearable: !required,
+    value,
+    onChange,
+    // Clearing goes through `onChangeSelectedOption`, not `onChange` — the empty
+    // string is these pickers' "nothing chosen", the same value an unset id has.
+    onChangeSelectedOption: (
+      option: { value: string } | undefined,
+      _checked: boolean
+    ) => {
+      if (!option) onChange?.("")
+    },
+    disabled,
+  }
+
+  return nested ? (
+    <F0Select<string, LeafRecord>
+      {...shared}
+      source={source}
+      mapOptions={(leaf) => ({
+        value: leaf.id,
+        label: leaf.name,
+        icon: leaf.icon,
+        // The row is read under its group heading, so it stays short. The TRIGGER
+        // has no heading above it — there, the leaf carries its whole path.
+        selectedLabel: leaf.path,
+      })}
+    />
+  ) : (
+    <F0Select
+      {...shared}
+      options={leaves.map((leaf) => ({
+        value: leaf.id,
+        label: leaf.name,
+        icon: leaf.icon,
+      }))}
+    />
+  )
+}

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
@@ -153,8 +153,11 @@ export function TreeSelector({
    * Not through the selected option's icon, which is the other way `F0Select` can
    * show one: that renders inside the value area (`px-3`) while a field icon is
    * absolutely placed at `left-2`, so two pickers side by side sat 4px apart —
-   * and worse, the icon would jump those 4px the moment you picked something.
-   * Options therefore carry no icon here at all; one slot, one position.
+   * and worse, the icon jumped those 4px the moment you picked something.
+   *
+   * Options still carry their icons, for the ROWS. `F0Select` leaves the selected
+   * option's icon out of the trigger whenever the field has one of its own, so
+   * only this slot ever draws there.
    */
   const selectedLeaf = value
     ? leaves.find((leaf) => leaf.id === value)
@@ -242,6 +245,7 @@ export function TreeSelector({
       mapOptions={(leaf) => ({
         value: leaf.id,
         label: leaf.name,
+        icon: leaf.icon,
         // The row is read under its group heading, so it stays short. The TRIGGER
         // has no heading above it — there, the leaf carries its whole path.
         selectedLabel: leaf.path,
@@ -253,6 +257,7 @@ export function TreeSelector({
       options={leaves.map((leaf) => ({
         value: leaf.id,
         label: leaf.name,
+        icon: leaf.icon,
       }))}
     />
   )

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/TreeSelector.tsx
@@ -102,7 +102,10 @@ export interface TreeSelectorProps {
   label: string
   /** Placeholder for the search box. Falls back to F0Select's own wording. */
   searchPlaceholder?: string
-  /** A fixed glyph for the field, when the items don't carry their own. */
+  /**
+   * The field's glyph while nothing is selected — and for good, when the items
+   * carry no icons of their own (projects). A selected leaf's own icon wins.
+   */
   fieldIcon?: IconType
   /** When false the picker offers a clear affordance. */
   required?: boolean
@@ -142,6 +145,21 @@ export function TreeSelector({
     () => items.some((item) => !!item.children?.length),
     [items]
   )
+
+  /**
+   * The trigger's glyph, ALWAYS through the field's own icon slot — the selected
+   * leaf's icon when there is one, the fallback otherwise.
+   *
+   * Not through the selected option's icon, which is the other way `F0Select` can
+   * show one: that renders inside the value area (`px-3`) while a field icon is
+   * absolutely placed at `left-2`, so two pickers side by side sat 4px apart —
+   * and worse, the icon would jump those 4px the moment you picked something.
+   * Options therefore carry no icon here at all; one slot, one position.
+   */
+  const selectedLeaf = value
+    ? leaves.find((leaf) => leaf.id === value)
+    : undefined
+  const triggerIcon = selectedLeaf?.icon ?? fieldIcon
 
   // A definition, not a `useDataSource` result: `F0Select` builds the source
   // itself. Memoized because its identity is what would otherwise refetch.
@@ -192,7 +210,7 @@ export function TreeSelector({
     label,
     hideLabel: true,
     placeholder: label,
-    icon: fieldIcon,
+    icon: triggerIcon,
     size: "sm" as const,
     showSearchBox: true,
     searchBoxPlaceholder: searchPlaceholder,
@@ -224,7 +242,6 @@ export function TreeSelector({
       mapOptions={(leaf) => ({
         value: leaf.id,
         label: leaf.name,
-        icon: leaf.icon,
         // The row is read under its group heading, so it stays short. The TRIGGER
         // has no heading above it — there, the leaf carries its whole path.
         selectedLabel: leaf.path,
@@ -236,7 +253,6 @@ export function TreeSelector({
       options={leaves.map((leaf) => ({
         value: leaf.id,
         label: leaf.name,
-        icon: leaf.icon,
       }))}
     />
   )

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.spec.tsx
@@ -167,6 +167,226 @@ describe("ClockInControls", () => {
     expect(screen.getByText("Custom location control")).toBeInTheDocument()
   })
 
+  describe("horizontal-bar variant", () => {
+    const clockedInDay = [
+      {
+        from: new Date("2024-03-20T09:02:00"),
+        to: new Date("2024-03-20T13:23:00"),
+        variant: "clocked-in" as const,
+      },
+    ]
+
+    it("shows the status, the running total, the day's start and what is left of it", () => {
+      render(
+        <ClockInControls
+          variant="horizontal-bar"
+          labels={defaultLabels}
+          trackedMinutes={4 * 60 + 21}
+          remainingMinutes={4 * 60 + 39}
+          data={clockedInDay}
+          locations={[]}
+          onChangeLocationId={() => {}}
+        />
+      )
+
+      expect(screen.getByText(defaultLabels.clockedIn)).toBeInTheDocument()
+      expect(screen.getByText("04:21")).toBeInTheDocument()
+      expect(screen.getByText("09:02")).toBeInTheDocument()
+      expect(
+        screen.getByText(`${defaultLabels.remainingTime} 04:39`)
+      ).toBeInTheDocument()
+    })
+
+    it("owns both pickers, each as a select it renders itself", () => {
+      const onChangeLocationId = vi.fn()
+      render(
+        <ClockInControls
+          variant="horizontal-bar"
+          labels={defaultLabels}
+          trackedMinutes={0}
+          remainingMinutes={8 * 60}
+          data={[]}
+          locations={[
+            { id: "1", name: "Office", icon: OfficeIcon },
+            { id: "2", name: "Home", icon: OfficeIcon },
+          ]}
+          locationId="1"
+          onChangeLocationId={onChangeLocationId}
+          projects={[{ id: "p1", name: "Design system" }]}
+          onChangeProjectId={() => {}}
+        />
+      )
+
+      // Both are real, focusable comboboxes the component built from data —
+      // neither is a consumer-supplied node.
+      expect(
+        screen.getByRole("combobox", { name: defaultLabels.selectLocation })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("combobox", { name: defaultLabels.selectProject })
+      ).toBeInTheDocument()
+      // The location's current choice shows on its trigger.
+      expect(screen.getByText("Office")).toBeInTheDocument()
+    })
+
+    it("offers a clear affordance only on the pickers that aren't required", () => {
+      const { rerender } = render(
+        <ClockInControls
+          variant="horizontal-bar"
+          labels={defaultLabels}
+          trackedMinutes={0}
+          data={[]}
+          locations={[{ id: "1", name: "Office", icon: OfficeIcon }]}
+          locationId="1"
+          onChangeLocationId={() => {}}
+          projects={[{ id: "p1", name: "Design system" }]}
+          projectId="p1"
+          onChangeProjectId={() => {}}
+        />
+      )
+
+      // Required by default: nothing to clear with.
+      expect(screen.queryAllByLabelText(/clear/i)).toHaveLength(0)
+
+      rerender(
+        <ClockInControls
+          variant="horizontal-bar"
+          labels={defaultLabels}
+          trackedMinutes={0}
+          data={[]}
+          locations={[{ id: "1", name: "Office", icon: OfficeIcon }]}
+          locationId="1"
+          onChangeLocationId={() => {}}
+          projects={[{ id: "p1", name: "Design system" }]}
+          projectId="p1"
+          onChangeProjectId={() => {}}
+          locationRequired={false}
+          projectRequired={false}
+        />
+      )
+
+      expect(screen.queryAllByLabelText(/clear/i)).toHaveLength(2)
+    })
+
+    it("keeps the same controls as the default variant", () => {
+      const onClockOut = vi.fn()
+      render(
+        <ClockInControls
+          variant="horizontal-bar"
+          labels={defaultLabels}
+          trackedMinutes={4 * 60 + 21}
+          data={clockedInDay}
+          locations={[]}
+          onChangeLocationId={() => {}}
+          onClockOut={onClockOut}
+        />
+      )
+
+      screen.getByText(defaultLabels.clockOut).click()
+      expect(onClockOut).toHaveBeenCalled()
+    })
+  })
+
+  describe("on a break, which action leads", () => {
+    const breakDay = [
+      {
+        from: new Date("2024-03-20T09:02:00"),
+        to: new Date("2024-03-20T12:00:00"),
+        variant: "clocked-in" as const,
+      },
+      {
+        from: new Date("2024-03-20T12:00:00"),
+        to: new Date("2024-03-20T12:34:00"),
+        variant: "break" as const,
+      },
+    ]
+
+    const renderOnBreak = (
+      extra: Partial<{
+        remainingMinutes: number
+        onBreakPromote: "resume" | "clock-out"
+      }>
+    ) =>
+      render(
+        <ClockInControls
+          labels={defaultLabels}
+          trackedMinutes={4 * 60}
+          data={breakDay}
+          locations={[]}
+          onChangeLocationId={() => {}}
+          {...extra}
+        />
+      )
+
+    /**
+     * The promoted action is the labelled button; the other is icon-only. Both
+     * labels stay in the DOM either way — `hideLabel` keeps the text for screen
+     * readers — so what tells them apart is whether that text is `sr-only`.
+     */
+    const isIconOnly = (label: string) =>
+      screen.getByText(label).className.includes("sr-only")
+
+    it("promotes resume while there are hours left", () => {
+      renderOnBreak({ remainingMinutes: 4 * 60 })
+
+      expect(isIconOnly(defaultLabels.resume)).toBe(false)
+      expect(isIconOnly(defaultLabels.clockOut)).toBe(true)
+      // Icon-only, but still named for anyone not looking at it.
+      expect(
+        screen.getByRole("button", { name: defaultLabels.clockOut })
+      ).toBeInTheDocument()
+    })
+
+    it("promotes clocking out once the day is in overtime", () => {
+      renderOnBreak({ remainingMinutes: -17 })
+
+      expect(isIconOnly(defaultLabels.clockOut)).toBe(false)
+      expect(isIconOnly(defaultLabels.resume)).toBe(true)
+    })
+
+    it("lets onBreakPromote override what the day would pick", () => {
+      renderOnBreak({ remainingMinutes: -17, onBreakPromote: "resume" })
+
+      expect(isIconOnly(defaultLabels.resume)).toBe(false)
+      expect(isIconOnly(defaultLabels.clockOut)).toBe(true)
+    })
+  })
+
+  describe("loading", () => {
+    it.each(["default", "horizontal-bar"] as const)(
+      "draws a placeholder instead of the %s controls",
+      (variant) => {
+        render(
+          <ClockInControls
+            variant={variant}
+            loading
+            labels={defaultLabels}
+            trackedMinutes={4 * 60 + 21}
+            remainingMinutes={4 * 60 + 39}
+            data={[
+              {
+                from: new Date("2024-03-20T09:02:00"),
+                to: new Date("2024-03-20T13:23:00"),
+                variant: "clocked-in",
+              },
+            ]}
+            locations={[]}
+            onChangeLocationId={() => {}}
+          />
+        )
+
+        expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true")
+        // Neither the day nor its controls: the data hasn't arrived.
+        expect(
+          screen.queryByText(defaultLabels.clockedIn)
+        ).not.toBeInTheDocument()
+        expect(
+          screen.queryByText(defaultLabels.clockOut)
+        ).not.toBeInTheDocument()
+      }
+    )
+  })
+
   it("does not render the location area (custom or built-in) when canShowLocation is false", () => {
     render(
       <ClockInControls

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
@@ -90,8 +90,9 @@ const BREAK_DAY: ClockInControlsProps["data"] = [
     from: new Date("2024-03-20T12:00:00"),
     to: new Date("2024-03-20T12:34:00"),
     variant: "break",
-    // Hovering a segment always gives its time range; `label` is what gets added
-    // after it — so this reads "12:00 – 12:34 • Lunch break".
+    // Hovering a segment always gives its range and duration; `label` is what
+    // gets added after that — so this reads
+    // "12:00 – 12:34 (34min) • Lunch break".
     label: "Lunch break",
   },
 ]

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
@@ -90,9 +90,9 @@ const BREAK_DAY: ClockInControlsProps["data"] = [
     from: new Date("2024-03-20T12:00:00"),
     to: new Date("2024-03-20T12:34:00"),
     variant: "break",
-    // `label` names this stretch on the bar: hover its segment and it says which
-    // break it was. Put whatever the tile should reveal there, times included.
-    label: "Lunch break · 12:00–12:34",
+    // Hovering a segment always gives its time range; `label` is what gets added
+    // after it — so this reads "12:00 – 12:34 • Lunch break".
+    label: "Lunch break",
   },
 ]
 
@@ -101,19 +101,19 @@ const OVERTIME_DAY: ClockInControlsProps["data"] = [
     from: new Date("2024-03-20T09:02:00"),
     to: new Date("2024-03-20T12:00:00"),
     variant: "clocked-in",
-    label: "Morning · Design system",
+    label: "Design system",
   },
   {
     from: new Date("2024-03-20T12:00:00"),
     to: new Date("2024-03-20T12:45:00"),
     variant: "break",
-    label: "Lunch break · 12:00–12:45",
+    label: "Lunch break",
   },
   {
     from: new Date("2024-03-20T12:45:00"),
     to: new Date("2024-03-20T18:17:00"),
     variant: "clocked-in",
-    label: "Afternoon · Onboarding revamp",
+    label: "Onboarding revamp",
   },
 ]
 

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.stories.tsx
@@ -7,7 +7,12 @@ import {
   Suitcase as SuitcaseIcon,
 } from "@/icons/app"
 
-import { ClockInControls } from "./index"
+import {
+  ClockInControls,
+  type ClockInControlsProps,
+  type ClockInLocation,
+  type ClockInProject,
+} from "./index"
 
 const defaultLabels = {
   clockedOut: "Clocked out",
@@ -21,6 +26,7 @@ const defaultLabels = {
   overtime: "Overtime",
   selectLocation: "Select location",
   selectProject: "Select project",
+  searchProject: "Search projects",
   paid: "Paid",
   unpaid: "Unpaid",
 }
@@ -60,6 +66,194 @@ const meta: Meta<typeof ClockInControls> = {
 export default meta
 type Story = StoryObj<typeof ClockInControls>
 
+/**
+ * The days the stories run on, as DATA rather than as other stories' `args`:
+ * `variant="horizontal-bar"` types the custom-render slots away, so spreading a
+ * story's `Partial<ClockInControlsProps>` into it no longer typechecks — which is
+ * the point of the union.
+ */
+const CLOCKED_IN_DAY: ClockInControlsProps["data"] = [
+  {
+    from: new Date("2024-03-20T09:02:00"),
+    to: new Date("2024-03-20T12:23:00"),
+    variant: "clocked-in",
+  },
+]
+
+const BREAK_DAY: ClockInControlsProps["data"] = [
+  {
+    from: new Date("2024-03-20T09:02:00"),
+    to: new Date("2024-03-20T12:00:00"),
+    variant: "clocked-in",
+  },
+  {
+    from: new Date("2024-03-20T12:00:00"),
+    to: new Date("2024-03-20T12:34:00"),
+    variant: "break",
+    // `label` names this stretch on the bar: hover its segment and it says which
+    // break it was. Put whatever the tile should reveal there, times included.
+    label: "Lunch break · 12:00–12:34",
+  },
+]
+
+const OVERTIME_DAY: ClockInControlsProps["data"] = [
+  {
+    from: new Date("2024-03-20T09:02:00"),
+    to: new Date("2024-03-20T12:00:00"),
+    variant: "clocked-in",
+    label: "Morning · Design system",
+  },
+  {
+    from: new Date("2024-03-20T12:00:00"),
+    to: new Date("2024-03-20T12:45:00"),
+    variant: "break",
+    label: "Lunch break · 12:00–12:45",
+  },
+  {
+    from: new Date("2024-03-20T12:45:00"),
+    to: new Date("2024-03-20T18:17:00"),
+    variant: "clocked-in",
+    label: "Afternoon · Onboarding revamp",
+  },
+]
+
+/**
+ * A REAL-SIZED book of work: 10 projects, 50 selectable leaves. That is past the
+ * picker's 20-per-page window, so the dropdown actually pages as you scroll and
+ * the search box has something to narrow — which is the state to design against,
+ * not a list of three.
+ */
+const MANY_PROJECTS: ClockInProject[] = [
+  {
+    name: "Design system",
+    parts: ["Components", "Tokens", "Documentation", "Icons", "Audits"],
+  },
+  {
+    name: "Onboarding revamp",
+    parts: ["Research", "Flows", "Copy", "Analytics", "Rollout"],
+  },
+  {
+    name: "Payroll engine",
+    parts: [
+      "Calculations",
+      "Filings",
+      "Reconciliation",
+      "Reporting",
+      "Migrations",
+    ],
+  },
+  {
+    name: "Mobile app",
+    parts: ["iOS", "Android", "Release train", "Crash triage", "Notifications"],
+  },
+  {
+    name: "Recruitment",
+    parts: ["Job board", "Pipelines", "Scorecards", "Referrals", "Offers"],
+  },
+  {
+    name: "Data platform",
+    parts: [
+      "Ingestion",
+      "Warehouse",
+      "Dashboards",
+      "Governance",
+      "Experiments",
+    ],
+  },
+  {
+    name: "Billing",
+    parts: ["Invoicing", "Dunning", "Taxes", "Plans", "Refunds"],
+  },
+  {
+    name: "Customer support",
+    parts: ["Inbox", "Macros", "Escalations", "Knowledge base", "Reporting"],
+  },
+  {
+    name: "Security",
+    parts: [
+      "Access reviews",
+      "Pen tests",
+      "Incident drills",
+      "Compliance",
+      "Training",
+    ],
+  },
+  {
+    name: "Internal tooling",
+    parts: ["Admin", "Feature flags", "Runbooks", "Alerting", "Cost control"],
+  },
+].map(({ name, parts }) => ({
+  id: name.toLowerCase().replace(/ /g, "-"),
+  name,
+  subprojects: parts.map((part) => ({
+    id: `${name}-${part}`.toLowerCase().replace(/ /g, "-"),
+    name: part,
+  })),
+}))
+
+/**
+ * THREE levels of location: type → city → work area. Selection is the leaf, the
+ * chain above it heads its group, and "Business trip" has no levels below it, so
+ * it is its own leaf.
+ */
+const NESTED_LOCATIONS: ClockInLocation[] = [
+  {
+    id: "office",
+    name: "Office",
+    icon: OfficeIcon,
+    sublocations: [
+      {
+        id: "office-barcelona",
+        name: "Barcelona",
+        sublocations: [
+          { id: "office-bcn-llucuna", name: "Llucuna A-3" },
+          { id: "office-bcn-tanger", name: "Tànger 98" },
+        ],
+      },
+      {
+        id: "office-madrid",
+        name: "Madrid",
+        sublocations: [
+          { id: "office-mad-castellana", name: "Castellana 200" },
+          { id: "office-mad-atocha", name: "Atocha 4" },
+        ],
+      },
+    ],
+  },
+  {
+    id: "home",
+    name: "Home",
+    icon: HomeIcon,
+    sublocations: [
+      { id: "home-primary", name: "Primary address" },
+      { id: "home-secondary", name: "Secondary address" },
+    ],
+  },
+  { id: "trip", name: "Business trip", icon: SuitcaseIcon },
+]
+
+/** Two projects with subprojects and one without, to show both shapes. */
+const PROJECTS: ClockInProject[] = [
+  {
+    id: "design-system",
+    name: "Design system",
+    subprojects: [
+      { id: "ds-components", name: "Components" },
+      { id: "ds-tokens", name: "Tokens" },
+      { id: "ds-docs", name: "Documentation" },
+    ],
+  },
+  {
+    id: "onboarding",
+    name: "Onboarding revamp",
+    subprojects: [
+      { id: "ob-research", name: "Research" },
+      { id: "ob-flows", name: "Flows" },
+    ],
+  },
+  { id: "internal", name: "Internal tooling" },
+]
+
 export const ClockedOut: Story = {
   args: {
     remainingMinutes: 8 * 60,
@@ -71,13 +265,7 @@ export const ClockedIn: Story = {
   args: {
     trackedMinutes: 4 * 60 + 21,
     remainingMinutes: 4 * 60 + 39,
-    data: [
-      {
-        from: new Date("2024-03-20T09:02:00"),
-        to: new Date("2024-03-20T12:23:00"),
-        variant: "clocked-in",
-      },
-    ],
+    data: CLOCKED_IN_DAY,
   },
 }
 
@@ -92,18 +280,7 @@ export const NoGraphNorRemainingTime: Story = {
 export const OnBreak: Story = {
   args: {
     remainingMinutes: 4 * 60 + 39,
-    data: [
-      {
-        from: new Date("2024-03-20T09:02:00"),
-        to: new Date("2024-03-20T12:00:00"),
-        variant: "clocked-in",
-      },
-      {
-        from: new Date("2024-03-20T12:00:00"),
-        to: new Date("2024-03-20T12:34:00"),
-        variant: "break",
-      },
-    ],
+    data: BREAK_DAY,
     breakTypeName: "Lunch break",
   },
 }
@@ -112,23 +289,7 @@ export const WithOvertime: Story = {
   args: {
     trackedMinutes: 4 * 60 + 21,
     remainingMinutes: -17,
-    data: [
-      {
-        from: new Date("2024-03-20T09:02:00"),
-        to: new Date("2024-03-20T12:00:00"),
-        variant: "clocked-in",
-      },
-      {
-        from: new Date("2024-03-20T12:00:00"),
-        to: new Date("2024-03-20T12:45:00"),
-        variant: "break",
-      },
-      {
-        from: new Date("2024-03-20T12:45:00"),
-        to: new Date("2024-03-20T18:17:00"),
-        variant: "clocked-in",
-      },
-    ],
+    data: OVERTIME_DAY,
   },
 }
 
@@ -241,9 +402,207 @@ export const WithHiddenLocationAndProject: Story = {
   },
 }
 
+/**
+ * `variant="horizontal-bar"` — the Home-widget arrangement from the custom-home
+ * prototype. Four full-width rows, each pinning its two halves to the tile's
+ * ends: status + running total on one line, the day as a horizontal bar, when it
+ * started and what is left of it, then the location and the controls. The day,
+ * the state machine and the controls are the SAME as in `default` — only their
+ * placement changes — so it fits a narrow rail where the 160px ring can't.
+ *
+ * This variant also OWNS its two pickers: `locationSelectorElement` and
+ * `projectSelectorElement` are typed away, and it renders `locations` as an
+ * `F0ButtonDropdown` and `projects` as an `F0Select` instead.
+ */
+export const HorizontalBar: Story = {
+  args: {
+    variant: "horizontal-bar",
+    trackedMinutes: 4 * 60 + 21,
+    remainingMinutes: 4 * 60 + 39,
+    data: CLOCKED_IN_DAY,
+  },
+}
+
+/**
+ * Clocked out is when the pickers are live: the location as an
+ * `F0ButtonDropdown`, the projects as an `F0Select` whose group headers are the
+ * parent projects and whose options are their subprojects — selection is always
+ * a leaf. `Internal tooling` has no subprojects, so it stands as its own option.
+ */
+export const HorizontalBarClockedOut: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 8 * 60,
+    data: [],
+    projects: PROJECTS,
+    projectId: "ds-tokens",
+    onChangeProjectId: () => {},
+  },
+}
+
+/**
+ * 50 selectable leaves across 10 projects — past the picker's 20-per-page window.
+ * Open it and the dropdown pages as you scroll; type in the search box and it
+ * narrows against BOTH the subproject and its parent ("design" keeps everything
+ * under Design system).
+ */
+export const HorizontalBarWithManyProjects: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 8 * 60,
+    data: [],
+    projects: MANY_PROJECTS,
+    onChangeProjectId: () => {},
+  },
+}
+
+/**
+ * `locationRequired={false}` / `projectRequired={false}` — the two pickers then
+ * offer a clear affordance and report the empty string once cleared. Both default
+ * to required, which is the behaviour before there was any way to clear.
+ */
+export const HorizontalBarWithOptionalPickers: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 8 * 60,
+    data: [],
+    projects: MANY_PROJECTS,
+    projectId: "design-system-tokens",
+    onChangeProjectId: () => {},
+    locationRequired: false,
+    projectRequired: false,
+  },
+}
+
+/**
+ * Locations nested three deep (type → city → work area) beside projects nested
+ * two. Both pickers group by the chain above the leaf — "Office · Barcelona"
+ * heads its work areas — and the trigger carries the whole path, since out there
+ * "Llucuna A-3" on its own says little. Searching "Barcelona" finds its areas
+ * even though none of them is named that.
+ */
+export const HorizontalBarWithNestedLocations: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 8 * 60,
+    data: [],
+    locations: NESTED_LOCATIONS,
+    locationId: "office-bcn-llucuna",
+    projects: MANY_PROJECTS,
+    onChangeProjectId: () => {},
+  },
+}
+
+/** With a flat project list there are no group headers to draw. */
+export const HorizontalBarWithFlatProjects: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 8 * 60,
+    data: [],
+    projects: [
+      { id: "internal", name: "Internal tooling" },
+      { id: "support", name: "Customer support" },
+    ],
+    onChangeProjectId: () => {},
+  },
+}
+
+/** On a break the bar carries the break segment, and the tag names it. */
+export const HorizontalBarOnBreak: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 4 * 60 + 39,
+    data: BREAK_DAY,
+    breakTypeName: "Lunch break",
+  },
+}
+
+/** Overtime paints past the target in the warning colour, as the ring does. */
+export const HorizontalBarWithOvertime: Story = {
+  args: {
+    variant: "horizontal-bar",
+    trackedMinutes: 4 * 60 + 21,
+    remainingMinutes: -17,
+    data: OVERTIME_DAY,
+  },
+}
+
+/**
+ * On a break INSIDE your hours: resuming leads, clocking out is the icon-only
+ * outline beside it. This is `onBreakPromote`'s default while time is left.
+ */
+export const HorizontalBarOnBreakPromotingResume: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 4 * 60 + 39,
+    data: BREAK_DAY,
+    breakTypeName: "Lunch break",
+  },
+}
+
+/**
+ * On a break PAST your hours: the day is done, so clocking out leads instead —
+ * the same swap `onBreakPromote="clock-out"` pins explicitly.
+ */
+export const HorizontalBarOnBreakInOvertime: Story = {
+  args: {
+    variant: "horizontal-bar",
+    trackedMinutes: 8 * 60 + 12,
+    remainingMinutes: -17,
+    data: BREAK_DAY,
+    breakTypeName: "Lunch break",
+  },
+}
+
+/**
+ * A long break name next to "On a break": it truncates, and hovering it shows the
+ * whole thing — `OneEllipsis` only mounts that tooltip when the text really clips.
+ */
+export const HorizontalBarWithLongBreakTypeName: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 4 * 60 + 39,
+    data: BREAK_DAY,
+    breakTypeName: "Lunch break — canteen, second shift",
+    onBreakPromote: "resume",
+  },
+}
+
+/**
+ * `loading` draws a placeholder shaped like the chosen variant — the same rows
+ * at the same heights — so the tile fills in with its data instead of changing
+ * shape under it.
+ */
+export const Loading: Story = {
+  args: {
+    ...ClockedIn.args,
+    loading: true,
+  },
+}
+
+/**
+ * Same args as {@link HorizontalBarWithManyProjects}, only waiting: the
+ * placeholder holds the same four rows AND a line for each picker that is
+ * actually coming, so nothing shifts when the day lands.
+ */
+export const LoadingHorizontalBar: Story = {
+  args: {
+    variant: "horizontal-bar",
+    remainingMinutes: 8 * 60,
+    data: [],
+    projects: MANY_PROJECTS,
+    onChangeProjectId: () => {},
+    loading: true,
+  },
+}
+
 export const WithCustomLocationSelector: Story = {
   args: {
-    ...ClockedOut.args,
+    remainingMinutes: 8 * 60,
+    data: [],
+    // A custom control is the `default` variant's offer only — `horizontal-bar`
+    // renders its own pickers, and types this slot away.
+    variant: "default",
     // When `locationSelectorElement` is provided it replaces the built-in flat
     // location select, letting the consumer render its own control — e.g. a
     // drill-in selector (location → workplace → work area).

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
@@ -2,14 +2,25 @@ import { motion } from "motion/react"
 import { Dispatch, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
-import { IconType } from "@/components/F0Icon"
 import { F0Select } from "@/components/F0Select"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { SolidPause, SolidPlay, SolidStop } from "@/icons/app"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 
 import { ClockInGraph, ClockInGraphProps } from "../ClockInGraph"
+import { getLabels } from "../ClockInGraph/helpers"
 import { getInfo } from "./helpers"
+import {
+  type ClockInLocation,
+  LocationSelector,
+  toLocationTree,
+} from "./LocationSelector"
+import { type ClockInProject, ProjectSelector } from "./ProjectSelector"
 import Selector from "./Selector"
+import { ClockInControlsSkeleton } from "./Skeleton"
+import { findLeaf } from "./TreeSelector"
+
+export type { ClockInLocation, ClockInProject }
 
 interface BreakType {
   id: string
@@ -19,7 +30,14 @@ interface BreakType {
   isPaid: boolean
 }
 
-export interface ClockInControlsProps {
+/**
+ * How the pieces are laid out. Both variants show the same day, run the same
+ * state machine and use the same controls — only their arrangement differs.
+ */
+export type ClockInControlsVariant = "default" | "horizontal-bar"
+
+/** Everything both variants take, on the same terms. */
+interface ClockInControlsBaseProps {
   /** Optional remaining time in minutes */
   remainingMinutes?: number
   /** Clock in entries data */
@@ -41,14 +59,26 @@ export interface ClockInControlsProps {
     selectProject: string
     paid: string
     unpaid: string
+    /**
+     * Placeholders for the pickers' search boxes (`horizontal-bar` only).
+     * Optional: without them the pickers fall back to F0Select's own wording.
+     */
+    searchProject?: string
+    searchLocation?: string
   }
+  /** The selected location — a leaf, when the list nests. */
   locationId?: string
   onChangeLocationId: Dispatch<string>
-  locations: {
-    id: string
-    name: string
-    icon: IconType
-  }[]
+  /**
+   * The locations to offer. Each may carry `sublocations`, two or three levels
+   * deep (location → workplace → work area), and selection is then a leaf.
+   *
+   * Nesting is drawn by the `horizontal-bar` variant, which owns its picker. The
+   * `default` variant's built-in select is flat and offers only the top level — it
+   * has `locationSelectorElement` for a consumer's own drill-in instead — though
+   * it still DISPLAYS a selected leaf wherever it sits in the tree.
+   */
+  locations: ClockInLocation[]
   breakTypes?: BreakType[]
   onChangeBreakTypeId?: Dispatch<string>
   canShowLocation?: boolean
@@ -63,7 +93,36 @@ export interface ClockInControlsProps {
   /** Callback when Break button is clicked */
   onBreak?: (breakTypeId?: string) => void
   canShowProject?: boolean
-  projectSelectorElement?: React.ReactNode
+  breakTypeName?: string
+  /**
+   * On a break, which action gets the primary button — the other becomes an
+   * icon-only outline beside it.
+   *
+   * Unset, it follows the day: `"clock-out"` once you're into overtime (the hours
+   * are done, so ending them is the useful move), `"resume"` while there are hours
+   * left. Set it to pin one regardless.
+   */
+  onBreakPromote?: "resume" | "clock-out"
+  /**
+   * Draws a placeholder shaped like the chosen `variant` instead of the
+   * controls — for when the day itself hasn't arrived yet. Prefer it over
+   * rendering a zeroed-out day: `trackedMinutes={0}` with no `data` is a real
+   * state ("clocked out, nothing tracked"), not a missing one.
+   */
+  loading?: boolean
+}
+
+/**
+ * The `default` variant, where the consumer may bring its OWN location and
+ * project controls as nodes: this is the arrangement Factorial already ships,
+ * and both slots are in use (e.g. a drill-in location selector).
+ */
+interface ClockInControlsDefaultProps extends ClockInControlsBaseProps {
+  /**
+   * The status and its controls beside the circular `ClockInGraph`, with the
+   * location/project row underneath.
+   */
+  variant?: "default"
   /**
    * Optional custom location control. When provided, it replaces the built-in
    * flat location `F0Select` (in both the editable clocked-out state and the
@@ -72,8 +131,58 @@ export interface ClockInControlsProps {
    * owns its data and editable/disabled state, mirroring `projectSelectorElement`.
    */
   locationSelectorElement?: React.ReactNode
-  breakTypeName?: string
+  projectSelectorElement?: React.ReactNode
+  projects?: never
+  projectId?: never
+  onChangeProjectId?: never
+  projectSelectorDisabled?: never
+  /** Only the `horizontal-bar` variant owns the pickers, so only it can relax them. */
+  projectRequired?: never
+  locationRequired?: never
 }
+
+/**
+ * The `horizontal-bar` variant, which owns BOTH selectors.
+ *
+ * The custom-render slots are typed away here (`never`) on purpose: this
+ * arrangement puts the two pickers on one line with the day's controls, and a
+ * consumer-supplied node in either slot is what would break that line — so it
+ * takes DATA instead and renders the pickers itself. Location becomes an
+ * `F0ButtonDropdown`, projects an `F0Select` whose groups are the subprojects.
+ */
+interface ClockInControlsHorizontalBarProps extends ClockInControlsBaseProps {
+  /**
+   * The Home-widget shape from the custom-home prototype: four full-width rows,
+   * each pinning its two halves to the tile's ends — status + running total on
+   * one line, the day as a horizontal bar, when it started and what is left of
+   * it, then the location and the controls. Fits a narrow rail, where the 160px
+   * ring does not.
+   */
+  variant: "horizontal-bar"
+  /** Not available in this variant — pass `locations` and let it render them. */
+  locationSelectorElement?: never
+  /** Not available in this variant — pass `projects` and let it render them. */
+  projectSelectorElement?: never
+  /** The projects to offer, each optionally with its own subprojects. */
+  projects?: ClockInProject[]
+  /** The selected project — or subproject, since selection is always a leaf. */
+  projectId?: string
+  onChangeProjectId?: Dispatch<string>
+  projectSelectorDisabled?: boolean
+  /**
+   * Whether a project must be chosen to clock in. When it isn't, the picker
+   * offers a clear affordance and reports the empty string once cleared.
+   * Defaults to `true` — the stricter reading, and the behaviour before there
+   * was any way to clear.
+   */
+  projectRequired?: boolean
+  /** The same for the location. Defaults to `true`. */
+  locationRequired?: boolean
+}
+
+export type ClockInControlsProps =
+  | ClockInControlsDefaultProps
+  | ClockInControlsHorizontalBarProps
 
 export function ClockInControls({
   trackedMinutes,
@@ -97,7 +206,16 @@ export function ClockInControls({
   canShowProject = true,
   projectSelectorElement,
   locationSelectorElement,
+  projects,
+  projectId,
+  onChangeProjectId,
+  projectSelectorDisabled = false,
+  projectRequired = true,
+  locationRequired = true,
   breakTypeName,
+  onBreakPromote,
+  variant = "default",
+  loading = false,
 }: ClockInControlsProps) {
   const { status, statusText, subtitle, statusColor } = getInfo({
     data,
@@ -144,12 +262,15 @@ export function ClockInControls({
     !locationSelectorDisabled &&
     canShowLocation
 
-  // const canSelectProject =
-  //   showLocationAndProjectSelectors &&
-  //   !projectSelectorDisabled &&
-  //   canShowProject
+  const canSelectProject =
+    showLocationAndProjectSelectors &&
+    !projectSelectorDisabled &&
+    canShowProject
 
-  const location = locations.find((location) => location.id === locationId)
+  // Tree-aware: with `sublocations` the selected id names a LEAF, which
+  // `locations.find` would miss. Both variants need the selected location to
+  // display, even the flat one that can't offer the drill-in.
+  const location = findLeaf(toLocationTree(locations), locationId)
 
   const locationOptions = locations.map((location) => ({
     value: location.id,
@@ -183,6 +304,303 @@ export function ClockInControls({
   ) : location ? (
     <F0TagRaw text={location.name} icon={location.icon} />
   ) : null
+
+  /**
+   * The `horizontal-bar` variant's location control — the SAME select whether or
+   * not it can be changed, disabled once the day is open rather than swapped for
+   * a read-only tag. A control that turns into a tag moves the line it sits on
+   * and makes the tile re-flow mid-day; disabled, it stays exactly where it was
+   * and still says what was picked.
+   */
+  const barLocationControl = locations.length ? (
+    <LocationSelector
+      locations={locations}
+      locationId={locationId}
+      onChangeLocationId={onChangeLocationId}
+      label={labels.selectLocation}
+      searchPlaceholder={labels.searchLocation}
+      required={locationRequired}
+      disabled={!canSelectLocation}
+    />
+  ) : null
+
+  /** The same deal for projects, as an `F0Select` grouped by parent project. */
+  const barProjectControl =
+    projects?.length && canShowProject ? (
+      <ProjectSelector
+        projects={projects}
+        projectId={projectId}
+        onChangeProjectId={onChangeProjectId}
+        label={labels.selectProject}
+        searchPlaceholder={labels.searchProject}
+        required={projectRequired}
+        disabled={!canSelectProject}
+      />
+    ) : null
+
+  /**
+   * Which action leads while you're on a break.
+   *
+   * Left to itself it follows the DAY: past your hours, the useful thing is to
+   * end them, so clocking out leads; inside them, you are coming back, so resume
+   * does. A consumer that knows better — a policy that always wants one of them
+   * forward — says so with `onBreakPromote`.
+   */
+  const promotedOnBreak =
+    onBreakPromote ?? ((remainingMinutes ?? 0) < 0 ? "clock-out" : "resume")
+
+  // The controls, once for both variants: the state machine, the break-type
+  // picker and the buttons' own hierarchy belong to the component, not to a
+  // layout, so a variant re-places them rather than redefining them.
+  const controls = (
+    <>
+      {status === "clocked-out" && (
+        // The nudge off the right edge is the DEFAULT layout's: it balances the
+        // lone button against the ring beside it. The bar variant pins its
+        // controls to the tile's edge, where that margin would be a gap.
+        <div className={variant === "default" ? "mr-3 @xs:mr-0" : undefined}>
+          <F0Button
+            onClick={onClockIn}
+            label={labels.clockIn}
+            icon={SolidPlay}
+          />
+        </div>
+      )}
+
+      {status === "clocked-in" && (
+        <>
+          {canShowBreakButton && (
+            <>
+              {breakTypeOptions.length > 1 && onChangeBreakTypeId ? (
+                <F0Select
+                  label={labels.break}
+                  hideLabel
+                  value=""
+                  options={breakTypeOptions}
+                  onChange={handleChangeBreakType}
+                  open={breakTypePickerOpen}
+                  onOpenChange={setBreakTypePickerOpen}
+                >
+                  <div aria-label="Select break type">
+                    <F0Button
+                      label={labels.break}
+                      variant="outline"
+                      icon={SolidPause}
+                      hideLabel
+                    />
+                  </div>
+                </F0Select>
+              ) : (
+                <F0Button
+                  onClick={handleClickBreakButton}
+                  label={labels.break}
+                  variant="outline"
+                  icon={SolidPause}
+                  hideLabel
+                />
+              )}
+            </>
+          )}
+          <F0Button
+            onClick={onClockOut}
+            label={labels.clockOut}
+            variant="outline"
+            icon={SolidStop}
+          />
+        </>
+      )}
+      {status === "break" &&
+        // The PROMOTED action is the primary button, labelled; the other is an
+        // icon-only outline beside it. Which one is promoted depends on where the
+        // day stands — see `promotedOnBreak`.
+        (promotedOnBreak === "clock-out" ? (
+          <>
+            <F0Button
+              onClick={onClockIn}
+              label={labels.resume}
+              variant="outline"
+              icon={SolidPlay}
+              hideLabel
+            />
+            <F0Button
+              onClick={onClockOut}
+              label={labels.clockOut}
+              icon={SolidStop}
+            />
+          </>
+        ) : (
+          <>
+            <F0Button
+              onClick={onClockOut}
+              label={labels.clockOut}
+              variant="outline"
+              icon={SolidStop}
+              hideLabel
+            />
+            <F0Button
+              onClick={onClockIn}
+              label={labels.resume}
+              icon={SolidPlay}
+            />
+          </>
+        ))}
+    </>
+  )
+
+  // Where you are and what you are on. The two selectors are the variants' one
+  // real difference in substance: `default` will take the consumer's own nodes,
+  // `horizontal-bar` renders its own from data (see the props union). The break
+  // tag is the same in both.
+  const locationControl =
+    variant === "horizontal-bar"
+      ? barLocationControl
+      : (locationSelectorElement ?? builtInLocationControl)
+
+  const projectControl =
+    variant === "horizontal-bar" ? barProjectControl : projectSelectorElement
+
+  const breakTag =
+    canShowBreakTypeName && breakTypeName ? (
+      <F0TagRaw text={breakTypeName} />
+    ) : null
+
+  const contextTags = (
+    <>
+      {canShowLocation && locationControl}
+      {canShowProject && projectControl}
+      {breakTag}
+    </>
+  )
+
+  // What the `horizontal-bar` footer has to place. Both pickers are FIELDS, and a
+  // field is `w-full` by nature: give either one a content-width slot and it
+  // pushes the line past the tile instead of fitting in it. So they share what
+  // the line has — `flex-1` each, `min-w-0` so a long project name truncates
+  // rather than widening its box.
+  const showLocation = canShowLocation && !!locationControl
+  const showProject = canShowProject && !!projectControl
+  const locationSlot = showLocation ? (
+    <div className="flex min-w-0 flex-1 flex-row">{locationControl}</div>
+  ) : null
+  const projectSlot = showProject ? (
+    <div className="min-w-0 flex-1">{projectControl}</div>
+  ) : null
+
+  // WHICH PICKER SHARES THE ACTIONS' LINE. One picker always does — that line is
+  // the prototype's own, and a lone picker on a line of its own would leave the
+  // buttons stranded under an empty half. With two, the PROJECT takes the line
+  // above (its names are the long ones, so it gets the full width) and the
+  // location keeps the buttons company.
+  const bothPickers = showLocation && showProject
+  const pickerAboveActions = bothPickers ? projectSlot : null
+  const pickerBesideActions = bothPickers
+    ? locationSlot
+    : (locationSlot ?? projectSlot)
+
+  if (loading) {
+    return (
+      <ClockInControlsSkeleton
+        variant={variant}
+        canSeeGraph={canSeeGraph}
+        canShowLocation={canShowLocation}
+        // Not `canShowProject` alone: that only says a project picker is ALLOWED.
+        // The placeholder should hold a line for one that is actually coming.
+        canShowProject={
+          canShowProject && !!(projects?.length ?? projectControl)
+        }
+      />
+    )
+  }
+
+  if (variant === "horizontal-bar") {
+    // The same numbers the ring puts inside itself — its own formatter, so the
+    // two variants can't disagree about the day: the running total, and when it
+    // started (or `--:--` before it does).
+    const { primaryLabel, time } = getLabels({
+      data,
+      trackedMinutes,
+      remainingMinutes: canSeeRemainingTime ? remainingMinutes : 0,
+    })
+
+    return (
+      <div className="flex flex-col gap-2">
+        {/* The state and the running total, one line, ONE type size: they are
+            two halves of one fact ("clocked out, nothing tracked yet"), so
+            neither is made subordinate to the other. No status dot here — the
+            bar below is coloured by that same state, and the total has the
+            place the dot holds in the default variant. */}
+        <div className="flex flex-row items-end justify-between gap-2">
+          <div className="flex min-w-0 flex-row items-baseline gap-1.5">
+            {/* `shrink-0`: the STATE is the headline and must read in full — left
+                shrinkable it lost to a long break name and became "On a…". */}
+            <span className="line-clamp-1 shrink-0 text-xl font-semibold text-f1-foreground">
+              {statusText}
+            </span>
+            {/* WHICH break, next to the fact that you're on one — it belongs to
+                the status, not to the controls. Break names are consumer copy and
+                can run long ("Lunch break — canteen, second shift"), so it
+                truncates; `OneEllipsis` mounts a tooltip only when it actually
+                clips, and the status keeps the room it needs first. */}
+            {canShowBreakTypeName && breakTypeName && (
+              <>
+                <span
+                  aria-hidden
+                  className="shrink-0 text-f1-foreground-secondary"
+                >
+                  ·
+                </span>
+                <OneEllipsis
+                  tag="span"
+                  className="min-w-0 flex-1 text-f1-foreground-secondary"
+                >
+                  {breakTypeName}
+                </OneEllipsis>
+              </>
+            )}
+          </div>
+          <span className="shrink-0 text-xl font-semibold tabular-nums text-f1-foreground">
+            {time}
+          </span>
+        </div>
+        {/* The same graph the default variant draws, in its rail geometry — so
+            the day is normalized and coloured in exactly one place. */}
+        {canSeeGraph && (
+          <ClockInGraph
+            variant="horizontal-bar"
+            data={data}
+            trackedMinutes={trackedMinutes}
+            remainingMinutes={canSeeRemainingTime ? remainingMinutes : 0}
+          />
+        )}
+        {/* The bar's two ends, labelled: when the day started, and what is left
+            of it — the same remaining/overtime string the default variant puts
+            under its status, so no new label is needed to translate. */}
+        <div className="flex flex-row items-center justify-between gap-2 text-f1-foreground-secondary">
+          <span className="tabular-nums">{primaryLabel}</span>
+          {subtitle && (
+            <span className="line-clamp-1 tabular-nums">{subtitle}</span>
+          )}
+        </div>
+        {/* THE FOOTER SPENDS LINES ON WHAT IS THERE: a picker on the actions'
+            line, and a second one — the project — on a line above it. Two pickers
+            plus the day's buttons on ONE line either wrapped unevenly or squeezed
+            a name down to an ellipsis in a 396px rail. */}
+        <div className="flex flex-col gap-2 pt-1">
+          {pickerAboveActions}
+          <div className="flex w-full flex-row items-center gap-2">
+            {/* No break tag down here: in this variant it reads beside the status
+                line above, where "on a break" is stated. */}
+            {pickerBesideActions}
+            {/* `ml-auto`: with no picker on this line the buttons still sit at the
+                far end, where the prototype has them. */}
+            <div className="ml-auto flex shrink-0 flex-row items-center gap-2">
+              {controls}
+            </div>
+          </div>
+        </div>
+      </div>
+    )
+  }
 
   return (
     <div className="@container">
@@ -224,74 +642,7 @@ export function ClockInControls({
             </div>
 
             <div className="flex justify-center gap-2 @xs:justify-start">
-              {status === "clocked-out" && (
-                <div className="mr-3 @xs:mr-0">
-                  <F0Button
-                    onClick={onClockIn}
-                    label={labels.clockIn}
-                    icon={SolidPlay}
-                  />
-                </div>
-              )}
-
-              {status === "clocked-in" && (
-                <>
-                  {canShowBreakButton && (
-                    <>
-                      {breakTypeOptions.length > 1 && onChangeBreakTypeId ? (
-                        <F0Select
-                          label={labels.break}
-                          hideLabel
-                          value=""
-                          options={breakTypeOptions}
-                          onChange={handleChangeBreakType}
-                          open={breakTypePickerOpen}
-                          onOpenChange={setBreakTypePickerOpen}
-                        >
-                          <div aria-label="Select break type">
-                            <F0Button
-                              label={labels.break}
-                              variant="neutral"
-                              icon={SolidPause}
-                              hideLabel
-                            />
-                          </div>
-                        </F0Select>
-                      ) : (
-                        <F0Button
-                          onClick={handleClickBreakButton}
-                          label={labels.break}
-                          variant="neutral"
-                          icon={SolidPause}
-                          hideLabel
-                        />
-                      )}
-                    </>
-                  )}
-                  <F0Button
-                    onClick={onClockOut}
-                    label={labels.clockOut}
-                    variant="neutral"
-                    icon={SolidStop}
-                  />
-                </>
-              )}
-              {status === "break" && (
-                <>
-                  <F0Button
-                    onClick={onClockOut}
-                    label={labels.clockOut}
-                    variant="neutral"
-                    icon={SolidStop}
-                    hideLabel
-                  />
-                  <F0Button
-                    onClick={onClockIn}
-                    label={labels.resume}
-                    icon={SolidPlay}
-                  />
-                </>
-              )}
+              {controls}
             </div>
           </div>
           {canSeeGraph && (
@@ -303,12 +654,7 @@ export function ClockInControls({
           )}
         </div>
         <div className="mt-6 flex flex-row flex-wrap items-center justify-center gap-2 @xs:justify-start">
-          {canShowLocation &&
-            (locationSelectorElement ?? builtInLocationControl)}
-          {canShowProject && projectSelectorElement}
-          {canShowBreakTypeName && breakTypeName && (
-            <F0TagRaw text={breakTypeName} />
-          )}
+          {contextTags}
         </div>
       </div>
     </div>

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
@@ -6,6 +6,7 @@ import { F0Select } from "@/components/F0Select"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { SolidPause, SolidPlay, SolidStop } from "@/icons/app"
 import { OneEllipsis } from "@/lib/OneEllipsis"
+import { cn } from "@/lib/utils"
 
 import { ClockInGraph, ClockInGraphProps } from "../ClockInGraph"
 import { getLabels } from "../ClockInGraph/helpers"
@@ -35,6 +36,27 @@ interface BreakType {
  * state machine and use the same controls — only their arrangement differs.
  */
 export type ClockInControlsVariant = "default" | "horizontal-bar"
+
+/**
+ * Drops a picker's field FILL so whatever the tile sits on shows through; its
+ * border still draws the field.
+ *
+ * This tile lives on a Home widget card, and that card is TRANSLUCENT
+ * (`bg-f1-background-inverse-secondary`, 5% white over the page in dark, 60% in
+ * light) while an F0 field paints an opaque `bg-f1-background` — the page's own
+ * colour. Two opaque fields on a see-through card read as darker (or whiter)
+ * rectangles than the card itself, which is why this widget looked like it had a
+ * different background from its neighbours. Nothing else in the rail puts an
+ * opaque surface inside a card.
+ *
+ * AD HOC on purpose, and it shows: it hooks the field wrapper by `data-testid`,
+ * because `F0Select`'s `className` goes to the dropdown rather than the trigger,
+ * so there is no honest handle for this yet. The general fix is a surface-only
+ * variant on `F0InputField` (bordered, no fill) exposed through `F0Select`, which
+ * every field-inside-a-widget would want — a Foundations change, not this PR's.
+ */
+const FIELD_WITHOUT_FILL =
+  "[&_[data-testid=input-field-wrapper]]:bg-transparent"
 
 /** Everything both variants take, on the same terms. */
 interface ClockInControlsBaseProps {
@@ -479,11 +501,24 @@ export function ClockInControls({
   // rather than widening its box.
   const showLocation = canShowLocation && !!locationControl
   const showProject = canShowProject && !!projectControl
+  // The fill is dropped only while a picker is live: once the day is open they
+  // are disabled, and that greyed fill is the only cue saying so.
   const locationSlot = showLocation ? (
-    <div className="flex min-w-0 flex-1 flex-row">{locationControl}</div>
+    <div
+      className={cn(
+        "flex min-w-0 flex-1 flex-row",
+        canSelectLocation && FIELD_WITHOUT_FILL
+      )}
+    >
+      {locationControl}
+    </div>
   ) : null
   const projectSlot = showProject ? (
-    <div className="min-w-0 flex-1">{projectControl}</div>
+    <div
+      className={cn("min-w-0 flex-1", canSelectProject && FIELD_WITHOUT_FILL)}
+    >
+      {projectControl}
+    </div>
   ) : null
 
   // WHICH PICKER SHARES THE ACTIONS' LINE. One picker always does — that line is

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { screen, zeroRender as render } from "@/testing/test-utils"
 
-import { HorizontalBar } from "./HorizontalBar"
+import { HorizontalBar, segmentTooltip } from "./HorizontalBar"
 
 /**
  * The tooltip, STUBBED — its real content sits behind Radix's open timer and a
@@ -47,11 +47,22 @@ describe("HorizontalBar", () => {
 
     const tooltips = screen.getAllByTestId("segment-tooltip")
     expect(tooltips.map((t) => t.getAttribute("data-label"))).toEqual([
-      // The range alone is the minimum, and needs nothing from the consumer…
-      "09:02 – 12:00",
+      // Range and duration are the minimum, and need nothing from the consumer…
+      "09:02 – 12:00 (2h 58min)",
       // …with `label` appended after a bullet.
-      "12:00 – 12:34 • Lunch break",
+      "12:00 – 12:34 (34min) • Lunch break",
     ])
+  })
+
+  it("says a duration the way people do", () => {
+    const durationOf = (from: string, to: string) =>
+      segmentTooltip({ value: 1, color: "green", from: at(from), to: at(to) })
+
+    // Under an hour: minutes alone.
+    expect(durationOf("12:00", "12:32")).toContain("(32min)")
+    // Over: hours first, and no zero minutes to read past on the hour.
+    expect(durationOf("09:00", "11:34")).toContain("(2h 34min)")
+    expect(durationOf("09:00", "11:00")).toContain("(2h)")
   })
 
   it("wraps nothing when there is no day yet, and hides the empty rail", () => {

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
@@ -13,12 +13,18 @@ import { HorizontalBar, segmentTooltip } from "./HorizontalBar"
 vi.mock("@/experimental/Overlays/Tooltip", () => ({
   TooltipInternal: ({
     label,
+    instant,
     children,
   }: {
     label?: string
+    instant?: boolean
     children: React.ReactNode
   }) => (
-    <div data-testid="segment-tooltip" data-label={label}>
+    <div
+      data-testid="segment-tooltip"
+      data-label={label}
+      data-instant={String(!!instant)}
+    >
       {children}
     </div>
   ),
@@ -52,6 +58,25 @@ describe("HorizontalBar", () => {
       // …with `label` appended after a bullet.
       "12:00 – 12:34 (34min) • Lunch break",
     ])
+  })
+
+  it("asks for a tooltip that can't take the pointer, so hovering can't loop", () => {
+    render(
+      <HorizontalBar
+        segments={[
+          { value: 1, color: "green", from: at("09:00"), to: at("12:00") },
+        ]}
+      />
+    )
+
+    // `instant` gives the content `pointer-events-none` and turns off hoverable
+    // content. Without it the tooltip lands inside the segment's hit area, covers
+    // the cursor, and the trigger's own pointer-leave closes it — then it reopens,
+    // and flickers for as long as you hover.
+    expect(screen.getByTestId("segment-tooltip")).toHaveAttribute(
+      "data-instant",
+      "true"
+    )
   })
 
   it("says a duration the way people do", () => {

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
@@ -24,36 +24,43 @@ vi.mock("@/experimental/Overlays/Tooltip", () => ({
   ),
 }))
 
+const at = (time: string) => new Date(`2024-03-20T${time}:00`)
+
 describe("HorizontalBar", () => {
-  it("hands each labelled segment's own label to its tooltip", () => {
+  it("tooltips every stretch of the day with its time range, label or no label", () => {
     render(
       <HorizontalBar
         segments={[
-          { value: 0.5, color: "green", label: "Morning · Design system" },
-          { value: 0.2, color: "orange", label: "Lunch break" },
+          { value: 0.5, color: "green", from: at("09:02"), to: at("12:00") },
+          {
+            value: 0.2,
+            color: "orange",
+            from: at("12:00"),
+            to: at("12:34"),
+            label: "Lunch break",
+          },
+          // The neutral remainder: the rest of the day, not a stretch of it.
           { value: 0.3, color: "grey" },
         ]}
       />
     )
 
     const tooltips = screen.getAllByTestId("segment-tooltip")
-    // Only the two labelled segments are wrapped; the remainder is just a bar.
     expect(tooltips.map((t) => t.getAttribute("data-label"))).toEqual([
-      "Morning · Design system",
-      "Lunch break",
+      // The range alone is the minimum, and needs nothing from the consumer…
+      "09:02 – 12:00",
+      // …with `label` appended after a bullet.
+      "12:00 – 12:34 • Lunch break",
     ])
   })
 
-  it("wraps nothing when no segment carries a label", () => {
-    render(
-      <HorizontalBar
-        segments={[
-          { value: 0.5, color: "green" },
-          { value: 0.5, color: "grey" },
-        ]}
-      />
+  it("wraps nothing when there is no day yet, and hides the empty rail", () => {
+    const { container } = render(
+      <HorizontalBar segments={[{ value: 1, color: "grey" }]} />
     )
 
     expect(screen.queryByTestId("segment-tooltip")).not.toBeInTheDocument()
+    // Nothing to announce: the totals are already text in the rows around it.
+    expect(container.firstElementChild).toHaveAttribute("aria-hidden")
   })
 })

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.spec.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, zeroRender as render } from "@/testing/test-utils"
+
+import { HorizontalBar } from "./HorizontalBar"
+
+/**
+ * The tooltip, STUBBED — its real content sits behind Radix's open timer and a
+ * portal, which neither jsdom nor the in-app browser will open. The WIRING is
+ * covered in `index.spec.tsx` (the segment is a labelled image); what is worth
+ * pinning here is what the tooltip is handed.
+ */
+vi.mock("@/experimental/Overlays/Tooltip", () => ({
+  TooltipInternal: ({
+    label,
+    children,
+  }: {
+    label?: string
+    children: React.ReactNode
+  }) => (
+    <div data-testid="segment-tooltip" data-label={label}>
+      {children}
+    </div>
+  ),
+}))
+
+describe("HorizontalBar", () => {
+  it("hands each labelled segment's own label to its tooltip", () => {
+    render(
+      <HorizontalBar
+        segments={[
+          { value: 0.5, color: "green", label: "Morning · Design system" },
+          { value: 0.2, color: "orange", label: "Lunch break" },
+          { value: 0.3, color: "grey" },
+        ]}
+      />
+    )
+
+    const tooltips = screen.getAllByTestId("segment-tooltip")
+    // Only the two labelled segments are wrapped; the remainder is just a bar.
+    expect(tooltips.map((t) => t.getAttribute("data-label"))).toEqual([
+      "Morning · Design system",
+      "Lunch break",
+    ])
+  })
+
+  it("wraps nothing when no segment carries a label", () => {
+    render(
+      <HorizontalBar
+        segments={[
+          { value: 0.5, color: "green" },
+          { value: 0.5, color: "grey" },
+        ]}
+      />
+    )
+
+    expect(screen.queryByTestId("segment-tooltip")).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
@@ -129,9 +129,22 @@ export function HorizontalBar({ segments }: { segments: ClockInSegment[] }) {
         )
 
         return tooltip ? (
-          // Quicker than the default: a 6px rail is a deliberate hover, and a
-          // 700ms wait on a target that thin reads as nothing happening.
-          <TooltipInternal key={index} label={tooltip} delay={200}>
+          /**
+           * `instant` is what stops the tooltip FLICKERING here, and only
+           * secondarily what makes it quick.
+           *
+           * The content sits 4px off the segment — inside the 8px hit area above
+           * it — so it lands under the pointer. Hoverable content then fights the
+           * trigger's own `onPointerLeave`: the tooltip covers the cursor, the
+           * trigger reports a leave and closes, the cursor is over the segment
+           * again, and it reopens, forever. `instant` gives the content
+           * `pointer-events-none` and disables hoverable content, so it can
+           * overlap without ever taking the pointer.
+           *
+           * Its 100ms delay is a bonus: a 6px rail is a deliberate hover, and the
+           * default 700ms wait on a target that thin reads as nothing happening.
+           */
+          <TooltipInternal key={index} label={tooltip} instant>
             {bar}
           </TooltipInternal>
         ) : (

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
@@ -1,15 +1,41 @@
 import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
+import { formatTime24Hours } from "@/lib/date"
 import { cn } from "@/lib/utils"
+
+/** What separates the parts of a segment's tooltip. */
+const DETAIL_SEPARATOR = " • "
 
 /** One stretch of the day, ready to draw: its share, its colour, what it was. */
 export type ClockInSegment = {
   value: number
   color: string
   /**
+   * When this stretch ran. Present on every segment cut from a clock-in entry,
+   * absent on the neutral remainder — which is the rest of the day, not a stretch
+   * of it, and so has nothing to say on hover.
+   */
+  from?: Date
+  to?: Date
+  /**
    * The entry's own `label`, when it carried one — which break this was, which
-   * task. Carried through `normalizeData` so a geometry can surface it.
+   * task. Appended to the time range rather than replacing it.
    */
   label?: string
+}
+
+/**
+ * A segment's hover text: its TIME RANGE always, and whatever the entry added
+ * after it.
+ *
+ * The range is the minimum worth saying about a stretch of the day and it needs
+ * nothing from the consumer, so every real segment gets a tooltip — `label` only
+ * adds to it.
+ */
+export const segmentTooltip = (segment: ClockInSegment): string | undefined => {
+  if (!segment.from || !segment.to) return undefined
+
+  const range = `${formatTime24Hours(segment.from)} – ${formatTime24Hours(segment.to)}`
+  return [range, segment.label].filter(Boolean).join(DETAIL_SEPARATOR)
 }
 
 /**
@@ -26,22 +52,24 @@ export type ClockInSegment = {
  * total in, so in this geometry the numbers belong to the layout around it (see
  * `ClockInControls`' own `horizontal-bar` variant).
  *
- * A segment that carries a `label` becomes hoverable and says what it was — the
- * only place a PAST stretch of the day is named ("Lunch break", once you're back
- * at work). Those segments are in the accessibility tree as labelled images, and
- * the rail as a whole is `aria-hidden` only while none of them is: with no labels
- * every number it encodes is already text in the rows around it, so announcing it
- * would just repeat them.
+ * Every stretch of the day is HOVERABLE and says when it ran — the only place a
+ * past stretch is accounted for once you've moved on from it — plus whatever its
+ * entry labelled it. Those segments are in the accessibility tree as labelled
+ * images; the rail as a whole is `aria-hidden` only when nothing in it has
+ * anything to say (an empty day), since the totals it encodes are already text in
+ * the rows around it.
  */
 export function HorizontalBar({ segments }: { segments: ClockInSegment[] }) {
-  const hasLabels = segments.some((segment) => !!segment.label)
+  const tooltips = segments.map(segmentTooltip)
 
   return (
     <div
-      aria-hidden={hasLabels ? undefined : true}
+      aria-hidden={tooltips.some(Boolean) ? undefined : true}
       className="flex h-1.5 w-full flex-row items-stretch gap-0.5"
     >
       {segments.map((segment, index) => {
+        const tooltip = tooltips[index]
+
         // The segments are a positional series with no identity of their own —
         // `normalizeData` returns shares and colours, not the entries. The bar
         // itself stays the flex item either way: `TooltipInternal` renders its
@@ -60,7 +88,7 @@ export function HorizontalBar({ segments }: { segments: ClockInSegment[] }) {
               // Both are free of layout: a pseudo-element hit-tests as its host,
               // and `scaleY` doesn't touch the row's height — the tile's
               // placeholder is measured against that.
-              segment.label &&
+              tooltip &&
                 "relative origin-center after:absolute after:-inset-x-px after:-inset-y-2 after:content-[''] motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:hover:scale-y-150"
             )}
             style={{
@@ -69,15 +97,15 @@ export function HorizontalBar({ segments }: { segments: ClockInSegment[] }) {
               flex: `${segment.value} 1 0%`,
               backgroundColor: segment.color,
             }}
-            role={segment.label ? "img" : undefined}
-            aria-label={segment.label}
+            role={tooltip ? "img" : undefined}
+            aria-label={tooltip}
           />
         )
 
-        return segment.label ? (
+        return tooltip ? (
           // Quicker than the default: a 6px rail is a deliberate hover, and a
           // 700ms wait on a target that thin reads as nothing happening.
-          <TooltipInternal key={index} label={segment.label} delay={200}>
+          <TooltipInternal key={index} label={tooltip} delay={200}>
             {bar}
           </TooltipInternal>
         ) : (

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
@@ -24,17 +24,38 @@ export type ClockInSegment = {
 }
 
 /**
- * A segment's hover text: its TIME RANGE always, and whatever the entry added
- * after it.
+ * How long a stretch lasted, read the way people say it: "2h 34min", "32min",
+ * "2h" on the hour — hours only once there is one, and no zero minutes to read
+ * past.
  *
- * The range is the minimum worth saying about a stretch of the day and it needs
- * nothing from the consumer, so every real segment gets a tooltip — `label` only
- * adds to it.
+ * The units are literals, like the 24-hour clock `formatTime24Hours` already
+ * imposes on this family. Both would need to move to `labels` together the day
+ * this has to speak another language.
+ */
+const formatDuration = (minutes: number): string => {
+  const hours = Math.floor(minutes / 60)
+  const rest = minutes % 60
+
+  if (!hours) return `${rest}min`
+  return rest ? `${hours}h ${rest}min` : `${hours}h`
+}
+
+/**
+ * A segment's hover text: WHEN it ran and HOW LONG it lasted, then whatever the
+ * entry added after that.
+ *
+ * The range and its duration are the minimum worth saying about a stretch of the
+ * day and they need nothing from the consumer, so every real segment gets a
+ * tooltip — `label` only adds to it.
  */
 export const segmentTooltip = (segment: ClockInSegment): string | undefined => {
   if (!segment.from || !segment.to) return undefined
 
-  const range = `${formatTime24Hours(segment.from)} – ${formatTime24Hours(segment.to)}`
+  const minutes = Math.round(
+    (segment.to.getTime() - segment.from.getTime()) / 60_000
+  )
+  const range = `${formatTime24Hours(segment.from)} – ${formatTime24Hours(segment.to)} (${formatDuration(minutes)})`
+
   return [range, segment.label].filter(Boolean).join(DETAIL_SEPARATOR)
 }
 
@@ -80,16 +101,21 @@ export function HorizontalBar({ segments }: { segments: ClockInSegment[] }) {
             className={cn(
               "min-w-0 rounded-full",
               // Only a segment with something to say behaves like a target: an
-              // INVISIBLE hit area, because a 6px rail is nothing to aim at
-              // (`::after` reaches 8px above and below — the gap the rail already
-              // has to its neighbouring rows, so it steals no hover from them —
-              // and 1px into each side gap, which is what makes a thin overtime
-              // tail hittable), and a subtle grow on hover so it reads as one.
-              // Both are free of layout: a pseudo-element hit-tests as its host,
-              // and `scaleY` doesn't touch the row's height — the tile's
-              // placeholder is measured against that.
+              // INVISIBLE hit area, because a 6px rail is nothing to aim at, and
+              // a subtle grow on hover so it reads as one.
+              //
+              // The area grows VERTICALLY only — 8px each way, into the gap the
+              // rail already has to its neighbouring rows, so it steals no hover
+              // from them and turns a 6px target into a 22px one. It deliberately
+              // does not reach sideways: 1px past the last segment was 1px of
+              // horizontal overflow on the whole tile, which is how a rail earns
+              // a stray scrollbar.
+              //
+              // Neither costs layout: a pseudo-element hit-tests as its host, and
+              // `scaleY` doesn't touch the row's height — the tile's placeholder
+              // is measured against that.
               tooltip &&
-                "relative origin-center after:absolute after:-inset-x-px after:-inset-y-2 after:content-[''] motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:hover:scale-y-150"
+                "relative origin-center after:absolute after:inset-x-0 after:-inset-y-2 after:content-[''] motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:hover:scale-y-150"
             )}
             style={{
               // `flex-basis: 0` so the share is decided by `value` alone rather

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/HorizontalBar.tsx
@@ -1,0 +1,89 @@
+import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
+import { cn } from "@/lib/utils"
+
+/** One stretch of the day, ready to draw: its share, its colour, what it was. */
+export type ClockInSegment = {
+  value: number
+  color: string
+  /**
+   * The entry's own `label`, when it carried one — which break this was, which
+   * task. Carried through `normalizeData` so a geometry can surface it.
+   */
+  label?: string
+}
+
+/**
+ * The day as a thin horizontal rail — `ClockInGraph`'s `horizontal-bar`
+ * geometry.
+ *
+ * It draws the SAME segments the ring does: `ClockInGraph` normalizes the day
+ * once and hands the result to whichever geometry is asked for, so the two can't
+ * disagree about the fill. Each segment takes its share of the WIDTH instead of
+ * the sweep, and the 2px gap between them is the ring's `paddingAngle` in the
+ * units a rail has.
+ *
+ * It draws NO text, unlike the ring: a 6px line has no hole to put the running
+ * total in, so in this geometry the numbers belong to the layout around it (see
+ * `ClockInControls`' own `horizontal-bar` variant).
+ *
+ * A segment that carries a `label` becomes hoverable and says what it was — the
+ * only place a PAST stretch of the day is named ("Lunch break", once you're back
+ * at work). Those segments are in the accessibility tree as labelled images, and
+ * the rail as a whole is `aria-hidden` only while none of them is: with no labels
+ * every number it encodes is already text in the rows around it, so announcing it
+ * would just repeat them.
+ */
+export function HorizontalBar({ segments }: { segments: ClockInSegment[] }) {
+  const hasLabels = segments.some((segment) => !!segment.label)
+
+  return (
+    <div
+      aria-hidden={hasLabels ? undefined : true}
+      className="flex h-1.5 w-full flex-row items-stretch gap-0.5"
+    >
+      {segments.map((segment, index) => {
+        // The segments are a positional series with no identity of their own —
+        // `normalizeData` returns shares and colours, not the entries. The bar
+        // itself stays the flex item either way: `TooltipInternal` renders its
+        // child directly (`asChild`), so wrapping adds no box to lay out.
+        const bar = (
+          <div
+            key={index}
+            className={cn(
+              "min-w-0 rounded-full",
+              // Only a segment with something to say behaves like a target: an
+              // INVISIBLE hit area, because a 6px rail is nothing to aim at
+              // (`::after` reaches 8px above and below — the gap the rail already
+              // has to its neighbouring rows, so it steals no hover from them —
+              // and 1px into each side gap, which is what makes a thin overtime
+              // tail hittable), and a subtle grow on hover so it reads as one.
+              // Both are free of layout: a pseudo-element hit-tests as its host,
+              // and `scaleY` doesn't touch the row's height — the tile's
+              // placeholder is measured against that.
+              segment.label &&
+                "relative origin-center after:absolute after:-inset-x-px after:-inset-y-2 after:content-[''] motion-safe:transition-transform motion-safe:duration-150 motion-safe:ease-out motion-safe:hover:scale-y-150"
+            )}
+            style={{
+              // `flex-basis: 0` so the share is decided by `value` alone rather
+              // than by the segment's (zero) content.
+              flex: `${segment.value} 1 0%`,
+              backgroundColor: segment.color,
+            }}
+            role={segment.label ? "img" : undefined}
+            aria-label={segment.label}
+          />
+        )
+
+        return segment.label ? (
+          // Quicker than the default: a 6px rail is a deliberate hover, and a
+          // 700ms wait on a target that thin reads as nothing happening.
+          <TooltipInternal key={index} label={segment.label} delay={200}>
+            {bar}
+          </TooltipInternal>
+        ) : (
+          bar
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.spec.ts
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.spec.ts
@@ -59,8 +59,14 @@ describe("ClockInGraph helpers", () => {
         {
           value: 0.75, // 90 minutes difference
           color: CLOCK_IN_COLORS["clocked-in"],
+          // A segment also carries WHEN its entry ran, which is what the
+          // horizontal bar answers a hover with.
+          from: new Date("2024-03-20T09:00:00"),
+          to: new Date("2024-03-20T10:30:00"),
+          label: undefined,
         },
         {
+          // The remainder is the rest of the day, not a stretch of it: no range.
           value: 0.25,
           color: CLOCK_IN_COLORS.empty,
         },

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.ts
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.ts
@@ -78,6 +78,11 @@ export const normalizeData = ({
 
         accumulatedOvertimeSeconds -= totalEntryOvertimeSeconds
 
+        // When and what this stretch was travels with every piece it is cut
+        // into: an overtime slice is still the same stretch of the day, so it
+        // answers a hover with the same range and label.
+        const context = { from: entry.from, to: entry.to, label: entry.label }
+
         if (entry.variant === "clocked-in" && overtimeOnly) {
           return [
             ...acc,
@@ -86,9 +91,7 @@ export const normalizeData = ({
                 totalEntryOvertimeSeconds / totalSecondsWithRemainingTime +
                 value,
               color: CLOCK_IN_COLORS.overtime,
-              // The entry's own context travels with every piece it is cut
-              // into: an overtime slice is still the same stretch of the day.
-              label: entry.label,
+              ...context,
             },
           ]
         }
@@ -98,12 +101,12 @@ export const normalizeData = ({
           {
             value: totalEntryOvertimeSeconds / totalSecondsWithRemainingTime,
             color: CLOCK_IN_COLORS.overtime,
-            label: entry.label,
+            ...context,
           },
           {
             value,
             color: CLOCK_IN_COLORS[entry.variant],
-            label: entry.label,
+            ...context,
           },
         ]
       }, [] as ClockInSegment[])

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.ts
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.ts
@@ -1,5 +1,6 @@
 import { formatTime24Hours } from "@/lib/date"
 import { getNormalizedRemainingMinutes } from "../ClockInControls/helpers"
+import type { ClockInSegment } from "./HorizontalBar"
 import { CLOCK_IN_COLORS, ClockInGraphProps } from "./index"
 
 const EMPTY_LABEL = "--:--"
@@ -62,49 +63,50 @@ export const normalizeData = ({
   let res = [
     ...dataCopy
       .reverse()
-      .reduce(
-        (acc, entry) => {
-          const totalEntrySeconds =
-            (entry.to.getTime() - entry.from.getTime()) / 1000
+      .reduce((acc, entry) => {
+        const totalEntrySeconds =
+          (entry.to.getTime() - entry.from.getTime()) / 1000
 
-          const totalEntryOvertimeSeconds =
-            entry.variant === "clocked-in"
-              ? Math.min(totalEntrySeconds, accumulatedOvertimeSeconds)
-              : 0
+        const totalEntryOvertimeSeconds =
+          entry.variant === "clocked-in"
+            ? Math.min(totalEntrySeconds, accumulatedOvertimeSeconds)
+            : 0
 
-          const finalEntrySeconds =
-            totalEntrySeconds - totalEntryOvertimeSeconds
+        const finalEntrySeconds = totalEntrySeconds - totalEntryOvertimeSeconds
 
-          const value = finalEntrySeconds / totalSecondsWithRemainingTime
+        const value = finalEntrySeconds / totalSecondsWithRemainingTime
 
-          accumulatedOvertimeSeconds -= totalEntryOvertimeSeconds
+        accumulatedOvertimeSeconds -= totalEntryOvertimeSeconds
 
-          if (entry.variant === "clocked-in" && overtimeOnly) {
-            return [
-              ...acc,
-              {
-                value:
-                  totalEntryOvertimeSeconds / totalSecondsWithRemainingTime +
-                  value,
-                color: CLOCK_IN_COLORS.overtime,
-              },
-            ]
-          }
-
+        if (entry.variant === "clocked-in" && overtimeOnly) {
           return [
             ...acc,
             {
-              value: totalEntryOvertimeSeconds / totalSecondsWithRemainingTime,
+              value:
+                totalEntryOvertimeSeconds / totalSecondsWithRemainingTime +
+                value,
               color: CLOCK_IN_COLORS.overtime,
-            },
-            {
-              value,
-              color: CLOCK_IN_COLORS[entry.variant],
+              // The entry's own context travels with every piece it is cut
+              // into: an overtime slice is still the same stretch of the day.
+              label: entry.label,
             },
           ]
-        },
-        [] as { value: number; color: string }[]
-      )
+        }
+
+        return [
+          ...acc,
+          {
+            value: totalEntryOvertimeSeconds / totalSecondsWithRemainingTime,
+            color: CLOCK_IN_COLORS.overtime,
+            label: entry.label,
+          },
+          {
+            value,
+            color: CLOCK_IN_COLORS[entry.variant],
+            label: entry.label,
+          },
+        ]
+      }, [] as ClockInSegment[])
       .reverse(),
     ...(leftEntry ? [leftEntry] : []),
   ]

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.spec.tsx
@@ -52,14 +52,17 @@ describe("ClockInGraph", () => {
       expect(container.textContent).toBe("")
     })
 
-    it("is hidden from assistive tech, since its numbers are text elsewhere", () => {
+    it("is hidden from assistive tech on an empty day, whose totals are text elsewhere", () => {
       const { container } = render(
         <ClockInGraph
           variant="horizontal-bar"
-          data={data}
-          trackedMinutes={60}
+          data={[]}
+          trackedMinutes={0}
+          remainingMinutes={8 * 60}
         />
       )
+      // Nothing has run, so the rail has nothing of its own to say. With entries
+      // it does — each one answers a hover with its time range.
       expect(container.firstElementChild).toHaveAttribute("aria-hidden")
     })
 
@@ -85,8 +88,11 @@ describe("ClockInGraph", () => {
         />
       )
 
-      // The labelled segment is in the a11y tree; the unlabelled ones aren't.
-      expect(screen.getByLabelText("Lunch break")).toBeInTheDocument()
+      // Every stretch carries its range; the labelled one appends to it.
+      expect(screen.getByLabelText("09:00 – 12:00")).toBeInTheDocument()
+      expect(
+        screen.getByLabelText("12:00 – 13:00 • Lunch break")
+      ).toBeInTheDocument()
       // And with something worth announcing, the rail is no longer hidden.
       expect(container.firstElementChild).not.toHaveAttribute("aria-hidden")
     })

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.spec.tsx
@@ -88,10 +88,10 @@ describe("ClockInGraph", () => {
         />
       )
 
-      // Every stretch carries its range; the labelled one appends to it.
-      expect(screen.getByLabelText("09:00 – 12:00")).toBeInTheDocument()
+      // Every stretch carries its range and duration; the labelled one appends.
+      expect(screen.getByLabelText("09:00 – 12:00 (3h)")).toBeInTheDocument()
       expect(
-        screen.getByLabelText("12:00 – 13:00 • Lunch break")
+        screen.getByLabelText("12:00 – 13:00 (1h) • Lunch break")
       ).toBeInTheDocument()
       // And with something worth announcing, the rail is no longer hidden.
       expect(container.firstElementChild).not.toHaveAttribute("aria-hidden")

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.spec.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
 
-import { ClockInGraph, ClockInGraphProps } from "./index"
+import { CLOCK_IN_COLORS, ClockInGraph, ClockInGraphProps } from "./index"
 
 describe("ClockInGraph", () => {
   it("renders with default props", () => {
@@ -20,5 +20,91 @@ describe("ClockInGraph", () => {
     const hours = 8
     render(<ClockInGraph data={data} trackedMinutes={hours * 60} />)
     expect(screen.getByText(`0${hours}:00`)).toBeInTheDocument()
+  })
+
+  describe("horizontal-bar variant", () => {
+    const data: ClockInGraphProps["data"] = [
+      {
+        from: new Date("2024-03-20T09:00:00"),
+        to: new Date("2024-03-20T12:00:00"),
+        variant: "clocked-in",
+      },
+      {
+        from: new Date("2024-03-20T12:00:00"),
+        to: new Date("2024-03-20T13:00:00"),
+        variant: "break",
+      },
+    ]
+
+    it("draws one segment per entry plus the remaining time, and no text", () => {
+      const { container } = render(
+        <ClockInGraph
+          variant="horizontal-bar"
+          data={data}
+          trackedMinutes={3 * 60}
+          remainingMinutes={5 * 60}
+        />
+      )
+
+      // Worked, break, and what is left of the day.
+      expect(container.firstElementChild?.children).toHaveLength(3)
+      // The rail carries no numbers of its own — the layout around it does.
+      expect(container.textContent).toBe("")
+    })
+
+    it("is hidden from assistive tech, since its numbers are text elsewhere", () => {
+      const { container } = render(
+        <ClockInGraph
+          variant="horizontal-bar"
+          data={data}
+          trackedMinutes={60}
+        />
+      )
+      expect(container.firstElementChild).toHaveAttribute("aria-hidden")
+    })
+
+    it("names a labelled stretch of the day, so a past break can be identified", () => {
+      const { container } = render(
+        <ClockInGraph
+          variant="horizontal-bar"
+          data={[
+            {
+              from: new Date("2024-03-20T09:00:00"),
+              to: new Date("2024-03-20T12:00:00"),
+              variant: "clocked-in",
+            },
+            {
+              from: new Date("2024-03-20T12:00:00"),
+              to: new Date("2024-03-20T13:00:00"),
+              variant: "break",
+              label: "Lunch break",
+            },
+          ]}
+          trackedMinutes={3 * 60}
+          remainingMinutes={5 * 60}
+        />
+      )
+
+      // The labelled segment is in the a11y tree; the unlabelled ones aren't.
+      expect(screen.getByLabelText("Lunch break")).toBeInTheDocument()
+      // And with something worth announcing, the rail is no longer hidden.
+      expect(container.firstElementChild).not.toHaveAttribute("aria-hidden")
+    })
+
+    it("fills with the empty colour when the day hasn't started", () => {
+      const { container } = render(
+        <ClockInGraph
+          variant="horizontal-bar"
+          data={[]}
+          trackedMinutes={0}
+          remainingMinutes={8 * 60}
+        />
+      )
+      const segments = container.firstElementChild?.children
+      expect(segments).toHaveLength(1)
+      expect(segments?.[0]).toHaveStyle({
+        backgroundColor: CLOCK_IN_COLORS.empty,
+      })
+    })
   })
 })

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.stories.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.stories.tsx
@@ -174,3 +174,40 @@ export const WithOvertime: Story = {
     ],
   },
 }
+
+/**
+ * `variant="horizontal-bar"` — the same day, the same segments and the same
+ * colours, laid along a full-width 6px rail instead of the dial's sweep. It
+ * carries no text: a line that thin has nowhere to put the running total, so in
+ * this variant the numbers belong to the layout around it — which is what
+ * `ClockInControls`' own `horizontal-bar` variant does with it.
+ */
+export const HorizontalBar: Story = {
+  args: {
+    ...WithAlternatingEntriesAndFinalClockedIn.args,
+    variant: "horizontal-bar",
+  },
+  render: (args) => (
+    <div className="w-[360px]">
+      <ClockInGraph {...args} />
+    </div>
+  ),
+}
+
+export const HorizontalBarEmpty: Story = {
+  ...HorizontalBar,
+  args: {
+    trackedMinutes: 0,
+    remainingMinutes: 8 * 60,
+    data: [],
+    variant: "horizontal-bar",
+  },
+}
+
+export const HorizontalBarWithOvertime: Story = {
+  ...HorizontalBar,
+  args: {
+    ...WithOvertime.args,
+    variant: "horizontal-bar",
+  },
+}

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.tsx
@@ -18,10 +18,13 @@ export interface ClockInGraphProps {
     to: Date
     variant: ClockInStatus
     /**
-     * What this stretch of the day WAS, beyond its state — which break, which
-     * task. The `horizontal-bar` geometry surfaces it on hover, which is the only
-     * place a past stretch gets named once you've moved on from it. The ring has
-     * nowhere to put it and ignores it.
+     * EXTRA context for this stretch of the day, beyond its state — which break,
+     * which task.
+     *
+     * The `horizontal-bar` geometry already tells you when a stretch ran when you
+     * hover it; this is appended to that range after a `•`, so pass only what the
+     * range doesn't already say. The ring has nowhere to put either and ignores
+     * them.
      */
     label?: string
   }[]

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.tsx
@@ -21,10 +21,10 @@ export interface ClockInGraphProps {
      * EXTRA context for this stretch of the day, beyond its state — which break,
      * which task.
      *
-     * The `horizontal-bar` geometry already tells you when a stretch ran when you
-     * hover it; this is appended to that range after a `•`, so pass only what the
-     * range doesn't already say. The ring has nowhere to put either and ignores
-     * them.
+     * The `horizontal-bar` geometry already tells you when a stretch ran and how
+     * long it lasted when you hover it; this is appended after a `•`, so pass only
+     * what that doesn't already say. The ring has nowhere to put either and
+     * ignores them.
      */
     label?: string
   }[]

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/index.tsx
@@ -1,8 +1,15 @@
 import { Cell, Pie, PieChart } from "recharts"
 
 import { getLabels, normalizeData } from "./helpers"
+import { HorizontalBar } from "./HorizontalBar"
 
 export type ClockInStatus = "clocked-in" | "break" | "clocked-out"
+
+/**
+ * The geometry the day is drawn in. Same segments, same colours, same
+ * `normalizeData` either way — only the shape differs.
+ */
+export type ClockInGraphVariant = "ring" | "horizontal-bar"
 
 export interface ClockInGraphProps {
   trackedMinutes?: number
@@ -10,8 +17,23 @@ export interface ClockInGraphProps {
     from: Date
     to: Date
     variant: ClockInStatus
+    /**
+     * What this stretch of the day WAS, beyond its state — which break, which
+     * task. The `horizontal-bar` geometry surfaces it on hover, which is the only
+     * place a past stretch gets named once you've moved on from it. The ring has
+     * nowhere to put it and ignores it.
+     */
+    label?: string
   }[]
   remainingMinutes?: number
+  /**
+   * - `ring` — the 160px dial, with the running total and the day's two ends
+   *   inside it.
+   * - `horizontal-bar` — the same day as a full-width 6px rail, and nothing
+   *   else: a line that thin has nowhere to put the numbers, so in this variant
+   *   the layout around it carries them (see `ClockInControls`).
+   */
+  variant?: ClockInGraphVariant
 }
 
 export const CLOCK_IN_COLORS = {
@@ -26,12 +48,17 @@ export function ClockInGraph({
   data = [],
   trackedMinutes = 0,
   remainingMinutes,
+  variant = "ring",
 }: ClockInGraphProps) {
   const normalizedData = normalizeData({
     data,
     trackedMinutes,
     remainingMinutes,
   })
+
+  if (variant === "horizontal-bar") {
+    return <HorizontalBar segments={normalizedData} />
+  }
 
   const { primaryLabel, secondaryLabel, time } = getLabels({
     data,

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -5,7 +5,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0OneIcon } from "@/kits/ai/F0OneIcon"
 import { F0Button } from "@/components/F0Button"
-import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
 import { F0Card } from "@/components/F0Card"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
@@ -20,15 +19,17 @@ import {
   ExternalLink,
   File,
   Globe,
+  Home as HomeIcon,
   PalmTree,
   Person,
   Receipt,
-  SolidPlay,
   Target,
 } from "@/icons/app"
 
-import { Skeleton } from "@/ui/skeleton"
-
+import {
+  ClockInControls,
+  type ClockInProject,
+} from "../ClockIn/ClockInControls"
 import { SlotWidget } from "../SlotWidget"
 import {
   homeSlot,
@@ -217,42 +218,136 @@ const mainColumnBlocks = () => [
 
 /* ================================ side rail ================================ */
 
+const CLOCK_IN_LABELS = {
+  clockedOut: "Clocked out",
+  clockedIn: "Clocked in",
+  onBreak: "On a break",
+  clockIn: "Clock in",
+  clockOut: "Clock out",
+  break: "Take a break",
+  resume: "Resume",
+  remainingTime: "Remaining time",
+  overtime: "Overtime",
+  selectLocation: "Select location",
+  selectProject: "Select project",
+  searchProject: "Search projects",
+  paid: "Paid",
+  unpaid: "Unpaid",
+}
+
+const CLOCK_IN_LOCATIONS = [
+  { id: "remote", name: "Remote", icon: HomeIcon },
+  { id: "office", name: "Office", icon: Building },
+]
+
 /**
- * The prototype's Clock in tile body, verbatim composition: state + running
- * total on one heading line, the day as a progress bar, started/left below it,
- * and the location selector + brand clock-in control on the last line. This is
- * the BESPOKE `clock-in` slot's renderer — the `Widget` frame + header come
- * from `SlotWidget`, like every other widget.
+ * A real-sized book of work: 10 projects, 50 selectable subprojects. Past the
+ * picker's 20-per-page window, so in the rail the project dropdown really pages
+ * as you scroll and its search box has something to narrow.
  */
-const ClockInBody = () => (
-  <div className="flex flex-col gap-2">
-    <div className="flex items-end justify-between">
-      <span className="text-xl font-semibold text-f1-foreground">
-        Clocked out
-      </span>
-      <span className="text-xl font-semibold tabular-nums text-f1-foreground">
-        0:00
-      </span>
-    </div>
-    <div className="h-1.5 rounded-full bg-f1-background-secondary" />
-    <div className="flex justify-between text-base text-f1-foreground-secondary">
-      <span>15:54</span>
-      <span>8h 00m left</span>
-    </div>
-    <div className="flex items-center justify-between pt-1">
-      <F0ButtonDropdown
-        mode="dropdown"
-        trigger="Remote"
-        items={[
-          { label: "Remote", value: "remote" },
-          { label: "Office", value: "office" },
-        ]}
-        onClick={() => {}}
-      />
-      <F0Button label="Clock in" icon={SolidPlay} onClick={() => {}} />
-    </div>
-  </div>
-)
+const CLOCK_IN_PROJECTS: ClockInProject[] = [
+  {
+    name: "Design system",
+    parts: ["Components", "Tokens", "Documentation", "Icons", "Audits"],
+  },
+  {
+    name: "Onboarding revamp",
+    parts: ["Research", "Flows", "Copy", "Analytics", "Rollout"],
+  },
+  {
+    name: "Payroll engine",
+    parts: [
+      "Calculations",
+      "Filings",
+      "Reconciliation",
+      "Reporting",
+      "Migrations",
+    ],
+  },
+  {
+    name: "Mobile app",
+    parts: ["iOS", "Android", "Release train", "Crash triage", "Notifications"],
+  },
+  {
+    name: "Recruitment",
+    parts: ["Job board", "Pipelines", "Scorecards", "Referrals", "Offers"],
+  },
+  {
+    name: "Data platform",
+    parts: [
+      "Ingestion",
+      "Warehouse",
+      "Dashboards",
+      "Governance",
+      "Experiments",
+    ],
+  },
+  {
+    name: "Billing",
+    parts: ["Invoicing", "Dunning", "Taxes", "Plans", "Refunds"],
+  },
+  {
+    name: "Customer support",
+    parts: ["Inbox", "Macros", "Escalations", "Knowledge base", "Reporting"],
+  },
+  {
+    name: "Security",
+    parts: [
+      "Access reviews",
+      "Pen tests",
+      "Incident drills",
+      "Compliance",
+      "Training",
+    ],
+  },
+  {
+    name: "Internal tooling",
+    parts: ["Admin", "Feature flags", "Runbooks", "Alerting", "Cost control"],
+  },
+].map(({ name, parts }) => ({
+  id: name.toLowerCase().replace(/ /g, "-"),
+  name,
+  subprojects: parts.map((part) => ({
+    id: `${name}-${part}`.toLowerCase().replace(/ /g, "-"),
+    name: part,
+  })),
+}))
+
+/**
+ * The rail's Clock in tile: F0's own `ClockInControls` in its `horizontal-bar`
+ * variant — state + running total on one heading line, the day as a horizontal
+ * bar, started/left below it, and the location selector + clock-in control on
+ * the last line. This is the BESPOKE `clock-in` slot's renderer; the `Widget`
+ * frame + header come from `SlotWidget`, like every other widget.
+ *
+ * ONE component covers both the content and the placeholder: `loading` draws the
+ * tile's own skeleton, shaped like this variant, so the slot's `skeleton` is
+ * this same render rather than a hand-built stand-in that has to be kept in
+ * step with it.
+ */
+const ClockInTile = ({ loading }: { loading?: boolean }) => {
+  const [locationId, setLocationId] = useState("remote")
+  const [projectId, setProjectId] = useState<string | undefined>()
+
+  return (
+    <ClockInControls
+      variant="horizontal-bar"
+      loading={loading}
+      labels={CLOCK_IN_LABELS}
+      data={[]}
+      trackedMinutes={0}
+      remainingMinutes={8 * 60}
+      locations={CLOCK_IN_LOCATIONS}
+      locationId={locationId}
+      onChangeLocationId={setLocationId}
+      projects={CLOCK_IN_PROJECTS}
+      projectId={projectId}
+      onChangeProjectId={setProjectId}
+      onClockIn={() => {}}
+      onClockOut={() => {}}
+    />
+  )
+}
 
 const COMMS = [
   {
@@ -425,37 +520,16 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
 ]
 
 /**
- * The `clock-in` tile's PLACEHOLDER: the same four lines the real tile has —
- * state + total, the day's bar, started/left, then the two controls.
- */
-const ClockInSkeleton = () => (
-  <div className="flex flex-col gap-2">
-    <div className="flex items-end justify-between">
-      <Skeleton className="h-6 w-28" />
-      <Skeleton className="h-6 w-12" />
-    </div>
-    <Skeleton className="h-1.5 rounded-full" />
-    <div className="flex justify-between">
-      <Skeleton className="h-5 w-12" />
-      <Skeleton className="h-5 w-20" />
-    </div>
-    <div className="flex items-center justify-between pt-1">
-      <Skeleton className="h-8 w-24 rounded-md" />
-      <Skeleton className="h-8 w-24 rounded-md" />
-    </div>
-  </div>
-)
-
-/**
  * The bespoke slot renderers this Home supplies — only `clock-in` here; every
  * other slot the rail and the feed use is a kit default. It declares its own
  * `skeleton` beside its `render`, so the tile has a placeholder shaped like
- * itself while the rail loads.
+ * itself while the rail loads — and both are the SAME component, told whether
+ * its data has landed (`ClockInControls`' `loading`).
  */
 const SLOT_RENDERERS: SlotRenderers = {
   "clock-in": {
-    render: () => <ClockInBody />,
-    skeleton: () => <ClockInSkeleton />,
+    render: () => <ClockInTile />,
+    skeleton: () => <ClockInTile loading />,
   },
 }
 
@@ -821,7 +895,8 @@ export const BannerAboveLayout: Story = {
  * How many placeholder items a slot draws is its own `expectedItemsCount`
  * (Communications expects 5 rows, Events 4), which is what keeps the loading
  * rail as tall as the loaded one. `clock-in` is bespoke, so its renderer brings
- * its own skeleton — see `SLOT_RENDERERS` above.
+ * its own skeleton — `ClockInControls` with `loading`, which draws a placeholder
+ * shaped like its `horizontal-bar` variant. See `SLOT_RENDERERS` above.
  *
  * The main column is freeform content rather than widgets, so it isn't part of
  * this: only what the layout renders as widgets has a loading state.

--- a/packages/react/src/ui/Action/Action.tsx
+++ b/packages/react/src/ui/Action/Action.tsx
@@ -162,8 +162,15 @@ export const Action = React.forwardRef<
     </button>
   )
 
-  const element = tooltip ? (
-    <TooltipInternal description={tooltip.toString()} delay={1000}>
+  const tooltipProps =
+    tooltip && typeof tooltip === "object"
+      ? tooltip
+      : tooltip
+        ? { description: tooltip.toString() }
+        : undefined
+
+  const element = tooltipProps ? (
+    <TooltipInternal {...tooltipProps} delay={1000}>
       {mainElement}
     </TooltipInternal>
   ) : (

--- a/packages/react/src/ui/Action/types.ts
+++ b/packages/react/src/ui/Action/types.ts
@@ -28,9 +28,11 @@ export type FontSize = (typeof fontSizes)[number]
 
 export interface ActionCommonProps {
   /**
-   * Tooltip
+   * Tooltip. A string is the description on its own; the object form adds a
+   * bold first line above it — for "which control this is" over "what it holds",
+   * the same two-line shape `F0Select`'s trigger tooltip uses.
    */
-  tooltip?: string | false
+  tooltip?: string | false | { label?: string; description: string }
   /**
    * The variant of the action.
    */


### PR DESCRIPTION
## Description

Adds an optional `variant="horizontal-bar"` to `ClockInControls`, rendering the clock-in tile as four full-width rows — status + running total, the day as a horizontal bar, its start and what is left of it, then the pickers and the day's controls — so it fits the 396px Home rail where the 160px ring cannot. It mirrors the custom-home prototype's Feed tile (`factorial-composer`, `home/custom-home/v2/ClockInWidget`), and the same component now backs the `clock-in` slot in the `NewHomeLayout` stories, replacing the hand-rolled mock that stood in for it.

## Screenshots (if applicable)

Storybook (`Domain specific/Home/ClockInControls`): `HorizontalBar`, `HorizontalBarWithManyProjects`, `HorizontalBarWithNestedLocations`, `HorizontalBarOnBreakInOvertime`, `HorizontalBarWithLongBreakTypeName`, `LoadingHorizontalBar`. The rail in context is `Domain specific/Home/NewHomeLayout` → `Default` / `Loading`.

## Implementation details

- feat: add `variant="horizontal-bar"` to `ClockInControls`, laying the day out as four rows and re-placing the existing controls rather than redefining them

  <details>
  <summary>Why the footer moves lines around</summary>

  Two pickers plus the day's buttons on one line either wrapped unevenly or squeezed a location's name to an ellipsis at rail width. So one picker shares the actions' line — the prototype's own last line — and a second one (the project, whose names are longest) takes the line above it.
  </details>

- feat: add `variant="ring" | "horizontal-bar"` to `ClockInGraph`, drawing the same normalized segments and colours as a 6px rail instead of a dial
- feat: tooltip every bar segment on hover with its TIME RANGE, computed from the entry — the only place a past stretch of the day is accounted for once you have moved on from it. An optional `label` per entry is appended to that range after a `•`, so it carries only what the range does not already say. Hoverable segments get an invisible `::after` hit area (a 6px rail is nothing to aim at) and a `motion-safe` `scaleY` grow so they read as targets
- feat: add a `loading` placeholder shaped like the chosen variant

  <details>
  <summary>Measured, not eyeballed</summary>

  The placeholder is 114px with one picker and 154px with two — row for row what the loaded tile measures, verified in the browser, so the rail does not shift when the day lands. It holds a line for a picker only when one is actually coming, not merely allowed.
  </details>

- feat: accept nested `sublocations` (location → workplace → work area) and nested `subprojects`, both through one shared `TreeSelector`: leaf-only selection, the ancestor chain as the group heading, the full path on the trigger, search matching every ancestor, and infinite-scroll paging
- feat: add `projectRequired` / `locationRequired` (default `true`); when off, the pickers offer a clear affordance and report `""`
- feat: add `onBreakPromote?: "resume" | "clock-out"` — unset, it follows the day: clock-out once in overtime, resume while hours remain. Non-primary controls are now `outline`
- feat: show the break type beside the "on a break" copy, truncating with a tooltip only when it actually clips (`OneEllipsis`)
- feat(F0Select): add `selectedLabel` for a trigger-only display, and a trigger hover tooltip naming the selection — plus the field's label only when `hideLabel` hides it

  <details>
  <summary>Why a separate label</summary>

  Trigger and row share one `label` today, so a row that reads fine under a group heading ("Tokens") is ambiguous alone. `selectedLabel` lets the trigger carry the path while the row stays short.
  </details>

- feat(F0ButtonDropdown): derive the trigger's label and icon from `value` in `dropdown` mode, as split mode already does, and tooltip the control's name over its selection
- feat(ui/Action): accept `tooltip` as `{ label, description }` for the two-line shape
- refactor(F0Select): collapse single-select's two `clearable` union members into `clearable?: boolean`

  <details>
  <summary>Why</summary>

  `clearable?: false` and `clearable: true` were otherwise identical members, so a computed `clearable={!required}` matched neither and every such call site had to cast. Strictly more permissive; no runtime change.
  </details>

- fix(F0Select): keep the trigger's wrapper unconditional, so a select no longer contracts to its content width when cleared
- test: add 34 tests across the tree pickers, the promote rule, the clear affordances, segment labels, and the new F0Select/F0ButtonDropdown behaviour

### Notes for review

- The `default` variant is untouched: its flat built-in select and `locationSelectorElement` escape hatch behave exactly as before, and it ignores nesting (though it still *displays* a selected leaf).
- Radix popovers and tooltips do not open under jsdom or the in-app browser, so tooltip and dropdown *content* is asserted against a stubbed tooltip; the wiring is asserted on the real thing.
- Known rough edge, documented in `TreeSelector`: in a MIXED list, a top-level item with no children heads its own group and appears again as the single row under it. F0Select's grouping is mandatory-or-nothing, so there is no ungrouped tail to put it in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### Public API changes

One deliberate type change, called out because the API check flags it:

**`ClockInControlsProps` is now a union type instead of an interface.** That is what makes the two variants enforceable — `horizontal-bar` owns its pickers, so `locationSelectorElement` / `projectSelectorElement` are typed away there, and a `default`-only prop can no longer be passed to it by accident. Also `locations[].icon` is now optional, since nested levels inherit the icon above them.

Nothing that compiles today stops compiling. Verified against this branch:

| Pattern | Result |
|---|---|
| `ClockInControlsProps['data']` — what `factorial`'s dashboard widget actually uses | compiles |
| The app's full JSX props (default variant, `locationSelectorElement`) | compiles |
| `interface X extends ClockInControlsProps` | breaks — a union cannot be extended |
| Spreading `Partial<ClockInControlsProps>` into a `horizontal-bar` variant | breaks — which is the point of the union |

Nothing in `factorial` extends it, so no consumer change is needed. Not marked `feat!`: no valid call site breaks and the component ships from `experimental`.

An earlier revision also collapsed `F0SelectProps`' two single-select `clearable` members into `clearable?: boolean` — a widening, but it retyped a public type that `SelectProps`, `BreadcrumbSelect`, `Breadcrumbs`, `BreadcrumbState` and `PageHeader` are all built on (11 flagged exports). That is reverted; the tree picker asserts the literal locally instead.
