### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.18.0",
+  "packages/react": "6.19.0",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.19.0](https://github.com/factorialco/f0/compare/f0-react-v6.18.0...f0-react-v6.19.0) (2026-08-11)
+
+
+### Features
+
+* **NewHomeLayout:** arrival stagger and a genie for the collapsing rail ([#5075](https://github.com/factorialco/f0/issues/5075)) ([2824c33](https://github.com/factorialco/f0/commit/2824c334ec27dc5f5653b6fcd541f5d3510165b6))
+
 ## [6.18.0](https://github.com/factorialco/f0/compare/f0-react-v6.17.0...f0-react-v6.18.0) (2026-08-11)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.18.0",
+  "version": "6.19.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.19.0</summary>

## [6.19.0](https://github.com/factorialco/f0/compare/f0-react-v6.18.0...f0-react-v6.19.0) (2026-08-11)


### Features

* **NewHomeLayout:** arrival stagger and a genie for the collapsing rail ([#5075](https://github.com/factorialco/f0/issues/5075)) ([2824c33](https://github.com/factorialco/f0/commit/2824c334ec27dc5f5653b6fcd541f5d3510165b6))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).