### PR TITLE
feat(OneApprovalHistory): add approval date to steps

### DIFF
--- a/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
@@ -1,3 +1,4 @@
+import { format } from "date-fns"
 import { FC, useMemo } from "react"
 
 import { F0AvatarList } from "@/components/avatars/F0AvatarList"
@@ -9,6 +10,7 @@ import {
   Question as QuestionIcon,
 } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
+import { useDateFnsLocale } from "@/lib/providers/l10n"
 
 type Status = "waiting" | "pending" | "approved" | "rejected"
 
@@ -24,7 +26,7 @@ export type ApprovalStepProps = {
   approvalsRequired?: number
   status: Status
   approvers: Approver[]
-  approvalDate?: string
+  approvalDate?: Date
 }
 
 const statusTagVariants: Record<Status, "neutral" | "positive" | "critical"> = {
@@ -79,6 +81,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
   approvalDate,
 }) => {
   const translations = useI18n()
+  const locale = useDateFnsLocale()
 
   const displayApprovalsRequired =
     approvalsRequired === 1
@@ -122,7 +125,9 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
         <F0AvatarList avatars={avatars} layout="fill" type="person" size="md" />
       </div>
       {approvalDate && (
-        <p className="text-sm text-f1-foreground-secondary">{approvalDate}</p>
+        <p className="text-sm text-f1-foreground-secondary">
+          {format(approvalDate, "PP", { locale })}
+        </p>
       )}
     </div>
   )

--- a/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
@@ -24,10 +24,6 @@ export type ApprovalStepProps = {
   approvalsRequired?: number
   status: Status
   approvers: Approver[]
-  /**
-   * Date when the step was resolved (approved or rejected), already formatted
-   * for display. The consumer owns the locale/format.
-   */
   approvalDate?: string
 }
 

--- a/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
@@ -24,6 +24,11 @@ export type ApprovalStepProps = {
   approvalsRequired?: number
   status: Status
   approvers: Approver[]
+  /**
+   * Date when the step was resolved (approved or rejected), already formatted
+   * for display. The consumer owns the locale/format.
+   */
+  approvalDate?: string
 }
 
 const statusTagVariants: Record<Status, "neutral" | "positive" | "critical"> = {
@@ -75,6 +80,7 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
   approvalsRequired = 1,
   status,
   approvers,
+  approvalDate,
 }) => {
   const translations = useI18n()
 
@@ -119,6 +125,9 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
       <div className="w-full">
         <F0AvatarList avatars={avatars} layout="fill" type="person" size="md" />
       </div>
+      {approvalDate && (
+        <p className="text-sm text-f1-foreground-secondary">{approvalDate}</p>
+      )}
     </div>
   )
 }

--- a/packages/react/src/sds/inbox/OneApprovalHistory/index.stories.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/index.stories.tsx
@@ -131,7 +131,7 @@ export const MultipleApprovals: Story = {
         approvalsRequired: 2,
         status: "approved",
         approvers: mockApprovers,
-        approvalDate: "Jan 15, 2026",
+        approvalDate: new Date("2026-01-15"),
       },
       {
         title: "HR Approval",
@@ -151,7 +151,7 @@ export const RejectedApproval: Story = {
         approvalsRequired: 1,
         status: "rejected",
         approvers: mockApprovers,
-        approvalDate: "Jan 15, 2026",
+        approvalDate: new Date("2026-01-15"),
       },
     ],
   },

--- a/packages/react/src/sds/inbox/OneApprovalHistory/index.stories.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/index.stories.tsx
@@ -131,6 +131,7 @@ export const MultipleApprovals: Story = {
         approvalsRequired: 2,
         status: "approved",
         approvers: mockApprovers,
+        approvalDate: "Jan 15, 2026",
       },
       {
         title: "HR Approval",
@@ -150,6 +151,7 @@ export const RejectedApproval: Story = {
         approvalsRequired: 1,
         status: "rejected",
         approvers: mockApprovers,
+        approvalDate: "Jan 15, 2026",
       },
     ],
   },

--- a/packages/react/src/sds/inbox/OneApprovalHistory/index.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react"
+import { FC, Fragment } from "react"
 
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
@@ -44,18 +44,18 @@ const _OneApprovalHistory: FC<OneApprovalHistoryProps> = ({ steps }) => {
         </div>
         <div className="flex w-full flex-col rounded-xl border border-solid border-f1-border">
           {steps.map((step, index) => (
-            <>
+            <Fragment key={step.title}>
               <ApprovalStep
-                key={step.title}
                 title={step.title}
                 approvalsRequired={step.approvalsRequired}
                 status={step.status}
                 approvers={step.approvers}
+                approvalDate={step.approvalDate}
               />
               {index !== steps.length - 1 && (
                 <div className="h-px w-full bg-f1-border-secondary" />
               )}
-            </>
+            </Fragment>
           ))}
         </div>
       </div>


### PR DESCRIPTION
## Description

Restores the approval date that the legacy approvals history showed before the migration to `OneApprovalHistory` ([FCT-60965](https://factorialmakers.atlassian.net/browse/FCT-60965)): clients reported they can no longer see when each step was approved. Steps now accept an optional, consumer-formatted `approvalDate` string rendered as secondary text below the approvers, keeping the component locale-agnostic. Aligned with Foundations in the ticket (owning team handles it as an improvement).

## Screenshots (if applicable)

See the updated `Inbox/ApprovalHistory` → `MultipleApprovals` and `RejectedApproval` stories.

<img width="620" height="620" alt="rejected-approval" src="https://github.com/user-attachments/assets/d18b17db-f570-4038-8092-46c2efa51865" />
<img width="620" height="980" alt="multiple-approvals" src="https://github.com/user-attachments/assets/d6369c71-2b49-4e5b-a78a-eda0421847b6" />


## Implementation details

- feat: add optional `approvalDate` prop to `ApprovalStepProps` and render it under the avatar list for resolved steps
- fix: key the step list with `Fragment key` instead of unkeyed fragment shorthand
- chore: cover `approvalDate` in the `MultipleApprovals` and `RejectedApproval` stories

[FCT-60965]: https://factorialmakers.atlassian.net/browse/FCT-60965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ