### PR TITLE
feat(ai): mention charts and data points in chat

### DIFF
--- a/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
@@ -1,0 +1,214 @@
+import type * as echarts from "echarts"
+import { useRef } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import type { F0DataChartPointClick } from "../types"
+
+import { usePointClick } from "../utils/usePointClick"
+
+/** Minimal stand-in for an ECharts instance: records handlers so tests can fire them. */
+function makeChartStub() {
+  const handlers: Record<string, ((params: unknown) => void)[]> = {}
+  const dispatched: { type: string }[] = []
+  let disposed = false
+  return {
+    handlers,
+    dispatched,
+    dispose: () => {
+      disposed = true
+    },
+    instance: {
+      on: (event: string, fn: (params: unknown) => void) => {
+        handlers[event] = [...(handlers[event] ?? []), fn]
+      },
+      off: (event: string, fn: (params: unknown) => void) => {
+        handlers[event] = (handlers[event] ?? []).filter((h) => h !== fn)
+      },
+      isDisposed: () => disposed,
+      dispatchAction: (action: { type: string }) => {
+        dispatched.push(action)
+      },
+    } as unknown as echarts.ECharts,
+  }
+}
+
+const Harness = ({
+  chart,
+  onPointClick,
+}: {
+  chart: echarts.ECharts
+  onPointClick?: (point: F0DataChartPointClick) => void
+}) => {
+  const ref = useRef<echarts.ECharts | null>(chart)
+  usePointClick(ref, onPointClick)
+  return null
+}
+
+const fire = (stub: ReturnType<typeof makeChartStub>, params: unknown) =>
+  stub.handlers["click"]?.forEach((h) => h(params))
+
+describe("usePointClick", () => {
+  it("reports the clicked mark, normalised", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Male",
+      seriesIndex: 1,
+      dataIndex: 0,
+      name: "Barcelona office",
+      value: 18,
+      event: { event: { clientX: 420, clientY: 260 } },
+    })
+
+    expect(onPointClick).toHaveBeenCalledWith({
+      seriesName: "Male",
+      category: "Barcelona office",
+      value: 18,
+      dataIndex: 0,
+      seriesIndex: 1,
+      clientX: 420,
+      clientY: 260,
+    })
+  })
+
+  it("takes the measure from the last entry of a tuple value (scatter)", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Salary vs tenure",
+      seriesIndex: 0,
+      dataIndex: 4,
+      name: "",
+      value: [3, 52000],
+    })
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 52000, category: "" })
+    )
+  })
+
+  it("dismisses the hover tooltip on a pick", () => {
+    const stub = makeChartStub()
+    render(<Harness chart={stub.instance} onPointClick={vi.fn()} />)
+
+    // Otherwise the tooltip and whatever answers the click stack over one mark.
+    fire(stub, { componentType: "series", seriesName: "Male", value: 18 })
+
+    expect(stub.dispatched).toEqual([{ type: "hideTip" }])
+  })
+
+  it("leaves the tooltip alone when the click is not a pick", () => {
+    const stub = makeChartStub()
+    render(<Harness chart={stub.instance} onPointClick={vi.fn()} />)
+
+    fire(stub, { componentType: "legend", name: "Male" })
+    fire(stub, { componentType: "series", seriesName: "Male", value: null })
+
+    expect(stub.dispatched).toEqual([])
+  })
+
+  it("falls back to 0,0 when the event carries no position", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, { componentType: "series", seriesName: "Male", value: 18 })
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ clientX: 0, clientY: 0 })
+    )
+  })
+
+  it("ignores clicks that are not on a series", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    // Axis labels and legend entries raise `click` too, and carry no value.
+    fire(stub, { componentType: "xAxis", value: "Barcelona office" })
+    fire(stub, { componentType: "legend", name: "Male" })
+
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("ignores a series click with no usable value", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    // A gap in the data must not be quoted. `Number(null)` and `Number("")`
+    // are both 0, so these would read as a real zero without an explicit guard.
+    fire(stub, { componentType: "series", seriesName: "Male", value: null })
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Male",
+      value: undefined,
+    })
+    fire(stub, { componentType: "series", seriesName: "Male", value: "" })
+    fire(stub, { componentType: "series", seriesName: "Male", value: "n/a" })
+
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("still reports a genuine zero", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Not specified",
+      name: "Tokyo office",
+      value: 0,
+    })
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 0 })
+    )
+  })
+
+  it("does nothing when no handler is supplied", () => {
+    const stub = makeChartStub()
+    render(<Harness chart={stub.instance} />)
+
+    // Binding still happens, so the listener must tolerate an absent handler.
+    expect(() =>
+      fire(stub, { componentType: "series", seriesName: "Male", value: 1 })
+    ).not.toThrow()
+  })
+
+  it("detaches on unmount", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    const { unmount } = render(
+      <Harness chart={stub.instance} onPointClick={onPointClick} />
+    )
+
+    unmount()
+
+    expect(stub.handlers["click"]).toHaveLength(0)
+    fire(stub, { componentType: "series", seriesName: "Male", value: 1 })
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("unmounts cleanly when the instance was already disposed", () => {
+    const stub = makeChartStub()
+    const { unmount } = render(
+      <Harness chart={stub.instance} onPointClick={vi.fn()} />
+    )
+
+    // `off` throws on a disposed instance, so cleanup has to skip it. The
+    // listener is left attached, which is harmless: a disposed chart emits
+    // nothing. Only the absence of a throw is meaningful here.
+    stub.dispose()
+    expect(() => unmount()).not.toThrow()
+  })
+})

--- a/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
@@ -7,6 +7,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useLegendSelection } from "../../utils/useLegendSelection"
 import {
@@ -28,6 +29,7 @@ export const BarChart = (props: F0DataChartBarProps) => {
   > | null>(null)
   const options = useBarChartOptions(ref, props, size, legendSelection)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef)

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -10,6 +10,7 @@ import type {
 
 import { formatPercent } from "../../utils/formatters"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useFunnelChartOptions } from "./useFunnelChartOptions"
 
@@ -37,6 +38,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
   const ref = useRef<HTMLDivElement>(null)
   const options = useFunnelChartOptions(ref, props)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   useLegendInteraction(chartRef)
 
   const sorted = sortFunnelData(series.data ?? [], sort)

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
@@ -5,6 +5,7 @@ import type { F0DataChartGaugeProps } from "../../types"
 import { resolveChartSize } from "../../utils/responsive"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useGaugeChartOptions } from "./useGaugeChartOptions"
 
 export const GaugeChart = (props: F0DataChartGaugeProps) => {
@@ -12,7 +13,8 @@ export const GaugeChart = (props: F0DataChartGaugeProps) => {
   const { width } = useContainerSize(ref)
   const size = resolveChartSize(width)
   const options = useGaugeChartOptions(ref, props, size)
-  useEChartsInstance(ref, options)
+  const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
 
   return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
@@ -9,6 +9,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useHeatmapChartOptions } from "./useHeatmapChartOptions"
 
 export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
@@ -18,6 +19,7 @@ export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
   const size = resolveChartSize(width)
   const options = useHeatmapChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
 

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -7,6 +7,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useLineChartOptions } from "./useLineChartOptions"
 
@@ -16,6 +17,7 @@ export const LineChart = (props: F0DataChartLineProps) => {
   const size = resolveChartSize(width)
   const options = useLineChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef)

--- a/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
@@ -5,6 +5,7 @@ import type { F0DataChartPieProps } from "../../types"
 import { resolveChartSize } from "../../utils/responsive"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { usePieChartOptions } from "./usePieChartOptions"
 
@@ -14,6 +15,7 @@ export const PieChart = (props: F0DataChartPieProps) => {
   const size = resolveChartSize(width)
   const options = usePieChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   useLegendInteraction(chartRef)
 
   return <div ref={ref} className="h-full w-full" />

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
@@ -5,6 +5,7 @@ import type { F0DataChartRadarProps } from "../../types"
 import { resolveChartSize } from "../../utils/responsive"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useRadarChartOptions } from "./useRadarChartOptions"
 
@@ -14,6 +15,7 @@ export const RadarChart = (props: F0DataChartRadarProps) => {
   const size = resolveChartSize(width)
   const options = useRadarChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   useLegendInteraction(chartRef)
 
   return <div ref={ref} className="h-full w-full" />

--- a/packages/react/src/kits/F0DataChart/components/ScatterChart/ScatterChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/ScatterChart/ScatterChart.tsx
@@ -7,6 +7,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useScatterChartOptions } from "./useScatterChartOptions"
 
@@ -16,6 +17,7 @@ export const ScatterChart = (props: F0DataChartScatterProps) => {
   const size = resolveChartSize(width)
   const options = useScatterChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef)

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -19,6 +19,7 @@ export type {
   F0DataChartPieDataPoint,
   F0DataChartPieProps,
   F0DataChartPieSeries,
+  F0DataChartPointClick,
   F0DataChartProps,
   F0DataChartRadarIndicator,
   F0DataChartRadarProps,

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -33,11 +33,43 @@ export interface F0DataChartEmptyStateProps {
 }
 
 /**
+ * The single mark a click landed on — one bar segment, one slice, one point.
+ *
+ * Note this is narrower than what an axis-triggered tooltip displays: hovering
+ * a category reveals every series at it, while a click can only ever identify
+ * the one mark under the cursor.
+ */
+export interface F0DataChartPointClick {
+  /** Series the mark belongs to, as shown in the legend ("Male"). */
+  seriesName: string
+  /** Category the mark sits at ("Barcelona office"). Empty for chart types with no category axis. */
+  category: string
+  /** Raw, unformatted value. Consumers apply their own formatting. */
+  value: number
+  /** Index of the clicked mark within its series. */
+  dataIndex: number
+  /** Index of the series the mark belongs to. */
+  seriesIndex: number
+  /**
+   * Where the click landed, in viewport coordinates — enough to anchor a
+   * floating element without the consumer having to reach for the chart's own
+   * geometry. Both are 0 if the event carried no position.
+   */
+  clientX: number
+  clientY: number
+}
+
+/**
  * Props shared by every `F0DataChart` variant.
  */
 interface F0DataChartCommonProps {
   /** Customize or opt out of the empty state shown when data is empty. */
   emptyState?: F0DataChartEmptyStateProps
+  /**
+   * Called when the user clicks a single mark (bar segment, slice, point).
+   * Omit to leave clicks inert, which is the default for every chart.
+   */
+  onPointClick?: (point: F0DataChartPointClick) => void
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
+++ b/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
@@ -1,0 +1,87 @@
+import type * as echarts from "echarts"
+import { type RefObject, useEffect, useRef } from "react"
+
+import type { F0DataChartPointClick } from "../types"
+
+/**
+ * Reports the single mark the user clicked — one bar segment, one slice, one
+ * point — normalised into {@link F0DataChartPointClick}.
+ *
+ * Works for every chart type because ECharts' item-level click params carry the
+ * same fields regardless of series type, so this binds once at the instance
+ * level rather than needing a variant per chart.
+ *
+ * Deliberately narrower than the hover tooltip: an axis-triggered tooltip shows
+ * every series at a category, but a click can only identify the mark under the
+ * cursor. Reconstructing the full category would mean reading back the option's
+ * series, which is a different feature.
+ *
+ * Dismisses the hover tooltip on a successful pick: the click is answered by
+ * something anchored at the same spot, and leaving the tooltip up would stack
+ * two floating panels over one mark.
+ */
+export function usePointClick(
+  chartRef: RefObject<echarts.ECharts | null>,
+  onPointClick: ((point: F0DataChartPointClick) => void) | undefined
+): void {
+  // Kept in a ref so a consumer passing an inline arrow doesn't detach and
+  // rebind the listener on every render.
+  const handlerRef = useRef(onPointClick)
+  handlerRef.current = onPointClick
+
+  useEffect(() => {
+    const chart = chartRef.current
+    if (!chart || typeof chart.on !== "function") return
+
+    const onClick = (params: unknown) => {
+      const handler = handlerRef.current
+      if (!handler) return
+
+      const p = params as {
+        componentType?: string
+        seriesName?: string
+        seriesIndex?: number
+        dataIndex?: number
+        name?: string
+        value?: unknown
+        // ECharts wraps the native event; `event.event` is the DOM original.
+        event?: { event?: { clientX?: number; clientY?: number } }
+      }
+
+      // Axis labels, legend entries and the like also raise `click`; only marks
+      // belonging to a series carry a value worth quoting.
+      if (p.componentType !== "series") return
+
+      // Bars and lines give a bare number; scatter and some stacked shapes give
+      // a tuple whose last entry is the measure.
+      const raw = Array.isArray(p.value) ? p.value[p.value.length - 1] : p.value
+      // `Number(null)` is 0 and `Number("")` is 0, so a gap in the data would
+      // otherwise be reported as a real zero.
+      if (raw === null || raw === undefined || raw === "") return
+      const value = Number(raw)
+      if (!Number.isFinite(value)) return
+
+      const native = p.event?.event
+
+      // `hideTip` is safe to fire even with no tooltip showing.
+      chart.dispatchAction({ type: "hideTip" })
+
+      handler({
+        seriesName: String(p.seriesName ?? ""),
+        category: String(p.name ?? ""),
+        value,
+        dataIndex: p.dataIndex ?? 0,
+        seriesIndex: p.seriesIndex ?? 0,
+        clientX: native?.clientX ?? 0,
+        clientY: native?.clientY ?? 0,
+      })
+    }
+
+    chart.on("click", onClick)
+    return () => {
+      // `off` throws on a disposed instance, which happens when the chart
+      // unmounts before this cleanup runs.
+      if (!chart.isDisposed?.()) chart.off("click", onClick)
+    }
+  }, [chartRef])
+}

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useEffect } from "react"
+
+import { F0AnalyticsDashboard } from "@/patterns/F0AnalyticsDashboard"
+import {
+  dashboardFilters,
+  dashboardPresets,
+  mixedItems,
+} from "@/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed"
+
+import { F0AiChat, F0AiChatProvider, useAiChat } from ".."
+
+import {
+  MockAiChatRuntimeProvider,
+  MockConnectedChatHeader,
+  MockConnectedChatInput,
+  MockConnectedMessagesContainer,
+} from "./_mock"
+
+/**
+ * Side-by-side harness: an editable dashboard on the left, the AI chat docked
+ * right — the arrangement the canvas mode produces in the real app, reduced to
+ * the two components the interaction spans.
+ */
+const WidgetDropLayout = () => {
+  const { setOpen } = useAiChat()
+
+  useEffect(() => {
+    setOpen(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    // `min-h-0` on both columns is load-bearing: flex items default to
+    // `min-height: auto`, so the tall dashboard would otherwise stretch the row
+    // (and with it the chat card) far past the viewport.
+    <div className="flex h-full w-full gap-2 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+        <F0AnalyticsDashboard
+          filters={dashboardFilters}
+          presets={dashboardPresets}
+          items={mixedItems}
+          editMode
+        />
+      </div>
+      <div className="flex min-h-0 w-[420px] shrink-0">
+        <F0AiChat
+          header={<MockConnectedChatHeader />}
+          messages={<MockConnectedMessagesContainer />}
+          input={<MockConnectedChatInput />}
+        />
+      </div>
+    </div>
+  )
+}
+
+const meta = {
+  title: "AI/F0AiChat/Widget drop",
+  component: F0AiChat,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["!autodocs", "experimental"],
+  decorators: [
+    (Story) => (
+      <div className="h-screen w-full overflow-hidden p-2">
+        <F0AiChatProvider enabled>
+          <MockAiChatRuntimeProvider>
+            <Story />
+          </MockAiChatRuntimeProvider>
+        </F0AiChatProvider>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof F0AiChat>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Drag a widget into the chat to quote it.
+ *
+ * Grab a widget by the drag handle that appears to the left of its header on
+ * hover, then move the cursor over the chat panel: it swaps to a dashed drop
+ * state reading **"Drop here to discuss with One"**. Release, and the widget's
+ * title lands in the composer's quote chip, ready for a question.
+ *
+ * Two things worth watching while dragging over the chat: the dashboard's own
+ * drop indicator disappears (releasing there must not also reorder the grid),
+ * and leaving the panel without releasing cancels cleanly.
+ */
+export const DragWidgetToQuote: Story = {
+  render: () => <WidgetDropLayout />,
+}

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  act,
+  fireEvent,
+  screen,
+  userEvent,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { WIDGET_DRAG_END, WIDGET_DRAG_START } from "@/lib/dnd/widgetDragEvents"
+
+import { F0AiChat } from "../F0AiChat"
+import {
+  AiChatStateProvider,
+  useAiChat,
+} from "../providers/AiChatStateProvider"
+
+const Probe = () => {
+  const { setOpen, pendingQuote } = useAiChat()
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open chat
+      </button>
+      <span data-testid="quote">{pendingQuote?.text ?? ""}</span>
+    </>
+  )
+}
+
+/**
+ * No `fileAttachments`, so the file-drop path is off throughout — these tests
+ * also cover that the widget overlay isn't gated behind an upload handler.
+ */
+const renderChat = () =>
+  render(
+    <AiChatStateProvider
+      enabled
+      chatHeader={<button type="button">Header action</button>}
+      chatMessages={<div>Messages</div>}
+      chatInput={<button type="button">Send</button>}
+    >
+      <Probe />
+      <F0AiChat />
+    </AiChatStateProvider>
+  )
+
+/** Stands in for the dashboard grid announcing a drag. */
+const startWidgetDrag = (title: string) =>
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(WIDGET_DRAG_START, { detail: { title } })
+    )
+  })
+
+const endWidgetDrag = () =>
+  act(() => {
+    window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
+  })
+
+const dropZone = () => {
+  const zone = document.querySelector("[data-ai-chat-dropzone]")
+  if (!(zone instanceof HTMLElement)) {
+    throw new Error("Expected the chat to expose a drop zone")
+  }
+  return zone
+}
+
+describe("F0AiChat widget drop", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("invites the drop as soon as the drag starts, before the pointer arrives", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+
+    startWidgetDrag("Headcount by department")
+
+    // No pointer has touched the chat — the announcement alone is enough.
+    expect(
+      screen.getByText("Drop here to discuss with One")
+    ).toBeInTheDocument()
+  })
+
+  it("quotes the dragged widget's title when released over the chat", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    startWidgetDrag("Headcount by department")
+    fireEvent.pointerUp(dropZone())
+
+    expect(screen.getByTestId("quote")).toHaveTextContent(
+      "Headcount by department"
+    )
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+  })
+
+  it("withdraws the invitation when the drag ends away from the chat", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    startWidgetDrag("Headcount by department")
+    endWidgetDrag()
+
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+
+    // A later stray release must not retroactively quote the widget.
+    fireEvent.pointerUp(dropZone())
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
+  })
+
+  it("ignores a release over the chat with no drag in flight", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    fireEvent.pointerUp(dropZone())
+
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
+  })
+
+  /**
+   * Regression guard. A fast drag can deliver the start announcement and the
+   * release inside a single React batch, so no re-render separates them. A
+   * release handler closing over the *state* would still read the pre-drag
+   * `null` and silently drop the quote — which is exactly what the real
+   * browser did before the payload moved into a ref. Both events go in one
+   * `act` here to reproduce that batching.
+   */
+  it("still quotes when start and release land in the same React batch", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(WIDGET_DRAG_START, {
+          detail: { title: "Headcount by department" },
+        })
+      )
+      fireEvent.pointerUp(dropZone())
+    })
+
+    expect(screen.getByTestId("quote")).toHaveTextContent(
+      "Headcount by department"
+    )
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -5,7 +5,10 @@ import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useMediaQuery } from "usehooks-ts"
 
+import type { WidgetDragStartDetail } from "@/lib/dnd/widgetDragEvents"
+
 import { useReducedMotion } from "@/lib/a11y"
+import { WIDGET_DRAG_END, WIDGET_DRAG_START } from "@/lib/dnd/widgetDragEvents"
 import { cn } from "@/lib/utils"
 
 import { DropOverlay } from "../../../F0AiChatTextArea"
@@ -47,6 +50,7 @@ export const SidebarWindow = ({
     fileDragOver,
     setFileDragOver,
     processDroppedFiles,
+    setPendingQuote,
     activeGame,
     closeGame,
     panelSide,
@@ -110,6 +114,52 @@ export const SidebarWindow = ({
     },
     [setFileDragOver]
   )
+
+  // ─── Dashboard widget drag → quote ──────────────────────────
+  // A widget drag is a plain pointer gesture, not native HTML5 drag-and-drop,
+  // so it fires no `dragenter` and the file handlers above never see it. The
+  // grid announces the gesture on `window` instead, which lets the invitation
+  // appear the moment the drag starts rather than when the cursor finally
+  // arrives — the user can see where the widget can go before aiming for it.
+  //
+  // The ref — not the state — is what the release reads, so a release that
+  // lands in the same React batch as the state update still sees the title
+  // instead of a stale `null`. The state exists to drive the overlay's render.
+  const dragQuoteRef = useRef<string | null>(null)
+  const [dragQuote, setDragQuote] = useState<string | null>(null)
+
+  const setDragQuoteBoth = useCallback((title: string | null) => {
+    dragQuoteRef.current = title
+    setDragQuote(title)
+  }, [])
+
+  useEffect(() => {
+    const onStart = (e: Event) => {
+      // Same freeze as the file drop: a clarifying flow owns the panel.
+      if (isClarifying) return
+      const detail = (e as CustomEvent<WidgetDragStartDetail>).detail
+      setDragQuoteBoth(detail?.title ?? "")
+    }
+    const onEnd = () => setDragQuoteBoth(null)
+
+    window.addEventListener(WIDGET_DRAG_START, onStart)
+    window.addEventListener(WIDGET_DRAG_END, onEnd)
+    return () => {
+      window.removeEventListener(WIDGET_DRAG_START, onStart)
+      window.removeEventListener(WIDGET_DRAG_END, onEnd)
+    }
+  }, [isClarifying, setDragQuoteBoth])
+
+  // Releasing over the chat quotes the widget. This is a handler on the card,
+  // so a release anywhere else simply never reaches it — the grid's own
+  // `pointerup` clears the invitation via WIDGET_DRAG_END.
+  const handlePointerUp = useCallback(() => {
+    const title = dragQuoteRef.current
+    if (title === null) return
+    setDragQuoteBoth(null)
+    if (title) setPendingQuote({ text: title })
+  }, [setDragQuoteBoth, setPendingQuote])
+
   const fullscreen = visualizationMode === "fullscreen"
   const [isResizing, setIsResizing] = useState(false)
   const isSmallScreen = useMediaQuery(`(max-width: ${breakpoints.md}px)`, {
@@ -206,22 +256,34 @@ export const SidebarWindow = ({
                   : "xs:rounded-r-xl"
                 : "xs:rounded-xl"
             )}
+            // Marks this card as a drop target for pointer-driven drags
+            // elsewhere in the app (the dashboard grid hit-tests for it to
+            // suppress its own reorder while the cursor is over the chat).
+            data-ai-chat-dropzone=""
             onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
+            onPointerUp={handlePointerUp}
           >
             <div className="relative flex h-full w-full flex-col overflow-hidden">
               {children}
             </div>
-            {canDrop && (
+            {/* `canDrop` gates only the file drop — quoting a dragged widget
+                needs no upload handler, so it renders on its own. */}
+            {(canDrop || dragQuote !== null) && (
               <DropOverlay
-                visible={fileDragOver}
-                onFilesDropped={(files) => {
-                  dragCounterRef.current = 0
-                  setFileDragOver(false)
-                  processDroppedFiles(files)
-                }}
+                visible={(canDrop && fileDragOver) || dragQuote !== null}
+                mode={dragQuote !== null ? "discuss" : "files"}
+                onFilesDropped={
+                  canDrop
+                    ? (files) => {
+                        dragCounterRef.current = 0
+                        setFileDragOver(false)
+                        processDroppedFiles(files)
+                      }
+                    : undefined
+                }
               />
             )}
             {activeGame === "pong" && <F0AiPong onClose={closeGame} />}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/DropOverlay.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/DropOverlay.tsx
@@ -1,15 +1,26 @@
 import { F0Icon } from "@/components/F0Icon/F0Icon"
-import { Upload } from "@/icons/app"
+import { Messages, Upload } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
 interface DropOverlayProps {
   visible: boolean
-  onFilesDropped: (files: File[]) => void
+  /**
+   * Handles a native file drop. Omit for `mode="discuss"`, where the drag is a
+   * pointer gesture and carries no `dataTransfer`.
+   */
+  onFilesDropped?: (files: File[]) => void
+  /** Which drop the overlay is inviting. */
+  mode?: "files" | "discuss"
 }
 
-export const DropOverlay = ({ visible, onFilesDropped }: DropOverlayProps) => {
+export const DropOverlay = ({
+  visible,
+  onFilesDropped,
+  mode = "files",
+}: DropOverlayProps) => {
   const translation = useI18n()
+  const isDiscuss = mode === "discuss"
 
   return (
     <div
@@ -31,15 +42,18 @@ export const DropOverlay = ({ visible, onFilesDropped }: DropOverlayProps) => {
       }}
       onDrop={(e) => {
         e.preventDefault()
+        if (!onFilesDropped) return
         const files = Array.from(e.dataTransfer.files)
         if (files.length > 0) {
           onFilesDropped(files)
         }
       }}
     >
-      <F0Icon icon={Upload} size="lg" color="bold" />
+      <F0Icon icon={isDiscuss ? Messages : Upload} size="lg" color="bold" />
       <p className="text-base font-normal text-f1-foreground">
-        {translation.ai.dropFilesHere}
+        {isDiscuss
+          ? translation.ai.dropWidgetToDiscuss
+          : translation.ai.dropFilesHere}
       </p>
     </div>
   )

--- a/packages/react/src/lib/dnd/widgetDragEvents.ts
+++ b/packages/react/src/lib/dnd/widgetDragEvents.ts
@@ -1,0 +1,17 @@
+/**
+ * Window events announcing a dashboard-widget drag, so drop targets elsewhere
+ * in the app can invite the drag from the moment it starts instead of waiting
+ * for the cursor to arrive.
+ *
+ * Deliberately plain DOM events rather than shared React state: the producer
+ * (`DashboardGrid`, a pattern) and the consumer (the AI chat panel, a kit)
+ * have no useful common ancestor to hang a context off, and neither needs to
+ * import the other. Promote this to context if a third party ever joins.
+ */
+export const WIDGET_DRAG_START = "f0:widget-drag-start"
+export const WIDGET_DRAG_END = "f0:widget-drag-end"
+
+export type WidgetDragStartDetail = {
+  /** Human-readable widget title, used as the quoted text. */
+  title: string
+}

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -453,6 +453,13 @@ export const defaultTranslations = {
       exporting: "Exporting…",
     },
     dashboardItem: {
+      /**
+       * Deliberately not `ai.ask` ("Ask One" by default here, but hosts
+       * override it — factorial renders it as plain "Ask" for the widget and
+       * insight-card buttons). This menu entry needs the product name spelled
+       * out, so it owns its own key.
+       */
+      askOne: "Ask One",
       chartType: "Chart type",
       errorTitle: "Error loading data",
       retry: "Retry",
@@ -487,6 +494,7 @@ export const defaultTranslations = {
       "Your message wasn't sent because one of the attachments failed to upload. Remove it or retry.",
     tooManyFilesError: "You can attach up to {{maxFiles}} files at once",
     dropFilesHere: "Drop your files here",
+    dropWidgetToDiscuss: "Drop here to discuss with One",
     reply: "Reply",
     removeQuote: "Remove quote",
     clarifyingQuestion: {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -370,6 +370,49 @@ describe("DashboardGrid", () => {
       expect(rowOrder(container)).toEqual(["category-totals", "expenses"])
     })
 
+    it("does not reorder when the gesture ends over the AI chat drop zone", () => {
+      const { container } = render(
+        <DashboardGrid items={makeCollectionItems(480)} filters={{}} editMode />
+      )
+      expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+
+      // Stand in for the chat panel. jsdom reports every rect as 0, so the
+      // zone has to report a real one for the containment check to mean
+      // anything — that zeroed default is also why the reorder test above is
+      // unaffected by this guard.
+      const chat = document.createElement("div")
+      chat.setAttribute("data-ai-chat-dropzone", "")
+      chat.getBoundingClientRect = () =>
+        ({ left: 400, right: 800, top: 0, bottom: 600 }) as unknown as DOMRect
+      document.body.appendChild(chat)
+
+      const grip = container.querySelector('[aria-label="Drag to reorder"]')
+      if (!(grip instanceof HTMLElement)) {
+        throw new Error("Expected a grip to be rendered")
+      }
+
+      fireEvent.pointerDown(grip, { button: 0 })
+      fireEvent(
+        document,
+        new MouseEvent("pointermove", {
+          clientX: 500,
+          clientY: 100,
+          bubbles: true,
+        })
+      )
+      fireEvent(
+        document,
+        new MouseEvent("pointerup", {
+          clientX: 500,
+          clientY: 100,
+          bubbles: true,
+        })
+      )
+
+      expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+      chat.remove()
+    })
+
     it("renders no grip when not in edit mode", () => {
       const { container } = render(
         <DashboardGrid items={makeCollectionItems(480)} filters={{}} />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
 import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
 
+import {
+  AiChatStateProvider,
+  useAiChat,
+} from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
+
 import { DashboardItem } from "../components/DashboardItem/DashboardItem"
 
 describe("DashboardItem", () => {
@@ -166,5 +171,58 @@ describe("DashboardItem — description action", () => {
       screen.getByRole("button", { name: "Show less" })
     ).toBeInTheDocument()
     expect(screen.queryByText("·")).not.toBeInTheDocument()
+  })
+
+  describe("Ask One", () => {
+    const QuoteProbe = () => {
+      const { pendingQuote, open } = useAiChat()
+      return (
+        <span
+          data-testid="probe"
+          data-quote={pendingQuote?.text ?? ""}
+          data-open={String(open)}
+        />
+      )
+    }
+
+    const openMenu = async () =>
+      userEvent.click(screen.getByLabelText("Other actions"))
+
+    it("offers the action and hands the widget to the chat", async () => {
+      render(
+        <AiChatStateProvider enabled>
+          <QuoteProbe />
+          <DashboardItem title="Headcount by workplace" isLoading={false}>
+            <div>Content</div>
+          </DashboardItem>
+        </AiChatStateProvider>
+      )
+
+      await openMenu()
+      await userEvent.click(screen.getByText("Ask One"))
+
+      const probe = screen.getByTestId("probe")
+      expect(probe).toHaveAttribute("data-quote", "Headcount by workplace")
+      // Opens the chat too — otherwise the quote lands somewhere unseen.
+      expect(probe).toHaveAttribute("data-open", "true")
+    })
+
+    it("is absent without a chat provider, where the setters are inert", async () => {
+      render(
+        <DashboardItem
+          title="Headcount by workplace"
+          isLoading={false}
+          actions={[{ label: "CSV", onClick: vi.fn() }]}
+        >
+          <div>Content</div>
+        </DashboardItem>
+      )
+
+      await openMenu()
+
+      expect(screen.queryByText("Ask One")).not.toBeInTheDocument()
+      // The rest of the menu is untouched.
+      expect(screen.getByText("Download")).toBeInTheDocument()
+    })
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/PointActionPopover.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/PointActionPopover.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  fireEvent,
+  screen,
+  userEvent,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { PointActionPopover } from "../components/ChartItem/PointActionPopover"
+
+const anchor = { clientX: 400, clientY: 300 }
+
+describe("PointActionPopover", () => {
+  it("renders nothing without an anchor", () => {
+    render(
+      <PointActionPopover anchor={null} onAsk={vi.fn()} onDismiss={vi.fn()} />
+    )
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("offers the single action and reports it", async () => {
+    const onAsk = vi.fn()
+    render(
+      <PointActionPopover anchor={anchor} onAsk={onAsk} onDismiss={vi.fn()} />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Ask One" }))
+
+    expect(onAsk).toHaveBeenCalledTimes(1)
+  })
+
+  it("dismisses on Escape", () => {
+    const onDismiss = vi.fn()
+    render(
+      <PointActionPopover
+        anchor={anchor}
+        onAsk={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    )
+
+    fireEvent.keyDown(document, { key: "Escape" })
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("dismisses on a pointer press outside", () => {
+    const onDismiss = vi.fn()
+    render(
+      <PointActionPopover
+        anchor={anchor}
+        onAsk={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    )
+
+    fireEvent.pointerDown(document.body)
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("survives a press on the action itself without dismissing first", () => {
+    const onDismiss = vi.fn()
+    const onAsk = vi.fn()
+    render(
+      <PointActionPopover anchor={anchor} onAsk={onAsk} onDismiss={onDismiss} />
+    )
+
+    // The outside-press listener is capture-phase, so it would otherwise fire
+    // before the button's own click and tear the popover down mid-gesture.
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Ask One" }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it("portals out of the widget so the card cannot clip it", () => {
+    const { container } = render(
+      <PointActionPopover anchor={anchor} onAsk={vi.fn()} onDismiss={vi.fn()} />
+    )
+
+    // Charts live inside `overflow-hidden` cards and scroll containers.
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.getByRole("button", { name: "Ask One" })).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -1,9 +1,12 @@
-import { useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 
 import type { IconType } from "@/components/F0Icon"
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import type { RecordType } from "@/hooks/datasource"
-import type { F0DataChartProps } from "@/kits/F0DataChart"
+import type {
+  F0DataChartPointClick,
+  F0DataChartProps,
+} from "@/kits/F0DataChart"
 import type {
   FiltersDefinition,
   FiltersState,
@@ -28,6 +31,7 @@ import {
   RadarChartSkeleton,
   ScatterChartSkeleton,
 } from "@/kits/F0DataChart"
+import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import { useI18n } from "@/lib/providers/i18n"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
@@ -50,6 +54,7 @@ import {
 } from "../../utils/chartDataAdapter"
 import { chartDataToTabular } from "../../utils/chartDataToTabular"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
+import { PointActionPopover } from "./PointActionPopover"
 
 // ---------------------------------------------------------------------------
 // Chart type option registry
@@ -491,6 +496,44 @@ export function ChartItem<Filters extends FiltersDefinition>({
 }: ChartItemProps<Filters>) {
   const translations = useI18n()
   const [viewMode, setViewMode] = useState<"chart" | "table">("chart")
+  const {
+    enabled: aiEnabled,
+    setPendingQuote,
+    setOpen: setAiChatOpen,
+  } = useAiChat()
+
+  /**
+   * The mark the user last clicked, held until they either choose the action or
+   * dismiss it. Clicking a chart offers to quote rather than quoting outright —
+   * charts get clicked while reading, and hijacking every click to open the
+   * chat would make exploring one hostile.
+   */
+  const [pickedPoint, setPickedPoint] = useState<F0DataChartPointClick | null>(
+    null
+  )
+
+  const handleAskAboutPoint = useCallback(() => {
+    if (!pickedPoint) return
+    const chart = item.chart
+    // Format through the chart's own formatter so the quoted number reads
+    // exactly as the tooltip did — a raw value can differ wildly from what was
+    // on screen (currency, compact notation, percentages).
+    const format =
+      ("tooltipValueFormatter" in chart && chart.tooltipValueFormatter) ||
+      ("valueFormatter" in chart && chart.valueFormatter) ||
+      null
+    const value = format ? format(pickedPoint.value) : String(pickedPoint.value)
+    const heading = pickedPoint.category
+      ? `${item.title} — ${pickedPoint.category}`
+      : item.title
+
+    setPendingQuote({
+      text: `${heading}\n${pickedPoint.seriesName}: ${value}`,
+    })
+    // Without this the quote would land in a panel the user cannot see.
+    setAiChatOpen(true)
+    setPickedPoint(null)
+  }, [item, pickedPoint, setPendingQuote, setAiChatOpen])
 
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -704,6 +747,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
           <div ref={chartContainerRef} className="h-full w-full px-4 py-3">
             <F0DataChart
               {...chartProps}
+              onPointClick={aiEnabled ? setPickedPoint : undefined}
               // Windowing rows is only offered where the reader can get them
               // back: this widget puts the count and a "show all" link in its
               // description. Without an expand handler there is nowhere for that
@@ -721,6 +765,11 @@ export function ChartItem<Filters extends FiltersDefinition>({
               // horizontal bar chart drops its row window and draws every
               // category at a fixed row height, growing the widget.
               {...(fitContent ? { showAllCategories: true } : {})}
+            />
+            <PointActionPopover
+              anchor={pickedPoint}
+              onAsk={handleAskAboutPoint}
+              onDismiss={() => setPickedPoint(null)}
             />
           </div>
         )

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { One as OneIcon } from "@/icons/ai"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+
+const GAP = 8
+const MIN_MARGIN = 8
+
+export type PointActionAnchor = {
+  /** Viewport coordinates of the click that opened this. */
+  clientX: number
+  clientY: number
+}
+
+export type PointActionPopoverProps = {
+  /** Click position; null hides the popover. */
+  anchor: PointActionAnchor | null
+  /** Called when the action is chosen. */
+  onAsk: () => void
+  /** Called when the popover should close without acting. */
+  onDismiss: () => void
+}
+
+/**
+ * Floating single-action menu anchored to a clicked chart mark — the same shape
+ * as the "Reply" affordance over a text selection in the chat, so quoting works
+ * the same way wherever the user starts.
+ *
+ * Portalled to `document.body`: the widget clips its content (`overflow-hidden`
+ * on the card, and charts sit inside scroll containers), which would cut a
+ * popover positioned within the tree.
+ */
+export function PointActionPopover({
+  anchor,
+  onAsk,
+  onDismiss,
+}: PointActionPopoverProps) {
+  const translations = useI18n()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(
+    null
+  )
+
+  // Sit above the click, flipping below when that would overflow the viewport
+  // top, and clamp horizontally so the button never hangs off-screen.
+  useLayoutEffect(() => {
+    if (!anchor) {
+      setCoords(null)
+      return
+    }
+    const el = containerRef.current
+    if (!el) return
+
+    const { offsetWidth: width, offsetHeight: height } = el
+    let top = anchor.clientY - height - GAP
+    if (top < MIN_MARGIN) top = anchor.clientY + GAP
+    top = Math.min(
+      Math.max(top, MIN_MARGIN),
+      window.innerHeight - height - MIN_MARGIN
+    )
+
+    const centered = anchor.clientX - width / 2
+    const left = Math.min(
+      Math.max(centered, MIN_MARGIN),
+      window.innerWidth - width - MIN_MARGIN
+    )
+
+    setCoords({ top, left })
+  }, [anchor])
+
+  // Dismiss on Escape or on a pointer press anywhere outside. The press is
+  // captured so it closes even when the click lands on another chart mark,
+  // which would otherwise re-anchor and re-open in the same gesture.
+  useEffect(() => {
+    if (!anchor) return
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDismiss()
+    }
+    const onPointerDown = (e: PointerEvent) => {
+      const el = containerRef.current
+      if (el && e.target instanceof Node && el.contains(e.target)) return
+      onDismiss()
+    }
+
+    document.addEventListener("keydown", onKeyDown)
+    document.addEventListener("pointerdown", onPointerDown, true)
+    return () => {
+      document.removeEventListener("keydown", onKeyDown)
+      document.removeEventListener("pointerdown", onPointerDown, true)
+    }
+  }, [anchor, onDismiss])
+
+  if (typeof document === "undefined") return null
+  if (!anchor) return null
+
+  return createPortal(
+    <div
+      ref={containerRef}
+      style={{
+        position: "fixed",
+        top: coords?.top ?? -9999,
+        left: coords?.left ?? -9999,
+        visibility: coords ? "visible" : "hidden",
+      }}
+      className={cn(
+        "z-50 rounded-md bg-f1-background p-1 border border-solid border-f1-border-secondary",
+        "drop-shadow"
+      )}
+    >
+      <ButtonInternal
+        type="button"
+        variant="ghost"
+        label={translations.ai.dashboardItem.askOne}
+        icon={OneIcon}
+        onClick={onAsk}
+      />
+    </div>,
+    document.body
+  )
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -8,6 +8,7 @@ import type {
 
 import { F0Icon } from "@/components/F0Icon"
 import Handle from "@/icons/app/Handle"
+import { WIDGET_DRAG_END, WIDGET_DRAG_START } from "@/lib/dnd/widgetDragEvents"
 import { cn } from "@/lib/utils"
 
 import type {
@@ -282,6 +283,23 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   // over a chart canvas or a full-width row all the same.
   const resolveDropTarget = useCallback(
     (clientX: number, clientY: number): typeof dropTarget => {
+      // The AI chat panel is a drop target of its own (drop a widget to quote
+      // it in the composer). Rows are matched on Y alone, and the chat shares
+      // that band, so without this the grid would paint a drop indicator
+      // behind the chat's overlay and commit a reorder on release. Returning
+      // null also makes `up`'s `if (draggedId && target)` skip `commitDrop`.
+      const chatEl = document.querySelector("[data-ai-chat-dropzone]")
+      if (chatEl) {
+        const c = chatEl.getBoundingClientRect()
+        if (
+          clientX >= c.left &&
+          clientX <= c.right &&
+          clientY >= c.top &&
+          clientY <= c.bottom
+        )
+          return null
+      }
+
       const rowEls = containerRef.current
         ? Array.from(
             containerRef.current.querySelectorAll<HTMLElement>(
@@ -346,6 +364,16 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       setDragId(id)
       setDropTarget(null)
 
+      // Announce the drag so other drop targets can invite it immediately,
+      // rather than waiting for the cursor to reach them. The AI chat listens
+      // for this to offer "discuss this widget" from the first moment of the
+      // gesture. Fired on `window` so the listener needs no shared ancestor.
+      window.dispatchEvent(
+        new CustomEvent(WIDGET_DRAG_START, {
+          detail: { title: itemMapRef.current.get(id)?.title ?? "" },
+        })
+      )
+
       const move = (ev: PointerEvent) => {
         const ghost = ghostRef.current
         if (ghost) {
@@ -367,6 +395,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
         dropTargetRef.current = null
         setDragId(null)
         setDropTarget(null)
+        window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
       }
       document.addEventListener("pointermove", move)
       document.addEventListener("pointerup", up)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -17,6 +17,8 @@ import {
   Minimize,
   InfoCircleLine,
 } from "@/icons/app"
+import { One as OneIcon } from "@/icons/ai"
+import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -122,6 +124,11 @@ export function DashboardItem({
    */
   const [isExplanationView, setIsExplanationView] = useState(false)
   const translations = useI18n()
+  const {
+    enabled: aiEnabled,
+    setPendingQuote,
+    setOpen: setAiChatOpen,
+  } = useAiChat()
 
   const handleDropdownOpenChange = (open: boolean) => {
     setIsDropdownOpen(open)
@@ -138,7 +145,13 @@ export function DashboardItem({
   const hasChartTypes = chartTypeOptions && chartTypeOptions.length > 0
   const hasExplanation = !!explanation && explanation.trim().length > 0
   const hasFullscreen = !!onFullscreenChange
-  const showMenu = hasDownloads || hasDelete || hasChartTypes || hasExplanation
+  // Keyboard-reachable twin of dragging the widget onto the chat. Gated on the
+  // chat actually being available: with no provider mounted `useAiChat()`
+  // returns an inert context whose setters are no-ops, so offering the action
+  // would do nothing.
+  const hasAskOne = aiEnabled && title.trim().length > 0
+  const showMenu =
+    hasAskOne || hasDownloads || hasDelete || hasChartTypes || hasExplanation
 
   if (error) {
     return (
@@ -321,6 +334,28 @@ export function DashboardItem({
                             <F0Icon icon={InfoCircleLine} />
                             <span className="flex-1">
                               {translations.ai.dashboardItem.dataExplanation}
+                            </span>
+                          </div>
+                        </DropdownMenuItem>
+                      </DropdownMenuGroup>
+                    )}
+
+                    {hasAskOne && (
+                      <DropdownMenuGroup>
+                        <DropdownMenuItem
+                          onClick={() => {
+                            // Fullscreen covers the chat, so step out of it
+                            // before handing the widget over — same reason the
+                            // delete action does.
+                            if (isFullscreen) onFullscreenChange?.(false)
+                            setPendingQuote({ text: title })
+                            setAiChatOpen(true)
+                          }}
+                        >
+                          <div className="flex w-full flex-row items-center gap-2">
+                            <F0Icon icon={OneIcon} />
+                            <span className="flex-1">
+                              {translations.ai.dashboardItem.askOne}
                             </span>
                           </div>
                         </DropdownMenuItem>


### PR DESCRIPTION
## Description

Lets a user bring a dashboard widget — or a single data point — into a conversation with One, so they can ask about what they're looking at without retyping it.

Three routes, all landing in the composer's existing quote chip:

| Gesture | Quote |
|---|---|
| Drag a widget onto the chat panel | `Headcount by workplace` |
| ⋯ menu → **Ask One** | `Headcount by workplace` |
| Click a mark → **Ask One** in the popover | `Headcount by workplace — Barcelona office`<br>`Male: 18` |

The drop invitation appears the **moment a drag starts**, not when the cursor reaches the chat, so the target is visible before the user aims for it.

Nothing here is on by default: every entry point is gated on an AI chat actually being mounted, so `F0AnalyticsDashboard` used standalone is unchanged.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Variant or improvement of existing pattern

## Screenshots (if applicable)

Best seen live — Storybook story **`AI/F0AiChat/Widget drop`** puts an editable dashboard beside an open chat and exercises all three routes. Screenshots to follow on the PR.

## Implementation details

### Why the file-drop plumbing couldn't be reused

The chat already has a drop state for files, but the two gestures are different browser mechanisms:

| | File drop | Widget drag |
|---|---|---|
| Mechanism | Native HTML5 drag-and-drop | Plain pointer gesture |
| Events | `dragenter`/`dragover`/`drop` + `dataTransfer` | `pointerdown` on grip → `document` `pointermove`/`pointerup` |
| Hit-test | Browser names the element | Manual `getBoundingClientRect()` math |

A pointer drag fires no `dragenter`, so the existing handlers never see it. `DropOverlay` gains a `mode` (`"files" | "discuss"`) and is reused; the wiring is new.

### How the drag and the chat talk

`DashboardGrid` dispatches `f0:widget-drag-start` / `f0:widget-drag-end` on `window` (names shared via `lib/dnd/widgetDragEvents.ts`); `ChatWindow` listens. Plain DOM events rather than shared state because the producer is a `pattern` and the consumer a `kit` with no useful common ancestor, and neither should import the other. The chat marks itself with `data-ai-chat-dropzone`, which the grid hit-tests.

### `onPointClick` on the chart kit

`F0DataChartCommonProps` gains `onPointClick`, so all nine variants get it from one addition. `usePointClick` binds once at the ECharts instance level — item-level click params are uniform across series types, so no per-chart variant is needed — and follows the existing `useLegendSelection` shape. Charts stay inert unless a handler is passed.

Quoted values format through the chart's own `tooltipValueFormatter`/`valueFormatter`, so the number reads as the tooltip did rather than as a raw float.

### Two bugs worth calling out

**A stale-closure drop, only reproducible in a real browser.** The release handler first read the pending title from state. A fast drag delivers the drag-start announcement and the release inside one React batch, so no re-render separates them and the handler saw the pre-drag `null` — the quote was silently discarded. The payload now lives in a ref; state only drives the render. There's a regression test that puts both events in a single `act`, and it fails if the read goes back to state.

**The grid would reorder *and* quote.** `resolveDropTarget` matches rows on Y alone (X only picks a slot within the row), and the chat shares that Y band — so releasing over the chat painted a drop indicator behind the overlay *and* committed a reorder. Guarded at the top of the function; returning `null` also makes the existing `if (draggedId && target)` skip `commitDrop`. Uses rect containment rather than `document.elementFromPoint`, which jsdom 26 doesn't implement.

### Notes for review

- `patterns/F0AnalyticsDashboard` now imports `useAiChat` (`patterns → kits`). `check-cycle-dependencies` reports no new cycles; `patterns/ApplicationFrame` sets the precedent.
- `PointActionPopover` mirrors `ReplyPopover` (the quote-on-text-selection affordance) so quoting looks the same wherever it starts. It must portal to `document.body` — charts sit inside `overflow-hidden` cards and scroll containers that would clip it.
- One new i18n key, `ai.dashboardItem.askOne`. Deliberately **not** `ai.ask`: hosts override that one (factorial renders it as plain "Ask") and it drives two other surfaces. `ai.dropWidgetToDiscuss` is the other new key.
- Clicking a mark also dismisses the hover tooltip, so two floating panels never stack over one mark.

### Verification

- Full unit suite: 6253 passed, 13 skipped. `tsc`, `oxlint` and `oxfmt` clean.
- 25 new tests across `usePointClick`, `PointActionPopover`, the widget-drop flow and the ⋯ menu.
- Both guard tests confirmed non-vacuous — each fails when its fix is reverted.
- Manually exercised in Storybook (`AI/F0AiChat/Widget drop`) with real mouse input, and end-to-end in a local Factorial against this build.

### Known gaps

- The click popover fires on any mark; if that reads as noisy in use, the alternative is requiring the chat to be open already.
- Not exercised on touch, where the grid's own drag gesture is the prior constraint.
- The `—` and `:` separators in the data-point quote are literal, not translated.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-pr
