### PR TITLE
feat(SlotWidget): feed visualization, row actions and width-aware sizing

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
@@ -1,6 +1,6 @@
 import { screen } from "@testing-library/react"
 import { Fragment } from "react"
-import { expect, test, vi } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
 
 /* eslint-disable no-constant-binary-expression */
 import { userEvent, zeroRender } from "@/testing/test-utils"
@@ -116,4 +116,76 @@ test("a link with a url is a real anchor, and only another host opens a tab", ()
   expect(
     screen.getByRole("link", { name: "Go to Calendar" })
   ).not.toHaveAttribute("target")
+})
+
+describe("a wider card speaks up", () => {
+  /**
+   * jsdom lays nothing out — every box is 0×0 — so the card's width is what this
+   * says it is. `clientWidth` rather than a bounding rect, because that is the
+   * metric the card reads (transforms must not change its type scale).
+   */
+  const withCardWidth = (width: number) => {
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(
+      function (this: HTMLElement) {
+        // `role="article"` is the Card's own — nothing else in the tree has it.
+        return this.getAttribute("role") === "article" ? width : 0
+      }
+    )
+  }
+
+  afterEach(() => vi.restoreAllMocks())
+
+  test("in a rail-width card the title and the footer button are unchanged", () => {
+    withCardWidth(396)
+    zeroRender(
+      <Widget
+        header={{ title: "Team" }}
+        action={{ label: "Go to Team", onClick: () => {} }}
+      >
+        <p>body</p>
+      </Widget>
+    )
+
+    expect(screen.getByRole("heading", { name: "Team" })).not.toHaveClass(
+      "text-lg"
+    )
+    // The chosen size lands on the button's INNER box, so the arbitrary
+    // variant on the root is what says which size it was given.
+    expect(
+      screen.getByRole("button", { name: "Go to Team" }).className
+    ).toContain("[&_.main]:h-6")
+  })
+
+  test("past 480px the title steps up a size, and so does the footer button", () => {
+    withCardWidth(600)
+    zeroRender(
+      <Widget
+        header={{ title: "Team" }}
+        action={{ label: "Go to Team", onClick: () => {} }}
+      >
+        <p>body</p>
+      </Widget>
+    )
+
+    expect(screen.getByRole("heading", { name: "Team" })).toHaveClass("text-lg")
+    expect(
+      screen.getByRole("button", { name: "Go to Team" }).className
+    ).toContain("[&_.main]:h-8")
+  })
+
+  test("a widget that asks for a button size still gets it", () => {
+    withCardWidth(600)
+    zeroRender(
+      <Widget
+        header={{ title: "Team" }}
+        action={{ label: "Go to Team", onClick: () => {}, size: "sm" }}
+      >
+        <p>body</p>
+      </Widget>
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Go to Team" }).className
+    ).toContain("[&_.main]:h-6")
+  })
 })

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -1,5 +1,12 @@
+import { useComposedRefs } from "@radix-ui/react-compose-refs"
 import { cva, type VariantProps } from "cva"
-import React, { forwardRef, ReactNode, useEffect } from "react"
+import React, {
+  forwardRef,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 
 import { F0Button, type F0ButtonProps } from "@/components/F0Button"
 import { F0Icon, IconType } from "@/components/F0Icon"
@@ -113,6 +120,65 @@ const InlineDot = () => (
 )
 
 /**
+ * A WIDER CARD SPEAKS UP. The same widget sits in a Home's 396px rail and in
+ * the main column beside it, and at the second width a 14px title over small
+ * glyphs reads as a footnote pinned to a large surface. Past this width the
+ * frame grows its title and its footer button, and its CONTENT grows its glyphs
+ * (see {@link useWidgetIsWide}).
+ *
+ * 480px, so the rail (396px) stays exactly as it is and only a card that has
+ * genuinely more room grows.
+ */
+const WIDE_WIDGET_PX = 480
+
+/**
+ * MEASURED, not asked for with a CSS container query, because two of the things
+ * that react to it are PROPS rather than classes — `F0Button`'s size, an
+ * avatar's — and one source of truth for "wide" beats a media query and a
+ * measurement that can disagree by a frame. It starts `false`, so the first
+ * paint is the card as it has always been and a wide one grows into it.
+ *
+ * `clientWidth`, NOT `getBoundingClientRect().width`: a bounding rect is
+ * multiplied by any `transform: scale()` an ancestor applies (a zoom-to-fit
+ * preview frame, a dragged card's lift), so a card would change its own type
+ * scale while it was being scaled. `clientWidth` is the layout metric and
+ * ignores transforms.
+ */
+const useIsWide = (ref: React.RefObject<HTMLElement | null>) => {
+  const [isWide, setIsWide] = useState(false)
+
+  useEffect(() => {
+    const element = ref.current
+    if (!element || typeof ResizeObserver === "undefined") return
+
+    const measure = () => setIsWide(element.clientWidth >= WIDE_WIDGET_PX)
+
+    measure()
+    const observer = new ResizeObserver(measure)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [ref])
+
+  return isWide
+}
+
+/**
+ * Whether the surrounding widget is WIDE, for content that has to size itself to
+ * the card it landed in — Home's list rows step their glyphs up a size here (see
+ * `slotRenderers`).
+ *
+ * A CONTEXT rather than a prop or a second measurement, because a widget's
+ * content is handed to the frame as `children`: it is built before the frame
+ * renders and cannot be told, but it renders INSIDE it and can therefore ask.
+ * One observer on the card answers for everything in it.
+ *
+ * `false` outside a `Widget`, so a row rendered on its own is the narrow one.
+ */
+const WidgetIsWideContext = React.createContext(false)
+
+export const useWidgetIsWide = () => React.useContext(WidgetIsWideContext)
+
+/**
  * The TITLE AS A LINK: title text plus a chevron, in one target that behaves like
  * a ghost button — a tint on hover, a ring on focus. The negative margin with the
  * matching padding is what keeps the title on the same line it sits on when it is
@@ -139,15 +205,28 @@ const TITLE_LINK_CLASS = cn(
 const WidgetTitle = ({
   title,
   link,
+  isWide,
 }: {
   title: string
   link?: NonNullable<WidgetProps["header"]>["link"]
+  /** The card has room: the title steps up a size (see {@link WIDE_WIDGET_PX}). */
+  isWide?: boolean
 }) => {
-  if (!link) return <CardTitle className="truncate">{title}</CardTitle>
+  // `text-lg` IS the design's wide title, token for token: 1rem on a 1.5rem line
+  // box at -0.01em (f0's `fontSize.lg`), `font-semibold` for its 600 — the one
+  // thing `CardTitle`'s own `font-medium` doesn't already give. Its `m-0`,
+  // `text-left` and `hsl(var(--neutral-100))` are the h3's computed values here
+  // and `text-f1-foreground` respectively, so nothing needs to say them twice.
+  //
+  // 24px is also the `min-h-6` the header row already reserves, so growing the
+  // title never moves anything beside it.
+  const titleClass = cn("truncate", isWide && "text-lg font-semibold")
+
+  if (!link) return <CardTitle className={titleClass}>{title}</CardTitle>
 
   const content = (
     <>
-      <CardTitle className="truncate">{title}</CardTitle>
+      <CardTitle className={titleClass}>{title}</CardTitle>
       {/* No colour of its own: `currentColor` makes it exactly the title's, and
           the two read as ONE label rather than a label beside a control. */}
       <F0Icon size="sm" icon={link.icon ?? ChevronRight} />
@@ -209,6 +288,11 @@ const Container = forwardRef<
   },
   ref
 ) {
+  // The card measures ITSELF, so the ref is both the caller's and ours.
+  const cardRef = useRef<HTMLDivElement>(null)
+  const composedRef = useComposedRefs(ref, cardRef)
+  const isWide = useIsWide(cardRef)
+
   useEffect(() => {
     if (!isDragging || !onDragEnd) return
     // The pointer can be released anywhere, so the end of a drag is a document
@@ -242,154 +326,173 @@ const Container = forwardRef<
   }
 
   return (
-    <Card
-      className={cn(
-        fullHeight ? "h-full" : "",
-        "relative flex gap-3 border-f1-border-secondary",
-        draggable && "hover:border-f1-border-hover",
-        selected &&
-          "border-f1-border-selected-bold shadow-[0_0_0_4px_hsl(var(--selected-50)/0.1)]",
-        isDragging &&
-          "cursor-grabbing border-f1-border-hover shadow-[0_6px_12px_0_hsl(var(--shadow)/0.06),0_16px_24px_-12px_hsl(var(--shadow)/0.05)]"
-      )}
-      ref={ref}
-    >
-      {header && (
-        <CardHeader className="-mr-1 -mt-1">
-          <div className="flex w-full flex-1 flex-col gap-4">
-            <div className="flex flex-1 flex-row flex-nowrap items-center justify-between gap-2">
-              {draggable && (
-                <div
-                  className="-ml-1 flex h-6 w-6 shrink-0 items-center justify-center text-f1-icon-secondary hover:cursor-grab"
-                  onMouseDown={onDragStart}
-                  data-gs-handle="true"
-                >
-                  <F0Icon icon={Handle} size="xs" />
-                </div>
-              )}
-              {/* `min-w-0` rather than `truncate`: the ellipsis belongs to the
+    <WidgetIsWideContext.Provider value={isWide}>
+      <Card
+        className={cn(
+          fullHeight ? "h-full" : "",
+          "relative flex gap-3 border-f1-border-secondary",
+          draggable && "hover:border-f1-border-hover",
+          selected &&
+            "border-f1-border-selected-bold shadow-[0_0_0_4px_hsl(var(--selected-50)/0.1)]",
+          isDragging &&
+            "cursor-grabbing border-f1-border-hover shadow-[0_6px_12px_0_hsl(var(--shadow)/0.06),0_16px_24px_-12px_hsl(var(--shadow)/0.05)]"
+        )}
+        ref={composedRef}
+      >
+        {header && (
+          <CardHeader className="-mr-1 -mt-1">
+            <div className="flex w-full flex-1 flex-col gap-4">
+              <div className="flex flex-1 flex-row flex-nowrap items-center justify-between gap-2">
+                {draggable && (
+                  <div
+                    className="-ml-1 flex h-6 w-6 shrink-0 items-center justify-center text-f1-icon-secondary hover:cursor-grab"
+                    onMouseDown={onDragStart}
+                    data-gs-handle="true"
+                  >
+                    <F0Icon icon={Handle} size="xs" />
+                  </div>
+                )}
+                {/* `min-w-0` rather than `truncate`: the ellipsis belongs to the
                   TITLE, which carries its own (see `WidgetTitle`), and an
                   `overflow: hidden` here clipped the linked title's hover
                   background where it bleeds past the content box. */}
-              <div className="flex min-h-6 min-w-0 grow flex-row items-center gap-1">
-                {header.title && (
-                  <WidgetTitle title={header.title} link={header.link} />
-                )}
-                {header.subtitle && (
-                  <div className="flex flex-row items-center gap-1">
-                    <InlineDot />
-                    <CardSubtitle className="truncate">
-                      {header.subtitle}
-                    </CardSubtitle>
-                  </div>
-                )}
-                {header.info && (
-                  <Tooltip label={header.info}>
-                    <F0Icon
-                      icon={InfoCircleLine}
-                      size="sm"
-                      className="text-f1-foreground-secondary"
+                <div className="flex min-h-6 min-w-0 grow flex-row items-center gap-1">
+                  {header.title && (
+                    <WidgetTitle
+                      title={header.title}
+                      link={header.link}
+                      isWide={isWide}
                     />
-                  </Tooltip>
-                )}
-                {header.count && (
-                  <div className="ml-0.5">
-                    <Counter value={header.count} />
-                  </div>
-                )}
-              </div>
-              <div className="flex flex-row items-center gap-3">
-                {alert && <F0TagAlert text={alert} level="critical" />}
-                {status && (
-                  <F0TagStatus text={status.text} variant={status.variant} />
-                )}
-                {AIButton && (
-                  <AIButtonComponent
-                    size="sm"
-                    label={t.ai.ask}
-                    onClick={AIButton}
-                    icon={OneIcon}
-                  />
-                )}
-                {actions && (
-                  <DropdownInternal items={actions} align="end">
-                    <F0Button
-                      icon={Ellipsis}
-                      label="Actions"
-                      variant="ghost"
+                  )}
+                  {header.subtitle && (
+                    <div className="flex flex-row items-center gap-1">
+                      <InlineDot />
+                      <CardSubtitle className="truncate">
+                        {header.subtitle}
+                      </CardSubtitle>
+                    </div>
+                  )}
+                  {header.info && (
+                    <Tooltip label={header.info}>
+                      <F0Icon
+                        icon={InfoCircleLine}
+                        size="sm"
+                        className="text-f1-foreground-secondary"
+                      />
+                    </Tooltip>
+                  )}
+                  {header.count && (
+                    <div className="ml-0.5">
+                      <Counter value={header.count} />
+                    </div>
+                  )}
+                </div>
+                <div className="flex flex-row items-center gap-3">
+                  {alert && <F0TagAlert text={alert} level="critical" />}
+                  {status && (
+                    <F0TagStatus text={status.text} variant={status.variant} />
+                  )}
+                  {AIButton && (
+                    <AIButtonComponent
                       size="sm"
-                      hideLabel
+                      label={t.ai.ask}
+                      onClick={AIButton}
+                      icon={OneIcon}
                     />
-                  </DropdownInternal>
-                )}
-                {/* No link here: it is the TITLE (see `WidgetTitle`). This
+                  )}
+                  {actions && (
+                    <DropdownInternal items={actions} align="end">
+                      <F0Button
+                        icon={Ellipsis}
+                        label="Actions"
+                        variant="ghost"
+                        size="sm"
+                        hideLabel
+                      />
+                    </DropdownInternal>
+                  )}
+                  {/* No link here: it is the TITLE (see `WidgetTitle`). This
                     corner belongs to the overflow menu. */}
+                </div>
               </div>
+              {header.comment && (
+                <div className="flex flex-row items-center gap-3 overflow-visible">
+                  <PrivateBox>
+                    <CardComment>{header.comment}</CardComment>
+                  </PrivateBox>
+                  {!!header.canBeBlurred && (
+                    <span>
+                      <F0Button
+                        icon={privacyModeEnabled ? EyeInvisible : EyeVisible}
+                        hideLabel
+                        label="hide/show"
+                        variant="outline"
+                        onClick={togglePrivacyMode}
+                        size="sm"
+                      />
+                    </span>
+                  )}
+                </div>
+              )}
             </div>
-            {header.comment && (
-              <div className="flex flex-row items-center gap-3 overflow-visible">
-                <PrivateBox>
-                  <CardComment>{header.comment}</CardComment>
-                </PrivateBox>
-                {!!header.canBeBlurred && (
-                  <span>
-                    <F0Button
-                      icon={privacyModeEnabled ? EyeInvisible : EyeVisible}
-                      hideLabel
-                      label="hide/show"
-                      variant="outline"
-                      onClick={togglePrivacyMode}
-                      size="sm"
-                    />
-                  </span>
-                )}
-              </div>
-            )}
-          </div>
-        </CardHeader>
-      )}
-      <CardContent className="flex h-full flex-col gap-4">
-        {summaries && (
-          <div className="flex flex-row">
-            {summaries.map((summary, index) => (
-              <div key={index} className="grow">
-                <div className="mb-0.5 text-sm text-f1-foreground-secondary">
-                  {summary.label}
-                </div>
-                <div className="flex flex-row items-end gap-0.5 text-2xl font-semibold">
-                  {!!summary.prefixUnit && (
-                    <div className="text-lg font-medium">
-                      {summary.prefixUnit}
-                    </div>
-                  )}
-                  {summary.value}
-                  {!!summary.postfixUnit && (
-                    <div className="text-lg font-medium">
-                      {summary.postfixUnit}
-                    </div>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
+          </CardHeader>
         )}
-        {React.Children.toArray(children)
-          .filter(isRealNode)
-          .map((child, index) => {
-            return (
-              <React.Fragment key={index}>
-                {index > 0 && <Separator bare />}
-                {child}
-              </React.Fragment>
-            )
-          })}
-      </CardContent>
-      {action && (
-        <CardFooter className={cn(footerClassName)}>
-          <F0Button variant="neutral" size="sm" {...action} />
-        </CardFooter>
-      )}
-    </Card>
+        <CardContent className="flex h-full flex-col gap-4">
+          {summaries && (
+            <div className="flex flex-row">
+              {summaries.map((summary, index) => (
+                <div key={index} className="grow">
+                  <div className="mb-0.5 text-sm text-f1-foreground-secondary">
+                    {summary.label}
+                  </div>
+                  <div className="flex flex-row items-end gap-0.5 text-2xl font-semibold">
+                    {!!summary.prefixUnit && (
+                      <div className="text-lg font-medium">
+                        {summary.prefixUnit}
+                      </div>
+                    )}
+                    {summary.value}
+                    {!!summary.postfixUnit && (
+                      <div className="text-lg font-medium">
+                        {summary.postfixUnit}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          {React.Children.toArray(children)
+            .filter(isRealNode)
+            .map((child, index) => {
+              return (
+                <React.Fragment key={index}>
+                  {index > 0 && <Separator bare />}
+                  {child}
+                </React.Fragment>
+              )
+            })}
+        </CardContent>
+        {action && (
+          <CardFooter className={cn(footerClassName)}>
+            {/* Both are DEFAULTS, not decisions: `action` is spread after them,
+              so a widget that asks for a particular variant or size still gets
+              it.
+
+              `outline` only once the card is WIDE. In the rail the footer button
+              sits directly under a dense stack of rows, and a bordered rectangle
+              across the card there reads as one more row; the filled `neutral`
+              reads as a control. With the room a wide card has, that fill
+              becomes the heaviest thing on the card and the border is enough. */}
+            <F0Button
+              variant={isWide ? "outline" : "neutral"}
+              size={isWide ? "md" : "sm"}
+              {...action}
+            />
+          </CardFooter>
+        )}
+      </Card>
+    </WidgetIsWideContext.Provider>
   )
 })
 

--- a/packages/react/src/lib/linkHandler.spec.tsx
+++ b/packages/react/src/lib/linkHandler.spec.tsx
@@ -187,6 +187,26 @@ describe("isExternalHref", () => {
     expect(isExternalHref(`https://${host()}/calendar#core.events`)).toBe(false)
   })
 
+  test("THIS hostname on another PORT is still this app", () => {
+    // The regression, as reported from the frontend: the app is served through
+    // a dev server on a port (`app.local.factorial.dev:8080`) while the links it
+    // renders carry none, so comparing `host` — which includes the port — sent
+    // every internal link to a new tab and tore the SPA down to get there.
+    const { hostname } = window.location
+
+    expect(
+      isExternalHref(
+        `https://${hostname}/dashboard#core.dashboardCompanyLinksEdit`
+      )
+    ).toBe(false)
+    expect(
+      isExternalHref(
+        `https://${hostname}:8080/dashboard#core.dashboardCompanyLinksEdit`
+      )
+    ).toBe(false)
+    expect(isExternalHref(`http://${hostname}:1234/dashboard`)).toBe(false)
+  })
+
   test("another host is external, fragment or not", () => {
     expect(isExternalHref("https://factorial.co")).toBe(true)
     expect(isExternalHref("https://help.factorial.co/article#top")).toBe(true)

--- a/packages/react/src/lib/linkHandler.tsx
+++ b/packages/react/src/lib/linkHandler.tsx
@@ -50,13 +50,21 @@ export type LinkProps = AnchorHTMLAttributes<HTMLAnchorElement> & {
  * `target="_blank"`. Everything else belongs in the current tab, where the app's
  * own router (`LinkProvider`'s `component`) can take the navigation.
  *
- * Three things are NOT external, and each of them used to be:
+ * Four things are NOT external, and each of them used to be:
  *
  * - A bare `#fragment`. It does not leave the DOCUMENT, let alone the site.
  * - The SAME HOST under a different scheme. `http://app.example.com/x` while you
  *   sit on `https://app.example.com` is the app you are already in; comparing
  *   ORIGINS (scheme included) called it another site and tore the SPA down to
  *   open a new tab. Hosts are what "same domain" means.
+ * - The same hostname on ANOTHER PORT. This compares `hostname`, not `host`, so
+ *   the port is ignored entirely: an app served through a dev server or a proxy
+ *   sits on one (`app.local.factorial.dev:8080`) while the links it renders are
+ *   written without one (`https://app.local.factorial.dev/dashboard#…`), and
+ *   comparing `host` sent every one of those to a new tab. A port is a way IN to
+ *   a machine, not a different site — and where a port genuinely does separate
+ *   two apps, the cost of being wrong here is one same-tab navigation, against a
+ *   torn-down SPA the other way.
  * - A non-web scheme (`mailto:`, `tel:`, `sms:`). The OS handles those; a tab
  *   would open only to close itself again.
  *
@@ -69,8 +77,9 @@ export const isExternalHref = (href?: string): boolean => {
   try {
     const url = new URL(href, window.location.href)
     if (url.protocol !== "http:" && url.protocol !== "https:") return false
-    // `host`, not `hostname`: a different port is a different app.
-    return url.host !== window.location.host
+    // `hostname`, not `host`: the port is how you reach this app, not which
+    // app it is — see the note above.
+    return url.hostname !== window.location.hostname
   } catch {
     return false
   }

--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -1,6 +1,7 @@
-import { describe, expect, test } from "vitest"
+import { describe, expect, test, vi } from "vitest"
 
-import { screen, zeroRender } from "@/testing/test-utils"
+import { Clock, Cross } from "@/icons/app"
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
 
 import { HomeListItem } from "./index"
 
@@ -105,5 +106,145 @@ describe("HomeListItem", () => {
     rerender(<HomeListItem title="row" href="https://developer.mozilla.org" />)
     expect(screen.getByRole("link")).toHaveAttribute("target", "_blank")
     expect(screen.getByRole("link")).toHaveAttribute("rel", "noreferrer")
+  })
+
+  describe("hover actions", () => {
+    const actions = [
+      { label: "Clock out", icon: Clock, onClick: vi.fn() },
+      { label: "Dismiss", icon: Cross, onClick: vi.fn(), critical: true },
+    ]
+
+    test("names each one, and calls only the one that was pressed", async () => {
+      const clockOut = vi.fn()
+      const dismiss = vi.fn()
+      zeroRender(
+        <HomeListItem
+          title="You never clocked out"
+          actions={[
+            { label: "Clock out", icon: Clock, onClick: clockOut },
+            { label: "Dismiss", icon: Cross, onClick: dismiss },
+          ]}
+        />
+      )
+
+      // Icon-only, so the label IS the accessible name.
+      await userEvent.click(screen.getByRole("button", { name: "Clock out" }))
+
+      expect(clockOut).toHaveBeenCalledTimes(1)
+      expect(dismiss).not.toHaveBeenCalled()
+    })
+
+    test("stays in the DOM while hidden, so Tab can reach it", () => {
+      zeroRender(<HomeListItem title="row" actions={actions} />)
+
+      // Hidden by opacity rather than by being absent or `aria-hidden`: a
+      // keyboard user tabs to it, and reaching it is what reveals the strip.
+      const button = screen.getByRole("button", { name: "Dismiss" })
+      expect(button).toBeInTheDocument()
+      expect(button.closest("[class*='opacity-0']")).not.toBeNull()
+      expect(
+        button.closest("[class*='group-focus-within:opacity-100']")
+      ).not.toBeNull()
+    })
+
+    test("lives OUTSIDE the anchor, so pressing one never follows the row", () => {
+      zeroRender(<HomeListItem title="row" href="/x" actions={actions} />)
+
+      const link = screen.getByRole("link", { name: "row" })
+      const button = screen.getByRole("button", { name: "Dismiss" })
+
+      // A button inside an anchor is invalid HTML and its click would navigate.
+      expect(link.contains(button)).toBe(false)
+    })
+
+    test("draws the label beside the glyph on request, and text-only without one", async () => {
+      zeroRender(
+        <HomeListItem
+          title="row"
+          actions={[
+            {
+              label: "Clock out",
+              icon: Clock,
+              showLabel: true,
+              onClick: vi.fn(),
+            },
+            { label: "Sign", onClick: vi.fn() },
+            { label: "Dismiss", icon: Cross, onClick: vi.fn() },
+          ]}
+        />
+      )
+
+      const button = (name: string) => screen.getByRole("button", { name })
+
+      // A named one draws its label; an icon-only one still CARRIES it, for
+      // screen readers alone — which is why every action is named either way.
+      expect(button("Clock out").querySelector(".sr-only")).toBeNull()
+      expect(button("Sign").querySelector(".sr-only")).toBeNull()
+      expect(button("Dismiss").querySelector(".sr-only")).toHaveTextContent(
+        "Dismiss"
+      )
+    })
+
+    test("an action with items opens a menu, and holds the strip open while it is up", async () => {
+      const laterToday = vi.fn()
+      const { container } = zeroRender(
+        <HomeListItem
+          title="Ada Lovelace's 3rd work anniversary"
+          actions={[
+            {
+              label: "Remind me later",
+              icon: Clock,
+              items: [
+                { type: "label", text: "Remind me" },
+                { label: "Later Today", onClick: laterToday },
+                { label: "Tomorrow", onClick: vi.fn() },
+              ],
+            },
+          ]}
+        />
+      )
+
+      // `classList`, not the class STRING: `group-hover:opacity-100` contains
+      // "opacity-100" as a substring, and the unprefixed class is the pin.
+      const pinned = () =>
+        container
+          .querySelector(".absolute.inset-y-0")
+          ?.classList.contains("opacity-100")
+
+      // Closed, the strip is hover-only.
+      expect(pinned()).toBe(false)
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Remind me later" })
+      )
+
+      expect(screen.getByText("Remind me")).toBeInTheDocument()
+      // Pinned: the menu is portalled, so reaching it leaves the row — without
+      // this the trigger would unmount from under its own menu.
+      expect(pinned()).toBe(true)
+
+      await userEvent.click(screen.getByText("Later Today"))
+      // The dropdown defers its item callbacks by 200ms (a Radix animation
+      // workaround), so the click alone hasn't fired it yet.
+      await waitFor(() => expect(laterToday).toHaveBeenCalledTimes(1))
+    })
+
+    test("makes an inert row highlight on hover — something happens there", () => {
+      const { container, rerender } = zeroRender(
+        <HomeListItem title="row" actions={actions} />
+      )
+
+      expect(
+        container.querySelector(
+          "[class*='group-hover:bg-f1-background-tertiary']"
+        )
+      ).not.toBeNull()
+
+      // Without actions an inert row has no hover state at all.
+      rerender(<HomeListItem title="row" />)
+      expect(
+        container.querySelector("[class*='bg-f1-background-tertiary']")
+      ).toBeNull()
+    })
   })
 })

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -1,11 +1,92 @@
-import { ReactNode } from "react"
+import { Fragment, ReactNode, useState } from "react"
 
 import { F0Avatar, type AvatarVariant } from "@/components/avatars/F0Avatar"
 import type { AvatarSize } from "@/components/avatars/internal/BaseAvatar"
-import { F0Icon } from "@/components/F0Icon"
+import { F0Button } from "@/components/F0Button"
+import { F0Icon, type IconType } from "@/components/F0Icon"
 import { ChevronRight } from "@/icons/app"
 import { isExternalHref, Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
+import { useWidgetIsWide } from "@/experimental/Widgets/Widget"
+import {
+  DropdownInternal,
+  type DropdownItem,
+} from "@/experimental/Navigation/Dropdown/internal.tsx"
+
+/**
+ * One of a row's hover actions: a button at the row's right that acts on THAT
+ * row.
+ *
+ * ICON-ONLY BY DEFAULT, because a row is a dense line of text and a strip of
+ * labelled buttons beside it would outweigh what it is about — `label` is then
+ * the accessible name and the tooltip rather than visible text.
+ *
+ * A row's PRIMARY action can say what it is (`showLabel`), and usually should
+ * when the glyph alone would be a guess: "Clock out" is a clock, and so is
+ * "Snooze". Keep it to ONE per row, leading, with the rest as glyphs — a strip
+ * of labelled buttons is a toolbar, not a row.
+ */
+export type HomeListItemAction = {
+  /** What it DOES, in words: "Clock out", "Dismiss". Never "OK" or "Go". */
+  label: string
+  /** Omit for a text-only button — then the label always shows. */
+  icon?: IconType
+  /** A destructive one — it draws as the critical button. */
+  critical?: boolean
+  /** Show the `label` beside the glyph instead of only in the tooltip. */
+  showLabel?: boolean
+} & (
+  | { onClick: () => void; items?: never }
+  | {
+      /**
+       * The action OPENS A MENU instead of doing one thing — "Remind me" over
+       * Later today / Tomorrow / Next Monday. Ordinary `DropdownItem`s, so a
+       * `{ type: "label", text }` heads the group and `{ type: "separator" }`
+       * divides it.
+       *
+       * The button is the same button either way, glyph or label: what changes
+       * is that pressing it opens the menu, and the strip STAYS OPEN while the
+       * menu is (the pointer has to leave the row to reach it).
+       */
+      items: DropdownItem[]
+      onClick?: never
+    }
+)
+
+/**
+ * THE HOVER ACTIONS, over the row's right edge.
+ *
+ * They are a SIBLING of the row rather than a child, because a link row is a
+ * real anchor and a button cannot live inside one. That also means a click on
+ * an action is never a click on the row.
+ *
+ * The gradient is what makes them readable over whatever they cover: it fades
+ * the CARD's background in from the right, so the row's own hover tint shows
+ * through on the left of the strip and the buttons sit on plain background. The
+ * transparent runway (`pl-16`) is the fade itself, and it must not swallow
+ * pointer events on its way — only the buttons take them, and only once the
+ * strip is actually showing.
+ */
+const ACTIONS_CLASS = cn(
+  "pointer-events-none absolute inset-y-0 right-0 z-10 flex items-center gap-1 rounded-r-md pl-16 pr-2",
+  "bg-gradient-to-l from-f1-background from-60% to-transparent",
+  // Hidden but still in the DOM and still focusable, so Tab reaches them —
+  // and reaching them is what reveals the strip (`group-focus-within`).
+  "opacity-0 transition-opacity motion-reduce:transition-none",
+  "group-hover:pointer-events-auto group-hover:opacity-100",
+  "group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+)
+
+/**
+ * The strip HELD OPEN regardless of the pointer, while one of its buttons has a
+ * menu up.
+ *
+ * A dropdown portals to the app's overlay layer, so reaching it means leaving
+ * the row: hover goes false, the strip fades, and the trigger unmounts from
+ * under its own menu. Pinning it is the same thing f0's own row-actions overlay
+ * does with `dropDownOpen`.
+ */
+const ACTIONS_PINNED_CLASS = "pointer-events-auto opacity-100"
 
 /**
  * The BASE row every Home list draws: a LEFT slot, a text stack and a RIGHT
@@ -20,6 +101,10 @@ import { cn } from "@/lib/utils"
  *
  * The text stack is three optional voices: `title` leads, `subtitle` murmurs on
  * the same line after a dot, `description` takes the second line.
+ *
+ * A row can also carry `actions` — what you can DO to it without leaving the
+ * widget (snooze it, dismiss it). They stay out of the way until the row is
+ * hovered or something inside it is focused.
  *
  * The `list` slot builds these rows from its schema (see `slotRenderers`) —
  * that's where the row's shape and sizing rules live.
@@ -38,6 +123,15 @@ export interface HomeListItemProps {
   description?: string
   /** Trailing slot: a tag, a counter, people. */
   right?: ReactNode
+  /**
+   * What can be DONE to this row, as icon buttons over its right edge. They
+   * appear on hover (and whenever anything in the row has focus, so they are
+   * reachable by keyboard) behind a fade that covers whatever `right` holds.
+   *
+   * A row with actions HIGHLIGHTS ON HOVER even when it is inert: something
+   * happens there, so it has to look like it does.
+   */
+  actions?: HomeListItemAction[]
   /** An accent dot on the left slot's corner — unseen/pending. */
   unread?: boolean
   /**
@@ -60,10 +154,17 @@ export function HomeListItem({
   subtitle,
   description,
   right,
+  actions,
   unread = false,
   href,
   showChevron = false,
 }: HomeListItemProps) {
+  const hasActions = Boolean(actions?.length)
+  // The card the row landed in — the row's controls step up with it.
+  const isWide = useWidgetIsWide()
+  // Which action's menu is up, by label — `null` for none. Not a boolean, so
+  // one menu closing can never hide a strip another one is still holding open.
+  const [openMenu, setOpenMenu] = useState<string | null>(null)
   const leading =
     left ?? (avatar ? <F0Avatar avatar={avatar} size={avatarSize} /> : null)
 
@@ -106,10 +207,24 @@ export function HomeListItem({
   const className = cn(
     "flex w-full items-center gap-3 rounded-md p-2 text-left",
     href &&
-      "cursor-pointer hover:bg-f1-background-tertiary focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring"
+      // `ring-inset`: the row is drawn inside a box that CLIPS (the item-churn
+      // animation closes a row's height, which needs `overflow: hidden` — see
+      // `HomeSlotItem`), and a ring drawn outside the row would lose its top
+      // and bottom edges to that clip.
+      "cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-f1-special-ring",
+    // The tint follows the POINTER over the whole row, actions strip included —
+    // which is the wrapper, not this element, once there are actions. Without
+    // the group version the row would go dark the moment the pointer crossed
+    // into the strip on its way to a button.
+    hasActions
+      ? "group-hover:bg-f1-background-tertiary group-focus-within:bg-f1-background-tertiary"
+      : href && "hover:bg-f1-background-tertiary",
+    // With a menu up the pointer is off the row entirely, but the row is still
+    // the thing being acted on — so it stays lit under its own open menu.
+    openMenu && "bg-f1-background-tertiary"
   )
 
-  return href ? (
+  const row = href ? (
     <Link
       href={href}
       className={cn(className, "no-underline")}
@@ -119,5 +234,61 @@ export function HomeListItem({
     </Link>
   ) : (
     <div className={className}>{content}</div>
+  )
+
+  if (!hasActions) return row
+
+  return (
+    <div className="group relative">
+      {row}
+      <div className={cn(ACTIONS_CLASS, openMenu && ACTIONS_PINNED_CLASS)}>
+        {actions?.map((action) => {
+          const button = (
+            <F0Button
+              icon={action.icon}
+              label={action.label}
+              // Hidden only when there is a glyph to carry the button AND the
+              // action didn't ask to be named — `F0Button` then turns the label
+              // into the accessible name and the tooltip. A button with neither
+              // an icon nor visible text would be an empty square.
+              hideLabel={Boolean(action.icon) && !action.showLabel}
+              variant={action.critical ? "critical" : "outline"}
+              // Up a step with the card, like everything else the row draws — a
+              // 24px button beside a 40px glyph is a control you have to aim at.
+              size={isWide ? "md" : "sm"}
+              onClick={action.onClick}
+            />
+          )
+
+          if (!action.items)
+            return <Fragment key={action.label}>{button}</Fragment>
+
+          return (
+            <DropdownInternal
+              key={action.label}
+              items={action.items}
+              // `end`, so the menu hangs under the strip's own right edge rather
+              // than off the card.
+              align="end"
+              // CONTROLLED, and it has to be: `DropdownInternal` only calls
+              // `onOpenChange` when `open` is passed too, and the row needs the
+              // answer to keep the strip up (see `ACTIONS_PINNED_CLASS`).
+              open={openMenu === action.label}
+              onOpenChange={(open) =>
+                setOpenMenu((current) =>
+                  open
+                    ? action.label
+                    : current === action.label
+                      ? null
+                      : current
+                )
+              }
+            >
+              {button}
+            </DropdownInternal>
+          )
+        })}
+      </div>
+    </div>
   )
 }

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -24,6 +24,36 @@ instead of crashing.
 <Canvas of={SlotWidgetStories.AllSlots} />
 <Controls of={SlotWidgetStories.AllSlots} />
 
+## A wider card speaks up
+
+The same widget sits in the Home's 396px rail and in the main column beside it,
+and at the second width a 14px title over 32px glyphs reads as a footnote pinned
+to a large surface. Past **480px** everything the card sizes for itself steps up
+one:
+
+|                                 | Rail (≤480px) | Wide        |
+| ------------------------------- | ------------- | ----------- |
+| Widget title                    | `text-base`   | `text-lg`   |
+| Footer button (`action`)        | `sm`          | `md`        |
+| A `list` row's leading glyph    | `sm` / `md`   | `md` / `lg` |
+| A `list` row's trailing face(s) | `sm`          | `md`        |
+
+The leading glyph keeps two steps because a row's own shape still decides
+between them — two-line rows carry the larger one (see **Prescriptive sizing**).
+The trailing faces stay a step behind the leading glyph: they are **who** a row
+is about, which is secondary to what it is, and matching the two turns the row
+into two competing anchors.
+
+There is nothing to configure. The card measures itself — `clientWidth`, so a
+`transform: scale()` on an ancestor (a zoom-to-fit preview, a dragged card's
+lift) never changes its type scale — and a widget dragged from the rail into the
+column grows on the way. A widget that asks for a particular `action.size` still
+gets it.
+
+Slots learn the card's width from **context**, not a prop: a widget's content is
+built before the frame renders, but it is drawn inside it. A bespoke renderer
+can ask the same question with `useWidgetIsWide()`.
+
 ## The way out IS the title
 
 `header.link` makes the widget's **title itself** the link: the title with a
@@ -230,13 +260,112 @@ listSlot(
 | --------------------- | -------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
 | `left`                | any avatar type (`person`, `team`, `company`, `file`, `flag`, `emoji`, `icon`), `module`, `alert` — or omitted | each row supplies that kind's data (`avatar`, `module`, or `alert`)                 |
 | `right`               | `counter`, one avatar type (e.g. a sender), or `<type>-list` (a strip of faces) — or omitted                   | each row supplies `count`, `rightAvatar`, or `avatars` (+ `remainingCount`)         |
+| `rightOptional`       | `true`                                                                                                         | the `right` data is allowed but not demanded — rows without it trail nothing        |
 | `subtitleRequired`    | `true`                                                                                                         | every row carries a `subtitle`, inline after the title                              |
 | `descriptionRequired` | `true`                                                                                                         | every row carries a `description` — the second line                                 |
+| `descriptionOptional` | `true`                                                                                                         | a second line is allowed but not demanded — some rows are two-line, some one        |
 | `clickBehavior`       | `"link"` — or omitted for inert rows                                                                           | every row carries an `href` and renders as a REAL anchor (see Click handling)       |
 | `maxVisibleItems`     | a number — or omitted to always show every row                                                                 | rows past it fold behind "View more (n)" / "View less" at the list's bottom         |
 | `compact`             | `true`                                                                                                         | forces the compact presentation at any count: descriptions in tooltips, `sm` glyphs |
 
-Rows may also carry `unread` for the accent dot on the left glyph.
+Rows may also carry `unread` for the accent dot on the left glyph, and
+`actions` for what can be done to that row (see **Row actions**).
+
+### Even rows, and rows that aren't
+
+The schema's default is **evenness**: declaring `right: "person"` means every
+row supplies a `rightAvatar`, and `descriptionRequired` means every row supplies
+a second line. That is what makes a list read as a list rather than a pile.
+
+A **feed** is the exception, and the two `…Optional` flags are how you say so.
+`rightOptional` and `descriptionOptional` keep the schema's type checking — the
+data still has to be the kind that was declared — while letting rows go without:
+
+```tsx
+listSlot(
+  {
+    left: "icon",
+    right: "person",
+    rightOptional: true, // ← only some rows came from a person
+    descriptionOptional: true, // ← only some rows have a second line
+    clickBehavior: "link",
+  },
+  [
+    {
+      id: "welcome",
+      title: "Welcome to the August cohort 🎉",
+      description: "9:12 · Marie Curie",
+      avatar: { icon: Envelope, color: "lilac" },
+      rightAvatar: { firstName: "Marie", lastName: "Curie" },
+      href: "/inbox/1",
+    },
+    // No second line, nobody behind it — and it still typechecks.
+    {
+      id: "leave",
+      title: "You have 5 days of leave expiring next month",
+      avatar: { icon: PalmTree, color: "army" },
+      href: "/time-off",
+    },
+  ]
+)
+```
+
+A list that allows a second line is still a **two-line list**: the glyphs stay
+`md` throughout, so the column of them lines up down the card whatever each
+row's height turns out to be. It also does **not auto-compact** past
+`LIST_COMPACT_AFTER` — see **Auto-compact** below.
+
+### Tinted icon glyphs
+
+`left: "icon"` rows take an optional `color` from f0's named palette —
+`viridian`, `malibu`, `yellow`, `purple`, `lilac`, `barbie`, `smoke`, `army`,
+`flubber`, `indigo`, `camel` (exported as `listIconColors`):
+
+```tsx
+avatar: { icon: Clock, color: "purple" }
+```
+
+The tile is the hue at a tenth of its strength and the icon is the hue itself,
+so a column of them stays legible. Colour here says **which kind of thing** the
+row is, not how urgent it is — a feed can give every category its own without
+any of them reading as an alarm. For "this is urgent", the left kind is `alert`.
+
+Without a `color` the row draws the neutral `F0AvatarIcon`, unchanged. Only the
+icon glyph takes one: every other left kind carries its own identity already (a
+face, a flag, a module's brand).
+
+### Row actions
+
+What can be **done** to a row — snooze it, dismiss it, clock out — goes in that
+row's `actions`. They are per **row**, not per schema, because unlike everything
+else about a row this genuinely varies: a feed mixes items you can dismiss with
+items there is nothing to dismiss about.
+
+```tsx
+actions: [
+  { label: "Clock out", icon: Clock, showLabel: true, onClick: clockOut },
+  { label: "Dismiss", icon: Cross, onClick: dismiss },
+]
+```
+
+They are **icon-only by default** — a row is a dense line of text and a strip of
+labelled buttons beside it would outweigh what the row is about — so `label` is
+the accessible name and the tooltip rather than visible text. Write it as what
+the action **does**: "Clock out", "Dismiss", never "OK".
+
+A row's **primary** action can say what it is with `showLabel`, and usually
+should when the glyph alone would be a guess (a clock is "clock out" and also
+"snooze"). An action with **no `icon`** is text-only and always shows its label.
+Keep it to one named action per row, leading, with the rest as glyphs — and to
+two actions in total: the strip covers the row's right-hand side while it shows.
+
+They appear on hover, and on **focus**: they stay in the DOM while hidden, so
+Tab reaches them and reaching them is what reveals the strip. The buttons sit
+**outside** the row's anchor, so pressing one never follows a link row — and a
+row with actions highlights on hover even when it is inert, because something
+does happen there.
+
+<Canvas of={SlotWidgetStories.NeedsYou} />
 
 ### Click handling
 
@@ -260,8 +389,17 @@ The row's right-hand side belongs to the schema's `right` instead.
 
 ### Prescriptive sizing
 
-Glyph sizes are **not configurable** — they follow the schema. Two-line rows
-(a required `description`) draw `md` glyphs; one-line rows draw `sm`.
+Glyph sizes are **not configurable** — they follow the schema and the card. Two
+things decide, and a row can argue with neither:
+
+- its **shape** — two-line rows (a `description` required or allowed) draw the
+  larger step, one-line rows the smaller, so the glyph is about as tall as the
+  text beside it either way;
+- the **card's width** — both steps move up one past 480px (see **A wider card
+  speaks up**).
+
+So a two-line row is `md` in the rail and `lg` in the main column; a one-line row
+is `sm` and `md`. Compacted rows are one-line by definition and take that step.
 
 ### View more
 
@@ -280,6 +418,11 @@ second-to-last list in the story above shows the whole pipeline.
 A slot can also opt into this presentation at any count with `compact: true` —
 useful when the descriptions are secondary enough to live in tooltips even on
 a short list.
+
+A `descriptionOptional` list is **exempt**: auto-compacting was written to tame
+a long column of uniformly two-line rows, and a mixed list is not that column —
+most of its rows are already one line, and folding away the few that aren't
+would hide the only thing telling them apart. `compact: true` still forces it.
 
 ### Recipes
 
@@ -342,6 +485,44 @@ listSlot({ clickBehavior: "link" }, [
   { id: "help", title: "Help center", href: "https://help.factorial.co" },
 ])
 ```
+
+## Items coming and going
+
+A widget's items change under the user while they are reading them — a row is
+dismissed, a request lands, a poll brings a shorter list. An item that vanishes
+between two blinks leaves them wondering which one they just lost, so every
+slot animates its own churn:
+
+- the item **fades**, and
+- its own **height closes on a spring**.
+
+Closing the item's height rather than just fading it is what keeps everything
+standing on it moving continuously: the rows below, the widget's footer button,
+and the card's own bottom edge. A row that only faded gave its space back in one
+frame, and the footer snapped up by a row's height while the fade was still
+settling.
+
+That is the one place in Home's motion vocabulary where a height is animated,
+and it costs an `overflow: hidden` per item — which is why a row's focus ring is
+an **inset** ring. Under `prefers-reduced-motion` nothing moves at all.
+
+There is nothing to turn on: `list` and `event-list` do it already. A **bespoke**
+renderer opts in with the same two wrappers, and the only requirement is a
+**stable key per item** — a positional key would animate every row below a
+removal as though it had been replaced:
+
+```tsx
+import { HomeSlotItem, HomeSlotItems } from "@/sds/Home/slotRenderers"
+;<HomeSlotItems>
+  {tasks.map((task) => (
+    <HomeSlotItem key={task.id}>
+      <AgentTaskRow task={task} />
+    </HomeSlotItem>
+  ))}
+</HomeSlotItems>
+```
+
+<Canvas of={SlotWidgetStories.ItemChurn} />
 
 ## The rest of the vocabulary
 

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -334,6 +334,25 @@ Without a `color` the row draws the neutral `F0AvatarIcon`, unchanged. Only the
 icon glyph takes one: every other left kind carries its own identity already (a
 face, a flag, a module's brand).
 
+#### A colour of your own
+
+`color` also takes a **hex** — `#RGB` or `#RRGGBB`:
+
+```tsx
+avatar: { icon: Calendar, color: event.color } // "#4F46E5"
+```
+
+**Prefer a palette name.** Those eleven hues were picked to sit beside each
+other in one column and to hold up in both themes, which is the whole job here:
+a feed's glyphs are read as a _set_, and a colour chosen per row without seeing
+the others is how a card ends up with two greens that mean different things.
+
+The hex is for the case the palette genuinely can't serve — a colour that is
+already **data**: a calendar's own colour, a module's brand, a category the user
+picked. It draws exactly like a palette hue (a tenth of it as the tile, the hue
+itself as the icon), so the two are the same glyph. A hex that can't be parsed
+falls back to the plain, untinted glyph rather than painting the tile black.
+
 ### Row actions
 
 What can be **done** to a row — snooze it, dismiss it, clock out — goes in that

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -536,6 +536,63 @@ describe("list slot schema", () => {
 
     expect(container.querySelector("[class*='colors.purple']")).not.toBeNull()
   })
+
+  test("a hex tints the glyph too — as channels on a variable, so both themes still apply", () => {
+    const { container } = zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ left: "icon" }, [
+            {
+              id: "1",
+              title: "Design sync",
+              avatar: { icon: Clock, color: "#4F46E5" },
+            },
+          ]),
+        ]}
+      />
+    )
+
+    const glyph = container.querySelector<HTMLElement>(
+      "[class*='--list-icon-tint']"
+    )
+    // The colour rides in on the variable while the classes stay literal —
+    // that is what keeps the `dark:` step working for a runtime value.
+    expect(glyph?.style.getPropertyValue("--list-icon-tint")).toBe("79 70 229")
+  })
+
+  test("a three-digit hex expands, and an unusable one falls back to the plain glyph", () => {
+    const { container, rerender } = zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ left: "icon" }, [
+            { id: "1", title: "Row", avatar: { icon: Clock, color: "#0af" } },
+          ]),
+        ]}
+      />
+    )
+
+    expect(
+      container
+        .querySelector<HTMLElement>("[class*='--list-icon-tint']")
+        ?.style.getPropertyValue("--list-icon-tint")
+    ).toBe("0 170 255")
+
+    rerender(
+      <SlotWidget
+        slots={[
+          listSlot({ left: "icon" }, [
+            { id: "1", title: "Row", avatar: { icon: Clock, color: "#nope" } },
+          ]),
+        ]}
+      />
+    )
+
+    // No tile painted black, no crash: the neutral bordered F0AvatarIcon.
+    expect(container.querySelector("[class*='--list-icon-tint']")).toBeNull()
+    expect(
+      container.querySelector(".border-f1-border-secondary")
+    ).not.toBeNull()
+  })
 })
 
 describe("SlotWidget loading", () => {

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -1,5 +1,6 @@
-import { describe, expect, test, vi } from "vitest"
+import { afterEach, describe, expect, test, vi } from "vitest"
 
+import { Clock, Cross } from "@/icons/app"
 import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
 
 import {
@@ -310,6 +311,230 @@ describe("list slot schema", () => {
     )
 
     expect(screen.getByText("3")).toBeInTheDocument()
+  })
+
+  test("descriptionOptional lets some rows carry a second line and others not — and the list stays two-line", () => {
+    const { container } = zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ left: "person", descriptionOptional: true }, [
+            {
+              id: "1",
+              title: "Ada",
+              description: "Due Today",
+              avatar: { firstName: "Ada", lastName: "Lovelace" },
+            },
+            {
+              id: "2",
+              title: "Alan",
+              avatar: { firstName: "Alan", lastName: "Turing" },
+            },
+          ]),
+        ]}
+      />
+    )
+
+    expect(screen.getByText("Due Today")).toBeInTheDocument()
+    // The glyphs stay md for BOTH rows, so the column of them lines up even
+    // though only one row is two lines tall.
+    expect(container.querySelectorAll(".size-8")).toHaveLength(2)
+    expect(container.querySelector(".size-6")).toBeNull()
+  })
+
+  test("a mixed list does NOT auto-compact — folding its few second lines away would hide the only thing telling those rows apart", () => {
+    const many = Array.from({ length: LIST_COMPACT_AFTER + 1 }, (_, i) => ({
+      id: String(i),
+      title: `Person ${i}`,
+      // Only the first row has one, which is the point of `descriptionOptional`.
+      ...(i === 0 ? { description: "Due Today" } : {}),
+      avatar: { firstName: `Person ${i}`, lastName: "Doe" },
+    }))
+    const { container } = zeroRender(
+      <SlotWidget
+        slots={[listSlot({ left: "person", descriptionOptional: true }, many)]}
+      />
+    )
+
+    expect(screen.getByText("Due Today")).toBeInTheDocument()
+    expect(container.querySelector(".size-8")).not.toBeNull()
+
+    // `compact: true` still forces it.
+    const { container: forced } = zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot(
+            { left: "person", descriptionOptional: true, compact: true },
+            many
+          ),
+        ]}
+      />
+    )
+    expect(forced.querySelector(".size-8")).toBeNull()
+  })
+
+  test("a row's actions are its own: named buttons that act on that row alone", async () => {
+    const dismissFirst = vi.fn()
+    zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ clickBehavior: "link" }, [
+            {
+              id: "1",
+              title: "You never clocked out",
+              href: "/attendance",
+              actions: [
+                { label: "Dismiss this", icon: Cross, onClick: dismissFirst },
+              ],
+            },
+            // The next row offers none — actions are per row, not per schema.
+            { id: "2", title: "Sign your contract", href: "/documents/1" },
+          ]),
+        ]}
+      />
+    )
+
+    expect(screen.getAllByRole("button", { name: /Dismiss/ })).toHaveLength(1)
+
+    await userEvent.click(screen.getByRole("button", { name: "Dismiss this" }))
+    expect(dismissFirst).toHaveBeenCalledTimes(1)
+  })
+
+  describe("glyphs follow the card they landed in", () => {
+    const withCardWidth = (width: number) => {
+      vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockImplementation(
+        function (this: HTMLElement) {
+          return this.getAttribute("role") === "article" ? width : 0
+        }
+      )
+    }
+
+    afterEach(() => vi.restoreAllMocks())
+
+    const twoLineList = (
+      <SlotWidget
+        slots={[
+          listSlot(
+            { left: "person", right: "person", descriptionRequired: true },
+            [
+              {
+                id: "1",
+                title: "Ada",
+                description: "Out until Friday",
+                avatar: { firstName: "Ada", lastName: "Lovelace" },
+                rightAvatar: { firstName: "Alan", lastName: "Turing" },
+              },
+            ]
+          ),
+        ]}
+      />
+    )
+
+    test("in the rail the leading glyph is md and the trailing face sm", () => {
+      withCardWidth(396)
+      const { container } = zeroRender(twoLineList)
+
+      expect(container.querySelector(".size-8")).not.toBeNull()
+      expect(container.querySelector(".size-10")).toBeNull()
+    })
+
+    test("past 480px both step up — the leading glyph to lg, the face to md", () => {
+      withCardWidth(600)
+      const { container } = zeroRender(twoLineList)
+
+      // The leading glyph is now lg (40px) and the trailing face md (32px),
+      // so the row keeps its two anchors a step apart.
+      expect(container.querySelector(".size-10")).not.toBeNull()
+      expect(container.querySelector(".size-8")).not.toBeNull()
+      expect(container.querySelector(".size-6")).toBeNull()
+    })
+
+    test("the placeholder draws the size the real glyph will be, so the card doesn't resize when data lands", () => {
+      withCardWidth(600)
+      const { container } = zeroRender(
+        <SlotWidget
+          loading
+          slots={[
+            listSlot({ left: "person", descriptionRequired: true }, [], {
+              expectedItemsCount: 2,
+            }),
+          ]}
+        />
+      )
+
+      expect(container.querySelectorAll(".size-10")).toHaveLength(2)
+    })
+  })
+
+  describe("items coming and going", () => {
+    const rows = (names: string[]) =>
+      names.map((name) => ({
+        id: name,
+        title: name,
+        avatar: { firstName: name, lastName: "Doe" },
+      }))
+
+    const listOf = (names: string[]) => (
+      <SlotWidget slots={[listSlot({ left: "person" }, rows(names))]} />
+    )
+
+    test("a row that goes away leaves — it is not stranded by its own exit animation", async () => {
+      const { rerender } = zeroRender(listOf(["Ada", "Alan", "Grace"]))
+
+      expect(screen.getByText("Alan")).toBeInTheDocument()
+
+      rerender(listOf(["Ada", "Grace"]))
+
+      // It animates out rather than vanishing, so it is still there for a beat.
+      // What matters is that it is GONE afterwards: an `AnimatePresence` whose
+      // exit never completes keeps a removed row in the DOM forever.
+      await waitFor(() =>
+        expect(screen.queryByText("Alan")).not.toBeInTheDocument()
+      )
+      expect(screen.getByText("Ada")).toBeInTheDocument()
+      expect(screen.getByText("Grace")).toBeInTheDocument()
+    })
+
+    test("a row that arrives is drawn", async () => {
+      const { rerender } = zeroRender(listOf(["Ada"]))
+
+      rerender(listOf(["Ada", "Grace"]))
+
+      await waitFor(() => expect(screen.getByText("Grace")).toBeInTheDocument())
+    })
+  })
+
+  test("an icon row's color tints its glyph; without one it draws the plain avatar", () => {
+    const { container, rerender } = zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ left: "icon" }, [
+            { id: "1", title: "Clocked out", avatar: { icon: Clock } },
+          ]),
+        ]}
+      />
+    )
+
+    // The neutral F0AvatarIcon: a bordered white tile.
+    expect(
+      container.querySelector(".border-f1-border-secondary")
+    ).not.toBeNull()
+    expect(container.querySelector("[class*='colors.purple']")).toBeNull()
+
+    rerender(
+      <SlotWidget
+        slots={[
+          listSlot({ left: "icon" }, [
+            {
+              id: "1",
+              title: "Clocked out",
+              avatar: { icon: Clock, color: "purple" },
+            },
+          ]),
+        ]}
+      />
+    )
+
+    expect(container.querySelector("[class*='colors.purple']")).not.toBeNull()
   })
 })
 

--- a/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
@@ -1,6 +1,18 @@
+import { useState } from "react"
+
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { Comment, PalmTree } from "@/icons/app"
+import {
+  Clock,
+  Comment,
+  Cross,
+  Envelope,
+  FileSigned,
+  PalmTree,
+  PersonPlus,
+  Receipt,
+  Sparkles,
+} from "@/icons/app"
 import { Skeleton } from "@/ui/skeleton"
 
 import {
@@ -16,8 +28,15 @@ const meta = {
   component: SlotWidget,
   tags: ["autodocs", "experimental"],
   decorators: [
-    (Story) => (
-      <div className="max-w-96">
+    // The rail's width by default (24rem ≈ the Home's 396px aside), because
+    // that is where most of these widgets live. A story that wants the main
+    // column's width says so with `parameters.widgetWidth` — see `NeedsYouWide`.
+    (Story, context) => (
+      <div
+        style={{
+          maxWidth: (context.parameters.widgetWidth as string) ?? "24rem",
+        }}
+      >
         <Story />
       </div>
     ),
@@ -328,6 +347,258 @@ export const AllLoadingSlots: Story = {
     header: { title: "Team", link: { title: "Go to Team", onClick: () => {} } },
     loading: true,
     slots: teamSlots.map(beforeItemsLand),
+  },
+}
+
+/**
+ * A FEED — the densest thing a `list` draws, and the one every part of the
+ * schema was built for. One slot, one schema, seven rows that do not look alike:
+ *
+ * - **`left: "icon"` with a `color` per row** — the tinted glyph says which
+ *   KIND of thing the row is at a glance, without any of them reading as an
+ *   alert (that's what `left: "alert"` is for).
+ * - **`descriptionOptional`** — only some rows have a second line ("Due Today",
+ *   the sender and the time). The glyphs stay `md` throughout, so the column of
+ *   them lines up down the card whatever each row's height turns out to be.
+ * - **`right: "person"`** — the rows that came from someone show who; the rest
+ *   trail nothing.
+ * - **row `actions`** — hover the first row (or Tab into the list): what you can
+ *   DO to a row appears over its right-hand side, behind a fade. Per row, not
+ *   per schema: the two AI prompts near the bottom offer nothing to act on. The
+ *   first row and the contract row lead with a NAMED action ("Clock out",
+ *   "Sign") and keep "Dismiss" as a glyph — a strip of labelled buttons would
+ *   outweigh the row it belongs to.
+ * - **`unread`** — the accent dot on the unopened message.
+ *
+ * The widget is 384px here, the width of the Home's rail. Widen the story and
+ * the frame's title and footer button step up a size with it.
+ */
+export const NeedsYou: Story = {
+  args: {
+    header: { title: "Needs you", count: 7 },
+    action: { label: "See all", onClick: () => {} },
+    slots: [
+      listSlot(
+        {
+          left: "icon",
+          right: "person",
+          rightOptional: true,
+          descriptionOptional: true,
+          clickBehavior: "link",
+        },
+        [
+          {
+            id: "clock-out",
+            title: "You clocked in but never clocked out yesterday",
+            avatar: { icon: Clock, color: "purple" },
+            href: "/attendance",
+            // The row's PRIMARY action says what it is — a clock glyph alone
+            // would be a guess between "clock out" and "snooze" — and the one
+            // beside it stays a glyph.
+            actions: [
+              {
+                label: "Clock out",
+                icon: Clock,
+                showLabel: true,
+                onClick: () => {},
+              },
+              { label: "Dismiss", icon: Cross, onClick: () => {} },
+            ],
+          },
+          {
+            id: "anniversary",
+            title: "Ada Lovelace's 3rd work anniversary",
+            description: "Due Today",
+            avatar: { icon: PersonPlus, color: "barbie" },
+            rightAvatar: { firstName: "Ada", lastName: "Lovelace" },
+            href: "/employees/ada",
+            // A MENU rather than one thing: "later" is a question, not an
+            // answer. The strip stays up while the menu is, because reaching
+            // the menu means leaving the row.
+            actions: [
+              {
+                label: "Remind me later",
+                icon: Clock,
+                items: [
+                  { type: "label", text: "Remind me" },
+                  { label: "Later Today", onClick: () => {} },
+                  { label: "Tomorrow", onClick: () => {} },
+                  { label: "Next Monday", onClick: () => {} },
+                ],
+              },
+              { label: "Dismiss", icon: Cross, onClick: () => {} },
+            ],
+          },
+          {
+            id: "welcome",
+            title: "Welcome to the August onboarding cohort 🎉",
+            description: "9:12 · Marie Curie",
+            avatar: { icon: Envelope, color: "lilac" },
+            unread: true,
+            rightAvatar: { firstName: "Marie", lastName: "Curie" },
+            href: "/inbox/1",
+          },
+          // No actions and nobody behind them: the two things the assistant
+          // offers to do for you, which there is nothing to dismiss about.
+          {
+            id: "expense",
+            title: "Snap a receipt and I'll file the expense",
+            avatar: { icon: Receipt, color: "viridian" },
+            href: "/expenses/new",
+          },
+          {
+            id: "policy",
+            title:
+              "Ask a policy question and I'll answer it or raise it with HR",
+            avatar: { icon: Sparkles, color: "indigo" },
+            href: "/assistant",
+          },
+          {
+            id: "contract",
+            title: "Sign your Q3 contract addendum",
+            description: "Due Today",
+            avatar: { icon: FileSigned, color: "malibu" },
+            href: "/documents/1",
+            // A text-only action: no glyph reads as "sign".
+            actions: [
+              { label: "Sign", showLabel: true, onClick: () => {} },
+              { label: "Dismiss", icon: Cross, onClick: () => {} },
+            ],
+          },
+          {
+            id: "leave",
+            title: "You have 5 days of leave expiring next month",
+            avatar: { icon: PalmTree, color: "army" },
+            href: "/time-off",
+            actions: [{ label: "Dismiss", icon: Cross, onClick: () => {} }],
+          },
+        ]
+      ),
+    ],
+  },
+}
+
+/**
+ * THE SAME WIDGET, given the main column's width instead of the rail's.
+ *
+ * Nothing about the slot changed — this is `NeedsYou`'s args in a wider box.
+ * Past 480px everything the card sizes for itself steps up one: the **title**,
+ * the **footer button**, each row's **leading glyph** (`md` → `lg`) and its
+ * **trailing faces** (`sm` → `md`). The faces stay a step behind the glyph — who
+ * a row is about is secondary to what it is.
+ *
+ * The TEXT doesn't grow: that is the content's scale, not the card's, and a feed
+ * whose copy resized with its container would just be a different feed at every
+ * width.
+ *
+ * Drag the story's boundary across 480px and it changes live — the card
+ * measures itself, so a widget moved from the rail into the column grows on
+ * the way.
+ */
+export const NeedsYouWide: Story = {
+  args: NeedsYou.args,
+  parameters: { widgetWidth: "40rem" },
+}
+
+/** The pool `ItemChurn` adds from, cycled so the button never runs out. */
+const CHURN_ITEMS = [
+  { title: "You never clocked out yesterday", icon: Clock, color: "purple" },
+  {
+    title: "Sign your Q3 contract addendum",
+    icon: FileSigned,
+    color: "malibu",
+  },
+  {
+    title: "Snap a receipt and I'll file it",
+    icon: Receipt,
+    color: "viridian",
+  },
+  { title: "5 days of leave expire next month", icon: PalmTree, color: "army" },
+  { title: "Welcome to the August cohort 🎉", icon: Envelope, color: "lilac" },
+] as const
+
+/**
+ * ITEMS COMING AND GOING — the playground for it. Three ways to change the list,
+ * so every direction is one click away:
+ *
+ * - **"Add an item"** in the footer appends one,
+ * - the widget's **⋯ menu** adds one at the TOP or removes the last,
+ * - and each row's **✕** (hover it) removes that row.
+ *
+ * A widget's items change under the user while they are reading them, so a row
+ * that vanished between two blinks would leave them wondering which one they
+ * just lost. The leaving row fades, and its own height closes on a spring — so
+ * the rows below it, the footer button and the card's bottom edge all move
+ * CONTINUOUSLY rather than snapping to the new size in one frame.
+ *
+ * The same wrapper does it for every slot type (`event-list` too, and any
+ * bespoke renderer that reaches for `HomeSlotItems`), and it does nothing at
+ * all under `prefers-reduced-motion`.
+ */
+export const ItemChurn: Story = {
+  // `render` owns the widget, but the story still has to satisfy
+  // `SlotWidget`'s required props. These args are unused.
+  args: { slots: [] },
+  render: function ItemChurnStory() {
+    // Rows by IDENTITY, not by index: the id is what tells the animation which
+    // row is which between two renders, and reusing one would make an added row
+    // read as an edit of whatever used to sit in that position.
+    const [rows, setRows] = useState(() =>
+      CHURN_ITEMS.slice(0, 3).map((item, index) => ({ ...item, id: index }))
+    )
+    const [nextId, setNextId] = useState(3)
+
+    const addRow = (atTop: boolean) => {
+      const item = CHURN_ITEMS[nextId % CHURN_ITEMS.length]
+      const row = { ...item, id: nextId }
+      setNextId((id) => id + 1)
+      setRows((current) => (atTop ? [row, ...current] : [...current, row]))
+    }
+
+    return (
+      <SlotWidget
+        header={{ title: "Needs you", count: rows.length }}
+        // The two moves a row cannot offer you: adding one, and adding it
+        // somewhere other than the end — which is the case that shows the rows
+        // below it gliding DOWN rather than the list redrawing.
+        actions={[
+          {
+            label: "Add at the top",
+            icon: Sparkles,
+            onClick: () => addRow(true),
+          },
+          {
+            label: "Remove the last",
+            icon: Cross,
+            onClick: () => setRows((current) => current.slice(0, -1)),
+          },
+        ]}
+        action={{ label: "Add an item", onClick: () => addRow(false) }}
+        slots={[
+          listSlot(
+            { left: "icon", clickBehavior: "link" },
+            rows.map((row) => ({
+              id: row.id,
+              title: row.title,
+              avatar: { icon: row.icon, color: row.color },
+              href: `/${row.id}`,
+              // Removing THE ONE YOU POINTED AT is the case worth watching: the
+              // rows under it are the ones that have to close the gap.
+              actions: [
+                {
+                  label: "Dismiss",
+                  icon: Cross,
+                  onClick: () =>
+                    setRows((current) =>
+                      current.filter((r) => r.id !== row.id)
+                    ),
+                },
+              ],
+            }))
+          ),
+        ]}
+      />
+    )
   },
 }
 

--- a/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
@@ -450,7 +450,10 @@ export const NeedsYou: Story = {
             id: "policy",
             title:
               "Ask a policy question and I'll answer it or raise it with HR",
-            avatar: { icon: Sparkles, color: "indigo" },
+            // A HEX rather than a palette name — what a row whose colour is
+            // already data uses (a calendar's own colour, a module's brand).
+            // It draws exactly like the named ones beside it.
+            avatar: { icon: Sparkles, color: "#4F46E5" },
             href: "/assistant",
           },
           {

--- a/packages/react/src/sds/Home/home-motion.spec.tsx
+++ b/packages/react/src/sds/Home/home-motion.spec.tsx
@@ -8,8 +8,10 @@ import {
   ENTRANCE_STAGGER_CAP_MS,
   ENTRANCE_STAGGER_MS,
   entranceDelay,
+  ITEM_CHURN_BULK_AFTER,
   useDelayedTrue,
   useElapsed,
+  useIsBulkChange,
 } from "./home-motion"
 
 describe("entranceDelay", () => {
@@ -129,5 +131,57 @@ describe("useDelayedTrue", () => {
     rerender({ value: true })
 
     expect(result.current).toBe(true)
+  })
+})
+
+describe("useIsBulkChange", () => {
+  test("one item coming or going is churn, not a replacement", () => {
+    const { result, rerender } = zeroRenderHook(
+      ({ count }: { count: number }) => useIsBulkChange(count),
+      { initialProps: { count: 5 } }
+    )
+
+    expect(result.current).toBe(false)
+
+    rerender({ count: 4 })
+    expect(result.current).toBe(false)
+
+    rerender({ count: 5 })
+    expect(result.current).toBe(false)
+  })
+
+  test(`more than ${ITEM_CHURN_BULK_AFTER} at once is the list being replaced`, () => {
+    const { result, rerender } = zeroRenderHook(
+      ({ count }: { count: number }) => useIsBulkChange(count),
+      { initialProps: { count: 3 } }
+    )
+
+    // "View more" revealing the rest: thirty rows is a new list, not thirty
+    // arrivals.
+    rerender({ count: 33 })
+    expect(result.current).toBe(true)
+
+    // …and folding them away again is the same thing in reverse.
+    rerender({ count: 3 })
+    expect(result.current).toBe(true)
+  })
+
+  test("the threshold is inclusive — exactly that many still animates", () => {
+    const { result, rerender } = zeroRenderHook(
+      ({ count }: { count: number }) => useIsBulkChange(count),
+      { initialProps: { count: 0 } }
+    )
+
+    rerender({ count: ITEM_CHURN_BULK_AFTER })
+    expect(result.current).toBe(false)
+
+    rerender({ count: ITEM_CHURN_BULK_AFTER * 2 + 1 })
+    expect(result.current).toBe(true)
+  })
+
+  test("the FIRST render is never a bulk change — a list that mounts full has not changed", () => {
+    const { result } = zeroRenderHook(() => useIsBulkChange(100))
+
+    expect(result.current).toBe(false)
   })
 })

--- a/packages/react/src/sds/Home/home-motion.tsx
+++ b/packages/react/src/sds/Home/home-motion.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode, useEffect, useState } from "react"
+import { type ReactNode, useEffect, useRef, useState } from "react"
 
-import { motion, type Transition } from "motion/react"
+import { AnimatePresence, motion, type Transition } from "motion/react"
 
 import { useReducedMotion } from "@/lib/a11y"
 import { cn } from "@/lib/utils"
@@ -20,9 +20,10 @@ import { cn } from "@/lib/utils"
  * Expanding reverses it: the glyphs bloom outward as the cards grow back in.
  *
  * Every value here is a TRANSFORM or an OPACITY, so the whole gesture is
- * composited: nothing in this file animates a width, a height or an offset. (The
- * one exception is the rail's grid column, which is the layout itself changing
- * shape — see `railWidthTransition`.)
+ * composited: nothing in this file animates a width, a height or an offset. Two
+ * exceptions, both of them the LAYOUT ITSELF changing shape rather than
+ * something moving through it — the rail's grid column (`railWidthTransition`)
+ * and an item's height as it joins or leaves a slot (`HomeSlotItem`).
  */
 
 /** Fast start, soft landing, NO overshoot (Material "emphasized decelerate"). */
@@ -249,6 +250,169 @@ export interface HomeEntranceProps {
   fullHeight?: boolean
   className?: string
   children: ReactNode
+}
+
+/* ------------------------------ item churn ------------------------------ */
+
+/**
+ * ONE ITEM COMING OR GOING — a row dismissed, a request that just landed.
+ *
+ * A widget's items change under the user while they are reading them, and an
+ * item that vanishes between two blinks leaves them wondering which one they
+ * just lost. The gesture is deliberately small: this is a list correcting
+ * itself, not the page announcing something.
+ *
+ * THE ITEM'S HEIGHT IS ANIMATED, and it is the exception this file's rule names
+ * (see the header): everything else here is a transform or an opacity.
+ *
+ * It has to be. A row that only faded and then vanished gave its space back in
+ * ONE FRAME, and everything under it — the rest of the list, the widget's footer
+ * button, the card's own bottom edge — snapped up by a row's height while the
+ * fade was still settling. Sliding the neighbours with `layout` fixes the rows
+ * and nothing else: the footer is not in the list, so it still jumped. Closing
+ * the row's own height is the only version where the CARD shrinks continuously,
+ * and everything standing on it follows for free.
+ *
+ * The cost is `overflow: hidden` on every item, which would clip a focus ring
+ * drawn outside its element — which is why `HomeListItem`'s is an INSET ring.
+ */
+export const ITEM_ENTER_MS = 220
+export const ITEM_EXIT_MS = 140
+/** How far an arriving item rises — half the page's, because it is one row. */
+export const ITEM_RISE_PX = 5
+
+/** Coming IN: the page's own ease, at a row's pace. */
+export const itemEnterTransition: Transition = {
+  duration: ITEM_ENTER_MS / 1000,
+  ease: HOME_EASE,
+}
+/** Going OUT: quicker, and accelerating — a row that leaves should be gone. */
+export const itemExitTransition: Transition = {
+  duration: ITEM_EXIT_MS / 1000,
+  ease: "easeIn",
+}
+/**
+ * The row's own height opening and closing. A spring, because this is the
+ * movement the eye actually follows — everything below it, the footer button and
+ * the card's bottom edge included, rides on it — and a spring is what makes that
+ * read as the card SETTLING rather than as a box being resized.
+ *
+ * No bounce (ζ ≈ 0.87): a card that overshot its new height would draw more
+ * attention to the gap than to the row that left it.
+ */
+export const itemSizeTransition: Transition = {
+  type: "spring",
+  stiffness: 520,
+  damping: 40,
+  mass: 0.8,
+}
+
+/**
+ * Past this many items changing at once, the churn animation is NOT what is
+ * happening — the list is being replaced.
+ *
+ * "View more" revealing thirty rows, a filter clearing, a widget's params
+ * swapping its whole contents: animating each of those individually is thirty
+ * springs on thirty heights (expensive) resolving into one shove of the card
+ * (unreadable). The gesture says "this one item changed", so it is only ever
+ * spent on a change small enough for that to be true; a bigger one is simply
+ * the new list.
+ */
+export const ITEM_CHURN_BULK_AFTER = 4
+
+/**
+ * Whether the item count changed by more than {@link ITEM_CHURN_BULK_AFTER}
+ * since the last render — i.e. whether THIS render is a bulk replacement rather
+ * than an item coming or going. Feed it to {@link HomeSlotItem}'s `animated`.
+ */
+export const useIsBulkChange = (
+  count: number,
+  threshold = ITEM_CHURN_BULK_AFTER
+): boolean => {
+  const previous = useRef(count)
+  // Read during render, committed after it: the answer has to be available to
+  // the same render that draws the new items, which an effect cannot do.
+  const isBulk = Math.abs(count - previous.current) > threshold
+
+  useEffect(() => {
+    previous.current = count
+  })
+
+  return isBulk
+}
+
+/**
+ * The list an item's arrival and departure is animated in. Wrap the items of
+ * ANY slot in it — `list` rows, `event-list` events, a bespoke renderer's own —
+ * and give each {@link HomeSlotItem} the item's stable id as its key.
+ *
+ * `initial={false}`: the items already there when the widget mounts have not
+ * arrived, they simply are. The widget's own entrance (`HomeEntrance`) is what
+ * brings the whole card in; without this every list would replay a row-by-row
+ * arrival inside it.
+ */
+export const HomeSlotItems = ({ children }: { children: ReactNode }) => (
+  <AnimatePresence initial={false}>{children}</AnimatePresence>
+)
+
+export interface HomeSlotItemProps {
+  className?: string
+  /**
+   * `false` puts the item straight where it belongs, with no enter or exit —
+   * for a render that is replacing the list rather than changing one item of it
+   * (see {@link useIsBulkChange}).
+   */
+  animated?: boolean
+  children: ReactNode
+}
+
+/**
+ * One item inside a {@link HomeSlotItems}. MUST carry the item's stable id as
+ * its `key` — that key is the only thing telling the list which items are the
+ * same ones between two renders, and a positional key would animate every row
+ * below a removal as though it had been replaced.
+ */
+export const HomeSlotItem = ({
+  className,
+  animated = true,
+  children,
+}: HomeSlotItemProps) => {
+  const reducedMotion = useReducedMotion()
+  // One switch for both reasons the gesture is skipped: the user asked for no
+  // motion, or this render is a new list rather than a changed one.
+  const still = reducedMotion || !animated
+
+  // `height: auto` is a real target for motion — it measures the item and
+  // animates to that number — but the row must be clipped while the number is
+  // wrong for its content, hence `overflow: hidden` throughout.
+  //
+  // The EXIT still has to be declared even when nothing animates: it is what
+  // `AnimatePresence` waits on, and an item with no exit at all is removed
+  // without one. At zero duration that is exactly the instant removal wanted.
+  return (
+    <motion.div
+      className={className}
+      style={{ overflow: "hidden" }}
+      initial={still ? false : { opacity: 0, height: 0, y: ITEM_RISE_PX }}
+      animate={{ opacity: 1, height: "auto", y: 0 }}
+      exit={{
+        opacity: 0,
+        height: 0,
+        transition: {
+          ...withReducedMotion(itemExitTransition, still),
+          // The fade is quick and the closing is a spring, so the row is
+          // already invisible while its space is still being given back.
+          height: withReducedMotion(itemSizeTransition, still),
+        },
+      }}
+      transition={{
+        ...withReducedMotion(itemEnterTransition, still),
+        height: withReducedMotion(itemSizeTransition, still),
+      }}
+    >
+      {children}
+    </motion.div>
+  )
 }
 
 /**

--- a/packages/react/src/sds/Home/slotRenderers.test-d.ts
+++ b/packages/react/src/sds/Home/slotRenderers.test-d.ts
@@ -122,6 +122,68 @@ test("clickBehavior: link is the ONLY click behavior — href, never onClick", (
   ])
 })
 
+test("the OPTIONAL flags let a feed mix rows the schema would otherwise even out", () => {
+  // Some rows two-line, some one — and some trailing a face, some nothing.
+  listSlot(
+    { right: "person", rightOptional: true, descriptionOptional: true },
+    [
+      { id: 1, title: "with both", description: "Due Today", rightAvatar: ada },
+      { id: 2, title: "with neither" },
+    ]
+  )
+
+  listSlot({ right: "counter", rightOptional: true }, [
+    { id: 1, title: "x", count: 3 },
+    { id: 2, title: "y" },
+  ])
+
+  // Optional means allowed, not unchecked: the data still has to be the kind
+  // the schema declared.
+  listSlot({ right: "person", rightOptional: true }, [
+    // @ts-expect-error a person slot still rejects a count
+    { id: 1, title: "x", count: 3 },
+  ])
+  listSlot({ descriptionOptional: true }, [
+    // @ts-expect-error a subtitle is still not allowed unless declared
+    { id: 1, title: "x", subtitle: "y" },
+  ])
+})
+
+test("an icon row may be tinted, and only with a colour from the palette", () => {
+  listSlot({ left: "icon" }, [
+    { id: 1, title: "Row", avatar: { icon: PalmTree, color: "purple" } },
+  ])
+
+  listSlot({ left: "icon" }, [
+    // @ts-expect-error "octarine" is not one of the palette's colours
+    { id: 1, title: "Row", avatar: { icon: PalmTree, color: "octarine" } },
+  ])
+  listSlot({ left: "person" }, [
+    // @ts-expect-error only the icon glyph takes a colour
+    { id: 1, title: "x", avatar: { ...ada, color: "purple" } },
+  ])
+})
+
+test("a row's actions are its own — no schema flag gates them", () => {
+  listSlot({}, [
+    {
+      id: 1,
+      title: "x",
+      actions: [{ label: "Dismiss", icon: PalmTree, onClick: () => {} }],
+    },
+    { id: 2, title: "y" },
+  ])
+
+  listSlot({}, [
+    {
+      id: 1,
+      title: "x",
+      // @ts-expect-error an action names what it does — the label is required
+      actions: [{ icon: PalmTree, onClick: () => {} }],
+    },
+  ])
+})
+
 test("the schema only speaks the declared kinds", () => {
   // @ts-expect-error not a left kind
   listSlot({ left: "banana" }, [])

--- a/packages/react/src/sds/Home/slotRenderers.test-d.ts
+++ b/packages/react/src/sds/Home/slotRenderers.test-d.ts
@@ -154,8 +154,13 @@ test("an icon row may be tinted, and only with a colour from the palette", () =>
     { id: 1, title: "Row", avatar: { icon: PalmTree, color: "purple" } },
   ])
 
+  // A hex of its own, for a colour that is already data.
   listSlot({ left: "icon" }, [
-    // @ts-expect-error "octarine" is not one of the palette's colours
+    { id: 1, title: "Row", avatar: { icon: PalmTree, color: "#4F46E5" } },
+  ])
+
+  listSlot({ left: "icon" }, [
+    // @ts-expect-error a bare name is neither a palette colour nor a hex
     { id: 1, title: "Row", avatar: { icon: PalmTree, color: "octarine" } },
   ])
   listSlot({ left: "person" }, [

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/components/avatars/F0AvatarModule"
 import type { AvatarSize } from "@/components/avatars/internal/BaseAvatar"
 import { F0Button } from "@/components/F0Button"
-import { type IconType } from "@/components/F0Icon"
+import { F0Icon, type IconType } from "@/components/F0Icon"
 import { cn } from "@/lib/utils"
 import { Counter } from "@/ui/Counter"
 import { Skeleton } from "@/ui/skeleton"
@@ -27,10 +27,25 @@ import {
   IndicatorsListProps,
 } from "@/experimental/Widgets/Content/IndicatorsList"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
-import { WidgetProps } from "@/experimental/Widgets/Widget"
+import { useWidgetIsWide, WidgetProps } from "@/experimental/Widgets/Widget"
 import { type F0FormSchema } from "@/patterns/F0Form"
 
-import { HomeListItem } from "./HomeListItem"
+import { HomeListItem, type HomeListItemAction } from "./HomeListItem"
+import { HomeSlotItem, HomeSlotItems, useIsBulkChange } from "./home-motion"
+
+/**
+ * The item-churn animation, re-exported so a BESPOKE renderer draws its items
+ * the way the built-in ones do: wrap the items in `HomeSlotItems` and each one
+ * in a `HomeSlotItem` keyed by its stable id. An item added or removed then
+ * fades while its height closes, so the card resizes continuously instead of
+ * jumping.
+ *
+ * `useIsBulkChange` is the other half of it: feed its answer to each item's
+ * `animated` so a render that REPLACES the list — "View more" revealing thirty
+ * rows, a filter clearing — draws the new list at once instead of animating
+ * every row of it.
+ */
+export { HomeSlotItem, HomeSlotItems, useIsBulkChange }
 
 /**
  * The Home kit's slot vocabulary and how each slot is drawn. `SlotWidget`
@@ -103,6 +118,100 @@ type AvatarData<T extends AvatarVariant["type"]> = Omit<
 export type ListLeftKind = AvatarVariant["type"] | "module" | "alert"
 
 /**
+ * The tint a row's ICON glyph can carry. f0's NAMED palette — the same hues
+ * `ui/Avatar` colours initials with — deliberately, rather than the semantic
+ * families (`critical`, `warning`, `positive`): a colour here says which KIND
+ * of thing the row is, so a feed can give every category its own without any of
+ * them reading as an alert. For "this is urgent", the left kind is `alert`.
+ */
+export const listIconColors = [
+  "viridian",
+  "malibu",
+  "yellow",
+  "purple",
+  "lilac",
+  "barbie",
+  "smoke",
+  "army",
+  "flubber",
+  "indigo",
+  "camel",
+] as const
+
+export type ListIconColor = (typeof listIconColors)[number]
+
+/**
+ * The tinted glyph, one literal class string per colour: Tailwind reads source
+ * text, so a class built from a variable never reaches the stylesheet.
+ *
+ * The tile is the hue at a TENTH of its strength and the icon is the hue
+ * itself, which is what keeps a row of them legible side by side — the icons
+ * carry the colour, the tiles only suggest it. Dark mode needs the tile
+ * stronger to register against the card at all, hence the second value.
+ */
+const LIST_ICON_TINT: Record<ListIconColor, string> = {
+  viridian:
+    "bg-[hsl(theme(colors.viridian.50)_/_0.1)] text-[hsl(theme(colors.viridian.50))] dark:bg-[hsl(theme(colors.viridian.50)_/_0.24)]",
+  malibu:
+    "bg-[hsl(theme(colors.malibu.50)_/_0.1)] text-[hsl(theme(colors.malibu.50))] dark:bg-[hsl(theme(colors.malibu.50)_/_0.24)]",
+  yellow:
+    "bg-[hsl(theme(colors.yellow.50)_/_0.1)] text-[hsl(theme(colors.yellow.50))] dark:bg-[hsl(theme(colors.yellow.50)_/_0.24)]",
+  purple:
+    "bg-[hsl(theme(colors.purple.50)_/_0.1)] text-[hsl(theme(colors.purple.50))] dark:bg-[hsl(theme(colors.purple.50)_/_0.24)]",
+  lilac:
+    "bg-[hsl(theme(colors.lilac.50)_/_0.1)] text-[hsl(theme(colors.lilac.50))] dark:bg-[hsl(theme(colors.lilac.50)_/_0.24)]",
+  barbie:
+    "bg-[hsl(theme(colors.barbie.50)_/_0.1)] text-[hsl(theme(colors.barbie.50))] dark:bg-[hsl(theme(colors.barbie.50)_/_0.24)]",
+  smoke:
+    "bg-[hsl(theme(colors.smoke.50)_/_0.1)] text-[hsl(theme(colors.smoke.50))] dark:bg-[hsl(theme(colors.smoke.50)_/_0.24)]",
+  army: "bg-[hsl(theme(colors.army.50)_/_0.1)] text-[hsl(theme(colors.army.50))] dark:bg-[hsl(theme(colors.army.50)_/_0.24)]",
+  flubber:
+    "bg-[hsl(theme(colors.flubber.50)_/_0.1)] text-[hsl(theme(colors.flubber.50))] dark:bg-[hsl(theme(colors.flubber.50)_/_0.24)]",
+  indigo:
+    "bg-[hsl(theme(colors.indigo.50)_/_0.1)] text-[hsl(theme(colors.indigo.50))] dark:bg-[hsl(theme(colors.indigo.50)_/_0.24)]",
+  camel:
+    "bg-[hsl(theme(colors.camel.50)_/_0.1)] text-[hsl(theme(colors.camel.50))] dark:bg-[hsl(theme(colors.camel.50)_/_0.24)]",
+}
+
+/** Every glyph size a `list` row draws at — see {@link listGlyphSize}. */
+type ListGlyphSize = "sm" | "md" | "lg"
+
+/** The same box `F0AvatarIcon` draws, so a tinted row lines up with a plain one. */
+const LIST_ICON_SIZE = {
+  sm: "size-6 rounded-sm",
+  md: "size-8 rounded",
+  lg: "size-10 rounded-md",
+} satisfies Record<ListGlyphSize, string>
+
+/**
+ * A `list` row's icon glyph WITH A TINT — the Home kit's own, because
+ * `F0AvatarIcon` is deliberately neutral (a white tile with a border) and
+ * colouring it is a Home decision, not a design-system one. Without a `color`
+ * a row draws the plain `F0AvatarIcon` instead; this is the same box either way.
+ */
+const ListIconGlyph = ({
+  icon,
+  color,
+  size,
+}: {
+  icon: IconType
+  color: ListIconColor
+  size: ListGlyphSize
+}) => (
+  <div
+    className={cn(
+      "flex aspect-square items-center justify-center",
+      LIST_ICON_SIZE[size],
+      LIST_ICON_TINT[color]
+    )}
+  >
+    {/* No `color`: F0Icon defaults to `currentColor`, which the tile's own
+        `text-` class has already set to the hue. */}
+    <F0Icon icon={icon} size={size} />
+  </div>
+)
+
+/**
  * What every row draws on its RIGHT: a counter, one avatar (e.g. the sender),
  * or a compact strip of avatars with an optional `remainingCount`.
  */
@@ -123,10 +232,29 @@ export interface ListSchema {
   left?: ListLeftKind
   /** The one right treatment every row draws. Omit for none. */
   right?: ListRightKind
+  /**
+   * The `right` treatment is ALLOWED but not demanded: rows that carry its data
+   * draw it and the rest trail nothing — a feed where only some items came from
+   * a person. Without this every row must supply it, which is what keeps an
+   * ordinary list even.
+   */
+  rightOptional?: boolean
   /** Every row carries an inline subtitle (on the title's line, after a dot). */
   subtitleRequired?: boolean
   /** Every row carries a second line — this is what makes rows two-line. */
   descriptionRequired?: boolean
+  /**
+   * A second line is ALLOWED but not demanded: some rows carry a `description`
+   * and others don't — a feed where only a few items have a due date or a
+   * sender. The list is still a two-line list (the glyphs stay `md`, so the
+   * column of them lines up); the rows without one are simply shorter.
+   *
+   * `descriptionRequired` wins when both are set: demanding it already allows it.
+   *
+   * Such a list does NOT auto-compact past {@link LIST_COMPACT_AFTER} rows —
+   * see {@link listCompacts}. `compact: true` still forces it.
+   */
+  descriptionOptional?: boolean
   /**
    * `"link"` rows each carry an `href` and render as REAL anchors (role
    * `link`, routed through the app's `LinkProvider`) — never an onClick;
@@ -153,16 +281,25 @@ type ListLeftData<L> = L extends "module"
   ? { module: ModuleId }
   : L extends "alert"
     ? { alert: AlertType }
-    : L extends AvatarVariant["type"]
-      ? { avatar: AvatarData<L> }
-      : object
+    : // The icon glyph takes a `color` no other left kind does — the rest carry
+      // their own identity (a face, a flag, a module's brand), an icon does not.
+      L extends "icon"
+      ? { avatar: AvatarData<"icon"> & { color?: ListIconColor } }
+      : L extends AvatarVariant["type"]
+        ? { avatar: AvatarData<L> }
+        : object
 
-type ListRightData<R> = R extends "counter"
-  ? { count: number }
+/** The row data a schema field demands, or merely allows under `rightOptional`. */
+type Demanded<T, Optional> = Optional extends true ? Partial<T> : T
+
+type ListRightData<R, Optional> = R extends "counter"
+  ? Demanded<{ count: number }, Optional>
   : R extends `${infer T extends F0AvatarListProps["type"]}-list`
-    ? { avatars: Array<AvatarData<T>>; remainingCount?: number }
+    ? Demanded<{ avatars: Array<AvatarData<T>> }, Optional> & {
+        remainingCount?: number
+      }
     : R extends AvatarVariant["type"]
-      ? { rightAvatar: AvatarData<R> }
+      ? Demanded<{ rightAvatar: AvatarData<R> }, Optional>
       : object
 
 type ListClickData<C> = C extends "link" ? { href: string } : object
@@ -174,16 +311,32 @@ type ListTextData<S extends ListSchema> = {
   : { subtitle?: never }) &
   (S["descriptionRequired"] extends true
     ? { description: string }
-    : { description?: never })
+    : S["descriptionOptional"] extends true
+      ? { description?: string }
+      : { description?: never })
+
+/**
+ * One HOVER ACTION on a `list` row: an icon button over the row's right edge
+ * that acts on that row alone — "Clock out", "Dismiss". Per ROW rather than per
+ * schema, because unlike everything else about a row what you can do to it is
+ * genuinely its own: a feed mixes items you can dismiss with items you can't.
+ */
+export type ListRowAction = HomeListItemAction
 
 /** One row of a `list` slot — its shape FOLLOWS from the slot's schema. */
 export type ListItem<S extends ListSchema = ListSchema> = {
   id: string | number
   /** An accent dot on the left glyph — unseen/pending. */
   unread?: boolean
+  /**
+   * What can be DONE to this row, revealed on hover (and on focus, so they are
+   * reachable by keyboard) behind a fade over whatever the row trails. Keep it
+   * to two: the strip covers the row's right-hand side while it shows.
+   */
+  actions?: ListRowAction[]
 } & ListTextData<S> &
   ListLeftData<S["left"]> &
-  ListRightData<S["right"]> &
+  ListRightData<S["right"], S["rightOptional"]> &
   ListClickData<S["clickBehavior"]>
 
 /** `list` params: the schema, then items shaped by it. Build with {@link listSlot}. */
@@ -197,6 +350,20 @@ export interface ListParams<S extends ListSchema = ListSchema> {
  * a tooltip on the row, and the glyphs drop to `sm`.
  */
 export const LIST_COMPACT_AFTER = 6
+
+/**
+ * Whether a list draws itself compact: asked for, or long enough to have earned
+ * it.
+ *
+ * Auto-compacting tames a long column of UNIFORMLY two-line rows — that is the
+ * wall it was written for. A list whose second line is OPTIONAL is not that
+ * column (most of its rows are already one line, and folding the few that
+ * aren't would hide the only thing distinguishing them), so it compacts only
+ * when the schema asks it to.
+ */
+const listCompacts = (schema: ListSchema, visibleRows: number): boolean =>
+  Boolean(schema.compact) ||
+  (!schema.descriptionOptional && visibleRows > LIST_COMPACT_AFTER)
 
 /** `event-list` params: f0 calendar-event rows (color band + date avatars). */
 export interface EventListParams {
@@ -461,7 +628,7 @@ type ListRow = {
   subtitle?: string
   description?: string
   unread?: boolean
-  avatar?: object
+  avatar?: object & { icon?: IconType; color?: ListIconColor }
   module?: ModuleId
   alert?: AlertType
   count?: number
@@ -469,18 +636,31 @@ type ListRow = {
   avatars?: AvatarData<F0AvatarListProps["type"]>[]
   remainingCount?: number
   href?: string
+  actions?: ListRowAction[]
 }
 
 /** The left props a row gets from its schema's `left` kind. */
 const listLeft = (
   left: ListLeftKind | undefined,
   row: ListRow,
-  avatarSize: AvatarSize & ("sm" | "md")
+  avatarSize: AvatarSize & ListGlyphSize
 ) => {
   if (left === "module" && row.module)
     return { left: <F0AvatarModule module={row.module} size={avatarSize} /> }
   if (left === "alert" && row.alert)
     return { left: <F0AvatarAlert type={row.alert} size={avatarSize} /> }
+  // A TINTED icon is the Home kit's own glyph, so it goes in as a node. An icon
+  // row without a `color` falls through to the plain `F0AvatarIcon` below.
+  if (left === "icon" && row.avatar?.icon && row.avatar.color)
+    return {
+      left: (
+        <ListIconGlyph
+          icon={row.avatar.icon}
+          color={row.avatar.color}
+          size={avatarSize}
+        />
+      ),
+    }
   if (left && row.avatar)
     return {
       avatar: { type: left, ...row.avatar } as AvatarVariant,
@@ -489,10 +669,16 @@ const listLeft = (
   return {}
 }
 
-/** The right node a row gets from its schema's `right` kind. */
+/**
+ * The right node a row gets from its schema's `right` kind. The faces are sized
+ * from the same step as the left glyph but one down: they are WHO a row is
+ * about, which is secondary to what it is, and a strip of them matching the
+ * leading glyph turns the row into two competing anchors.
+ */
 const listRight = (
   right: ListRightKind | undefined,
-  row: ListRow
+  row: ListRow,
+  avatarSize: "sm" | "md"
 ): ReactNode => {
   if (!right) return undefined
   if (right === "counter")
@@ -501,7 +687,7 @@ const listRight = (
     return row.avatars && row.avatars.length > 0 ? (
       <F0AvatarList
         type={right.slice(0, -"-list".length) as F0AvatarListProps["type"]}
-        size="sm"
+        size={avatarSize}
         // Explicit, because it is the prop that actually produces the compact
         // strip this slot documents. The deprecated `layout="compact"` that
         // used to sit here was inert, so the strip was really sized by the
@@ -514,10 +700,26 @@ const listRight = (
   return row.rightAvatar ? (
     <F0Avatar
       avatar={{ type: right, ...row.rightAvatar } as AvatarVariant}
-      size="sm"
+      size={avatarSize}
     />
   ) : undefined
 }
+
+/**
+ * How big a row's LEADING glyph draws. Prescriptive, from two things the row
+ * cannot argue with:
+ *
+ * - its own SHAPE — two-line rows carry a bigger glyph than one-line ones, so
+ *   the glyph is about as tall as the text beside it either way;
+ * - the CARD's width — in the Home's 396px rail a 40px tile beside a truncated
+ *   title is the loudest thing in the widget, and in the main column the same
+ *   row at rail size reads as a list that forgot to grow. Past the frame's wide
+ *   threshold every step moves up one (see `useWidgetIsWide`).
+ *
+ * Compact rows are one-line by definition, so they take the one-line step.
+ */
+const listGlyphSize = (twoLine: boolean, isWide: boolean): ListGlyphSize =>
+  isWide ? (twoLine ? "lg" : "md") : twoLine ? "md" : "sm"
 
 /**
  * The `list` slot's body. A component rather than a plain render function
@@ -532,39 +734,62 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
   const { schema, items } = params
   const allRows = items as ListRow[]
   const [expanded, setExpanded] = useState(false)
+  // ASKED, not measured: the slot is built before the frame renders but drawn
+  // inside it, so the card it landed in is the one thing it can only learn from
+  // context. `false` for a list rendered outside a `Widget`.
+  const isWide = useWidgetIsWide()
 
   const max = schema.maxVisibleItems
   const overflows = max != null && allRows.length > max
   const rows = overflows && !expanded ? allRows.slice(0, max) : allRows
+  // "View more" can reveal thirty rows at once, and thirty of them animating in
+  // is a shove rather than a change — past a few, the list is simply new.
+  const isBulkChange = useIsBulkChange(rows.length)
 
-  const compact = Boolean(schema.compact) || rows.length > LIST_COMPACT_AFTER
-  const twoLine = Boolean(schema.descriptionRequired) && !compact
-  const avatarSize = twoLine ? "md" : "sm"
+  const compact = listCompacts(schema, rows.length)
+  // A list that ALLOWS a second line is a two-line list even where a given row
+  // has none: the glyphs keep the two-line step so the column of them lines up
+  // down the card.
+  const twoLine =
+    (Boolean(schema.descriptionRequired) ||
+      Boolean(schema.descriptionOptional)) &&
+    !compact
+  const avatarSize = listGlyphSize(twoLine, isWide)
+  const rightAvatarSize = isWide ? "md" : "sm"
 
   return (
     <div className={cn(slotRowBleed(ctx), "flex flex-col")}>
-      {rows.map(({ href, description, ...row }) => {
-        const node = (
-          <HomeListItem
-            title={row.title}
-            subtitle={row.subtitle}
-            description={compact ? undefined : description}
-            unread={row.unread}
-            {...listLeft(schema.left, row, avatarSize)}
-            right={listRight(schema.right, row)}
-            href={schema.clickBehavior === "link" ? href : undefined}
-          />
-        )
-        return compact && description ? (
-          // The hidden second line surfaces on hover. The span is the
-          // tooltip's trigger — HomeListItem doesn't forward trigger props.
-          <Tooltip key={row.id} label={description}>
-            <span className="block">{node}</span>
-          </Tooltip>
-        ) : (
-          <div key={row.id}>{node}</div>
-        )
-      })}
+      {/* Keyed by the row's OWN id, so a row that goes away is the one that
+          animates out and the rest close the gap. */}
+      <HomeSlotItems>
+        {rows.map(({ href, description, ...row }) => {
+          const node = (
+            <HomeListItem
+              title={row.title}
+              subtitle={row.subtitle}
+              description={compact ? undefined : description}
+              unread={row.unread}
+              {...listLeft(schema.left, row, avatarSize)}
+              right={listRight(schema.right, row, rightAvatarSize)}
+              actions={row.actions}
+              href={schema.clickBehavior === "link" ? href : undefined}
+            />
+          )
+          return (
+            <HomeSlotItem key={row.id} animated={!isBulkChange}>
+              {compact && description ? (
+                // The hidden second line surfaces on hover. The span is the
+                // tooltip's trigger — HomeListItem doesn't forward trigger props.
+                <Tooltip label={description}>
+                  <span className="block">{node}</span>
+                </Tooltip>
+              ) : (
+                node
+              )}
+            </HomeSlotItem>
+          )
+        })}
+      </HomeSlotItems>
       {overflows ? (
         <div className="mt-1 self-start">
           {/* `neutral`, the same button a widget's own call to action is (the
@@ -580,6 +805,41 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
           />
         </div>
       ) : null}
+    </div>
+  )
+}
+
+/**
+ * The `event-list` slot's body. A component rather than a plain render function
+ * for the same reason `ListSlot` is one: the churn animation asks whether this
+ * render is a bulk replacement, and that is a hook.
+ *
+ * The events are drawn here rather than through `CalendarEventList` for one
+ * reason: that component's `showAllItems` container has no gap, and its `gap`
+ * prop only reaches the overflow path — so `EVENT_LIST_GAP` has to sit on the
+ * DIRECT parent of the event items, which is this container.
+ */
+function EventListSlot({
+  params,
+  ctx,
+}: {
+  params: EventListParams
+  ctx: HomeRenderCtx
+}) {
+  const { events } = params
+  const isBulkChange = useIsBulkChange(events.length)
+
+  return (
+    <div className={cn(slotRowBleed(ctx), "flex flex-col", EVENT_LIST_GAP)}>
+      {/* The same churn the `list` rows get — an event dropping off the widget
+          should read as one leaving, not as a redraw. */}
+      <HomeSlotItems>
+        {events.map((event) => (
+          <HomeSlotItem key={event.title} animated={!isBulkChange}>
+            <CalendarEvent {...event} />
+          </HomeSlotItem>
+        ))}
+      </HomeSlotItems>
     </div>
   )
 }
@@ -604,6 +864,13 @@ export const SLOT_SKELETON_ITEM_TESTID = "slot-skeleton-item"
  * than as items, so the placeholder titles vary the way real ones do.
  */
 const SKELETON_TITLE_WIDTHS = ["w-1/2", "w-2/3", "w-2/5", "w-3/5"]
+
+/** A placeholder glyph's box per step — the rounding is the schema's business. */
+const SKELETON_GLYPH_SIZE = {
+  sm: "size-6",
+  md: "size-8",
+  lg: "size-10",
+} satisfies Record<ListGlyphSize, string>
 
 const skeletonTitleWidth = (index: number) =>
   SKELETON_TITLE_WIDTHS[index % SKELETON_TITLE_WIDTHS.length]
@@ -635,14 +902,23 @@ const ListSlotSkeleton = ({
   ctx: HomeSkeletonCtx
 }) => {
   const schema = params.schema ?? {}
+  const isWide = useWidgetIsWide()
   // Rows past `maxVisibleItems` fold behind "View more", so the loaded list
   // never shows more than that — nor should the placeholder.
   const count = Math.max(
     0,
     Math.min(ctx.expectedItemsCount, schema.maxVisibleItems ?? Infinity)
   )
-  const compact = Boolean(schema.compact) || count > LIST_COMPACT_AFTER
-  const twoLine = Boolean(schema.descriptionRequired) && !compact
+  const compact = listCompacts(schema, count)
+  // Same rule the real list follows, so the glyphs are the size they will be.
+  const twoLine =
+    (Boolean(schema.descriptionRequired) ||
+      Boolean(schema.descriptionOptional)) &&
+    !compact
+  // The SECOND LINE, though, is only drawn where every row is going to have
+  // one: with `descriptionOptional` some rows won't, and a placeholder that
+  // promises a line each would leave the card taller than what replaces it.
+  const twoLinePlaceholder = Boolean(schema.descriptionRequired) && !compact
   // More items than the list will show means the loaded list carries the "View
   // more" button at its bottom — so the placeholder leaves room for it.
   const overflows = ctx.expectedItemsCount > count
@@ -660,14 +936,15 @@ const ListSlotSkeleton = ({
             <Skeleton
               className={cn(
                 "shrink-0",
-                twoLine ? "size-8" : "size-6",
+                // The size the real glyph will be — same rule, same card.
+                SKELETON_GLYPH_SIZE[listGlyphSize(twoLine, isWide)],
                 schema.left === "person" ? "rounded-full" : "rounded-sm"
               )}
             />
           ) : null}
           <div className="flex min-w-0 flex-1 flex-col">
             <SkeletonLine className={skeletonTitleWidth(index)} />
-            {twoLine ? <SkeletonLine className="w-1/4" /> : null}
+            {twoLinePlaceholder ? <SkeletonLine className="w-1/4" /> : null}
           </div>
           {schema.right ? (
             <Skeleton className="h-4 w-10 shrink-0 rounded-sm" />
@@ -767,16 +1044,9 @@ export const defaultSlotRenderers: SlotRenderers = {
   // prop only reaches the overflow path — so `EVENT_LIST_GAP` has to sit on the
   // DIRECT parent of the event items, which is this container.
   "event-list": {
-    render: (params, ctx) => {
-      const { events } = params as EventListParams
-      return (
-        <div className={cn(slotRowBleed(ctx), "flex flex-col", EVENT_LIST_GAP)}>
-          {events.map((event) => (
-            <CalendarEvent key={event.title} {...event} />
-          ))}
-        </div>
-      )
-    },
+    render: (params, ctx) => (
+      <EventListSlot params={params as EventListParams} ctx={ctx} />
+    ),
     skeleton: (_params, ctx) => <EventListSlotSkeleton ctx={ctx} />,
   },
   indicators: {

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -1,4 +1,4 @@
-import { ReactNode, useState } from "react"
+import { type CSSProperties, ReactNode, useState } from "react"
 
 import { type z } from "zod"
 
@@ -138,7 +138,24 @@ export const listIconColors = [
   "camel",
 ] as const
 
-export type ListIconColor = (typeof listIconColors)[number]
+export type ListIconPaletteColor = (typeof listIconColors)[number]
+
+/**
+ * A row's glyph tint: one of {@link listIconColors}, or a HEX of your own.
+ *
+ * Prefer a palette name. Those eleven hues were picked to sit beside each other
+ * in one column and to hold up in both themes, which is the whole job here — a
+ * feed's glyphs are read as a SET, and a colour chosen per row without seeing
+ * the others is how a card ends up with two greens that mean different things.
+ *
+ * The hex is for the case the palette genuinely cannot serve: a colour that is
+ * already data — a calendar's own colour, a module's brand, a category a user
+ * picked themselves. It is treated exactly like a palette hue (a tenth of it as
+ * the tile, the hue itself as the icon), so a bespoke colour and a named one
+ * still draw the same glyph. `#RGB` and `#RRGGBB` both parse; anything else
+ * falls back to the plain, untinted glyph rather than drawing nothing.
+ */
+export type ListIconColor = ListIconPaletteColor | `#${string}`
 
 /**
  * The tinted glyph, one literal class string per colour: Tailwind reads source
@@ -149,7 +166,7 @@ export type ListIconColor = (typeof listIconColors)[number]
  * carry the colour, the tiles only suggest it. Dark mode needs the tile
  * stronger to register against the card at all, hence the second value.
  */
-const LIST_ICON_TINT: Record<ListIconColor, string> = {
+const LIST_ICON_TINT: Record<ListIconPaletteColor, string> = {
   viridian:
     "bg-[hsl(theme(colors.viridian.50)_/_0.1)] text-[hsl(theme(colors.viridian.50))] dark:bg-[hsl(theme(colors.viridian.50)_/_0.24)]",
   malibu:
@@ -173,6 +190,53 @@ const LIST_ICON_TINT: Record<ListIconColor, string> = {
     "bg-[hsl(theme(colors.camel.50)_/_0.1)] text-[hsl(theme(colors.camel.50))] dark:bg-[hsl(theme(colors.camel.50)_/_0.24)]",
 }
 
+/**
+ * A hex as the `r g b` channels those `rgb(… / …)` classes take — `#4F46E5` →
+ * `"79 70 229"`. `#RGB` expands the way CSS expands it; anything else is
+ * `undefined`, which is what makes an unusable colour fall back to the plain
+ * glyph instead of painting the tile black.
+ */
+const hexChannels = (hex: string): string | undefined => {
+  const digits = hex.slice(1)
+  const full =
+    digits.length === 3
+      ? digits
+          .split("")
+          .map((digit) => digit + digit)
+          .join("")
+      : digits
+  if (!/^[0-9a-f]{6}$/i.test(full)) return undefined
+  const value = parseInt(full, 16)
+  return `${(value >> 16) & 255} ${(value >> 8) & 255} ${value & 255}`
+}
+
+/**
+ * The custom-hex tint. The COLOUR comes in as a CSS variable and the classes
+ * stay literal, which is what keeps the two theme steps working: an inline
+ * style cannot carry a `dark:` variant, and a Tailwind class cannot carry a
+ * value that is only known at runtime. The variable is the seam between them.
+ */
+const LIST_ICON_TINT_CUSTOM = cn(
+  "bg-[rgb(var(--list-icon-tint)_/_0.1)] text-[rgb(var(--list-icon-tint))]",
+  "dark:bg-[rgb(var(--list-icon-tint)_/_0.24)]"
+)
+
+/** How a glyph paints itself: a palette class, or the variable + its classes. */
+const listIconTint = (
+  color: ListIconColor
+): { className: string; style?: CSSProperties } | undefined => {
+  if (!color.startsWith("#"))
+    return { className: LIST_ICON_TINT[color as ListIconPaletteColor] }
+
+  const channels = hexChannels(color)
+  return channels
+    ? {
+        className: LIST_ICON_TINT_CUSTOM,
+        style: { "--list-icon-tint": channels } as CSSProperties,
+      }
+    : undefined
+}
+
 /** Every glyph size a `list` row draws at — see {@link listGlyphSize}. */
 type ListGlyphSize = "sm" | "md" | "lg"
 
@@ -191,19 +255,20 @@ const LIST_ICON_SIZE = {
  */
 const ListIconGlyph = ({
   icon,
-  color,
+  tint,
   size,
 }: {
   icon: IconType
-  color: ListIconColor
+  tint: NonNullable<ReturnType<typeof listIconTint>>
   size: ListGlyphSize
 }) => (
   <div
     className={cn(
       "flex aspect-square items-center justify-center",
       LIST_ICON_SIZE[size],
-      LIST_ICON_TINT[color]
+      tint.className
     )}
+    style={tint.style}
   >
     {/* No `color`: F0Icon defaults to `currentColor`, which the tile's own
         `text-` class has already set to the hue. */}
@@ -650,17 +715,17 @@ const listLeft = (
   if (left === "alert" && row.alert)
     return { left: <F0AvatarAlert type={row.alert} size={avatarSize} /> }
   // A TINTED icon is the Home kit's own glyph, so it goes in as a node. An icon
-  // row without a `color` falls through to the plain `F0AvatarIcon` below.
-  if (left === "icon" && row.avatar?.icon && row.avatar.color)
-    return {
-      left: (
-        <ListIconGlyph
-          icon={row.avatar.icon}
-          color={row.avatar.color}
-          size={avatarSize}
-        />
-      ),
-    }
+  // row without a `color` — or with one that cannot be parsed — falls through to
+  // the plain `F0AvatarIcon` below.
+  if (left === "icon" && row.avatar?.icon && row.avatar.color) {
+    const tint = listIconTint(row.avatar.color)
+    if (tint)
+      return {
+        left: (
+          <ListIconGlyph icon={row.avatar.icon} tint={tint} size={avatarSize} />
+        ),
+      }
+  }
   if (left && row.avatar)
     return {
       avatar: { type: left, ...row.avatar } as AvatarVariant,


### PR DESCRIPTION
## Description

Teaches the Home `list` slot to draw a **feed** — the "Needs you" visualization — and makes a widget size itself to the card it landed in. Plus a `target="_blank"` fix that was biting the frontend.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Bug fix

Everything here is additive: existing `listSlot` schemas, items and widgets render exactly as before.

## Implementation details

### 1. The feed, in `list` slots

The schema could not express the mock, in four separate ways:

| Mock | Before | Now |
| --- | --- | --- |
| Tinted colored glyph on the left | `F0AvatarIcon` is neutral only | `left: "icon"` rows take a `color` from f0's named palette (`listIconColors`) |
| Only *some* rows have a second line | `descriptionRequired` is all-or-nothing (`description?: never` otherwise) | `descriptionOptional` |
| Only *some* rows trail a face | `right: "person"` demands `rightAvatar` on every row | `rightOptional` |
| Action buttons on row hover | nothing | per-row `actions` |

Both `…Optional` flags keep the schema's type checking — the data still has to be the kind that was declared — they only stop *demanding* it. The default stays evenness; a feed opts out explicitly.

Two consequences worth reviewing:

- A `descriptionOptional` list **no longer auto-compacts** past `LIST_COMPACT_AFTER` (6) rows. That rule tames a long column of uniformly two-line rows; a mixed list isn't one, and folding away the few second lines it has would hide the only thing telling those rows apart. The mock has 7 rows and would otherwise have lost them. `compact: true` still forces it.
- The tinted glyph is **Home's own**, not a new `F0AvatarIcon` prop — colouring the icon avatar is a Home decision, so the design system component is untouched and colourless rows still draw it.

### 2. Row actions

Icon buttons over the row's right edge, behind a gradient fade — the same treatment `OneDataCollection`'s `itemActions` uses. They are:

- **outside the row's anchor**, so pressing one never follows a link row;
- **in the DOM while hidden** (opacity, not absence), so Tab reaches them and reaching them reveals the strip;
- available as icon-only (default), **icon + label** (`showLabel`), **text-only** (no `icon`), or a **dropdown** (`items` instead of `onClick`) — the strip stays pinned while that menu is up, because the menu portals out and reaching it means leaving the row.

A row with actions also highlights on hover even when it is inert: something happens there.

### 3. A wider card speaks up

Past **480px** everything the card sizes for itself steps up one — title (`text-lg`/`font-semibold`), footer button (`md`, and `outline` rather than `neutral`), a row's leading glyph and its trailing faces. Text does not grow: that is the content's scale, not the card's.

The card measures itself with `clientWidth` (not a bounding rect, so an ancestor's `transform: scale()` can't change its type scale) and publishes the answer through **`useWidgetIsWide()`**. A context rather than a prop because a widget's content is handed to the frame as `children` — built before the frame renders, but drawn inside it.

⚠️ **This touches every `Widget` consumer, not just Home.** The sizes are defaults, so `action.size` still wins.

### 4. Items coming and going

Adding or removing an item now animates, in every slot type. The item fades and **its own height closes on a spring**, so the rows below it, the footer button and the card's bottom edge move continuously rather than snapping by a row's height in one frame.

This is the one place in Home's motion vocabulary that animates a height — the rationale is in `home-motion.tsx`. It costs an `overflow: hidden` per item, which is why a row's focus ring is now an **inset** ring.

A change of **more than four items at once** — "View more" revealing thirty — is a new list rather than churn, and is drawn at once instead of as thirty springs (`useIsBulkChange`). Bespoke renderers get the same two wrappers from `slotRenderers`.

### 5. `isExternalHref` sent internal links to a new tab

Reported from the frontend: on `app.local.factorial.dev`, a link to `https://app.local.factorial.dev/dashboard#core.dashboardCompanyLinksEdit` opened in a new tab.

`isExternalHref` compared `host`, which includes the port. An app served through a dev server or a proxy sits on one while the links it renders are written without one, so every internal link looked like another site — `target="_blank"`, and the SPA torn down to get there. It now compares `hostname`.

## Screenshots

Storybook: `Home/SlotWidget` → **Needs you**, **Needs you (wide)**, **Item churn**.

## Testing

- [x] `vitest run` — full suite green (6252 passing)
- [x] `tsc --noEmit` — no new errors
- [x] `oxlint` — clean
- [x] Type-level tests for the new schema fields in `slotRenderers.test-d.ts` (every `@ts-expect-error` load-bearing)
- [x] Verified in Storybook in light and dark: tinted glyphs, mixed rows, hover actions (icon / labelled / dropdown), wide-vs-rail sizing, and the footer travelling smoothly across frames during a removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
