### PR TITLE
fix(OneTable): match column highlight color to design

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -160,12 +160,12 @@ export function TableCell({
         // The row hover keeps reading through the highlighted cell, so a hovered
         // row stays one uniform surface.
         highlighted &&
-          "bg-f1-background-secondary group-hover:bg-f1-background-hover",
+          "bg-[hsl(var(--neutral-2))] group-hover:bg-f1-background-hover",
         // Sticky cells paint their opaque background on the `before` layer;
         // the highlighted tint has to land there too or it stays hidden under it.
         highlighted &&
           isSticky &&
-          "before:bg-f1-background-secondary group-hover:before:bg-f1-background-hover",
+          "before:bg-[hsl(var(--neutral-2))] group-hover:before:bg-f1-background-hover",
         href && "cursor-pointer",
         className
       )}

--- a/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
@@ -196,14 +196,17 @@ describe("TableHead and TableCell highlighted", () => {
       </OneTable>
     )
 
+    // The header paints the tint as a gradient image, the cell as a bg color;
+    // both carry the same token, so the assertion targets that.
+    const highlightClass = "hsl(var(--neutral-2))"
     const [plainHead, highlightedHead] = screen.getAllByRole("columnheader")
-    expect(highlightedHead.className).toMatch(/bg-f1-background-secondary/)
+    expect(highlightedHead.className).toContain(highlightClass)
     expect(highlightedHead).toHaveAttribute("data-highlighted", "true")
-    expect(plainHead.className).not.toMatch(/bg-f1-background-secondary/)
+    expect(plainHead.className).not.toContain(highlightClass)
     expect(plainHead).not.toHaveAttribute("data-highlighted")
 
     const [plainCell, highlightedCell] = screen.getAllByRole("cell")
-    expect(highlightedCell.className).toMatch(/bg-f1-background-secondary/)
-    expect(plainCell.className).not.toMatch(/bg-f1-background-secondary/)
+    expect(highlightedCell.className).toContain(highlightClass)
+    expect(plainCell.className).not.toContain(highlightClass)
   })
 })

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -324,7 +324,11 @@ export function TableHead({
           (isScrolled || isScrolledRight) &&
           "relative bg-f1-background z-10 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:w-full before:bg-f1-border-secondary before:content-['']",
         isSticky && "sticky",
-        highlighted && "bg-f1-background-secondary",
+        // The tint is a background-image over the opaque header background,
+        // not a bg-color swap: an alpha bg-color would let the `thead::before`
+        // top rule bleed through and double up with the one painted on top.
+        highlighted &&
+          "bg-[linear-gradient(hsl(var(--neutral-2)),hsl(var(--neutral-2)))]",
         hidden && "after:hidden",
         handleCellClick && "cursor-pointer",
         className

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1266,10 +1266,9 @@ export const TableWithHighlightedHeaderGroup: Story = {
     const canvas = within(canvasElement)
 
     // The highlighted group's spanning header is emphasized.
+    const highlightClass = "hsl(var(--neutral-2))"
     const augustGroup = await canvas.findByRole("button", { name: "August" })
-    expect(augustGroup.closest("th")?.className).toContain(
-      "bg-f1-background-secondary"
-    )
+    expect(augustGroup.closest("th")?.className).toContain(highlightClass)
 
     // Every column of the highlighted group carries the emphasis and the marker:
     // the group header plus its three expanded columns.
@@ -1278,7 +1277,7 @@ export const TableWithHighlightedHeaderGroup: Story = {
     )
     expect(highlightedHeaders.length).toBe(4)
     highlightedHeaders.forEach((header) => {
-      expect(header.className).toContain("bg-f1-background-secondary")
+      expect(header.className).toContain(highlightClass)
     })
 
     // Collapsing the highlighted month keeps its visible total column emphasized.
@@ -1294,7 +1293,7 @@ export const TableWithHighlightedHeaderGroup: Story = {
       expect(collapsedHighlighted.length).toBe(2)
       expect(
         collapsedHighlighted[collapsedHighlighted.length - 1].className
-      ).toContain("bg-f1-background-secondary")
+      ).toContain(highlightClass)
     })
   },
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -378,6 +378,10 @@ describe("TableCollection", () => {
       expect(firstNameCell).toHaveStyle({ minWidth: "220px" })
     })
 
+    // The header paints the tint as a gradient image, the cell as a bg color;
+    // both carry the same token, so the assertion targets that.
+    const HIGHLIGHT_BG_CLASS = "hsl(var(--neutral-2))"
+
     it("applies the highlighted background to the highlighted column's header and cells", async () => {
       const columnsWithHighlighted = [
         { label: "name", render: (item: Person) => item.name },
@@ -411,17 +415,17 @@ describe("TableCollection", () => {
       })
 
       const emailHeader = screen.getByRole("columnheader", { name: "email" })
-      expect(emailHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(emailHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
       expect(emailHeader).toHaveAttribute("data-highlighted", "true")
 
       const nameHeader = screen.getByRole("columnheader", { name: "name" })
-      expect(nameHeader.className).not.toMatch(/bg-f1-background-secondary/)
+      expect(nameHeader.className).not.toMatch(HIGHLIGHT_BG_CLASS)
 
       const emailCell = screen.getAllByText(testData[0].email)[0].closest("td")
-      expect(emailCell?.className).toMatch(/bg-f1-background-secondary/)
+      expect(emailCell?.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const nameCell = screen.getAllByText(testData[0].name)[0].closest("td")
-      expect(nameCell?.className).not.toMatch(/bg-f1-background-secondary/)
+      expect(nameCell?.className).not.toMatch(HIGHLIGHT_BG_CLASS)
     })
 
     it("emphasizes every highlighted column", async () => {
@@ -462,17 +466,15 @@ describe("TableCollection", () => {
       })
 
       const nameHeader = screen.getByRole("columnheader", { name: "name" })
-      expect(nameHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(nameHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const emailHeader = screen.getByRole("columnheader", { name: "email" })
-      expect(emailHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(emailHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const displayNameHeader = screen.getByRole("columnheader", {
         name: "displayName",
       })
-      expect(displayNameHeader.className).not.toMatch(
-        /bg-f1-background-secondary/
-      )
+      expect(displayNameHeader.className).not.toMatch(HIGHLIGHT_BG_CLASS)
     })
 
     it("highlights the spanning header of the highlighted column's group", async () => {
@@ -516,14 +518,12 @@ describe("TableCollection", () => {
       const contactGroupHeader = screen.getByRole("columnheader", {
         name: "Contact",
       })
-      expect(contactGroupHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(contactGroupHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const identityGroupHeader = screen.getByRole("columnheader", {
         name: "Identity",
       })
-      expect(identityGroupHeader.className).not.toMatch(
-        /bg-f1-background-secondary/
-      )
+      expect(identityGroupHeader.className).not.toMatch(HIGHLIGHT_BG_CLASS)
     })
 
     it("highlights every column of a highlighted header group", async () => {
@@ -567,21 +567,21 @@ describe("TableCollection", () => {
       const contactGroupHeader = screen.getByRole("columnheader", {
         name: "Contact",
       })
-      expect(contactGroupHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(contactGroupHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const emailHeader = screen.getByRole("columnheader", { name: "email" })
-      expect(emailHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(emailHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const displayNameHeader = screen.getByRole("columnheader", {
         name: "displayName",
       })
-      expect(displayNameHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(displayNameHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const nameHeader = screen.getByRole("columnheader", { name: "name" })
-      expect(nameHeader.className).not.toMatch(/bg-f1-background-secondary/)
+      expect(nameHeader.className).not.toMatch(HIGHLIGHT_BG_CLASS)
 
       const emailCell = screen.getAllByText(testData[0].email)[0].closest("td")
-      expect(emailCell?.className).toMatch(/bg-f1-background-secondary/)
+      expect(emailCell?.className).toMatch(HIGHLIGHT_BG_CLASS)
     })
 
     it("combines a highlighted header group with independently highlighted columns", async () => {
@@ -622,10 +622,10 @@ describe("TableCollection", () => {
       })
 
       const nameHeader = screen.getByRole("columnheader", { name: "name" })
-      expect(nameHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(nameHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
 
       const emailHeader = screen.getByRole("columnheader", { name: "email" })
-      expect(emailHeader.className).toMatch(/bg-f1-background-secondary/)
+      expect(emailHeader.className).toMatch(HIGHLIGHT_BG_CLASS)
     })
 
     it("applies minWidth in grouped header placeholders for ungrouped columns", async () => {


### PR DESCRIPTION
## Description

Softens the highlighted-column emphasis in OneTable (used by OneDataCollection's `highlighted` column/header-group option) from `bg-f1-background-secondary` (`--neutral-10`, ~6% tint) to `--neutral-2` (~2% tint), matching the column highlight in the HC Planning cost visualization design. It also fixes a doubled top border on highlighted header cells that made the table's top rule look darker over the highlighted group.

[Link to Figma Design](https://www.figma.com/design/RptN7ZgQs5NT40f1ONdy0d/HC-Planning---Cost-Visualization?node-id=364-19249)

## Implementation details

- fix: highlighted cells and headers now use `hsl(var(--neutral-2))`, the token whose composite over white matches the design's `#FAFBFC`

  <details>
  <summary>Why an arbitrary value instead of a semantic token?</summary>

  No `f1` semantic background token maps to `--neutral-2`. Using the CSS variable directly follows existing precedent in the repo (e.g. ProductUpdates and the OneDataCollection Graph visualization use `bg-[hsl(var(--neutral-2))]` / `--neutral-3`), and stays theme-aware in dark mode.
  </details>

- fix: header cells paint the highlight tint as a background-image over the opaque header background instead of replacing it

  <details>
  <summary>Why?</summary>

  `thead::before` draws the table's 1px top rule behind the header cells and a second copy is painted on top. Regular headers cover the back copy with their opaque `bg-f1-background`; replacing that with an alpha tint let it bleed through, so highlighted headers showed the rule twice (measured `#CED3DC` vs `#E7EAEE` on neighbors). Layering the tint as a gradient image keeps the opaque base and brings the highlighted header's rule back to a single copy (`#E2E6EB`).
  </details>

- test: highlight assertions in TableHead and Table tests now target the shared `hsl(var(--neutral-2))` token, which both the cell (bg color) and header (gradient) classes carry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

BEFORE

<img width="1609" height="617" alt="image" src="https://github.com/user-attachments/assets/f9410101-f17b-4470-b1cf-85bea0ce927c" />


NOW

<img width="338" height="302" alt="Captura de pantalla 2026-08-11 a las 16 39 29" src="https://github.com/user-attachments/assets/acadba85-1290-4414-8979-4a5c27ac236b" />
