### PR TITLE
fix(icons): remove stale shapes from Multitask icon

### DIFF
--- a/packages/react/src/icons/app/Multitask.tsx
+++ b/packages/react/src/icons/app/Multitask.tsx
@@ -11,13 +11,6 @@ const SvgMultitask = (
     ref={ref}
     {...props}
   >
-    <rect width={5} height={5} x={4} y={4} stroke="currentColor" rx={1} />
-    <rect width={5} height={5} x={15} y={4} stroke="currentColor" rx={1} />
-    <rect width={5} height={5} x={4} y={15} stroke="currentColor" rx={1} />
-    <rect width={5} height={5} x={15} y={15} stroke="currentColor" rx={1} />
-    <path stroke="currentColor" strokeLinecap="round" d="M9 6.5H15" />
-    <path stroke="currentColor" strokeLinecap="round" d="M6.5 9V15" />
-    <path stroke="currentColor" strokeLinecap="round" d="M17.5 9V15" />
     <path
       stroke="currentColor"
       strokeLinecap="round"


### PR DESCRIPTION
## Description

The generated `Multitask.tsx` had drifted from its source asset and was rendering two glyphs stacked on top of each other — the old connected-nodes icon and the current checklist icon — which made it unreadable in the icon gallery and anywhere the icon is used. This restores it to just the checklist glyph defined in `packages/core/assets/icons/app/multitask.svg`.

## Screenshots (if applicable)

**Before** — the connected-nodes glyph (4 rounded rects + 3 connectors) drawn over the checklist:

<img width="692" height="670" alt="image" src="https://github.com/user-attachments/assets/4351e3c9-9d70-45dd-b02b-775cb1ab957b" />

**After** — only the checklist glyph (3 checkmarks + 3 text lines).

<img width="290" height="286" alt="image" src="https://github.com/user-attachments/assets/5e0a3123-4408-4601-83b5-aab627558eba" />

## Implementation details

- fix: remove the 4 `<rect>` nodes and 3 connector paths from `Multitask.tsx`, leaving only the 6 checklist paths

  <details>
  <summary>Why?</summary>

  Re-running the icon generator (`npx @svgr/cli` over `@factorialco/f0-core/assets/icons/app/multitask.svg`) emits exactly the 6 checklist paths and no rects, confirming the removed shapes were leftovers from a previous version of the asset that survived an incomplete regeneration. `packages/react-native/src/icons/app/Multitask.tsx` was already correct and needed no change, and `packages/react/icons/` is a gitignored build artifact.
  </details>