### PR TITLE
feat(OneDataCollection): support disabled item actions with tooltip

### DIFF
--- a/packages/react/src/experimental/Navigation/Dropdown/__tests__/Dropdown.test.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/__tests__/Dropdown.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
 import { Add, Pencil } from "@/icons/app"
@@ -95,6 +96,49 @@ describe("Dropdown (experimental) — disabled", () => {
     expect(screen.queryByText("Create")).not.toBeInTheDocument()
     rerender(<Dropdown items={items} />)
     expect(screen.queryByText("Create")).not.toBeInTheDocument()
+  })
+})
+
+describe("Dropdown (experimental) — per-item disabled", () => {
+  it("renders an item with `disabled` as a disabled menu item, leaving siblings enabled", async () => {
+    render(
+      <Dropdown
+        items={[
+          { label: "Create", onClick: vi.fn(), icon: Add },
+          { label: "Delete", onClick: vi.fn(), icon: Pencil, disabled: true },
+        ]}
+      />
+    )
+    await userEvent.click(screen.getByRole("button"))
+    const deleteItem = (await screen.findByText("Delete")).closest(
+      '[role="menuitem"]'
+    )
+    expect(deleteItem).toHaveAttribute("data-disabled")
+    const createItem = screen.getByText("Create").closest('[role="menuitem"]')
+    expect(createItem).not.toHaveAttribute("data-disabled")
+  })
+
+  it("shows `disabledTooltip` on hover over a disabled item", async () => {
+    render(
+      <Dropdown
+        items={[
+          {
+            label: "Delete",
+            onClick: vi.fn(),
+            icon: Pencil,
+            disabled: true,
+            disabledTooltip: "People on active contracts can't be deleted",
+          },
+        ]}
+      />
+    )
+    await userEvent.click(screen.getByRole("button"))
+    await userEvent.hover(await screen.findByText("Delete"))
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "People on active contracts can't be deleted"
+      )
+    })
   })
 })
 

--- a/packages/react/src/experimental/Navigation/Dropdown/index.stories.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.stories.tsx
@@ -310,6 +310,34 @@ export const DisabledWithCustomTrigger: Story = {
   },
 }
 
+/**
+ * A single item can be disabled with `disabled: true` — it stays VISIBLE but
+ * greyed-out and non-interactive (unlike `enabled: false`, which removes it).
+ * Pair it with `disabledTooltip` to explain on hover why the action is
+ * unavailable; the tooltip works despite the disabled item's `pointer-events:
+ * none`. Open the menu and hover "Delete" to see it.
+ */
+export const DisabledItemWithTooltip: Story = {
+  args: {
+    items: [
+      {
+        label: "Edit",
+        onClick: () => console.log("Edit clicked"),
+        icon: Icons.Pencil,
+      },
+      {
+        label: "Delete",
+        onClick: () => console.log("Delete clicked"),
+        icon: Icons.Delete,
+        critical: true,
+        disabled: true,
+        disabledTooltip:
+          "You can't delete this while people with active contracts are assigned to it",
+      },
+    ],
+  },
+}
+
 export const MobileDropdown: Story = {
   args: {
     items: [

--- a/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
@@ -8,6 +8,7 @@ import { DataAttributes } from "@/global.types"
 import { EllipsisHorizontal } from "@/icons/app"
 import { Link } from "@/lib/linkHandler"
 import { useI18n } from "@/lib/providers/i18n"
+import { TooltipWrapper } from "@/lib/tooltip-wrapper"
 import { cn } from "@/lib/utils"
 import {
   DropdownMenu,
@@ -36,6 +37,13 @@ export type DropdownItemObject = Pick<NavigationItem, "label" | "href"> & {
   critical?: boolean
   avatar?: AvatarVariant
   disabled?: boolean
+  /**
+   * Tooltip shown on hover while the item is `disabled` — use it to explain why
+   * the action is unavailable. Ignored when the item is not disabled. The
+   * tooltip trigger re-enables pointer events, so it works despite the disabled
+   * item's `pointer-events: none`.
+   */
+  disabledTooltip?: string
 }
 
 export type DropdownInternalProps = {
@@ -64,6 +72,7 @@ const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
     icon: _icon,
     avatar: _avatar,
     description: _description,
+    disabledTooltip,
     href,
     critical,
     disabled,
@@ -75,29 +84,35 @@ const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
     critical && "text-f1-foreground-critical"
   )
 
+  // The tooltip only makes sense while disabled (it explains why the action is
+  // unavailable). `TooltipWrapper` is a no-op when the tooltip is undefined and
+  // re-enables pointer events on its trigger, so hover fires even though a
+  // disabled item sets `pointer-events: none`.
   return (
-    <DropdownMenuItem
-      asChild
-      className={cn(itemClass, "cursor-pointer")}
-      disabled={disabled}
-    >
-      {href ? (
-        <Link
-          href={href}
-          className={cn(
-            itemClass,
-            "text-f1-foreground no-underline hover:cursor-pointer"
-          )}
-          {...props}
-        >
-          <DropdownItemContent item={item} />
-        </Link>
-      ) : (
-        <div {...props} className={itemClass}>
-          <DropdownItemContent item={item} />
-        </div>
-      )}
-    </DropdownMenuItem>
+    <TooltipWrapper tooltip={disabled ? disabledTooltip : undefined}>
+      <DropdownMenuItem
+        asChild
+        className={cn(itemClass, "cursor-pointer")}
+        disabled={disabled}
+      >
+        {href ? (
+          <Link
+            href={href}
+            className={cn(
+              itemClass,
+              "text-f1-foreground no-underline hover:cursor-pointer"
+            )}
+            {...props}
+          >
+            <DropdownItemContent item={item} />
+          </Link>
+        ) : (
+          <div {...props} className={itemClass}>
+            <DropdownItemContent item={item} />
+          </div>
+        )}
+      </DropdownMenuItem>
+    </TooltipWrapper>
   )
 }
 

--- a/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
@@ -84,36 +84,44 @@ const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
     critical && "text-f1-foreground-critical"
   )
 
-  // The tooltip only makes sense while disabled (it explains why the action is
-  // unavailable). `TooltipWrapper` is a no-op when the tooltip is undefined and
-  // re-enables pointer events on its trigger, so hover fires even though a
-  // disabled item sets `pointer-events: none`.
-  return (
-    <TooltipWrapper tooltip={disabled ? disabledTooltip : undefined}>
-      <DropdownMenuItem
-        asChild
-        className={cn(itemClass, "cursor-pointer")}
-        disabled={disabled}
-      >
-        {href ? (
-          <Link
-            href={href}
-            className={cn(
-              itemClass,
-              "text-f1-foreground no-underline hover:cursor-pointer"
-            )}
-            {...props}
-          >
-            <DropdownItemContent item={item} />
-          </Link>
-        ) : (
-          <div {...props} className={itemClass}>
-            <DropdownItemContent item={item} />
-          </div>
-        )}
-      </DropdownMenuItem>
-    </TooltipWrapper>
+  const menuItem = (
+    <DropdownMenuItem
+      asChild
+      className={cn(itemClass, "cursor-pointer")}
+      disabled={disabled}
+    >
+      {href ? (
+        <Link
+          href={href}
+          className={cn(
+            itemClass,
+            "text-f1-foreground no-underline hover:cursor-pointer"
+          )}
+          {...props}
+        >
+          <DropdownItemContent item={item} />
+        </Link>
+      ) : (
+        <div {...props} className={itemClass}>
+          <DropdownItemContent item={item} />
+        </div>
+      )}
+    </DropdownMenuItem>
   )
+
+  // A disabled item sets `pointer-events: none`, so it emits NO hover events —
+  // the tooltip must hang off a wrapper span that keeps pointer events and that
+  // the hover passes THROUGH to (same approach as F0FormEditableTable). Only a
+  // disabled item with a tooltip gets the wrapper; every other item renders bare.
+  if (disabled && disabledTooltip) {
+    return (
+      <TooltipWrapper tooltip={disabledTooltip}>
+        <span className="block w-full cursor-not-allowed">{menuItem}</span>
+      </TooltipWrapper>
+    )
+  }
+
+  return menuItem
 }
 
 function renderDropdownItem(

--- a/packages/react/src/patterns/OneDataCollection/__tests__/item-actions.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/item-actions.test.tsx
@@ -79,6 +79,23 @@ describe("filterItemActions", () => {
     expect(result[0].label).toBe("Enabled Action")
   })
 
+  it("should KEEP a `disabled` action (disabled greys it out; only enabled:false removes it)", () => {
+    const actions: ItemActionsDefinition<TestRecord> = () => [
+      {
+        label: "Disabled but visible",
+        onClick: () => {},
+        disabled: true,
+        disabledTooltip: "You can't do this right now",
+      },
+    ]
+    const result = filterItemActions(actions, mockItem)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      disabled: true,
+      disabledTooltip: "You can't do this right now",
+    })
+  })
+
   it("should handle mixed action types correctly", () => {
     const actions: ItemActionsDefinition<TestRecord> = () => [
       {

--- a/packages/react/src/patterns/OneDataCollection/item-actions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/item-actions.tsx
@@ -6,8 +6,21 @@ import { RecordType } from "@/hooks/datasource"
 
 export type ActionDefinition =
   | DropdownItemSeparator
-  | (Pick<DropdownItemObject, "label" | "icon" | "description" | "critical"> & {
+  | (Pick<
+      DropdownItemObject,
+      | "label"
+      | "icon"
+      | "description"
+      | "critical"
+      | "disabled"
+      | "disabledTooltip"
+    > & {
       onClick: () => void
+      /**
+       * `false` REMOVES the action from the menu (see `filterItemActions`). To
+       * instead keep it VISIBLE but greyed-out and non-interactive, leave
+       * `enabled` unset and use `disabled` (+ `disabledTooltip` to explain why).
+       */
       enabled?: boolean
       type?: "primary" | "secondary" | "other"
       hideLabel?: boolean


### PR DESCRIPTION
## Description

Row (⋮) item actions in `OneDataCollection` (and the underlying experimental `Dropdown`) can now be **disabled** instead of only removed. A `disabled` action stays **visible but greyed-out and non-interactive**, with an optional `disabledTooltip` shown on hover to explain why — the counterpart to `enabled: false`, which removes the action from the menu entirely.

**Motivation:** consumers (first case: Factorial's Job Catalog per-row Delete) want to show an action that can't be performed right now *and say why*, rather than silently hiding it. Today the row dropdown has no way to do that — `enabled: false` drops the item, and there was no `disabled`/tooltip escape hatch.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Variant or improvement of existing pattern

## Lifecycle phase (if applicable)

N/A — additive, backwards-compatible props on an existing experimental component/pattern. No new component, no promotion.

## Screenshots (if applicable)

New Storybook story: **Dropdown → `DisabledItemWithTooltip`**. Open the menu and hover the greyed-out "Delete" item to see the tooltip.

## Implementation details

The plumbing already existed — this is a small, additive change:

- **`Dropdown/internal.tsx`**: the dropdown item already greys out via Radix `disabled` (`data-disabled` → `opacity-50` + `pointer-events: none`). Added `disabledTooltip?: string` to `DropdownItemObject` and wrapped the item in the existing `TooltipWrapper`, whose trigger re-enables pointer events so the tooltip fires despite the disabled item's `pointer-events: none`. `TooltipWrapper` is a no-op when no tooltip is passed.
- **`OneDataCollection/item-actions.tsx`**: exposed `disabled` + `disabledTooltip` on the row `ActionDefinition` (they flow through the existing `actionsToDropdownItems` spread unchanged). Documented the distinction from `enabled`: `enabled: false` **removes** the action; `disabled: true` keeps it **visible but disabled**.
- **`filterItemActions` is unchanged** — a `disabled` action with `enabled` left unset already passes the filter, so it renders (greyed) instead of being dropped. Fully backwards-compatible.

### API

```tsx
itemActions: (item) => [
  {
    label: "Delete",
    icon: Delete,
    critical: true,
    disabled: item.hasActiveContracts,
    disabledTooltip: item.hasActiveContracts
      ? "You can't delete this while people are assigned to it"
      : undefined,
    onClick: () => openDeleteDialog(item), // only fires when not disabled
  },
]
```

### Tests

- `item-actions.test.tsx`: a `disabled` action is **kept** by `filterItemActions` (not removed, unlike `enabled: false`).
- `Dropdown.test.tsx`: a per-item `disabled` action renders `aria-disabled`/`data-disabled` (siblings stay enabled); `disabledTooltip` appears on hover.
- All green; `oxlint`, `oxfmt`, and `tsc` clean for the changed files.

> Note: the story is args-only (no `play`) to avoid adding an a11y skip (per the AGENTS ratchet); the disabled + hover-tooltip behavior is covered by the Vitest tests above. Happy to add a Storybook interaction/a11y test if preferred.
