### PR TITLE
fix(F0DataChart): stop totalling grouped bar tooltips

### DIFF
--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1072,6 +1072,7 @@ describe("BarChart — item tooltip", () => {
     render(
       <F0DataChart
         type="bar"
+        stacked
         categories={["A", "B"]}
         series={[
           { name: "S1", data: [30, 10] },
@@ -1088,6 +1089,33 @@ describe("BarChart — item tooltip", () => {
     expect(html).toContain("30.0%")
     expect(html).toContain("of total")
     expect(html).toContain((100).toLocaleString())
+  })
+
+  // Side-by-side bars are independent measures, not parts of a whole: summing
+  // three average salaries produces a number that is not an average of
+  // anything, and a share of that sum makes the bars look like slices of a pie.
+  it("omits share and total on a grouped chart, however many series", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["Barcelona"]}
+        series={[
+          { name: "Not specified", data: [104000] },
+          { name: "Male", data: [45700] },
+          { name: "Female", data: [49500] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Barcelona",
+      seriesName: "Not specified",
+      value: 104000,
+      dataIndex: 0,
+    })
+    expect(html).toContain((104000).toLocaleString())
+    expect(html).not.toContain("of total")
+    expect(html).not.toContain("52.2%")
+    expect(html).not.toContain((199200).toLocaleString())
   })
 
   it("hides share of total for single-series charts", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1091,9 +1091,10 @@ describe("BarChart — item tooltip", () => {
     expect(html).toContain((100).toLocaleString())
   })
 
-  // Side-by-side bars are independent measures, not parts of a whole: summing
-  // three average salaries produces a number that is not an average of
-  // anything, and a share of that sum makes the bars look like slices of a pie.
+  // Nothing tells the component whether a grouped measure is additive, so it
+  // never totals a group. Here it shouldn't: summing three average salaries
+  // produces a number that is not an average of anything, and a share of that
+  // sum makes the bars look like slices of a pie.
   it("omits share and total on a grouped chart, however many series", () => {
     render(
       <F0DataChart

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -1191,7 +1191,7 @@ export function useBarChartOptions(
 
     // Bar charts use an item-triggered tooltip about the hovered bar or
     // segment (pairing with the stacked series highlight) instead of the axis
-    // tooltip listing every series: value large, then — with several
+    // tooltip listing every series: value large, then — on a stack of several
     // same-signed series — the hovered value's share of the category total,
     // that total, and the target when there is one.
     //
@@ -1214,22 +1214,30 @@ export function useBarChartOptions(
           const value = Number(p.value)
           const dataIndex = p.dataIndex ?? 0
           const target = targetMap.get(seriesName)?.[dataIndex]
-          // Share-of-total context only means something with several series
-          // pushing the same way: a single-series bar is always 100% of its own
-          // category, and a category mixing gains with losses has no "total"
-          // the parts add up to — 24 hires against a net of 19 would read as
-          // 126.3%, and near-cancellation makes that ratio arbitrarily large.
-          // Signed categories therefore show the value alone.
           const categoryValues = visibleSeries.map((s) => {
             // A series can be shorter than `categories`.
             const point = s.data[dataIndex]
             return point === undefined ? 0 : getValue(point) || 0
           })
+          // Only a stack has a total in the first place: its segments are
+          // parts of the very bar being hovered. Grouped bars are independent
+          // measures set side by side, so adding them up invents a quantity
+          // that describes nothing — three average salaries summed are not an
+          // average of anything, and a share of that sum makes separate
+          // measurements look like slices of one pie.
+          //
+          // Even stacked, the share only means something with several series
+          // pushing the same way: a single-series bar is always 100% of its own
+          // category, and a category mixing gains with losses has no "total"
+          // the parts add up to — 24 hires against a net of 19 would read as
+          // 126.3%, and near-cancellation makes that ratio arbitrarily large.
+          // Signed categories therefore show the value alone.
           const hasMixedSigns =
             categoryValues.some((v) => v > 0) &&
             categoryValues.some((v) => v < 0)
           const total = categoryValues.reduce((sum, v) => sum + v, 0)
-          const showTotal = visibleSeries.length > 1 && !hasMixedSigns
+          const showTotal =
+            stacked && visibleSeries.length > 1 && !hasMixedSigns
 
           // No "from previous" row here: bar categories are not necessarily a
           // sequence (locations, departments), so comparing a bar with the one

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -1214,17 +1214,15 @@ export function useBarChartOptions(
           const value = Number(p.value)
           const dataIndex = p.dataIndex ?? 0
           const target = targetMap.get(seriesName)?.[dataIndex]
-          const categoryValues = visibleSeries.map((s) => {
-            // A series can be shorter than `categories`.
-            const point = s.data[dataIndex]
-            return point === undefined ? 0 : getValue(point) || 0
-          })
-          // Only a stack has a total in the first place: its segments are
-          // parts of the very bar being hovered. Grouped bars are independent
-          // measures set side by side, so adding them up invents a quantity
-          // that describes nothing — three average salaries summed are not an
-          // average of anything, and a share of that sum makes separate
-          // measurements look like slices of one pie.
+          // Only a stack has a total this component can be sure of: its
+          // segments are parts of the very bar being hovered. Grouped bars
+          // sometimes add up to something real — male and female headcount
+          // side by side sums to the category's headcount — but just as often
+          // they don't: headcount, open positions and turnovers share an axis
+          // and nothing else, and three average salaries summed are not an
+          // average of anything. Layout is the only signal available here, so
+          // the guard gives up a right total on the additive groups to stop
+          // inventing one on the rest.
           //
           // Even stacked, the share only means something with several series
           // pushing the same way: a single-series bar is always 100% of its own
@@ -1232,12 +1230,23 @@ export function useBarChartOptions(
           // the parts add up to — 24 hires against a net of 19 would read as
           // 126.3%, and near-cancellation makes that ratio arbitrarily large.
           // Signed categories therefore show the value alone.
+          //
+          // Gated before the sum rather than after it: neither row can render
+          // on a grouped chart, so neither the map nor the reduce is worth
+          // running on every hover.
+          const stackHasTotal = stacked && visibleSeries.length > 1
+          const categoryValues = stackHasTotal
+            ? visibleSeries.map((s) => {
+                // A series can be shorter than `categories`.
+                const point = s.data[dataIndex]
+                return point === undefined ? 0 : getValue(point) || 0
+              })
+            : []
           const hasMixedSigns =
             categoryValues.some((v) => v > 0) &&
             categoryValues.some((v) => v < 0)
           const total = categoryValues.reduce((sum, v) => sum + v, 0)
-          const showTotal =
-            stacked && visibleSeries.length > 1 && !hasMixedSigns
+          const showTotal = stackHasTotal && !hasMixedSigns
 
           // No "from previous" row here: bar categories are not necessarily a
           // sequence (locations, departments), so comparing a bar with the one


### PR DESCRIPTION
## Description

A bar chart's item tooltip showed the hovered value's share of the category total whenever more than one series was visible, grouped charts included — but the sum of side-by-side bars is only a real quantity when those bars happen to be additive, and nothing tells the component whether they are. On "average base salary by workplace (male vs female)" it added three averages into a €199,229.86 "total" and reported the hovered bar as "52.2% of total", making separate measurements read as slices of a pie. Both rows are now gated on `stacked`, where the total genuinely is the length of the bar being hovered; grouped tooltips show the value (and target) alone.

**This is a trade-off, not a strict improvement.** A grouped headcount by gender *is* parts of a whole — male and female bars sum to the category's real headcount — and that chart loses a correct, useful row here. `stacked` is a proxy: layout is the only signal available, since the component has no way to know whether a measure is additive. Giving up a right number on the additive groups is the better side of the trade against shipping a wrong one on averages, rates and medians, but it is a trade rather than a strictly better rule. If a consumer turns up needing the total back, the escape hatch is an opt-in (`showCategoryTotal`) rather than reverting the guard.

## Screenshots (if applicable)

**Before** — `Bar/Multiple Series`, hovering New York's headcount. Headcount 145 is reported as "87.9% of total" of a 165 built from headcount + open positions + turnovers: three measures that share an axis and nothing else.

<img width="1268" height="768" alt="before-grouped" src="https://github.com/user-attachments/assets/2d4ddcb0-6a42-4d91-9724-2f93d81e0a0f" />

**After** — same bar, same hover. The invented total and its share are gone.

<img width="1268" height="768" alt="after-grouped" src="https://github.com/user-attachments/assets/d7a1d769-4303-446f-ae96-32b4b633464f" />

**Unchanged** — `Bar/Stacked` still shows both rows. Here the total is the height of the bar under the cursor, and the segments really are parts of it.

<img width="1268" height="768" alt="stacked-unchanged" src="https://github.com/user-attachments/assets/e57d7831-8bc1-4221-b8eb-7e993116a8a6" />

## Implementation details

- fix: show the share-of-total and total rows only on stacked bar charts

  <details>
  <summary>Why?</summary>

  The guard was `visibleSeries.length > 1 && !hasMixedSigns` — it asked how many series there were, never how they were laid out. Adding `stacked &&` is the whole behavior change; the rest of the diff is the comment explaining which chart shapes have a total at all, and tests.

  Non-additive metrics make the bug obvious (averages, rates, medians), and the `Bar/Multiple Series` shape is wrong on its own terms too: headcount, open positions and turnovers are not parts of one another. Additive groups are the case this costs something — see the trade-off note above.
  </details>

- perf: compute the category sum only when a total can render

  <details>
  <summary>Why?</summary>

  `categoryValues` (a map over every visible series) and `total` fed a `showTotal` that is now always `false` on grouped charts, so both ran on every hover and were thrown away. Gating them on the same condition also makes the intent readable off the code rather than only out of the comment.
  </details>

- test: cover a grouped chart showing no share and no total, and pin the existing multi-series case to `stacked` — which is what it was actually testing
