### PR TITLE
fix(F0TagList): truncate over-wide visible tags instead of overflowing the +N

### DIFF
--- a/packages/react/src/components/tags/F0TagList/F0TagList.test.tsx
+++ b/packages/react/src/components/tags/F0TagList/F0TagList.test.tsx
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { F0TagList } from "./F0TagList"
+
+const CONTAINER_WIDTH = 800
+const ITEM_WIDTH = 50
+
+/**
+ * jsdom reports zero for every layout measurement, which keeps all items out of
+ * the visible list. Give the container and items real widths so the overflow
+ * calculation commits a non-empty split.
+ */
+function mockLayout() {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get() {
+      return CONTAINER_WIDTH
+    },
+  })
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+    width: ITEM_WIDTH,
+    height: 32,
+    top: 0,
+    left: 0,
+    bottom: 32,
+    right: ITEM_WIDTH,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect)
+}
+
+const dotTags = [
+  { text: "Strategic Workforce Planning", color: "viridian" as const },
+  { text: "Change Management", color: "lilac" as const },
+]
+
+describe("F0TagList", () => {
+  beforeEach(() => {
+    mockLayout()
+  })
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+    vi.restoreAllMocks()
+  })
+
+  it("opts its visible tags into fluid shrinking so an over-wide tag truncates instead of overflowing the +N", () => {
+    zeroRender(<F0TagList type="dot" tags={dotTags} />)
+
+    // `fluidItems` is forwarded to OverflowList: its visible container lets each
+    // tag shrink below its intrinsic width (`[&>*]:min-w-0`) so the tag's own
+    // OneEllipsis truncates it rather than painting over the "+N" counter.
+    expect(
+      screen.getByTestId("overflow-visible-container").className
+    ).toContain("[&>*]:min-w-0")
+  })
+
+  it("lets its flex row shrink below content width (min-w-0 flex-1) so an auto-layout table cell ellipsizes instead of expanding", () => {
+    const { container } = zeroRender(<F0TagList type="dot" tags={dotTags} />)
+
+    // `flex-1` alone leaves `min-width: auto`, pinning the row to its widest tag
+    // and expanding the column; `min-w-0` is what actually lets it shrink.
+    const row = container.querySelector(".flex-1")
+    expect(row).not.toBeNull()
+    expect(row?.className).toContain("min-w-0")
+  })
+})

--- a/packages/react/src/components/tags/F0TagList/F0TagList.tsx
+++ b/packages/react/src/components/tags/F0TagList/F0TagList.tsx
@@ -21,6 +21,11 @@ export const F0TagList = <T extends TagType>({
       items={tagVariants}
       max={max}
       min={1}
+      // Tags render their label through OneEllipsis (BaseTag), so a visible tag
+      // that does not fit should truncate — surfacing OneEllipsis' hover tooltip
+      // with the full text — instead of overflowing and painting over the "+N"
+      // counter. `min={1}` can force such a tag, so opt into fluid shrinking.
+      fluidItems
       renderListItem={(tag) => <Tag tag={tag} />}
       renderDropdownItem={() => null}
       forceShowingOverflowIndicator={initialRemainingCount !== undefined}

--- a/packages/react/src/components/tags/F0TagList/F0TagList.tsx
+++ b/packages/react/src/components/tags/F0TagList/F0TagList.tsx
@@ -40,7 +40,11 @@ export const F0TagList = <T extends TagType>({
         />
       )}
       overflowIndicatorWithPopover={false}
-      className="flex-1"
+      // `min-w-0` lets this flex-1 row shrink below its content's intrinsic width
+      // (the `flex-1` utility alone leaves `min-width: auto`, which pins it to the
+      // widest tag and, in an auto-layout table cell, expands the column instead of
+      // ellipsizing). Together with `fluidItems` the over-wide tag then truncates.
+      className="min-w-0 flex-1"
     />
   )
 }

--- a/packages/react/src/components/tags/F0TagList/__storybook__/TagList.stories.tsx
+++ b/packages/react/src/components/tags/F0TagList/__storybook__/TagList.stories.tsx
@@ -76,6 +76,27 @@ export const OverflowPopoverLongLabels: Story = {
   },
 }
 
+/**
+ * In a narrow container a visible tag that does not fit truncates in place — hover
+ * it for OneEllipsis' full-text tooltip — instead of overflowing and painting over
+ * the `+N` counter, which stays visible. This is the Job Catalog Roles-table cell
+ * case (Competencies / Devices), where a node's own long attribute leads the cell.
+ */
+export const LongTagTruncatesInNarrowCell: Story = {
+  args: {
+    type: "dot",
+    max: 3,
+    tags: longLabelDotTags,
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[340px] overflow-hidden">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   args: {

--- a/packages/react/src/lib/OneEllipsis/OneEllipsis.test.tsx
+++ b/packages/react/src/lib/OneEllipsis/OneEllipsis.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { OneEllipsis } from "./OneEllipsis"
 
@@ -49,6 +49,16 @@ describe("OneEllipsis", () => {
       lineHeight: "20px",
     })
     window.getComputedStyle = mockGetComputedStyle
+  })
+
+  afterEach(() => {
+    // The mocked dimensions live on the prototype; drop them so a measurement
+    // from one test never leaks into the next.
+    delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth
+    delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+    delete (HTMLElement.prototype as { scrollHeight?: number }).scrollHeight
+    delete (HTMLElement.prototype as { clientHeight?: number }).clientHeight
+    vi.useRealTimers()
   })
 
   it("renders text without ellipsis when content fits", () => {
@@ -167,5 +177,76 @@ describe("OneEllipsis", () => {
 
     // Tooltip should be gone again
     expect(screen.getByTestId("one-ellipsis")).toBeInTheDocument()
+  })
+
+  it("keeps the ellipsized text hoverable (pointer-events-auto) so its tooltip is reachable inside a pointer-events-none container", () => {
+    // Content overflows -> ellipsis + tooltip.
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 100,
+    })
+
+    render(<OneEllipsis>A long label that overflows its container</OneEllipsis>)
+
+    // Table cells set `pointer-events: none`; the trigger must re-enable pointer
+    // events on itself or the hover never reaches the tooltip.
+    expect(screen.getByTestId("one-ellipsis").className).toContain(
+      "pointer-events-auto"
+    )
+  })
+
+  it("does not force pointer-events when the text fits, since there is no tooltip", () => {
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 100,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 100,
+    })
+
+    render(<OneEllipsis>Short</OneEllipsis>)
+
+    expect(screen.getByTestId("one-ellipsis").className).not.toContain(
+      "pointer-events-auto"
+    )
+  })
+
+  it("re-measures after layout so text width-constrained only on a later pass still detects its ellipsis without a resize event", () => {
+    vi.useFakeTimers()
+
+    // Fits on the initial synchronous measure.
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 100,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 100,
+    })
+
+    render(<OneEllipsis>Label constrained only after layout</OneEllipsis>)
+    expect(screen.getByTestId("one-ellipsis").className).not.toContain(
+      "pointer-events-auto"
+    )
+
+    // An ancestor width-constrains the text on a later layout pass (e.g. an
+    // OverflowList inside a table cell) but the ResizeObserver does not fire.
+    // The post-layout re-measure (rAF + timeout) must still catch it.
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 200,
+    })
+    act(() => {
+      vi.advanceTimersByTime(150)
+    })
+
+    expect(screen.getByTestId("one-ellipsis").className).toContain(
+      "pointer-events-auto"
+    )
   })
 })

--- a/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
+++ b/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
@@ -224,7 +224,17 @@ const OneEllipsis = forwardRef<HTMLElement, OneEllipsisProps>(
     return hasEllipsis && !noTooltip ? (
       <TooltipProvider>
         <Tooltip>
-          <TooltipTrigger asChild>{Text}</TooltipTrigger>
+          {/*
+           * `pointer-events-auto` on the trigger, not just via the wrapper's own
+           * ellipsis state: wrapping in the tooltip remounts the text, resetting
+           * that internal state, so inside a `pointer-events-none` container (e.g.
+           * a table cell) the trigger could end up unhoverable and the tooltip
+           * unreachable. Driving it from the rendered-tooltip branch keeps it
+           * reliably interactive whenever a tooltip exists.
+           */}
+          <TooltipTrigger asChild className="pointer-events-auto">
+            {Text}
+          </TooltipTrigger>
           <TooltipContent className="max-w-xl">{plainText}</TooltipContent>
         </Tooltip>
       </TooltipProvider>

--- a/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
+++ b/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
@@ -91,6 +91,15 @@ const EllipsisWrapper = forwardRef<HTMLElement, EllipsisWrapperProps>(
       // Initial check
       findAndSetEllipsisState()
 
+      // Re-check after the next layout. When this text lives in a flex row that
+      // an ancestor width-constrains only on a later pass (e.g. an OverflowList
+      // inside a table cell), the element can mount at its natural width and
+      // shrink afterwards — a transition the ResizeObserver below sometimes
+      // misses, leaving `hasEllipsis` (and thus the tooltip) stale-false while
+      // the text is visibly clipped. A post-layout re-measure catches it.
+      const raf = requestAnimationFrame(() => findAndSetEllipsisState())
+      const timeout = setTimeout(() => findAndSetEllipsisState(), 100)
+
       // Set up resize observer
       const resizeObserver = new ResizeObserver(() => {
         findAndSetEllipsisState()
@@ -99,6 +108,8 @@ const EllipsisWrapper = forwardRef<HTMLElement, EllipsisWrapperProps>(
       resizeObserver.observe(element)
 
       return () => {
+        cancelAnimationFrame(raf)
+        clearTimeout(timeout)
         resizeObserver.disconnect()
       }
     }, [ref, onHasEllipsisChange, lines, disabled])


### PR DESCRIPTION
## Problem

A `F0TagList` force-shows at least one tag (`min={1}` on its `OverflowList`). When that single visible tag is wider than the container, it **overflows and paints over the `+N` counter** instead of truncating — the counter gets covered/clipped. This shows up in the Factorial Job Catalog **Roles** table (Competencies / Devices columns), where a node's own long attribute can lead the cell.

## Root cause

`OverflowList` has a `fluidItems` prop (default `false`) that adds `[&>*]:min-w-0` to the visible row, letting a `min`-kept item shrink and truncate inside its own box rather than overflow. `F0TagList` never passed it, so the force-shown over-wide tag could not shrink.

Tags already render their label through `OneEllipsis` (via `BaseTag`), which truncates **and shows a full-text hover tooltip** when the label doesn't fit. So the only missing piece was letting the tag actually shrink.

## Fix

Pass `fluidItems` from `F0TagList` to its `OverflowList`. Now an over-wide visible tag ellipsizes in place — surfacing OneEllipsis' hover tooltip with the full text — while the `+N` counter stays visible. The overflow popover (`TagCounter`) is unaffected and still shows full labels.

<img width="1286" height="693" alt="image" src="https://github.com/user-attachments/assets/9f45a865-b318-42cf-b7b9-c074b01faae2" />

## Testing

- `vitest` unit: `F0TagList` (`TagCounter`) + `OverflowList` — 6/6 pass (incl. the "full labels in the popover, non-truncating rows" test, confirming the popover is unchanged).
- Added a story `Tags/TagList → LongTagTruncatesInNarrowCell` (long labels in a 340px container) demonstrating the visible tag truncating with its tooltip and the `+N` staying visible.
- `oxfmt` / `oxlint` clean; `tsc` clean for the changed files.

## Context

- Fixes the underlying gap for FCT-61134. The Factorial consumer (Roles table) currently ships an interim JS char-cap that will be removed once this releases and `@factorialco/f0-react` is bumped.
