### PR TITLE
feat(F0AiMessagesContainer): add initialMessageCta welcome CTA

### DIFF
--- a/packages/react/src/kits/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -26,7 +26,10 @@ import {
   UserMessage as F0UserMessage,
   type F0UserMessageExtraProps,
 } from "./components/UserMessage"
-import { WelcomeScreen } from "./components/WelcomeScreen"
+import {
+  WelcomeScreen,
+  type WelcomeScreenCta,
+} from "./components/WelcomeScreen"
 import { type Message, type RenderableTurn } from "./types"
 import { useMessageScroll } from "./useMessageScroll"
 
@@ -58,6 +61,9 @@ export type F0AiMessagesContainerProps = {
   initialMessageCaption?: string
   /** Smaller secondary line below the welcome phrase. */
   initialMessageSubtitle?: string
+  /** Optional call-to-action pill rendered above the welcome phrase (e.g. a
+   *  "How to use One" shortcut). Only shown on the empty welcome screen. */
+  initialMessageCta?: WelcomeScreenCta
   /** Called when the user clicks the welcome phrase (used by F0AiChat to open
    *  the pong easter egg). When omitted the phrase is non-interactive. */
   onWelcomeClick?: () => void
@@ -114,6 +120,7 @@ const Messages = ({
   initialMessage,
   initialMessageCaption,
   initialMessageSubtitle,
+  initialMessageCta,
   onWelcomeClick,
   renderToolCall,
   onReplyQuote,
@@ -300,6 +307,7 @@ const Messages = ({
                   messages={welcomeMessages}
                   caption={initialMessageCaption}
                   subtitle={initialMessageSubtitle}
+                  cta={initialMessageCta}
                   onClick={onWelcomeClick}
                   fullscreen={fullscreen}
                 />

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/__stories__/F0AiMessagesContainer.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/__stories__/F0AiMessagesContainer.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { expect, waitFor, within } from "storybook/test"
 
+import { AlertCircleLine } from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0AiMessagesContainer } from "../F0AiMessagesContainer"
@@ -169,6 +170,18 @@ export const EmptyWelcomeWithCaptionAndSubtitle: Story = {
     initialMessageCaption: "Analytics mode:",
     initialMessageSubtitle:
       "Ask about employees, contracts, absences, and presence. More data soon.",
+  },
+}
+
+export const EmptyWelcomeWithCta: Story = {
+  args: {
+    turns: [],
+    initialMessage: "Skip the boring part of your job",
+    initialMessageCta: {
+      label: "How to use One",
+      icon: AlertCircleLine,
+      onClick: () => console.log("welcome CTA clicked"),
+    },
   },
 }
 

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/__tests__/F0AiMessagesContainer.test.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/__tests__/F0AiMessagesContainer.test.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
-import { screen, zeroRender } from "@/testing/test-utils"
+import { screen, userEvent, zeroRender } from "@/testing/test-utils"
 
 import { F0AiMessagesContainer } from "../F0AiMessagesContainer"
 
@@ -22,5 +22,22 @@ describe("F0AiMessagesContainer", () => {
       )
     ).toBeInTheDocument()
     expect(screen.getByText("Ask a data question.")).toBeInTheDocument()
+  })
+
+  it("renders the welcome CTA and fires its onClick", async () => {
+    const onClick = vi.fn()
+    const user = userEvent.setup()
+    zeroRender(
+      <F0AiMessagesContainer
+        turns={[]}
+        initialMessage="Ask a data question."
+        initialMessageCta={{ label: "How to use One", onClick }}
+      />
+    )
+
+    const cta = screen.getByRole("button", { name: "How to use One" })
+    await user.click(cta)
+
+    expect(onClick).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -1,7 +1,20 @@
 import { useEffect, useRef, useState, type KeyboardEvent } from "react"
 
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { type IconType } from "@/components/F0Icon"
 import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
+
+/**
+ * Optional call-to-action rendered as a pill above the welcome phrase (e.g. a
+ * "How to use One" shortcut). The host owns `onClick`; f0 owns the pill styling
+ * so it stays consistent with the rest of the welcome screen.
+ */
+export type WelcomeScreenCta = {
+  label: string
+  icon?: IconType
+  onClick: () => void
+}
 
 const CHAR_IN_MS = 35
 const CHAR_OUT_MS = 22
@@ -22,6 +35,8 @@ export interface WelcomeScreenProps {
   caption?: string
   /** Smaller secondary line below the phrase (e.g. available data areas). */
   subtitle?: string
+  /** Optional call-to-action pill rendered above the caption/phrase. */
+  cta?: WelcomeScreenCta
   /**
    * Optional click handler on the phrase itself. When set, the phrase becomes
    * keyboard-activatable (Enter / Space) and gets a subtle hover hint. Used by
@@ -40,6 +55,7 @@ export const WelcomeScreen = ({
   messages,
   caption,
   subtitle,
+  cta,
   onClick,
   fullscreen = false,
 }: WelcomeScreenProps) => {
@@ -120,6 +136,16 @@ export const WelcomeScreen = ({
       )}
     >
       <div className="flex flex-col items-center">
+        {cta && (
+          <ButtonInternal
+            variant="neutral"
+            size="sm"
+            className="mb-4"
+            label={cta.label}
+            icon={cta.icon}
+            onClick={cta.onClick}
+          />
+        )}
         {caption && (
           <p className="animate-in fade-in-0 text-center text-2xl font-semibold leading-[28px] text-f1-foreground-secondary duration-500">
             {caption}

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/index.ts
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/index.ts
@@ -3,6 +3,8 @@ export {
   type F0AiMessagesContainerProps,
 } from "./F0AiMessagesContainer"
 
+export { type WelcomeScreenCta } from "./components/WelcomeScreen"
+
 export { useToolCallId } from "./components/AssistantMessage"
 
 export {


### PR DESCRIPTION
## Description

Adds an optional `initialMessageCta` prop to `F0AiMessagesContainer` that renders a small neutral button (icon + label) above the welcome greeting on the empty chat screen, wired to a host-supplied `onClick`. This lets host apps (e.g. Factorial's One chat) place a shortcut such as "How to use One" above the greeting without owning the welcome-screen layout.

## Screenshots (if applicable)

<img width="551" height="1288" alt="image" src="https://github.com/user-attachments/assets/70a015ec-6fbf-4899-af3e-4606ce5b4645" />

## Implementation details

- feat: add `initialMessageCta` prop, threaded through to `WelcomeScreen` and rendered as a small neutral `ButtonInternal` (icon + label) above the caption/phrase
- feat: export the new `WelcomeScreenCta` type from the container barrel
- test: cover CTA rendering and `onClick`
- docs: add the `Empty Welcome With Cta` Storybook story