### PR TITLE
feat(F0DataChart): show how many entities a segment covers

### DIFF
--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1300,6 +1300,189 @@ describe("BarChart — item tooltip", () => {
     expect(description).not.toContain("Category 21")
   })
 
+  // The count of entities behind a bar: how many people an average was taken
+  // over, which the plotted value alone never says.
+  describe("segment context", () => {
+    const salary = {
+      categories: ["Engineering", "Sales"],
+      series: [{ name: "Average salary", data: [52400, 41000] }],
+    }
+
+    it("adds a row naming what it counts", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          {...salary}
+          context={[{ name: "Active headcount", data: [1204, 380] }]}
+        />
+      )
+
+      const html = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Average salary",
+        value: 52400,
+        dataIndex: 0,
+      })
+      expect(html).toContain("1,204")
+      expect(html).toContain("Active headcount")
+    })
+
+    // The value formatter carries the plotted measure's unit. Running a
+    // headcount through it renders a different quantity, not a restyled one.
+    it("formats the count as a plain integer, never in the measure's unit", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          {...salary}
+          valueFormatter={(v) => `€${v.toLocaleString("en-US")}`}
+          context={[{ name: "Active headcount", data: [1204, 380] }]}
+        />
+      )
+
+      const html = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Average salary",
+        value: 52400,
+        dataIndex: 0,
+      })
+      expect(html).toContain("€52,400")
+      expect(html).toContain("1,204")
+      expect(html).not.toContain("€1,204")
+    })
+
+    it("reads a single entry for every series", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          categories={["Engineering"]}
+          series={[
+            { name: "Average salary", data: [52400] },
+            { name: "Median salary", data: [50000] },
+          ]}
+          context={[{ name: "Active headcount", data: [1204] }]}
+        />
+      )
+
+      const html = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Median salary",
+        value: 50000,
+        dataIndex: 0,
+      })
+      expect(html).toContain("1,204")
+    })
+
+    // A split chart's segment is a cell: the women in Engineering are not the
+    // people in Engineering, so each series carries its own counts.
+    it("picks the hovered series' entry when the chart is split", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          categories={["Engineering"]}
+          series={[
+            { name: "Female", data: [48900] },
+            { name: "Male", data: [55100] },
+          ]}
+          context={[
+            { name: "Active headcount", data: [612] },
+            { name: "Active headcount", data: [592] },
+          ]}
+        />
+      )
+
+      const html = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Male",
+        value: 55100,
+        dataIndex: 0,
+      })
+      expect(html).toContain("592")
+      expect(html).not.toContain("612")
+    })
+
+    it("omits the row when the entry has no count for that bar", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          {...salary}
+          context={[{ name: "Active headcount", data: [1204] }]}
+        />
+      )
+
+      const html = getTooltipFormatter()?.({
+        name: "Sales",
+        seriesName: "Average salary",
+        value: 41000,
+        dataIndex: 1,
+      })
+      expect(html).not.toContain("Active headcount")
+    })
+
+    // "1 people" is the sloppiness the formatter exists to avoid: only the
+    // count decides whether the label is singular.
+    it("lets a formatter inflect the label to agree with the count", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          {...salary}
+          context={[{ name: "Active headcount", data: [256, 1] }]}
+          contextLabelFormatter={(count) => (count === 1 ? "person" : "people")}
+        />
+      )
+
+      const many = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Average salary",
+        value: 52400,
+        dataIndex: 0,
+      })
+      const one = getTooltipFormatter()?.({
+        name: "Sales",
+        seriesName: "Average salary",
+        value: 41000,
+        dataIndex: 1,
+      })
+
+      // The count and its label sit in separate elements, so assert on each.
+      expect(many).toContain(">256<")
+      expect(many).toContain("people")
+      expect(many).not.toContain("Active headcount")
+      expect(one).toContain(">1<")
+      expect(one).toContain("person")
+    })
+
+    it("falls back to the entry name when no formatter is given", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          {...salary}
+          context={[{ name: "Active headcount", data: [1204, 380] }]}
+        />
+      )
+
+      const html = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Average salary",
+        value: 52400,
+        dataIndex: 0,
+      })
+      expect(html).toContain("Active headcount")
+    })
+
+    it("renders the usual tooltip when no context is given", () => {
+      render(<F0DataChart type="bar" {...salary} />)
+
+      const html = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Average salary",
+        value: 52400,
+        dataIndex: 0,
+      })
+      expect(html).toContain("52,400")
+      expect(html).not.toContain("headcount")
+    })
+  })
+
   it("lets a caller's own echartsOptions.tooltip win over the built-in one", () => {
     const ownFormatter = () => "custom tooltip"
     render(

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1400,6 +1400,36 @@ describe("BarChart — item tooltip", () => {
       expect(html).not.toContain("612")
     })
 
+    // With one entry it stands for every series. With several, a series that
+    // matches none has no count of its own — reporting the first entry's would
+    // be a plausible wrong number rather than a visible gap.
+    it("omits the row for an unmatched series when entries are per-series", () => {
+      render(
+        <F0DataChart
+          type="bar"
+          categories={["Engineering"]}
+          series={[
+            { name: "Female", data: [48900] },
+            { name: "Male", data: [55100] },
+            { name: "Not specified", data: [51000] },
+          ]}
+          context={[
+            { name: "Active headcount", data: [612] },
+            { name: "Active headcount", data: [592] },
+          ]}
+        />
+      )
+
+      const html = getTooltipFormatter()?.({
+        name: "Engineering",
+        seriesName: "Not specified",
+        value: 51000,
+        dataIndex: 0,
+      })
+      expect(html).not.toContain("Active headcount")
+      expect(html).not.toContain("612")
+    })
+
     it("omits the row when the entry has no count for that bar", () => {
       render(
         <F0DataChart

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -206,3 +206,92 @@ describe("LineChart — tooltip value formatting", () => {
     expect(hoverFirstPoint()).toContain("107,505 €")
   })
 })
+
+// The count of entities behind a plotted point — how many people an average
+// was taken over, which the value alone never says.
+describe("LineChart — segment context", () => {
+  const trend = {
+    categories: ["Jan", "Feb"],
+    series: [{ name: "Average absence days", data: [3.2, 4.1] }],
+  }
+
+  const hover = (dataIndex: number, seriesName = "Average absence days") =>
+    getLatestOption().tooltip?.formatter?.([
+      { axisValue: "Jan", seriesName, value: 3.2, dataIndex },
+    ])
+
+  it("adds a row naming what it counts", () => {
+    render(
+      <F0DataChart
+        type="line"
+        {...trend}
+        context={[{ name: "Active headcount", data: [1204, 380] }]}
+      />
+    )
+
+    const html = hover(0)
+    expect(html).toContain("1,204")
+    expect(html).toContain("Active headcount")
+  })
+
+  it("lets a formatter inflect the label to agree with the count", () => {
+    render(
+      <F0DataChart
+        type="line"
+        {...trend}
+        context={[{ name: "Active headcount", data: [256, 1] }]}
+        contextLabelFormatter={(count) => (count === 1 ? "person" : "people")}
+      />
+    )
+
+    expect(hover(0)).toContain("people")
+    expect(hover(1)).toContain("person")
+  })
+
+  // The value formatter carries the plotted measure's unit; a headcount is not
+  // measured in it.
+  it("formats the count as a plain integer, never in the measure's unit", () => {
+    render(
+      <F0DataChart
+        type="line"
+        {...trend}
+        valueFormatter={(v) => `${v} days`}
+        context={[{ name: "Active headcount", data: [1204, 380] }]}
+      />
+    )
+
+    const html = hover(0)
+    expect(html).toContain("1,204")
+    expect(html).not.toContain("1,204 days")
+  })
+
+  // A multi-series card already lists every series; per-series counts would
+  // double its length, so only a single shared entry earns a row there.
+  it("adds one shared row to a multi-series card", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["Jan"]}
+        series={[
+          { name: "Engineering", data: [3.2] },
+          { name: "Sales", data: [2.1] },
+        ]}
+        context={[{ name: "Active headcount", data: [1204] }]}
+      />
+    )
+
+    const html = getLatestOption().tooltip?.formatter?.([
+      { axisValue: "Jan", seriesName: "Engineering", value: 3.2, dataIndex: 0 },
+      { axisValue: "Jan", seriesName: "Sales", value: 2.1, dataIndex: 0 },
+    ])
+    expect(html).toContain("Engineering")
+    expect(html).toContain("Sales")
+    expect(html).toContain("1,204")
+  })
+
+  it("renders the usual tooltip when no context is given", () => {
+    render(<F0DataChart type="line" {...trend} />)
+
+    expect(hover(0)).not.toContain("headcount")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
@@ -160,3 +160,66 @@ describe("PieChart — tooltip", () => {
     expect(html).not.toContain("NaN")
   })
 })
+
+// A slice is a segment like a bar is: the count says how many entities the
+// share was computed over.
+describe("PieChart — segment context", () => {
+  const context = [{ name: "Active headcount", data: [1204, 380, 1] }]
+
+  it("adds a row naming what the slice counts", () => {
+    render(<F0DataChart {...pieProps} context={context} />)
+
+    const html = hover({ name: "Engineering", value: 45, dataIndex: 0 })
+    expect(html).toContain("1,204")
+    expect(html).toContain("Active headcount")
+  })
+
+  it("reads the entry for the hovered slice", () => {
+    render(<F0DataChart {...pieProps} context={context} />)
+
+    const html = hover({ name: "Design", value: 18, dataIndex: 1 })
+    expect(html).toContain("380")
+    expect(html).not.toContain("1,204")
+  })
+
+  it("lets a formatter inflect the label to agree with the count", () => {
+    render(
+      <F0DataChart
+        {...pieProps}
+        context={context}
+        contextLabelFormatter={(count) => (count === 1 ? "person" : "people")}
+      />
+    )
+
+    expect(hover({ name: "Product", value: 22, dataIndex: 2 })).toContain(
+      "person"
+    )
+    expect(hover({ name: "Engineering", value: 45, dataIndex: 0 })).toContain(
+      "people"
+    )
+  })
+
+  // The value formatter carries the plotted measure's unit, which a headcount
+  // is not measured in.
+  it("formats the count as a plain integer, never in the measure's unit", () => {
+    render(
+      <F0DataChart
+        {...pieProps}
+        context={context}
+        valueFormatter={(v) => `${v} FTE`}
+      />
+    )
+
+    const html = hover({ name: "Engineering", value: 45, dataIndex: 0 })
+    expect(html).toContain("45 FTE")
+    expect(html).toContain("1,204")
+    expect(html).not.toContain("1,204 FTE")
+  })
+
+  it("renders the usual tooltip when no context is given", () => {
+    render(<F0DataChart {...pieProps} />)
+
+    const html = hover({ name: "Engineering", value: 45, dataIndex: 0 })
+    expect(html).not.toContain("headcount")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
@@ -216,6 +216,16 @@ describe("PieChart — segment context", () => {
     expect(html).not.toContain("1,204 FTE")
   })
 
+  // Defaulting the index to 0 would report the first slice's count for every
+  // slice — the same number beside three different values, and no way to tell.
+  it("omits the row when the hovered slice cannot be identified", () => {
+    render(<F0DataChart {...pieProps} context={context} />)
+
+    const html = hover({ name: "Design", value: 18 })
+    expect(html).not.toContain("Active headcount")
+    expect(html).not.toContain("1,204")
+  })
+
   it("renders the usual tooltip when no context is given", () => {
     render(<F0DataChart {...pieProps} />)
 

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -10,6 +10,8 @@ import type {
   F0DataChartBarSeries,
 } from "../../types"
 
+import type { ValueTooltipRow } from "../../utils/options"
+
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
 import {
   buildBaseChartOptions,
@@ -846,6 +848,8 @@ export function useBarChartOptions(
   {
     categories,
     series,
+    context,
+    contextLabelFormatter,
     orientation = "vertical",
     stacked = false,
     showLegend = true,
@@ -1189,6 +1193,32 @@ export function useBarChartOptions(
           })
     }
 
+    // How many entities the hovered bar covers. Counts are formatted as plain
+    // integers rather than through `formatTooltipValue`: that formatter carries
+    // the plotted measure's unit, and a headcount shown as "€1,204.00" is a
+    // different quantity, not a differently styled one.
+    //
+    // Resolved by series NAME, because a target ghost series shifts the indices
+    // ECharts reports; `context` is indexed against the props `series` array.
+    // A single entry serves every series — the population of a category does
+    // not change with the measure plotted against it.
+    const contextRow = (
+      seriesName: string,
+      dataIndex: number
+    ): ValueTooltipRow | undefined => {
+      if (!context?.length) return undefined
+
+      const entry = context[series.findIndex((s) => s.name === seriesName)]
+      const resolved = entry ?? context[0]
+      const count = resolved?.data[dataIndex]
+      if (count === undefined || !Number.isFinite(count)) return undefined
+
+      return {
+        value: count.toLocaleString(),
+        label: contextLabelFormatter?.(count) ?? resolved.name,
+      }
+    }
+
     // Bar charts use an item-triggered tooltip about the hovered bar or
     // segment (pairing with the stacked series highlight) instead of the axis
     // tooltip listing every series: value large, then — on a stack of several
@@ -1273,6 +1303,7 @@ export function useBarChartOptions(
                   value: formatTooltipValue(target),
                   label: i18n.dataChart.tooltip.target,
                 },
+                contextRow(seriesName, dataIndex),
               ],
             },
             theme
@@ -1359,6 +1390,8 @@ export function useBarChartOptions(
   }, [
     categories,
     series,
+    context,
+    contextLabelFormatter,
     orientation,
     stacked,
     showLegend,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -1208,10 +1208,16 @@ export function useBarChartOptions(
     ): ValueTooltipRow | undefined => {
       if (!context?.length) return undefined
 
+      // Falling back to the first entry is only right for the single-entry
+      // case above, where one count genuinely describes every series. With
+      // several entries an unmatched series has no count of its own, and
+      // entry 0's would be a plausible wrong number rather than a visible gap.
       const entry = context[series.findIndex((s) => s.name === seriesName)]
-      const resolved = entry ?? context[0]
+      const resolved = entry ?? (context.length === 1 ? context[0] : undefined)
       const count = resolved?.data[dataIndex]
-      if (count === undefined || !Number.isFinite(count)) return undefined
+      if (!resolved || count === undefined || !Number.isFinite(count)) {
+        return undefined
+      }
 
       return {
         value: count.toLocaleString(),

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -10,6 +10,8 @@ import type {
   F0DataChartLineType,
 } from "../../types"
 
+import type { ValueTooltipRow } from "../../utils/options"
+
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
 import {
   buildBaseChartOptions,
@@ -146,6 +148,8 @@ export function useLineChartOptions(
   {
     categories,
     series,
+    context,
+    contextLabelFormatter,
     lineType = "linear",
     showArea = true,
     showDots = false,
@@ -200,6 +204,27 @@ export function useLineChartOptions(
       valueFormatter
     )
 
+    // How many entities the hovered point covers. Formatted as a plain integer
+    // rather than through `formatTooltipValue`, which carries the plotted
+    // measure's unit — a headcount shown as "€1,204.00" is a different
+    // quantity, not a differently styled one.
+    const contextRow = (
+      seriesName: string,
+      dataIndex: number
+    ): ValueTooltipRow | undefined => {
+      if (!context?.length) return undefined
+
+      const entry =
+        context[series.findIndex((s) => s.name === seriesName)] ?? context[0]
+      const count = entry?.data[dataIndex]
+      if (count === undefined || !Number.isFinite(count)) return undefined
+
+      return {
+        value: count.toLocaleString(),
+        label: contextLabelFormatter?.(count) ?? entry.name,
+      }
+    }
+
     // Lines keep the axis trigger — a line is too thin to hover reliably —
     // but render the shared tooltip card. With one series that is the same
     // card every other chart type shows; with several, the category heads
@@ -238,20 +263,33 @@ export function useLineChartOptions(
                 i18n.dataChart.tooltip.fromPrevious,
                 theme
               ),
+              contextRow(String(first.seriesName ?? ""), dataIndex),
             ],
           },
           theme
         )
       }
 
+      // The multi-series card is already a list of series, so a count per
+      // series would double its length. One entry means one population for the
+      // whole category, which is a single honest row; per-series counts belong
+      // to marks the reader can hover individually.
+      const sharedContext =
+        context?.length === 1 && points[0]
+          ? contextRow(String(points[0].seriesName ?? ""), points[0].dataIndex ?? 0)
+          : undefined
+
       return renderValueTooltip(
         {
           title: category,
-          rows: points.map((point) => ({
-            marker: point.marker,
-            value: formatTooltipValue(Number(point.value)),
-            label: String(point.seriesName ?? ""),
-          })),
+          rows: [
+            ...points.map((point) => ({
+              marker: point.marker,
+              value: formatTooltipValue(Number(point.value)),
+              label: String(point.seriesName ?? ""),
+            })),
+            sharedContext,
+          ],
         },
         theme
       )
@@ -278,6 +316,8 @@ export function useLineChartOptions(
   }, [
     categories,
     series,
+    context,
+    contextLabelFormatter,
     lineType,
     showArea,
     showDots,

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -214,10 +214,16 @@ export function useLineChartOptions(
     ): ValueTooltipRow | undefined => {
       if (!context?.length) return undefined
 
-      const entry =
-        context[series.findIndex((s) => s.name === seriesName)] ?? context[0]
+      // One entry serves every series — a category's population does not
+      // change with the measure plotted against it. That fallback is only
+      // right for the single-entry case: with several, an unmatched series has
+      // no count of its own, and entry 0's would be a plausible wrong number.
+      const matched = context[series.findIndex((s) => s.name === seriesName)]
+      const entry = matched ?? (context.length === 1 ? context[0] : undefined)
       const count = entry?.data[dataIndex]
-      if (count === undefined || !Number.isFinite(count)) return undefined
+      if (!entry || count === undefined || !Number.isFinite(count)) {
+        return undefined
+      }
 
       return {
         value: count.toLocaleString(),
@@ -276,7 +282,10 @@ export function useLineChartOptions(
       // to marks the reader can hover individually.
       const sharedContext =
         context?.length === 1 && points[0]
-          ? contextRow(String(points[0].seriesName ?? ""), points[0].dataIndex ?? 0)
+          ? contextRow(
+              String(points[0].seriesName ?? ""),
+              points[0].dataIndex ?? 0
+            )
           : undefined
 
       return renderValueTooltip(

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -183,8 +183,12 @@ export function usePieChartOptions(
           // A pie has one series, so a single context entry covers every
           // slice. Counts stay plain integers: `formatTooltipValue` carries
           // the plotted measure's unit, and a headcount is not in euros.
+          // No `?? 0` on the index: without one there is no way to tell which
+          // slice is hovered, and defaulting would report slice 0's count for
+          // every one of them.
           const entry = context?.[0]
-          const count = entry?.data[p.dataIndex ?? 0]
+          const count =
+            p.dataIndex === undefined ? undefined : entry?.data[p.dataIndex]
           const hasCount = count !== undefined && Number.isFinite(count)
           return renderValueTooltip(
             {

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -43,6 +43,8 @@ export function usePieChartOptions(
   containerRef: RefObject<HTMLDivElement | null>,
   {
     series,
+    context,
+    contextLabelFormatter,
     innerRadius = 0,
     showLegend = true,
     showLabels = true,
@@ -174,9 +176,16 @@ export function usePieChartOptions(
             name?: string
             value?: number
             percent?: number
+            dataIndex?: number
           }
           const val = Number(p.value ?? 0)
           const total = dataPoints.reduce((sum, point) => sum + point.value, 0)
+          // A pie has one series, so a single context entry covers every
+          // slice. Counts stay plain integers: `formatTooltipValue` carries
+          // the plotted measure's unit, and a headcount is not in euros.
+          const entry = context?.[0]
+          const count = entry?.data[p.dataIndex ?? 0]
+          const hasCount = count !== undefined && Number.isFinite(count)
           return renderValueTooltip(
             {
               marker: p.marker,
@@ -191,6 +200,11 @@ export function usePieChartOptions(
                   value: formatTooltipValue(total),
                   label: i18n.dataChart.tooltip.total,
                 },
+                hasCount &&
+                  entry && {
+                    value: count.toLocaleString(),
+                    label: contextLabelFormatter?.(count) ?? entry.name,
+                  },
               ],
             },
             theme
@@ -207,6 +221,8 @@ export function usePieChartOptions(
     return baseOptions
   }, [
     series,
+    context,
+    contextLabelFormatter,
     innerRadius,
     showLegend,
     showLabels,

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -26,6 +26,7 @@ export type {
   F0DataChartScatterDataPoint,
   F0DataChartScatterProps,
   F0DataChartScatterSeries,
+  F0DataChartSegmentContext,
 } from "./types"
 
 export { DataChartEmptyStateView } from "./components/EmptyState/DataChartEmptyStateView"

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -59,6 +59,43 @@ export type F0DataChartBarDataPoint =
     }
 
 /**
+ * A count of the entities behind each segment of a chart — the population a
+ * value was computed over, carried alongside the plotted marks rather than as
+ * one of them.
+ */
+export interface F0DataChartSegmentContext {
+  /** What is being counted, e.g. "Active headcount". Labels the tooltip row. */
+  name: string
+  /** One count per segment, positionally aligned with the plotted data. */
+  data: number[]
+}
+
+/**
+ * Segment counts, shared by the chart types whose marks each stand for a group
+ * of entities: bar, line and pie.
+ */
+interface F0DataChartContextProps {
+  /**
+   * How many entities each mark covers, shown as a tooltip row beneath the
+   * value. The value alone never says it: an average salary of €52,400 reads
+   * very differently over 12 people than over 1,200.
+   *
+   * Never drawn — only the plotted series produces marks — so these counts
+   * cannot be mistaken for data of their own. Entries mirror the series by
+   * index; pass a single entry when one count covers every series (the
+   * population of a category does not change with the measure plotted against
+   * it) and one per series when a split gives each cell its own.
+   */
+  context?: F0DataChartSegmentContext[]
+  /**
+   * Name what a context count refers to, given the count itself — so the label
+   * can agree with it in number ("1 person" against "256 people"). Falls back
+   * to {@link F0DataChartSegmentContext.name}, which cannot inflect.
+   */
+  contextLabelFormatter?: (count: number) => string
+}
+
+/**
  * A series of bars to render in the chart.
  */
 export interface F0DataChartBarSeries {
@@ -136,7 +173,8 @@ interface F0DataChartBaseProps extends F0DataChartCommonProps {
 /**
  * Bar chart variant props.
  */
-export interface F0DataChartBarProps extends F0DataChartBaseProps {
+export interface F0DataChartBarProps
+  extends F0DataChartBaseProps, F0DataChartContextProps {
   /** Chart type */
   type: "bar"
   /** One or more data series to render as bars */
@@ -232,7 +270,8 @@ export interface F0DataChartBarProps extends F0DataChartBaseProps {
 /**
  * Line chart variant props.
  */
-export interface F0DataChartLineProps extends F0DataChartBaseProps {
+export interface F0DataChartLineProps
+  extends F0DataChartBaseProps, F0DataChartContextProps {
   /** Chart type */
   type: "line"
   /** One or more data series to render as lines */
@@ -370,7 +409,8 @@ export interface F0DataChartPieSeries {
  * Pies do NOT use category/value axes — segment names come from the data
  * points themselves. This interface is separate from `F0DataChartBaseProps`.
  */
-export interface F0DataChartPieProps extends F0DataChartCommonProps {
+export interface F0DataChartPieProps
+  extends F0DataChartCommonProps, F0DataChartContextProps {
   /** Chart type */
   type: "pie"
   /** The pie series to render */

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
@@ -354,6 +354,20 @@ function fetchSatisfactionScores(
         ],
       },
     ],
+    // An average of 4.2 says nothing about how many people it averages over —
+    // four responses or four hundred. The count rides alongside the series so
+    // the tooltip, the table view and the exports can all say which.
+    context: [
+      {
+        name: "Active headcount",
+        data: [
+          Math.round(145 * dm.Engineering),
+          Math.round(89 * dm.Product),
+          Math.round(67 * dm.Design),
+          Math.round(42 * dm.Marketing),
+        ],
+      },
+    ],
   }))
 }
 
@@ -926,6 +940,7 @@ export const mixedItems: DashboardItem<DashboardFiltersType>[] = [
     chart: {
       type: "bar",
       orientation: "horizontal",
+      contextLabelFormatter: (count) => (count === 1 ? "person" : "people"),
     },
     fetchData: fetchSatisfactionScores,
   },

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartDataToTabular.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartDataToTabular.test.ts
@@ -86,3 +86,102 @@ describe("chartDataToTabular — scatter", () => {
     expect(rows[0]).toMatchObject({ series: "Eng", x: 111, y: 9 })
   })
 })
+
+describe("chartDataToTabular — segment context", () => {
+  const barConfig = { type: "bar" } as const
+
+  const withContext: DashboardChartData = {
+    categories: ["Engineering", "Sales"],
+    series: [{ name: "Average salary", data: [52400, 41000] }],
+    context: [{ name: "Active headcount", data: [1204, 380] }],
+  }
+
+  it("adds the count as its own column", () => {
+    const { columns, rows } = chartDataToTabular(barConfig, withContext)
+
+    expect(columns).toEqual(["Category", "Average salary", "Active headcount"])
+    expect(rows).toEqual([
+      {
+        Category: "Engineering",
+        "Average salary": 52400,
+        context_0: 1204,
+      },
+      { Category: "Sales", "Average salary": 41000, context_0: 380 },
+    ])
+  })
+
+  // The label is data — on the chat path the series name is LLM-generated, so
+  // one colliding with the measure title is an ordinary outcome, not a bug.
+  it("keys the count column independently of its label", () => {
+    const { keys } = chartDataToTabular(barConfig, {
+      ...withContext,
+      series: [{ name: "Active headcount", data: [1, 2] }],
+    })
+
+    expect(keys).toEqual(["Category", "Active headcount", "context_0"])
+  })
+
+  it("names one column per series when the chart is split", () => {
+    const { columns, rows } = chartDataToTabular(barConfig, {
+      categories: ["Engineering"],
+      series: [
+        { name: "Female", data: [48900] },
+        { name: "Male", data: [55100] },
+      ],
+      context: [
+        { name: "Active headcount", data: [612] },
+        { name: "Active headcount", data: [592] },
+      ],
+    })
+
+    expect(columns).toEqual([
+      "Category",
+      "Female",
+      "Male",
+      "Active headcount (Female)",
+      "Active headcount (Male)",
+    ])
+    expect(rows[0]).toMatchObject({ context_0: 612, context_1: 592 })
+  })
+
+  it("leaves the table untouched when no context is present", () => {
+    const { columns, keys } = chartDataToTabular(barConfig, {
+      categories: ["Engineering"],
+      series: [{ name: "Average salary", data: [52400] }],
+    })
+
+    expect(columns).toEqual(["Category", "Average salary"])
+    expect(keys).toBeUndefined()
+  })
+})
+
+describe("chartDataToTabular — pie segment context", () => {
+  const pieConfig = { type: "pie" } as const
+
+  it("adds the count as its own column, keyed independently of its label", () => {
+    const { columns, keys, rows } = chartDataToTabular(pieConfig, {
+      series: {
+        name: "Average salary",
+        data: [
+          { name: "Engineering", value: 52400 },
+          { name: "Sales", value: 41000 },
+        ],
+      },
+      context: [{ name: "Active headcount", data: [1204, 380] }],
+    })
+
+    expect(columns).toEqual(["Name", "Value", "Active headcount"])
+    expect(keys).toEqual(["Name", "Value", "context_0"])
+    expect(rows[0]).toMatchObject({ Name: "Engineering", context_0: 1204 })
+    expect(rows[1]).toMatchObject({ Name: "Sales", context_0: 380 })
+  })
+
+  it("leaves the table untouched when no context is present", () => {
+    const { columns, keys } = chartDataToTabular(pieConfig, {
+      series: { name: "Average salary", data: [{ name: "Eng", value: 52400 }] },
+    })
+
+    expect(columns).toEqual(["Name", "Value"])
+    expect(keys).toBeUndefined()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
@@ -154,3 +154,58 @@ describe("buildChartProps — tooltipValueFormatter", () => {
     expect(props.tooltipValueFormatter).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// Segment counts have to survive the route the props actually take. A line item
+// takes the cross-type transform on EVERY render — `detectDataShape` reports
+// any array-series data as "bar", so a line's detected shape never equals its
+// target type — and that branch rebuilds the props from scratch.
+// ---------------------------------------------------------------------------
+
+describe("buildChartProps — segment context", () => {
+  const dataWithContext: DashboardChartData = {
+    categories: ["A", "B"],
+    series: [{ name: "X", data: [1, 2] }],
+    context: [{ name: "Active headcount", data: [1204, 380] }],
+  }
+
+  const contextItem = (chart: DashboardChartConfig): DashboardChartItem => ({
+    id: "item",
+    title: "Item",
+    type: "chart",
+    chart,
+    fetchData: () => Promise.resolve(dataWithContext),
+  })
+
+  const propsFor = (chart: DashboardChartConfig) =>
+    buildChartProps(contextItem(chart), dataWithContext) as {
+      context?: { name: string; data: number[] }[]
+      contextLabelFormatter?: (count: number) => string
+    }
+
+  it("reaches a line chart, which never takes the native path", () => {
+    const props = propsFor({ type: "line" })
+
+    expect(props.context).toEqual([
+      { name: "Active headcount", data: [1204, 380] },
+    ])
+  })
+
+  it("reaches a bar chart on the native path", () => {
+    expect(propsFor({ type: "bar" }).context).toEqual([
+      { name: "Active headcount", data: [1204, 380] },
+    ])
+  })
+
+  it("carries the label formatter through the transform too", () => {
+    const formatter = (count: number) => (count === 1 ? "person" : "people")
+    const props = propsFor({ type: "line", contextLabelFormatter: formatter })
+
+    expect(props.contextLabelFormatter).toBe(formatter)
+  })
+
+  // Its slices are not the categories the counts were aligned to.
+  it("does not hand counts to a type that cannot place them", () => {
+    expect(propsFor({ type: "funnel" }).context).toBeUndefined()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
@@ -204,8 +204,33 @@ describe("buildChartProps — segment context", () => {
     expect(props.contextLabelFormatter).toBe(formatter)
   })
 
+  // A pie's slices ARE the categories the counts were aligned to, and
+  // `pieToTabular` emits the context column either way — so without this the
+  // table kept a count column the tooltip had lost.
+  it("reaches a pie transformed from another type", () => {
+    expect(propsFor({ type: "pie" }).context).toEqual([
+      { name: "Active headcount", data: [1204, 380] },
+    ])
+  })
+
+  it("carries the label formatter to a pie as well", () => {
+    const formatter = (count: number) => `${count} people`
+    const props = propsFor({ type: "pie", contextLabelFormatter: formatter })
+
+    expect(props.contextLabelFormatter).toBe(formatter)
+  })
+
   // Its slices are not the categories the counts were aligned to.
   it("does not hand counts to a type that cannot place them", () => {
     expect(propsFor({ type: "funnel" }).context).toBeUndefined()
+  })
+
+  // The formatter travels with the counts. A funnel has no such prop, so
+  // passing it along would be handing a type a prop it does not accept.
+  it("does not hand the label formatter to a type that gets no counts", () => {
+    const formatter = (count: number) => `${count} people`
+    const props = propsFor({ type: "funnel", contextLabelFormatter: formatter })
+
+    expect(props.contextLabelFormatter).toBeUndefined()
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -215,6 +215,20 @@ export function buildChartProps(
   if ("showLegend" in item.chart) {
     shared.showLegend = item.chart.showLegend
   }
+  // Segment counts survive a transform between the types that render them.
+  // A line item reaches this path on every render, not just after a user
+  // transform: `detectDataShape` reports any array-series data as "bar", so a
+  // line's shape never equals its target type.
+  if (
+    "contextLabelFormatter" in item.chart &&
+    item.chart.contextLabelFormatter
+  ) {
+    shared.contextLabelFormatter = item.chart.contextLabelFormatter
+  }
+  const contextForTarget =
+    data.context && (targetType === "bar" || targetType === "line")
+      ? { context: data.context }
+      : {}
   // Only bar targets inherit the source config's `showLabels`. Other types keep
   // their own default, so transforming a pie (labels on by default) into a line
   // doesn't drag labels along. `undefined` is not an explicit value — letting it
@@ -241,6 +255,7 @@ export function buildChartProps(
         ...config,
         ...shared,
         ...(orientation ? { orientation } : {}),
+        ...contextForTarget,
         categories: adapted.categories ?? [],
         series: adapted.series,
       } as F0DataChartProps
@@ -249,6 +264,7 @@ export function buildChartProps(
       return {
         ...config,
         ...shared,
+        ...contextForTarget,
         categories: adapted.categories ?? [],
         series: adapted.series,
       } as F0DataChartProps
@@ -320,7 +336,11 @@ function buildNativeChartProps(
       return { ...chart, series: funnelSeries } as F0DataChartProps
     }
     case "pie":
-      return { ...chart, series: data.series } as F0DataChartProps
+      return {
+        ...chart,
+        series: data.series,
+        ...(data.context ? { context: data.context } : {}),
+      } as F0DataChartProps
     case "radar":
       return {
         ...chart,
@@ -362,6 +382,7 @@ function buildNativeChartProps(
         ...(chart.type === "bar"
           ? { showLabels: chart.showLabels ?? true }
           : {}),
+        ...(data.context ? { context: data.context } : {}),
         categories,
         series,
       } as F0DataChartProps

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -219,15 +219,25 @@ export function buildChartProps(
   // A line item reaches this path on every render, not just after a user
   // transform: `detectDataShape` reports any array-series data as "bar", so a
   // line's shape never equals its target type.
-  if (
-    "contextLabelFormatter" in item.chart &&
-    item.chart.contextLabelFormatter
-  ) {
-    shared.contextLabelFormatter = item.chart.contextLabelFormatter
-  }
+  //
+  // Bar, line and pie are the types that render a context row, matching the
+  // native path. Pie belongs here because `pieToTabular` emits the context
+  // column regardless: without it, transforming a bar into a pie left the
+  // table showing a count column the tooltip had lost. Slices come from the
+  // same categories the counts were aligned to, so the indices still line up.
+  //
+  // The formatter travels with the counts rather than in `shared`, which every
+  // branch spreads — a funnel or a gauge has no `contextLabelFormatter` prop.
   const contextForTarget =
-    data.context && (targetType === "bar" || targetType === "line")
-      ? { context: data.context }
+    data.context &&
+    (targetType === "bar" || targetType === "line" || targetType === "pie")
+      ? {
+          context: data.context,
+          ...("contextLabelFormatter" in item.chart &&
+          item.chart.contextLabelFormatter
+            ? { contextLabelFormatter: item.chart.contextLabelFormatter }
+            : {}),
+        }
       : {}
   // Only bar targets inherit the source config's `showLabels`. Other types keep
   // their own default, so transforming a pie (labels on by default) into a line
@@ -278,6 +288,7 @@ export function buildChartProps(
       return {
         ...config,
         ...shared,
+        ...contextForTarget,
         series: adapted.series,
       } as F0DataChartProps
     case "radar":

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -47,6 +47,12 @@ export interface BarChartConfig extends ChartConfigBase {
   orientation?: "vertical" | "horizontal"
   /** Stack all series into a single bar per category. @default false */
   stacked?: boolean
+  /**
+   * Name what {@link DashboardChartData.context} counts, given the count — so
+   * the tooltip label agrees with it in number ("1 person" against "256
+   * people"). Falls back to the context entry's own `name`.
+   */
+  contextLabelFormatter?: (count: number) => string
 }
 
 export interface LineChartConfig extends ChartConfigBase {
@@ -57,6 +63,12 @@ export interface LineChartConfig extends ChartConfigBase {
   showArea?: boolean
   /** Show data point dots on the lines. @default false */
   showDots?: boolean
+  /**
+   * Name what {@link DashboardChartData.context} counts, given the count — so
+   * the tooltip label agrees with it in number ("1 person" against "256
+   * people"). Falls back to the context entry's own `name`.
+   */
+  contextLabelFormatter?: (count: number) => string
 }
 
 export interface FunnelChartConfig {
@@ -105,6 +117,12 @@ export interface PieChartConfig {
    * while the tooltip carries the exact figure.
    */
   tooltipValueFormatter?: (value: number) => string
+  /**
+   * Name what {@link DashboardChartData.context} counts, given the count — so
+   * the tooltip label agrees with it in number ("1 person" against "256
+   * people"). Falls back to the context entry's own `name`.
+   */
+  contextLabelFormatter?: (count: number) => string
 }
 
 export interface RadarChartConfig {
@@ -226,6 +244,18 @@ export interface DashboardChartData {
     | { value: number; name?: string }
   /** Heatmap data points as [xIndex, yIndex, value] tuples. */
   data?: [number, number, number][]
+  /**
+   * How many entities each plotted segment covers — the population behind the
+   * value, which the value alone never states: an average salary of €52,400
+   * describes a very different team over 12 people than over 1,200.
+   *
+   * Mirrors {@link series}: one entry per series when the counts differ between
+   * them (a chart split by a dimension counts each cell), otherwise a single
+   * entry every series reads. Chart renderers draw `series` alone, so a count
+   * can never be plotted as a mark of its own — it reaches the reader through
+   * the table view, the exports, and the bar tooltip.
+   */
+  context?: { name: string; data: number[] }[]
   /**
    * Scatter series — x/y pairs, optionally split into color groups. Kept on
    * its own field rather than reusing `series` or `data` so shape detection

--- a/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartDataToTabular.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartDataToTabular.ts
@@ -64,6 +64,11 @@ export function chartDataToTabular(
   }
 }
 
+/** Row key for a context column, so a data-provided label can never claim it. */
+function contextKey(index: number): string {
+  return `context_${index}`
+}
+
 function barLineToTabular(data: DashboardChartData): TabularResult {
   const categories = data.categories ?? []
   const rawSeries = data.series
@@ -71,7 +76,7 @@ function barLineToTabular(data: DashboardChartData): TabularResult {
     | F0DataChartBarSeries[]
     | F0DataChartLineSeries[]
   const seriesNames = series.map((s: { name: string }) => s.name)
-  const columns = ["Category", ...seriesNames]
+  const context = data.context ?? []
 
   const rows = categories.map((cat, i) => {
     const row: Record<string, unknown> = { Category: cat }
@@ -80,10 +85,34 @@ function barLineToTabular(data: DashboardChartData): TabularResult {
         (s as { name: string; data: unknown[] }).data[i]
       )
     }
+    context.forEach((entry, entryIndex) => {
+      row[contextKey(entryIndex)] = entry.data[i] ?? null
+    })
     return row
   })
 
-  return { columns, rows }
+  if (context.length === 0) {
+    return { columns: ["Category", ...seriesNames], rows }
+  }
+
+  // Several entries mean one count per series, so each header has to say which
+  // series it counts — every entry carries the same measure name. A single
+  // entry counts the category itself and needs no qualifier.
+  const contextColumns = context.map((entry, entryIndex) => {
+    const seriesName = seriesNames[entryIndex]
+    return context.length > 1 && seriesName
+      ? `${entry.name} (${seriesName})`
+      : entry.name
+  })
+
+  return {
+    columns: [...["Category", ...seriesNames], ...contextColumns],
+    keys: [
+      ...["Category", ...seriesNames],
+      ...context.map((_, entryIndex) => contextKey(entryIndex)),
+    ],
+    rows,
+  }
 }
 
 function funnelToTabular(data: DashboardChartData): TabularResult {
@@ -114,13 +143,23 @@ function funnelToTabular(data: DashboardChartData): TabularResult {
 
 function pieToTabular(data: DashboardChartData): TabularResult {
   const series = data.series as F0DataChartPieSeries
+  // A pie has one series, so at most one context entry describes every slice.
+  const context = data.context?.[0]
   const rows = (series?.data ?? []).map(
-    (d: { name: string; value: number }) => ({
+    (d: { name: string; value: number }, index: number) => ({
       Name: d.name,
       Value: d.value,
+      ...(context ? { [contextKey(0)]: context.data[index] ?? null } : {}),
     })
   )
-  return { columns: ["Name", "Value"], rows }
+
+  if (!context) return { columns: ["Name", "Value"], rows }
+
+  return {
+    columns: ["Name", "Value", context.name],
+    keys: ["Name", "Value", contextKey(0)],
+    rows,
+  }
 }
 
 function radarToTabular(data: DashboardChartData): TabularResult {


### PR DESCRIPTION
## The problem

A chart states its value but not the population behind it. An average salary of €52,400 describes a very different team over 12 people than over 1,200, and nothing on screen says which. Today the only way to find out is to build a second widget.

## What this adds

An optional `context` on **bar, line and pie** — counts carried alongside the plotted marks rather than as marks of their own:

```
● Average base salary        ● United States
  United States                €48,347.66
  €48,347.66                   12.4% of total
  256 people                   €390,237.56 total
                               256 people
```

Renderers draw `series` alone, so a count can never be mistaken for data. It reaches the reader three ways, all from the single `chartDataToTabular` that feeds them: the **tooltip row**, the **table view**, and the **CSV and Excel exports**.

`contextLabelFormatter` names what is being counted *given the count*, so the label agrees with it in number — **"1 person"** against **"256 people"**. It falls back to the entry's own `name`, which cannot inflect, so consumers that don't pass one still get a sensible label.

## Decisions worth reviewing

**Counts render as plain integers, never through `valueFormatter`.** That formatter carries the plotted measure's unit; a headcount shown as "€1,204.00" is a different quantity, not a differently styled one.

**Entries mirror `series` by index.** A chart split by a dimension carries a count per cell — the women in Engineering are not the people in Engineering. A single entry serves every series, since a category's population doesn't change with the measure plotted against it.

**Funnel and scatter are excluded.** A funnel's stages are sequential steps of one process, where the count is usually the plotted value itself. A scatter names each point with an entity dimension (the schema's own example is `employee_full_name`), so every count would be 1.

**The line multi-series card takes one shared row, not one per series.** That card already lists every series; per-series counts would double its length.

## One bug worth calling out

`buildChartProps` needed the counts on **both** of its routes.

`detectDataShape` reports any array-series data as `"bar"` — it honours the hint for pie-vs-funnel but not bar-vs-line. So a line item's detected shape never equals its target type, and **every line chart renders through the cross-type transform branch on every render**, not just after a user transform. That branch rebuilds props from `defaultChartConfig` plus a fixed allowlist.

Passing the counts on the native path alone worked on bar and pie and silently did nothing on line. `chartLabelDefaults.test.ts` now pins both routes — the line case fails without the fix.

I deliberately did **not** change `detectDataShape` to honour the hint. That would put line back on the native path and is probably the right long-term fix, but it changes which config every existing line chart is built from — a deliberate change, not a side effect of this one.

## Testing

- 8 new tooltip tests across bar, line and pie: label, inflection, the plain-integer rule, per-series lookup on a split, missing counts, and the no-context fallback.
- Table/export coverage for bar and pie, including that the column is keyed independently of its data-provided label.
- `buildChartProps` tests pinning both prop-building routes.
- Storybook: hover *Satisfaction Scores* in `patterns-analyticsdashboard--mixed-dashboard`, and switch it to the table view.

Verified end to end in the Factorial app against real cube data on all three chart types.

The `BarChart.test.tsx` label-width failures noted in an earlier revision of this description are gone: they came from the unreviewed base commit, and #5097's merged version fixes them. This branch is now rebased straight onto `main` and the whole `F0DataChart` / `F0AnalyticsDashboard` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

