### PR TITLE
fix(F0Select): let custom triggers fill the container height

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -1197,8 +1197,16 @@ const F0SelectComponent = forwardRef(function Select<
      * overflowed a narrow column) nor stretched (it left a gap inside it). A plain
      * full-width block passes the width straight through, which is all this
      * wrapper is for.
+     *
+     * Custom triggers also get `h-full`: they center their content against the
+     * consumer's fixed-height container (e.g. F0PhoneInput's country trigger),
+     * and this box must pass that height through like it passes the width.
      */
-    const box = <div className="w-full min-w-0">{trigger}</div>
+    const box = (
+      <div className={cn("w-full min-w-0", children && "h-full")}>
+        {trigger}
+      </div>
+    )
 
     return selectedTooltipText ? (
       <TooltipInternal
@@ -1259,7 +1267,7 @@ const F0SelectComponent = forwardRef(function Select<
       <SelectTrigger ref={ref} asChild>
         {children ? (
           <div
-            className="flex w-full items-center justify-between"
+            className="flex h-full w-full items-center justify-between"
             aria-label={label || placeholder}
           >
             {children}

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -1203,7 +1203,7 @@ const F0SelectComponent = forwardRef(function Select<
      * and this box must pass that height through like it passes the width.
      */
     const box = (
-      <div className={cn("w-full min-w-0", children && "h-full")}>
+      <div className={cn("w-full min-w-0", !!children && "h-full")}>
         {trigger}
       </div>
     )

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -1414,6 +1414,8 @@ export const WithCustomTrigger: Story = {
 }
 
 export const CustomTriggerFillsContainerHeight: Story = {
+  // A regression guard, not documentation
+  tags: ["!dev"],
   args: {
     label: "Choose a color",
     onChange: fn(),
@@ -1443,16 +1445,16 @@ export const CustomTriggerFillsContainerHeight: Story = {
     /*
      * A custom trigger sizes its content against the consumer's container, so
      * every wrapper F0Select renders in between has to pass that height
-     * through. Asserted in real pixels because a wrapper that swallows the
-     * height still renders a perfectly valid DOM, with a 1px tolerance for
-     * subpixel layout under display scaling.
+     * through — a wrapper that swallows it still renders a valid DOM, so this
+     * has to be real pixels. 1px tolerance for subpixel display scaling.
      */
     const trigger = canvas.getByRole("combobox")
-    const field = canvas.getByTestId("fixed-height-field")
-    const drift = Math.abs(
-      trigger.getBoundingClientRect().height -
-        field.getBoundingClientRect().height
-    )
+    const fieldHeight = canvas
+      .getByTestId("fixed-height-field")
+      .getBoundingClientRect().height
+    // Without layout (0 vs 0) the comparison below would pass vacuously
+    await expect(fieldHeight).toBeGreaterThan(0)
+    const drift = Math.abs(trigger.getBoundingClientRect().height - fieldHeight)
     await expect(drift).toBeLessThanOrEqual(1)
   },
 }

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -1413,6 +1413,50 @@ export const WithCustomTrigger: Story = {
   ),
 }
 
+export const CustomTriggerFillsContainerHeight: Story = {
+  args: {
+    label: "Choose a color",
+    onChange: fn(),
+    value: "red",
+    options: [
+      { value: "red", label: "Red" },
+      { value: "green", label: "Green" },
+    ],
+  },
+  render: ({ value, options, onChange, ...args }) => (
+    <div className="flex h-10 items-center" data-testid="fixed-height-field">
+      <div className="h-full shrink-0">
+        <F0Select
+          label="Choose a color"
+          value={value}
+          options={options}
+          onChange={onChange}
+          {...args}
+        >
+          <span className="flex h-full items-center px-2">Red</span>
+        </F0Select>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    /*
+     * A custom trigger sizes its content against the consumer's container, so
+     * every wrapper F0Select renders in between has to pass that height
+     * through. Asserted in real pixels because a wrapper that swallows the
+     * height still renders a perfectly valid DOM, with a 1px tolerance for
+     * subpixel layout under display scaling.
+     */
+    const trigger = canvas.getByRole("combobox")
+    const field = canvas.getByTestId("fixed-height-field")
+    const drift = Math.abs(
+      trigger.getBoundingClientRect().height -
+        field.getBoundingClientRect().height
+    )
+    await expect(drift).toBeLessThanOrEqual(1)
+  },
+}
+
 export const WithOnCreate: Story = {
   args: {
     label: "Select Employee",

--- a/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.stories.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.stories.tsx
@@ -60,6 +60,16 @@ export const Prefilled: Story = {
     const input = canvas.getByRole("textbox")
     await expect(input).toHaveValue("674 89 79 45")
     await expect(canvas.getByText("+34")).toBeInTheDocument()
+    // The country trigger spans the field, so flag, dial code and number share
+    // a baseline — it collapses whenever F0Select stops passing height through.
+    // Compared with a 1px tolerance: layout is subpixel under display scaling
+    // while clientHeight is rounded, and the collapse this guards is ~10px
+    const trigger = canvas.getByTestId("phone-input-country-trigger")
+    const field = canvas.getByTestId("input-field-wrapper")
+    const drift = Math.abs(
+      trigger.getBoundingClientRect().height - field.clientHeight
+    )
+    await expect(drift).toBeLessThanOrEqual(1)
   },
 }
 

--- a/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.stories.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/__stories__/F0PhoneInput.stories.tsx
@@ -41,6 +41,31 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {}
 
+/**
+ * The country trigger spans the field, so flag, dial code and number share a
+ * baseline — it collapses whenever F0Select stops passing the height through.
+ * Measured against the field's content box, which is what the trigger's
+ * `h-full` resolves against: `clientHeight` on its own would silently fold in
+ * any padding the field grows later and fail an alignment that is still right.
+ * 1px tolerance because layout is subpixel under display scaling while the
+ * content box is rounded, and the collapse this guards is ~10px.
+ */
+const expectCountryTriggerSpansField = async (
+  canvas: ReturnType<typeof within>
+) => {
+  const trigger = canvas.getByTestId("phone-input-country-trigger")
+  const field = canvas.getByTestId("input-field-wrapper")
+  const { paddingTop, paddingBottom } = getComputedStyle(field)
+  const fieldHeight =
+    field.clientHeight -
+    (parseFloat(paddingTop) || 0) -
+    (parseFloat(paddingBottom) || 0)
+  // Without layout (0 vs 0) the comparison below would pass vacuously
+  await expect(fieldHeight).toBeGreaterThan(0)
+  const drift = Math.abs(trigger.getBoundingClientRect().height - fieldHeight)
+  await expect(drift).toBeLessThanOrEqual(1)
+}
+
 export const NoDefaultCountry: Story = {
   args: {
     defaultCountry: undefined,
@@ -48,6 +73,8 @@ export const NoDefaultCountry: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
     await expect(canvas.queryByText(/^\+\d/)).not.toBeInTheDocument()
+    // Nothing selected: F0Select renders the trigger box without its tooltip
+    await expectCountryTriggerSpansField(canvas)
   },
 }
 
@@ -60,16 +87,7 @@ export const Prefilled: Story = {
     const input = canvas.getByRole("textbox")
     await expect(input).toHaveValue("674 89 79 45")
     await expect(canvas.getByText("+34")).toBeInTheDocument()
-    // The country trigger spans the field, so flag, dial code and number share
-    // a baseline — it collapses whenever F0Select stops passing height through.
-    // Compared with a 1px tolerance: layout is subpixel under display scaling
-    // while clientHeight is rounded, and the collapse this guards is ~10px
-    const trigger = canvas.getByTestId("phone-input-country-trigger")
-    const field = canvas.getByTestId("input-field-wrapper")
-    const drift = Math.abs(
-      trigger.getBoundingClientRect().height - field.clientHeight
-    )
-    await expect(drift).toBeLessThanOrEqual(1)
+    await expectCountryTriggerSpansField(canvas)
   },
 }
 


### PR DESCRIPTION
## Description

`F0PhoneInput`'s country trigger wraps itself in `h-full` to size against the field, but F0Select never passed that height down: neither the tooltip box nor the element Radix's `SelectTrigger` renders onto has a height, so `height: 100%` resolved against an auto-height parent and collapsed to content height. The flag, dial code and chevron sat ~5px above the number's baseline.

Not a regression from #5074 — measured in Chromium on the real class chain, the trigger was 23px in a 30px field both before and after that PR, and is 30px with this patch. The break dates from `F0PhoneInput` itself (#4880), which was written against a height chain that never conducted. It surfaced while adopting the component in Factorial's ATS edit-phone modal (factorialco/factorial#109580).

## Type of change

- [x] Bug fix

## Implementation details

Pass `h-full` through both elements F0Select renders in custom-trigger mode — the tooltip box and the `SelectTrigger` element — mirroring how both already pass the width through. Both are load-bearing: each in turn has to have a definite height for the next `height: 100%` to resolve. Default (non-custom) triggers are untouched and keep their intrinsic height.

The `children` gate on the box is scoping rather than correctness: measured with the gate removed, the default field is unchanged, because the box growing does not stretch the `F0InputField` inside it. The gate stays because the class has no business being on a trigger that never reads it.

## Verification

jsdom has no layout engine, so this needs real pixels. Measured with Playwright against local Storybook, across every custom-trigger consumer:

| Story | Trigger height before → after |
|---|---|
| Phone input / Prefilled | **20px → 30px** ✅ fixed |
| Phone input / No Default Country | **20px → 30px** ✅ fixed |
| ClockInControls / Sidebar / Breadcrumbs | unchanged |

The other three consumers have no definite-height container, so `h-full` resolves to `auto` there. Downstream in Factorial the custom-trigger consumers are `EntitySelectorV2`/`EmployeeSelectorV2` pass-throughs and ticketing's `CoverageHoursSection` — all in auto-height rows, so none of them move.

## Regression guards

Assertions that run in CI via `test-storybook` (Playwright), the only layer that can see this class of bug:

- **`F0Select` → `CustomTriggerFillsContainerHeight`** — a custom trigger inside a fixed-height container must match that container's height. Guards the contract for *every* consumer, and fails for any future wrapper inserted into the trigger chain. Tagged `!dev` since it is a guard rather than documentation.
- **`F0PhoneInput` → `Prefilled` and `NoDefaultCountry`** — both, because with a country selected the box renders inside the tooltip trigger and without one it renders bare; the two paths can diverge.

Verified both ways: they pass against the patched component and **fail against the unfixed one** (`F0Select` 1 failed / 44 passed, `F0PhoneInput` 2 failed / 8 passed).

The phone guard measures the field's **content box** — `clientHeight` minus computed vertical padding — because that is what `h-full` resolves against, so padding added later cannot fail an alignment that is still correct. Heights compare with a 1px tolerance (`getBoundingClientRect()` is a subpixel float, the content box is rounded); measured drift is <0.5px when the height passes through and ~10px when it does not. Each guard first asserts a non-zero container, so a layout-less environment fails loudly instead of passing `0 ≈ 0`.

Also green: `tsc`, oxlint, oxfmt, the F0Select + F0PhoneInput unit suites, and both story suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Before:

<img width="735" height="291" alt="Screenshot 2026-08-12 at 15 35 41" src="https://github.com/user-attachments/assets/55eb90b2-466d-4980-ada9-c630cea70792" />


After:

<img width="680" height="362" alt="Screenshot 2026-08-12 at 15 35 37" src="https://github.com/user-attachments/assets/761cd67a-282d-4a88-a2d9-de998e0613b7" />
