### PR TITLE
fix(CategoryBarChart): show every segment in a single hover tooltip

### DIFF
--- a/packages/react/src/kits/Charts/CategoryBarChart/CategoryBarTooltipContent.tsx
+++ b/packages/react/src/kits/Charts/CategoryBarChart/CategoryBarTooltipContent.tsx
@@ -1,0 +1,100 @@
+import { cn } from "@/lib/utils"
+import { TooltipContent } from "@/ui/tooltip"
+
+/** Half of Radix's 700ms default: the tooltip is the only way to read the labels. */
+export const CATEGORY_BAR_TOOLTIP_DELAY_MS = 350
+
+export function formatCategoryBarPercentage(
+  value: number,
+  total: number
+): string {
+  const percentage = total > 0 ? (value / total) * 100 : 0
+  return percentage % 1 === 0 ? percentage.toFixed(0) : percentage.toFixed(1)
+}
+
+export interface CategoryBarSource {
+  name: string
+  value: number
+}
+
+export type CategoryBarSegment<T extends CategoryBarSource> = T & {
+  key: string
+  percentage: number
+  color: string
+}
+
+/** `resolveColor` is a callback because the two bars use different color systems. */
+export function buildCategoryBarSegments<T extends CategoryBarSource>(
+  items: T[],
+  total: number,
+  resolveColor: (item: T, index: number) => string
+): CategoryBarSegment<T>[] {
+  return items
+    .map((item, index) => ({
+      ...item,
+      key: `${item.name}-${index}`,
+      percentage: total > 0 ? (item.value / total) * 100 : 0,
+      color: resolveColor(item, index),
+    }))
+    .filter((segment) => segment.percentage > 0)
+}
+
+export function toCategoryBarTooltipItems<T extends CategoryBarSource>(
+  segments: CategoryBarSegment<T>[],
+  total: number
+): CategoryBarTooltipItem[] {
+  return segments.map((segment) => ({
+    key: segment.key,
+    name: segment.name,
+    color: segment.color,
+    valueLabel: `${segment.value} (${formatCategoryBarPercentage(segment.value, total)}%)`,
+  }))
+}
+
+export interface CategoryBarTooltipItem {
+  key: string
+  name: string
+  color: string
+  /** Pre-formatted, e.g. `"12 (60%)"`. */
+  valueLabel: string
+}
+
+interface CategoryBarTooltipContentProps {
+  items: CategoryBarTooltipItem[]
+  /** Segment under the pointer; the rest are dimmed. Keyed, not indexed, so a
+   * data refresh mid-hover can't dim the wrong row. */
+  activeKey?: string
+}
+
+/** Lists every segment, so one hover reveals the whole legend. */
+export function CategoryBarTooltipContent({
+  items,
+  activeKey,
+}: CategoryBarTooltipContentProps) {
+  const hasActiveRow = items.some((item) => item.key === activeKey)
+
+  return (
+    <TooltipContent className="flex flex-col gap-0.5 text-sm">
+      {items.map((item) => (
+        <div
+          key={item.key}
+          className={cn(
+            "flex items-center gap-1",
+            hasActiveRow && item.key !== activeKey && "opacity-50"
+          )}
+        >
+          <div
+            className="h-2.5 w-2.5 shrink-0 rounded-full"
+            style={{ backgroundColor: item.color }}
+          />
+          <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary">
+            {item.name}
+          </span>
+          <span className="ml-auto font-mono font-medium tabular-nums text-f1-foreground-inverse">
+            {item.valueLabel}
+          </span>
+        </div>
+      ))}
+    </TooltipContent>
+  )
+}

--- a/packages/react/src/kits/Charts/CategoryBarChart/index.tsx
+++ b/packages/react/src/kits/Charts/CategoryBarChart/index.tsx
@@ -1,14 +1,17 @@
-import { ForwardedRef } from "react"
+import { ForwardedRef, useState } from "react"
 
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/ui/tooltip"
+import { cn, focusRing } from "@/lib/utils"
+import { Tooltip, TooltipProvider, TooltipTrigger } from "@/ui/tooltip"
 
 import { getCategoricalColor, getColor } from "../utils/colors"
 import { fixedForwardRef } from "../utils/forwardRef"
+import {
+  buildCategoryBarSegments,
+  CATEGORY_BAR_TOOLTIP_DELAY_MS,
+  CategoryBarTooltipContent,
+  formatCategoryBarPercentage,
+  toCategoryBarTooltipItems,
+} from "./CategoryBarTooltipContent"
 
 export interface CategoryBarProps {
   data: {
@@ -25,62 +28,58 @@ const _CategoryBarChart = (
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const total = data.reduce((sum, category) => sum + category.value, 0)
+  const [activeKey, setActiveKey] = useState<string | undefined>(undefined)
+
+  const segments = buildCategoryBarSegments(data, total, (category, index) =>
+    category.color ? getColor(category.color) : getCategoricalColor(index)
+  )
+
+  const tooltipItems = toCategoryBarTooltipItems(segments, total)
 
   return (
-    <TooltipProvider>
+    <TooltipProvider delayDuration={CATEGORY_BAR_TOOLTIP_DELAY_MS}>
       <div className="w-full" ref={ref}>
-        <div className="flex h-2 gap-1 overflow-hidden">
-          {data.map((category, index) => {
-            const percentage = (category.value / total) * 100
-            const color = category.color
-              ? getColor(category.color)
-              : getCategoricalColor(index)
-
-            const formatPercentage = (value: number): string => {
-              const percentage = (value / total) * 100
-              return percentage % 1 === 0
-                ? percentage.toFixed(0)
-                : percentage.toFixed(1)
-            }
-
-            if (percentage === 0) {
-              return null
-            }
-
-            return (
-              <Tooltip key={category.name}>
-                <TooltipTrigger
-                  className="h-full cursor-default overflow-hidden rounded-2xs"
-                  style={{ width: `${percentage}%` }}
-                  title={category.name}
-                  asChild
-                >
-                  <div
-                    className="h-full w-full"
-                    style={{ backgroundColor: color }}
-                    role="img"
-                    title={category.name}
-                    tabIndex={0}
-                  />
-                </TooltipTrigger>
-                {!hideTooltip && (
-                  <TooltipContent className="flex items-center gap-1 text-sm">
-                    <div
-                      className="h-2.5 w-2.5 shrink-0 translate-y-px rounded-full"
-                      style={{ backgroundColor: color }}
-                    />
-                    <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary dark:text-f1-foreground-secondary">
-                      {category.name}
-                    </span>
-                    <span className="font-mono font-medium tabular-nums text-f1-foreground-inverse dark:text-f1-foreground">
-                      {category.value} ({formatPercentage(category.value)}%)
-                    </span>
-                  </TooltipContent>
-                )}
-              </Tooltip>
-            )
-          })}
-        </div>
+        <Tooltip>
+          {/* `role="group"`, not `img`: an img subtree is presentational, which
+              would prune the per-segment labels. */}
+          <TooltipTrigger asChild>
+            <div
+              className={cn(
+                "pointer-events-auto flex h-2 w-full cursor-default gap-1 overflow-hidden",
+                focusRing()
+              )}
+              onMouseLeave={() => setActiveKey(undefined)}
+              onMouseOver={(event) => {
+                if (event.target === event.currentTarget) {
+                  setActiveKey(undefined)
+                }
+              }}
+              role="group"
+              aria-label="Category bar chart"
+              tabIndex={segments.length > 0 ? 0 : undefined}
+            >
+              {segments.map((segment) => (
+                <div
+                  key={segment.key}
+                  className="pointer-events-auto h-full overflow-hidden rounded-2xs"
+                  style={{
+                    width: `${segment.percentage}%`,
+                    backgroundColor: segment.color,
+                  }}
+                  role="img"
+                  aria-label={`${segment.name}: ${segment.value} (${formatCategoryBarPercentage(segment.value, total)}%)`}
+                  onMouseEnter={() => setActiveKey(segment.key)}
+                />
+              ))}
+            </div>
+          </TooltipTrigger>
+          {!hideTooltip && tooltipItems.length > 0 && (
+            <CategoryBarTooltipContent
+              items={tooltipItems}
+              activeKey={activeKey}
+            />
+          )}
+        </Tooltip>
       </div>
       {legend && (
         <div

--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
@@ -7,6 +7,8 @@ import * as CategoryBarChartStories from "./categoryBarChart.stories"
 
 Horizontal stacked proportional bar chart cell. Displays category distribution as colored segments with tooltip on hover. Mirrors the standalone `CategoryBarChart` kit but sized for table cells (no legend).
 
+Hovering anywhere in the cell — the bar, the gaps between segments, or the empty space above and below it — opens a single tooltip listing **every** segment, so the reader gets the whole legend at once instead of hovering each segment in turn. Hovering a specific segment drills down to it: that row is highlighted and the rest are dimmed.
+
 #### Value type
 
 ```
@@ -16,7 +18,7 @@ type value = {
     value: number         // absolute count
     color?: CategoryBarColor // optional: a 15-palette base-color token (e.g. "viridian", "yellow", "barbie") OR a legacy token ("categorical-1"…"categorical-8", "feedback-*"); falls back to the categorical palette by index
   }>
-  hideTooltip?: boolean   // when true, suppresses hover tooltips
+  hideTooltip?: boolean   // when true, suppresses the hover tooltip
   loading?: boolean       // when true, renders a skeleton (same size as the bar) until data arrives
 }
 ```
@@ -31,7 +33,7 @@ type value = {
 
 #### InsideClickableTableCell
 
-Replicates OneTable's cell mechanics (a `pointer-events-none` content wrapper plus a stretched navigation link). The chart segments re-enable pointer events so the tooltip opens on hover/focus while a click still navigates the row.
+Replicates OneTable's cell mechanics (a `pointer-events-none` content wrapper plus a stretched navigation link). The bar re-enables pointer events so the tooltip opens on hover/focus while a click still navigates the row.
 
 <Canvas of={CategoryBarChartStories.InsideClickableTableCell} />
 
@@ -51,7 +53,7 @@ The cell inside a OneDataCollection-like table with clickable rows: tooltips ope
 
 #### HiddenTooltip
 
-Set `hideTooltip: true` on the value to suppress the per-segment tooltip. Segments still render and stay focusable.
+Set `hideTooltip: true` on the value to suppress the tooltip. The bar still renders and stays focusable.
 
 <Canvas of={CategoryBarChartStories.HiddenTooltip} />
 

--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
@@ -6,11 +6,8 @@ import { cn } from "@/lib/utils"
 import { Cell, mockItem } from "../../../__stories__/shared"
 
 /**
- * Replicates OneTable's TableCell mechanics: the content wrapper is
- * `pointer-events-none` and a stretched link (`pointer-events-auto`) captures
- * the row-navigation click, which the wrapper forwards via `onClick`. The chart
- * segments re-enable pointer events so the tooltip still opens on hover/focus
- * while a click still navigates the row.
+ * Mirrors OneTable's TableCell wrapper chain (`experimental/OneTable/TableCell`),
+ * `h-full` included - without it the mock under-reports the real hover area.
  */
 function ClickableTableCell({
   children,
@@ -21,12 +18,14 @@ function ClickableTableCell({
 }) {
   const linkRef = useRef<HTMLAnchorElement>(null)
   return (
-    <div className={cn("relative", className)}>
-      <div
-        className="pointer-events-none relative z-[1]"
-        onClick={() => linkRef.current?.click()}
-      >
-        {children}
+    <div className={cn("relative h-full", className)}>
+      <div className="pointer-events-none h-full items-start">
+        <div
+          className="relative z-[1] h-full"
+          onClick={() => linkRef.current?.click()}
+        >
+          {children}
+        </div>
       </div>
       <a
         ref={linkRef}
@@ -81,7 +80,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Horizontal stacked proportional bar chart cell. Displays category distribution as colored segments with a tooltip on hover/focus. Mirrors the standalone CategoryBarChart kit but sized for table cells.\n\n- **Tooltip**: shown by default per segment (color dot + name + value/percentage). Set `hideTooltip: true` on the value to suppress it.\n- **Loading**: set `loading: true` to render a skeleton with the same height/width as the loaded bar until the data is there, instead of flashing the empty dash.\n- **Clickable cells**: inside OneDataCollection the cell sits in a `pointer-events-none` wrapper with a stretched navigation link. The bar segments re-enable pointer events so the tooltip still opens, while a click on the cell navigates the row.",
+          "Horizontal stacked proportional bar chart cell. Displays category distribution as colored segments with a tooltip on hover/focus. Mirrors the standalone CategoryBarChart kit but sized for table cells.\n\n- **Tooltip**: one tooltip for the whole cell, listing *every* segment (color dot + name + value/percentage), so a single hover anywhere in the cell — bar, gaps, or the empty space above and below it — reveals the full legend instead of forcing the reader to hover each segment. Hovering a specific segment drills down to it: that row is highlighted and the rest are dimmed. Set `hideTooltip: true` on the value to suppress it.\n- **Loading**: set `loading: true` to render a skeleton with the same height/width as the loaded bar until the data is there, instead of flashing the empty dash.\n- **Clickable cells**: inside OneDataCollection the cell sits in a `pointer-events-none` wrapper with a stretched navigation link. The bar segments re-enable pointer events so the tooltip still opens, while a click on the cell navigates the row.",
       },
     },
   },
@@ -271,10 +270,10 @@ const value = {
               key={row.team}
               className="border-0 border-b border-solid border-f1-border-secondary hover:bg-f1-background-hover"
             >
-              <td className="py-3 pr-4 align-middle text-f1-foreground">
+              <td className="h-full py-3 pr-4 align-top text-f1-foreground">
                 {wrap(row.team)}
               </td>
-              <td className="w-1/2 py-3 align-middle">
+              <td className="h-full w-1/2 py-3 align-top">
                 {wrap(
                   <Cell
                     item={mockItem}

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
@@ -1,5 +1,7 @@
-import { render, screen } from "@testing-library/react"
+import { fireEvent, waitFor } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender as render } from "@/testing/test-utils"
 
 import { ValueDisplayRendererContext } from "../../renderers"
 import {
@@ -213,6 +215,179 @@ describe("CategoryBarChartCell", () => {
     expect(
       container.querySelector('[role="img"][aria-label*="%"]')
     ).not.toBeInTheDocument()
+  })
+
+  it("uses a single tooltip trigger for the whole bar, not one per segment", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Office", value: 15 },
+        { name: "Remote", value: 10 },
+        { name: "Hybrid", value: 5 },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    // Radix marks its trigger with data-state; there must be exactly one for
+    // the whole bar so hovering any segment (or the gaps) opens the same tooltip
+    expect(container.querySelectorAll("[data-state]").length).toBe(1)
+  })
+
+  it("lists every segment in the tooltip, not only the hovered one", async () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Office", value: 15 },
+        { name: "Remote", value: 10 },
+        { name: "Hybrid", value: 5 },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    const trigger = container.querySelector("[data-state]") as HTMLElement
+    fireEvent.focus(trigger)
+
+    const content = await waitFor(() => {
+      const el = document.querySelector(
+        "[data-radix-popper-content-wrapper] [data-state]"
+      )
+      expect(el).toBeInTheDocument()
+      return el as HTMLElement
+    })
+
+    // Radix appends a visually-hidden copy of the content (a <span>) for screen
+    // readers, so read the visible rows only — one <div> per segment.
+    const rows = Array.from(content.children)
+      .filter((child) => child.tagName === "DIV")
+      .map((row) =>
+        Array.from(row.querySelectorAll("span")).map((span) => span.textContent)
+      )
+
+    expect(rows).toEqual([
+      ["Office", "15 (50%)"],
+      ["Remote", "10 (33.3%)"],
+      ["Hybrid", "5 (16.7%)"],
+    ])
+  })
+
+  it("does not open a tooltip when hideTooltip is true", async () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Office", value: 15 },
+        { name: "Remote", value: 5 },
+      ],
+      hideTooltip: true,
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    const trigger = container.querySelector("[data-state]") as HTMLElement
+    fireEvent.focus(trigger)
+
+    // Wait for the trigger to actually reach the open state before asserting no
+    // content rendered — asserting absence immediately would pass even if the
+    // tooltip opened a moment later.
+    await waitFor(() => {
+      expect(trigger.getAttribute("data-state")).not.toBe("closed")
+    })
+    expect(
+      document.querySelector("[data-radix-popper-content-wrapper]")
+    ).toBeNull()
+  })
+
+  it("dims every row except the segment under the pointer", async () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Office", value: 15 },
+        { name: "Remote", value: 10 },
+        { name: "Hybrid", value: 5 },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    const trigger = container.querySelector("[data-state]") as HTMLElement
+    fireEvent.focus(trigger)
+
+    const content = await waitFor(() => {
+      const el = document.querySelector(
+        "[data-radix-popper-content-wrapper] [data-state]"
+      )
+      expect(el).toBeInTheDocument()
+      return el as HTMLElement
+    })
+
+    const rowOpacities = () =>
+      Array.from(content.children)
+        .filter((child) => child.tagName === "DIV")
+        .map((row) => row.className.includes("opacity-50"))
+
+    // Opened by focus: no segment is under the pointer, so no row is dimmed
+    expect(rowOpacities()).toEqual([false, false, false])
+
+    const segments = container.querySelectorAll(
+      '[role="img"][aria-label*="%"]'
+    ) as NodeListOf<HTMLElement>
+    fireEvent.mouseEnter(segments[1])
+
+    await waitFor(() => {
+      expect(rowOpacities()).toEqual([true, false, true])
+    })
+
+    fireEvent.mouseLeave(
+      container.querySelector(".flex.h-2") as unknown as HTMLElement
+    )
+
+    await waitFor(() => {
+      expect(rowOpacities()).toEqual([false, false, false])
+    })
+  })
+
+  it("enlarges the hover target beyond the bar inside a table cell", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [{ name: "Office", value: 15 }],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    // The bar is 8px in a line-height-tall wrapper, but the table cell around it
+    // is roughly a row high. Padding grows the hit box and the matching negative
+    // margin keeps the layout box — and the bar's alignment — unchanged.
+    const trigger = container.querySelector(
+      '[data-cell-type="categoryBarChart"]'
+    ) as HTMLElement
+    expect(trigger).toHaveClass("box-content", "py-2.5", "-my-2.5")
+  })
+
+  it("keeps the whole cell hoverable, not just the segments", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Office", value: 15 },
+        { name: "Remote", value: 5 },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    // The trigger is the cell wrapper, so it needs pointer events re-enabled
+    // too — OneTable renders cell content inside a pointer-events-none wrapper.
+    expect(
+      container.querySelector('[data-cell-type="categoryBarChart"]')
+    ).toHaveClass("pointer-events-auto")
+  })
+
+  it("keeps the bar as a single tab stop instead of one per segment", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [
+        { name: "Office", value: 15 },
+        { name: "Remote", value: 10 },
+        { name: "Hybrid", value: 5 },
+      ],
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    expect(container.querySelectorAll('[tabindex="0"]').length).toBe(1)
   })
 
   it("handles duplicate names with unique keys", () => {

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
@@ -1,22 +1,24 @@
 import { getCategoricalColor, getColor } from "@/kits/Charts/utils/colors"
-import { CSSProperties } from "react"
+import { CSSProperties, useState } from "react"
 
 import { Skeleton } from "@/ui/skeleton"
+import {
+  buildCategoryBarSegments,
+  CATEGORY_BAR_TOOLTIP_DELAY_MS,
+  CategoryBarTooltipContent,
+  formatCategoryBarPercentage,
+  toCategoryBarTooltipItems,
+} from "@/kits/Charts/CategoryBarChart/CategoryBarTooltipContent"
 import {
   type ChartColorToken,
   chartColorTokens,
   resolveChartColorToken,
 } from "@/kits/F0DataChart/utils/colors"
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/ui/tooltip"
+import { Tooltip, TooltipProvider, TooltipTrigger } from "@/ui/tooltip"
 
 import { tableDisplayClassNames } from "../../const"
 import { ValueDisplayRendererContext } from "../../renderers"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
 /**
  * Legacy `kits/Charts` color tokens, resolved as `hsl(var(--chart-*))`.
@@ -105,11 +107,6 @@ function cellWrapperStyle(meta: ValueDisplayRendererContext): CSSProperties {
     : { minHeight: CELL_MIN_HEIGHT_PX, minWidth: 80 }
 }
 
-function formatPercentage(value: number, total: number): string {
-  const pct = (value / total) * 100
-  return pct % 1 === 0 ? pct.toFixed(0) : pct.toFixed(1)
-}
-
 function EmptyCell({ meta }: { meta: ValueDisplayRendererContext }) {
   return (
     <div
@@ -121,6 +118,89 @@ function EmptyCell({ meta }: { meta: ValueDisplayRendererContext }) {
     >
       –
     </div>
+  )
+}
+
+/**
+ * A real component, not inline in `CategoryBarChartCell`: renderers call that as
+ * a plain function, so it can't hold hooks.
+ */
+function CategoryBar({
+  dataPoints,
+  total,
+  hideTooltip,
+  meta,
+}: {
+  dataPoints: CategoryBarDataPoint[]
+  total: number
+  hideTooltip?: boolean
+  meta: ValueDisplayRendererContext
+}) {
+  const [activeKey, setActiveKey] = useState<string | undefined>(undefined)
+
+  const segments = buildCategoryBarSegments(dataPoints, total, (point, index) =>
+    point.color ? resolveSegmentColor(point.color) : getCategoricalColor(index)
+  )
+
+  const tooltipItems = toCategoryBarTooltipItems(segments, total)
+
+  return (
+    <TooltipProvider delayDuration={CATEGORY_BAR_TOOLTIP_DELAY_MS}>
+      <Tooltip>
+        {/* `role="group"`, not `img`: an img subtree is presentational, which
+            would prune the per-segment labels. */}
+        <TooltipTrigger asChild>
+          <div
+            className={cn(
+              cellWrapperClassName(),
+              "pointer-events-auto",
+              focusRing(),
+              // Enlarges the hit box; the negative margin cancels it so the
+              // layout box is unchanged. `h-full` can't be used instead - it
+              // doesn't resolve through a table row.
+              meta.visualization === "table" && "-my-2.5 box-content py-2.5"
+            )}
+            style={cellWrapperStyle(meta)}
+            data-cell-type="categoryBarChart"
+            role="group"
+            aria-label="Category bar chart"
+            tabIndex={0}
+          >
+            {/* Leaving the bar, or crossing a gap between segments, clears the
+                drill-down. */}
+            <div
+              className="flex h-2 w-full gap-1 overflow-hidden"
+              onMouseLeave={() => setActiveKey(undefined)}
+              onMouseOver={(event) => {
+                if (event.target === event.currentTarget) {
+                  setActiveKey(undefined)
+                }
+              }}
+            >
+              {segments.map((segment) => (
+                <div
+                  key={segment.key}
+                  className="pointer-events-auto h-full overflow-hidden rounded-2xs"
+                  style={{
+                    width: `${segment.percentage}%`,
+                    backgroundColor: segment.color,
+                  }}
+                  role="img"
+                  aria-label={`${segment.name}: ${segment.value} (${formatCategoryBarPercentage(segment.value, total)}%)`}
+                  onMouseEnter={() => setActiveKey(segment.key)}
+                />
+              ))}
+            </div>
+          </div>
+        </TooltipTrigger>
+        {!hideTooltip && tooltipItems.length > 0 && (
+          <CategoryBarTooltipContent
+            items={tooltipItems}
+            activeKey={activeKey}
+          />
+        )}
+      </Tooltip>
+    </TooltipProvider>
   )
 }
 
@@ -154,57 +234,11 @@ export const CategoryBarChartCell = (
   }
 
   return (
-    <div
-      className={cellWrapperClassName()}
-      style={cellWrapperStyle(meta)}
-      data-cell-type="categoryBarChart"
-      role="img"
-      aria-label="Category bar chart"
-    >
-      <TooltipProvider>
-        <div className="flex h-2 w-full gap-1 overflow-hidden">
-          {dataPoints.map((point, index) => {
-            const percentage = (point.value / total) * 100
-            const color = point.color
-              ? resolveSegmentColor(point.color)
-              : getCategoricalColor(index)
-
-            if (percentage === 0) return null
-
-            return (
-              <Tooltip key={`${point.name}-${index}`}>
-                <TooltipTrigger
-                  className="pointer-events-auto h-full cursor-default overflow-hidden rounded-2xs"
-                  style={{ width: `${percentage}%` }}
-                  asChild
-                >
-                  <div
-                    className="h-full w-full"
-                    style={{ backgroundColor: color }}
-                    role="img"
-                    aria-label={`${point.name}: ${point.value} (${formatPercentage(point.value, total)}%)`}
-                    tabIndex={0}
-                  />
-                </TooltipTrigger>
-                {!args.hideTooltip && (
-                  <TooltipContent className="flex items-center gap-1 text-sm">
-                    <div
-                      className="h-2.5 w-2.5 shrink-0 rounded-full"
-                      style={{ backgroundColor: color }}
-                    />
-                    <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary">
-                      {point.name}
-                    </span>
-                    <span className="font-mono font-medium tabular-nums text-f1-foreground-inverse">
-                      {point.value} ({formatPercentage(point.value, total)}%)
-                    </span>
-                  </TooltipContent>
-                )}
-              </Tooltip>
-            )
-          })}
-        </div>
-      </TooltipProvider>
-    </div>
+    <CategoryBar
+      dataPoints={dataPoints}
+      total={total}
+      hideTooltip={args.hideTooltip}
+      meta={meta}
+    />
   )
 }


### PR DESCRIPTION
## Description

Reading a multi-colour category bar meant hovering every block in turn: each segment had its own tooltip showing only that segment's label. This replaces the per-segment tooltips with **one tooltip per bar that lists every segment**, so a single hover reveals the whole legend.

Applies to both category bars: the `kits/Charts/CategoryBarChart` kit (used by `sds/Profile/CategoryBarSection`) and the `categoryBarChart` value-display cell (used as a OneDataCollection/OneTable column).

## Type of change

- [x] Bug fix

## Lifecycle phase (if applicable)

n/a - usability fix to existing components, no API change.

## Screenshots (if applicable)

Hovering the tiny 4.4% "New Hires" segment now surfaces all five categories at once, with the hovered row at full strength and the others dimmed:

<!-- screenshots to attach: kit tooltip (light + dark), value-display cell in a DataCollection table -->

## Implementation details

**One tooltip for the whole bar.** A single Radix `Tooltip` wraps the bar instead of one per segment, so hovering any block - or the gaps between them - opens the same tooltip. Rows are `dot + name + value (percentage)`, values right-aligned.

**Hover a segment to drill down.** Each segment tracks `onMouseEnter`, and the hovered row stays at full strength while the rest drop to 50% opacity. Leaving the bar without leaving the cell clears the drill-down, so the tooltip goes back to showing all segments evenly.

**Whole-cell hover area (value-display cell only).** The tooltip trigger is the cell wrapper, not the 8px bar, so the tooltip opens anywhere in the cell - including the empty space above and below the bar. The kit keeps a bar-level trigger; it has no cell wrapper to expand into and adding vertical padding would shift the surrounding layout.

**Faster open.** `delayDuration` is 350ms instead of Radix's 700ms default, shared as `CATEGORY_BAR_TOOLTIP_DELAY_MS`. The tooltip is the only way to read the labels, so the wait was the main cost of the chart.

**Shared tooltip body.** `CategoryBarTooltipContent` is extracted so both bars stay in sync.

**Enlarged hover target.** The trigger was the 8px bar inside a wrapper one text-line tall, while the table cell around it is roughly a row high, so hovering "the cell" mostly missed. Padding now grows the hit box and a matching negative margin cancels it, leaving row height and the bar's alignment with the row text unchanged (`box-content` is what makes the padding add to the box rather than be absorbed by it).

Measured against a faithful OneTable mock, in a 45px cell:

| Column config | Hover height |
| --- | --- |
| Auto-width | **36px** (was 8px) |
| Fixed-width (`overflow-hidden`) | **16px** |

**Known limitation, deliberate:** fixed-width columns are clipped because OneTable's inner cell wrapper adds `overflow-hidden`. Covering the full cell there needs a change in `experimental/OneTable/TableCell`, a primitive behind every cell type, so it is intentionally out of scope here. An absolutely-positioned hit layer was tried first and does not work: it needs an ancestor with a resolved height, and `h-full` does not resolve through a table row.

Also out of scope for the same reason: cmd/middle-click on the cell navigates in the same tab instead of a new one, because OneTable replays the click via `linkRef.current?.click()`, which drops modifier keys. That affects any cell that re-enables pointer events, not just this one.

### Compatibility

No API change - `CategoryBarProps` and `CategoryBarChartCellValue` (including `hideTooltip` and `loading`) are untouched, so existing DataCollection columns and every other consumer keep working with no edits.

Two things were verified rather than assumed, since both are easy to break here:

- **OneTable clickable rows still navigate.** The cell sits in a `pointer-events-none` wrapper with a stretched navigation link beneath it. The bar and its segments keep `pointer-events-auto`, so the tooltip opens on hover/focus while a click still navigates the row - confirmed in the browser against the `InsideClickableTableCell` story after the trigger was widened to the whole cell.
- **Hooks placement.** Value-display renderers are called as plain functions (`CategoryBarChartCell(args, meta)`), not as components, so the hover state lives in an extracted `CategoryBar` component rather than in the renderer function.

Behaviour changes worth knowing:

- The tooltip anchors to the bar rather than the hovered segment, so it no longer slides as the pointer moves across blocks.
- The bar is a single tab stop instead of one per segment. Per-segment `aria-label`s are unchanged; the kit's segments gained the `aria-label` the cell already had, replacing a duplicate native `title` tooltip.

### Verification

- `tsc --noEmit`: clean
- Unit tests: 502 files / 6244 tests pass. The 15 existing `categoryBarChart` tests pass unmodified; 4 added (single trigger, all-segments-listed, `hideTooltip`, single tab stop).
- Storybook: verified off-bar hover, segment drill-down, the 350ms delay, dark mode, and row-click navigation.

Review notes folded in: hovered segment is tracked by key rather than index (a data refresh mid-hover can no longer dim the wrong row), crossing the gap between segments clears the drill-down, an empty or all-zero bar no longer opens an empty tooltip, the single tab stop gained `focusRing()` and an accessible name, `role="group"` replaces `role="img"` on the wrappers so the per-segment labels are not pruned as presentational, and the cell dropped `cursor-default` so clickable rows keep their pointer cursor.
