### PR TITLE
feat(NewHomeLayout): configurable widgets, and no edit mode to enter first

### DIFF
--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -1192,6 +1192,46 @@ describe("Select", () => {
       // The other group remains collapsed
       expect(screen.queryByText("Carol")).not.toBeInTheDocument()
     })
+
+    /**
+     * ONE SCROLLPORT. The virtualized list is rendered through Radix's
+     * `Select.Viewport` with `asChild`, so Radix merges its own
+     * `overflow: hidden auto; flex: 1 1 0%` onto the virtualizer's SIZER — which
+     * made a second scroll container inside the `ScrollArea` that already scrolls
+     * the list. Two nested scrollers is the "double scroll" a grouped list is long
+     * enough to expose: the wheel fills the inner one, then hands off to the outer.
+     */
+    it("leaves the scrolling to ONE element, not two", async () => {
+      const user = userEvent.setup()
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          source={buildSource(true)}
+          mapOptions={mapOptions}
+          onChange={() => {}}
+        />
+      )
+
+      await openSelect(user)
+      await waitFor(() => {
+        expect(screen.getByText("Engineer")).toBeInTheDocument()
+      })
+
+      const sizer = document.querySelector<HTMLElement>(
+        "[data-radix-select-viewport]"
+      )
+      expect(sizer).not.toBeNull()
+      // The spacer must not scroll, and must not be shrinkable below the height
+      // the virtualizer gave it.
+      expect(sizer!.style.overflow).toBe("visible")
+      // `flex: none` as the browser stores it.
+      expect(sizer!.style.flex).toBe("0 0 auto")
+    })
+
+    // NOTE: the other half of this fix — that expanding a group no longer scrolls
+    // the list back to the selection — has no honest test here. jsdom has no
+    // layout, so the virtualizer's scroll is a no-op and any assertion about it
+    // passes whether the bug is present or not. It is verified in a browser.
   })
 
   describe("onCreate", () => {

--- a/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react"
 import { Fragment } from "react"
-import { expect, test } from "vitest"
+import { expect, test, vi } from "vitest"
 
 /* eslint-disable no-constant-binary-expression */
 import { userEvent, zeroRender } from "@/testing/test-utils"
@@ -41,7 +41,29 @@ test("there is one separator between each valid element", async () => {
   expect(separators).toHaveLength(2)
 })
 
-test("the header link names itself: its title is the accessible name AND the tooltip", async () => {
+test("the link IS the title: the widget's name is what you click", async () => {
+  const onClick = vi.fn()
+  zeroRender(
+    <Widget
+      header={{
+        title: "Communications",
+        link: { title: "Go to Communications", onClick },
+      }}
+    >
+      <p>body</p>
+    </Widget>
+  )
+
+  // Named for the DESTINATION (a title alone can't say where it goes), while
+  // the visible text is the title itself.
+  const link = screen.getByRole("button", { name: "Go to Communications" })
+  expect(link).toHaveTextContent("Communications")
+
+  await userEvent.click(link)
+  expect(onClick).toHaveBeenCalled()
+})
+
+test("hovering the title says where it goes", async () => {
   zeroRender(
     <Widget
       header={{
@@ -53,11 +75,45 @@ test("the header link names itself: its title is the accessible name AND the too
     </Widget>
   )
 
-  // Icon-only, so the title is all a screen reader has to go on.
-  const link = screen.getByRole("button", { name: "Go to Communications" })
+  await userEvent.hover(
+    screen.getByRole("button", { name: "Go to Communications" })
+  )
 
-  await userEvent.hover(link)
+  // The title alone says WHAT you are looking at; the tooltip says what
+  // clicking it does.
   expect(
     await screen.findByRole("tooltip", { name: /Go to Communications/ })
   ).toBeInTheDocument()
+})
+
+test("a link with a url is a real anchor, and only another host opens a tab", () => {
+  const { rerender } = zeroRender(
+    <Widget
+      header={{
+        title: "Resources",
+        link: { title: "Go to factorial.co", url: "https://factorial.co" },
+      }}
+    >
+      <p>body</p>
+    </Widget>
+  )
+
+  const external = screen.getByRole("link", { name: "Go to factorial.co" })
+  expect(external).toHaveAttribute("href", "https://factorial.co")
+  expect(external).toHaveAttribute("target", "_blank")
+
+  rerender(
+    <Widget
+      header={{
+        title: "Events",
+        link: { title: "Go to Calendar", url: "/calendar#core.events" },
+      }}
+    >
+      <p>body</p>
+    </Widget>
+  )
+
+  expect(
+    screen.getByRole("link", { name: "Go to Calendar" })
+  ).not.toHaveAttribute("target")
 })

--- a/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
@@ -80,6 +80,20 @@ export const WithAction: Story = {
   },
 }
 
+/**
+ * Two footer buttons: `action` takes an ARRAY for a card that carries both its
+ * own call to action and the way out of it, side by side in the footer.
+ */
+export const WithTwoActions: Story = {
+  args: {
+    ...meta.args,
+    action: [
+      { label: "Sign now", onClick: fn() },
+      { label: "Go to Documents", onClick: fn() },
+    ],
+  },
+}
+
 export const WithCriticalAlert: Story = {
   args: {
     ...meta.args,

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -17,13 +17,14 @@ import { Counter } from "@/ui/Counter"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { PrivateBox } from "@/sds/Profile/PrivateBox"
 import {
-  ExternalLink,
+  ChevronRight,
   EyeInvisible,
   EyeVisible,
   Handle,
   InfoCircleLine,
 } from "@/icons/app"
 import { withDataTestId } from "@/lib/data-testid"
+import { isExternalHref, Link } from "@/lib/linkHandler"
 import { experimentalComponent } from "@/lib/experimental"
 import { usePrivacyMode } from "@/lib/privacyMode"
 import { withSkeleton } from "@/lib/skeleton"
@@ -34,7 +35,6 @@ import {
   CardContent,
   CardFooter,
   CardHeader,
-  CardLink,
   CardSubtitle,
   CardTitle,
 } from "@/ui/Card"
@@ -48,22 +48,37 @@ export interface WidgetProps {
     comment?: string
     info?: string
     canBeBlurred?: boolean
+    /**
+     * The way out of the widget: it makes the TITLE ITSELF the link — the title
+     * with a chevron after it, one ghost-button-shaped target that lights up on
+     * hover. Nothing sits in the header's top-right (that is the overflow menu's)
+     * and nothing sits in the footer (that is `action`'s): the name of the widget
+     * IS the way into it.
+     */
     link?: {
       /**
-       * What following the link DOES, in words — "Go to Communities". The
-       * control is icon-only, so this is the only thing that says where it
-       * goes: it is its tooltip and its accessible name, and it is required
-       * for exactly that reason.
+       * What following it DOES, in words — "Go to Communities". The visible text
+       * is the widget's title, so this is what a screen reader announces
+       * instead: it names the DESTINATION, which a title alone cannot.
        */
       title: string
       url?: string
       onClick?: () => void
-      /** Defaults to the external-link glyph. */
+      /** Defaults to the chevron. */
       icon?: IconType
     }
     count?: number
   }
+  /** The card's footer button — its call to action. `neutral`/`sm` by default. */
   action?: F0ButtonProps
+  /**
+   * Extra classes for the FOOTER row that `action` draws in. For content that
+   * BLEEDS past the card's content box and wants the footer brought onto its
+   * line — Home's row-based slots bleed 8px, which eats the gap above the footer
+   * and offsets it from the rows (see `SlotWidget`). Spacing only; `F0Button`
+   * takes no className of its own, so this is the seam for it.
+   */
+  footerClassName?: string
   summaries?: Array<{
     label: string
     value: string | number
@@ -97,6 +112,80 @@ const InlineDot = () => (
   <div className="min-h-[0.15rem] min-w-[0.15rem] rounded-full bg-f1-foreground-secondary" />
 )
 
+/**
+ * The TITLE AS A LINK: title text plus a chevron, in one target that behaves like
+ * a ghost button — a tint on hover, a ring on focus. The negative margin with the
+ * matching padding is what keeps the title on the same line it sits on when it is
+ * NOT a link, so the header doesn't shift between the two.
+ */
+const TITLE_LINK_CLASS = cn(
+  "-mx-1.5 inline-flex min-w-0 items-center gap-1 rounded-sm px-1.5 py-0.5",
+  "border-none bg-transparent text-left no-underline",
+  // The COLOUR lives here, on the link, for two reasons: an anchor otherwise
+  // falls back to the browser's blue, and `F0Icon` paints itself from
+  // `currentColor` — so the chevron is the title's colour by inheritance rather
+  // than by being told twice.
+  "text-f1-foreground",
+  "cursor-pointer transition-colors hover:bg-f1-background-secondary-hover",
+  "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring"
+)
+
+/**
+ * The widget's title, linked or not. Linked, it is a real anchor when it has a
+ * `url` (so it can be opened in a new tab, copied, middle-clicked — and only
+ * ANOTHER HOST opens a tab by itself) and a button when all it has is an
+ * `onClick`.
+ */
+const WidgetTitle = ({
+  title,
+  link,
+}: {
+  title: string
+  link?: NonNullable<WidgetProps["header"]>["link"]
+}) => {
+  if (!link) return <CardTitle className="truncate">{title}</CardTitle>
+
+  const content = (
+    <>
+      <CardTitle className="truncate">{title}</CardTitle>
+      {/* No colour of its own: `currentColor` makes it exactly the title's, and
+          the two read as ONE label rather than a label beside a control. */}
+      <F0Icon size="sm" icon={link.icon ?? ChevronRight} />
+    </>
+  )
+
+  // `aria-label` names the DESTINATION while the visible text stays the title.
+  // The title is contained in it ("Communications" in "Go to Communications"),
+  // which is what WCAG's label-in-name asks for.
+  const control = link.url ? (
+    <Link
+      href={link.url}
+      onClick={link.onClick}
+      aria-label={link.title}
+      className={TITLE_LINK_CLASS}
+      {...(isExternalHref(link.url)
+        ? { target: "_blank" as const, rel: "noreferrer" }
+        : {})}
+    >
+      {content}
+    </Link>
+  ) : (
+    <button
+      type="button"
+      onClick={link.onClick}
+      aria-label={link.title}
+      className={TITLE_LINK_CLASS}
+    >
+      {content}
+    </button>
+  )
+
+  // The tooltip says WHERE, above the title: the visible text is the widget's
+  // name, which tells you what you are looking at but not what clicking it does.
+  // Same words as the accessible name, so both audiences get the destination.
+  return <Tooltip label={link.title}>{control}</Tooltip>
+}
+
 const Container = forwardRef<
   HTMLDivElement,
   WidgetProps & { children: ReactNode }
@@ -105,6 +194,7 @@ const Container = forwardRef<
     header,
     children,
     action,
+    footerClassName,
     summaries,
     alert,
     status,
@@ -151,10 +241,6 @@ const Container = forwardRef<
     )
   }
 
-  const handleLinkClick = () => {
-    header?.link?.onClick?.()
-  }
-
   return (
     <Card
       className={cn(
@@ -181,9 +267,13 @@ const Container = forwardRef<
                   <F0Icon icon={Handle} size="xs" />
                 </div>
               )}
-              <div className="flex min-h-6 grow flex-row items-center gap-1 truncate">
+              {/* `min-w-0` rather than `truncate`: the ellipsis belongs to the
+                  TITLE, which carries its own (see `WidgetTitle`), and an
+                  `overflow: hidden` here clipped the linked title's hover
+                  background where it bleeds past the content box. */}
+              <div className="flex min-h-6 min-w-0 grow flex-row items-center gap-1">
                 {header.title && (
-                  <CardTitle className="truncate">{header.title}</CardTitle>
+                  <WidgetTitle title={header.title} link={header.link} />
                 )}
                 {header.subtitle && (
                   <div className="flex flex-row items-center gap-1">
@@ -232,18 +322,8 @@ const Container = forwardRef<
                     />
                   </DropdownInternal>
                 )}
-                {header.link && (
-                  // The glyph alone can't say where it goes, so `title` is
-                  // shown as a tooltip as well as being the accessible name.
-                  <Tooltip label={header.link.title}>
-                    <CardLink
-                      onClick={handleLinkClick}
-                      href={header.link.url}
-                      title={header.link.title}
-                      icon={header.link.icon ?? ExternalLink}
-                    />
-                  </Tooltip>
-                )}
+                {/* No link here: it is the TITLE (see `WidgetTitle`). This
+                    corner belongs to the overflow menu. */}
               </div>
             </div>
             {header.comment && (
@@ -305,7 +385,7 @@ const Container = forwardRef<
           })}
       </CardContent>
       {action && (
-        <CardFooter>
+        <CardFooter className={cn(footerClassName)}>
           <F0Button variant="neutral" size="sm" {...action} />
         </CardFooter>
       )}

--- a/packages/react/src/lib/linkHandler.spec.tsx
+++ b/packages/react/src/lib/linkHandler.spec.tsx
@@ -1,7 +1,12 @@
 import { render, screen } from "@testing-library/react"
 import { describe, expect, test } from "vitest"
 
-import { Link, LinkProvider, useNavigation } from "./linkHandler"
+import {
+  isExternalHref,
+  Link,
+  LinkProvider,
+  useNavigation,
+} from "./linkHandler"
 
 describe("LinkProvider", () => {
   test("allows LinkProvider to change the component", async () => {
@@ -152,5 +157,49 @@ describe("useLink", () => {
     expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
       "true"
     )
+  })
+})
+
+/**
+ * The one rule that decides `target="_blank"`. Everything that can still be
+ * handled by the app in this tab must not open another one.
+ */
+describe("isExternalHref", () => {
+  const host = () => window.location.host
+
+  test("a bare fragment is not even a navigation", () => {
+    expect(isExternalHref("#core.whatever")).toBe(false)
+  })
+
+  test("a path, with or without a fragment, stays here", () => {
+    expect(isExternalHref("/calendar")).toBe(false)
+    expect(isExternalHref("/calendar#core.events")).toBe(false)
+    expect(isExternalHref("calendar?tab=week#core.events")).toBe(false)
+  })
+
+  test("THIS host is this app, absolute url and fragment included", () => {
+    expect(isExternalHref(`http://${host()}/calendar#core.events`)).toBe(false)
+  })
+
+  test("THIS host under a different scheme is still this app", () => {
+    // The regression: comparing origins made an `https:` href to the host you
+    // are already on look like another site, and it opened in a new tab.
+    expect(isExternalHref(`https://${host()}/calendar#core.events`)).toBe(false)
+  })
+
+  test("another host is external, fragment or not", () => {
+    expect(isExternalHref("https://factorial.co")).toBe(true)
+    expect(isExternalHref("https://help.factorial.co/article#top")).toBe(true)
+  })
+
+  test("a non-web scheme is the OS's business, not a new tab's", () => {
+    expect(isExternalHref("mailto:hello@factorial.co")).toBe(false)
+    expect(isExternalHref("tel:+34600000000")).toBe(false)
+  })
+
+  test("nothing, or something unparseable, is not external", () => {
+    expect(isExternalHref()).toBe(false)
+    expect(isExternalHref("")).toBe(false)
+    expect(isExternalHref("http://")).toBe(false)
   })
 })

--- a/packages/react/src/lib/linkHandler.tsx
+++ b/packages/react/src/lib/linkHandler.tsx
@@ -45,6 +45,37 @@ export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
   disabled?: boolean
 }
 
+/**
+ * Whether an href LEAVES THIS APP — the only thing that should ever decide
+ * `target="_blank"`. Everything else belongs in the current tab, where the app's
+ * own router (`LinkProvider`'s `component`) can take the navigation.
+ *
+ * Three things are NOT external, and each of them used to be:
+ *
+ * - A bare `#fragment`. It does not leave the DOCUMENT, let alone the site.
+ * - The SAME HOST under a different scheme. `http://app.example.com/x` while you
+ *   sit on `https://app.example.com` is the app you are already in; comparing
+ *   ORIGINS (scheme included) called it another site and tore the SPA down to
+ *   open a new tab. Hosts are what "same domain" means.
+ * - A non-web scheme (`mailto:`, `tel:`, `sms:`). The OS handles those; a tab
+ *   would open only to close itself again.
+ *
+ * Anything unparseable is treated as internal: a new tab is the more disruptive
+ * guess, so it is not the one to make when in doubt.
+ */
+export const isExternalHref = (href?: string): boolean => {
+  if (!href || href.startsWith("#")) return false
+  if (typeof window === "undefined") return false
+  try {
+    const url = new URL(href, window.location.href)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false
+    // `host`, not `hostname`: a different port is a different app.
+    return url.host !== window.location.host
+  } catch {
+    return false
+  }
+}
+
 function stripTrailingSlash(path: string) {
   return path.endsWith("/") ? path.slice(0, -1) : path
 }

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -959,6 +959,17 @@ export const defaultTranslations = {
     submit: "Submit",
     stepOf: "Step {{current}} of {{total}}",
   },
+  widgets: {
+    /** Turns a widget over to read what it is telling you (Home's `info`). */
+    whatThisMeans: "What this info means?",
+    /** The button on that other side, which turns it back. */
+    gotIt: "Got it",
+    /** The widget menu's own items, and the dialogs they open. */
+    editParams: "Edit params",
+    editParamsTitle: "Edit widget params",
+    removeWidget: "Remove widget",
+    addWidget: "Add widget",
+  },
   pdfViewer: {
     toolbar: "Document toolbar",
     previousPage: "Previous page",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -969,6 +969,8 @@ export const defaultTranslations = {
     editParamsTitle: "Edit widget params",
     removeWidget: "Remove widget",
     addWidget: "Add widget",
+    /** Heads the widgets a Home suggests, at the top of the picker. */
+    recommended: "Recommended",
   },
   pdfViewer: {
     toolbar: "Document toolbar",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -971,6 +971,8 @@ export const defaultTranslations = {
     addWidget: "Add widget",
     /** Heads the widgets a Home suggests, at the top of the picker. */
     recommended: "Recommended",
+    /** Why a drop onto a pinned widget was refused. `{{title}}` is its name. */
+    cannotMoveHere: "You can't move a widget here — {{title}} is locked.",
   },
   pdfViewer: {
     toolbar: "Document toolbar",

--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -84,12 +84,22 @@ describe("HomeListItem", () => {
     expect(container.querySelector("svg")).not.toBeNull()
   })
 
-  test("relative and # hrefs stay in this tab; other domains open a new one", () => {
+  test("only another HOST opens a new tab — this one never does", () => {
     const { rerender } = zeroRender(<HomeListItem title="row" href="/inside" />)
 
     expect(screen.getByRole("link")).not.toHaveAttribute("target")
 
     rerender(<HomeListItem title="row" href="#section" />)
+    expect(screen.getByRole("link")).not.toHaveAttribute("target")
+
+    // The app's own host, absolute and with a fragment — including under the
+    // OTHER scheme, which used to read as a different site and open a new tab.
+    rerender(
+      <HomeListItem
+        title="row"
+        href={`https://${window.location.host}/calendar#core.events`}
+      />
+    )
     expect(screen.getByRole("link")).not.toHaveAttribute("target")
 
     rerender(<HomeListItem title="row" href="https://developer.mozilla.org" />)

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -4,7 +4,7 @@ import { F0Avatar, type AvatarVariant } from "@/components/avatars/F0Avatar"
 import type { AvatarSize } from "@/components/avatars/internal/BaseAvatar"
 import { F0Icon } from "@/components/F0Icon"
 import { ChevronRight } from "@/icons/app"
-import { Link } from "@/lib/linkHandler"
+import { isExternalHref, Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
 
 /**
@@ -43,28 +43,13 @@ export interface HomeListItemProps {
   /**
    * Renders the row as a REAL link — an anchor with this href (role `link`,
    * middle-click, copy address), routed through the app's `LinkProvider`.
-   * The row's ONLY click behavior: relative and `#` hrefs open in the same
-   * tab, hrefs to other domains open in a new one.
+   * The row's ONLY click behavior: only an href to ANOTHER HOST opens a new tab
+   * (see `isExternalHref`) — a path, a `#fragment` and this host under any
+   * scheme all stay in this tab, where the app's router takes them.
    */
   href?: string
   /** A trailing chevron. Off — the row's link affordance is the row itself. */
   showChevron?: boolean
-}
-
-/**
- * Whether an href leaves the current domain — those rows open in a new tab.
- * Relative paths and `#` fragments resolve against the current origin, so
- * they stay in this one.
- */
-const isExternal = (href: string) => {
-  if (typeof window === "undefined") return false
-  try {
-    return (
-      new URL(href, window.location.origin).origin !== window.location.origin
-    )
-  } catch {
-    return false
-  }
 }
 
 export function HomeListItem({
@@ -128,7 +113,7 @@ export function HomeListItem({
     <Link
       href={href}
       className={cn(className, "no-underline")}
-      {...(isExternal(href) ? { target: "_blank", rel: "noreferrer" } : {})}
+      {...(isExternalHref(href) ? { target: "_blank", rel: "noreferrer" } : {})}
     >
       {content}
     </Link>

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -167,13 +167,23 @@ describe("NewHomeLayout", () => {
       ).not.toBeInTheDocument()
     })
 
-    test("offers the collapse toggle and the edit button", () => {
+    test("offers the collapse toggle, and no edit toggle at all", () => {
       renderLayout(1400)
 
       expect(
         screen.getByLabelText("Collapse widgets panel")
       ).toBeInTheDocument()
-      expect(screen.getByLabelText("Edit Home")).toBeInTheDocument()
+      expect(screen.queryByLabelText("Edit Home")).not.toBeInTheDocument()
+    })
+
+    /**
+     * Arranging is always available, so the chrome for it is on the widgets
+     * themselves: the unlocked one carries a menu, the pinned one carries none.
+     */
+    test("gives an unlocked widget its own menu, with no mode to enter", () => {
+      renderLayout(1400, { onRemoveWidget: () => {} })
+
+      expect(screen.getAllByRole("button", { name: "Actions" })).toHaveLength(1)
     })
 
     test("collapsing by hand swaps the rail for its glyph strip", async () => {
@@ -184,14 +194,6 @@ describe("NewHomeLayout", () => {
       expect(screen.getByLabelText("Expand widgets panel")).toBeInTheDocument()
       // Collapsed, each widget is a button rather than a card.
       expect(screen.getByRole("button", { name: "clock" })).toBeInTheDocument()
-    })
-
-    test("the edit button turns into a confirm while editing", async () => {
-      renderLayout(1400)
-
-      await userEvent.click(screen.getByLabelText("Edit Home"))
-
-      expect(screen.getByLabelText("Done editing")).toBeInTheDocument()
     })
   })
 
@@ -213,10 +215,9 @@ describe("NewHomeLayout", () => {
       ).not.toBeInTheDocument()
     })
 
-    test("hides the edit button, and still offers to add", () => {
+    test("still offers to add — the strip's one arranging affordance", () => {
       const { container } = renderLayout(1000)
 
-      expect(screen.queryByLabelText("Edit Home")).not.toBeInTheDocument()
       // Scoped to the STRIP: the main column offers to add too, and both controls
       // are named the same thing because they are the same offer in two places.
       const strip = container.querySelector("aside.-m-1") as HTMLElement

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -16,6 +16,7 @@ import { One } from "@/icons/ai"
 import {
   Building,
   Calendar,
+  Check,
   ChevronRight,
   Clock,
   Comment,
@@ -27,6 +28,7 @@ import {
   PalmTree,
   Person,
   Receipt,
+  Settings,
   Target,
 } from "@/icons/app"
 
@@ -45,7 +47,7 @@ import {
   widgetTitle,
 } from "../slotRenderers"
 import { type WidgetContainerSide } from "../WidgetContainer"
-import { WidgetCatalog } from "../WidgetCatalog"
+import { WidgetCatalog, type WidgetCatalogGroup } from "../WidgetCatalog"
 import { ApplicationFrame } from "@/patterns/ApplicationFrame"
 import { Sidebar } from "@/patterns/Navigation/Sidebar/Sidebar"
 import { SidebarFooter } from "@/patterns/Navigation/Sidebar/Footer"
@@ -160,7 +162,7 @@ const FeedSection = ({
     {viewMore ? (
       <div className="flex justify-end pt-1">
         <F0Button
-          variant="outline"
+          variant="neutral"
           size="sm"
           label={`View more (${viewMore})`}
           onClick={() => {}}
@@ -582,6 +584,12 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
       title: "Communications",
       link: { title: "Go to Communications", url: "/communications" },
     },
+    // THIS WIDGET'S OWN actions: they lead its three-dots menu, above the items
+    // every widget carries (and above "Remove widget", behind its separator).
+    actions: [
+      { label: "Mark all as read", icon: Check, onClick: () => {} },
+      { label: "Notification settings", icon: Settings, onClick: () => {} },
+    ],
     slots: [
       listSlot(
         { left: "module", descriptionRequired: true, clickBehavior: "link" },
@@ -689,7 +697,7 @@ const LOADING_RIGHT_WIDGETS: HomeWidgetItem[] = RIGHT_WIDGETS.map((widget) => ({
  * The catalog the picker offers. Every preview is the REAL widget — the same
  * `SlotWidget` render the rail makes — so what you preview is what gets added.
  */
-const CATALOG = [
+const CATALOG_ITEMS = [
   ...RIGHT_WIDGETS.map((widget) => ({
     id: widget.id,
     // `widgetTitle` rather than the header's own: a configurable widget's title
@@ -909,6 +917,45 @@ const CATALOG = [
   },
 ]
 
+/**
+ * THE PICKER’S DOMAINS, in the order it shows them, each headed by its module’s
+ * glyph. The labels are the app’s words: f0’s `modules` registry carries icons,
+ * not names.
+ */
+const CATALOG_GROUPS: WidgetCatalogGroup[] = [
+  { id: "time", label: "Time & attendance", module: "time-tracking" },
+  { id: "comms", label: "Communication", module: "communities" },
+  { id: "calendar", label: "Calendar", module: "calendar" },
+  { id: "performance", label: "Performance", module: "goals" },
+  { id: "org", label: "Organization", module: "employees" },
+  { id: "docs", label: "Documents", module: "documents" },
+]
+
+/** Which domain each widget belongs to. `resources` deliberately has none — it
+ * lands in the unheaded run after the groups, which is what a widget that fits
+ * no domain should do. */
+const CATALOG_DOMAIN: Record<string, string> = {
+  "clock-in": "time",
+  "time-off": "time",
+  communications: "comms",
+  events: "calendar",
+  goals: "performance",
+  tasks: "performance",
+  team: "org",
+  people: "org",
+  offices: "org",
+  documents: "docs",
+}
+
+/** What this Home suggests first. Optional: drop it and the section is gone. */
+const RECOMMENDED_IDS = new Set(["clock-in", "events"])
+
+const CATALOG = CATALOG_ITEMS.map((item) => ({
+  ...item,
+  group: CATALOG_DOMAIN[item.id],
+  recommended: RECOMMENDED_IDS.has(item.id),
+}))
+
 const Home = () => {
   const [open, setOpen] = useState(false)
   const [side, setSide] = useState<WidgetContainerSide>("main")
@@ -957,6 +1004,7 @@ const Home = () => {
         isOpen={open}
         onClose={() => setOpen(false)}
         widgets={CATALOG}
+        groups={CATALOG_GROUPS}
         onAdd={() => setOpen(false)}
         previewWidth={side === "right" ? 396 : 768}
       />

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1,6 +1,10 @@
 import { useState, type ReactNode } from "react"
 
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { z } from "zod"
+
+import { createDataSourceDefinition } from "@/hooks/datasource"
+import { f0FormField } from "@/patterns/F0Form"
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0OneIcon } from "@/kits/ai/F0OneIcon"
@@ -32,10 +36,13 @@ import {
 } from "../ClockIn/ClockInControls"
 import { SlotWidget } from "../SlotWidget"
 import {
+  fromParams,
   homeSlot,
   type HomeWidgetItem,
   listSlot,
+  resolveWidgetHeader,
   type SlotRenderers,
+  widgetTitle,
 } from "../slotRenderers"
 import { type WidgetContainerSide } from "../WidgetContainer"
 import { WidgetCatalog } from "../WidgetCatalog"
@@ -419,6 +426,133 @@ const RAIL_EVENTS = [
   },
 ]
 
+/* ===================== what makes a widget CONFIGURABLE ===================== */
+
+/** What the teams field's datasource serves. */
+type Team = { id: string; name: string; people: number }
+
+const TEAMS: Team[] = [
+  { id: "design", name: "Design", people: 8 },
+  { id: "engineering", name: "Engineering", people: 42 },
+  { id: "people", name: "People", people: 6 },
+  { id: "sales", name: "Sales", people: 17 },
+  { id: "support", name: "Support", people: 11 },
+]
+
+/**
+ * A DATASOURCE, not a list of options: the field searches it, so the widget can
+ * be pointed at things nobody could enumerate at build time (every team in the
+ * company). The same definition any F0Form select takes.
+ */
+const teamsSource = createDataSourceDefinition<Team>({
+  dataAdapter: {
+    fetchData: async ({ search }) => {
+      const needle = search?.toLowerCase()
+      return {
+        records: needle
+          ? TEAMS.filter((team) => team.name.toLowerCase().includes(needle))
+          : TEAMS,
+      }
+    },
+  },
+})
+
+/**
+ * The EVENTS widget's params, as a plain F0Form schema — params belong on the
+ * widgets a Home already has, not on a widget invented to carry them.
+ *
+ * Every field type the dialog can draw is here: an enum (select), a
+ * datasource-backed MULTI select, a number, a date and a datetime. REQUIRED vs
+ * OPTIONAL is just zod: `period`, `teams` and `maxEvents` must be set — the
+ * dialog won't save without them — while `since` and `digestAt` are `.optional()`
+ * and can be left alone.
+ */
+const EVENTS_PARAMS = z.object({
+  period: f0FormField(z.enum(["week", "month", "quarter"]), {
+    label: "Period",
+    options: [
+      { value: "week", label: "This week" },
+      { value: "month", label: "This month" },
+      { value: "quarter", label: "This quarter" },
+    ],
+  }),
+  teams: f0FormField(z.array(z.string()).min(1), {
+    label: "Teams",
+    placeholder: "Pick at least one team",
+    showSearchBox: true,
+    multiple: true,
+    source: teamsSource,
+    mapOptions: (team: Team) => ({
+      value: team.id,
+      label: team.name,
+      description: `${team.people} people`,
+    }),
+  }),
+  maxEvents: f0FormField(z.number().min(1).max(8), {
+    label: "Events to show",
+  }),
+  since: f0FormField(z.date().optional(), {
+    label: "Only after",
+  }),
+  digestAt: f0FormField(z.date().optional(), {
+    label: "Send me a digest at",
+    fieldType: "datetime",
+  }),
+})
+
+type EventsParams = z.infer<typeof EVENTS_PARAMS>
+
+const PERIOD_LABEL: Record<string, string> = {
+  week: "this week",
+  month: "this month",
+  quarter: "this quarter",
+}
+
+const teamNames = (ids: string[] = []) =>
+  ids.map((id) => TEAMS.find((team) => team.id === id)?.name ?? id).join(", ")
+
+/**
+ * The Events widget, BUILT FROM ITS PARAMS. Its `title` and `info` are functions
+ * of them — the card names the teams it is showing, and its info side explains
+ * what the list covers — while the slot's events are cut to `maxEvents` HERE, in
+ * the app, which is the only place that knows where events come from.
+ */
+const eventsWidget = (params: EventsParams): HomeWidgetItem => {
+  const shown = RAIL_EVENTS.slice(0, params.maxEvents)
+  return {
+    id: "events",
+    icon: Calendar,
+    paramsSchema: EVENTS_PARAMS,
+    params,
+    header: {
+      title: fromParams(EVENTS_PARAMS, (p) =>
+        p.teams?.length ? `Events · ${teamNames(p.teams)}` : "Events"
+      ),
+      info: fromParams(
+        EVENTS_PARAMS,
+        (p) =>
+          `The next ${p.maxEvents ?? 0} events ${PERIOD_LABEL[p.period ?? "week"]} for ${teamNames(p.teams) || "no team"}${
+            p.since ? `, from ${p.since.toLocaleDateString()} on` : ""
+          }.`
+      ),
+      count: shown.length,
+      // A `#` destination — a fragment on the page the app is already on. It
+      // must NOT open a new tab (see `isExternalHref`).
+      link: { title: "Go to Calendar", url: "/calendar#core.events" },
+    },
+    slots: [homeSlot("event-list", { showAllItems: true, events: shown })],
+  }
+}
+
+/** The Events widget as a Home the user already set up would have it. */
+const EVENTS_DEFAULTS: EventsParams = {
+  period: "week",
+  teams: ["design", "engineering"],
+  maxEvents: 4,
+  since: undefined,
+  digestAt: undefined,
+}
+
 /**
  * The rail as DATA — HomeWidgetItems with their catalog `icon`, so the layout
  * can collapse them to an avatar strip when it runs out of width. The bespoke
@@ -428,11 +562,14 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
   {
     id: "clock-in",
     icon: Clock,
-    // Pinned: you always want the clock, so edit mode leaves it alone.
+    // Pinned: you always want the clock, so it can't be dragged or removed.
     locked: true,
+    // A `url`, not an `onClick`: the footer control is then a REAL link — an
+    // anchor you can middle-click and copy — and this one stays in the tab
+    // (same host), which is what every in-app destination should do.
     header: {
       title: "Clock in",
-      link: { title: "Go to Time tracking", onClick: () => {} },
+      link: { title: "Go to Time tracking", url: "/time-tracking" },
     },
     slots: [{ visualization: "clock-in", params: {} }],
   },
@@ -443,7 +580,7 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
     hasUpdates: true,
     header: {
       title: "Communications",
-      link: { title: "Go to Communications", onClick: () => {} },
+      link: { title: "Go to Communications", url: "/communications" },
     },
     slots: [
       listSlot(
@@ -458,22 +595,13 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
       ),
     ],
   },
-  {
-    id: "events",
-    icon: Calendar,
-    header: {
-      title: "Events",
-      count: 8,
-      link: { title: "Go to Calendar", onClick: () => {} },
-    },
-    slots: [
-      homeSlot("event-list", { showAllItems: true, events: RAIL_EVENTS }),
-    ],
-  },
-  // External navigation, both flavors: the header's link carries a real `url`
-  // (an anchor, opened by the browser), and every row's `href` is an outside
-  // website — link rows render as REAL anchors (via the app's LinkProvider),
-  // so external URLs just work.
+  // The CONFIGURABLE one: it declares a `paramsSchema`, so its three-dots menu
+  // carries "Edit params" — and its title, its info and the events it lists all
+  // follow what you set there.
+  eventsWidget(EVENTS_DEFAULTS),
+  // ANOTHER HOST, both flavors: the widget's link and every row's `href` point
+  // off this site. These are the only links that open a new tab — the widgets
+  // above navigate in place, fragment and all.
   {
     id: "resources",
     icon: Globe,
@@ -564,11 +692,16 @@ const LOADING_RIGHT_WIDGETS: HomeWidgetItem[] = RIGHT_WIDGETS.map((widget) => ({
 const CATALOG = [
   ...RIGHT_WIDGETS.map((widget) => ({
     id: widget.id,
-    title: widget.header?.title ?? widget.id,
+    // `widgetTitle` rather than the header's own: a configurable widget's title
+    // can be a function of its params, and a catalog row needs the text.
+    title: widgetTitle(widget),
+    // The same sentence the widget's info side shows, under the preview.
+    info: resolveWidgetHeader(widget.header, widget.params)?.info,
     icon: widget.icon!,
     preview: (
       <SlotWidget
         header={widget.header}
+        params={widget.params}
         slots={widget.slots}
         slotRenderers={SLOT_RENDERERS}
       />
@@ -779,14 +912,37 @@ const CATALOG = [
 const Home = () => {
   const [open, setOpen] = useState(false)
   const [side, setSide] = useState<WidgetContainerSide>("main")
+  // The configurable widget's params live with the app, next to the rail's
+  // order: both are things the user set and the app persists.
+  const [eventsParams, setEventsParams] = useState(EVENTS_DEFAULTS)
   const [rail, setRail] = useState(RIGHT_WIDGETS)
+  // The widget is REBUILT from its params — that is the app's half of the deal:
+  // the layout resolves what the params merely say (title, info), while the
+  // slots' data can only come from here.
+  const railWidgets = rail.map((widget) =>
+    widget.id === "events" ? eventsWidget(eventsParams) : widget
+  )
   return (
     <div className="h-full w-full p-6">
       <NewHomeLayout
-        rightWidgets={rail}
+        rightWidgets={railWidgets}
         slotRenderers={SLOT_RENDERERS}
         editableWidgetContainers={["right"]}
         onRemoveWidget={(id) => setRail((w) => w.filter((x) => x.id !== id))}
+        onChangeWidgetParams={(id, params) => {
+          if (id === "events") setEventsParams(params as EventsParams)
+        }}
+        // The preview rebuilds the widget the same way the rail does, so the
+        // dialog shows the events the params will really produce — not just the
+        // title following along.
+        renderWidgetPreview={(widget, params) =>
+          widget.id === "events" ? (
+            <SlotWidget
+              {...eventsWidget(params as EventsParams)}
+              slotRenderers={SLOT_RENDERERS}
+            />
+          ) : null
+        }
         onReorderWidgets={(_, ids) =>
           setRail((w) => ids.flatMap((id) => w.filter((x) => x.id === id)))
         }
@@ -858,8 +1014,13 @@ type Story = StoryObj<typeof meta>
  * "Needs you" / "One working for you" feed) next to a fixed 396px rail (Clock in,
  * Communications, Events — every widget wrapped in the f0 `Widget` frame), no
  * divider between columns. Both columns end in "+ Add widget"
- * (`onClickAddNewWidget`), which opens the `WidgetCatalog` dialog; "Edit Home"
- * toggles the per-widget remove chrome.
+ * (`onClickAddNewWidget`), which opens the `WidgetCatalog` dialog.
+ *
+ * THERE IS NO EDIT MODE. A widget is removed from the three-dots menu in its own
+ * header and moved by dragging the card itself (no handle glyph — the grab
+ * cursor is the affordance), at any time; the clock is `locked`, so it offers
+ * neither. Each widget's way out sits in its FOOTER as a named button ("Go to
+ * Calendar"), since the header's top-right is the menu's.
  */
 export const Default: Story = {
   render: () => <Home />,

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -17,12 +17,14 @@ import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
 import Menu from "@/icons/app/Menu"
-import { Check, Pencil, Plus } from "@/icons/app"
+// No `Pencil`/`Check`: there is no edit mode to toggle any more.
+import { Plus } from "@/icons/app"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import { SidebarIconSvg } from "@/patterns/Navigation/Sidebar/Icon"
 import { Action } from "@/ui/Action"
 import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
 import {
@@ -47,9 +49,11 @@ import { useRailMotion } from "./useRailMotion"
 import { useScrollFade } from "../useScrollFade"
 import { WidgetContainer, type WidgetContainerSide } from "../WidgetContainer"
 import {
+  widgetTitle,
   type HomeRenderCtx,
   type HomeWidgetItem,
   type SlotRenderers,
+  type WidgetParams,
 } from "../slotRenderers"
 
 /**
@@ -122,7 +126,9 @@ const CollapsedGlyph = ({
   return (
     <motion.button
       type="button"
-      aria-label={widget.header?.title ?? widget.id}
+      // `widgetTitle`, not the header's own: a configurable widget's title can be
+      // a function of its params, and an aria-label needs the text.
+      aria-label={widgetTitle(widget)}
       aria-expanded={open}
       onMouseEnter={(event) => onOpen(widget.id, event.currentTarget)}
       onClick={(event) =>
@@ -150,7 +156,7 @@ const CollapsedGlyph = ({
           <F0AvatarIcon icon={widget.icon} size="lg" />
         ) : (
           <span className="flex h-10 w-10 items-center justify-center rounded-lg border border-solid border-f1-border-secondary bg-f1-background font-medium text-f1-foreground-secondary">
-            {(widget.header?.title ?? widget.id).charAt(0)}
+            {widgetTitle(widget).charAt(0)}
           </span>
         )}
         {widget.hasUpdates ? (
@@ -174,12 +180,10 @@ const TWO_COLUMN_MIN_PX = 768
 const PANEL_LEAVE_MS = 150
 /** How far the floating panel clears the strip it comes out of. */
 const PANEL_GAP_PX = 8
-/**
- * Names the add control in both places it appears — the strip's glyph here and the
- * column's placeholder in `WidgetContainer`, which shares the default. Neither
- * shows it: it is a tooltip and an accessible name.
- */
-const ADD_WIDGET_LABEL = "Add widget"
+// The add control's name comes from the PROVIDER (`t.widgets.addWidget`) — it is
+// the same offer in the strip's glyph here and in the column's placeholder
+// (`WidgetContainer`), and neither shows it: it is a tooltip and an accessible
+// name.
 
 export interface NewHomeLayoutProps {
   /** Freeform main-column content on top (greeting, shortcut cards, ranked feed…). */
@@ -195,19 +199,33 @@ export interface NewHomeLayoutProps {
   /** Full override of how a whole widget is drawn. Defaults to `SlotWidget`. */
   renderWidget?: (widget: HomeWidgetItem, ctx: HomeRenderCtx) => ReactNode
   /**
-   * Edit mode. Omit it and the layout owns the state itself, toggled by its own
-   * edit button; pass it to drive edit mode from outside.
-   */
-  editing?: boolean
-  /** Called when the layout's edit button is pressed. */
-  onEditingChange?: (editing: boolean) => void
-  /**
-   * Which containers a user may actually edit. In edit mode only these show
-   * remove controls and the add placeholder; the others stay put. Both by default.
+   * Which containers a user may arrange. Only these offer "Remove widget",
+   * dragging and the add placeholder; the others stay put. Both by default.
    */
   editableWidgetContainers?: WidgetContainerSide[]
-  /** Called with a widget id when its remove control is clicked (edit mode only). */
+  /**
+   * Called with a widget id when its "Remove widget" menu item is used — the
+   * three-dots menu in the widget's own header.
+   */
   onRemoveWidget?: (id: string) => void
+  /**
+   * Called with a widget id and its new params when its "Edit params" dialog is
+   * saved. Providing it is what offers that item, in the same menu, for every
+   * widget that declares a `paramsSchema`. PERSIST what it hands you and pass it
+   * back as the widget's `params` — rebuilding the widget's slots for the new
+   * params is the app's own job, since only it knows where their data comes from.
+   */
+  onChangeWidgetParams?: (id: string, params: WidgetParams) => void
+  /**
+   * Draws a widget for params being tried out in that dialog, before they are
+   * saved. Defaults to the widget with those params swapped in — which is
+   * already live for everything they derive (title, info); supply this to
+   * rebuild its slots as well.
+   */
+  renderWidgetPreview?: (
+    widget: HomeWidgetItem,
+    params: WidgetParams
+  ) => ReactNode
   /** When set, renders a "+ Add widget" affordance at the bottom of each column. */
   onClickAddNewWidget?: (side: WidgetContainerSide) => void
   /** Called with a side and its widget ids in their new order after a drag. */
@@ -260,10 +278,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       aside,
       slotRenderers,
       renderWidget,
-      editing,
-      onEditingChange,
       editableWidgetContainers = ["main", "right"],
       onRemoveWidget,
+      onChangeWidgetParams,
+      renderWidgetPreview,
       onClickAddNewWidget,
       onReorderWidgets,
       period = "morning",
@@ -276,6 +294,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     },
     ref
   ) {
+    const t = useI18n()
     const { sidebarState, toggleSidebar, isSmallScreen } = useSidebar()
     const reducedMotion = useReducedMotion()
     const rootRef = useRef<HTMLDivElement | null>(null)
@@ -311,16 +330,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     const [hasMeasured, setHasMeasured] = useState(false)
     if (rootWidth > 0 && !hasMeasured) setHasMeasured(true)
 
-    // Uncontrolled by default: the layout's own edit button drives it. Passing
-    // `editing` hands control to the caller.
-    const [editingState, setEditingState] = useState(false)
     const [manualCollapsed, setManualCollapsed] = useState<boolean | null>(null)
-    const isEditing = editing ?? editingState
-    const toggleEditing = () => {
-      const next = !isEditing
-      if (editing === undefined) setEditingState(next)
-      onEditingChange?.(next)
-    }
     const canEditSide = (side: WidgetContainerSide) =>
       editableWidgetContainers.includes(side)
 
@@ -330,6 +340,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       ) : (
         <SlotWidget
           header={widget.header}
+          params={widget.params}
           fullHeight={widget.fullHeight}
           slots={widget.slots}
           loading={widget.loading}
@@ -599,13 +610,15 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
         >
           <GradientWash period={period} />
         </div>
-        {/* The edit toggle sits in its OWN grid row spanning both columns, so it
-            takes real layout space instead of floating over the widgets below.
-            Entering edit mode is what makes `editableWidgetContainers` take
-            effect (remove controls + the add placeholder appear in the
-            containers it lists). */}
-        {/* Chrome, not content: it arrives on the main column's first beat rather
-            than waiting its turn behind it. */}
+        {/* The page's own controls sit in their OWN grid row spanning both
+            columns, so they take real layout space instead of floating over the
+            widgets below. There is NO EDIT TOGGLE: a widget is removed from its
+            own three-dots menu and moved by dragging it, at any time, so there
+            is no mode to switch into (`editableWidgetContainers` decides which
+            columns offer that at all).
+
+            Chrome, not content: it arrives on the main column's first beat
+            rather than waiting its turn behind it. */}
         <HomeEntrance
           order={0}
           className="col-span-full flex flex-row items-center justify-between"
@@ -624,20 +637,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             <span />
           )}
           <div className="flex flex-row items-center gap-2">
-            {/* Not while the rail is collapsed: arranging widgets you cannot see
-                is not an offer worth making. In edit mode the button becomes the
-                primary action — a check to confirm — rather than staying the
-                pencil that got you here. */}
-            {collapsed ? null : (
-              <F0Button
-                variant={isEditing ? "default" : "ghost"}
-                size="md"
-                hideLabel
-                icon={isEditing ? Check : Pencil}
-                label={isEditing ? "Done editing" : "Edit Home"}
-                onClick={toggleEditing}
-              />
-            )}
             {/* Collapsing the rail by hand — but only while that is a real
                 choice. Once the layout is too narrow for both columns the rail
                 is collapsed regardless, so a toggle there would be a control
@@ -698,7 +697,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             slotRenderers={slotRenderers}
             renderWidget={renderWidget}
             ctx={ctx}
-            editing={isEditing}
             disableEdition={!canEditSide("main")}
             onReorder={
               onReorderWidgets
@@ -706,6 +704,9 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 : undefined
             }
             onRemoveWidget={onRemoveWidget}
+            onChangeWidgetParams={onChangeWidgetParams}
+            renderWidgetPreview={renderWidgetPreview}
+            paramsPreviewWidth={mainWidth}
             onClickAddNewWidget={
               onClickAddNewWidget
                 ? () => onClickAddNewWidget("main")
@@ -784,10 +785,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               {canEditSide("right") && onClickAddNewWidget ? (
                 // The same control the column's placeholder is — a dashed box
                 // around one glyph, named only on hover — at the strip's size.
-                <Tooltip label={ADD_WIDGET_LABEL}>
+                <Tooltip label={t.widgets.addWidget}>
                   <motion.button
                     type="button"
-                    aria-label={ADD_WIDGET_LABEL}
+                    aria-label={t.widgets.addWidget}
                     onClick={() => onClickAddNewWidget("right")}
                     className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
                     initial={{ opacity: 0 }}
@@ -805,8 +806,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               ) : null}
             </motion.aside>
           )}
-        </AnimatePresence>
-        {/* THE RAIL BODY — one mount, whatever the rail is doing.
+        </AnimatePresence>        {/* THE RAIL BODY — one mount, whatever the rail is doing.
 
             Expanded it is the rail's column. Collapsed it is the FLOATING PANEL:
             the same element, taken out of the grid and put at the expanded rail
@@ -882,7 +882,11 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               slotRenderers={slotRenderers}
               renderWidget={renderWidget}
               ctx={ctx}
-              editing={isEditing}
+              // NOT gated on `collapsed`: whether the column is arrangeable
+              // decides its tree's SHAPE (a draggable column is wrapped in a
+              // DndContext), and a shape that changed when the rail collapsed
+              // would rebuild every widget in it — the one thing this rail
+              // exists to avoid.
               disableEdition={!canEditSide("right")}
               onReorder={
                 onReorderWidgets
@@ -890,6 +894,9 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                   : undefined
               }
               onRemoveWidget={onRemoveWidget}
+              onChangeWidgetParams={onChangeWidgetParams}
+              renderWidgetPreview={renderWidgetPreview}
+              paramsPreviewWidth={asideWidth}
               // Not from the panel: collapsed, the strip carries the add
               // affordance, and a placeholder under a single floating widget
               // would be an offer in the wrong place.

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -806,7 +806,8 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               ) : null}
             </motion.aside>
           )}
-        </AnimatePresence>        {/* THE RAIL BODY — one mount, whatever the rail is doing.
+        </AnimatePresence>{" "}
+        {/* THE RAIL BODY — one mount, whatever the rail is doing.
 
             Expanded it is the rail's column. Collapsed it is the FLOATING PANEL:
             the same element, taken out of the grid and put at the expanded rail

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -24,26 +24,83 @@ instead of crashing.
 <Canvas of={SlotWidgetStories.AllSlots} />
 <Controls of={SlotWidgetStories.AllSlots} />
 
-## The header link
+## The way out IS the title
 
-`header.link` is the widget's way out — an icon-only control in the header's
-top-right, drawn with the **external-link** glyph (pass `icon` to override it).
-Being icon-only, it carries nothing that says where it goes, so its `title` is
-**required** and does that job twice: it is the control's **tooltip** and its
-accessible name.
-
-Write it as the action, naming the destination — the user should know where
-they are about to land before they click:
+`header.link` makes the widget's **title itself** the link: the title with a
+chevron after it, in one ghost-button-shaped target that lights up on hover.
+Nothing is added to the header's top-right (that belongs to the **overflow
+menu**) and nothing to the footer (that belongs to `action`, the widget's own
+call to action) — the name of the widget is the way into it.
 
 ```tsx
 header={{
   title: "Communications",
-  link: { title: "Go to Communications", onClick: openCommunications },
+  link: { title: "Go to Communications", url: "/communications" },
 }}
 ```
 
-Not `"Open"`, `"View"`, or the destination on its own: with several widgets on
-a Home, a column of identical "Open" tooltips says nothing.
+`title` is **required** and names the DESTINATION: the visible text is the
+widget's title, so this is what a screen reader announces instead. Write it as
+the action — not `"Open"` or `"View"`, which say nothing when several widgets
+have one.
+
+Prefer a **`url`**: it makes a real anchor, so the link can be middle-clicked,
+copied and opened in a new tab, and it goes through the app's `LinkProvider`.
+Use `onClick` only for a destination the app opens itself (a dialog, a panel) —
+that can only be a button. **Only another HOST opens a new tab**: a path, a
+`#fragment` and this host under any scheme all stay in this tab (see
+`isExternalHref`).
+
+## The info side
+
+`header.info` is not a tooltip beside the title — it is the widget's **other
+side**. The widget's three-dots menu offers **"What this info means?"** (copy
+from the f0 provider, `t.widgets.whatThisMeans`) and the card **turns over**:
+half a turn with a small jump, the title still in place, the sentence centered,
+and a **"Got it"** button to turn back.
+
+That is room enough to explain a widget in a sentence, which a tooltip cramped
+beside the title never was. Both widget dialogs show the same sentence under
+their preview, so it is also what you read when you are about to add or
+configure the widget.
+
+## Configurable widgets: params
+
+A widget can declare `paramsSchema` — **an F0Form schema** — and the params it is
+currently set to. That is all it takes for its menu to offer **"Edit params"** and
+for `WidgetUpdateDialog` to draw the fields:
+
+```tsx
+paramsSchema: z.object({
+  period: f0FormField(z.enum(["week", "month"]), { label: "Period", options: [...] }),
+  teams: f0FormField(z.array(z.string()).min(1), {
+    label: "Teams",
+    source: teamsDataSource,          // a DATASOURCE, searchable
+    mapOptions: (team) => ({ value: team.id, label: team.name }),
+    multiple: true,                   // single selection: drop `multiple`
+  }),
+  maxEvents: f0FormField(z.number().min(1).max(8), { label: "Events to show" }),
+  since: f0FormField(z.date().optional(), { label: "Only after" }),
+  digestAt: f0FormField(z.date().optional(), { label: "Digest at", fieldType: "datetime" }),
+}),
+params: { period: "week", teams: ["design"], maxEvents: 4 },
+```
+
+Because it is F0Form's own vocabulary, `z.date()` gets a date picker, `z.enum()`
+a select, and a datasource-backed field a searchable one. **Required is just
+zod**: a field that isn't `.optional()` cannot be left empty, and the dialog
+won't save until it is filled.
+
+`title` and `info` may be **functions of the params** (`fromParams` types them
+against the schema), so the card names what it is currently showing:
+
+```tsx
+title: fromParams(EVENTS_PARAMS, (p) => `Events · ${teamNames(p.teams)}`)
+```
+
+What the params CAN'T do by themselves is rebuild the widget's slots — only the
+app knows where that data comes from. Persist what `onChangeWidgetParams` hands
+you, pass it back as the widget's `params`, and rebuild the slots from it.
 
 ## Loading
 

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -51,6 +51,23 @@ that can only be a button. **Only another HOST opens a new tab**: a path, a
 `#fragment` and this host under any scheme all stay in this tab (see
 `isExternalHref`).
 
+## The widget's own actions
+
+A widget declares what only it can do as `actions` — ordinary `DropdownItem`s —
+and they lead its **three-dots menu**:
+
+```tsx
+actions: [
+  { label: "Mark all as read", icon: Check, onClick: markAllRead },
+  { label: "Notification settings", icon: Settings, onClick: openSettings },
+],
+```
+
+The column adds what every widget carries **after** them — "What this info
+means?", "Edit params" — and "Remove widget" last, behind a separator, because it
+is the one that cannot be undone. A `locked` widget still shows its actions: being
+mandatory says nothing about what it can do.
+
 ## The info side
 
 `header.info` is not a tooltip beside the title — it is the widget's **other

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -1,6 +1,6 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, test, vi } from "vitest"
 
-import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
 
 import {
   DEFAULT_EXPECTED_ITEMS_COUNT,
@@ -486,5 +486,177 @@ describe("SlotWidget chrome", () => {
     expect(screen.getByText("Gross")).toBeInTheDocument()
     expect(screen.getByText("3,200")).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "Sign now" })).toBeInTheDocument()
+  })
+
+  /**
+   * The way out of a widget is a NAMED BUTTON under its content, not an icon in
+   * the header's top-right — that corner is the overflow menu's now.
+   */
+  describe("the header's link", () => {
+    test("makes the TITLE the way out", async () => {
+      const onClick = vi.fn()
+      zeroRender(
+        <SlotWidget
+          header={{
+            title: "Events",
+            link: { title: "Go to Calendar", onClick },
+          }}
+          slots={slots}
+        />
+      )
+
+      const link = screen.getByRole("button", { name: "Go to Calendar" })
+      // The visible text is the widget's name; the accessible name is where it
+      // goes. Nothing is added to the footer for it.
+      expect(link).toHaveTextContent("Events")
+
+      await userEvent.click(link)
+      expect(onClick).toHaveBeenCalled()
+    })
+
+    test("is a real anchor when it carries a url", () => {
+      zeroRender(
+        <SlotWidget
+          header={{
+            title: "Resources",
+            link: { title: "Go to factorial.co", url: "https://factorial.co" },
+          }}
+          slots={slots}
+        />
+      )
+
+      expect(
+        screen.getByRole("link", { name: "Go to factorial.co" })
+      ).toHaveAttribute("href", "https://factorial.co")
+    })
+
+    test("opens another HOST in a new tab, and this one in place", () => {
+      const { rerender } = zeroRender(
+        <SlotWidget
+          header={{
+            title: "Resources",
+            link: { title: "Go out", url: "https://factorial.co" },
+          }}
+          slots={slots}
+        />
+      )
+
+      expect(screen.getByRole("link", { name: "Go out" })).toHaveAttribute(
+        "target",
+        "_blank"
+      )
+
+      // A fragment on this app — the case that used to open a new tab.
+      rerender(
+        <SlotWidget
+          header={{
+            title: "Events",
+            link: { title: "Go to Calendar", url: "/calendar#core.events" },
+          }}
+          slots={slots}
+        />
+      )
+
+      expect(
+        screen.getByRole("link", { name: "Go to Calendar" })
+      ).not.toHaveAttribute("target")
+    })
+
+    test("leaves the FOOTER to the widget's own call to action", () => {
+      zeroRender(
+        <SlotWidget
+          header={{
+            title: "Documents",
+            link: { title: "Go to Documents", onClick: () => {} },
+          }}
+          action={{ label: "Sign now", onClick: () => {} }}
+          slots={slots}
+        />
+      )
+
+      // Two separate things: the CTA in the footer, the way out as the title.
+      expect(
+        screen.getByRole("button", { name: "Sign now" })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Go to Documents" })
+      ).toHaveTextContent("Documents")
+    })
+  })
+
+  /**
+   * `header.info` is the widget's OTHER SIDE: the card turns over to it, keeping
+   * its title, and one small button turns it back.
+   */
+  describe("the info side", () => {
+    const withInfo = {
+      title: "Hours",
+      info: "Hours logged this week against a 38h weekly target.",
+    }
+
+    test("is out of reach until the card is turned", () => {
+      zeroRender(<SlotWidget header={withInfo} slots={slots} />)
+
+      // The face EXISTS — it is the card's other side, and it is what gives the
+      // turn something to turn to — but it is hidden from the a11y tree and from
+      // the pointer while it faces away. (`backface-visibility` is what hides it
+      // visually, and jsdom computes no 3D, so this is the assertion that means
+      // anything here.)
+      expect(
+        screen.queryByRole("button", { name: "Got it" })
+      ).not.toBeInTheDocument()
+      expect(
+        screen.getByText(withInfo.info).closest("[aria-hidden]")
+      ).toHaveAttribute("aria-hidden", "true")
+    })
+
+    test("keeps the title, centers the info and offers a way back", async () => {
+      const onFlipBack = vi.fn()
+      zeroRender(
+        <SlotWidget
+          header={withInfo}
+          slots={slots}
+          flipped
+          onFlipBack={onFlipBack}
+        />
+      )
+
+      // The title is on BOTH faces — twice in the tree, once per side.
+      expect(screen.getAllByText("Hours")).toHaveLength(2)
+      expect(screen.getByText(withInfo.info)).toBeInTheDocument()
+
+      await userEvent.click(screen.getByRole("button", { name: "Got it" }))
+      expect(onFlipBack).toHaveBeenCalled()
+    })
+
+    test("a widget with no info has no other side to turn to", () => {
+      const { container } = zeroRender(
+        <SlotWidget header={{ title: "Events" }} slots={slots} />
+      )
+
+      expect(container.querySelector("[data-turning]")).toBeNull()
+      expect(
+        screen.queryByRole("button", { name: "Got it" })
+      ).not.toBeInTheDocument()
+    })
+  })
+
+  test("puts its actions in the header's overflow menu", async () => {
+    const onClick = vi.fn()
+    zeroRender(
+      <SlotWidget
+        header={{ title: "Events" }}
+        actions={[{ label: "Remove widget", onClick }]}
+        slots={slots}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Actions" }))
+    await userEvent.click(
+      screen.getByRole("menuitem", { name: "Remove widget" })
+    )
+
+    // The dropdown defers its items' onClick past its own close animation.
+    await waitFor(() => expect(onClick).toHaveBeenCalled())
   })
 })

--- a/packages/react/src/sds/Home/SlotWidget/index.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.tsx
@@ -1,5 +1,9 @@
-import { Fragment } from "react"
+import { Fragment, useEffect, useRef, useState } from "react"
 
+import { F0Button } from "@/components/F0Button"
+import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
 import { Separator } from "@/ui/separator"
 
 import { Widget, WidgetProps } from "@/experimental/Widgets/Widget"
@@ -9,10 +13,13 @@ import {
   defaultSlotSkeleton,
   DEFAULT_EXPECTED_ITEMS_COUNT,
   resolveSlotRenderer,
+  resolveWidgetHeader,
   type HomeWidgetChrome,
+  type HomeWidgetHeader,
   type HomeRenderCtx,
   type HomeWidgetSlot,
   type SlotRenderers,
+  type WidgetParams,
 } from "../slotRenderers"
 
 /**
@@ -28,9 +35,32 @@ import {
  * `loading` swaps every slot's content for that visualization's SKELETON,
  * keeping the frame, the chrome and the seams — the card doesn't change shape
  * when the data lands, it fills in.
+ *
+ * THE WAY OUT IS A FOOTER BUTTON. `header.link` is still how a widget declares
+ * it, but it lands under the content as a named button rather than as an
+ * icon in the header's top-right: that corner belongs to the overflow menu
+ * (`actions`), and a button that says "Go to Calendar" needs no tooltip to say
+ * where it goes.
+ *
+ * A CONFIGURABLE widget's `header.title` and `header.info` may be functions of
+ * its `params` — "Hours · Design team" rather than "Hours" — so the card says
+ * what it is currently showing.
+ *
+ * `header.info` is NOT an icon in the header: it is the widget's OTHER SIDE. The
+ * card turns over to show it (see `flipped`), which is room enough to explain
+ * itself in a sentence instead of a tooltip cramped beside the title.
  */
 export type SlotWidgetProps = HomeWidgetChrome & {
-  header?: WidgetProps["header"]
+  header?: HomeWidgetHeader
+  /** The params `header.title` / `header.info` are computed from, if they are. */
+  params?: WidgetParams
+  /**
+   * Shows the widget's BACK — `header.info`, centered — by turning the card
+   * over. The column drives it from the widget's own menu (`WidgetContainer`).
+   */
+  flipped?: boolean
+  /** Turns it back. Called when the back face is clicked. */
+  onFlipBack?: () => void
   fullHeight?: boolean
   slots: HomeWidgetSlot[]
   /**
@@ -40,15 +70,46 @@ export type SlotWidgetProps = HomeWidgetChrome & {
   loading?: boolean
   /** Per-visualization renderers, MERGED OVER `defaultSlotRenderers`. */
   slotRenderers?: SlotRenderers
-  /** Forwarded to the f0 `Widget`: its own drag handle and dragging state. */
-  draggable?: boolean
-  onDragStart?: () => void
+  /**
+   * The header's overflow menu — the three dots at its top-right. This is where
+   * a column's "Remove widget" lands (see `WidgetContainer`).
+   */
+  actions?: WidgetProps["actions"]
+  /** Forwarded to the f0 `Widget`: the lifted look while the card is dragged. */
   isDragging?: boolean
   ctx?: HomeRenderCtx
 }
 
+/**
+ * The footer's own spacing, and it exists because of the slots above it: a
+ * row-based slot BLEEDS 8px past the card's content box on every side but the
+ * top (`SLOT_ROW_BLEED`), and the last slot keeps that bleed at its bottom. So
+ * the frame's 12px gap above the footer is already 8px spent — `mt-2` buys it
+ * back — and the rows the button sits under start 8px to its left, which
+ * `-ml-0.5` nudges it toward.
+ */
+const FOOTER_CLASS = "-ml-0.5 mt-2"
+
+/**
+ * THE TURN. A widget's info lives on its back, so getting there is a flip: half
+ * a turn on Y, and a JUMP out of the column and back — the card lifts toward you
+ * while it rotates, which is what makes it read as one object turning over
+ * rather than two faces crossfading.
+ *
+ * PLAIN CSS, deliberately. Driving `rotateY` through motion here left the card
+ * frozen at an angle: a widget re-renders for reasons that have nothing to do
+ * with the turn (a drag, new data), and each of those re-entered motion's
+ * animation. A transition on a transform is owned by the browser and cannot be
+ * interrupted by a render at all.
+ */
+const FLIP_MS = 450
+const FLIP_EASING = "cubic-bezier(0.4, 0, 0.1, 1)"
+/** How far the card lifts toward you at the top of the jump. */
+const FLIP_JUMP = 1.04
+
 export function SlotWidget({
   header,
+  params,
   fullHeight,
   action,
   summaries,
@@ -57,24 +118,57 @@ export function SlotWidget({
   slots,
   loading = false,
   slotRenderers,
-  draggable,
-  onDragStart,
+  actions,
+  flipped = false,
+  onFlipBack,
   isDragging,
   ctx = {},
 }: SlotWidgetProps) {
+  const t = useI18n()
+  const shouldReduceMotion = useReducedMotion()
+  // The jump is a there-and-back, so it is a moment rather than a state: it is
+  // switched on by the turn STARTING and off when the turn has landed. Only a
+  // change of `flipped` can start it — a drag's re-renders never do.
+  const [jumping, setJumping] = useState(false)
+  const mounted = useRef(false)
+  useEffect(() => {
+    // Not on mount: a card that is already showing a side has not turned to it.
+    if (!mounted.current) {
+      mounted.current = true
+      return
+    }
+    if (shouldReduceMotion) return
+    setJumping(true)
+    const landed = setTimeout(() => setJumping(false), FLIP_MS)
+    return () => clearTimeout(landed)
+  }, [flipped, shouldReduceMotion])
   const renderers = slotRenderers
     ? { ...defaultSlotRenderers, ...slotRenderers }
     : defaultSlotRenderers
 
-  return (
+  // Everything the params decide (title, info) is resolved first, so from here
+  // down the header is the plain one the frame takes. The LINK stays in it: the
+  // frame draws it as the title itself.
+  // `info` comes OUT: it is not a tooltip beside the title, it is what the card
+  // shows when it is turned over.
+  const { info, ...headerRest } = resolveWidgetHeader(header, params) ?? {}
+  // Dropping `info` can leave the header with nothing in it — then there is no
+  // header row to draw, unless the overflow menu needs one to sit in.
+  const headerProps =
+    Object.values(headerRest).some((value) => value !== undefined) ||
+    (actions && actions.length > 0)
+      ? headerRest
+      : undefined
+
+  const front = (
     <Widget
-      header={header}
+      header={headerProps}
       fullHeight={fullHeight}
       action={action}
+      footerClassName={FOOTER_CLASS}
+      actions={actions}
       summaries={summaries}
       {...(alert ? { alert } : { status })}
-      draggable={draggable}
-      onDragStart={onDragStart}
       isDragging={isDragging}
     >
       {/* ONE child, so the Widget frame's internal `gap-4` applies once to the
@@ -126,5 +220,94 @@ export function SlotWidget({
         })}
       </div>
     </Widget>
+  )
+
+  // Nothing to turn over to: the card is just the card.
+  if (!info) return front
+
+  return (
+    // The scene. `perspective` is what makes the turn a TURN — without it the
+    // rotation is a flat squeeze — and it lives on the parent so the faces share
+    // one vanishing point.
+    <div
+      className="[perspective:1200px]"
+      style={{ height: fullHeight ? "100%" : undefined }}
+    >
+      {/* THE JUMP, on its own element: the lift and the turn are two transforms,
+          and giving each its own box keeps them from overwriting one another. */}
+      <div
+        className="h-full"
+        // The lift is a moment, so it leaves no other trace in the DOM — this is
+        // how a test (and a pair of eyes on a slowed-down clock) can see it.
+        data-turning={jumping || undefined}
+        style={{
+          transform: `scale(${jumping ? FLIP_JUMP : 1})`,
+          transition: shouldReduceMotion
+            ? undefined
+            : `transform ${FLIP_MS / 2}ms ease-out`,
+        }}
+      >
+        {/* THE TURN. */}
+        <div
+          className="relative h-full [transform-style:preserve-3d]"
+          style={{
+            transform: `rotateY(${flipped ? 180 : 0}deg)`,
+            // No transition under reduced motion: the card still turns (the back
+            // has to become visible — `backface-visibility` hides whichever face
+            // points away), it just gets there at once.
+            transition: shouldReduceMotion
+              ? undefined
+              : `transform ${FLIP_MS}ms ${FLIP_EASING}`,
+          }}
+        >
+          {/* THE FRONT stays in the flow — it is what gives the card its height,
+              so the back can match it without measuring anything. Hidden once it
+              faces away, rather than showing through mirrored. */}
+          <div
+            className={cn(
+              "[backface-visibility:hidden]",
+              flipped && "pointer-events-none"
+            )}
+            aria-hidden={flipped}
+          >
+            {front}
+          </div>
+          {/* THE BACK: the same box, half a turn ahead. It KEEPS THE TITLE, in
+              the place the front wears it, so what you are reading about is never
+              in doubt — then the sentence itself, centered, and one small button
+              to turn back. */}
+          <div
+            aria-hidden={!flipped}
+            className={cn(
+              "absolute inset-0 flex flex-col gap-4",
+              "rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-4",
+              "[backface-visibility:hidden] [transform:rotateY(180deg)]",
+              !flipped && "pointer-events-none"
+            )}
+          >
+            {headerProps?.title ? (
+              <div className="min-h-6 truncate font-medium text-f1-foreground">
+                {headerProps.title}
+              </div>
+            ) : null}
+            {/* The info takes the room the slots had, centered in it. */}
+            <div className="flex flex-1 flex-col items-center justify-center gap-4 text-center">
+              <p className="m-0 text-lg font-medium text-f1-foreground-secondary">
+                {info}
+              </p>
+              <F0Button
+                variant="neutral"
+                size="sm"
+                label={t.widgets.gotIt}
+                onClick={onFlipBack}
+                // Out of the tab order while it faces away: a control nobody can
+                // see should not be the next thing Tab lands on.
+                {...(flipped ? {} : { tabIndex: -1 })}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   )
 }

--- a/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, test, vi } from "vitest"
+
+import { Calendar, Clock, File } from "@/icons/app"
+import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+
+import { WidgetCatalog, type WidgetCatalogGroup } from "./index"
+
+const GROUPS: WidgetCatalogGroup[] = [
+  { id: "time", label: "Time & attendance", module: "time-tracking" },
+  { id: "docs", label: "Files", module: "documents" },
+]
+
+const WIDGETS = [
+  { id: "clock", title: "Clock in", icon: Clock, preview: <p>clock</p> },
+  { id: "time-off", title: "Time off", icon: Clock, preview: <p>time off</p> },
+  { id: "docs", title: "Documents", icon: File, preview: <p>docs</p> },
+  { id: "events", title: "Events", icon: Calendar, preview: <p>events</p> },
+]
+
+const grouped = [
+  { ...WIDGETS[0], group: "time", recommended: true },
+  { ...WIDGETS[1], group: "time" },
+  { ...WIDGETS[2], group: "docs" },
+  // No group at all: it belongs to the unheaded run after the groups.
+  WIDGETS[3],
+]
+
+const TITLES = ["Clock in", "Time off", "Documents", "Events"]
+
+/**
+ * The picker's WIDGET ROWS, in the order they are read. The dialog's own chrome
+ * (its close button, the CTA) is not part of the list.
+ */
+const listed = () =>
+  screen
+    .getAllByRole("button")
+    .map((el) => el.textContent?.trim())
+    .filter((text) => text && TITLES.includes(text))
+
+const render = (props = {}) =>
+  zeroRender(
+    <WidgetCatalog
+      isOpen
+      onClose={() => {}}
+      onAdd={() => {}}
+      widgets={grouped}
+      groups={GROUPS}
+      {...props}
+    />
+  )
+
+describe("WidgetCatalog", () => {
+  test("reads recommended first, then each domain, then what has no domain", () => {
+    render()
+
+    expect(screen.getByText("Recommended")).toBeInTheDocument()
+    expect(screen.getByText("Time & attendance")).toBeInTheDocument()
+    expect(screen.getByText("Files")).toBeInTheDocument()
+
+    // Clock in is LIFTED to the top and not repeated under its domain; Events,
+    // which has no domain, comes last with no heading of its own.
+    expect(listed()).toEqual(["Clock in", "Time off", "Documents", "Events"])
+  })
+
+  test("previews the first row it shows, which is a recommended one", () => {
+    render()
+
+    expect(screen.getByText("clock")).toBeInTheDocument()
+  })
+
+  test("a domain with nothing left in it stops being a heading", async () => {
+    render()
+
+    await userEvent.type(screen.getByRole("searchbox"), "time")
+
+    // "Time off" survives the search; the Files domain has nothing left.
+    expect(screen.getByText("Time & attendance")).toBeInTheDocument()
+    expect(screen.queryByText("Files")).not.toBeInTheDocument()
+    // Nothing recommended matches either.
+    expect(screen.queryByText("Recommended")).not.toBeInTheDocument()
+  })
+
+  test("says so when the search matches nothing", async () => {
+    render()
+
+    await userEvent.type(screen.getByRole("searchbox"), "zzz")
+
+    expect(screen.getByText(/No widgets match/)).toBeInTheDocument()
+  })
+
+  test("without groups it is the flat list it always was", () => {
+    render({ widgets: WIDGETS, groups: undefined })
+
+    expect(screen.queryByText("Recommended")).not.toBeInTheDocument()
+    expect(screen.queryByText("Time & attendance")).not.toBeInTheDocument()
+    expect(listed()).toEqual(["Clock in", "Time off", "Documents", "Events"])
+  })
+
+  test("adds the widget the picker is previewing", async () => {
+    const onAdd = vi.fn()
+    render({ onAdd })
+
+    await userEvent.click(screen.getByText("Time off"))
+    await userEvent.click(screen.getByRole("button", { name: "Add widget" }))
+
+    expect(onAdd).toHaveBeenCalledWith("time-off")
+  })
+})

--- a/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
@@ -4,7 +4,7 @@ import { Calendar, Clock, File, PalmTree, Receipt, Target } from "@/icons/app"
 
 import { homeSlot, listSlot } from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
-import { WidgetCatalog } from "./index"
+import { WidgetCatalog, type WidgetCatalogGroup } from "./index"
 
 /**
  * Beyond its header and slots, a widget may carry the `Widget` frame's own
@@ -121,6 +121,33 @@ const CATALOG = [
   },
 ]
 
+/**
+ * THE DOMAINS, each headed by its module glyph. Labels are the app's own words —
+ * f0's `modules` registry carries icons, not names.
+ */
+const GROUPS: WidgetCatalogGroup[] = [
+  { id: "time", label: "Time & attendance", module: "time-tracking" },
+  { id: "money", label: "Payroll", module: "compensations" },
+  { id: "performance", label: "Performance", module: "goals" },
+  { id: "docs", label: "Documents", module: "documents" },
+]
+
+/** Which domain each widget sits in. `events` has none on purpose: it lands in
+ * the unheaded run after the groups. */
+const DOMAIN: Record<string, string> = {
+  "clock-in": "time",
+  "time-off": "time",
+  payroll: "money",
+  goals: "performance",
+  documents: "docs",
+}
+
+const GROUPED_CATALOG = CATALOG.map((item) => ({
+  ...item,
+  group: DOMAIN[item.id],
+  recommended: item.id === "clock-in" || item.id === "payroll",
+}))
+
 const meta = {
   title: "Home/WidgetCatalog",
   component: WidgetCatalog,
@@ -129,7 +156,8 @@ const meta = {
     isOpen: true,
     onClose: () => {},
     onAdd: () => {},
-    widgets: CATALOG,
+    widgets: GROUPED_CATALOG,
+    groups: GROUPS,
     previewWidth: 396,
   },
 } satisfies Meta<typeof WidgetCatalog>
@@ -139,7 +167,19 @@ type Story = StoryObj<typeof meta>
 
 /**
  * The "Add widget" picker: searchable icon + title rows on the left, a LIVE
- * preview of the selected widget on the right at the target column's width,
- * and the Add widget CTA in the footer.
+ * preview of the selected widget on the right at the target column's width, and
+ * the Add widget CTA in the footer.
+ *
+ * The rows are organised BY DOMAIN, each group headed by its module glyph, with
+ * what this Home recommends lifted to the top. A widget in no domain (`events`
+ * here) follows the groups without a heading of its own.
  */
 export const Default: Story = {}
+
+/**
+ * Both are optional: with no `groups` and nothing `recommended`, the picker is the
+ * flat list it has always been.
+ */
+export const Flat: Story = {
+  args: { widgets: CATALOG, groups: undefined },
+}

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -3,9 +3,10 @@ import { ReactNode, useState } from "react"
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { IconType } from "@/components/F0Icon"
 import { F0SearchInput } from "@/components/F0SearchInput"
+import { cn } from "@/lib/utils"
 import { F0Dialog } from "@/patterns/F0Dialog"
 
-import { WidgetPreviewPane } from "../WidgetPreview"
+import { useWidgetDialogLayout, WidgetPreviewPane } from "../WidgetPreview"
 
 /** One entry in the widget catalog dialog. */
 export interface WidgetCatalogItem {
@@ -59,6 +60,7 @@ export function WidgetCatalog({
   previewWidth = 396,
   title = "Add widget",
 }: WidgetCatalogProps) {
+  const { position, bodyClassName, asideClassName } = useWidgetDialogLayout()
   const [query, setQuery] = useState("")
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
@@ -75,6 +77,9 @@ export function WidgetCatalog({
       isOpen={isOpen}
       onClose={onClose}
       title={title}
+      // Fullscreen on a narrow screen — a two-column picker cannot live in a
+      // centered box there (see `useWidgetDialogLayout`).
+      position={position}
       width="xl"
       primaryAction={{
         label: "Add widget",
@@ -82,9 +87,9 @@ export function WidgetCatalog({
         onClick: () => selected && onAdd(selected.id),
       }}
     >
-      <div className="flex h-full min-h-96 gap-4">
+      <div className={bodyClassName}>
         {/* The picker: a search field leading the widget rows. */}
-        <div className="flex w-80 shrink-0 flex-col gap-2">
+        <div className={cn("flex flex-col gap-2", asideClassName)}>
           <F0SearchInput
             value={query}
             onChange={setQuery}

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -1,9 +1,15 @@
-import { ReactNode, useState } from "react"
+import { Fragment, ReactNode, useMemo, useState } from "react"
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
-import { IconType } from "@/components/F0Icon"
+import {
+  modules,
+  type ModuleId,
+} from "@/components/avatars/F0AvatarModule/modules"
+import { F0Icon, IconType } from "@/components/F0Icon"
 import { F0SearchInput } from "@/components/F0SearchInput"
+import { Star } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { useI18n } from "@/lib/providers/i18n"
 import { F0Dialog } from "@/patterns/F0Dialog"
 
 import { useWidgetDialogLayout, WidgetPreviewPane } from "../WidgetPreview"
@@ -24,6 +30,32 @@ export interface WidgetCatalogItem {
    * sentence is worth reading, so the picker says it without being asked.
    */
   info?: string
+  /**
+   * Which `groups` entry this widget belongs under. A widget whose group isn't
+   * declared (or which has none) is listed after the groups, without a heading.
+   */
+  group?: string
+  /**
+   * LIFTS IT to a "Recommended" section at the very top, and out of its group —
+   * a widget offered twice reads as two widgets. Optional in every sense: with
+   * nothing recommended there is no section.
+   */
+  recommended?: boolean
+}
+
+/**
+ * One DOMAIN in the picker: a heading the widgets under it belong to.
+ *
+ * The label is the app's own words because f0's `modules` registry maps ids to
+ * ICONS ONLY — there are no module names to borrow, and a domain may well cover
+ * two modules or none.
+ */
+export interface WidgetCatalogGroup {
+  /** What an item's `group` points at. */
+  id: string
+  label: string
+  /** The domain's module: its glyph heads the group. */
+  module?: ModuleId
 }
 
 export interface WidgetCatalogProps {
@@ -34,6 +66,11 @@ export interface WidgetCatalogProps {
   /** Called with the chosen widget id when the CTA is pressed. */
   onAdd: (id: string) => void
   /**
+   * The DOMAINS the picker is organised into, in the order to show them. Omit it
+   * and the list is flat — grouping is an offer, not a requirement.
+   */
+  groups?: WidgetCatalogGroup[]
+  /**
    * Content width of the column this was opened from — the preview is capped
    * to it, so a rail-bound widget previews at rail width.
    */
@@ -42,11 +79,33 @@ export interface WidgetCatalogProps {
 }
 
 /**
+ * A section's heading: its glyph and its name.
+ *
+ * QUIET, and monochrome. The module's glyph is drawn as a plain icon rather than
+ * as the coloured `F0AvatarModule` square: a heading sits directly above a column
+ * of `lg` widget avatars, and a second coloured badge at a smaller size beside it
+ * competed with them for the eye instead of labelling them. Small, secondary and
+ * uppercase reads as a divider — which is all this is.
+ *
+ * The space is ABOVE it (`pt-5`), not below, so a heading belongs to the rows that
+ * follow rather than floating between two groups.
+ */
+const SectionHeader = ({ label, icon }: { label: string; icon?: IconType }) => (
+  <div className="flex items-center gap-1.5 px-2 pb-1 pt-5 first:pt-1">
+    {icon ? <F0Icon icon={icon} size="sm" color="secondary" /> : null}
+    <h6 className="m-0 text-xs font-medium uppercase tracking-wide text-f1-foreground-secondary">
+      {label}
+    </h6>
+  </div>
+)
+
+/**
  * WidgetCatalog — the "Add widget" dialog, mirroring the custom-home prototype:
  * a searchable picker on the left (icon + title rows, the selected row tinted),
  * a LIVE preview of the highlighted widget on the right at the width it will
- * really get, and the "Add widget" CTA in the dialog footer. `width="xl"`
- * rather than fullscreen.
+ * really get, and the "Add widget" CTA in the dialog footer. FULLSCREEN off a
+ * large display, and the two columns stack on a narrow screen
+ * (`useWidgetDialogLayout`).
  *
  * Selection follows the filter: if the selected row is filtered out, the first
  * remaining row takes over, so the preview always shows something the CTA can
@@ -57,30 +116,79 @@ export function WidgetCatalog({
   onClose,
   widgets,
   onAdd,
+  groups,
   previewWidth = 396,
   title = "Add widget",
 }: WidgetCatalogProps) {
-  const { position, bodyClassName, asideClassName } = useWidgetDialogLayout()
+  const t = useI18n()
+  const { position, width, bodyClassName, asideClassName } =
+    useWidgetDialogLayout()
   const [query, setQuery] = useState("")
   const [selectedId, setSelectedId] = useState<string | null>(null)
 
   const needle = query.trim().toLowerCase()
-  const shown = needle
-    ? widgets.filter((w) => w.title.toLowerCase().includes(needle))
-    : widgets
 
-  // Selection follows the filter — never preview a row the list isn't showing.
-  const selected = shown.find((w) => w.id === selectedId) ?? shown[0] ?? null
+  /**
+   * THE LIST AS IT IS READ: recommended first, then each declared domain that has
+   * anything in it, then whatever belongs to no domain — with the search already
+   * applied, so a group whose widgets are all filtered out disappears rather than
+   * leaving an empty heading behind.
+   */
+  const sections = useMemo(() => {
+    const shown = needle
+      ? widgets.filter((w) => w.title.toLowerCase().includes(needle))
+      : widgets
+    const recommended = shown.filter((w) => w.recommended)
+    // Recommended widgets are LIFTED out of their group, not copied into two
+    // places: the same row twice reads as two different widgets.
+    const rest = shown.filter((w) => !w.recommended)
+    const declared = new Set((groups ?? []).map((group) => group.id))
+    const loose = rest.filter((w) => !w.group || !declared.has(w.group))
+
+    return [
+      ...(recommended.length
+        ? [
+            {
+              id: "recommended",
+              label: t.widgets.recommended,
+              icon: Star,
+              items: recommended,
+            },
+          ]
+        : []),
+      ...(groups ?? [])
+        .map((group) => ({
+          ...group,
+          icon: group.module ? modules[group.module] : undefined,
+          items: rest.filter((w) => w.group === group.id),
+        }))
+        .filter((section) => section.items.length > 0),
+      // No heading: these belong to nothing in particular, and inventing "Other"
+      // for them would claim they do.
+      ...(loose.length ? [{ id: "ungrouped", items: loose }] : []),
+    ] as Array<{
+      id: string
+      label?: string
+      icon?: IconType
+      items: WidgetCatalogItem[]
+    }>
+  }, [widgets, groups, needle, t])
+
+  // Selection follows the ORDER THE LIST IS IN, so "the first one" is the first
+  // one you can see — and never a row the search has filtered out.
+  const ordered = sections.flatMap((section) => section.items)
+  const selected =
+    ordered.find((w) => w.id === selectedId) ?? ordered[0] ?? null
 
   return (
     <F0Dialog
       isOpen={isOpen}
       onClose={onClose}
       title={title}
-      // Fullscreen on a narrow screen — a two-column picker cannot live in a
-      // centered box there (see `useWidgetDialogLayout`).
+      // Fullscreen unless the display is big enough for a centered box to be
+      // worth it — these two columns want the room (`useWidgetDialogLayout`).
       position={position}
-      width="xl"
+      width={width}
       primaryAction={{
         label: "Add widget",
         disabled: !selected,
@@ -96,25 +204,32 @@ export function WidgetCatalog({
             placeholder="Search widgets"
           />
           <div className="flex flex-col gap-1 overflow-y-auto">
-            {shown.map((w) => (
-              <button
-                key={w.id}
-                type="button"
-                onClick={() => setSelectedId(w.id)}
-                className={
-                  "flex items-center gap-3 rounded-md p-2 text-left " +
-                  (selected?.id === w.id
-                    ? "bg-f1-background-selected"
-                    : "hover:bg-f1-background-tertiary")
-                }
-              >
-                <F0AvatarIcon icon={w.icon} size="lg" />
-                <span className="truncate font-medium text-f1-foreground">
-                  {w.title}
-                </span>
-              </button>
+            {sections.map((section) => (
+              <Fragment key={section.id}>
+                {section.label ? (
+                  <SectionHeader label={section.label} icon={section.icon} />
+                ) : null}
+                {section.items.map((w) => (
+                  <button
+                    key={w.id}
+                    type="button"
+                    onClick={() => setSelectedId(w.id)}
+                    className={
+                      "flex items-center gap-3 rounded-md p-2 text-left " +
+                      (selected?.id === w.id
+                        ? "bg-f1-background-selected"
+                        : "hover:bg-f1-background-tertiary")
+                    }
+                  >
+                    <F0AvatarIcon icon={w.icon} size="lg" />
+                    <span className="truncate font-medium text-f1-foreground">
+                      {w.title}
+                    </span>
+                  </button>
+                ))}
+              </Fragment>
             ))}
-            {shown.length === 0 ? (
+            {ordered.length === 0 ? (
               <div className="p-2 text-f1-foreground-secondary">
                 No widgets match your search.
               </div>

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -5,6 +5,8 @@ import { IconType } from "@/components/F0Icon"
 import { F0SearchInput } from "@/components/F0SearchInput"
 import { F0Dialog } from "@/patterns/F0Dialog"
 
+import { WidgetPreviewPane } from "../WidgetPreview"
+
 /** One entry in the widget catalog dialog. */
 export interface WidgetCatalogItem {
   id: string
@@ -15,6 +17,12 @@ export interface WidgetCatalogItem {
    * `SlotWidget`), so the preview can't drift from what gets added.
    */
   preview: ReactNode
+  /**
+   * What this widget is telling you — the widget's own `header.info`, shown under
+   * the preview. Deciding whether to add a widget is exactly the moment that
+   * sentence is worth reading, so the picker says it without being asked.
+   */
+  info?: string
 }
 
 export interface WidgetCatalogProps {
@@ -108,15 +116,16 @@ export function WidgetCatalog({
             ) : null}
           </div>
         </div>
-        {/* The preview: the real widget, centered on the page grey, at the
-            width the target column will really give it. */}
-        <div className="flex min-w-0 flex-1 items-center justify-center rounded-lg bg-f1-background-secondary p-6">
-          {selected ? (
-            <div className="w-full" style={{ maxWidth: `${previewWidth}px` }}>
-              {selected.preview}
-            </div>
-          ) : null}
-        </div>
+        {/* The preview: the real widget, centered on the page grey, at the width
+            the target column will really give it — and it JUMPS in as you move
+            down the list, so each row you land on announces its widget. */}
+        <WidgetPreviewPane
+          previewKey={selected?.id}
+          info={selected?.info}
+          previewWidth={previewWidth}
+        >
+          {selected?.preview}
+        </WidgetPreviewPane>
       </div>
     </F0Dialog>
   )

--- a/packages/react/src/sds/Home/WidgetContainer/SortableWidget.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/SortableWidget.tsx
@@ -1,7 +1,6 @@
-import { type CSSProperties, ReactNode } from "react"
-
 import { useSortable } from "@dnd-kit/sortable"
 import { CSS } from "@dnd-kit/utilities"
+import { type CSSProperties, ReactNode } from "react"
 
 import { cn } from "@/lib/utils"
 
@@ -54,6 +53,11 @@ export const SortableWidget = ({
     <div
       ref={setNodeRef}
       style={style}
+      // Which widget's box this is. A LOCKED widget is not a dnd-kit droppable —
+      // that is what stops it being displaced — so dnd-kit never reports it as
+      // the thing you are over, and the column has to hit-test the dragged card
+      // against these boxes itself to say why a drop there won't happen.
+      data-widget-id={id}
       className={cn(
         !disabled && "cursor-grab active:cursor-grabbing",
         // The overlay clone is the visible card while this one is dragged;

--- a/packages/react/src/sds/Home/WidgetContainer/SortableWidget.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/SortableWidget.tsx
@@ -7,8 +7,6 @@ import { cn } from "@/lib/utils"
 
 /** What the sortable state hands to the widget being rendered. */
 export interface SortableWidgetState {
-  /** Show the widget's own drag handle. False for a locked widget. */
-  draggable: boolean
   isDragging: boolean
 }
 
@@ -20,13 +18,11 @@ export interface SortableWidgetProps {
 }
 
 /**
- * One draggable widget in an editable column. It contributes no drag chrome of
- * its own: the f0 `Widget` already draws a handle beside its title when
- * `draggable`, so this reports the sortable state through its render callback
- * and lets the design system own the affordance.
- *
- * dnd-kit's listeners sit on a wrapper rather than on the handle itself — the
- * handle lives inside `Widget`, so the events reach it by bubbling.
+ * One draggable widget in an editable column. THE WHOLE CARD IS THE HANDLE and
+ * there is no handle glyph: dragging is always available (no edit mode to enter
+ * first), so a permanent grip icon on every widget would be chrome the user
+ * never asked for. The grab cursor is the affordance; `WidgetContainer`'s sensor
+ * is what keeps a press on a row or a button from becoming a drag.
  *
  * The card the pointer carries is NOT this one: while dragging, this in-list
  * card turns invisible (still holding its slot for the shuffle) and a clone
@@ -74,7 +70,7 @@ export const SortableWidget = ({
       // pointer-only drag surface.
       {...(disabled ? {} : listeners)}
     >
-      {children({ draggable: !disabled, isDragging })}
+      {children({ isDragging })}
     </div>
   )
 }

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -196,6 +196,58 @@ describe("WidgetContainer", () => {
       ).toBeInTheDocument()
     })
 
+    test("a widget's OWN actions lead its menu, above the chrome", async () => {
+      const onExport = vi.fn()
+      zeroRender(
+        <WidgetContainer
+          widgets={[
+            widget("events", {
+              header: { title: "events", info: "What these events are." },
+              actions: [{ label: "Export as CSV", onClick: onExport }],
+            }),
+          ]}
+          onRemoveWidget={() => {}}
+        />
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "Actions" }))
+
+      // The widget's own item first, then what every widget carries, and the
+      // destructive one last.
+      expect(
+        screen.getAllByRole("menuitem").map((i) => i.textContent?.trim())
+      ).toEqual(["Export as CSV", "What this info means?", "Remove widget"])
+
+      await userEvent.click(
+        screen.getByRole("menuitem", { name: "Export as CSV" })
+      )
+      await waitFor(() => expect(onExport).toHaveBeenCalled())
+    })
+
+    test("its actions show even where the column forbids arranging", async () => {
+      zeroRender(
+        <WidgetContainer
+          widgets={[
+            widget("events", {
+              actions: [{ label: "Mark all as read", onClick: () => {} }],
+            }),
+          ]}
+          disableEdition
+          onRemoveWidget={() => {}}
+        />
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "Actions" }))
+
+      // What the widget DOES is not arranging chrome — only removal is.
+      expect(
+        screen.getByRole("menuitem", { name: "Mark all as read" })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole("menuitem", { name: "Remove widget" })
+      ).not.toBeInTheDocument()
+    })
+
     test("a LOCKED widget can still be configured, just not removed", async () => {
       const schema = z.object({
         limit: f0FormField(z.number(), { label: "Limit" }),

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -1,7 +1,9 @@
 import { describe, expect, test, vi } from "vitest"
+import { z } from "zod"
 
 import { Calendar, Clock } from "@/icons/app"
-import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+import { f0FormField } from "@/patterns/F0Form"
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
 
 import { type HomeWidgetItem } from "../slotRenderers"
 import { WidgetContainer } from "./index"
@@ -21,8 +23,16 @@ const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) => ({
 
 const WIDGETS = [widget("clock"), widget("events")]
 
+/** Opens the menu of the widget at `index` and returns its remove item. */
+const openMenu = async (index: number) => {
+  await userEvent.click(
+    screen.getAllByRole("button", { name: "Actions" })[index]
+  )
+  return screen.queryByRole("menuitem", { name: "Remove widget" })
+}
+
 describe("WidgetContainer", () => {
-  test("view mode offers no arranging — but adding is always on offer", () => {
+  test("every widget offers removal — there is no mode to enter first", () => {
     zeroRender(
       <WidgetContainer
         widgets={WIDGETS}
@@ -31,23 +41,18 @@ describe("WidgetContainer", () => {
       />
     )
 
-    expect(screen.queryAllByLabelText("Remove widget")).toHaveLength(0)
+    expect(screen.getAllByRole("button", { name: "Actions" })).toHaveLength(2)
     expect(
       screen.getByRole("button", { name: "Add widget" })
     ).toBeInTheDocument()
   })
 
-  test("edit mode gives every widget a remove control", () => {
+  test("offers no menu at all without onRemoveWidget", () => {
     zeroRender(
-      <WidgetContainer
-        widgets={WIDGETS}
-        editing
-        onRemoveWidget={() => {}}
-        onClickAddNewWidget={() => {}}
-      />
+      <WidgetContainer widgets={WIDGETS} onClickAddNewWidget={() => {}} />
     )
 
-    expect(screen.getAllByLabelText("Remove widget")).toHaveLength(2)
+    expect(screen.queryAllByRole("button", { name: "Actions" })).toHaveLength(0)
     expect(
       screen.getByRole("button", { name: "Add widget" })
     ).toBeInTheDocument()
@@ -57,112 +62,224 @@ describe("WidgetContainer", () => {
     zeroRender(
       <WidgetContainer
         widgets={WIDGETS}
-        editing
         disableEdition
         onRemoveWidget={() => {}}
         onClickAddNewWidget={() => {}}
       />
     )
 
-    expect(screen.queryAllByLabelText("Remove widget")).toHaveLength(0)
+    expect(screen.queryAllByRole("button", { name: "Actions" })).toHaveLength(0)
     expect(
       screen.queryByRole("button", { name: "Add widget" })
     ).not.toBeInTheDocument()
   })
 
-  test("reports the widget a remove control belongs to", async () => {
+  test("reports the widget its remove item belongs to", async () => {
     const onRemoveWidget = vi.fn()
+    zeroRender(
+      <WidgetContainer widgets={WIDGETS} onRemoveWidget={onRemoveWidget} />
+    )
+
+    const remove = await openMenu(1)
+    await userEvent.click(remove!)
+
+    // The dropdown defers its items' onClick past its own close animation.
+    await waitFor(() => expect(onRemoveWidget).toHaveBeenCalledWith("events"))
+  })
+
+  test("takes the remove item's copy from removeLabel", async () => {
     zeroRender(
       <WidgetContainer
         widgets={WIDGETS}
-        editing
-        onRemoveWidget={onRemoveWidget}
+        removeLabel="Take this off my Home"
+        onRemoveWidget={() => {}}
       />
     )
 
-    await userEvent.click(screen.getAllByLabelText("Remove widget")[1])
+    await userEvent.click(screen.getAllByRole("button", { name: "Actions" })[0])
 
-    expect(onRemoveWidget).toHaveBeenCalledWith("events")
+    expect(
+      screen.getByRole("menuitem", { name: "Take this off my Home" })
+    ).toBeInTheDocument()
   })
 
   describe("a locked widget", () => {
     const LOCKED = [widget("clock", { locked: true }), widget("events")]
 
-    test("cannot be removed, and says why with a lock in the header", () => {
-      zeroRender(
-        <WidgetContainer widgets={LOCKED} editing onRemoveWidget={() => {}} />
-      )
+    test("has no menu — being mandatory, removal is not a choice", () => {
+      zeroRender(<WidgetContainer widgets={LOCKED} onRemoveWidget={() => {}} />)
 
-      // Only the unlocked widget offers removal.
-      expect(screen.getAllByLabelText("Remove widget")).toHaveLength(1)
-      expect(
-        screen.getByLabelText("This widget is mandatory in your company.")
-      ).toBeInTheDocument()
+      // Only the unlocked widget carries one.
+      expect(screen.getAllByRole("button", { name: "Actions" })).toHaveLength(1)
     })
 
-    test("shows the lock only while editing — in view mode it is an ordinary widget", () => {
-      const { rerender } = zeroRender(<WidgetContainer widgets={LOCKED} />)
+    test("the menu that IS there belongs to the unlocked widget", async () => {
+      const onRemoveWidget = vi.fn()
+      zeroRender(
+        <WidgetContainer widgets={LOCKED} onRemoveWidget={onRemoveWidget} />
+      )
+
+      const remove = await openMenu(0)
+      await userEvent.click(remove!)
+
+      await waitFor(() => expect(onRemoveWidget).toHaveBeenCalledWith("events"))
+    })
+  })
+
+  /**
+   * The menu is the widget's own: what it can be TURNED OVER to, what it can be
+   * CONFIGURED into, and only then the destructive one.
+   */
+  describe("a widget's other menu items", () => {
+    test("offers the info side when the widget has one, and turns the card", async () => {
+      zeroRender(
+        <WidgetContainer
+          widgets={[
+            widget("clock", {
+              header: { title: "clock", info: "What the clock counts." },
+            }),
+          ]}
+        />
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "Actions" }))
+      await userEvent.click(
+        screen.getByRole("menuitem", { name: "What this info means?" })
+      )
+
+      // The card is turned: its other side is reachable now, with a way back.
+      // (The dropdown defers its items' onClick past its own close animation.)
+      await waitFor(() =>
+        expect(
+          screen.getByRole("button", { name: "Got it" })
+        ).toBeInTheDocument()
+      )
+      expect(screen.getByText("What the clock counts.")).toBeInTheDocument()
+    })
+
+    test("says nothing about info when the widget has none", async () => {
+      zeroRender(
+        <WidgetContainer widgets={WIDGETS} onRemoveWidget={() => {}} />
+      )
+
+      await userEvent.click(
+        screen.getAllByRole("button", { name: "Actions" })[0]
+      )
 
       expect(
-        screen.queryByLabelText("This widget is mandatory in your company.")
+        screen.queryByRole("menuitem", { name: "What this info means?" })
       ).not.toBeInTheDocument()
+    })
 
-      rerender(<WidgetContainer widgets={LOCKED} editing />)
+    test("offers Edit params only for a widget that declares them", async () => {
+      const schema = z.object({
+        limit: f0FormField(z.number(), { label: "Limit" }),
+      })
+      zeroRender(
+        <WidgetContainer
+          widgets={[
+            widget("clock", { paramsSchema: schema, params: { limit: 3 } }),
+            widget("events"),
+          ]}
+          onChangeWidgetParams={() => {}}
+        />
+      )
 
+      const menus = screen.getAllByRole("button", { name: "Actions" })
+      // Only the configurable widget has a menu at all here: the other is
+      // offered neither params nor removal.
+      expect(menus).toHaveLength(1)
+
+      await userEvent.click(menus[0])
       expect(
-        screen.getByLabelText("This widget is mandatory in your company.")
+        screen.getByRole("menuitem", { name: "Edit params" })
       ).toBeInTheDocument()
     })
 
-    test("takes the tooltip copy from lockedLabel", () => {
+    test("a LOCKED widget can still be configured, just not removed", async () => {
+      const schema = z.object({
+        limit: f0FormField(z.number(), { label: "Limit" }),
+      })
       zeroRender(
-        <WidgetContainer widgets={LOCKED} editing lockedLabel="Pinned by IT" />
+        <WidgetContainer
+          widgets={[
+            widget("clock", {
+              locked: true,
+              paramsSchema: schema,
+              params: { limit: 3 },
+            }),
+          ]}
+          onRemoveWidget={() => {}}
+          onChangeWidgetParams={() => {}}
+        />
       )
 
-      expect(screen.getByLabelText("Pinned by IT")).toBeInTheDocument()
+      await userEvent.click(screen.getByRole("button", { name: "Actions" }))
+
+      expect(
+        screen.getByRole("menuitem", { name: "Edit params" })
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByRole("menuitem", { name: "Remove widget" })
+      ).not.toBeInTheDocument()
     })
   })
 
   describe("dragging", () => {
     test("is not offered without onReorder", () => {
-      const { container } = zeroRender(
-        <WidgetContainer widgets={WIDGETS} editing />
-      )
+      const { container } = zeroRender(<WidgetContainer widgets={WIDGETS} />)
 
       expect(container.querySelectorAll(".cursor-grab")).toHaveLength(0)
     })
 
     test("is not offered for a single widget", () => {
       const { container } = zeroRender(
-        <WidgetContainer
-          widgets={[widget("clock")]}
-          editing
-          onReorder={() => {}}
-        />
+        <WidgetContainer widgets={[widget("clock")]} onReorder={() => {}} />
       )
 
       expect(container.querySelectorAll(".cursor-grab")).toHaveLength(0)
     })
 
-    test("is offered in edit mode with onReorder, and skips the locked widget", () => {
-      const { container } = zeroRender(
-        <WidgetContainer
-          widgets={[widget("clock", { locked: true }), widget("events")]}
-          editing
-          onReorder={() => {}}
-        />
-      )
-
-      // Each draggable wrapper carries the grab cursor; a locked one doesn't.
-      expect(container.querySelectorAll(".cursor-grab")).toHaveLength(1)
-    })
-
-    test("is not offered in view mode", () => {
+    test("needs no mode: with onReorder the widgets are draggable as they are", () => {
       const { container } = zeroRender(
         <WidgetContainer widgets={WIDGETS} onReorder={() => {}} />
       )
 
+      // Each draggable wrapper carries the grab cursor.
+      expect(container.querySelectorAll(".cursor-grab")).toHaveLength(2)
+    })
+
+    test("skips the locked widget", () => {
+      const { container } = zeroRender(
+        <WidgetContainer
+          widgets={[widget("clock", { locked: true }), widget("events")]}
+          onReorder={() => {}}
+        />
+      )
+
+      expect(container.querySelectorAll(".cursor-grab")).toHaveLength(1)
+    })
+
+    test("is not offered in a disableEdition column", () => {
+      const { container } = zeroRender(
+        <WidgetContainer
+          widgets={WIDGETS}
+          disableEdition
+          onReorder={() => {}}
+        />
+      )
+
       expect(container.querySelectorAll(".cursor-grab")).toHaveLength(0)
+    })
+
+    test("draws no drag handle — the whole card is the grip", () => {
+      const { container } = zeroRender(
+        <WidgetContainer widgets={WIDGETS} onReorder={() => {}} />
+      )
+
+      // The f0 `Widget`'s handle marks itself for gridstack; nothing here asks
+      // for it.
+      expect(container.querySelectorAll("[data-gs-handle]")).toHaveLength(0)
     })
   })
 })

--- a/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
@@ -20,7 +20,13 @@ const WIDGETS: HomeWidgetItem[] = [
   {
     id: "events",
     icon: Calendar,
-    header: { title: "Events", count: 2 },
+    // The way out of a widget: declared as `header.link`, drawn as a button in
+    // the card's FOOTER (see `SlotWidget`).
+    header: {
+      title: "Events",
+      count: 2,
+      link: { title: "Go to Calendar", onClick: () => {} },
+    },
     slots: [
       listSlot({ clickBehavior: "link" }, [
         { id: "1", title: "Design sync", href: "/calendar/1" },
@@ -53,31 +59,33 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 /**
- * View mode: the widgets and the add placeholder — adding is ALWAYS on offer;
- * edit mode is only for arranging what's already there.
+ * There is NO EDIT MODE. Every widget is draggable by its whole card (no handle
+ * glyph) and carries "Remove widget" in the three-dots menu at its header's
+ * top-right, and the column ends in the add placeholder — arranging a Home is
+ * something you just do.
  */
 export const Default: Story = {}
 
 /**
- * Edit mode: the movable widgets gain a remove control and become draggable.
- * A `locked` widget (the first here) stays inert — no drag, no remove.
+ * A `locked` widget (the first here) is inert: it can't be dragged, nothing can
+ * displace it, and it offers no menu at all — being mandatory, removing it is
+ * not a choice the user has.
  */
-export const Editing: Story = {
+export const WithLockedWidget: Story = {
   args: {
-    editing: true,
     widgets: [{ ...WIDGETS[0], locked: true }, WIDGETS[1]],
   },
 }
 
 /**
- * `disableEdition` opts a column out entirely: no remove controls, no
- * dragging, and not even the add placeholder.
+ * `disableEdition` opts a column out entirely: no remove menus, no dragging,
+ * and not even the add placeholder.
  */
 export const EditingDisabled: Story = {
-  args: { editing: true, disableEdition: true },
+  args: { disableEdition: true },
 }
 
 /** The rail variant — a tighter gap between its widgets than the main column. */
 export const RightSide: Story = {
-  args: { side: "right", editing: true },
+  args: { side: "right" },
 }

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -334,15 +334,21 @@ export function WidgetContainer({
   // same column is a fairground, not an explanation.
   const [flippedId, setFlippedId] = useState<string | null>(null)
   /**
-   * A widget's own menu items, in the order they read: what it can be CHANGED
-   * into first, then the destructive one.
+   * ONE MENU PER WIDGET, in the order it reads:
    *
-   * A LOCKED widget can still be configured — mandatory says nothing about
-   * fixed — it just isn't offered removal. A widget offered neither gets no
-   * menu at all, rather than an empty one.
+   * 1. THE WIDGET'S OWN `actions` — what this particular widget does ("Mark all
+   *    as read", "Export"). They come first because they are the reason a user
+   *    opens the menu; the rest is chrome every widget has.
+   * 2. What it is telling you (`header.info`), and what it can be configured into.
+   * 3. Removing it, behind a separator, because it is the one that cannot be
+   *    undone.
+   *
+   * A LOCKED widget can still act and still be configured — mandatory says
+   * nothing about fixed — it just isn't offered removal. A widget offered nothing
+   * at all gets no menu, rather than an empty one.
    */
   const menuItems = (widget: HomeWidgetItem): DropdownItem[] => {
-    const items: DropdownItem[] = []
+    const items: DropdownItem[] = [...(widget.actions ?? [])]
     // What the widget is telling you, if it says. Its copy is the PROVIDER's
     // (`t.widgets.whatThisMeans`), not this column's: the question a user asks of
     // a widget is the same question in every product that ships one.
@@ -358,13 +364,17 @@ export function WidgetContainer({
         icon: Sliders,
         onClick: () => setEditingParamsId(widget.id),
       })
-    if (canEdit && !widget.locked && onRemoveWidget)
+    if (canEdit && !widget.locked && onRemoveWidget) {
+      // A separator only when there is something to separate it FROM — a menu
+      // that opens on a rule reads as if an item failed to render.
+      if (items.length > 0) items.push({ type: "separator" })
       items.push({
         label: removeLabel ?? t.widgets.removeWidget,
         icon: Delete,
         critical: true,
         onClick: () => onRemoveWidget(widget.id),
       })
+    }
     return items
   }
   const handleDragEnd = ({ active, over }: DragEndEvent) => {

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -337,39 +337,56 @@ export function WidgetContainer({
   const [flippedId, setFlippedId] = useState<string | null>(null)
   const columnRef = useRef<HTMLDivElement>(null)
   /**
-   * The LOCKED widget the POINTER was over when a drop happened, if any — the
-   * reason that drop is about to be refused.
+   * The LOCKED widget a drop was aiming at, if any — the reason it is about to be
+   * refused.
    *
    * Hit-tested against the DOM rather than taken from dnd-kit: a locked widget is
    * not a droppable (that is what keeps other widgets from displacing it), so
    * dnd-kit never reports it as `over`, and without this the refusal would have no
    * name to give.
    *
-   * THE POINTER, not the dragged card's box. A tall widget cannot put its middle
-   * over a card near the top of the column — it would have to hang off the top of
-   * the window to manage it — so testing the card missed exactly the gesture people
-   * make: pick up a big widget, carry it up to the pinned one, let go. The pointer
-   * is where the intent is.
+   * "AIMING AT IT" is the card covering more than half of it — the dragged card's
+   * box straddling the locked card's midline. That is the geometry of taking a
+   * slot, and unlike the two obvious tests it does not depend on where the card
+   * happened to be grabbed:
+   *
+   * - The dragged card's own MIDDLE is unreachable for a tall widget over a card
+   *   near the top of the column: it would have to hang off the top of the window.
+   * - The POINTER misses the ordinary gesture. Grab a 414px card 250px down, carry
+   *   it up until it visibly sits in the first slot, and the pointer is still 30px
+   *   BELOW the pinned card — the grab offset went with it.
+   *
+   * The pointer is still worth asking about, for the opposite grab: held near its
+   * bottom edge, the card can cover the locked one while hanging off the top of the
+   * viewport, and then the pointer is the only thing left inside it.
    */
-  const lockedUnderPointer = ({ activatorEvent, delta }: DragEndEvent) => {
+  const lockedTargetOf = ({ activatorEvent, delta, active }: DragEndEvent) => {
+    const dragged = active.rect.current.translated
     const start = activatorEvent as Partial<
       Pick<globalThis.PointerEvent, "clientX" | "clientY">
     >
-    if (start.clientX == null || start.clientY == null) return undefined
-    const x = start.clientX + delta.x
-    const y = start.clientY + delta.y
+    const x = start.clientX == null ? null : start.clientX + delta.x
+    const y = start.clientY == null ? null : start.clientY + delta.y
+
     return widgets.find((widget) => {
       if (!widget.locked) return false
       const box = columnRef.current
         ?.querySelector(`[data-widget-id="${widget.id}"]`)
         ?.getBoundingClientRect()
-      return (
-        !!box &&
+      if (!box) return false
+
+      const midline = box.top + box.height / 2
+      const covered =
+        !!dragged && dragged.top <= midline && dragged.bottom >= midline
+      const pointedAt =
+        x != null &&
+        y != null &&
         x >= box.left &&
         x <= box.right &&
         y >= box.top &&
         y <= box.bottom
-      )
+
+      return covered || pointedAt
     })
   }
   /**
@@ -420,7 +437,7 @@ export function WidgetContainer({
     const { active, over } = event
     // A DROP ON A LOCKED WIDGET is refused, and says so. Silence was the old
     // behaviour and it read as a bug: the card sprang back with no reason given.
-    const blocking = lockedUnderPointer(event)
+    const blocking = lockedTargetOf(event)
     if (blocking) {
       toasts.open({
         variant: "warning",

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -1,11 +1,4 @@
 import {
-  type CSSProperties,
-  type PointerEvent,
-  ReactNode,
-  useState,
-} from "react"
-
-import {
   closestCenter,
   DndContext,
   type DragEndEvent,
@@ -20,31 +13,40 @@ import {
   SortableContext,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable"
+import {
+  type CSSProperties,
+  type PointerEvent,
+  ReactNode,
+  useRef,
+  useState,
+} from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
-import { Delete, Ellipsis, InfoCircleLine, Plus, Sliders } from "@/icons/app"
-import { useI18n } from "@/lib/providers/i18n"
 import {
   DropdownInternal,
   type DropdownItem,
 } from "@/experimental/Navigation/Dropdown/internal"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { toasts } from "@/hooks/toast"
+import { Delete, Ellipsis, InfoCircleLine, Plus, Sliders } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
 import { arrivalWindowMs, useElapsed } from "../home-motion"
-import { SlotWidget } from "../SlotWidget"
-import { SortableWidget } from "./SortableWidget"
-import { WidgetMotion, type WidgetStow } from "./WidgetMotion"
-import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
 import {
   resolveWidgetHeader,
+  widgetTitle,
   type HomeRenderCtx,
   type HomeWidgetChrome,
   type HomeWidgetItem,
   type SlotRenderers,
   type WidgetParams,
 } from "../slotRenderers"
+import { SlotWidget } from "../SlotWidget"
+import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
+import { SortableWidget } from "./SortableWidget"
+import { WidgetMotion, type WidgetStow } from "./WidgetMotion"
 
 /**
  * WHAT CANNOT START A DRAG. The whole card is the drag surface — there is no
@@ -333,6 +335,43 @@ export function WidgetContainer({
   // Which widget is showing its back. One at a time: two cards mid-turn in the
   // same column is a fairground, not an explanation.
   const [flippedId, setFlippedId] = useState<string | null>(null)
+  const columnRef = useRef<HTMLDivElement>(null)
+  /**
+   * The LOCKED widget the POINTER was over when a drop happened, if any — the
+   * reason that drop is about to be refused.
+   *
+   * Hit-tested against the DOM rather than taken from dnd-kit: a locked widget is
+   * not a droppable (that is what keeps other widgets from displacing it), so
+   * dnd-kit never reports it as `over`, and without this the refusal would have no
+   * name to give.
+   *
+   * THE POINTER, not the dragged card's box. A tall widget cannot put its middle
+   * over a card near the top of the column — it would have to hang off the top of
+   * the window to manage it — so testing the card missed exactly the gesture people
+   * make: pick up a big widget, carry it up to the pinned one, let go. The pointer
+   * is where the intent is.
+   */
+  const lockedUnderPointer = ({ activatorEvent, delta }: DragEndEvent) => {
+    const start = activatorEvent as Partial<
+      Pick<globalThis.PointerEvent, "clientX" | "clientY">
+    >
+    if (start.clientX == null || start.clientY == null) return undefined
+    const x = start.clientX + delta.x
+    const y = start.clientY + delta.y
+    return widgets.find((widget) => {
+      if (!widget.locked) return false
+      const box = columnRef.current
+        ?.querySelector(`[data-widget-id="${widget.id}"]`)
+        ?.getBoundingClientRect()
+      return (
+        !!box &&
+        x >= box.left &&
+        x <= box.right &&
+        y >= box.top &&
+        y <= box.bottom
+      )
+    })
+  }
   /**
    * ONE MENU PER WIDGET, in the order it reads:
    *
@@ -377,7 +416,21 @@ export function WidgetContainer({
     }
     return items
   }
-  const handleDragEnd = ({ active, over }: DragEndEvent) => {
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    // A DROP ON A LOCKED WIDGET is refused, and says so. Silence was the old
+    // behaviour and it read as a bug: the card sprang back with no reason given.
+    const blocking = lockedUnderPointer(event)
+    if (blocking) {
+      toasts.open({
+        variant: "warning",
+        title: t.widgets.cannotMoveHere.replace(
+          "{{title}}",
+          widgetTitle(blocking)
+        ),
+      })
+      return
+    }
     if (!over || active.id === over.id) return
     const ids = widgets.map((widget) => widget.id)
     const from = ids.indexOf(String(active.id))
@@ -506,6 +559,7 @@ export function WidgetContainer({
 
   return (
     <div
+      ref={columnRef}
       className={cn(
         // `relative` so this column is what a widget's `offsetTop` is measured
         // from: the stow maps a widget onto its glyph by that offset, and an

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -1,4 +1,9 @@
-import { type CSSProperties, ReactNode, useState } from "react"
+import {
+  type CSSProperties,
+  type PointerEvent,
+  ReactNode,
+  useState,
+} from "react"
 
 import {
   closestCenter,
@@ -6,6 +11,7 @@ import {
   type DragEndEvent,
   DragOverlay,
   PointerSensor,
+  type PointerSensorOptions,
   useSensor,
   useSensors,
 } from "@dnd-kit/core"
@@ -15,8 +21,14 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable"
 
+import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
-import { Cross, LockLocked, Plus } from "@/icons/app"
+import { Delete, Ellipsis, InfoCircleLine, Plus, Sliders } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import {
+  DropdownInternal,
+  type DropdownItem,
+} from "@/experimental/Navigation/Dropdown/internal"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { cn } from "@/lib/utils"
 
@@ -24,23 +36,60 @@ import { arrivalWindowMs, useElapsed } from "../home-motion"
 import { SlotWidget } from "../SlotWidget"
 import { SortableWidget } from "./SortableWidget"
 import { WidgetMotion, type WidgetStow } from "./WidgetMotion"
+import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
 import {
+  resolveWidgetHeader,
   type HomeRenderCtx,
   type HomeWidgetChrome,
   type HomeWidgetItem,
   type SlotRenderers,
+  type WidgetParams,
 } from "../slotRenderers"
 
 /**
- * The interaction the header arrow has (copied from `CardLink`), so a control
- * standing in its place feels identical on hover and focus.
+ * WHAT CANNOT START A DRAG. The whole card is the drag surface — there is no
+ * handle to grab — so a pointer-down that lands on something you can operate
+ * must stay a click: dnd-kit's own PointerSensor has no such guard, and with
+ * dragging always on (rather than only inside an edit mode) every row link, tag
+ * and control in a widget would otherwise be 4px of travel away from becoming a
+ * drag.
  */
-const CARD_LINK_CLASS = cn(
-  "group inline-flex aspect-square h-6 items-center justify-center gap-1",
-  "rounded-sm border border-solid border-transparent bg-transparent",
-  "whitespace-nowrap px-0 text-base font-medium text-f1-foreground",
-  "cursor-pointer transition-colors hover:bg-f1-background-secondary-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring focus-visible:ring-offset-1"
-)
+const INTERACTIVE = [
+  "a",
+  "button",
+  "input",
+  "select",
+  "textarea",
+  "label",
+  "[role='button']",
+  "[role='link']",
+  "[role='menuitem']",
+  "[role='switch']",
+  "[role='checkbox']",
+  "[role='tab']",
+  "[contenteditable='true']",
+].join(",")
+
+class WidgetDragSensor extends PointerSensor {
+  static activators = [
+    {
+      eventName: "onPointerDown" as const,
+      handler: (
+        { nativeEvent: event }: PointerEvent<Element>,
+        { onActivation }: PointerSensorOptions
+      ) => {
+        // The base sensor's own two conditions, kept as they are — a secondary
+        // pointer or any button but the left one is not a drag.
+        if (!event.isPrimary || event.button !== 0) return false
+        const target = event.target
+        if (target instanceof Element && target.closest(INTERACTIVE))
+          return false
+        onActivation?.({ event })
+        return true
+      },
+    },
+  ]
+}
 
 /**
  * The drop settle, matching SurveyFormBuilder's: that builder reorders with
@@ -139,21 +188,22 @@ export interface WidgetContainerProps {
   slotRenderers?: SlotRenderers
   /** Full override of how a whole widget is drawn. Defaults to `SlotWidget`. */
   renderWidget?: (widget: HomeWidgetItem, ctx: HomeRenderCtx) => ReactNode
-  /** Whether the Home is currently in edit mode. */
-  editing?: boolean
   /**
-   * Opts this container OUT of editing entirely: even in edit mode it shows no
-   * remove controls and no add placeholder. For a column whose contents are
-   * fixed (a curated feed, say) rather than user-arranged.
+   * Opts this container OUT of arranging entirely: no remove item in any
+   * widget's menu, no dragging, no add placeholder. For a column whose contents
+   * are fixed (a curated feed, say) rather than user-arranged.
    */
   disableEdition?: boolean
-  /** Called with a widget id when its remove control is clicked. */
+  /**
+   * Called with a widget id when its "Remove widget" menu item is used. Omit it
+   * and no widget offers removal.
+   */
   onRemoveWidget?: (id: string) => void
   /** Called when the add placeholder is clicked. The container knows its side. */
   onClickAddNewWidget?: () => void
   /**
    * Called with the column's widget ids in their new order after a drag. Omit
-   * it and the column is not draggable, even in edit mode.
+   * it and the column is not draggable.
    */
   onReorder?: (ids: string[]) => void
   /**
@@ -187,10 +237,38 @@ export interface WidgetContainerProps {
    * `NewHomeLayout` knows those, which is why they come in from outside.
    */
   stow?: Omit<WidgetStow, "stowed" | "instant"> & { stowed: boolean }
-  /** Tooltip on a locked widget's lock icon. */
-  lockedLabel?: string
-  /** Tooltip and accessible name for the add placeholder, which shows no text. */
+  /**
+   * Tooltip and accessible name for the add placeholder, which shows no text.
+   * Defaults to the provider's `t.widgets.addWidget`.
+   */
   addWidgetLabel?: string
+  /**
+   * Called with a widget id and its NEW params when its params dialog is saved.
+   * Providing it is what puts "Edit params" in the menu of every widget that
+   * declares a `paramsSchema` — locked widgets included, since being mandatory
+   * says nothing about being configurable.
+   */
+  onChangeWidgetParams?: (id: string, params: WidgetParams) => void
+  /**
+   * Draws a widget for params the user is trying out in that dialog, before they
+   * are saved. Defaults to the widget as it is with those params swapped in —
+   * enough for everything the params DERIVE (its title, its info); supply this
+   * to rebuild its slots too, which only the app can do.
+   */
+  renderWidgetPreview?: (
+    widget: HomeWidgetItem,
+    params: WidgetParams
+  ) => ReactNode
+  /** Content width the params dialog previews a widget at. */
+  paramsPreviewWidth?: number
+  /**
+   * The copy of the remove item in a widget's menu. Defaults to the PROVIDER's
+   * (`t.widgets.removeWidget`) — override it only for a column that means
+   * something more specific by removing.
+   */
+  removeLabel?: string
+  /** The copy of the params item. Defaults to `t.widgets.editParams`. */
+  editParamsLabel?: string
   ctx?: HomeRenderCtx
   className?: string
   style?: CSSProperties
@@ -198,13 +276,14 @@ export interface WidgetContainerProps {
 
 /**
  * WidgetContainer — one column of Home widgets, and the only thing that knows
- * how a column is edited.
+ * how a column is arranged.
  *
  * It renders its `children` (freeform content) followed by each widget through
- * `SlotWidget`, ending in an "Add widget" placeholder — adding is ALWAYS on
- * offer. EDIT MODE (`editing`) is for arranging what's already there: every
- * widget gains a remove control and becomes draggable. `disableEdition` opts
- * a column out of all of it, placeholder included.
+ * `SlotWidget`, ending in an "Add widget" placeholder. THERE IS NO EDIT MODE:
+ * every widget is draggable (the whole card, no handle) and carries "Remove
+ * widget" in its own overflow menu, so rearranging a Home is something you just
+ * do rather than something you switch into. `disableEdition` opts a column out
+ * of all of it, placeholder included.
  *
  * `NewHomeLayout` uses one of these per side; nothing about the column's own
  * width or background lives here (that's the layout's job), so the same
@@ -216,7 +295,6 @@ export function WidgetContainer({
   children,
   slotRenderers,
   renderWidget,
-  editing = false,
   disableEdition = false,
   onRemoveWidget,
   onClickAddNewWidget,
@@ -224,24 +302,71 @@ export function WidgetContainer({
   visibleWidgetId,
   entrance = {},
   stow,
-  lockedLabel = "This widget is mandatory in your company.",
-  addWidgetLabel = "Add widget",
+  addWidgetLabel,
+  onChangeWidgetParams,
+  renderWidgetPreview,
+  paramsPreviewWidth,
+  removeLabel,
+  editParamsLabel,
   ctx = {},
   className,
   style,
 }: WidgetContainerProps) {
-  const canEdit = editing && !disableEdition
+  const t = useI18n()
+  const canEdit = !disableEdition
   const isHidden = (widget: HomeWidgetItem) =>
     visibleWidgetId !== undefined && widget.id !== visibleWidgetId
   const canDrag = canEdit && onReorder != null && widgets.length > 1
   // The widget being dragged: its in-list card hides while a clone rides the
   // pointer in the DragOverlay (see below).
   const [activeId, setActiveId] = useState<string | null>(null)
-  // A small activation distance so a click on a widget's own control still
-  // reads as a click rather than the start of a drag.
+  // A small activation distance so a press on a widget still reads as a press
+  // rather than the start of a drag — the sensor itself already refuses to
+  // start one from anything operable inside the card.
   const sensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 4 } })
+    useSensor(WidgetDragSensor, { activationConstraint: { distance: 4 } })
   )
+  // Which widget's params are being edited, if any — the dialog is the column's
+  // (one at a time), not one mounted per card.
+  const [editingParamsId, setEditingParamsId] = useState<string | null>(null)
+  const editingParams = widgets.find((w) => w.id === editingParamsId)
+  // Which widget is showing its back. One at a time: two cards mid-turn in the
+  // same column is a fairground, not an explanation.
+  const [flippedId, setFlippedId] = useState<string | null>(null)
+  /**
+   * A widget's own menu items, in the order they read: what it can be CHANGED
+   * into first, then the destructive one.
+   *
+   * A LOCKED widget can still be configured — mandatory says nothing about
+   * fixed — it just isn't offered removal. A widget offered neither gets no
+   * menu at all, rather than an empty one.
+   */
+  const menuItems = (widget: HomeWidgetItem): DropdownItem[] => {
+    const items: DropdownItem[] = []
+    // What the widget is telling you, if it says. Its copy is the PROVIDER's
+    // (`t.widgets.whatThisMeans`), not this column's: the question a user asks of
+    // a widget is the same question in every product that ships one.
+    if (resolveWidgetHeader(widget.header, widget.params)?.info)
+      items.push({
+        label: t.widgets.whatThisMeans,
+        icon: InfoCircleLine,
+        onClick: () => setFlippedId(widget.id),
+      })
+    if (widget.paramsSchema && onChangeWidgetParams)
+      items.push({
+        label: editParamsLabel ?? t.widgets.editParams,
+        icon: Sliders,
+        onClick: () => setEditingParamsId(widget.id),
+      })
+    if (canEdit && !widget.locked && onRemoveWidget)
+      items.push({
+        label: removeLabel ?? t.widgets.removeWidget,
+        icon: Delete,
+        critical: true,
+        onClick: () => onRemoveWidget(widget.id),
+      })
+    return items
+  }
   const handleDragEnd = ({ active, over }: DragEndEvent) => {
     if (!over || active.id === over.id) return
     const ids = widgets.map((widget) => widget.id)
@@ -272,77 +397,48 @@ export function WidgetContainer({
 
   const render = (
     widget: HomeWidgetItem,
-    drag?: { draggable: boolean; isDragging: boolean }
+    drag?: { isDragging: boolean },
+    /** Params to draw it with instead of its own — the params dialog's preview. */
+    params: WidgetParams | undefined = widget.params
   ) => {
-    const node = renderWidget ? (
-      renderWidget(widget, ctx)
-    ) : (
-      <SlotWidget
-        {...widgetChrome(widget)}
-        header={
-          // In edit mode the remove control takes the arrow's place, so the
-          // link is dropped rather than sitting under it.
-          canEdit ? { ...widget.header, link: undefined } : widget.header
-        }
-        fullHeight={widget.fullHeight}
-        slots={widget.slots}
-        loading={widget.loading}
-        slotRenderers={slotRenderers}
-        ctx={ctx}
-        draggable={drag?.draggable}
-        isDragging={drag?.isDragging}
-      />
-    )
-    if (!canEdit) return node
-    // A locked widget can't be removed. In edit mode it swaps its header arrow
-    // for a lock, in that same spot, so it reads as deliberately fixed.
-    if (widget.locked)
+    const items = menuItems(widget)
+    // The default render puts the menu where the frame keeps its own overflow
+    // menu — the header's top-right — rather than laying a control over the card.
+    if (!renderWidget)
       return (
-        <div className="relative">
-          {renderWidget ? (
-            renderWidget(widget, ctx)
-          ) : (
-            <SlotWidget
-              {...widgetChrome(widget)}
-              header={{ ...widget.header, link: undefined }}
-              fullHeight={widget.fullHeight}
-              slots={widget.slots}
-              loading={widget.loading}
-              slotRenderers={slotRenderers}
-              ctx={ctx}
-            />
-          )}
-          <span
-            className="absolute right-4 top-4 z-10"
-            // `img` because a bare span may not carry aria-label
-            // (axe: aria-prohibited-attr) — this names the lock glyph.
-            role="img"
-            aria-label={lockedLabel}
-          >
-            <Tooltip label={lockedLabel}>
-              <F0Icon
-                size="md"
-                icon={LockLocked}
-                className="text-f1-icon-bold"
-              />
-            </Tooltip>
-          </span>
-        </div>
+        <SlotWidget
+          {...widgetChrome(widget)}
+          header={widget.header}
+          params={params}
+          fullHeight={widget.fullHeight}
+          slots={widget.slots}
+          loading={widget.loading}
+          slotRenderers={slotRenderers}
+          ctx={ctx}
+          actions={items.length > 0 ? items : undefined}
+          flipped={flippedId === widget.id}
+          onFlipBack={() => setFlippedId(null)}
+          isDragging={drag?.isDragging}
+        />
       )
+    const node = renderWidget(widget, ctx)
+    if (items.length === 0) return node
+    // A CUSTOM render has no header for the menu to live in, so the column puts
+    // one over the card, in the same corner the frame would have drawn it.
     return (
       <div className="relative">
         {node}
-        {/* The same control the header's arrow is — a bare button around an
-            `sm` F0Icon in `text-f1-icon-bold` (see `CardLink`) — sitting exactly
-            where that arrow sits, so removing reads as replacing it. */}
-        <button
-          type="button"
-          aria-label="Remove widget"
-          onClick={() => onRemoveWidget?.(widget.id)}
-          className={cn("absolute right-4 top-4 z-10", CARD_LINK_CLASS)}
-        >
-          <F0Icon size="sm" icon={Cross} className="text-f1-icon-bold" />
-        </button>
+        <div className="absolute right-3 top-3 z-10">
+          <DropdownInternal items={items} align="end">
+            <F0Button
+              icon={Ellipsis}
+              label="Actions"
+              variant="ghost"
+              size="sm"
+              hideLabel
+            />
+          </DropdownInternal>
+        </div>
       </div>
     )
   }
@@ -429,8 +525,8 @@ export function WidgetContainer({
             items={widgets.map((widget) => widget.id)}
             strategy={verticalListSortingStrategy}
           >
-            {/* The same gap the static list uses, so entering edit mode doesn't
-                reflow the column. */}
+            {/* The same gap the static list uses, so a column that becomes
+                draggable (a second widget lands in it) doesn't reflow. */}
             <div
               className={cn(
                 "flex flex-col",
@@ -463,7 +559,7 @@ export function WidgetContainer({
                 // Solid backdrop: Card's own background is translucent, and the
                 // clone rides over whatever the column shows beneath it.
                 <div className="cursor-grabbing rounded-xl bg-f1-background [&_*]:shadow-none">
-                  {render(active, { draggable: true, isDragging: true })}
+                  {render(active, { isDragging: true })}
                 </div>
               ) : null
             })()}
@@ -476,18 +572,42 @@ export function WidgetContainer({
           </WidgetSlot>
         ))
       )}
-      {/* NOT edit-gated: adding is always on offer — edit mode is for
-          arranging and removing what's already there. `disableEdition`
-          columns still never offer it. */}
+      {/* Adding, like removing and reordering, is always on offer.
+          `disableEdition` columns never offer any of it. */}
       {!disableEdition && onClickAddNewWidget
         ? enter(
             widgets.length,
             <AddWidgetPlaceholder
               onClick={onClickAddNewWidget}
-              label={addWidgetLabel}
+              label={addWidgetLabel ?? t.widgets.addWidget}
             />
           )
         : null}
+      {/* "Edit params". ONE dialog for the column, keyed by the widget it is
+          editing so switching widgets starts a fresh form rather than carrying
+          the last one's values into it. */}
+      {editingParams?.paramsSchema && onChangeWidgetParams ? (
+        <WidgetUpdateDialog
+          key={editingParams.id}
+          isOpen
+          onClose={() => setEditingParamsId(null)}
+          schema={editingParams.paramsSchema}
+          params={editingParams.params}
+          // The widget's own info, under the preview and rewritten as the fields
+          // change — the same sentence its info side would show.
+          info={editingParams.header?.info}
+          previewWidth={paramsPreviewWidth}
+          // The preview is the WIDGET, drawn with the params being tried out —
+          // so whatever they derive (its title, its info) is what you watch
+          // change. Its slots can only follow if the app rebuilds them.
+          renderPreview={(params) =>
+            renderWidgetPreview
+              ? renderWidgetPreview(editingParams, params)
+              : render(editingParams, undefined, params)
+          }
+          onSave={(params) => onChangeWidgetParams(editingParams.id, params)}
+        />
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/Home/WidgetPreview/index.tsx
+++ b/packages/react/src/sds/Home/WidgetPreview/index.tsx
@@ -1,8 +1,6 @@
-import { ReactNode } from "react"
-
-import { useMediaQuery } from "usehooks-ts"
-
 import { breakpoints } from "@factorialco/f0-core"
+import { ReactNode } from "react"
+import { useMediaQuery } from "usehooks-ts"
 
 import { cn } from "@/lib/utils"
 
@@ -107,27 +105,29 @@ export function WidgetPreviewPane({
   previewWidth = 396,
 }: WidgetPreviewPaneProps) {
   return (
-    // TOP-ALIGNED, not centred. The dialog is fullscreen at most sizes, so the
-    // stage is tall: a card floating in the middle of it reads as lost, and the
-    // eye has to hunt for it after scanning the list on the left. Sitting near
-    // the top, with generous air above, it is where you look first.
-    <div className="flex min-w-0 flex-1 flex-col items-center gap-6 overflow-y-auto rounded-lg bg-f1-background-secondary px-6 pb-6 pt-10">
-      <div
-        // The key is what makes this a NEW element, and a new element is what
-        // replays the animation — a class alone would only play once.
-        key={previewKey}
-        className={cn("w-full", WIDGET_ARRIVAL_CLASS)}
-        style={{ maxWidth: `${previewWidth}px` }}
-      >
-        {children}
+    <div className="flex min-w-0 flex-1 flex-col overflow-y-auto rounded-lg bg-f1-background-secondary p-6">
+      {/* CENTRED VERTICALLY, by `my-auto` rather than the pane's `justify-center`:
+          the pane scrolls, and a centred flex line whose content outgrows it has
+          its top cut off with no way to scroll back up to it. Auto margins centre
+          the same way while there is room and collapse when there isn't. */}
+      <div className="my-auto flex w-full flex-col items-center gap-6">
+        <div
+          // The key is what makes this a NEW element, and a new element is what
+          // replays the animation — a class alone would only play once.
+          key={previewKey}
+          className={cn("w-full", WIDGET_ARRIVAL_CLASS)}
+          style={{ maxWidth: `${previewWidth}px` }}
+        >
+          {children}
+        </div>
+        {info ? (
+          // Not inside the card: this is about the widget, so it sits under it,
+          // in the pane — the same words the card's own info side would show.
+          <p className="m-0 max-w-96 text-center text-f1-foreground-secondary">
+            {info}
+          </p>
+        ) : null}
       </div>
-      {info ? (
-        // Not inside the card: this is about the widget, so it sits under it, in
-        // the pane — the same words the card's own info side would show.
-        <p className="m-0 max-w-96 text-center text-f1-foreground-secondary">
-          {info}
-        </p>
-      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/Home/WidgetPreview/index.tsx
+++ b/packages/react/src/sds/Home/WidgetPreview/index.tsx
@@ -1,6 +1,59 @@
 import { ReactNode } from "react"
 
+import { useMediaQuery } from "usehooks-ts"
+
+import { breakpoints } from "@factorialco/f0-core"
+
 import { cn } from "@/lib/utils"
+
+/**
+ * WHEN A CENTERED DIALOG IS WORTH IT. The widget dialogs are two columns — a list
+ * or a form beside the widget itself — and a centered `xl` box has to fit both at
+ * their real widths (a 320px column, a 396px preview) with air around them and
+ * still leave the page visible behind. That takes a LARGE EXTERNAL DISPLAY.
+ *
+ * Everything smaller goes FULLSCREEN, laptops included: on a MacBook Pro the
+ * centered box eats most of the screen anyway, so it pays the cost of a modal
+ * without the benefit — you see a sliver of page around it and get less room for
+ * the two halves. Below this the dialog takes the screen and the columns stack.
+ *
+ * ONE NUMBER, ONE PLACE: change it here and both dialogs follow.
+ */
+const CENTERED_DIALOG_QUERY = "(min-width: 1800px) and (min-height: 900px)"
+
+/**
+ * How the widget dialogs lay themselves out — one decision taken once, because
+ * both of them make it: `WidgetCatalog` (pick a widget) and `WidgetUpdateDialog`
+ * (configure one) are the same offer at different moments, and a dialog that
+ * behaved differently between them would say they were different things.
+ */
+export const useWidgetDialogLayout = () => {
+  const roomForCentered = useMediaQuery(CENTERED_DIALOG_QUERY, {
+    initializeWithValue: true,
+    defaultValue: false,
+  })
+  // Stacking is for the genuinely narrow: a fullscreen dialog on a laptop still
+  // has room for two columns, and stacking there would waste it.
+  const stacked = useMediaQuery(`(max-width: ${breakpoints.md}px)`, {
+    initializeWithValue: true,
+    defaultValue: false,
+  })
+  return {
+    /** Hand straight to `F0Dialog`. */
+    position: roomForCentered ? ("center" as const) : ("fullscreen" as const),
+    /** The body's own classes: one column on a narrow screen, two otherwise. */
+    bodyClassName: cn(
+      "flex h-full min-h-96 gap-4",
+      stacked ? "flex-col" : "flex-row"
+    ),
+    /**
+     * The left column's: it gives up its fixed width when stacked, and the
+     * preview keeps its own height rather than being squeezed by it.
+     */
+    asideClassName: stacked ? "w-full shrink-0" : "w-80 shrink-0",
+    stacked,
+  }
+}
 
 /**
  * THE ARRIVAL. A preview lands with a small zoom-and-fade rather than appearing —

--- a/packages/react/src/sds/Home/WidgetPreview/index.tsx
+++ b/packages/react/src/sds/Home/WidgetPreview/index.tsx
@@ -1,0 +1,73 @@
+import { ReactNode } from "react"
+
+import { cn } from "@/lib/utils"
+
+/**
+ * THE ARRIVAL. A preview lands with a small zoom-and-fade rather than appearing —
+ * the same lift the card's own info side jumps with (`SlotWidget`), so presenting
+ * a widget reads one way across the kit.
+ *
+ * Tailwind's animate classes rather than a JS animation, on purpose: this plays
+ * when the element MOUNTS (a `key` change is what replays it), which is exactly
+ * when there is no state to drive an animation from — and it costs nothing while
+ * nothing is arriving. `motion-reduce:animate-none` is the plugin's own opt-out.
+ */
+const WIDGET_ARRIVAL_CLASS =
+  "animate-in fade-in zoom-in-95 duration-300 ease-out motion-reduce:animate-none"
+
+export interface WidgetPreviewPaneProps {
+  /**
+   * What is being previewed. CHANGING IT REPLAYS the arrival — the preview is
+   * announcing that it is now a different widget. Keep it stable while only the
+   * widget's params change, or the card re-lands at every keystroke.
+   */
+  previewKey?: string
+  /** The widget, drawn as the column will really draw it. */
+  children: ReactNode
+  /**
+   * What this widget is telling you — the same sentence its own info side shows,
+   * here at the pane's bottom, where it explains the preview above it without
+   * having to be asked for.
+   */
+  info?: string
+  /** Content width of the column the widget will live in. */
+  previewWidth?: number
+}
+
+/**
+ * WidgetPreviewPane — the right-hand half of both widget dialogs: the widget on
+ * the page grey, at the width its column will really give it, with its `info`
+ * underneath.
+ *
+ * One component rather than two identical blocks because the two dialogs are the
+ * same offer at different moments — `WidgetCatalog` previews a widget you are
+ * about to add, `WidgetUpdateDialog` one you are configuring — and a preview that
+ * behaved differently between them would say they were different things.
+ */
+export function WidgetPreviewPane({
+  previewKey,
+  children,
+  info,
+  previewWidth = 396,
+}: WidgetPreviewPaneProps) {
+  return (
+    <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg bg-f1-background-secondary p-6">
+      <div
+        // The key is what makes this a NEW element, and a new element is what
+        // replays the animation — a class alone would only play once.
+        key={previewKey}
+        className={cn("w-full", WIDGET_ARRIVAL_CLASS)}
+        style={{ maxWidth: `${previewWidth}px` }}
+      >
+        {children}
+      </div>
+      {info ? (
+        // Not inside the card: this is about the widget, so it sits under it, in
+        // the pane — the same words the card's own info side would show.
+        <p className="m-0 max-w-96 text-center text-f1-foreground-secondary">
+          {info}
+        </p>
+      ) : null}
+    </div>
+  )
+}

--- a/packages/react/src/sds/Home/WidgetPreview/index.tsx
+++ b/packages/react/src/sds/Home/WidgetPreview/index.tsx
@@ -7,40 +7,43 @@ import { breakpoints } from "@factorialco/f0-core"
 import { cn } from "@/lib/utils"
 
 /**
- * WHEN A CENTERED DIALOG IS WORTH IT. The widget dialogs are two columns — a list
- * or a form beside the widget itself — and a centered `xl` box has to fit both at
- * their real widths (a 320px column, a 396px preview) with air around them and
- * still leave the page visible behind. That takes a LARGE EXTERNAL DISPLAY.
- *
- * Everything smaller goes FULLSCREEN, laptops included: on a MacBook Pro the
- * centered box eats most of the screen anyway, so it pays the cost of a modal
- * without the benefit — you see a sliver of page around it and get less room for
- * the two halves. Below this the dialog takes the screen and the columns stack.
- *
- * ONE NUMBER, ONE PLACE: change it here and both dialogs follow.
- */
-const CENTERED_DIALOG_QUERY = "(min-width: 1800px) and (min-height: 900px)"
-
-/**
  * How the widget dialogs lay themselves out — one decision taken once, because
  * both of them make it: `WidgetCatalog` (pick a widget) and `WidgetUpdateDialog`
  * (configure one) are the same offer at different moments, and a dialog that
  * behaved differently between them would say they were different things.
+ *
+ * FULLSCREEN, unless the display is genuinely big. These dialogs are two columns —
+ * a list or a form beside the widget itself — and a centered `xl` box has to fit
+ * both at their real widths (a 320px column, a 396px preview) with air around them
+ * AND still leave enough page around the edges to be worth being a modal. On a
+ * laptop, and on an ordinary 1080p monitor, it manages that only by taking most of
+ * the screen anyway: the cost of a modal without the benefit. So those go
+ * fullscreen, and only a large display gets the centered box.
+ *
+ * The number is deliberately past a 1920-wide monitor and every laptop, so what
+ * qualifies is a 2560-class display. It is the ONE knob here; change it and both
+ * dialogs follow.
  */
+const CENTERED_DIALOG_QUERY = "(min-width: 2200px) and (min-height: 900px)"
+
 export const useWidgetDialogLayout = () => {
   const roomForCentered = useMediaQuery(CENTERED_DIALOG_QUERY, {
     initializeWithValue: true,
     defaultValue: false,
   })
-  // Stacking is for the genuinely narrow: a fullscreen dialog on a laptop still
-  // has room for two columns, and stacking there would waste it.
+  // Stacking IS a size question: two columns need the width for two columns.
   const stacked = useMediaQuery(`(max-width: ${breakpoints.md}px)`, {
     initializeWithValue: true,
     defaultValue: false,
   })
   return {
-    /** Hand straight to `F0Dialog`. */
+    /** Hand straight to `F0Dialog`, with `width` below. */
     position: roomForCentered ? ("center" as const) : ("fullscreen" as const),
+    /**
+     * What the centered box is capped to. Fullscreen neutralises it (F0Dialog has
+     * a compound variant for exactly that), so it is passed unconditionally.
+     */
+    width: "xl" as const,
     /** The body's own classes: one column on a narrow screen, two otherwise. */
     bodyClassName: cn(
       "flex h-full min-h-96 gap-4",
@@ -104,7 +107,11 @@ export function WidgetPreviewPane({
   previewWidth = 396,
 }: WidgetPreviewPaneProps) {
   return (
-    <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg bg-f1-background-secondary p-6">
+    // TOP-ALIGNED, not centred. The dialog is fullscreen at most sizes, so the
+    // stage is tall: a card floating in the middle of it reads as lost, and the
+    // eye has to hunt for it after scanning the list on the left. Sitting near
+    // the top, with generous air above, it is where you look first.
+    <div className="flex min-w-0 flex-1 flex-col items-center gap-6 overflow-y-auto rounded-lg bg-f1-background-secondary px-6 pb-6 pt-10">
       <div
         // The key is what makes this a NEW element, and a new element is what
         // replays the animation — a class alone would only play once.

--- a/packages/react/src/sds/Home/WidgetUpdateDialog/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetUpdateDialog/index.stories.tsx
@@ -1,0 +1,220 @@
+import { useState } from "react"
+
+import type { Meta, StoryObj } from "@storybook/react-vite"
+import { z } from "zod"
+
+import { createDataSourceDefinition } from "@/hooks/datasource"
+import { f0FormField } from "@/patterns/F0Form"
+
+import { fromParams, homeSlot, type WidgetParams } from "../slotRenderers"
+import { SlotWidget } from "../SlotWidget"
+import { WidgetUpdateDialog } from "./index"
+
+/** What the teams field's datasource serves. */
+type Team = { id: string; name: string; people: number }
+
+const TEAMS: Team[] = [
+  { id: "design", name: "Design", people: 8 },
+  { id: "engineering", name: "Engineering", people: 42 },
+  { id: "people", name: "People", people: 6 },
+  { id: "sales", name: "Sales", people: 17 },
+]
+
+/**
+ * A DATASOURCE rather than a fixed list of options: the field searches it, so a
+ * widget can be pointed at things nobody could enumerate at build time.
+ */
+const teamsSource = createDataSourceDefinition<Team>({
+  dataAdapter: {
+    fetchData: async ({ search }) => {
+      const needle = search?.toLowerCase()
+      return {
+        records: needle
+          ? TEAMS.filter((team) => team.name.toLowerCase().includes(needle))
+          : TEAMS,
+      }
+    },
+  },
+})
+
+/**
+ * The params of the Events widget, as an F0Form schema: an enum (select), a
+ * datasource-backed MULTI select, a number, a date and a datetime. What is
+ * REQUIRED is just what zod says — `since` and `digestAt` are `.optional()`, the
+ * rest are not, and the dialog cannot be saved until they are filled.
+ */
+const EVENTS_PARAMS = z.object({
+  period: f0FormField(z.enum(["week", "month", "quarter"]), {
+    label: "Period",
+    options: [
+      { value: "week", label: "This week" },
+      { value: "month", label: "This month" },
+      { value: "quarter", label: "This quarter" },
+    ],
+  }),
+  teams: f0FormField(z.array(z.string()).min(1), {
+    label: "Teams",
+    placeholder: "Pick at least one team",
+    showSearchBox: true,
+    multiple: true,
+    source: teamsSource,
+    mapOptions: (team: Team) => ({
+      value: team.id,
+      label: team.name,
+      description: `${team.people} people`,
+    }),
+  }),
+  maxEvents: f0FormField(z.number().min(1).max(8), {
+    label: "Events to show",
+  }),
+  since: f0FormField(z.date().optional(), { label: "Only after" }),
+  digestAt: f0FormField(z.date().optional(), {
+    label: "Send me a digest at",
+    fieldType: "datetime",
+  }),
+})
+
+type EventsParams = z.infer<typeof EVENTS_PARAMS>
+
+const PERIOD_LABEL: Record<string, string> = {
+  week: "this week",
+  month: "this month",
+  quarter: "this quarter",
+}
+
+const teamNames = (ids: string[] = []) =>
+  ids.map((id) => TEAMS.find((team) => team.id === id)?.name ?? id).join(", ")
+
+/**
+ * REAL events, not placeholders: a preview is only worth looking at if the widget
+ * in it looks like the one you will get — the coloured spine, the two lines, the
+ * date chip an `event-list` row draws.
+ */
+const EVENTS = [
+  {
+    title: "Sarah's birthday",
+    subtitle: "Turns 30 🎉",
+    description: "Sarah Nowak turns 30 — the team is signing a card.",
+    isPending: false,
+    color: "#F59E0B",
+    fromDate: new Date(2026, 6, 24),
+  },
+  {
+    title: "Company holiday",
+    subtitle: "2 days off",
+    description: "Offices closed Thursday and Friday for the summer break.",
+    isPending: false,
+    color: "#10B981",
+    fromDate: new Date(2026, 6, 30),
+    toDate: new Date(2026, 6, 31),
+  },
+  {
+    title: "Team offsite",
+    subtitle: "Costa Brava · not confirmed",
+    description: "Two days in Costa Brava — waiting on final numbers.",
+    isPending: false,
+    color: "#14B8A6",
+    fromDate: new Date(2026, 7, 3),
+    toDate: new Date(2026, 7, 4),
+  },
+  {
+    title: "Monthly all-hands",
+    subtitle: "Q3 roadmap update",
+    description: "Q3 roadmap and hiring update — bring questions.",
+    isPending: false,
+    color: "#6366F1",
+    fromDate: new Date(2026, 7, 7),
+  },
+]
+
+/** The widget the dialog previews — the SAME render the rail would make. */
+const eventsPreview = (params: EventsParams) => (
+  <SlotWidget
+    params={params}
+    header={{
+      title: fromParams(EVENTS_PARAMS, (p) =>
+        p.teams?.length ? `Events · ${teamNames(p.teams)}` : "Events"
+      ),
+      count: Math.min(params.maxEvents ?? 0, EVENTS.length),
+      link: { title: "Go to Calendar", url: "/calendar#core.events" },
+    }}
+    slots={[
+      homeSlot("event-list", {
+        showAllItems: true,
+        events: EVENTS.slice(0, params.maxEvents),
+      }),
+    ]}
+  />
+)
+
+const DEFAULTS: EventsParams = {
+  period: "week",
+  teams: ["design"],
+  maxEvents: 3,
+  since: undefined,
+  digestAt: undefined,
+}
+
+/**
+ * The dialog SAVES, so a story that only logs would never show what saving does.
+ * This keeps the params it is given and hands them straight back, which is what
+ * an app does with them.
+ */
+const ConfigurableWidget = () => {
+  const [params, setParams] = useState<EventsParams>(DEFAULTS)
+  return (
+    <WidgetUpdateDialog
+      isOpen
+      onClose={() => {}}
+      schema={EVENTS_PARAMS}
+      params={params}
+      info={fromParams(
+        EVENTS_PARAMS,
+        (p) =>
+          `The next ${p.maxEvents ?? 0} events ${PERIOD_LABEL[p.period ?? "week"]} for ${teamNames(p.teams) || "no team"}.`
+      )}
+      renderPreview={(next) => eventsPreview(next as EventsParams)}
+      onSave={(next) => setParams(next as EventsParams)}
+    />
+  )
+}
+
+const meta = {
+  title: "Home/WidgetUpdateDialog",
+  component: WidgetUpdateDialog,
+  tags: ["autodocs", "experimental"],
+  args: {
+    isOpen: true,
+    onClose: () => {},
+    schema: EVENTS_PARAMS,
+    params: DEFAULTS as WidgetParams,
+    renderPreview: (params) => eventsPreview(params as EventsParams),
+    onSave: () => {},
+    previewWidth: 396,
+  },
+} satisfies Meta<typeof WidgetUpdateDialog>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * "Edit params" — the twin of `WidgetCatalog`: the same `xl` dialog, the widget's
+ * own params as FIELDS on the left, a live preview of it on the right at the
+ * width its column will give it, and its info line underneath.
+ *
+ * Nothing here is hand-built. The fields are the widget's `paramsSchema` handed to
+ * `F0Form`, so a `z.date()` gets a date picker, a `z.enum()` a select, and a
+ * datasource-backed field a searchable (here multi) select. The preview follows
+ * every VALID edit — an invalid form keeps the last good one — and nothing reaches
+ * the widget until Save.
+ */
+export const Default: Story = { render: () => <ConfigurableWidget /> }
+
+/**
+ * A widget being configured for the FIRST time: the params it must have are
+ * empty, so the fields show what is required and Save refuses until they are
+ * filled (the schema is the only place that says so).
+ */
+export const NothingSetYet: Story = {
+  args: { params: {} },
+}

--- a/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
@@ -1,0 +1,157 @@
+import { ReactNode, useEffect, useState } from "react"
+
+import { useI18n } from "@/lib/providers/i18n"
+import { F0Dialog } from "@/patterns/F0Dialog"
+import { F0Form, useF0Form } from "@/patterns/F0Form"
+
+import { WidgetPreviewPane } from "../WidgetPreview"
+import {
+  type FromWidgetParams,
+  type WidgetParams,
+  type WidgetParamsSchema,
+} from "../slotRenderers"
+
+/** The info line for the params in hand — it may be fixed or computed. */
+const resolveInfo = (
+  info: FromWidgetParams<string> | undefined,
+  params: WidgetParams
+) => (typeof info === "function" ? info(params) : info)
+
+/**
+ * How long after the last keystroke the preview catches up. F0Form's autosubmit
+ * is what tells us the values changed AND that they are valid, so this is the
+ * debounce on the preview rather than on any saving — short enough to feel live,
+ * long enough not to redraw the card mid-word.
+ */
+const PREVIEW_DELAY_MS = 250
+
+export interface WidgetUpdateDialogProps {
+  isOpen: boolean
+  onClose: () => void
+  /**
+   * The widget's params schema — an F0Form schema, so these fields come with
+   * their types, their datasources and their validation already declared.
+   */
+  schema: WidgetParamsSchema
+  /** The params the widget has now: what the form opens with. */
+  params?: WidgetParams
+  /**
+   * Draws the widget for the params the user is TRYING OUT — called with each
+   * valid edit, before anything is saved.
+   */
+  renderPreview: (params: WidgetParams) => ReactNode
+  /**
+   * What this widget is telling you, shown under the preview. A function of the
+   * params — the widget's own `header.info` — so the explanation is rewritten as
+   * you configure it, which is the fastest way to see what a param actually does.
+   */
+  info?: FromWidgetParams<string>
+  /** Called with the new params when the dialog is saved. */
+  onSave: (params: WidgetParams) => void
+  /**
+   * Content width of the column the widget lives in — the preview is capped to
+   * it, so a rail widget previews at rail width (as in `WidgetCatalog`).
+   */
+  previewWidth?: number
+  /** Defaults to the provider's `t.widgets.editParamsTitle`. */
+  title?: string
+  saveLabel?: string
+}
+
+/**
+ * WidgetUpdateDialog — "Edit params", the twin of `WidgetCatalog`: the same `xl`
+ * dialog, the FIELDS on the left and a LIVE preview of the widget on the right,
+ * at the width its column will really give it.
+ *
+ * The fields are not hand-built: they are the widget's own `paramsSchema` handed
+ * to `F0Form`, so a `z.date()` gets a date picker, a `z.enum()` a select, a
+ * datasource-backed field its searchable (single or multi) select, and a param
+ * that isn't `.optional()` simply cannot be left empty — the dialog can't save
+ * until it is filled.
+ *
+ * The preview follows every VALID edit (an invalid form keeps the last good
+ * one), which is why the widget's `title` and `info` may be functions of its
+ * params: you watch the card become what you are configuring.
+ */
+export function WidgetUpdateDialog({
+  isOpen,
+  onClose,
+  schema,
+  params,
+  renderPreview,
+  info,
+  onSave,
+  previewWidth = 396,
+  title,
+  saveLabel = "Save",
+}: WidgetUpdateDialogProps) {
+  const t = useI18n()
+  const { formRef, getValues, trigger } = useF0Form()
+  // What the PREVIEW is drawn from: the last values that validated, starting
+  // from the widget's own. Never the raw form state — a half-typed number is not
+  // something to redraw a widget for.
+  const [preview, setPreview] = useState<WidgetParams>(params ?? {})
+
+  // Reopening shows the widget as it IS, not as it was left the last time: the
+  // dialog can be closed on a preview that was never saved.
+  useEffect(() => {
+    if (isOpen) setPreview(params ?? {})
+  }, [isOpen, params])
+
+  return (
+    <F0Dialog
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title ?? t.widgets.editParamsTitle}
+      width="xl"
+      primaryAction={{
+        label: saveLabel,
+        // Validation before saving is the FORM's, not ours: `trigger` surfaces
+        // the same errors the fields would show, and a schema that says a param
+        // is required is the only place "you must set this" is written down.
+        onClick: async () => {
+          if (!(await trigger())) return
+          onSave(getValues())
+          onClose()
+        },
+      }}
+    >
+      <div className="flex h-full min-h-96 gap-4">
+        <div className="w-80 shrink-0 overflow-y-auto">
+          <F0Form
+            formRef={formRef}
+            name="widget-params"
+            schema={schema}
+            defaultValues={params}
+            // Autosubmit is the change signal, not a save: it hands us the
+            // values every time they settle AND validate, which is exactly what
+            // the preview wants. Saving stays with the dialog's own action, so
+            // nothing is committed to the widget until it is pressed.
+            submitConfig={{
+              type: "autosubmit",
+              delay: PREVIEW_DELAY_MS,
+              hideActionBar: true,
+            }}
+            // The dialog already provides the padding around this column.
+            styling={{ noPadding: true }}
+            onSubmit={(values: WidgetParams) => {
+              setPreview(values)
+              return { success: true }
+            }}
+          />
+        </div>
+        {/* The preview: the same pane the catalog uses, so configuring a widget
+            and choosing one look like the same thing. It jumps in with the
+            dialog; from then on it just follows the fields, because a jump per
+            keystroke would be noise rather than feedback. */}
+        <WidgetPreviewPane
+          previewKey="widget-params"
+          info={resolveInfo(info, preview)}
+          previewWidth={previewWidth}
+        >
+          {renderPreview(preview)}
+        </WidgetPreviewPane>
+      </div>
+    </F0Dialog>
+  )
+}

--- a/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
@@ -1,10 +1,11 @@
 import { ReactNode, useEffect, useState } from "react"
 
+import { cn } from "@/lib/utils"
 import { useI18n } from "@/lib/providers/i18n"
 import { F0Dialog } from "@/patterns/F0Dialog"
 import { F0Form, useF0Form } from "@/patterns/F0Form"
 
-import { WidgetPreviewPane } from "../WidgetPreview"
+import { useWidgetDialogLayout, WidgetPreviewPane } from "../WidgetPreview"
 import {
   type FromWidgetParams,
   type WidgetParams,
@@ -86,6 +87,7 @@ export function WidgetUpdateDialog({
   saveLabel = "Save",
 }: WidgetUpdateDialogProps) {
   const t = useI18n()
+  const { position, bodyClassName, asideClassName } = useWidgetDialogLayout()
   const { formRef, getValues, trigger } = useF0Form()
   // What the PREVIEW is drawn from: the last values that validated, starting
   // from the widget's own. Never the raw form state — a half-typed number is not
@@ -103,6 +105,9 @@ export function WidgetUpdateDialog({
       isOpen={isOpen}
       onClose={onClose}
       title={title ?? t.widgets.editParamsTitle}
+      // Fullscreen on a narrow screen: the fields and the preview stack there,
+      // and neither is usable inside a centered box (see `useWidgetDialogLayout`).
+      position={position}
       width="xl"
       primaryAction={{
         label: saveLabel,
@@ -116,8 +121,8 @@ export function WidgetUpdateDialog({
         },
       }}
     >
-      <div className="flex h-full min-h-96 gap-4">
-        <div className="w-80 shrink-0 overflow-y-auto">
+      <div className={bodyClassName}>
+        <div className={cn("overflow-y-auto", asideClassName)}>
           <F0Form
             formRef={formRef}
             name="widget-params"

--- a/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
@@ -87,7 +87,8 @@ export function WidgetUpdateDialog({
   saveLabel = "Save",
 }: WidgetUpdateDialogProps) {
   const t = useI18n()
-  const { position, bodyClassName, asideClassName } = useWidgetDialogLayout()
+  const { position, width, bodyClassName, asideClassName } =
+    useWidgetDialogLayout()
   const { formRef, getValues, trigger } = useF0Form()
   // What the PREVIEW is drawn from: the last values that validated, starting
   // from the widget's own. Never the raw form state — a half-typed number is not
@@ -105,10 +106,11 @@ export function WidgetUpdateDialog({
       isOpen={isOpen}
       onClose={onClose}
       title={title ?? t.widgets.editParamsTitle}
-      // Fullscreen on a narrow screen: the fields and the preview stack there,
-      // and neither is usable inside a centered box (see `useWidgetDialogLayout`).
+      // Fullscreen unless the display is big enough for a centered box to be
+      // worth it — the fields and the preview want the room
+      // (`useWidgetDialogLayout`).
       position={position}
-      width="xl"
+      width={width}
       primaryAction={{
         label: saveLabel,
         // Validation before saving is the FORM's, not ours: `trigger` surfaces

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -387,6 +387,17 @@ export type HomeWidgetItem = HomeWidgetChrome & {
   id: string
   header?: HomeWidgetHeader
   /**
+   * THIS WIDGET'S OWN menu items — "Mark all as read", "Export as CSV", whatever
+   * it can do that no other widget can. They go in the widget's three-dots menu,
+   * FIRST: the column adds what every widget carries (what its info means, its
+   * params, removing it) after them, and removing it sits behind a separator.
+   *
+   * Ordinary `DropdownItem`s, so they take an `icon`, a `description`, `critical`
+   * for a destructive one, `disabled`, or a `type: "separator"` of your own to
+   * group them. A `locked` widget still shows them.
+   */
+  actions?: WidgetProps["actions"]
+  /**
    * The widget is CONFIGURABLE: these are the params the user may set, as an
    * F0Form schema. Declaring it — together with the layout's
    * `onChangeWidgetParams` — is what puts "Edit params" in the widget's menu.
@@ -552,8 +563,11 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
       })}
       {overflows ? (
         <div className="mt-1 self-start">
+          {/* `neutral`, the same button a widget's own call to action is (the
+              frame's `action`): "View more" is something you press, and a ghost
+              button under a dense list of rows reads as another row. */}
           <F0Button
-            variant="ghost"
+            variant="neutral"
             size="sm"
             label={
               expanded ? "View less" : `View more (${allRows.length - max})`
@@ -658,7 +672,7 @@ const ListSlotSkeleton = ({
       ))}
       {overflows ? (
         <div className="mt-1 self-start">
-          {/* An `sm` ghost button — what "View more (n)" will be. */}
+          {/* An `sm` neutral button — what "View more (n)" will be. */}
           <Skeleton className="h-6 w-24 rounded-sm" />
         </div>
       ) : null}

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -1,5 +1,7 @@
 import { ReactNode, useState } from "react"
 
+import { type z } from "zod"
+
 import { F0Avatar, type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { F0AvatarAlert } from "@/components/avatars/F0AvatarAlert"
 import {
@@ -26,6 +28,7 @@ import {
 } from "@/experimental/Widgets/Content/IndicatorsList"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { WidgetProps } from "@/experimental/Widgets/Widget"
+import { type F0FormSchema } from "@/patterns/F0Form"
 
 import { HomeListItem } from "./HomeListItem"
 
@@ -128,7 +131,8 @@ export interface ListSchema {
    * `"link"` rows each carry an `href` and render as REAL anchors (role
    * `link`, routed through the app's `LinkProvider`) — never an onClick;
    * that's the only click behavior rows have. Omit for inert rows.
-   * Same-tab for relative and `#` hrefs, `target="_blank"` for other domains.
+   * Same-tab for paths, `#` fragments and this host under any scheme;
+   * `target="_blank"` only for ANOTHER host (see `isExternalHref`).
    */
   clickBehavior?: "link"
   /**
@@ -263,10 +267,138 @@ export type HomeWidgetChrome = Pick<WidgetProps, "action" | "summaries"> &
     | { status?: WidgetProps["status"]; alert?: never }
   )
 
+/* ---------------------------- configurable widgets ---------------------------- */
+
+/**
+ * What a user has CONFIGURED about a widget — the values of the fields its
+ * `paramsSchema` declares, keyed by field name. Dates arrive as `Date`s, a
+ * multi-select as an array: whatever the schema's zod types say.
+ */
+export type WidgetParams = Record<string, unknown>
+
+/**
+ * A widget's params SCHEMA: an F0Form schema, so the fields are declared once —
+ * in zod, with their f0 field config — and F0Form draws and validates them.
+ *
+ * That buys the whole vocabulary rather than a bespoke one: `z.string()`,
+ * `z.number()`, `z.date()` (`fieldType: "datetime"` for a time as well),
+ * `z.enum()`, and a select fed by a DATASOURCE (`source` + `mapOptions`, with
+ * `multiple` for many) — `z.array()` for the multi-select's value. A field is
+ * REQUIRED unless its zod type is `.optional()`, so "the user must set this"
+ * needs nothing new either.
+ *
+ * ```tsx
+ * paramsSchema: z.object({
+ *   since: f0FormField(z.date(), { label: "Since" }),
+ *   team: f0FormField(z.array(z.string()), {
+ *     label: "Teams",
+ *     source: teamsDataSource,
+ *     mapOptions: (team) => ({ value: team.id, label: team.name }),
+ *     multiple: true,
+ *   }),
+ * })
+ * ```
+ */
+export type WidgetParamsSchema = F0FormSchema
+
+/**
+ * A widget property that may be COMPUTED FROM ITS PARAMS instead of fixed — the
+ * title that says which team it is showing, the info that explains the period
+ * you picked. It gets the params the widget has now (`{}` when it has none), so
+ * the same function serves a widget before and after it is configured.
+ */
+export type FromWidgetParams<T> = T | ((params: WidgetParams) => T)
+
+/**
+ * A params-driven value, TYPED against the widget's own schema — how to write a
+ * `title` or an `info` that reads its params without casting at every access:
+ *
+ * ```tsx
+ * title: fromParams(HOURS_PARAMS, (p) => `Hours · ${p.period ?? "this week"}`)
+ * ```
+ *
+ * The params arrive `Partial`, and that is not a formality: a widget exists
+ * before it is configured (the moment it is added, or while its dialog is open
+ * on an incomplete form), so every field has to be treated as possibly unset.
+ * The schema argument is there only to carry the type.
+ */
+export const fromParams =
+  <S extends WidgetParamsSchema, T>(
+    _schema: S,
+    compute: (params: Partial<z.infer<S>>) => T
+  ) =>
+  (params: WidgetParams): T =>
+    compute(params as Partial<z.infer<S>>)
+
+/**
+ * A Home widget's header. The frame's, except that the two things a user reads
+ * to know WHAT they are looking at may follow the params they set.
+ */
+export type HomeWidgetHeader = Omit<
+  NonNullable<WidgetProps["header"]>,
+  "title" | "info"
+> & {
+  title?: FromWidgetParams<string>
+  /**
+   * The `i` beside the title: hovering it explains the widget. Takes the params
+   * too, so it can say what the numbers actually cover.
+   */
+  info?: FromWidgetParams<string>
+}
+
+/** Resolves a header's params-driven parts against the params in hand. */
+export const resolveWidgetHeader = (
+  header: HomeWidgetHeader | undefined,
+  params: WidgetParams = {}
+): WidgetProps["header"] => {
+  if (!header) return undefined
+  const { title, info, ...rest } = header
+  const from = <T,>(value: FromWidgetParams<T> | undefined) =>
+    typeof value === "function"
+      ? (value as (params: WidgetParams) => T)(params)
+      : value
+  return { ...rest, title: from(title), info: from(info) }
+}
+
+/**
+ * A widget's title as TEXT — resolved against its own params, and falling back
+ * to its id so there is always something to name it by (an aria-label on the
+ * collapsed rail's glyph, a row in the catalog).
+ */
+export const widgetTitle = (widget: {
+  id: string
+  header?: HomeWidgetHeader
+  params?: WidgetParams
+}): string =>
+  resolveWidgetHeader(widget.header, widget.params)?.title ?? widget.id
+
+/**
+ * Whether every REQUIRED param of a schema is set — what "this widget can't be
+ * shown until you configure it" comes down to. Use it to send a freshly added
+ * widget straight into its params dialog.
+ */
+export const widgetParamsAreComplete = (
+  schema: WidgetParamsSchema | undefined,
+  params: WidgetParams | undefined
+): boolean => (schema ? schema.safeParse(params ?? {}).success : true)
+
 /** A widget as handed to the layout: header + an ordered list of slots. */
 export type HomeWidgetItem = HomeWidgetChrome & {
   id: string
-  header?: WidgetProps["header"]
+  header?: HomeWidgetHeader
+  /**
+   * The widget is CONFIGURABLE: these are the params the user may set, as an
+   * F0Form schema. Declaring it — together with the layout's
+   * `onChangeWidgetParams` — is what puts "Edit params" in the widget's menu.
+   */
+  paramsSchema?: WidgetParamsSchema
+  /**
+   * The params it is configured with right now. They drive whatever the widget
+   * derives from them (its `title`, its `info`) and are the dialog's starting
+   * point; rebuilding the SLOTS for new params is the app's own job, since only
+   * it knows where their data comes from.
+   */
+  params?: WidgetParams
   fullHeight?: boolean
   /**
    * The widget's catalog glyph — shown for it in the collapsed rail and in the
@@ -274,9 +406,9 @@ export type HomeWidgetItem = HomeWidgetChrome & {
    */
   icon?: IconType
   /**
-   * PINNED: the widget stays put. In edit mode it shows no remove control and
-   * does not wiggle (nor drag, once dragging lands) — for widgets a user must
-   * always have, like Clock in.
+   * PINNED: the widget stays put. It offers no "Remove widget" in its menu, it
+   * cannot be dragged, and no other widget can displace it — for widgets a user
+   * must always have, like Clock in.
    */
   locked?: boolean
   /**

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -153,11 +153,19 @@ const SelectContent = forwardRef<
       )
     }, [value])
 
+    /**
+     * Where the selected item sits in the list, or -1 when it isn't there at all
+     * (nothing selected, or its group is collapsed).
+     *
+     * `?? -1` rather than `|| 0`: `findIndex` returns -1 on a miss and `-1 || 0`
+     * is `-1` — truthy — so the miss used to be handed to `scrollToIndex`, which
+     * clamps it and scrolled the list to the top. A miss now means "don't scroll".
+     */
     const positionIndex = useMemo(() => {
       return (
         items?.findIndex(
           (item) => item.value !== undefined && valueArray.has(item.value)
-        ) || 0
+        ) ?? -1
       )
     }, [items, valueArray])
 
@@ -191,10 +199,28 @@ const SelectContent = forwardRef<
       }
     }, [virtualizer, animationStarted, asList])
 
+    /**
+     * REVEALING THE SELECTION IS AN OPENING GESTURE, once per session, not
+     * something that happens again whenever its index moves.
+     *
+     * Keyed on the index, this re-ran mid-scroll: the index shifts whenever the
+     * list above the selection changes — which is exactly what expanding or
+     * collapsing a GROUP does — and the list jumped back under the pointer. So it
+     * now fires for the first valid index of an open session and then stands down
+     * until the list closes again.
+     */
+    const revealedSelection = useRef(false)
     useEffect(() => {
-      // Scroll to selected item when position changes
+      // A closed list starts a fresh session. `asList` never closes, so its one
+      // reveal is on mount.
+      if (!open && !asList) revealedSelection.current = false
+    }, [open, asList])
+    useEffect(() => {
+      if (revealedSelection.current || positionIndex < 0) return
+      if (!open && !asList) return
+      revealedSelection.current = true
       virtualizer.scrollToIndex(positionIndex)
-    }, [virtualizer, positionIndex])
+    }, [asList, open, positionIndex, virtualizer])
 
     const virtualItems = virtualizer.getVirtualItems()
 
@@ -218,6 +244,16 @@ const SelectContent = forwardRef<
           height: virtualizer.getTotalSize() + VIEWBOX_VERTICAL_PADDING,
           width: "100%",
           position: "relative",
+          // ONE SCROLLPORT, and it is the ScrollArea's (`parentRef`, which is what
+          // the virtualizer measures and scrolls). This div is Radix's
+          // `Select.Viewport` via `asChild`, so Radix merges its own
+          // `overflow: hidden auto; flex: 1 1 0%` onto it — a SECOND scroller
+          // nested inside the first, and a spacer that flex could shrink below the
+          // height the virtualizer just gave it. Both are overridden here, where
+          // the child's style wins the merge: the wheel then moves one list
+          // instead of handing off between two.
+          overflow: "visible",
+          flex: "none",
         }}
       >
         <div

--- a/packages/react/src/ui/dropdown-menu.tsx
+++ b/packages/react/src/ui/dropdown-menu.tsx
@@ -97,6 +97,13 @@ const DropdownMenuItem = React.forwardRef<
     ref={ref}
     className={cn(
       "relative flex cursor-default select-none items-center rounded py-2 pl-3 pr-5 text-base font-medium outline-none transition-colors after:absolute after:inset-x-1 after:inset-y-0 after:h-full after:rounded after:bg-f1-background-hover after:opacity-0 after:transition-opacity after:duration-75 after:content-[''] first:pt-3 first:after:top-1 first:after:h-[calc(100%-0.25rem)] last:pb-3 last:after:bottom-1 last:after:h-[calc(100%-0.25rem)] hover:after:opacity-100 focus:after:opacity-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      // THE ONLY ITEM is both the first and the last, and `first:`/`last:` then
+      // pull the highlight in opposite directions with a fixed height between
+      // them: over-constrained, so one inset is dropped and the highlight runs
+      // flush to that edge — the menu reads as missing its padding on one side.
+      // Insetting from both ends and letting the height follow is the same 4px
+      // gap the multi-item cases get.
+      "only:after:inset-y-1 only:after:h-auto",
       "focus:outline-none focus:ring-0 focus:ring-transparent", // Temporal fix for Gamma issue
       inset && "pl-8",
       className


### PR DESCRIPTION
## Description

Home widgets are arranged **without a mode to enter first**: no edit toggle, no drag handle. Every widget is draggable by its whole card and carries its own three-dots menu, and widgets can now be **configured** — a widget declares its params as an F0Form schema and gets an "Edit params" dialog for free.

Follows #5075 (arrival stagger + genie), rebased on top of it.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Bug fix
- [x] Other: removes two `NewHomeLayout` props (`editing`, `onEditingChange`) — see API changes

## Lifecycle phase (if applicable)

Not applicable — `NewHomeLayout` and the Home kit stay in `experimental`/`sds`.

- Linked #f0-support thread: n/a
- Phase exit criteria met: n/a

## Screenshots (if applicable)

The rail with a configurable widget (`Events · Design, Engineering`), the title links with their chevrons, and no edit toggle in the page's own controls:

| Home | The info side | Edit params |
| --- | --- | --- |
| Title links + three-dots menus | Card turns over, title kept, "Got it" to turn back | Fields left, live preview right, info underneath |

Stories to look at:

- `Home/NewHomeLayout` → **Default** — the Events widget is the configurable one
- `Home/WidgetUpdateDialog` → **Default** / **Nothing Set Yet** (new)
- `Home/WidgetContainer` → **Default** / **With Locked Widget**

## Implementation details

**No edit mode.** `WidgetContainer` drops `editing`; dragging is on whenever `onReorder` is given and the column has more than one widget. There is no handle glyph — the whole card is the grip, and a `WidgetDragSensor` (a `PointerSensor` subclass) refuses to start a drag from anything operable (`a`, `button`, inputs, `role=button/link/menuitem/…`), so row links keep working. `locked` widgets still can't be dragged or displaced.

**The widget menu.** Three items, each only when it applies: "What this info means?" (turns the card over to `header.info`, centered, with a "Got it" button — plain CSS transitions, since a re-render mid-flight interrupted a JS animation and left the card frozen at an angle), "Edit params", and "Remove widget". A `locked` widget can still be configured, just not removed. Copy lives in the i18n provider under `t.widgets.*`.

**Configurable widgets.** `HomeWidgetItem` gains `paramsSchema` (an F0Form schema: `z.date()`, datetime, `z.number()`, `z.enum()`, and datasource-backed single/multi selects) plus `params`. Required is just zod — a non-`.optional()` field can't be left empty and the dialog won't save. `title` and `info` may be functions of the params (`fromParams` types them against the schema). New `WidgetUpdateDialog` mirrors `WidgetCatalog`; both share a new `WidgetPreviewPane` that shows the widget's info under the preview and replays the arrival on change. Rebuilding a widget's *slots* stays with the app (`onChangeWidgetParams` → persist → pass back as `params`).

**The link is the title.** `Widget`'s `header.link` now makes the title itself the link — title + chevron in the title's colour, one ghost-hover target, with a tooltip above naming the destination. `aria-label` keeps the destination for screen readers while the visible text stays the title (label-in-name holds).

**Fixes**

- `isExternalHref` (new, in `lib/linkHandler`) compares **hosts**, so a same-host link under another scheme is no longer treated as another site and torn out into a new tab. `#fragments` and `mailto:`/`tel:` are never external. Used by the title link and Home's list rows.
- A dropdown menu with a **single item** insets its hover highlight from both ends instead of running flush to one edge (`first:`/`last:` were over-constraining it). Affects every one-item dropdown in f0.

### API changes for consumers

- `NewHomeLayout`: **removed** `editing` and `onEditingChange`; **added** `onChangeWidgetParams` and `renderWidgetPreview`.
- `WidgetContainer` (internal): `editing` and `lockedLabel` removed; `onChangeWidgetParams`, `renderWidgetPreview`, `paramsPreviewWidth`, `removeLabel`, `editParamsLabel` added.
- `Widget`: `header.link` renders as the linked title rather than an icon in the header's top-right. No other consumer passes `header.link` today.

### Checks

`tsc` clean, oxlint clean, formatted. 257 tests pass across `sds/Home`, `experimental/Widgets`, `lib/linkHandler`, the i18n provider, the Dropdown and its consumers, and Dashboard. New coverage for the title link (button/anchor/target/tooltip), the info side, the params menu items, and `isExternalHref`. Behaviour also verified by hand in Storybook: drag from the header reorders while the same gesture from a row link does nothing, the flip and "Got it" work, and Save commits params to the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)