### PR TITLE
fix(F0PhoneInput): keep prefix-less legacy numbers visible

### DIFF
--- a/packages/react/src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx
@@ -143,6 +143,14 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
       [value, fallbackCountry]
     )
 
+    // A national number with no dial code and no defaultCountry has no E.164
+    // form — pass the raw digits through so the legacy value stays visible
+    const rawNumber = useMemo(() => {
+      if (e164) return undefined
+      const raw = value?.number?.trim()
+      return raw && !raw.startsWith("+") ? raw : undefined
+    }, [e164, value])
+
     const [country, setCountry] = useState<PhoneCountry | undefined>(
       () => countryForValue(value) ?? fallbackCountry
     )
@@ -229,7 +237,7 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
     }
 
     const noEdit = disabled || readonly
-    const showClear = clearable && !noEdit && !!e164
+    const showClear = clearable && !noEdit && !!(e164 ?? rawNumber)
 
     return (
       <div
@@ -263,7 +271,7 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
         >
           <RPNInput
             className="flex h-full min-w-0 flex-1 items-center"
-            value={e164 ?? undefined}
+            value={(e164 ?? rawNumber ?? undefined) as Value | undefined}
             onChange={handleChange}
             onCountryChange={handleCountryChange}
             defaultCountry={country ?? fallbackCountry}

--- a/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.mdx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.mdx
@@ -103,9 +103,10 @@ Incoming values are normalized, so legacy data renders correctly:
           <code>{'{ prefix: undefined, number: "674897945" }'}</code>
         </td>
         <td>
-          Needs <code>defaultCountry</code> to be representable; otherwise the
-          field renders empty and the stored value is preserved until the user
-          edits
+          Parsed as national for <code>defaultCountry</code> when set; otherwise
+          the country is unknown, so the raw digits stay visible next to the
+          globe and picking a country adopts them as that country&apos;s
+          national number
         </td>
       </tr>
       <tr>
@@ -135,6 +136,8 @@ Incoming values are normalized, so legacy data renders correctly:
 <Canvas of={Stories.Prefilled} />
 
 <Canvas of={Stories.LegacyFullNumber} />
+
+<Canvas of={Stories.LegacyPrefixlessNumber} />
 
 ### Pinned countries
 

--- a/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.stories.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.stories.tsx
@@ -74,6 +74,18 @@ export const LegacyFullNumber: Story = {
   },
 }
 
+export const LegacyPrefixlessNumber: Story = {
+  args: {
+    defaultValue: { prefix: undefined, number: "650090492" },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // Prefix-less national numbers stay visible next to the country-less globe
+    await expect(canvas.getByRole("textbox")).toHaveValue("650090492")
+    await expect(canvas.queryByText(/^\+\d/)).not.toBeInTheDocument()
+  },
+}
+
 export const PinnedCountries: Story = {
   args: {
     pinnedCountries: ["es", "gb", "us", "fr", "de", "it", "pt"],

--- a/packages/react/src/experimental/Forms/F0PhoneInput/__tests__/F0PhoneInput.test.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/__tests__/F0PhoneInput.test.tsx
@@ -252,6 +252,67 @@ describe("F0PhoneInput", () => {
     expect(getInput().value).toBe("07400 123456")
   })
 
+  it("prefills a prefix-less national number as raw digits with no country", () => {
+    render(
+      <F0PhoneInput
+        label="Phone"
+        value={{ prefix: undefined, number: "650090492" }}
+      />
+    )
+
+    expect(getInput().value).toBe("650090492")
+    const trigger = getCountryTrigger()
+    expect(within(trigger).queryByText(/^\+\d/)).not.toBeInTheDocument()
+  })
+
+  it("adopts the raw digits as the national number when a country is picked", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <F0PhoneInput
+        label="Phone"
+        defaultValue={{ prefix: undefined, number: "650090492" }}
+        onChange={onChange}
+      />
+    )
+
+    await openCountrySelect(user)
+    await user.type(screen.getByRole("searchbox"), "Spain")
+    await user.click(await screen.findByRole("option", { name: /Spain/ }))
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(
+        { prefix: "+34", number: "650090492" },
+        expect.objectContaining({
+          country: "es",
+          e164: "+34650090492",
+          isValid: true,
+        })
+      )
+    )
+    await waitFor(() => expect(getInput().value).toBe("650 09 04 92"))
+  })
+
+  it("shows the clear button for a prefix-less raw value", async () => {
+    const onChange = vi.fn()
+    render(
+      <F0PhoneInput
+        label="Phone"
+        clearable
+        defaultValue={{ prefix: undefined, number: "650090492" }}
+        onChange={onChange}
+      />
+    )
+
+    await userEvent.click(screen.getByTestId("clear-button"))
+
+    expect(onChange).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ e164: undefined, isValid: false })
+    )
+    expect(getInput().value).toBe("")
+  })
+
   it("changes the country from the selector and keeps the number", async () => {
     const user = userEvent.setup()
     const onCountryChange = vi.fn()


### PR DESCRIPTION
## Description

A stored national number with no dial code and no `defaultCountry` to fall back on (`phone: '650090492'`, `phone_prefix: NULL` — the broken pair the component exists to let users repair) rendered an **empty input**: `valueToE164` cannot express a country-less national number as E.164, so the field showed nothing and fixing the record meant retyping the digits blind. Found while adopting `F0PhoneInput` in Factorial's ATS edit-phone modal (factorialco/factorial#109580), where exactly these records are the ones recruiters open the modal to fix.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

Before: opening the modal for `{ phone: '650090492', phone_prefix: NULL }` shows an empty field with the globe trigger. After: the raw digits `650090492` stay visible next to the globe; picking Spain formats them as `650 09 04 92` and emits `{ prefix: '+34', number: '650090492' }`.

## Implementation details

- fix: pass the raw digits through to react-phone-number-input when the value cannot resolve to E.164 (non-`+` number, no derivable country) — they display as-is next to the country-less globe, and selecting a country adopts them as that country's national number and emits the normalized pair; the clear button now also accounts for this state

  <details>
  <summary>Why no country guessing, and why this is safe</summary>

  The country of a bare national number is genuinely unknown (`650090492` is a valid subscriber number in several countries), so the component neither guesses nor rewrites: the digits render untouched, `isValid` stays `false`, and form-level validation keeps blocking save until the user picks the country — the same explicit-choice semantics the value-model docs promise ("legacy data is passed through untouched until the user edits it"). react-phone-number-input natively treats pending input as national on country selection, so no new state machinery was needed.
  </details>

- test: three new cases — raw digits render with no selected country, picking a country adopts them and emits the normalized pair with `isValid: true`, clear button shows for the raw state (60 suite tests pass)
- docs: story `LegacyPrefixlessNumber` with play assertions, and the input-normalization table row updated (it previously documented the empty-field behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)