### PR TITLE
fix(F0Select): one scrollport for a grouped list, and no jump on expand

### DIFF
--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -1192,6 +1192,46 @@ describe("Select", () => {
       // The other group remains collapsed
       expect(screen.queryByText("Carol")).not.toBeInTheDocument()
     })
+
+    /**
+     * ONE SCROLLPORT. The virtualized list is rendered through Radix's
+     * `Select.Viewport` with `asChild`, so Radix merges its own
+     * `overflow: hidden auto; flex: 1 1 0%` onto the virtualizer's SIZER — which
+     * made a second scroll container inside the `ScrollArea` that already scrolls
+     * the list. Two nested scrollers is the "double scroll" a grouped list is long
+     * enough to expose: the wheel fills the inner one, then hands off to the outer.
+     */
+    it("leaves the scrolling to ONE element, not two", async () => {
+      const user = userEvent.setup()
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          source={buildSource(true)}
+          mapOptions={mapOptions}
+          onChange={() => {}}
+        />
+      )
+
+      await openSelect(user)
+      await waitFor(() => {
+        expect(screen.getByText("Engineer")).toBeInTheDocument()
+      })
+
+      const sizer = document.querySelector<HTMLElement>(
+        "[data-radix-select-viewport]"
+      )
+      expect(sizer).not.toBeNull()
+      // The spacer must not scroll, and must not be shrinkable below the height
+      // the virtualizer gave it.
+      expect(sizer!.style.overflow).toBe("visible")
+      // `flex: none` as the browser stores it.
+      expect(sizer!.style.flex).toBe("0 0 auto")
+    })
+
+    // NOTE: the other half of this fix — that expanding a group no longer scrolls
+    // the list back to the selection — has no honest test here. jsdom has no
+    // layout, so the virtualizer's scroll is a no-op and any assertion about it
+    // passes whether the bug is present or not. It is verified in a browser.
   })
 
   describe("onCreate", () => {

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -153,11 +153,19 @@ const SelectContent = forwardRef<
       )
     }, [value])
 
+    /**
+     * Where the selected item sits in the list, or -1 when it isn't there at all
+     * (nothing selected, or its group is collapsed).
+     *
+     * `?? -1` rather than `|| 0`: `findIndex` returns -1 on a miss and `-1 || 0`
+     * is `-1` — truthy — so the miss used to be handed to `scrollToIndex`, which
+     * clamps it and scrolled the list to the top. A miss now means "don't scroll".
+     */
     const positionIndex = useMemo(() => {
       return (
         items?.findIndex(
           (item) => item.value !== undefined && valueArray.has(item.value)
-        ) || 0
+        ) ?? -1
       )
     }, [items, valueArray])
 
@@ -191,10 +199,28 @@ const SelectContent = forwardRef<
       }
     }, [virtualizer, animationStarted, asList])
 
+    /**
+     * REVEALING THE SELECTION IS AN OPENING GESTURE, once per session, not
+     * something that happens again whenever its index moves.
+     *
+     * Keyed on the index, this re-ran mid-scroll: the index shifts whenever the
+     * list above the selection changes — which is exactly what expanding or
+     * collapsing a GROUP does — and the list jumped back under the pointer. So it
+     * now fires for the first valid index of an open session and then stands down
+     * until the list closes again.
+     */
+    const revealedSelection = useRef(false)
     useEffect(() => {
-      // Scroll to selected item when position changes
+      // A closed list starts a fresh session. `asList` never closes, so its one
+      // reveal is on mount.
+      if (!open && !asList) revealedSelection.current = false
+    }, [open, asList])
+    useEffect(() => {
+      if (revealedSelection.current || positionIndex < 0) return
+      if (!open && !asList) return
+      revealedSelection.current = true
       virtualizer.scrollToIndex(positionIndex)
-    }, [virtualizer, positionIndex])
+    }, [asList, open, positionIndex, virtualizer])
 
     const virtualItems = virtualizer.getVirtualItems()
 
@@ -218,6 +244,16 @@ const SelectContent = forwardRef<
           height: virtualizer.getTotalSize() + VIEWBOX_VERTICAL_PADDING,
           width: "100%",
           position: "relative",
+          // ONE SCROLLPORT, and it is the ScrollArea's (`parentRef`, which is what
+          // the virtualizer measures and scrolls). This div is Radix's
+          // `Select.Viewport` via `asChild`, so Radix merges its own
+          // `overflow: hidden auto; flex: 1 1 0%` onto it — a SECOND scroller
+          // nested inside the first, and a spacer that flex could shrink below the
+          // height the virtualizer just gave it. Both are overridden here, where
+          // the child's style wins the merge: the wheel then moves one list
+          // instead of handing off between two.
+          overflow: "visible",
+          flex: "none",
         }}
       >
         <div


### PR DESCRIPTION
## Description

A grouped `F0Select` was hard to scroll: the wheel filled one scroller and then handed off to another, and expanding a group threw the list back to the selection. Both causes are in the shared `SelectContent`, so this fixes every select that virtualizes a long list — grouping just makes the list long enough to expose it.

## Type of change

- [x] Bug fix

## Lifecycle phase (if applicable)

Not applicable.

- Linked #f0-support thread: n/a
- Phase exit criteria met: n/a

## Screenshots (if applicable)

Measured in the browser rather than screenshotted, since the symptom is behavioural. Walking the open popover for elements that can scroll:

**Before** — two, one inside the other:

| depth | element | overflow-y |
| --- | --- | --- |
| 6 | `ScrollArea` viewport | `scroll` |
| 8 | Radix `Select.Viewport` | `auto` |

**After** — one:

| depth | element | overflow-y |
| --- | --- | --- |
| 6 | `ScrollArea` viewport | `scroll` |

The sizer now reports `overflow: visible; flex: 0 0 auto`.

Stories: `Select` → **With Data Source Grouping**, **With Many Collapsible Groups**.

## Implementation details

**Two nested scrollers.** The virtualized list is rendered through `SelectPrimitive.Viewport` with `asChild`, so Radix merges its own `overflow: hidden auto; flex: 1 1 0%` onto the **virtualizer's sizer** — the element whose only job is to be as tall as the list. That put a second scroll container inside the `ScrollArea` that already scrolls the list, and `flex: 1 1 0%` let the spacer be shrunk below the height the virtualizer had just given it, which is what made the inner one scrollable at all. The sizer now overrides both (`overflow: visible; flex: none`); the child wins Radix's style merge, which is how its `height` already reached the DOM. Note `asList` renders with no Radix viewport at all — one scrollport — which is why that mode never had the problem.

**The list jumped.** `virtualizer.scrollToIndex` ran from an effect keyed on the selected item's **index**, and that index moves whenever the list above it changes — exactly what expanding or collapsing a group does. Revealing the selection is an opening gesture, so it now fires once per open session (`asList` never closes, so its one reveal is on mount) and then stands down.

**`?? -1` instead of `|| 0`.** `findIndex` returns `-1` on a miss and `-1 || 0` is `-1` — truthy — so a select with nothing selected, or with its selection inside a collapsed group, handed `-1` to `scrollToIndex`, which clamps it and scrolled the list to the top. A miss now means "don't scroll".

### Checks

`tsc` clean, oxlint clean. 596 tests pass across `F0Select`, `ui/Select`, `BreadcrumbSelect`, `F0ButtonDropdown` and `F0Form` (which embeds selects). Added a regression test that the sizer is not a scroll container.

One caveat, stated plainly: the "expanding a group doesn't scroll the list" half has **no unit test**. jsdom has no layout, so the virtualizer's scroll is a no-op there and any assertion about it passes whether the bug is present or not — a green test would have been meaningless. That half is verified in a browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)