### PR TITLE
feat(OneDataCollection): add boldRootRows table option

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1299,6 +1299,104 @@ export const TableWithHighlightedHeaderGroup: Story = {
   },
 }
 
+export const TableWithBoldRootRows: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Setting `boldRootRows` on a table with nested rows renders the cell text of the root rows (depth 0) in bold, so aggregate rows stand out from their children — the shape of a headcount or cost breakdown where the top level totals its reporting lines.",
+      },
+    },
+  },
+  render: () => {
+    type CostRow = {
+      id: number
+      name: string
+      headcount: number
+      cost: number
+      children?: CostRow[]
+    }
+
+    const records: CostRow[] = [
+      {
+        id: 1,
+        name: "EoP Headcount",
+        headcount: 1334,
+        cost: 3724800,
+        children: [
+          { id: 11, name: "Bernat Farrero", headcount: 720, cost: 2010200 },
+          { id: 12, name: "Jordi Romero", headcount: 334, cost: 1714600 },
+        ],
+      },
+      {
+        id: 2,
+        name: "Fixed agreement costs",
+        headcount: 410,
+        cost: 1120400,
+        children: [
+          { id: 21, name: "Operations", headcount: 210, cost: 640300 },
+          { id: 22, name: "Support & Admin", headcount: 200, cost: 480100 },
+        ],
+      },
+    ]
+
+    const eur = (value: number) => `€${value.toLocaleString("en-US")}`
+
+    const source = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: async () => ({ records }),
+      },
+      itemsWithChildren: (item: CostRow) => !!item.children?.length,
+      fetchChildren: async ({ item }: { item: CostRow }) => ({
+        records: item.children ?? [],
+      }),
+    })
+
+    return (
+      <OneDataCollection
+        source={source}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              boldRootRows: true,
+              columns: [
+                { label: "Reporting line", render: (item) => item.name },
+                {
+                  label: "Headcount",
+                  align: "right",
+                  render: (item) => item.headcount.toLocaleString("en-US"),
+                },
+                {
+                  label: "Cost",
+                  align: "right",
+                  render: (item) => eur(item.cost),
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Root rows carry the bold emphasis.
+    const rootCell = await canvas.findByText("EoP Headcount")
+    expect(rootCell.closest("tr")?.className).toContain("font-semibold")
+
+    // Expanding a root row reveals children without the emphasis. The chevron
+    // svg itself is pointer-events-none; its wrapping div takes the click.
+    const chevron = canvasElement.querySelector(".lucide-chevron-right")
+    expect(chevron).not.toBeNull()
+    await userEvent.click(chevron!.parentElement as Element)
+
+    const childCell = await canvas.findByText("Bernat Farrero")
+    expect(childCell.closest("tr")?.className).not.toContain("font-semibold")
+  },
+}
+
 export const StrikedRowsVisualization: Story = {
   render: () => {
     const records = [

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -110,6 +110,7 @@ export const TableCollection = <
   allowColumnHiding,
   allowColumnReordering,
   referenceRowType,
+  boldRootRows,
   headerGroups: headerGroupsOption,
   onHeaderGroupCollapsedChange,
   bordered,
@@ -878,6 +879,7 @@ export const TableCollection = <
                       checkColumnWidth={checkColumnWidth}
                       tableWithChildren={tableWithChildren}
                       referenceRowType={referenceRowType}
+                      boldRootRows={boldRootRows}
                       rowWrapper={RowWrapper}
                       cellRenderer={cellRenderer}
                       fromVisualization={fromVisualization}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -298,6 +298,125 @@ describe("TableCollection", () => {
     })
   })
 
+  describe("boldRootRows", () => {
+    type NestedPerson = Person & { children?: NestedPerson[] }
+
+    const parent: NestedPerson = {
+      id: 1,
+      name: "Parent Row",
+      email: "parent@example.com",
+      displayName: "Parent Row",
+      children: [
+        {
+          id: 2,
+          name: "Leaf Row",
+          email: "leaf@example.com",
+          displayName: "Leaf Row",
+        },
+      ],
+    }
+
+    const createNestedSource = () =>
+      ({
+        currentFilters: {},
+        setCurrentFilters: vi.fn(),
+        currentSortings: null,
+        setCurrentSortings: vi.fn(),
+        currentNavigationFilters: {},
+        setCurrentNavigationFilters: vi.fn(),
+        navigationFilters: undefined,
+        currentSearch: undefined,
+        debouncedCurrentSearch: undefined,
+        setCurrentSearch: vi.fn(),
+        isLoading: false,
+        setIsLoading: vi.fn(),
+        currentGrouping: undefined,
+        setCurrentGrouping: vi.fn(),
+        itemsWithChildren: (item: NestedPerson) => !!item.children?.length,
+        fetchChildren: ({ item }: { item: NestedPerson }) => ({
+          records: item.children ?? [],
+        }),
+        dataAdapter: {
+          paginationType: "pages",
+          fetchData: async () => ({
+            records: [parent],
+            type: "pages",
+            total: 1,
+            perPage: 20,
+            currentPage: 1,
+            pagesCount: 1,
+          }),
+        },
+      }) as unknown as DataCollectionSource<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+
+    // Child rows (depth > 0) staying regular is covered by the
+    // TableWithBoldRootRows story play test: expanding a nested row here
+    // triggers a pre-existing jsdom-only render loop in useData when a later
+    // test renders a failing fetch (see useData.ts subscription error path).
+    it("bolds root rows", async () => {
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createNestedSource()}
+          boldRootRows
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Parent Row")).toBeInTheDocument()
+      })
+
+      const parentRow = screen.getByText("Parent Row").closest("tr")
+      expect(parentRow?.className).toMatch(/font-semibold/)
+    })
+
+    it("keeps every row regular when the option is off", async () => {
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createNestedSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Parent Row")).toBeInTheDocument()
+      })
+
+      const parentRow = screen.getByText("Parent Row").closest("tr")
+      expect(parentRow?.className).not.toMatch(/font-semibold/)
+    })
+  })
+
   describe("features", () => {
     it("renders custom column formatting", async () => {
       const columnsWithCustomRender = [

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -94,6 +94,8 @@ export type RowProps<
   nestedRowProps?: NestedRowProps
   /** Optional predicate to apply a row-level visual variant. */
   referenceRowType?: (item: R) => "none" | "striped" | "striked"
+  /** In a table with nested rows, renders root rows (depth 0) in bold. */
+  boldRootRows?: boolean
   /** Custom cell renderer, passed through from Table to Row */
   cellRenderer?: React.ComponentType<CellRendererProps<R, Sortings, Summaries>>
   /** Row wrapper for child rows (provides per-row context, e.g. editing state) */

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -75,6 +75,8 @@ export type RowProps<
   isNew?: boolean
   /** Optional predicate to apply a row-level visual variant. */
   referenceRowType?: (item: R) => ReferenceType
+  /** In a table with nested rows, renders root rows (depth 0) in bold. */
+  boldRootRows?: boolean
   /** Optional custom cell renderer. When provided, wraps each cell's content. */
   cellRenderer?: React.ComponentType<
     CellRendererProps<R, Sortings, Summaries> & { isLastColumn?: boolean }
@@ -156,6 +158,7 @@ const RowComponentInner = <
     disableHover = false,
     isNew = false,
     referenceRowType: referenceRowTypeFn,
+    boldRootRows = false,
     cellRenderer: CellRenderer,
     rowWrapper,
     fromVisualization,
@@ -270,6 +273,7 @@ const RowComponentInner = <
         nestedRowProps={nestedRowProps}
         tableWithChildren={tableWithChildren}
         referenceRowType={referenceRowTypeFn}
+        boldRootRows={boldRootRows}
         cellRenderer={CellRenderer}
         rowWrapper={rowWrapper}
         headerGroups={headerGroups}
@@ -305,6 +309,12 @@ const RowComponentInner = <
         disableHover && "hover:bg-transparent",
         isSelected && "bg-f1-background-selected-secondary",
         flashing && "animate-row-flash",
+        // Cells inherit the weight; renderers that set their own (tags,
+        // deltas) and the first cell's explicit font-medium keep theirs.
+        boldRootRows &&
+          tableWithChildren &&
+          (nestedRowProps?.depth ?? 0) === 0 &&
+          "font-semibold",
         referenceTypeClasses[referenceRowType]
       )}
     >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -201,6 +201,14 @@ export type TableVisualizationOptions<
 
   /** Maps a row to a visual variant: `"striped"`, `"striked"`, or `"none"`. */
   referenceRowType?: (item: R) => ReferenceType
+
+  /**
+   * In a table with nested rows, renders the cell text of the root rows
+   * (depth 0) in bold so aggregate rows stand out from their children.
+   * Cells that fix their own weight (tags, deltas) keep it.
+   * @default false
+   */
+  boldRootRows?: boolean
   /**
    * Header group configuration. Keys are the `headerGroupId` values used in
    * column definitions. Pass a string for a plain spanning label, or a


### PR DESCRIPTION
## Description

Adds an optional `boldRootRows` option to the OneDataCollection table visualization. In a table with nested rows it renders the cell text of the root rows (depth 0) in bold so aggregate rows stand out from their children, as in the HC Planning cost breakdown where the top level totals its reporting lines.

[Link to Figma Design](https://www.figma.com/design/RptN7ZgQs5NT40f1ONdy0d/HC-Planning---Cost-Visualization?node-id=364-19249)

## Implementation details

- feat: add `boldRootRows?: boolean` to `TableVisualizationOptions`, threaded through Row/NestedRow; root rows get `font-semibold` on the `<tr>` and cells inherit it

  <details>
  <summary>Scope of the emphasis</summary>

  Only applies when the table actually has nested rows (`tableWithChildren`) and the row is at depth 0. Cells that set their own weight keep it: the first cell's explicit `font-medium`, tags, and deltas are unaffected — matching the design, where the first column and the variance pills stay regular across depths.
  </details>

- test: unit tests cover the option on (root rows bold) and off (all rows regular)
- test: `TableWithBoldRootRows` story with a play test that expands a root row and asserts children stay regular

  <details>
  <summary>Why is the child-row assertion in a story instead of the unit test?</summary>

  Expanding a nested row in `Table.test.tsx` trips a pre-existing jsdom-only render loop in `useData`'s subscription error path when a later test in the same file renders a failing fetch (worker OOMs). Reproduced without this feature's code — it is unrelated to `boldRootRows`. The expansion flow is therefore covered in Chromium via the story play test.
  </details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="1594" height="307" alt="Captura de pantalla 2026-08-12 a las 10 31 25" src="https://github.com/user-attachments/assets/03fb83f8-00e6-43c4-b191-094eed797bd5" />
