### PR TITLE
feat(NewHomeLayout): arrival stagger and a genie for the collapsing rail

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
   zeroRender,
 } from "@/testing/test-utils"
 
@@ -213,10 +214,15 @@ describe("NewHomeLayout", () => {
     })
 
     test("hides the edit button, and still offers to add", () => {
-      renderLayout(1000)
+      const { container } = renderLayout(1000)
 
       expect(screen.queryByLabelText("Edit Home")).not.toBeInTheDocument()
-      expect(screen.getByLabelText("Add widget")).toBeInTheDocument()
+      // Scoped to the STRIP: the main column offers to add too, and both controls
+      // are named the same thing because they are the same offer in two places.
+      const strip = container.querySelector("aside.-m-1") as HTMLElement
+      expect(
+        within(strip).getByRole("button", { name: "Add widget" })
+      ).toBeInTheDocument()
     })
 
     test("badges the glyph of a widget with updates, and only that one", () => {

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -3,7 +3,13 @@ import { beforeEach, describe, expect, test, vi } from "vitest"
 import { useEffect, useState } from "react"
 
 import { Calendar, Clock } from "@/icons/app"
-import { act, screen, userEvent, zeroRender } from "@/testing/test-utils"
+import {
+  act,
+  screen,
+  userEvent,
+  waitFor,
+  zeroRender,
+} from "@/testing/test-utils"
 
 import { type HomeWidgetItem, type SlotRenderers } from "../slotRenderers"
 import { NewHomeLayout } from "./index"
@@ -332,6 +338,27 @@ describe("NewHomeLayout", () => {
       expect(screen.getByLabelText("Expand widgets panel")).toBeInTheDocument()
       expect(screen.getByText("08:00")).toBeInTheDocument()
       expect(clockMounts).toBe(1)
+    })
+
+    /**
+     * The cards have a JOURNEY TO MAKE when the rail collapses: each one scales
+     * down onto its own glyph (`WidgetMotion`'s stow). The panel's one-widget
+     * filter therefore has to wait for the retract to finish — applied on the frame
+     * the collapse begins, as it once was, every card is `display: none` before it
+     * has moved a pixel and the whole animation plays on an empty box.
+     */
+    test("keeps the cards drawn while they retract into the strip", async () => {
+      await renderDeferredRail(1400)
+
+      await userEvent.click(screen.getByLabelText("Collapse widgets panel"))
+
+      // Still in the column's flow, on its way into the glyph.
+      expect(screen.getByText("08:00").closest("[hidden]")).toBeNull()
+
+      // …and handed over to the strip once it has got there.
+      await waitFor(() =>
+        expect(screen.getByText("08:00").closest("[hidden]")).not.toBeNull()
+      )
     })
 
     /**

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -333,5 +333,21 @@ describe("NewHomeLayout", () => {
       expect(screen.getByText("08:00")).toBeInTheDocument()
       expect(clockMounts).toBe(1)
     })
+
+    /**
+     * A HIDDEN container reports `clientWidth` 0 — the same thing the layout sees
+     * before it has measured anything. It must not read that as "no rail yet":
+     * the rail would be dropped and every widget in it built again when the
+     * container came back.
+     */
+    test("a container that reports no width keeps them mounted", async () => {
+      await renderDeferredRail(1400)
+
+      resizeLayoutTo(0)
+      resizeLayoutTo(1400)
+
+      expect(screen.getByText("08:00")).toBeVisible()
+      expect(clockMounts).toBe(1)
+    })
   })
 })

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -697,9 +697,20 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 "-m-1 flex min-h-0 flex-col items-start gap-2 overflow-y-auto p-1",
                 SCROLLBAR_HIDDEN
               )}
-              // Placed, not flowed — it shares this cell with the retracting rail
-              // body for a moment (see the main column).
-              style={{ gridColumn: 2, gridRow: 2 }}
+              style={{
+                // Placed, not flowed — it shares this cell with the retracting
+                // rail body for a moment (see the main column).
+                gridColumn: 2,
+                gridRow: 2,
+                // Pinned for the same reason the rail body is: stretched to a cell
+                // that is mid-flight between the rail's width and the strip's, the
+                // glyphs would ride that width and slide the best part of 400px
+                // sideways over the gesture. Sized to their own content against
+                // the cell's right edge, they arrive where they stay — which is
+                // what lets the cards look like they are going INTO them.
+                width: "fit-content",
+                justifySelf: "end",
+              }}
               initial={{ opacity: 1 }}
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -483,6 +483,24 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           // transform.
           width: asideWidth,
           justifySelf: "end",
+          // IT BLEEDS THROUGH THE GUTTER, exactly as the main column does: the
+          // negative margin grows its box by the gutter at each end while an equal
+          // padding puts the content back on the line it was on. Two things come
+          // out of that, and the second is why it is here.
+          //
+          // Its clip edge becomes the window's edge, so cards scroll off the
+          // screen instead of stopping short inside the page. And its scroll fade
+          // — which is drawn from the BORDER BOX — lands in the gutter rather than
+          // over the first card, putting it on the same line as the main column's.
+          // Without it the two columns faded at different heights, and the rail
+          // dimmed content that was not going anywhere.
+          //
+          // Only in the column. The floating panel is positioned from `top`, and a
+          // margin there would take it off its glyph.
+          marginTop: -bleed,
+          marginBottom: -bleed,
+          paddingTop: bleed,
+          paddingBottom: bleed,
           ...(rail.mode === "retracting" ? { pointerEvents: "none" } : null),
           ...railFade.style,
         }

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -423,6 +423,21 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     const railInPanel = rail.mode === "panel"
 
     /**
+     * The widget the panel is showing — or the one it is still putting back.
+     *
+     * The panel takes `GENIE_CLOSE_MS` to go into its glyph, and dropping its
+     * widget on the frame the hover ends leaves an EMPTY card to do that
+     * animation: the content vanishes at once and a bare rounded box shrinks away
+     * after it. So the widget stays the panel's until the panel has actually gone
+     * (`panelHidden`), which is also what keeps it from snapping to its stowed
+     * size halfway through the fade.
+     */
+    const closingId = useRef<string | null>(null)
+    if (openId) closingId.current = openId
+    const panelWidgetId =
+      openId ?? (rail.panelHidden ? null : closingId.current)
+
+    /**
      * WHERE the rail body sits, in each of its presentations. `transformOrigin` is
      * the constant: the strip's corner is what every genie scale on this element is
      * taken from, whichever presentation it is in.
@@ -826,7 +841,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               // panel's one-widget filter belongs to the panel; while the rail is
               // still retracting the column is still a column, and its cards have a
               // journey to make (`stow`).
-              visibleWidgetId={railInPanel ? openId : undefined}
+              visibleWidgetId={railInPanel ? panelWidgetId : undefined}
               // The strip they are going into: glyphs a fixed pitch apart, and how
               // small a card has to get to be one of them.
               stow={{

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -3,12 +3,22 @@ import {
   type CSSProperties,
   forwardRef,
   Fragment,
+  isValidElement,
   ReactNode,
   useEffect,
   useLayoutEffect,
   useRef,
   useState,
 } from "react"
+
+import {
+  animate,
+  AnimatePresence,
+  motion,
+  type Transition,
+  useMotionValue,
+  useTransform,
+} from "motion/react"
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
@@ -17,8 +27,32 @@ import { Check, Pencil } from "@/icons/app"
 import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import { SidebarIconSvg } from "@/patterns/Navigation/Sidebar/Icon"
 import { Action } from "@/ui/Action"
+import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
 
+import {
+  entranceDelay,
+  entranceTransition,
+  GENIE_CLOSE_MS,
+  GENIE_GLYPH_DELAY_MS,
+  GENIE_GLYPH_ENTER_SCALE,
+  GENIE_GLYPH_EXIT_SCALE,
+  GENIE_GLYPH_OPEN_SCALE,
+  GENIE_ORIGIN,
+  GENIE_RETRACT_MS,
+  GENIE_RETRACTED_OFFSET_PX,
+  GENIE_RETRACTED_SCALE,
+  genieCloseTransition,
+  geniePanelGlideTransition,
+  genieOpenTransition,
+  glyphTransition,
+  HomeEntrance,
+  INSTANT_TRANSITION,
+  railWidthTransition,
+  RIGHT_AREA_DELAY_MS,
+  useDelayedTrue,
+  withReducedMotion,
+} from "../home-motion"
 import { SlotWidget } from "../SlotWidget"
 import { useScrollFade } from "../useScrollFade"
 import { WidgetContainer, type WidgetContainerSide } from "../WidgetContainer"
@@ -168,11 +202,15 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     ref
   ) {
     const { sidebarState, toggleSidebar, isSmallScreen } = useSidebar()
+    const reducedMotion = useReducedMotion()
     const rootRef = useRef<HTMLDivElement | null>(null)
     const [rootWidth, setRootWidth] = useState(0)
     // Hover state of the collapsed strip: which widget floats, and where.
     const [openId, setOpenId] = useState<string | null>(null)
     const [panelTop, setPanelTop] = useState(0)
+    // Whether the panel should GLIDE to `panelTop` or simply be there — see
+    // `openFromAnchor`.
+    const [panelGlide, setPanelGlide] = useState(false)
     const leaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     // The rail collapses when the grid can't give both columns their width —
@@ -188,6 +226,27 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       observer.observe(el)
       return () => observer.disconnect()
     }, [])
+
+    // WE HAVE A WIDTH, and once we have had one we always have one: a hidden
+    // container reports `clientWidth` 0, and letting that put the layout back to
+    // "unmeasured" would tear the rail down and rebuild every widget in it when
+    // it came back — the one thing this layout exists to prevent. Adjusting it
+    // during the render that first sees a width, rather than from an effect, keeps
+    // it from lagging a paint behind the measurement.
+    const [hasMeasured, setHasMeasured] = useState(false)
+    if (rootWidth > 0 && !hasMeasured) setHasMeasured(true)
+
+    // THE FIRST PAINT IS NOT A GESTURE. The first render cannot know how wide the
+    // box is — measuring needs the DOM — so `collapsed` always resolves one render
+    // late, and animating that resolution would play a collapse the rail never
+    // left: every narrow first load would open with the cards retracting into a
+    // strip they were never out of. Collapse stays instant until the layout has
+    // been on screen once; from there, a change is something that happened.
+    const [settled, setSettled] = useState(false)
+    useEffect(() => {
+      if (rootWidth > 0) setSettled(true)
+    }, [rootWidth])
+    const animateCollapse = settled && !reducedMotion
 
     // Uncontrolled by default: the layout's own edit button drives it. Passing
     // `editing` hands control to the caller.
@@ -239,6 +298,40 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       rightWidgets.length > 0 &&
       (autoCollapsed || (manualCollapsed ?? false))
     const railWidth = collapsed ? COLLAPSED_RAIL_WIDTH : asideWidth
+    // NOTHING ON THE RIGHT UNTIL THE BOX HAS BEEN MEASURED. Which presentation
+    // the rail is in — column, strip, or nothing at all — is decided entirely by
+    // the width, and the first render does not have it yet. Drawn before then, the
+    // rail's first committed state is a GUESS that the very next render (the
+    // layout effect's, still before paint) corrects — and motion cannot tell that
+    // correction apart from a collapse the user asked for, so it animates it: the
+    // page would open by playing a collapse the rail was never out of. Mounting
+    // one render later, the rail's first state is already the right one and
+    // `initial={false}` puts it there outright.
+    //
+    // One render later, NOT one paint later — the measurement lands in a layout
+    // effect, so nothing has been drawn in between.
+    const sideReady = hasSide && hasMeasured
+
+    // THE RAIL'S COLUMN, animated so the space the main column gets back arrives
+    // over the same beat the cards retract over. A collapse that snapped the grid
+    // while the cards animated would read as a jump with an animation next to it.
+    //
+    // Driven as a MOTION VALUE rather than through `animate`, and committed from a
+    // LAYOUT effect, because the first resolution must not animate and gating a
+    // `transition` prop on that is not reliable: the unmeasured render and the
+    // measured one land in the same batch, so motion starts one animation and
+    // reads the later render's transition — the page would open by playing a
+    // collapse the rail was never out of. `jump` cannot be batched away.
+    const railWidthValue = useMotionValue(railWidth)
+    const railWidthPx = useTransform(railWidthValue, (width) => `${width}px`)
+    useLayoutEffect(() => {
+      if (!animateCollapse) {
+        railWidthValue.jump(railWidth)
+        return
+      }
+      const controls = animate(railWidthValue, railWidth, railWidthTransition)
+      return () => controls.stop()
+    }, [railWidth, animateCollapse, railWidthValue])
 
     // STACKED (below `md`): there is no rail at all, not even the strip — the
     // window is too narrow to spend 40px on a column. The rail's widgets fold
@@ -252,20 +345,32 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     // The pins go BETWEEN blocks of `children` — after `stackedPinsAfter` of
     // them — because "just under the shortcuts" is a place inside content this
     // layout doesn't own. Splitting the children is the only way to reach it.
-    const stackedChildren = !stacked
-      ? children
-      : (() => {
-          const blocks = Children.toArray(children)
-          return (
-            <>
-              {blocks.slice(0, stackedPinsAfter)}
-              {loosePins.pinned.map((widget) => (
-                <Fragment key={widget.id}>{render(widget)}</Fragment>
-              ))}
-              {blocks.slice(stackedPinsAfter)}
-            </>
-          )
-        })()
+    const childBlocks = Children.toArray(children)
+    const mainBlocks = !stacked
+      ? childBlocks
+      : [
+          ...childBlocks.slice(0, stackedPinsAfter),
+          ...loosePins.pinned.map((widget) => (
+            <Fragment key={widget.id}>{render(widget)}</Fragment>
+          )),
+          ...childBlocks.slice(stackedPinsAfter),
+        ]
+    // ARRIVAL, in reading order: each block of the main column rises in one beat
+    // after the one above it, and the widgets under them (the container's own
+    // `entrance.order`) carry the same count on rather than restarting it — a
+    // widget below the feed arrives AFTER the feed, not alongside it.
+    //
+    // Each block keeps the key `Children.toArray` gave it, so the wrapper is
+    // identified by the block it wraps: keyed by index instead, reordering the
+    // content would re-key every wrapper below the change and replay its entrance.
+    const mainChildren = mainBlocks.map((block, order) => (
+      <HomeEntrance
+        key={isValidElement(block) && block.key != null ? block.key : order}
+        order={order}
+      >
+        {block}
+      </HomeEntrance>
+    ))
 
     const openWidget = collapsed
       ? rightWidgets.find((widget) => widget.id === openId)
@@ -277,6 +382,52 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     useEffect(() => {
       if (!collapsed) setOpenId(null)
     }, [collapsed])
+
+    // THE GENIE. Collapsing has to look like the cards going INTO the glyphs, so
+    // the rail's PRESENTATION lags the decision by exactly the retract: the grid
+    // column starts narrowing and the strip starts arriving the moment
+    // `collapsed` flips, while the rail body spends `GENIE_RETRACT_MS` shrinking
+    // toward the strip's corner before it becomes the floating panel.
+    //
+    // Hovering a glyph mid-retract skips the rest of it — what you asked for is
+    // the panel, and finishing an animation you interrupted is not an answer.
+    const retracted = useDelayedTrue(
+      collapsed,
+      animateCollapse ? GENIE_RETRACT_MS : 0
+    )
+    const railMode: "column" | "retracting" | "panel" = !collapsed
+      ? "column"
+      : retracted || openWidget
+        ? "panel"
+        : "retracting"
+    const railInPanel = railMode === "panel"
+    // Out = the rail is showing something: the whole column, or one widget
+    // floating out of a glyph. Everything else is retracted into the strip.
+    const railOut = railMode === "column" || openWidget != null
+    // `hidden` is `display: none`, which would cut the retract-into-the-glyph
+    // short, so it arrives only once that has played out. Closed already at mount
+    // is not a change, so it is not delayed (`useDelayedTrue`).
+    const panelHidden = useDelayedTrue(
+      openWidget == null,
+      reducedMotion ? 0 : GENIE_CLOSE_MS
+    )
+    // Gated on `animateCollapse` for the same reason the grid column is: until
+    // the box has been measured once the rail's state is being RESOLVED rather
+    // than changed, and resolving is not a gesture to animate.
+    const railTransition: Transition = !animateCollapse
+      ? INSTANT_TRANSITION
+      : {
+          ...(railOut ? genieOpenTransition : genieCloseTransition),
+          // Between two glyphs the panel glides; on the way out of one it must
+          // not travel at all (see `openFromAnchor`).
+          y: panelGlide ? geniePanelGlideTransition : INSTANT_TRANSITION,
+        }
+    // Collapsing puts the glyphs in as the cards finish retracting — they overlap
+    // on purpose. On the FIRST paint there is no retract to follow, so they are
+    // simply the right area arriving after the main one.
+    const glyphDelayMs = animateCollapse
+      ? GENIE_GLYPH_DELAY_MS
+      : RIGHT_AREA_DELAY_MS
 
     const cancelLeave = () => {
       if (leaveTimer.current) clearTimeout(leaveTimer.current)
@@ -294,11 +445,16 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           anchor.getBoundingClientRect().top - root.getBoundingClientRect().top
         setPanelTop(Math.max(0, top))
       }
+      // Opening from nothing, the panel APPEARS at its glyph, so it has to be
+      // there before it fades in. Moving between glyphs while it is already open
+      // is the opposite: there it GLIDES, and that glide is what says the panel
+      // is one thing showing a different widget rather than two panels.
+      setPanelGlide(openId != null)
       setOpenId(id)
     }
 
     return (
-      <div
+      <motion.div
         ref={(node) => {
           rootRef.current = node
           if (typeof ref === "function") ref(node)
@@ -312,7 +468,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
         )}
         style={
           {
-            "--home-aside-w": `${railWidth}px`,
+            // The rail's column, as a motion value the grid template reads: the
+            // template is a keyword list and cannot be interpolated, so the one
+            // number in it is animated on its own.
+            "--home-aside-w": railWidthPx,
             // FILL THE BOX THE PAGE GIVES US, not the window. This used to be
             // `calc(100svh - 2 * bleed)`, which assumed the layout's box WAS the
             // viewport minus its own gutter — true only while nothing else is on
@@ -334,11 +493,15 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             // always fits; an expanded one waits until there is room for both.
             // `!stacked` first: stacked renders no rail at all, so reserving its
             // column would leave an empty strip down the side.
+            // The px fallback is what the column is worth before motion has
+            // written the variable for the first time — an unresolvable `var()`
+            // would invalidate the whole declaration and drop the rail's column
+            // for that frame.
             gridTemplateColumns:
-              hasSide &&
+              sideReady &&
               !stacked &&
               (collapsed || rootWidth >= TWO_COLUMN_MIN_PX)
-                ? `minmax(0, 1fr) ${railWidth}px`
+                ? `minmax(0, 1fr) var(--home-aside-w, ${railWidth}px)`
                 : "minmax(0, 1fr)",
           } as CSSProperties
         }
@@ -365,7 +528,12 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             Entering edit mode is what makes `editableWidgetContainers` take
             effect (remove controls + the add placeholder appear in the
             containers it lists). */}
-        <div className="col-span-full flex flex-row items-center justify-between">
+        {/* Chrome, not content: it arrives on the main column's first beat rather
+            than waiting its turn behind it. */}
+        <HomeEntrance
+          order={0}
+          className="col-span-full flex flex-row items-center justify-between"
+        >
           {/* The main-menu trigger, on the same terms as `DaytimePage`: shown
               only when the sidebar isn't already there to be seen. */}
           {isSmallScreen || sidebarState === "hidden" ? (
@@ -417,7 +585,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               </Action>
             ) : null}
           </div>
-        </div>
+        </HomeEntrance>
         {/* Main column: its own scroll region, no mask — a reading column should
             not have the text you are reading dimmed at the edges.
 
@@ -430,6 +598,13 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           ref={mainFade.ref}
           className={cn("relative min-h-0 overflow-y-auto", SCROLLBAR_HIDDEN)}
           style={{
+            // Placed rather than flowed, because the strip and the rail body
+            // BOTH want this row's second column and for a moment mid-collapse
+            // both are in it. Auto-placement would push the second one onto a row
+            // of its own; explicitly placed, they simply overlap — which is what
+            // a handover between two presentations of the same rail should do.
+            gridColumn: 1,
+            gridRow: 2,
             marginTop: -bleed,
             marginBottom: -bleed,
             paddingTop: bleed,
@@ -460,76 +635,133 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 ? () => onClickAddNewWidget("main")
                 : undefined
             }
+            // The widgets pick the stagger up where the freeform blocks left it.
+            entrance={{ order: mainChildren.length }}
           >
-            {stackedChildren}
+            {mainChildren}
           </WidgetContainer>
         </div>
-        {stacked || !hasSide || !collapsed ? null : (
-          // The collapsed strip: one avatar per widget, the widget's own
-          // catalog glyph. Hover/click floats the widget over the feed.
-          // NO FADE HERE: the strip is a short column of 40px glyphs, and a
-          // mask over those washes the glyphs themselves out rather than
-          // hinting at content past an edge. The fade belongs to the expanded
-          // rail, where the content is tall cards.
-          // `-m-1 p-1`: the hasUpdates dot pokes 2px past the 40px glyphs,
-          // and the scrollport would clip it — bleed the scrollport out by
-          // 4px (padding puts the glyphs back) so the dot stays inside it.
-          <aside
-            className={cn(
-              "-m-1 flex min-h-0 flex-col gap-2 overflow-y-auto p-1",
-              SCROLLBAR_HIDDEN
-            )}
-            onMouseLeave={scheduleLeave}
-            onMouseEnter={cancelLeave}
-          >
-            {rightWidgets.map((widget) => (
-              <button
-                key={widget.id}
-                type="button"
-                aria-label={widget.header?.title ?? widget.id}
-                aria-expanded={openId === widget.id}
-                onMouseEnter={(event) =>
-                  openFromAnchor(widget.id, event.currentTarget)
-                }
-                onClick={(event) =>
-                  openId === widget.id
-                    ? setOpenId(null)
-                    : openFromAnchor(widget.id, event.currentTarget)
-                }
-                className="rounded-lg"
-              >
-                {/* Same accent dot HomeListItem uses for unread rows. */}
-                <span className="relative inline-flex">
-                  {widget.icon ? (
-                    <F0AvatarIcon icon={widget.icon} size="lg" />
-                  ) : (
-                    <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-solid border-f1-border-secondary bg-f1-background font-medium text-f1-foreground-secondary">
-                      {(widget.header?.title ?? widget.id).charAt(0)}
-                    </span>
+        {/* AnimatePresence so the strip can LEAVE: expanding, each glyph blooms
+            outward as the card it becomes grows in behind it. Without it the
+            glyphs would simply be gone on the frame the rail opens, and the
+            expand would read as a swap rather than as the reverse of the
+            collapse. */}
+        <AnimatePresence>
+          {stacked || !sideReady || !collapsed ? null : (
+            // The collapsed strip: one avatar per widget, the widget's own
+            // catalog glyph. Hover/click floats the widget over the feed.
+            // NO FADE HERE: the strip is a short column of 40px glyphs, and a
+            // mask over those washes the glyphs themselves out rather than
+            // hinting at content past an edge. The fade belongs to the expanded
+            // rail, where the content is tall cards.
+            // `-m-1 p-1`: the hasUpdates dot pokes 2px past the 40px glyphs,
+            // and the scrollport would clip it — bleed the scrollport out by
+            // 4px (padding puts the glyphs back) so the dot stays inside it.
+            <motion.aside
+              key="collapsed-strip"
+              className={cn(
+                // `items-start` so a glyph is 40px wide whatever the column is
+                // doing: the strip lives in the rail's column, and that column
+                // spends the collapse on its way DOWN from the full rail width —
+                // stretched, the glyphs would start card-wide and shrink.
+                "-m-1 flex min-h-0 flex-col items-start gap-2 overflow-y-auto p-1",
+                SCROLLBAR_HIDDEN
+              )}
+              // Placed, not flowed — it shares this cell with the retracting rail
+              // body for a moment (see the main column).
+              style={{ gridColumn: 2, gridRow: 2 }}
+              initial={{ opacity: 1 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={withReducedMotion(
+                { duration: GENIE_CLOSE_MS / 1000, ease: "easeIn" },
+                reducedMotion
+              )}
+              onMouseLeave={scheduleLeave}
+              onMouseEnter={cancelLeave}
+            >
+              {rightWidgets.map((widget, order) => (
+                <motion.button
+                  key={widget.id}
+                  type="button"
+                  aria-label={widget.header?.title ?? widget.id}
+                  aria-expanded={openId === widget.id}
+                  onMouseEnter={(event) =>
+                    openFromAnchor(widget.id, event.currentTarget)
+                  }
+                  onClick={(event) =>
+                    openId === widget.id
+                      ? setOpenId(null)
+                      : openFromAnchor(widget.id, event.currentTarget)
+                  }
+                  className="rounded-lg"
+                  // A glyph arrives from LARGER than life — the card that just
+                  // shrank into it — and leaves the other way, blooming back out
+                  // into the card. Held slightly forward while its widget floats,
+                  // so the glyph and the panel read as one object.
+                  initial={{
+                    opacity: 0,
+                    scale: reducedMotion ? 1 : GENIE_GLYPH_ENTER_SCALE,
+                  }}
+                  animate={{
+                    opacity: 1,
+                    scale: openId === widget.id ? GENIE_GLYPH_OPEN_SCALE : 1,
+                  }}
+                  exit={{
+                    opacity: 0,
+                    scale: reducedMotion ? 1 : GENIE_GLYPH_EXIT_SCALE,
+                  }}
+                  whileHover={reducedMotion ? undefined : { scale: 1.08 }}
+                  whileTap={reducedMotion ? undefined : { scale: 0.94 }}
+                  transition={withReducedMotion(
+                    {
+                      ...glyphTransition,
+                      delay: entranceDelay(order, glyphDelayMs),
+                    },
+                    reducedMotion
                   )}
-                  {widget.hasUpdates ? (
-                    // Same dot HomeListItem draws for unread rows — the ring
-                    // keeps it legible over any glyph.
-                    <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
-                  ) : null}
-                </span>
-              </button>
-            ))}
-            {/* Always offered, not only in edit mode: collapsed, the strip has
-                  no edit affordance of its own, and adding a widget is the one
-                  thing you would still want from it. */}
-            {canEditSide("right") && onClickAddNewWidget ? (
-              <button
-                type="button"
-                aria-label="Add widget"
-                onClick={() => onClickAddNewWidget("right")}
-                className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:text-f1-foreground"
-              >
-                +
-              </button>
-            ) : null}
-          </aside>
-        )}
+                >
+                  {/* Same accent dot HomeListItem uses for unread rows. */}
+                  <span className="relative inline-flex">
+                    {widget.icon ? (
+                      <F0AvatarIcon icon={widget.icon} size="lg" />
+                    ) : (
+                      <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-solid border-f1-border-secondary bg-f1-background font-medium text-f1-foreground-secondary">
+                        {(widget.header?.title ?? widget.id).charAt(0)}
+                      </span>
+                    )}
+                    {widget.hasUpdates ? (
+                      // Same dot HomeListItem draws for unread rows — the ring
+                      // keeps it legible over any glyph.
+                      <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
+                    ) : null}
+                  </span>
+                </motion.button>
+              ))}
+              {/* Always offered, not only in edit mode: collapsed, the strip has
+                    no edit affordance of its own, and adding a widget is the one
+                    thing you would still want from it. */}
+              {canEditSide("right") && onClickAddNewWidget ? (
+                <motion.button
+                  type="button"
+                  aria-label="Add widget"
+                  onClick={() => onClickAddNewWidget("right")}
+                  className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:text-f1-foreground"
+                  initial={{ opacity: 0 }}
+                  animate={{ opacity: 1 }}
+                  exit={{ opacity: 0 }}
+                  transition={entranceTransition(
+                    rightWidgets.length,
+                    glyphDelayMs,
+                    reducedMotion
+                  )}
+                >
+                  +
+                </motion.button>
+              ) : null}
+            </motion.aside>
+          )}
+        </AnimatePresence>
         {/* THE RAIL BODY — one mount, whatever the rail is doing.
 
             Expanded it is the rail's column. Collapsed it is the FLOATING PANEL:
@@ -547,31 +779,77 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             replacing it. (Stacked is the exception, and cannot be otherwise:
             below `md` the rail's widgets belong to the main column's flow,
             interleaved with content this layout doesn't own.) */}
-        {stacked || !hasSide ? null : (
-          <aside
+        {stacked || !sideReady ? null : (
+          <motion.aside
             ref={railFade.ref}
             // With nothing hovered there is no panel to see or to read out — but
-            // its widgets stay mounted underneath, which is the whole point.
-            hidden={collapsed && !openWidget}
+            // its widgets stay mounted underneath, which is the whole point. It
+            // waits for the retract, because `display: none` cannot be animated
+            // out of: applied on the frame the rail collapses, it would delete the
+            // cards instead of letting them go into the glyphs.
+            hidden={railInPanel && panelHidden}
             className={cn(
               "min-h-0 overflow-y-auto",
               SCROLLBAR_HIDDEN,
               // Above the feed it floats over, and opaque: the widget behind it
               // must not read through the card.
-              collapsed && "absolute z-10 rounded-xl bg-f1-background"
+              railInPanel && "absolute z-10 rounded-xl bg-f1-background",
+              // RETRACTING it is still in the grid, but it has lifted off the
+              // column it is leaving: over the main column rather than beside it.
+              railMode === "retracting" && "relative z-10"
             )}
             style={
-              collapsed
+              railInPanel
                 ? {
-                    top: panelTop,
+                    // The strip is at this corner, so this is where the widget
+                    // comes out of and goes back into. Every genie scale on this
+                    // element is taken from here.
+                    transformOrigin: GENIE_ORIGIN,
+                    // `top` is fixed and the offset to the hovered glyph is a
+                    // TRANSFORM (`y`), so moving between glyphs composites
+                    // instead of relaying out the panel on every frame.
+                    top: 0,
                     right: COLLAPSED_RAIL_WIDTH + 8,
                     width: asideWidth,
                     // The panel grows to its widget, up to what is left below
                     // its glyph, and scrolls past that.
                     maxHeight: `calc(100% - ${panelTop}px)`,
+                    pointerEvents: openWidget ? undefined : "none",
                   }
-                : railFade.style
+                : {
+                    transformOrigin: GENIE_ORIGIN,
+                    gridColumn: 2,
+                    gridRow: 2,
+                    // Mid-retract the column is already on its way down to the
+                    // strip's 40px, so the cards keep the width they had and hang
+                    // off the cell's left edge while they shrink into it —
+                    // otherwise they would be squeezed narrow on the way out,
+                    // which reads as the rail being crushed rather than stowed.
+                    ...(railMode === "retracting"
+                      ? {
+                          width: asideWidth,
+                          justifySelf: "end" as const,
+                          pointerEvents: "none" as const,
+                        }
+                      : null),
+                    ...railFade.style,
+                  }
             }
+            // No mount animation of its own: the rail ARRIVES through its
+            // widgets' stagger (`entrance` below), and a fade of the whole column
+            // on top of that would be the same arrival animated twice.
+            initial={false}
+            animate={{
+              opacity: railOut ? 1 : 0,
+              scale: railOut ? 1 : GENIE_RETRACTED_SCALE,
+              // Toward the strip while it shrinks, so it converges on the glyph
+              // rather than just fading where it stood.
+              x: railOut ? 0 : GENIE_RETRACTED_OFFSET_PX,
+              // Only the panel is offset from its own box; in the grid it sits
+              // where the grid put it.
+              y: railInPanel ? panelTop : 0,
+            }}
+            transition={railTransition}
             onMouseEnter={collapsed ? cancelLeave : undefined}
             onMouseLeave={collapsed ? scheduleLeave : undefined}
           >
@@ -600,14 +878,19 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                   ? () => onClickAddNewWidget("right")
                   : undefined
               }
+              // THE RIGHT AREA COMES AFTER THE MAIN ONE. Its widgets start their
+              // own stagger once the main column has had its beat — the rail is
+              // context, and context that lands with the content it is context for
+              // reads as noise.
+              entrance={{ delayMs: RIGHT_AREA_DELAY_MS }}
             >
               {/* The rail's freeform content belongs to the COLUMN, not to one
                   widget floating out of it. */}
               {collapsed ? null : aside}
             </WidgetContainer>
-          </aside>
+          </motion.aside>
         )}
-      </div>
+      </motion.div>
     )
   }
 )

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -11,14 +11,7 @@ import {
   useState,
 } from "react"
 
-import {
-  animate,
-  AnimatePresence,
-  motion,
-  type Transition,
-  useMotionValue,
-  useTransform,
-} from "motion/react"
+import { AnimatePresence, motion } from "motion/react"
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
@@ -33,27 +26,22 @@ import { cn } from "@/lib/utils"
 import {
   entranceDelay,
   entranceTransition,
-  GENIE_CLOSE_MS,
-  GENIE_GLYPH_DELAY_MS,
   GENIE_GLYPH_ENTER_SCALE,
   GENIE_GLYPH_EXIT_SCALE,
+  GENIE_GLYPH_HOVER_SCALE,
   GENIE_GLYPH_OPEN_SCALE,
+  GENIE_GLYPH_TAP_SCALE,
   GENIE_ORIGIN,
-  GENIE_RETRACT_MS,
   GENIE_RETRACTED_OFFSET_PX,
   GENIE_RETRACTED_SCALE,
   genieCloseTransition,
-  geniePanelGlideTransition,
-  genieOpenTransition,
   glyphTransition,
   HomeEntrance,
-  INSTANT_TRANSITION,
-  railWidthTransition,
   RIGHT_AREA_DELAY_MS,
-  useDelayedTrue,
   withReducedMotion,
 } from "../home-motion"
 import { SlotWidget } from "../SlotWidget"
+import { useRailMotion } from "./useRailMotion"
 import { useScrollFade } from "../useScrollFade"
 import { WidgetContainer, type WidgetContainerSide } from "../WidgetContainer"
 import {
@@ -97,6 +85,78 @@ const GradientWash = ({
 const COLLAPSED_RAIL_WIDTH = 40
 
 /**
+ * One widget as the collapsed strip shows it: its own catalog glyph, standing in
+ * for the whole card.
+ *
+ * It ARRIVES FROM LARGER THAN LIFE — the card that just shrank into it — and
+ * leaves the other way, blooming back out into the card it becomes. While its
+ * widget is floating it holds itself slightly forward, so the glyph and the panel
+ * read as one object rather than a button and a popover.
+ */
+const CollapsedGlyph = ({
+  widget,
+  order,
+  open,
+  delayMs,
+  onOpen,
+  onClose,
+}: {
+  widget: HomeWidgetItem
+  /** Place in the strip's stagger. */
+  order: number
+  open: boolean
+  /** When this strip's first glyph starts arriving. */
+  delayMs: number
+  onOpen: (id: string, anchor: HTMLElement) => void
+  onClose: () => void
+}) => {
+  const reducedMotion = useReducedMotion()
+
+  return (
+    <motion.button
+      type="button"
+      aria-label={widget.header?.title ?? widget.id}
+      aria-expanded={open}
+      onMouseEnter={(event) => onOpen(widget.id, event.currentTarget)}
+      onClick={(event) =>
+        open ? onClose() : onOpen(widget.id, event.currentTarget)
+      }
+      className="rounded-lg"
+      initial={{
+        opacity: 0,
+        scale: reducedMotion ? 1 : GENIE_GLYPH_ENTER_SCALE,
+      }}
+      animate={{ opacity: 1, scale: open ? GENIE_GLYPH_OPEN_SCALE : 1 }}
+      exit={{ opacity: 0, scale: reducedMotion ? 1 : GENIE_GLYPH_EXIT_SCALE }}
+      whileHover={
+        reducedMotion ? undefined : { scale: GENIE_GLYPH_HOVER_SCALE }
+      }
+      whileTap={reducedMotion ? undefined : { scale: GENIE_GLYPH_TAP_SCALE }}
+      transition={withReducedMotion(
+        { ...glyphTransition, delay: entranceDelay(order, delayMs) },
+        reducedMotion
+      )}
+    >
+      {/* Same accent dot HomeListItem uses for unread rows. */}
+      <span className="relative inline-flex">
+        {widget.icon ? (
+          <F0AvatarIcon icon={widget.icon} size="lg" />
+        ) : (
+          <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-solid border-f1-border-secondary bg-f1-background font-medium text-f1-foreground-secondary">
+            {(widget.header?.title ?? widget.id).charAt(0)}
+          </span>
+        )}
+        {widget.hasUpdates ? (
+          // Same dot HomeListItem draws for unread rows — the ring keeps it
+          // legible over any glyph.
+          <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
+        ) : null}
+      </span>
+    </motion.button>
+  )
+}
+
+/**
  * The columns scroll without showing a bar — the scroll-aware fades already
  * hint at overflowed content, so a bar is just noise on the gradient.
  */
@@ -105,6 +165,8 @@ const COLUMN_GAP_PX = 16
 /** Tailwind's `md` — below it the layout is one column unless the rail is collapsed. */
 const TWO_COLUMN_MIN_PX = 768
 const PANEL_LEAVE_MS = 150
+/** How far the floating panel clears the strip it comes out of. */
+const PANEL_GAP_PX = 8
 
 export interface NewHomeLayoutProps {
   /** Freeform main-column content on top (greeting, shortcut cards, ranked feed…). */
@@ -236,18 +298,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     const [hasMeasured, setHasMeasured] = useState(false)
     if (rootWidth > 0 && !hasMeasured) setHasMeasured(true)
 
-    // THE FIRST PAINT IS NOT A GESTURE. The first render cannot know how wide the
-    // box is — measuring needs the DOM — so `collapsed` always resolves one render
-    // late, and animating that resolution would play a collapse the rail never
-    // left: every narrow first load would open with the cards retracting into a
-    // strip they were never out of. Collapse stays instant until the layout has
-    // been on screen once; from there, a change is something that happened.
-    const [settled, setSettled] = useState(false)
-    useEffect(() => {
-      if (rootWidth > 0) setSettled(true)
-    }, [rootWidth])
-    const animateCollapse = settled && !reducedMotion
-
     // Uncontrolled by default: the layout's own edit button drives it. Passing
     // `editing` hands control to the caller.
     const [editingState, setEditingState] = useState(false)
@@ -298,40 +348,13 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       rightWidgets.length > 0 &&
       (autoCollapsed || (manualCollapsed ?? false))
     const railWidth = collapsed ? COLLAPSED_RAIL_WIDTH : asideWidth
-    // NOTHING ON THE RIGHT UNTIL THE BOX HAS BEEN MEASURED. Which presentation
-    // the rail is in — column, strip, or nothing at all — is decided entirely by
-    // the width, and the first render does not have it yet. Drawn before then, the
-    // rail's first committed state is a GUESS that the very next render (the
-    // layout effect's, still before paint) corrects — and motion cannot tell that
-    // correction apart from a collapse the user asked for, so it animates it: the
-    // page would open by playing a collapse the rail was never out of. Mounting
-    // one render later, the rail's first state is already the right one and
-    // `initial={false}` puts it there outright.
-    //
-    // One render later, NOT one paint later — the measurement lands in a layout
-    // effect, so nothing has been drawn in between.
+    // NOTHING ON THE RIGHT UNTIL THE BOX HAS BEEN MEASURED. Which presentation the
+    // rail is in — column, strip, or nothing at all — is decided entirely by the
+    // width, so drawn before there is one its first state is a guess the next
+    // render corrects, and motion animates corrections (see `useRailMotion`).
+    // Waiting costs nothing visible: the measurement lands in a layout effect, so
+    // this is one render later, not one paint later.
     const sideReady = hasSide && hasMeasured
-
-    // THE RAIL'S COLUMN, animated so the space the main column gets back arrives
-    // over the same beat the cards retract over. A collapse that snapped the grid
-    // while the cards animated would read as a jump with an animation next to it.
-    //
-    // Driven as a MOTION VALUE rather than through `animate`, and committed from a
-    // LAYOUT effect, because the first resolution must not animate and gating a
-    // `transition` prop on that is not reliable: the unmeasured render and the
-    // measured one land in the same batch, so motion starts one animation and
-    // reads the later render's transition — the page would open by playing a
-    // collapse the rail was never out of. `jump` cannot be batched away.
-    const railWidthValue = useMotionValue(railWidth)
-    const railWidthPx = useTransform(railWidthValue, (width) => `${width}px`)
-    useLayoutEffect(() => {
-      if (!animateCollapse) {
-        railWidthValue.jump(railWidth)
-        return
-      }
-      const controls = animate(railWidthValue, railWidth, railWidthTransition)
-      return () => controls.stop()
-    }, [railWidth, animateCollapse, railWidthValue])
 
     // STACKED (below `md`): there is no rail at all, not even the strip — the
     // window is too narrow to spend 40px on a column. The rail's widgets fold
@@ -383,51 +406,51 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       if (!collapsed) setOpenId(null)
     }, [collapsed])
 
-    // THE GENIE. Collapsing has to look like the cards going INTO the glyphs, so
-    // the rail's PRESENTATION lags the decision by exactly the retract: the grid
-    // column starts narrowing and the strip starts arriving the moment
-    // `collapsed` flips, while the rail body spends `GENIE_RETRACT_MS` shrinking
-    // toward the strip's corner before it becomes the floating panel.
-    //
-    // Hovering a glyph mid-retract skips the rest of it — what you asked for is
-    // the panel, and finishing an animation you interrupted is not an answer.
-    const retracted = useDelayedTrue(
+    // How the rail moves, and the one number the grid template reads. The genie
+    // lives in there; the geometry it moves through stays here.
+    const rail = useRailMotion({
       collapsed,
-      animateCollapse ? GENIE_RETRACT_MS : 0
-    )
-    const railMode: "column" | "retracting" | "panel" = !collapsed
-      ? "column"
-      : retracted || openWidget
-        ? "panel"
-        : "retracting"
-    const railInPanel = railMode === "panel"
-    // Out = the rail is showing something: the whole column, or one widget
-    // floating out of a glyph. Everything else is retracted into the strip.
-    const railOut = railMode === "column" || openWidget != null
-    // `hidden` is `display: none`, which would cut the retract-into-the-glyph
-    // short, so it arrives only once that has played out. Closed already at mount
-    // is not a change, so it is not delayed (`useDelayedTrue`).
-    const panelHidden = useDelayedTrue(
-      openWidget == null,
-      reducedMotion ? 0 : GENIE_CLOSE_MS
-    )
-    // Gated on `animateCollapse` for the same reason the grid column is: until
-    // the box has been measured once the rail's state is being RESOLVED rather
-    // than changed, and resolving is not a gesture to animate.
-    const railTransition: Transition = !animateCollapse
-      ? INSTANT_TRANSITION
-      : {
-          ...(railOut ? genieOpenTransition : genieCloseTransition),
-          // Between two glyphs the panel glides; on the way out of one it must
-          // not travel at all (see `openFromAnchor`).
-          y: panelGlide ? geniePanelGlideTransition : INSTANT_TRANSITION,
+      open: openWidget != null,
+      glide: panelGlide,
+      drawn: sideReady,
+      width: railWidth,
+    })
+    const railInPanel = rail.mode === "panel"
+
+    /**
+     * WHERE the rail body sits, in each of its presentations. `transformOrigin` is
+     * the constant: the strip's corner is what every genie scale on this element is
+     * taken from, whichever presentation it is in.
+     */
+    const railStyle: CSSProperties = railInPanel
+      ? {
+          transformOrigin: GENIE_ORIGIN,
+          // `top` is fixed and the offset to the hovered glyph is a TRANSFORM
+          // (`y`), so moving between glyphs composites instead of relaying the
+          // panel out on every frame.
+          top: 0,
+          right: COLLAPSED_RAIL_WIDTH + PANEL_GAP_PX,
+          width: asideWidth,
+          // The panel grows to its widget, up to what is left below its glyph,
+          // and scrolls past that.
+          maxHeight: `calc(100% - ${panelTop}px)`,
+          pointerEvents: openWidget ? undefined : "none",
         }
-    // Collapsing puts the glyphs in as the cards finish retracting — they overlap
-    // on purpose. On the FIRST paint there is no retract to follow, so they are
-    // simply the right area arriving after the main one.
-    const glyphDelayMs = animateCollapse
-      ? GENIE_GLYPH_DELAY_MS
-      : RIGHT_AREA_DELAY_MS
+      : {
+          transformOrigin: GENIE_ORIGIN,
+          // Placed, not flowed: mid-collapse the strip is in this same cell, and
+          // auto-placement would push one of them onto a row of its own.
+          gridColumn: 2,
+          gridRow: 2,
+          // Mid-retract the column is already on its way down to the strip's
+          // width, so the cards keep the width they had and hang off the cell's
+          // left edge while they shrink into it — squeezed narrow on the way out,
+          // the rail reads as crushed rather than stowed.
+          ...(rail.mode === "retracting"
+            ? { width: asideWidth, justifySelf: "end", pointerEvents: "none" }
+            : null),
+          ...railFade.style,
+        }
 
     const cancelLeave = () => {
       if (leaveTimer.current) clearTimeout(leaveTimer.current)
@@ -471,7 +494,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             // The rail's column, as a motion value the grid template reads: the
             // template is a keyword list and cannot be interpolated, so the one
             // number in it is animated on its own.
-            "--home-aside-w": railWidthPx,
+            "--home-aside-w": rail.widthPx,
             // FILL THE BOX THE PAGE GIVES US, not the window. This used to be
             // `calc(100svh - 2 * bleed)`, which assumed the layout's box WAS the
             // viewport minus its own gutter — true only while nothing else is on
@@ -674,69 +697,22 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={withReducedMotion(
-                { duration: GENIE_CLOSE_MS / 1000, ease: "easeIn" },
+                genieCloseTransition,
                 reducedMotion
               )}
               onMouseLeave={scheduleLeave}
               onMouseEnter={cancelLeave}
             >
               {rightWidgets.map((widget, order) => (
-                <motion.button
+                <CollapsedGlyph
                   key={widget.id}
-                  type="button"
-                  aria-label={widget.header?.title ?? widget.id}
-                  aria-expanded={openId === widget.id}
-                  onMouseEnter={(event) =>
-                    openFromAnchor(widget.id, event.currentTarget)
-                  }
-                  onClick={(event) =>
-                    openId === widget.id
-                      ? setOpenId(null)
-                      : openFromAnchor(widget.id, event.currentTarget)
-                  }
-                  className="rounded-lg"
-                  // A glyph arrives from LARGER than life — the card that just
-                  // shrank into it — and leaves the other way, blooming back out
-                  // into the card. Held slightly forward while its widget floats,
-                  // so the glyph and the panel read as one object.
-                  initial={{
-                    opacity: 0,
-                    scale: reducedMotion ? 1 : GENIE_GLYPH_ENTER_SCALE,
-                  }}
-                  animate={{
-                    opacity: 1,
-                    scale: openId === widget.id ? GENIE_GLYPH_OPEN_SCALE : 1,
-                  }}
-                  exit={{
-                    opacity: 0,
-                    scale: reducedMotion ? 1 : GENIE_GLYPH_EXIT_SCALE,
-                  }}
-                  whileHover={reducedMotion ? undefined : { scale: 1.08 }}
-                  whileTap={reducedMotion ? undefined : { scale: 0.94 }}
-                  transition={withReducedMotion(
-                    {
-                      ...glyphTransition,
-                      delay: entranceDelay(order, glyphDelayMs),
-                    },
-                    reducedMotion
-                  )}
-                >
-                  {/* Same accent dot HomeListItem uses for unread rows. */}
-                  <span className="relative inline-flex">
-                    {widget.icon ? (
-                      <F0AvatarIcon icon={widget.icon} size="lg" />
-                    ) : (
-                      <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-solid border-f1-border-secondary bg-f1-background font-medium text-f1-foreground-secondary">
-                        {(widget.header?.title ?? widget.id).charAt(0)}
-                      </span>
-                    )}
-                    {widget.hasUpdates ? (
-                      // Same dot HomeListItem draws for unread rows — the ring
-                      // keeps it legible over any glyph.
-                      <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
-                    ) : null}
-                  </span>
-                </motion.button>
+                  widget={widget}
+                  order={order}
+                  open={openId === widget.id}
+                  delayMs={rail.glyphDelayMs}
+                  onOpen={openFromAnchor}
+                  onClose={() => setOpenId(null)}
+                />
               ))}
               {/* Always offered, not only in edit mode: collapsed, the strip has
                     no edit affordance of its own, and adding a widget is the one
@@ -752,7 +728,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                   exit={{ opacity: 0 }}
                   transition={entranceTransition(
                     rightWidgets.length,
-                    glyphDelayMs,
+                    rail.glyphDelayMs,
                     reducedMotion
                   )}
                 >
@@ -787,7 +763,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             // waits for the retract, because `display: none` cannot be animated
             // out of: applied on the frame the rail collapses, it would delete the
             // cards instead of letting them go into the glyphs.
-            hidden={railInPanel && panelHidden}
+            hidden={railInPanel && rail.panelHidden}
             className={cn(
               "min-h-0 overflow-y-auto",
               SCROLLBAR_HIDDEN,
@@ -796,60 +772,24 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               railInPanel && "absolute z-10 rounded-xl bg-f1-background",
               // RETRACTING it is still in the grid, but it has lifted off the
               // column it is leaving: over the main column rather than beside it.
-              railMode === "retracting" && "relative z-10"
+              rail.mode === "retracting" && "relative z-10"
             )}
-            style={
-              railInPanel
-                ? {
-                    // The strip is at this corner, so this is where the widget
-                    // comes out of and goes back into. Every genie scale on this
-                    // element is taken from here.
-                    transformOrigin: GENIE_ORIGIN,
-                    // `top` is fixed and the offset to the hovered glyph is a
-                    // TRANSFORM (`y`), so moving between glyphs composites
-                    // instead of relaying out the panel on every frame.
-                    top: 0,
-                    right: COLLAPSED_RAIL_WIDTH + 8,
-                    width: asideWidth,
-                    // The panel grows to its widget, up to what is left below
-                    // its glyph, and scrolls past that.
-                    maxHeight: `calc(100% - ${panelTop}px)`,
-                    pointerEvents: openWidget ? undefined : "none",
-                  }
-                : {
-                    transformOrigin: GENIE_ORIGIN,
-                    gridColumn: 2,
-                    gridRow: 2,
-                    // Mid-retract the column is already on its way down to the
-                    // strip's 40px, so the cards keep the width they had and hang
-                    // off the cell's left edge while they shrink into it —
-                    // otherwise they would be squeezed narrow on the way out,
-                    // which reads as the rail being crushed rather than stowed.
-                    ...(railMode === "retracting"
-                      ? {
-                          width: asideWidth,
-                          justifySelf: "end" as const,
-                          pointerEvents: "none" as const,
-                        }
-                      : null),
-                    ...railFade.style,
-                  }
-            }
+            style={railStyle}
             // No mount animation of its own: the rail ARRIVES through its
             // widgets' stagger (`entrance` below), and a fade of the whole column
             // on top of that would be the same arrival animated twice.
             initial={false}
             animate={{
-              opacity: railOut ? 1 : 0,
-              scale: railOut ? 1 : GENIE_RETRACTED_SCALE,
+              opacity: rail.out ? 1 : 0,
+              scale: rail.out ? 1 : GENIE_RETRACTED_SCALE,
               // Toward the strip while it shrinks, so it converges on the glyph
               // rather than just fading where it stood.
-              x: railOut ? 0 : GENIE_RETRACTED_OFFSET_PX,
+              x: rail.out ? 0 : GENIE_RETRACTED_OFFSET_PX,
               // Only the panel is offset from its own box; in the grid it sits
               // where the grid put it.
               y: railInPanel ? panelTop : 0,
             }}
-            transition={railTransition}
+            transition={rail.transition}
             onMouseEnter={collapsed ? cancelLeave : undefined}
             onMouseLeave={collapsed ? scheduleLeave : undefined}
           >

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -15,8 +15,10 @@ import { AnimatePresence, motion } from "motion/react"
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
+import { F0Icon } from "@/components/F0Icon"
 import Menu from "@/icons/app/Menu"
-import { Check, Pencil } from "@/icons/app"
+import { Check, Pencil, Plus } from "@/icons/app"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import { SidebarIconSvg } from "@/patterns/Navigation/Sidebar/Icon"
 import { Action } from "@/ui/Action"
@@ -172,6 +174,12 @@ const TWO_COLUMN_MIN_PX = 768
 const PANEL_LEAVE_MS = 150
 /** How far the floating panel clears the strip it comes out of. */
 const PANEL_GAP_PX = 8
+/**
+ * Names the add control in both places it appears — the strip's glyph here and the
+ * column's placeholder in `WidgetContainer`, which shares the default. Neither
+ * shows it: it is a tooltip and an accessible name.
+ */
+const ADD_WIDGET_LABEL = "Add widget"
 
 export interface NewHomeLayoutProps {
   /** Freeform main-column content on top (greeting, shortcut cards, ranked feed…). */
@@ -756,22 +764,26 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                     no edit affordance of its own, and adding a widget is the one
                     thing you would still want from it. */}
               {canEditSide("right") && onClickAddNewWidget ? (
-                <motion.button
-                  type="button"
-                  aria-label="Add widget"
-                  onClick={() => onClickAddNewWidget("right")}
-                  className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:text-f1-foreground"
-                  initial={{ opacity: 0 }}
-                  animate={{ opacity: 1 }}
-                  exit={{ opacity: 0 }}
-                  transition={entranceTransition(
-                    rightWidgets.length,
-                    rail.glyphDelayMs,
-                    reducedMotion
-                  )}
-                >
-                  +
-                </motion.button>
+                // The same control the column's placeholder is — a dashed box
+                // around one glyph, named only on hover — at the strip's size.
+                <Tooltip label={ADD_WIDGET_LABEL}>
+                  <motion.button
+                    type="button"
+                    aria-label={ADD_WIDGET_LABEL}
+                    onClick={() => onClickAddNewWidget("right")}
+                    className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
+                    transition={entranceTransition(
+                      rightWidgets.length,
+                      rail.glyphDelayMs,
+                      reducedMotion
+                    )}
+                  >
+                    <F0Icon size="md" icon={Plus} />
+                  </motion.button>
+                </Tooltip>
               ) : null}
             </motion.aside>
           )}

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -442,13 +442,20 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           // auto-placement would push one of them onto a row of its own.
           gridColumn: 2,
           gridRow: 2,
-          // Mid-retract the column is already on its way down to the strip's
-          // width, so the cards keep the width they had and hang off the cell's
-          // left edge while they shrink into it — squeezed narrow on the way out,
-          // the rail reads as crushed rather than stowed.
-          ...(rail.mode === "retracting"
-            ? { width: asideWidth, justifySelf: "end", pointerEvents: "none" }
-            : null),
+          // THE CARDS ARE NEVER SIZED BY THE GESTURE. Their column spends the
+          // collapse somewhere between the strip's width and the rail's, and a
+          // rail that took that width would re-lay-out every card on every frame:
+          // the headings and the list rows would re-wrap their way through the
+          // whole animation, which is the one thing that makes a transition look
+          // broken rather than fast.
+          //
+          // So the rail is pinned to the width it ENDS at and anchored to the
+          // cell's right edge, which does not move. The cards are laid out once,
+          // at their final width, and everything you see them do after that is a
+          // transform.
+          width: asideWidth,
+          justifySelf: "end",
+          ...(rail.mode === "retracting" ? { pointerEvents: "none" } : null),
           ...railFade.style,
         }
 

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -83,6 +83,11 @@ const GradientWash = ({
 
 /** Collapsed-rail geometry (mirrors the prototype's railMode). */
 const COLLAPSED_RAIL_WIDTH = 40
+/**
+ * The gap between the strip's glyphs — `gap-2` on the strip below, and the number
+ * a stowing widget needs to know where its own glyph is. Keep the two in step.
+ */
+const GLYPH_GAP_PX = 8
 
 /**
  * One widget as the collapsed strip shows it: its own catalog glyph, standing in
@@ -798,11 +803,11 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             // on top of that would be the same arrival animated twice.
             initial={false}
             animate={{
-              opacity: rail.out ? 1 : 0,
-              scale: rail.out ? 1 : GENIE_RETRACTED_SCALE,
+              opacity: rail.bodyOut ? 1 : 0,
+              scale: rail.bodyOut ? 1 : GENIE_RETRACTED_SCALE,
               // Toward the strip while it shrinks, so it converges on the glyph
               // rather than just fading where it stood.
-              x: rail.out ? 0 : GENIE_RETRACTED_OFFSET_PX,
+              x: rail.bodyOut ? 0 : GENIE_RETRACTED_OFFSET_PX,
               // Only the panel is offset from its own box; in the grid it sits
               // where the grid put it.
               y: railInPanel ? panelTop : 0,
@@ -814,9 +819,21 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             <WidgetContainer
               side="right"
               widgets={rightWidgets}
-              // Collapsed, this container IS the panel: one widget shown, the
-              // others hidden rather than dropped.
-              visibleWidgetId={collapsed ? openId : undefined}
+              // Only ONCE THE STRIP HAS THEM. This used to key off `collapsed`,
+              // which hid every card on the very frame the collapse began — so the
+              // cards were `display: none` before they had moved a pixel, and the
+              // retract animated an empty box while they simply blinked out. The
+              // panel's one-widget filter belongs to the panel; while the rail is
+              // still retracting the column is still a column, and its cards have a
+              // journey to make (`stow`).
+              visibleWidgetId={railInPanel ? openId : undefined}
+              // The strip they are going into: glyphs a fixed pitch apart, and how
+              // small a card has to get to be one of them.
+              stow={{
+                stowed: collapsed,
+                pitch: COLLAPSED_RAIL_WIDTH + GLYPH_GAP_PX,
+                scale: COLLAPSED_RAIL_WIDTH / asideWidth,
+              }}
               slotRenderers={slotRenderers}
               renderWidget={renderWidget}
               ctx={ctx}

--- a/packages/react/src/sds/Home/NewHomeLayout/useRailMotion.ts
+++ b/packages/react/src/sds/Home/NewHomeLayout/useRailMotion.ts
@@ -1,0 +1,161 @@
+import { useEffect, useLayoutEffect, useState } from "react"
+
+import {
+  animate,
+  type MotionValue,
+  type Transition,
+  useMotionValue,
+  useTransform,
+} from "motion/react"
+
+import { useReducedMotion } from "@/lib/a11y"
+
+import {
+  GENIE_CLOSE_MS,
+  GENIE_GLYPH_DELAY_MS,
+  GENIE_RETRACT_MS,
+  genieCloseTransition,
+  geniePanelGlideTransition,
+  genieOpenTransition,
+  INSTANT_TRANSITION,
+  railWidthTransition,
+  RIGHT_AREA_DELAY_MS,
+  useDelayedTrue,
+} from "../home-motion"
+
+/** What the rail body is at this moment. One element, three presentations. */
+export type RailMode =
+  /** The rail's own column, holding every widget. */
+  | "column"
+  /** On its way into the strip: lifted out of the column, shrinking. */
+  | "retracting"
+  /** A single widget floating out of the glyph you hovered. */
+  | "panel"
+
+export interface RailMotion {
+  mode: RailMode
+  /** The rail is showing something — the column, or one floating widget. */
+  out: boolean
+  /** `display: none`, which arrives only once the retract has played out. */
+  panelHidden: boolean
+  transition: Transition
+  /** The rail column's width, for the grid template's variable. */
+  widthPx: MotionValue<string>
+  /** When the strip's first glyph starts arriving. */
+  glyphDelayMs: number
+}
+
+export interface RailMotionOptions {
+  collapsed: boolean
+  /** Whether a widget is floating out of the strip. */
+  open: boolean
+  /**
+   * Whether the panel should travel to its new offset. True only between two
+   * glyphs — see `NewHomeLayout`'s `openFromAnchor`.
+   */
+  glide: boolean
+  /** Whether the rail is being drawn at all (the layout has a width for it). */
+  drawn: boolean
+  /** What the rail's column is worth right now: full width, or the strip. */
+  width: number
+}
+
+/**
+ * How the rail MOVES: the genie, and the column width the genie has to agree
+ * with. Everything that decides it lives here so the layout can stay about
+ * layout.
+ *
+ * THE GENIE. Collapsing must not read as one thing being swapped for another, so
+ * the rail's presentation LAGS the decision: the grid column starts narrowing and
+ * the strip starts arriving the moment `collapsed` flips, while the rail body
+ * spends `GENIE_RETRACT_MS` shrinking toward the strip's corner before it becomes
+ * the floating panel. Hovering a glyph mid-retract skips the rest of it — what you
+ * asked for is the panel, and finishing an animation you interrupted is not an
+ * answer.
+ *
+ * Nothing here unmounts to animate. Every one of these is the SAME render moved
+ * around, because a rail widget that is rebuilt has lost whatever it had loaded,
+ * timed or animated (see `WidgetContainer`'s `visibleWidgetId`).
+ */
+export const useRailMotion = ({
+  collapsed,
+  open,
+  glide,
+  drawn,
+  width,
+}: RailMotionOptions): RailMotion => {
+  const reducedMotion = useReducedMotion()
+
+  /**
+   * FROM HERE ON, A CHANGE IS SOMETHING THAT HAPPENED — before it, the layout is
+   * still working out where the rail goes.
+   *
+   * The first render cannot know how wide the box is (measuring needs the DOM), so
+   * the rail's state always resolves a render late, and motion cannot tell that
+   * correction apart from a collapse the user asked for: it would animate it, and
+   * every narrow first load would open with the cards retracting into a strip they
+   * were never out of.
+   *
+   * Effect-based ON PURPOSE. It has to turn true one commit LATER than the state
+   * it qualifies — computed during render it would qualify the resolution itself,
+   * which is the whole thing it exists to exclude.
+   */
+  const [live, setLive] = useState(false)
+  useEffect(() => {
+    if (drawn) setLive(true)
+  }, [drawn])
+  const animated = live && !reducedMotion
+
+  const retracted = useDelayedTrue(collapsed, animated ? GENIE_RETRACT_MS : 0)
+  const mode: RailMode = !collapsed
+    ? "column"
+    : retracted || open
+      ? "panel"
+      : "retracting"
+  const out = mode === "column" || open
+
+  /**
+   * THE COLUMN, animated so the space the main column gets back arrives over the
+   * same beat the cards retract over — snapped, the collapse reads as a jump with
+   * an animation next to it.
+   *
+   * A motion value rather than an `animate` prop, committed from a LAYOUT effect,
+   * because `jump` cannot be batched away: gating a `transition` prop instead is
+   * not enough, since the unmeasured render and the measured one land in motion's
+   * same batch and it reads the later one's transition.
+   */
+  const widthValue = useMotionValue(width)
+  const widthPx = useTransform(widthValue, (px) => `${px}px`)
+  useLayoutEffect(() => {
+    // Nothing reads the variable until the rail is drawn, so there is nothing to
+    // animate from either.
+    if (!drawn) return
+    if (!animated) {
+      widthValue.jump(width)
+      return
+    }
+    const controls = animate(widthValue, width, railWidthTransition)
+    return () => controls.stop()
+  }, [drawn, animated, width, widthValue])
+
+  return {
+    mode,
+    out,
+    widthPx,
+    // `display: none` cannot be animated out of: applied on the frame the panel
+    // closes it would delete the widget instead of letting it go into the glyph.
+    panelHidden: useDelayedTrue(!open, reducedMotion ? 0 : GENIE_CLOSE_MS),
+    transition: !animated
+      ? INSTANT_TRANSITION
+      : {
+          ...(out ? genieOpenTransition : genieCloseTransition),
+          // Between two glyphs the panel glides; on the way out of one it must
+          // not travel at all.
+          y: glide ? geniePanelGlideTransition : INSTANT_TRANSITION,
+        },
+    // Collapsing puts the glyphs in as the cards finish retracting — they overlap
+    // on purpose. On the first paint there is no retract to follow, so they are
+    // simply the right area arriving after the main one.
+    glyphDelayMs: live ? GENIE_GLYPH_DELAY_MS : RIGHT_AREA_DELAY_MS,
+  }
+}

--- a/packages/react/src/sds/Home/NewHomeLayout/useRailMotion.ts
+++ b/packages/react/src/sds/Home/NewHomeLayout/useRailMotion.ts
@@ -34,8 +34,15 @@ export type RailMode =
 
 export interface RailMotion {
   mode: RailMode
-  /** The rail is showing something — the column, or one floating widget. */
-  out: boolean
+  /**
+   * Whether the rail BODY should be at full size and opacity.
+   *
+   * Only the floating panel is ever anything else. Collapsing is not the body's
+   * animation to play: its cards go into their own glyphs one by one (see
+   * `WidgetMotion`'s stow), and a block that also shrank would be the same
+   * gesture happening twice at two scales.
+   */
+  bodyOut: boolean
   /** `display: none`, which arrives only once the retract has played out. */
   panelHidden: boolean
   transition: Transition
@@ -112,7 +119,8 @@ export const useRailMotion = ({
     : retracted || open
       ? "panel"
       : "retracting"
-  const out = mode === "column" || open
+  const inPanel = mode === "panel"
+  const bodyOut = !inPanel || open
 
   /**
    * THE COLUMN, animated so the space the main column gets back arrives over the
@@ -140,19 +148,23 @@ export const useRailMotion = ({
 
   return {
     mode,
-    out,
+    bodyOut,
     widthPx,
     // `display: none` cannot be animated out of: applied on the frame the panel
     // closes it would delete the widget instead of letting it go into the glyph.
     panelHidden: useDelayedTrue(!open, reducedMotion ? 0 : GENIE_CLOSE_MS),
-    transition: !animated
-      ? INSTANT_TRANSITION
-      : {
-          ...(out ? genieOpenTransition : genieCloseTransition),
-          // Between two glyphs the panel glides; on the way out of one it must
-          // not travel at all.
-          y: glide ? geniePanelGlideTransition : INSTANT_TRANSITION,
-        },
+    // ONLY THE PANEL ANIMATES. In the column and mid-retract the body snaps to
+    // full size, because the cards are the ones moving — animated, it would fade
+    // the whole block in on top of every card growing out of its glyph.
+    transition:
+      !animated || !inPanel
+        ? INSTANT_TRANSITION
+        : {
+            ...(open ? genieOpenTransition : genieCloseTransition),
+            // Between two glyphs the panel glides; on the way out of one it must
+            // not travel at all.
+            y: glide ? geniePanelGlideTransition : INSTANT_TRANSITION,
+          },
     // Collapsing puts the glyphs in as the cards finish retracting — they overlap
     // on purpose. On the first paint there is no retract to follow, so they are
     // simply the right area arriving after the main one.

--- a/packages/react/src/sds/Home/WidgetContainer/WidgetMotion.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/WidgetMotion.tsx
@@ -1,0 +1,137 @@
+import { type ReactNode, useLayoutEffect, useRef, useState } from "react"
+
+import { motion } from "motion/react"
+
+import { useReducedMotion } from "@/lib/a11y"
+import { cn } from "@/lib/utils"
+
+import {
+  ENTRANCE_RISE_PX,
+  entranceTransition,
+  GENIE_ORIGIN,
+  INSTANT_TRANSITION,
+  stowInTransition,
+  stowOutTransition,
+} from "../home-motion"
+
+/** A widget's place in its column's arrival. */
+export interface WidgetArrival {
+  /** Position in the shared stagger. */
+  order: number
+  /** Milliseconds before the column's first widget. */
+  delayMs: number
+  /**
+   * Whether the page is still arriving. False puts the widget straight where it
+   * belongs: edit mode re-parents every card, and a wrapper that animated on every
+   * mount would replay the arrival on each toggle of the pencil.
+   */
+  arriving: boolean
+}
+
+/** Where a widget goes while the rail is collapsed. */
+export interface WidgetStow {
+  /** Whether this widget belongs in the strip rather than in the column. */
+  stowed: boolean
+  /** Vertical distance between the glyphs widgets stow onto. */
+  pitch: number
+  /** How small a widget has to get to be a glyph. */
+  scale: number
+  /**
+   * Whether to take the position without animating. True while the rail is
+   * ALREADY collapsed, when a widget leaving or joining the strip means the
+   * floating panel opened or closed — and the panel animates that itself, so the
+   * card inside it must simply be full size.
+   */
+  instant: boolean
+}
+
+export interface WidgetMotionProps {
+  arrival?: WidgetArrival
+  stow?: WidgetStow
+  /**
+   * The widget's own `fullHeight`. This wrapper is the flex item the card used to
+   * be, so it has to carry the full-height chain or the card's `h-full` resolves
+   * against a box with no height of its own.
+   */
+  fullHeight?: boolean
+  children: ReactNode
+}
+
+/**
+ * Everything one widget does that isn't its content: how it ARRIVES, and how it
+ * goes into and comes out of its glyph.
+ *
+ * THE STOW is what makes a card and its glyph read as one object. The card scales
+ * down onto its OWN glyph — not toward the strip in general — and fades as the
+ * glyph fades in underneath it; opening the rail runs it backwards, so each glyph
+ * looks like it grows into the widget it stands for.
+ *
+ * The mapping needs no measuring of the strip, because the strip's geometry is
+ * known: glyphs are a fixed `pitch` apart from the top of this column, and their
+ * right edge is this column's right edge (both are pinned there by
+ * `NewHomeLayout`). So the widget's right edge is already where it needs to be —
+ * scaling from that corner leaves only a vertical distance to cover, and the only
+ * thing to look up is where this widget currently sits.
+ *
+ * ONE wrapper, not one per behaviour: a second box would be a second flex item to
+ * reason about, and adding or removing either of them mid-life would change the
+ * tree's shape — which is what unmounts a render.
+ */
+export const WidgetMotion = ({
+  arrival,
+  stow,
+  fullHeight,
+  children,
+}: WidgetMotionProps) => {
+  const reducedMotion = useReducedMotion()
+  const ref = useRef<HTMLDivElement>(null)
+  const [stowY, setStowY] = useState(0)
+
+  const stowed = stow?.stowed ?? false
+  const order = arrival?.order ?? 0
+
+  useLayoutEffect(() => {
+    if (!stow?.stowed) return
+    const el = ref.current
+    // A widget the strip already owns is `display: none` and has no box to
+    // measure — and the offset it came in on is exactly where it grows back FROM,
+    // so keeping it is right as well as necessary.
+    if (!el?.offsetParent) return
+    // `offsetTop` rather than a rect: it is a LAYOUT value, so it reports where
+    // the widget belongs even once this very element is scaled away from there.
+    setStowY(order * stow.pitch - el.offsetTop)
+  }, [stow?.stowed, stow?.pitch, order])
+
+  const transition = reducedMotion
+    ? INSTANT_TRANSITION
+    : arrival?.arriving
+      ? entranceTransition(order, arrival.delayMs)
+      : !stow || stow.instant
+        ? INSTANT_TRANSITION
+        : stowed
+          ? stowInTransition
+          : stowOutTransition
+
+  return (
+    <motion.div
+      ref={ref}
+      className={cn(fullHeight && "h-full")}
+      // The glyph is at this corner of the column, so this is the corner a widget
+      // shrinks onto and grows out of.
+      style={{ transformOrigin: GENIE_ORIGIN }}
+      initial={
+        arrival?.arriving
+          ? { opacity: 0, y: reducedMotion ? 0 : ENTRANCE_RISE_PX }
+          : false
+      }
+      animate={{
+        opacity: stowed ? 0 : 1,
+        y: stowed ? stowY : 0,
+        scale: stowed ? (stow?.scale ?? 1) : 1,
+      }}
+      transition={transition}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -32,7 +32,9 @@ describe("WidgetContainer", () => {
     )
 
     expect(screen.queryAllByLabelText("Remove widget")).toHaveLength(0)
-    expect(screen.getByText(/Add widget/)).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Add widget" })
+    ).toBeInTheDocument()
   })
 
   test("edit mode gives every widget a remove control", () => {
@@ -46,7 +48,9 @@ describe("WidgetContainer", () => {
     )
 
     expect(screen.getAllByLabelText("Remove widget")).toHaveLength(2)
-    expect(screen.getByText(/Add widget/)).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Add widget" })
+    ).toBeInTheDocument()
   })
 
   test("disableEdition opts the column out of everything, adding included", () => {
@@ -61,7 +65,9 @@ describe("WidgetContainer", () => {
     )
 
     expect(screen.queryAllByLabelText("Remove widget")).toHaveLength(0)
-    expect(screen.queryByText(/Add widget/)).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Add widget" })
+    ).not.toBeInTheDocument()
   })
 
   test("reports the widget a remove control belongs to", async () => {

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -313,16 +313,14 @@ export function WidgetContainer({
     )
   }
 
+  const arrival = entrance === false ? null : entrance
   /**
    * The arrival is a ONE-SHOT: once the page has landed, a card that mounts is
    * not arriving, it is just there. Edit mode is why this matters — the sortable
    * branch is a different tree, so toggling the pencil remounts every card, and
    * without this the whole column would fade back in each time.
    */
-  const arrived = useElapsed(
-    arrivalWindowMs(entrance === false ? 0 : entrance.delayMs)
-  )
-  const arriving = entrance !== false && !arrived
+  const arrived = useElapsed(arrivalWindowMs(arrival?.delayMs))
 
   /**
    * Wraps one block in its arrival. With `entrance` off it hands the block back
@@ -330,17 +328,17 @@ export function WidgetContainer({
    * because that box is the flex item the widget itself would have been.
    */
   const enter = (order: number, node: ReactNode, fullHeight?: boolean) =>
-    entrance === false ? (
-      node
-    ) : (
+    arrival ? (
       <HomeEntrance
-        order={(entrance.order ?? 0) + order}
-        delayMs={entrance.delayMs ?? 0}
-        arriving={arriving}
+        order={(arrival.order ?? 0) + order}
+        delayMs={arrival.delayMs}
+        arriving={!arrived}
         fullHeight={fullHeight}
       >
         {node}
       </HomeEntrance>
+    ) : (
+      node
     )
 
   return (

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -20,6 +20,7 @@ import { Cross, LockLocked } from "@/icons/app"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 
+import { arrivalWindowMs, HomeEntrance, useElapsed } from "../home-motion"
 import { SlotWidget } from "../SlotWidget"
 import { SortableWidget } from "./SortableWidget"
 import {
@@ -145,6 +146,17 @@ export interface WidgetContainerProps {
    * out over the feed from this same container rather than mounting a copy.
    */
   visibleWidgetId?: string | null
+  /**
+   * How this column's widgets ARRIVE: each one fades and rises into place, in
+   * order, one beat after the last (`home-motion`).
+   *
+   * `order` is where the first widget sits in the page's SHARED stagger, so a
+   * column that has freeform content above it can hand over the rhythm instead
+   * of restarting it; `delayMs` holds the whole column back (what makes the side
+   * rail land after the main column). `false` mounts the widgets outright, with
+   * no wrapper of any kind around them.
+   */
+  entrance?: false | { order?: number; delayMs?: number }
   /** Tooltip on a locked widget's lock icon. */
   lockedLabel?: string
   ctx?: HomeRenderCtx
@@ -178,6 +190,7 @@ export function WidgetContainer({
   onClickAddNewWidget,
   onReorder,
   visibleWidgetId,
+  entrance = {},
   lockedLabel = "This widget is mandatory in your company.",
   ctx = {},
   className,
@@ -300,6 +313,36 @@ export function WidgetContainer({
     )
   }
 
+  /**
+   * The arrival is a ONE-SHOT: once the page has landed, a card that mounts is
+   * not arriving, it is just there. Edit mode is why this matters — the sortable
+   * branch is a different tree, so toggling the pencil remounts every card, and
+   * without this the whole column would fade back in each time.
+   */
+  const arrived = useElapsed(
+    arrivalWindowMs(entrance === false ? 0 : entrance.delayMs)
+  )
+  const arriving = entrance !== false && !arrived
+
+  /**
+   * Wraps one block in its arrival. With `entrance` off it hands the block back
+   * untouched — an entrance that is not happening must not leave a box behind,
+   * because that box is the flex item the widget itself would have been.
+   */
+  const enter = (order: number, node: ReactNode, fullHeight?: boolean) =>
+    entrance === false ? (
+      node
+    ) : (
+      <HomeEntrance
+        order={(entrance.order ?? 0) + order}
+        delayMs={entrance.delayMs ?? 0}
+        arriving={arriving}
+        fullHeight={fullHeight}
+      >
+        {node}
+      </HomeEntrance>
+    )
+
   return (
     <div
       className={cn(
@@ -335,10 +378,16 @@ export function WidgetContainer({
                 side === "main" ? "gap-6" : "gap-4"
               )}
             >
-              {widgets.map((widget) => (
+              {widgets.map((widget, order) => (
                 <WidgetSlot key={widget.id} hidden={isHidden(widget)}>
                   <SortableWidget id={widget.id} disabled={widget.locked}>
-                    {(state) => render(widget, state)}
+                    {/* The arrival wrapper sits INSIDE the sortable rather than
+                        around it: dnd-kit measures the element it holds the ref
+                        to, and a transformed ancestor would offset every rect it
+                        reads while a drag is in flight. */}
+                    {(state) =>
+                      enter(order, render(widget, state), widget.fullHeight)
+                    }
                   </SortableWidget>
                 </WidgetSlot>
               ))}
@@ -364,18 +413,21 @@ export function WidgetContainer({
           </DragOverlay>
         </DndContext>
       ) : (
-        widgets.map((widget) => (
+        widgets.map((widget, order) => (
           <WidgetSlot key={widget.id} hidden={isHidden(widget)}>
-            {render(widget)}
+            {enter(order, render(widget), widget.fullHeight)}
           </WidgetSlot>
         ))
       )}
       {/* NOT edit-gated: adding is always on offer — edit mode is for
           arranging and removing what's already there. `disableEdition`
           columns still never offer it. */}
-      {!disableEdition && onClickAddNewWidget ? (
-        <AddWidgetPlaceholder onClick={onClickAddNewWidget} />
-      ) : null}
+      {!disableEdition && onClickAddNewWidget
+        ? enter(
+            widgets.length,
+            <AddWidgetPlaceholder onClick={onClickAddNewWidget} />
+          )
+        : null}
     </div>
   )
 }

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -20,9 +20,10 @@ import { Cross, LockLocked } from "@/icons/app"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 
-import { arrivalWindowMs, HomeEntrance, useElapsed } from "../home-motion"
+import { arrivalWindowMs, useElapsed } from "../home-motion"
 import { SlotWidget } from "../SlotWidget"
 import { SortableWidget } from "./SortableWidget"
+import { WidgetMotion, type WidgetStow } from "./WidgetMotion"
 import {
   type HomeRenderCtx,
   type HomeWidgetChrome,
@@ -157,6 +158,16 @@ export interface WidgetContainerProps {
    * no wrapper of any kind around them.
    */
   entrance?: false | { order?: number; delayMs?: number }
+  /**
+   * THE STOW: where this column's widgets go when the rail collapses. Each card
+   * scales down onto its own glyph and fades, and grows back out of it when the
+   * rail opens, so a card and its glyph read as one object rather than two
+   * representations that replace each other. See `WidgetMotion`.
+   *
+   * `pitch` and `scale` describe the strip the widgets are going into — only
+   * `NewHomeLayout` knows those, which is why they come in from outside.
+   */
+  stow?: Omit<WidgetStow, "stowed" | "instant"> & { stowed: boolean }
   /** Tooltip on a locked widget's lock icon. */
   lockedLabel?: string
   ctx?: HomeRenderCtx
@@ -191,6 +202,7 @@ export function WidgetContainer({
   onReorder,
   visibleWidgetId,
   entrance = {},
+  stow,
   lockedLabel = "This widget is mandatory in your company.",
   ctx = {},
   className,
@@ -323,28 +335,55 @@ export function WidgetContainer({
   const arrived = useElapsed(arrivalWindowMs(arrival?.delayMs))
 
   /**
-   * Wraps one block in its arrival. With `entrance` off it hands the block back
-   * untouched — an entrance that is not happening must not leave a box behind,
-   * because that box is the flex item the widget itself would have been.
+   * The stow as it applies to ONE widget. The widget the panel is currently
+   * floating is the exception: it is the only one at full size while the rail is
+   * collapsed, and it must simply BE there — the panel animates its own arrival
+   * out of the glyph, and a card growing inside a panel that is already growing is
+   * the same gesture played twice.
    */
-  const enter = (order: number, node: ReactNode, fullHeight?: boolean) =>
-    arrival ? (
-      <HomeEntrance
-        order={(arrival.order ?? 0) + order}
-        delayMs={arrival.delayMs}
-        arriving={!arrived}
-        fullHeight={fullHeight}
+  const stowOf = (widget: HomeWidgetItem): WidgetStow | undefined =>
+    stow && {
+      ...stow,
+      stowed: stow.stowed && widget.id !== visibleWidgetId,
+      instant: stow.stowed,
+    }
+
+  /**
+   * Wraps one widget in everything it does that isn't its content. With no
+   * arrival and no stow it hands the widget back untouched — a wrapper that has
+   * nothing to do must not leave a box behind, because that box is the flex item
+   * the widget itself would have been.
+   */
+  const enter = (order: number, node: ReactNode, widget?: HomeWidgetItem) => {
+    const widgetStow = widget ? stowOf(widget) : undefined
+    if (!arrival && !widgetStow) return node
+    return (
+      <WidgetMotion
+        arrival={
+          arrival
+            ? {
+                order: (arrival.order ?? 0) + order,
+                delayMs: arrival.delayMs ?? 0,
+                arriving: !arrived,
+              }
+            : undefined
+        }
+        stow={widgetStow}
+        fullHeight={widget?.fullHeight}
       >
         {node}
-      </HomeEntrance>
-    ) : (
-      node
+      </WidgetMotion>
     )
+  }
 
   return (
     <div
       className={cn(
-        "flex flex-col [&_*]:shadow-none",
+        // `relative` so this column is what a widget's `offsetTop` is measured
+        // from: the stow maps a widget onto its glyph by that offset, and an
+        // unpositioned column would hand the job to whatever ancestor happened to
+        // be positioned instead (see `WidgetMotion`).
+        "relative flex flex-col [&_*]:shadow-none",
         // The main column's freeform content wants more air than the rail's
         // stack of cards.
         side === "main" ? "gap-6" : "gap-4",
@@ -383,9 +422,7 @@ export function WidgetContainer({
                         around it: dnd-kit measures the element it holds the ref
                         to, and a transformed ancestor would offset every rect it
                         reads while a drag is in flight. */}
-                    {(state) =>
-                      enter(order, render(widget, state), widget.fullHeight)
-                    }
+                    {(state) => enter(order, render(widget, state), widget)}
                   </SortableWidget>
                 </WidgetSlot>
               ))}
@@ -413,7 +450,7 @@ export function WidgetContainer({
       ) : (
         widgets.map((widget, order) => (
           <WidgetSlot key={widget.id} hidden={isHidden(widget)}>
-            {enter(order, render(widget), widget.fullHeight)}
+            {enter(order, render(widget), widget)}
           </WidgetSlot>
         ))
       )}

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -16,7 +16,7 @@ import {
 } from "@dnd-kit/sortable"
 
 import { F0Icon } from "@/components/F0Icon"
-import { Cross, LockLocked } from "@/icons/app"
+import { Cross, LockLocked, Plus } from "@/icons/app"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 
@@ -99,14 +99,33 @@ const WidgetSlot = ({
   </div>
 )
 
-const AddWidgetPlaceholder = ({ onClick }: { onClick: () => void }) => (
-  <button
-    type="button"
-    onClick={onClick}
-    className="flex items-center justify-center gap-1 rounded-xl border border-dashed border-f1-border py-4 text-f1-foreground-secondary hover:text-f1-foreground"
-  >
-    <span aria-hidden>+</span> Add widget
-  </button>
+/**
+ * The offer at the foot of a column. A GLYPH, not a sentence: it sits under a
+ * stack of cards that are all content, and a labelled button competes with them
+ * for the eye every time you look down the column. The label is still there, on
+ * hover and to a screen reader — it is just not taking up the room.
+ *
+ * `w-full` because a `<button>` shrinks to fit even as a flex box: it used to be a
+ * direct flex item of the column and got stretched for free, and it no longer is
+ * (its arrival wrapper is in between).
+ */
+const AddWidgetPlaceholder = ({
+  onClick,
+  label,
+}: {
+  onClick: () => void
+  label: string
+}) => (
+  <Tooltip label={label}>
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      className="flex w-full items-center justify-center rounded-xl border border-dashed border-f1-border py-4 text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
+    >
+      <F0Icon size="md" icon={Plus} />
+    </button>
+  </Tooltip>
 )
 
 export interface WidgetContainerProps {
@@ -170,6 +189,8 @@ export interface WidgetContainerProps {
   stow?: Omit<WidgetStow, "stowed" | "instant"> & { stowed: boolean }
   /** Tooltip on a locked widget's lock icon. */
   lockedLabel?: string
+  /** Tooltip and accessible name for the add placeholder, which shows no text. */
+  addWidgetLabel?: string
   ctx?: HomeRenderCtx
   className?: string
   style?: CSSProperties
@@ -204,6 +225,7 @@ export function WidgetContainer({
   entrance = {},
   stow,
   lockedLabel = "This widget is mandatory in your company.",
+  addWidgetLabel = "Add widget",
   ctx = {},
   className,
   style,
@@ -460,7 +482,10 @@ export function WidgetContainer({
       {!disableEdition && onClickAddNewWidget
         ? enter(
             widgets.length,
-            <AddWidgetPlaceholder onClick={onClickAddNewWidget} />
+            <AddWidgetPlaceholder
+              onClick={onClickAddNewWidget}
+              label={addWidgetLabel}
+            />
           )
         : null}
     </div>

--- a/packages/react/src/sds/Home/home-motion.spec.tsx
+++ b/packages/react/src/sds/Home/home-motion.spec.tsx
@@ -1,0 +1,133 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import { act, zeroRenderHook } from "@/testing/test-utils"
+
+import {
+  arrivalWindowMs,
+  ENTRANCE_MS,
+  ENTRANCE_STAGGER_CAP_MS,
+  ENTRANCE_STAGGER_MS,
+  entranceDelay,
+  useDelayedTrue,
+  useElapsed,
+} from "./home-motion"
+
+describe("entranceDelay", () => {
+  test("gives each block one more beat than the one above it", () => {
+    expect(entranceDelay(0)).toBe(0)
+    expect(entranceDelay(1)).toBeCloseTo(ENTRANCE_STAGGER_MS / 1000)
+    expect(entranceDelay(2)).toBeCloseTo((2 * ENTRANCE_STAGGER_MS) / 1000)
+  })
+
+  test("caps the stagger, so the tail of a long column lands together", () => {
+    const capped = ENTRANCE_STAGGER_CAP_MS / 1000
+
+    expect(entranceDelay(50)).toBe(capped)
+    expect(entranceDelay(500)).toBe(capped)
+  })
+
+  test("the cap applies to the stagger, not to the base delay", () => {
+    // Otherwise a column held back (the side rail) would have its own rhythm
+    // clipped by a ceiling meant for the number of blocks above it.
+    expect(entranceDelay(50, 200)).toBeCloseTo(
+      0.2 + ENTRANCE_STAGGER_CAP_MS / 1000
+    )
+  })
+})
+
+describe("useElapsed", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  test("starts closed and opens once the window has passed", () => {
+    const { result } = zeroRenderHook(() => useElapsed(300))
+
+    // The arrival is still running, so a card mounting now IS arriving.
+    expect(result.current).toBe(false)
+
+    act(() => vi.advanceTimersByTime(300))
+
+    // From here a card that mounts — edit mode re-parents them all — is not
+    // arriving, it is simply there.
+    expect(result.current).toBe(true)
+  })
+
+  test("no window at all is already over", () => {
+    const { result } = zeroRenderHook(() => useElapsed(0))
+
+    expect(result.current).toBe(true)
+  })
+})
+
+describe("arrivalWindowMs", () => {
+  test("covers the last block's delay plus the time it takes to land", () => {
+    expect(arrivalWindowMs()).toBe(ENTRANCE_STAGGER_CAP_MS + ENTRANCE_MS)
+    expect(arrivalWindowMs(220)).toBe(
+      220 + ENTRANCE_STAGGER_CAP_MS + ENTRANCE_MS
+    )
+  })
+})
+
+describe("useDelayedTrue", () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  test("already true at mount is not a change, so it is not delayed", () => {
+    const { result } = zeroRenderHook(() => useDelayedTrue(true, 200))
+
+    expect(result.current).toBe(true)
+  })
+
+  test("waits out the delay before turning true", () => {
+    const { result, rerender } = zeroRenderHook(
+      ({ value }) => useDelayedTrue(value, 200),
+      { initialProps: { value: false } }
+    )
+
+    rerender({ value: true })
+    expect(result.current).toBe(false)
+
+    act(() => vi.advanceTimersByTime(199))
+    expect(result.current).toBe(false)
+
+    act(() => vi.advanceTimersByTime(1))
+    expect(result.current).toBe(true)
+  })
+
+  test("turns false at once — the flag that starts an animation never waits", () => {
+    const { result, rerender } = zeroRenderHook(
+      ({ value }) => useDelayedTrue(value, 200),
+      { initialProps: { value: true } }
+    )
+
+    rerender({ value: false })
+
+    expect(result.current).toBe(false)
+  })
+
+  test("a value that goes false again mid-delay never turns true", () => {
+    const { result, rerender } = zeroRenderHook(
+      ({ value }) => useDelayedTrue(value, 200),
+      { initialProps: { value: false } }
+    )
+
+    rerender({ value: true })
+    act(() => vi.advanceTimersByTime(100))
+    rerender({ value: false })
+    act(() => vi.advanceTimersByTime(500))
+
+    expect(result.current).toBe(false)
+  })
+
+  test("no delay resolves without a timer at all", () => {
+    const { result, rerender } = zeroRenderHook(
+      ({ value }) => useDelayedTrue(value, 0),
+      { initialProps: { value: false } }
+    )
+
+    // Reduced motion passes 0 here, and it must not need a tick to take effect.
+    rerender({ value: true })
+
+    expect(result.current).toBe(true)
+  })
+})

--- a/packages/react/src/sds/Home/home-motion.tsx
+++ b/packages/react/src/sds/Home/home-motion.tsx
@@ -99,6 +99,9 @@ export const GENIE_GLYPH_ENTER_SCALE = 1.18
 export const GENIE_GLYPH_EXIT_SCALE = 1.3
 /** A glyph whose widget is floating, held slightly forward. */
 export const GENIE_GLYPH_OPEN_SCALE = 1.06
+/** …and the pointer's own feedback on it, under the open state. */
+export const GENIE_GLYPH_HOVER_SCALE = 1.08
+export const GENIE_GLYPH_TAP_SCALE = 0.94
 
 /** Coming OUT: physical, with the faintest settle (ζ ≈ 0.82 — no visible bounce). */
 export const genieOpenTransition: Transition = {

--- a/packages/react/src/sds/Home/home-motion.tsx
+++ b/packages/react/src/sds/Home/home-motion.tsx
@@ -134,6 +134,22 @@ export const geniePanelGlideTransition: Transition = {
   mass: 0.8,
 }
 /**
+ * A widget going INTO its glyph. It ACCELERATES away — a card being stowed should
+ * leave, not be set down — and it has to be gone by the time the strip owns it
+ * (`GENIE_RETRACT_MS`), because that is when the column stops drawing it at all.
+ */
+export const stowInTransition: Transition = {
+  duration: GENIE_RETRACT_MS / 1000,
+  ease: "easeIn",
+}
+/**
+ * …and coming back OUT of it. The same spring the floating panel uses, so a
+ * widget growing out of a glyph and a widget springing out of a glyph are visibly
+ * the same gesture at two sizes.
+ */
+export const stowOutTransition: Transition = genieOpenTransition
+
+/**
  * The rail's grid column, collapsing from its full width to the strip. The one
  * animated LAYOUT value on the page: the main column has to give the space back
  * over the same beat the cards retract over, or the collapse reads as a jump

--- a/packages/react/src/sds/Home/home-motion.tsx
+++ b/packages/react/src/sds/Home/home-motion.tsx
@@ -1,0 +1,266 @@
+import { type ReactNode, useEffect, useState } from "react"
+
+import { motion, type Transition } from "motion/react"
+
+import { useReducedMotion } from "@/lib/a11y"
+import { cn } from "@/lib/utils"
+
+/**
+ * Home's motion vocabulary. Two separate things happen on this page, and they
+ * must not borrow each other's timing:
+ *
+ * ARRIVAL — the page lands the way it is read. The MAIN column's blocks rise in
+ * on a stagger and the SIDE RAIL follows them, because the rail is context and
+ * context that arrives with the content it is context for reads as noise.
+ *
+ * THE GENIE — collapsing the rail must not read as one thing being swapped for
+ * another. The column of cards RETRACTS toward the strip — scaled from its top
+ * right corner, which is exactly where the strip is — while the glyphs shrink
+ * into place; hovering a glyph sends the same widget back out of that corner.
+ * Expanding reverses it: the glyphs bloom outward as the cards grow back in.
+ *
+ * Every value here is a TRANSFORM or an OPACITY, so the whole gesture is
+ * composited: nothing in this file animates a width, a height or an offset. (The
+ * one exception is the rail's grid column, which is the layout itself changing
+ * shape — see `railWidthTransition`.)
+ */
+
+/** Fast start, soft landing, NO overshoot (Material "emphasized decelerate"). */
+export const HOME_EASE: [number, number, number, number] = [0.05, 0.7, 0.1, 1]
+
+/** For anything that must not animate at all (reduced motion, first paint). */
+export const INSTANT_TRANSITION: Transition = { duration: 0 }
+
+/* ------------------------------- arrival -------------------------------- */
+
+/** How long one block takes to arrive. */
+export const ENTRANCE_MS = 320
+/** How far it rises on the way in — small: this is a settle, not a slide. */
+export const ENTRANCE_RISE_PX = 10
+/** Gap between consecutive blocks. Rhythm, not a parade. */
+export const ENTRANCE_STAGGER_MS = 55
+/**
+ * Stagger ceiling. Blocks hold their space from the first frame (they arrive at
+ * opacity 0, not at zero height), so an uncapped stagger would leave the bottom
+ * of a long column blank for over a second. The first ~6 keep the rhythm and
+ * the rest land together.
+ */
+export const ENTRANCE_STAGGER_CAP_MS = 330
+/**
+ * How long the right area waits for the main one. Long enough that the main
+ * column is unmistakably first, short enough that the page still reads as ONE
+ * arrival rather than two.
+ */
+export const RIGHT_AREA_DELAY_MS = 220
+
+/** When the nth block of a stagger starts, in seconds (motion's unit). */
+export const entranceDelay = (order: number, delayMs = 0): number =>
+  (delayMs + Math.min(order * ENTRANCE_STAGGER_MS, ENTRANCE_STAGGER_CAP_MS)) /
+  1000
+
+export const entranceTransition = (
+  order: number,
+  delayMs = 0,
+  reducedMotion = false
+): Transition =>
+  reducedMotion
+    ? INSTANT_TRANSITION
+    : {
+        duration: ENTRANCE_MS / 1000,
+        ease: HOME_EASE,
+        delay: entranceDelay(order, delayMs),
+      }
+
+/* -------------------------------- genie --------------------------------- */
+
+/**
+ * The collapsed strip sits at the rail's top right corner, so that corner is
+ * where a widget retracts to and comes back out of. Every genie scale is taken
+ * from here — it is the whole reason the two states read as the same widget.
+ */
+export const GENIE_ORIGIN = "top right"
+/** How long the column of cards spends shrinking into the strip. */
+export const GENIE_RETRACT_MS = 180
+/** …and how long a floating widget spends going back in. */
+export const GENIE_CLOSE_MS = 140
+/**
+ * The glyphs start arriving BEFORE the cards have finished retracting: the
+ * overlap is what makes it read as a transfer rather than as a sequence of two
+ * animations.
+ */
+export const GENIE_GLYPH_DELAY_MS = 90
+/** How small a retracted widget gets before it is gone. */
+export const GENIE_RETRACTED_SCALE = 0.9
+/** …and how far toward the strip it slides while it shrinks. */
+export const GENIE_RETRACTED_OFFSET_PX = 10
+/** A glyph arrives from LARGER than life: a card that just shrank into it. */
+export const GENIE_GLYPH_ENTER_SCALE = 1.18
+/** Expanding, it leaves the other way — blooming out into the card it becomes. */
+export const GENIE_GLYPH_EXIT_SCALE = 1.3
+/** A glyph whose widget is floating, held slightly forward. */
+export const GENIE_GLYPH_OPEN_SCALE = 1.06
+
+/** Coming OUT: physical, with the faintest settle (ζ ≈ 0.82 — no visible bounce). */
+export const genieOpenTransition: Transition = {
+  type: "spring",
+  stiffness: 420,
+  damping: 32,
+  mass: 0.9,
+}
+/** Going IN: a tween. A spring's overshoot on the way out reads as a bounce. */
+export const genieCloseTransition: Transition = {
+  duration: GENIE_CLOSE_MS / 1000,
+  ease: "easeIn",
+}
+/** The glyphs' own arrival — springier than the panel; they are small. */
+export const glyphTransition: Transition = {
+  type: "spring",
+  stiffness: 420,
+  damping: 26,
+  mass: 0.7,
+}
+/**
+ * Moving the OPEN panel from one glyph to the next. It glides rather than cuts,
+ * which is what says "same panel, different widget" — and it only ever runs
+ * between two glyphs, never on the way out of one (see `NewHomeLayout`).
+ */
+export const geniePanelGlideTransition: Transition = {
+  type: "spring",
+  stiffness: 520,
+  damping: 38,
+  mass: 0.8,
+}
+/**
+ * The rail's grid column, collapsing from its full width to the strip. The one
+ * animated LAYOUT value on the page: the main column has to give the space back
+ * over the same beat the cards retract over, or the collapse reads as a jump
+ * with an animation next to it.
+ */
+// Left unannotated on purpose: this one is handed to `animate()` for a single
+// motion value, whose options are narrower than a whole element's `Transition`.
+export const railWidthTransition = {
+  duration: 0.28,
+  ease: HOME_EASE,
+}
+
+export const withReducedMotion = (
+  transition: Transition,
+  reducedMotion: boolean
+): Transition => (reducedMotion ? INSTANT_TRANSITION : transition)
+
+/* -------------------------------- hooks --------------------------------- */
+
+/**
+ * `value`, but only once it has been true for `delayMs` — and false the INSTANT
+ * it turns false.
+ *
+ * For a presentation change that has to wait for an exit animation to finish:
+ * the flag that would cut the animation short (a `hidden`, a reposition) arrives
+ * late, while the flag that STARTS one is never delayed. Already-true at mount
+ * is not a change, so it is not delayed either.
+ */
+export const useDelayedTrue = (value: boolean, delayMs: number): boolean => {
+  const [delayed, setDelayed] = useState(value)
+
+  useEffect(() => {
+    if (!value) {
+      setDelayed(false)
+      return
+    }
+    if (delayMs <= 0) {
+      setDelayed(true)
+      return
+    }
+    const timer = setTimeout(() => setDelayed(true), delayMs)
+    return () => clearTimeout(timer)
+  }, [value, delayMs])
+
+  return delayed
+}
+
+/**
+ * False on mount, true once `delayMs` has passed — for "that moment is over".
+ *
+ * The mirror of `useDelayedTrue`, which reports a value that has SETTLED; this
+ * one reports that a WINDOW has closed, so it must start out false however long
+ * the window is.
+ */
+export const useElapsed = (delayMs: number): boolean => {
+  const [elapsed, setElapsed] = useState(delayMs <= 0)
+
+  useEffect(() => {
+    if (delayMs <= 0) {
+      setElapsed(true)
+      return
+    }
+    const timer = setTimeout(() => setElapsed(true), delayMs)
+    return () => clearTimeout(timer)
+  }, [delayMs])
+
+  return elapsed
+}
+
+/** How long the whole arrival takes, from the first block to the last landing. */
+export const arrivalWindowMs = (delayMs = 0): number =>
+  delayMs + ENTRANCE_STAGGER_CAP_MS + ENTRANCE_MS
+
+/* ------------------------------ components ------------------------------ */
+
+export interface HomeEntranceProps {
+  /** Position in the stagger. 0 lands first. */
+  order?: number
+  /** Milliseconds before the stagger's first block. */
+  delayMs?: number
+  /**
+   * Whether this block still has an arrival to play. `false` puts it straight
+   * where it belongs — for a wrapper that MOUNTS after the page has arrived, which
+   * is not the same thing as arriving: entering edit mode re-parents every card
+   * (the sortable branch is a different tree), and a wrapper that animated on
+   * every mount would replay the whole page's arrival on each toggle.
+   *
+   * The wrapper still renders either way. Dropping it once the arrival is over
+   * would change the tree's shape, and changing shape is what unmounts a render.
+   */
+  arriving?: boolean
+  /**
+   * The wrapped widget's own `fullHeight`. This wrapper becomes the flex item
+   * the card used to be, so it has to carry the full-height chain or the card's
+   * `h-full` resolves against a box that has no height of its own.
+   */
+  fullHeight?: boolean
+  className?: string
+  children: ReactNode
+}
+
+/**
+ * One block arriving: a fade with a small rise, at its place in the shared
+ * stagger. Opacity and transform only, so a column of these costs one
+ * composited layer each and no layout.
+ */
+export const HomeEntrance = ({
+  order = 0,
+  delayMs = 0,
+  arriving = true,
+  fullHeight,
+  className,
+  children,
+}: HomeEntranceProps) => {
+  const reducedMotion = useReducedMotion()
+
+  return (
+    <motion.div
+      className={cn(fullHeight && "h-full", className)}
+      // `initial={false}` is motion's "already there": it writes the target on the
+      // first render and animates nothing.
+      initial={
+        arriving
+          ? { opacity: 0, y: reducedMotion ? 0 : ENTRANCE_RISE_PX }
+          : false
+      }
+      animate={{ opacity: 1, y: 0 }}
+      transition={entranceTransition(order, delayMs, reducedMotion)}
+    >
+      {children}
+    </motion.div>
+  )
+}

--- a/packages/react/src/sds/Home/useScrollFade.ts
+++ b/packages/react/src/sds/Home/useScrollFade.ts
@@ -1,4 +1,4 @@
-import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react"
+import { type CSSProperties, useEffect, useMemo, useState } from "react"
 
 /** How far an overflowing end is faded out, in px. */
 export const SCROLL_FADE_PX = 24
@@ -14,11 +14,21 @@ export const SCROLL_FADE_PX = 24
  * there, so a column that fits is not masked at all.
  */
 export function useScrollFade(fade: number = SCROLL_FADE_PX) {
-  const ref = useRef<HTMLDivElement | null>(null)
+  /**
+   * A CALLBACK ref held in state, not a `useRef`: the region does not always
+   * exist on the first render. A layout that has to measure itself before it
+   * knows whether to draw its scroll region at all mounts that region a render
+   * late, and an effect that read a plain ref once on mount found nothing there,
+   * attached no listeners, and — with nothing to depend on — never looked again.
+   * The whole column then scrolled unmasked forever.
+   *
+   * Keeping the node in state re-runs the effect when it arrives, and again if it
+   * is ever replaced.
+   */
+  const [el, setEl] = useState<HTMLElement | null>(null)
   const [ends, setEnds] = useState({ top: false, bottom: false })
 
   useEffect(() => {
-    const el = ref.current
     if (!el) return
 
     const read = () => {
@@ -45,7 +55,7 @@ export function useScrollFade(fade: number = SCROLL_FADE_PX) {
       el.removeEventListener("scroll", read)
       observer?.disconnect()
     }
-  }, [])
+  }, [el])
 
   const style = useMemo<CSSProperties>(() => {
     if (!ends.top && !ends.bottom) return {}
@@ -57,5 +67,5 @@ export function useScrollFade(fade: number = SCROLL_FADE_PX) {
     return { maskImage: mask, WebkitMaskImage: mask }
   }, [ends, fade])
 
-  return { ref, style }
+  return { ref: setEl, style }
 }


### PR DESCRIPTION
## Description

Motion for `NewHomeLayout` and `WidgetContainer`, in three parts:

1. **Arrival** — the page lands the way it is read. The main column's blocks (greeting, shortcuts, feed, then its widgets) rise in on a shared stagger, and the **side rail follows them**. The rail is context, and context that arrives with the content it is context for reads as noise.
2. **The morph** — collapsing the rail makes each card **scale down onto its own glyph** and fade as that glyph fades in underneath it. Expanding runs it backwards, so a glyph looks like it *grows into* the widget it stands for rather than being replaced by it.
3. **Hover, collapsed** — a glyph sends its widget back out of the corner it went into (spring, scaled from that same origin), the glyph holds itself slightly forward while open, and moving between glyphs makes the panel *glide* rather than cut.

The vocabulary lives in `sds/Home/home-motion.tsx`; the rail's own state machine in `NewHomeLayout/useRailMotion.ts`; per-widget motion in `WidgetContainer/WidgetMotion.tsx`.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Bug fix (see below — the collapse was animating an empty box)

## Screenshots (if applicable)

Storybook: **Domain specific → Home → NewHomeLayout → Default**. Resize past the two-column threshold (or use the collapse toggle) for the morph; hover the glyphs while collapsed.

## Implementation details

### Bugs found and fixed on the way

- **The collapse was not animating anything.** `visibleWidgetId` keyed off `collapsed`, so every card went `display: none` on the very frame the gesture began — the cards blinked out, the glyphs appeared, and the retract played on an empty box. The panel's one-widget filter now waits until the strip actually owns the widgets.
- **The cards were being sized by the gesture.** They took their width from a column travelling between 40px and 396px, so every card re-laid-out each frame and its headings and rows re-wrapped through the whole animation. The rail is now pinned to the width it *ends* at, anchored to the cell's right edge.
- **The glyphs slid ~356px sideways** during the gesture, for the mirror-image reason — so the cards were retracting toward a target that was itself still moving. Same fix, applied to the strip.
- **The closing panel emptied before it had gone**: its widget was dropped on the frame the hover ended, so a bare rounded box did the 140ms fade.

### The morph needs no measuring of the strip

Because the strip's geometry is known once both ends are pinned: glyphs are a fixed pitch apart from the top of the column and share its right edge. Scaling from that corner leaves only a vertical distance to cover, and the only thing to look up is where the widget currently sits — `offsetTop`, a **layout** value, so it still reports where the widget belongs even once the element is scaled away from there.

Verified to the pixel with the frozen `initial` transforms neutralised: **every card's stow target lands on its own glyph with 0px delta on both the top and the right edge**.

### What the mechanics protect

- **The rail's widgets stay mounted** through every presentation change (#5065). Nothing here unmounts to animate.
- **`display: none` cannot be animated out of**, so it arrives only once the retract has played (`useDelayedTrue`).
- **The rail is not drawn until the box has been measured once.** Drawn earlier its first state is a guess the next render corrects, and motion cannot tell that correction apart from a collapse the user asked for. The gate is **sticky** — a hidden container reports width 0, and treating that as "unmeasured" would tear the rail down and rebuild every widget in it (test).
- **The strip and the rail body share one grid cell explicitly.** Mid-collapse both are in flow, and auto-placement pushed one onto a row of its own.
- **The arrival is a one-shot.** Edit mode re-parents every card, and without this the column faded back in on every toggle of the pencil.
- The rail **body** no longer retracts as a block — its cards do it one by one, and a block that also shrank would be the same gesture twice at two scales.
- `prefers-reduced-motion` collapses all of it to zero duration.

`WidgetContainer` gains two props: `entrance` and `stow`. Both default to something sensible and both can be switched off; with neither, widgets mount with **no wrapper at all** — a wrapper with nothing to do must not leave a box behind, because that box is the flex item the widget itself would have been.

## Testing

- `pnpm vitest src/sds/Home` — **134 passing**, 13 new (`home-motion.spec.tsx` for the hooks and stagger maths; `NewHomeLayout` tests that a container reporting no width keeps the rail's widgets mounted, and that the cards stay drawn while they retract).
- `oxlint` / `oxfmt` clean; no new type errors.
- Verified numerically in Storybook at 1440 and 1920: the collapse resolves instantly on load (no phantom animation); the rail's edges and its cards' width are **identical** across a forced sweep of the column from 396px to 40px; the glyphs are stationary across the same sweep; the stow targets land pixel-exact; mid-retract both asides sit in cell `2/2` with no third row; the panel opens at its glyph with only the hovered widget shown.

**One limitation, stated plainly:** the browser pane available to me produces zero animation frames (`document.visibilityState` is permanently `hidden`), so motion can never settle in it. I verified the **geometry and DOM state** of every phase numerically, but I did **not** watch a single animation play. The timing, easing and spring values want a human eye on them in Storybook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
