### PR TITLE
feat(F0AiChatTextArea): add inside placement for welcome suggestions

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -10,11 +10,13 @@ import { cn } from "@/lib/utils"
 
 import { useRevealOnChange } from "../F0AiChat/hooks/useRevealOnChange"
 import { useAiChat } from "../F0AiChat/providers/AiChatStateProvider"
+import { F0OneIcon } from "../F0OneIcon"
 import { ActionBar } from "./components/ActionBar"
 import { AttachedFilesList } from "./components/AttachedFilesList"
 import { CreditWarningWrapper } from "./components/CreditWarningWrapper"
 import { MentionPopover } from "./components/MentionPopover"
 import { PendingQuoteChip } from "./components/PendingQuoteChip"
+import { SubmitButton } from "./components/SubmitButton"
 import { TextareaField } from "./components/TextareaField"
 import { WelcomeScreenCardsRow } from "./components/WelcomeScreenCardsRow"
 import { WelcomeScreenSuggestionsRow } from "./components/WelcomeScreenSuggestionsRow"
@@ -83,6 +85,7 @@ export const F0AiChatTextArea = ({
   fullscreen = false,
   welcomeScreenSuggestions,
   onSuggestionClick,
+  welcomeScreenSuggestionsPlacement = "above",
   welcomeScreenCards,
   ref,
 }: F0AiChatTextAreaProps) => {
@@ -329,9 +332,11 @@ export const F0AiChatTextArea = ({
   const hasOverlay =
     mentions.mentions.length > 0 || mentions.inlineCompletion !== null
 
-  // Welcome suggestions row. On the welcome screen it always sits above the
-  // textarea (both sidepanel and fullscreen); the popover opens upward so it
-  // doesn't cover the composer.
+  // Welcome suggestions row. `above` (the default) stands it over the composer
+  // in both sidepanel and fullscreen, popover opening upward so it doesn't cover
+  // the field. `inside` moves it into the field's foot — see the prop's doc for
+  // what that does to the send button.
+  const suggestionsInside = welcomeScreenSuggestionsPlacement === "inside"
   const showSuggestions =
     isWelcomeScreen &&
     !!welcomeScreenSuggestions &&
@@ -343,9 +348,33 @@ export const F0AiChatTextArea = ({
       suggestions={welcomeScreenSuggestions}
       onItemClick={handleSuggestionClick}
       onItemHover={setHoveredSuggestion}
-      side="top"
+      // Inside the field the empty space is BELOW it, not above: opening upward
+      // would cover the text the reader is about to type. Radix still flips on a
+      // collision, so a field pinned to the bottom of a sidepanel is safe.
+      side={suggestionsInside ? "bottom" : "top"}
+      reserveTwoRows={!suggestionsInside}
     />
   ) : null
+
+  // THE BAR SHAPE the `inside` placement implies: One's mark leading the field
+  // and the send button trailing the text, so the suggestions can have the band
+  // below them to themselves. Named apart from `suggestionsInside` because this
+  // is about the composer's own layout and it does NOT switch off with the
+  // welcome screen — a bar that put send back in the action row on the first
+  // message would change shape under the reader mid-conversation.
+  const inlineComposerBar = suggestionsInside
+
+  // Which controls the action row would still have to itself once the bar takes
+  // the send button away. With none of them the row is 24px of padding around
+  // nothing, so it isn't rendered at all and the field is just its two bands.
+  // `canRecord` covers the recording state too — the waveform's cancel · confirm
+  // pair lives in this row, and it can only be reached when recording is on.
+  const actionRowHasControls = !!onUploadFiles || !!toolbarStart || canRecord
+  const showActionRow = !inlineComposerBar || actionRowHasControls
+  // While recording, the row below owns the whole gesture (waveform + cancel ·
+  // confirm). A send button beside the text would be a second, live way out of a
+  // recording that the row is already handling.
+  const showInlineSubmit = inlineComposerBar && !isRecording
 
   // Welcome cards sit below the composer on the fullscreen welcome screen
   // (same gate the footer slot uses). Each card carries its own `onClick`;
@@ -380,7 +409,7 @@ export const F0AiChatTextArea = ({
       {...(fullscreen ? composerReveal : {})}
     >
       <div className="flex w-full max-w-content flex-col gap-2">
-        {suggestionsRow && <div>{suggestionsRow}</div>}
+        {suggestionsRow && !suggestionsInside && <div>{suggestionsRow}</div>}
         <CreditWarningWrapper creditWarning={creditWarning}>
           <motion.form
             aria-busy={inProgress}
@@ -519,43 +548,119 @@ export const F0AiChatTextArea = ({
                     removeLabel={translation.ai.removeFile}
                   />
 
-                  <TextareaField
-                    textareaRef={textareaRef}
-                    highlightRef={highlightRef}
-                    inputValue={inputValue}
-                    onInputChange={(value, cursorPos) => {
-                      setInputValue(value)
-                      setCursorPosition(cursorPos)
-                    }}
-                    onKeyDown={handleKeyDown}
-                    onCursorUpdate={updateCursorPosition}
-                    onScroll={syncHighlightScroll}
-                    highlightSegments={highlightSegments}
-                    hasOverlay={hasOverlay}
-                    multiplePlaceholders={multiplePlaceholders}
-                    placeholders={effectivePlaceholders}
-                    resolvedDefaultPlaceholder={resolvedDefaultPlaceholder}
-                    inProgress={inProgress}
-                  />
+                  {/* THE TEXT BAND. A flex row only in the `inside` layout,
+                      where One's mark leads the text and the send button trails
+                      it. `items-end` is what keeps the button on the LAST line
+                      as the textarea grows, instead of floating beside the
+                      middle of the text.
 
-                  <ActionBar
-                    onUploadFiles={onUploadFiles}
-                    toolbarStart={toolbarStart}
-                    isAtMaxFiles={isAtMaxFiles}
-                    maxFiles={maxFiles}
-                    acceptValue={acceptValue}
-                    fileInputRef={fileInputRef}
-                    handleFileSelect={handleFileSelect}
-                    inProgress={inProgress}
-                    hasDataToSend={hasDataToSend}
-                    isPreSending={isPreSending || pendingSubmit}
-                    canRecord={canRecord}
-                    recordingStatus={recorder.status}
-                    recordingStream={recorder.stream}
-                    onStartRecording={handleStartRecording}
-                    onStopRecording={recorder.stop}
-                    onCancelRecording={handleCancelRecording}
-                  />
+                      `TextareaField` is `flex-1` already and its own layers
+                      carry the field's 12px inset (top and bottom), so this row
+                      adds no vertical padding of its own — the two things beside
+                      the text align against that inset. */}
+                  <div
+                    className={cn(inlineComposerBar && "flex items-end pr-3")}
+                  >
+                    {/* ONE'S MARK, leading the field. `pl-3` is the field's own
+                        left inset; the 12px gap to the text after it is
+                        `TextareaField`'s own `px-3`, so the mark and the text
+                        sit on the same grid as everything else in the box.
+
+                        `self-center` overrides the row's `items-end`: the mark
+                        belongs on the text's optical line, and bottom-aligning a
+                        22px mark against the row left it sitting low. It costs
+                        nothing once the field has grown, since the text cell is
+                        then the tallest thing in the row.
+
+                        Spins while a response streams — F0OneIcon's own
+                        affordance for exactly this, and the only moving part the
+                        composer has to say the AI is working. */}
+                    {inlineComposerBar && (
+                      <div className="flex shrink-0 self-center pl-3">
+                        <F0OneIcon size="sm" spin={inProgress} />
+                      </div>
+                    )}
+                    <TextareaField
+                      textareaRef={textareaRef}
+                      highlightRef={highlightRef}
+                      inputValue={inputValue}
+                      onInputChange={(value, cursorPos) => {
+                        setInputValue(value)
+                        setCursorPosition(cursorPos)
+                      }}
+                      onKeyDown={handleKeyDown}
+                      onCursorUpdate={updateCursorPosition}
+                      onScroll={syncHighlightScroll}
+                      highlightSegments={highlightSegments}
+                      hasOverlay={hasOverlay}
+                      multiplePlaceholders={multiplePlaceholders}
+                      placeholders={effectivePlaceholders}
+                      resolvedDefaultPlaceholder={resolvedDefaultPlaceholder}
+                      inProgress={inProgress}
+                    />
+                    {/* `pb-[10px]`, not `pb-3`, and the number is derived rather
+                        than eyeballed: the field's inset is 12px and a 24px
+                        button overhangs a 20px line by 2px at each end, so
+                        bottom-aligning it 10px above the text cell's floor lands
+                        its centre exactly on the line's centre. `pb-3` would sit
+                        it 2px low on one line — and, because the button is
+                        taller than the line, visibly high against the top
+                        border. Grown past one line the same 10px keeps it on the
+                        last line. */}
+                    {showInlineSubmit && (
+                      <div className="shrink-0 pb-[10px] pl-2">
+                        <SubmitButton
+                          inProgress={inProgress}
+                          hasDataToSend={hasDataToSend}
+                          isPreSending={isPreSending || pendingSubmit}
+                          recordingStatus={recorder.status}
+                          size="sm"
+                        />
+                      </div>
+                    )}
+                  </div>
+
+                  {/* THE SUGGESTIONS BAND, inside the field. `px-3` is the
+                      field's own inset — the chips line up with the text above
+                      them and nothing indents them further, which is the point
+                      of putting them in here. `pb-3` closes the box; the 12px
+                      above them comes from the text band's own bottom slack.
+
+                      Clicks are STOPPED here rather than bubbling to the form,
+                      whose onClick focuses the textarea — the same guard
+                      `toolbarStart` takes. Without it, pressing a chip would pull
+                      focus off the trigger and break the popover's own
+                      Escape-restores-focus handling. */}
+                  {suggestionsRow && suggestionsInside && (
+                    <div
+                      className="px-3 pb-3"
+                      onClick={(event) => event.stopPropagation()}
+                    >
+                      {suggestionsRow}
+                    </div>
+                  )}
+
+                  {showActionRow && (
+                    <ActionBar
+                      onUploadFiles={onUploadFiles}
+                      toolbarStart={toolbarStart}
+                      isAtMaxFiles={isAtMaxFiles}
+                      maxFiles={maxFiles}
+                      acceptValue={acceptValue}
+                      fileInputRef={fileInputRef}
+                      handleFileSelect={handleFileSelect}
+                      inProgress={inProgress}
+                      hasDataToSend={hasDataToSend}
+                      isPreSending={isPreSending || pendingSubmit}
+                      canRecord={canRecord}
+                      recordingStatus={recorder.status}
+                      recordingStream={recorder.stream}
+                      onStartRecording={handleStartRecording}
+                      onStopRecording={recorder.stop}
+                      onCancelRecording={handleCancelRecording}
+                      showSubmit={!inlineComposerBar}
+                    />
+                  )}
                 </motion.div>
               )}
             </AnimatePresence>

--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -623,8 +623,14 @@ export const F0AiChatTextArea = ({
                   {/* THE SUGGESTIONS BAND, inside the field. `px-3` is the
                       field's own inset — the chips line up with the text above
                       them and nothing indents them further, which is the point
-                      of putting them in here. `pb-3` closes the box; the 12px
-                      above them comes from the text band's own bottom slack.
+                      of putting them in here. `pb-3` closes the box.
+
+                      `pt-1` ON TOP OF the text band's own 12px bottom slack, for
+                      16px between the two bands — which is v2's `gap-4` between
+                      the same two rows, arrived at from the other direction.
+                      12px alone read as cramped against the chips (Saul,
+                      2026-08-13): they are 32px tall against a 20px line, so the
+                      gap has to clear the taller thing to look like a gap.
 
                       Clicks are STOPPED here rather than bubbling to the form,
                       whose onClick focuses the textarea — the same guard
@@ -633,7 +639,7 @@ export const F0AiChatTextArea = ({
                       Escape-restores-focus handling. */}
                   {suggestionsRow && suggestionsInside && (
                     <div
-                      className="px-3 pb-3"
+                      className="px-3 pb-3 pt-1"
                       onClick={(event) => event.stopPropagation()}
                     >
                       {suggestionsRow}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -259,6 +259,7 @@ type WrapperProps = {
   disclaimer?: AiChatDisclaimer
   footer?: React.ReactNode
   welcomeScreenSuggestions?: WelcomeScreenSuggestion[]
+  welcomeScreenSuggestionsPlacement?: "above" | "inside"
   welcomeScreenCards?: F0AiChatWelcomeCard[]
   isWelcomeScreen?: boolean
   fullscreen?: boolean
@@ -278,6 +279,7 @@ const Wrapper = ({
   disclaimer,
   footer,
   welcomeScreenSuggestions,
+  welcomeScreenSuggestionsPlacement,
   welcomeScreenCards,
   isWelcomeScreen,
   fullscreen,
@@ -345,6 +347,7 @@ const Wrapper = ({
         disclaimer={disclaimer}
         footer={footer}
         welcomeScreenSuggestions={welcomeScreenSuggestions}
+        welcomeScreenSuggestionsPlacement={welcomeScreenSuggestionsPlacement}
         onSuggestionClick={(item) => {
           // Suggestions always send a prompt (item.prompt, falling back to its
           // title) — unlike cards, the host doesn't branch on behavior.
@@ -522,6 +525,65 @@ export const WithWelcomeSuggestions: Story = {
           name: "April leave and overtime summary",
         })
       ).not.toBeInTheDocument()
+    })
+  },
+}
+
+// `welcomeScreenSuggestionsPlacement: "inside"` — the suggestions move INTO the
+// field, at its foot, and the send button moves onto the textarea's own line.
+// With no attachments, dictation or `toolbarStart` the composer is exactly two
+// bands (text + send, then the chips), which is the home-page "ask" bar shape.
+// Note there is no `fullscreen`: this placement doesn't need the welcome screen's
+// vertical room, because it isn't claiming any space above the field.
+export const WithWelcomeSuggestionsInside: Story = {
+  args: {
+    isWelcomeScreen: true,
+    welcomeScreenSuggestions: WELCOME_SUGGESTIONS,
+    welcomeScreenSuggestionsPlacement: "inside",
+    placeholders: ROTATING_PLACEHOLDERS,
+    disclaimer: DISCLAIMER,
+  },
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+
+    await step("The chips sit inside the field, above its bottom edge", () => {
+      const textarea = canvasElement.querySelector(
+        'textarea[name="one-ai-input"]'
+      )!
+      const trigger = page.getByRole("button", { name: "Analyze" })
+      const form = textarea.closest("form")!
+
+      // Inside the form → enclosed by the field's border and focus highlight.
+      expect(form.contains(trigger)).toBe(true)
+      // …and after the textarea, so it reads as the field's foot.
+      expect(
+        textarea.compareDocumentPosition(trigger) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy()
+    })
+
+    await step("Send trails the text instead of sitting in its own row", () => {
+      const textarea = canvasElement.querySelector(
+        'textarea[name="one-ai-input"]'
+      )!
+      // The text band: TextareaField's grid, then the row that holds it.
+      const textBand = textarea.parentElement!.parentElement!
+      const send = page.getByRole("button", { name: /send/i })
+      const trigger = page.getByRole("button", { name: "Analyze" })
+
+      expect(textBand.contains(send)).toBe(true)
+      // …and the chips are their own band under it, not in this one.
+      expect(textBand.contains(trigger)).toBe(false)
+    })
+
+    await step("Picking a group opens its panel", async () => {
+      await userEvent.click(page.getByRole("button", { name: "Analyze" }))
+      await expect(
+        page.getByRole("dialog", { name: "Analyze" })
+      ).toBeInTheDocument()
+      await expect(
+        page.getByRole("button", { name: "April leave and overtime summary" })
+      ).toBeInTheDocument()
     })
   },
 }

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.suggestionsInside.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.suggestionsInside.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { ChartVerticalBars } from "@/icons/app"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { type WelcomeScreenSuggestion } from "../../F0AiChat/types"
+
+vi.mock("../components/TextareaField", () => ({
+  TextareaField: () => <textarea aria-label="Message" readOnly />,
+}))
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+const suggestions: WelcomeScreenSuggestion[] = [
+  {
+    icon: ChartVerticalBars,
+    label: "Analyze",
+    items: [{ title: "April leave summary" }],
+  },
+]
+
+const sendButton = () => screen.getByRole("button", { name: /send/i })
+const trigger = () => screen.getByRole("button", { name: /analyze/i })
+const textarea = () => screen.getByRole("textbox", { name: "Message" })
+
+describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
+  it("renders the suggestions inside the form, below the textarea", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    const form = textarea().closest("form")
+    // Enclosed by the field itself — its border and focus highlight are the form's.
+    expect(form?.contains(trigger())).toBe(true)
+    // …and after the textarea, so the row reads as the field's foot.
+    expect(
+      textarea().compareDocumentPosition(trigger()) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("keeps the suggestions outside the form with the default placement", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    expect(textarea().closest("form")?.contains(trigger())).toBe(false)
+  })
+
+  it("moves the send button onto the textarea's own band", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    // The band is the row wrapping the mocked TextareaField.
+    const band = textarea().parentElement
+    expect(band?.contains(sendButton())).toBe(true)
+    // The chips are a separate band under it, not part of the text row.
+    expect(band?.contains(trigger())).toBe(false)
+  })
+
+  it("renders exactly one send button (the action row gives its up)", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
+  })
+
+  it("drops the action row when it has no controls left to hold", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    // No attachments, no dictation, no toolbarStart: an action row would be
+    // 24px of padding around nothing.
+    expect(
+      screen.queryByRole("button", { name: /attach/i })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /record/i })
+    ).not.toBeInTheDocument()
+    // The chips band is the last thing in the form — nothing follows it.
+    const form = textarea().closest("form")!
+    const chipsBand = trigger().closest("form > div > div")
+    expect(form.contains(chipsBand)).toBe(true)
+  })
+
+  it("keeps the action row for the controls that stay in it", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+        toolbarStart={<button type="button">Pick a model</button>}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Pick a model" })
+    ).toBeInTheDocument()
+    // The send button did NOT come back with it.
+    expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
+    expect(textarea().parentElement?.contains(sendButton())).toBe(true)
+  })
+
+  it("keeps the send button inline once the welcome screen is gone", () => {
+    // The suggestions are welcome-screen-only, but the bar must not change
+    // shape under the reader when the first message lands.
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    expect(screen.queryByRole("button", { name: /analyze/i })).toBeNull()
+    expect(textarea().parentElement?.contains(sendButton())).toBe(true)
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/ActionBar.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/ActionBar.tsx
@@ -1,18 +1,12 @@
 import { type ReactNode, type RefObject } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
-import {
-  ArrowUp,
-  Check,
-  Cross,
-  Microphone,
-  Paperclip,
-  SolidStop,
-} from "@/icons/app"
+import { Check, Cross, Microphone, Paperclip } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 
 import { type RecorderStatus } from "../useAudioRecorder"
 import { RecordingWaveform } from "./RecordingWaveform"
+import { SubmitButton } from "./SubmitButton"
 
 interface ActionBarProps {
   onUploadFiles: ((files: File[]) => Promise<unknown>) | undefined
@@ -32,6 +26,18 @@ interface ActionBarProps {
   onStartRecording?: () => void
   onStopRecording?: () => void
   onCancelRecording?: () => void
+  /**
+   * Whether this row owns the send / stop button. False in the `inside`
+   * suggestions layout, where the button sits on the textarea's own line and
+   * this row is left with the attachment, host and dictation controls.
+   *
+   * Only the idle row honours it — the recording row's cancel · confirm pair is
+   * not the submit button and must never be dropped, or a recording would have
+   * no way to end.
+   *
+   * @default true
+   */
+  showSubmit?: boolean
 }
 
 export const ActionBar = ({
@@ -51,6 +57,7 @@ export const ActionBar = ({
   onStartRecording,
   onStopRecording,
   onCancelRecording,
+  showSubmit = true,
 }: ActionBarProps) => {
   const translation = useI18n()
 
@@ -144,24 +151,12 @@ export const ActionBar = ({
             loading={recordingStatus === "transcribing"}
           />
         )}
-        {recordingStatus !== "transcribing" && inProgress ? (
-          <ButtonInternal
-            type="submit"
-            variant="neutral"
-            label={translation.ai.stopAnswerGeneration}
-            icon={SolidStop}
-            hideLabel
-          />
-        ) : (
-          <ButtonInternal
-            type="submit"
-            // Stays enabled while an attachment uploads so the click queues the
-            // send (fired once the upload finishes) instead of being a no-op.
-            disabled={!hasDataToSend || isPreSending}
-            variant={"default"}
-            label={translation.ai.sendMessage}
-            icon={ArrowUp}
-            hideLabel
+        {showSubmit && (
+          <SubmitButton
+            inProgress={inProgress}
+            hasDataToSend={hasDataToSend}
+            isPreSending={isPreSending}
+            recordingStatus={recordingStatus}
           />
         )}
       </div>

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/SubmitButton.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/SubmitButton.tsx
@@ -1,0 +1,66 @@
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { ArrowUp, SolidStop } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+
+import { type RecorderStatus } from "../useAudioRecorder"
+
+interface SubmitButtonProps {
+  inProgress?: boolean
+  hasDataToSend: boolean
+  isPreSending?: boolean
+  recordingStatus?: RecorderStatus
+  /**
+   * `md` (32px) for the action row, where the button stands in a row of its own
+   * peers. `sm` (24px) when it trails the text inline: a 32px button beside a
+   * 20px line of text cannot be centred on that line without eating the field's
+   * top inset, which is what makes it look pinned to the border.
+   *
+   * @default "md"
+   */
+  size?: "sm" | "md"
+}
+
+/**
+ * The composer's send / stop control.
+ *
+ * Extracted from `ActionBar` because the `inside` suggestions layout moves it
+ * out of the action row and onto the textarea's own line — both placements must
+ * render the exact same button (same labels, same disabled rule, same
+ * stop-while-streaming swap), so there is one definition rather than two.
+ */
+export const SubmitButton = ({
+  inProgress,
+  hasDataToSend,
+  isPreSending,
+  recordingStatus = "idle",
+  size = "md",
+}: SubmitButtonProps) => {
+  const translation = useI18n()
+
+  if (recordingStatus !== "transcribing" && inProgress) {
+    return (
+      <ButtonInternal
+        type="submit"
+        variant="neutral"
+        size={size}
+        label={translation.ai.stopAnswerGeneration}
+        icon={SolidStop}
+        hideLabel
+      />
+    )
+  }
+
+  return (
+    <ButtonInternal
+      type="submit"
+      size={size}
+      // Stays enabled while an attachment uploads so the click queues the
+      // send (fired once the upload finishes) instead of being a no-op.
+      disabled={!hasDataToSend || isPreSending}
+      variant="default"
+      label={translation.ai.sendMessage}
+      icon={ArrowUp}
+      hideLabel
+    />
+  )
+}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -62,6 +62,19 @@ export type WelcomeScreenSuggestionsRowProps = {
    * the row below the textarea.
    */
   side?: "top" | "bottom"
+  /**
+   * Reserve height for two chip rows so a suggestion-set swap that wraps 1↔2
+   * rows cannot shift the layout above the row.
+   *
+   * True for the row standing above the composer, where the reservation is
+   * free — it sits in the empty space the welcome screen already has. False
+   * when the row is rendered INSIDE the field: there the reservation is not
+   * free, it is 72px of permanent dead height inside a bordered box, and the
+   * field grows and shrinks with its own text anyway.
+   *
+   * @default true
+   */
+  reserveTwoRows?: boolean
 }
 
 /**
@@ -74,6 +87,7 @@ export const WelcomeScreenSuggestionsRow = ({
   onItemClick,
   onItemHover,
   side = "top",
+  reserveTwoRows = true,
 }: WelcomeScreenSuggestionsRowProps) => {
   const [activeIdx, setActiveIdx] = useState<number | null>(null)
   const rowRef = useRef<HTMLDivElement>(null)
@@ -100,8 +114,14 @@ export const WelcomeScreenSuggestionsRow = ({
           reservation lives on this outer box and NOT on the anchor: Radix
           positions the popover off the anchor's border box, so anchoring the
           reserved height would float a single-row popover ~40px above the
-          chips it belongs to. */}
-      <div className="flex min-h-[72px] w-full items-end">
+          chips it belongs to. See `reserveTwoRows` for why the inside
+          placement opts out. */}
+      <div
+        className={cn(
+          "flex w-full items-end",
+          reserveTwoRows && "min-h-[72px]"
+        )}
+      >
         <PopoverAnchor asChild>
           <div
             ref={rowRef}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/types.ts
@@ -148,6 +148,40 @@ export type F0AiChatTextAreaProps = {
   ) => void
 
   /**
+   * Where the welcome suggestions row sits relative to the composer.
+   *
+   * - `"above"` (the default) — its own block over the field, the arrangement
+   *   every consumer has had: the row stands on the page, the field below it is
+   *   a plain composer, and its popover opens upward into the welcome screen's
+   *   empty space.
+   *
+   * - `"inside"` — the row moves INTO the field, at its foot, so the field's own
+   *   border and AI focus highlight enclose it and the composer reads as a
+   *   single bar about two lines tall. Its popover opens downward, because up is
+   *   now the text you are about to type.
+   *
+   * ⚠️ `"inside"` IS A COMPOSER SHAPE, NOT JUST A POSITION. It also moves the
+   * send button onto the textarea's own line (at `sm`, centred on the text) and
+   * puts One's mark in front of the text. Neither is a feature bolted onto this
+   * prop — they are what make the placement possible and legible. The action row
+   * is full-width, so a chips row plus an action row inside one field is three
+   * stacked bands and the "single bar" is gone; with send trailing the text there
+   * are two, text then suggestions. The attachment, host (`toolbarStart`) and
+   * dictation controls keep their own row when the host enables them; with none
+   * of them the field is just the two bands.
+   *
+   * THE INLINE SEND FOLLOWS THE PROP, NOT THE WELCOME STATE. The suggestions
+   * themselves are welcome-screen-only as they always were, but a composer that
+   * put send back in the action row the moment the first message landed would
+   * change shape under the reader mid-conversation. `"inside"` therefore keeps
+   * the two-band bar for the whole thread; after the welcome screen it is simply
+   * a bar with no chips in it.
+   *
+   * @default "above"
+   */
+  welcomeScreenSuggestionsPlacement?: "above" | "inside"
+
+  /**
    * Cards rendered as a grid below the composer on the fullscreen welcome
    * screen. Each card carries its own `onClick`; the host decides the behavior.
    *


### PR DESCRIPTION
## Description

Adds `welcomeScreenSuggestionsPlacement="inside"` to `F0AiChatTextArea`, which moves the welcome suggestions row into the composer field at its foot so the field's own border and AI focus highlight enclose it. This is the composer shape the [factorial-composer v2 Home prototype](https://github.com/factorialco/factorial-composer/pull/48/changes) built locally as `OneComposer` + `SuggestionsRow` — that prototype had to rebuild F0's composer from scratch precisely because this arrangement wasn't reachable through any prop, and its own doc comment names the three blockers. The default stays `"above"`, so every existing consumer renders byte-for-byte as before.

## Screenshots

<img width="698" height="199" alt="Screenshot 2026-08-13 at 12 15 03" src="https://github.com/user-attachments/assets/f58ac35e-5d2d-461d-808b-f36e324ded4d" />
