### PR TITLE
feat(NewHomeLayout): virtualize a column's widgets

### DIFF
--- a/packages/react/src/experimental/Widgets/Layout/exports.tsx
+++ b/packages/react/src/experimental/Widgets/Layout/exports.tsx
@@ -6,8 +6,11 @@
 export * from "../../../sds/Home/NewHomeLayout"
 export * from "../../../sds/Home/slotRenderers"
 export * from "../../../sds/Home/WidgetCatalog"
-// Named by NewHomeLayoutProps (`editableWidgetContainers`, the add callback),
-// so the type is public even though the component is not.
-export type { WidgetContainerSide } from "../../../sds/Home/WidgetContainer"
+// Named by NewHomeLayoutProps (`editableWidgetContainers`, the add callback,
+// `virtualization`), so the types are public even though the component is not.
+export type {
+  WidgetContainerSide,
+  WidgetVirtualization,
+} from "../../../sds/Home/WidgetContainer"
 export * from "./Dashboard"
 export * from "./WidgetStrip"

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -1,10 +1,11 @@
-import { beforeEach, describe, expect, test, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
 import { useEffect, useState } from "react"
 
 import { Calendar, Clock } from "@/icons/app"
 import {
   act,
+  fireEvent,
   screen,
   userEvent,
   waitFor,
@@ -149,6 +150,7 @@ beforeEach(() => {
         resizeCallbacks.push(callback)
       }
       observe() {}
+      unobserve() {}
       disconnect() {}
     }
   )
@@ -382,6 +384,121 @@ describe("NewHomeLayout", () => {
 
       expect(screen.getByText("08:00")).toBeVisible()
       expect(clockMounts).toBe(1)
+    })
+  })
+
+  /**
+   * The COLLAPSED STRIP is a scroll region like the two columns, so it says when
+   * there are glyphs past an end — and, like them, only while there really are.
+   */
+  describe("the collapsed strip's fade", () => {
+    const METRICS = ["scrollHeight", "clientHeight"] as const
+
+    /** A strip with more glyphs than fit: 2000px of them in a 500px column. */
+    const overflowing = () => {
+      const heights = { scrollHeight: 2000, clientHeight: 500 }
+      for (const prop of METRICS)
+        Object.defineProperty(HTMLElement.prototype, prop, {
+          configurable: true,
+          get: () => heights[prop],
+        })
+    }
+
+    // Back to jsdom's own (on `Element`, which HTMLElement inherits from), so the
+    // test below sees a strip that fits.
+    afterEach(() => {
+      for (const prop of METRICS) delete HTMLElement.prototype[prop]
+    })
+
+    test("masks the bottom while glyphs are cut off there, and the top once scrolled", () => {
+      overflowing()
+      const { container } = renderLayout(1000, {
+        rightWidgets: Array.from({ length: 40 }, (_, i) => widget(`w-${i}`)),
+      })
+      const strip = container.querySelector("aside.-m-1") as HTMLElement
+
+      // At the top there is nothing above to hint at — only the bottom fades.
+      expect(strip.style.maskImage).toContain(
+        "black 0, black calc(100% - 24px)"
+      )
+      expect(strip.style.maskImage).toContain("transparent 100%")
+
+      strip.scrollTop = 300
+      fireEvent.scroll(strip)
+
+      expect(strip.style.maskImage).toContain("transparent 0, black 24px")
+    })
+
+    test("leaves a strip that fits unmasked", () => {
+      const { container } = renderLayout(1000)
+      const strip = container.querySelector("aside.-m-1") as HTMLElement
+
+      expect(strip.style.maskImage).toBe("")
+    })
+  })
+
+  /**
+   * A column that can hold more widgets than a screen keeps only the ones you can
+   * see. The layout's part is small — which sides do it, and what each of them is
+   * on screen OF (its own scroll region) — and the column's own tests cover the
+   * rest.
+   */
+  describe("virtualizing a column", () => {
+    const MANY = Array.from({ length: 100 }, (_, index) =>
+      widget(`left-${index}`)
+    )
+
+    /**
+     * The heights jsdom has none of. A widget's card is 200px and every other box
+     * — the scroll region among them — is 400, read through both metrics because
+     * the scroll region is measured by `offsetHeight` and a card by its rect.
+     */
+    const mockHeights = () => {
+      const heightOf = (el: HTMLElement) =>
+        el.hasAttribute("data-index") ? 200 : 400
+      vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+        function (this: HTMLElement) {
+          return heightOf(this)
+        }
+      )
+      vi.spyOn(
+        HTMLElement.prototype,
+        "getBoundingClientRect"
+      ).mockImplementation(function (this: HTMLElement) {
+        const height = heightOf(this)
+        return {
+          top: 0,
+          left: 0,
+          right: 400,
+          bottom: height,
+          width: 400,
+          height,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        } as DOMRect
+      })
+    }
+
+    afterEach(() => vi.restoreAllMocks())
+
+    test("mounts only the main column's on-screen widgets", () => {
+      mockHeights()
+      renderLayout(1400, {
+        leftWidgets: MANY,
+        virtualizedWidgetContainers: ["main"],
+        virtualization: { estimateHeight: 200 },
+      })
+
+      expect(screen.getAllByText("left-0").length).toBeGreaterThan(0)
+      expect(screen.queryByText("left-99")).not.toBeInTheDocument()
+    })
+
+    test("mounts them all for a side that did not ask", () => {
+      mockHeights()
+      renderLayout(1400, { leftWidgets: MANY })
+
+      expect(screen.getAllByText("left-99").length).toBeGreaterThan(0)
     })
   })
 })

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react"
+import { useEffect, useState, type ReactNode } from "react"
 
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { z } from "zod"
@@ -1121,4 +1121,102 @@ export const Loading: Story = {
       </NewHomeLayout>
     </div>
   ),
+}
+
+/* ============================== virtualization ============================== */
+
+/**
+ * `count` widgets, cycling the rail's real ones so every card is a card with data
+ * in it, each numbered so you can see where in the column you are. The clock is
+ * left out: it is `locked`, and a hundred pinned widgets is not a column anyone
+ * is arranging.
+ */
+const manyWidgets = (count: number): HomeWidgetItem[] => {
+  const source = RIGHT_WIDGETS.filter((widget) => !widget.locked)
+  return Array.from({ length: count }, (_, index) => {
+    const widget = source[index % source.length]
+    return {
+      ...widget,
+      id: `${widget.id}-${index}`,
+      header: {
+        ...resolveWidgetHeader(widget.header, widget.params),
+        title: `${index + 1}. ${widgetTitle(widget)}`,
+      },
+      // One configurable widget per column is the point; a hundred dialogs is
+      // not.
+      paramsSchema: undefined,
+      params: undefined,
+    } as HomeWidgetItem
+  })
+}
+
+/**
+ * HOW MANY WIDGET CARDS ARE IN THE DOM right now, watched rather than counted
+ * once: it is the number the story exists to show, and scrolling is what changes
+ * it.
+ */
+const MountedCount = ({ of }: { of: number }) => {
+  const [mounted, setMounted] = useState(0)
+  const [root, setRoot] = useState<HTMLElement | null>(null)
+
+  useEffect(() => {
+    const page = root?.ownerDocument.body
+    if (!page) return
+    const read = () =>
+      setMounted(page.querySelectorAll("[data-widget-id]").length)
+    read()
+    const observer = new MutationObserver(read)
+    observer.observe(page, { childList: true, subtree: true })
+    return () => observer.disconnect()
+  }, [root])
+
+  return (
+    <div
+      ref={setRoot}
+      className="pointer-events-none fixed bottom-4 right-4 z-50 rounded-lg bg-f1-background-inverse px-3 py-2 font-medium text-f1-foreground-inverse"
+    >
+      {mounted} of {of} widgets in the DOM
+    </div>
+  )
+}
+
+/**
+ * A HOME WITH MORE WIDGETS THAN A SCREEN — 60 in the main column, 40 in the rail
+ * — with both sides VIRTUALIZED (`virtualizedWidgetContainers`). Only the cards
+ * you can see are in the DOM: the badge in the corner counts them, and scrolling
+ * either column keeps the number where it is while the widget numbers climb.
+ *
+ * Everything else about the column is unchanged. The full height is held open, so
+ * both scrollbars describe all 100 widgets; dragging still reorders (only the
+ * cards in view get out of the way as you go); and the rail still collapses into
+ * its strip, which is where virtualization stands aside — a floating panel is one
+ * card in a box of its own, not a column.
+ *
+ * Off by default, and worth leaving off for a Home of a dozen widgets: a widget
+ * that scrolls out is UNMOUNTED, and what it had loaded, timed or animated starts
+ * again when it comes back.
+ */
+export const ManyWidgets: Story = {
+  render: () => {
+    const left = manyWidgets(60)
+    const right = manyWidgets(40)
+    return (
+      <div className="h-full w-full p-6">
+        <NewHomeLayout
+          leftWidgets={left}
+          rightWidgets={right}
+          slotRenderers={SLOT_RENDERERS}
+          virtualizedWidgetContainers={["main", "right"]}
+          onRemoveWidget={() => {}}
+          onReorderWidgets={() => {}}
+        >
+          {/* The main column's freeform content, above the widgets and scrolling
+              in the same box — which is what the placed cards have to be offset
+              past. */}
+          {mainColumnBlocks()}
+        </NewHomeLayout>
+        <MountedCount of={left.length + right.length} />
+      </div>
+    )
+  },
 }

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -47,7 +47,11 @@ import {
 import { SlotWidget } from "../SlotWidget"
 import { useRailMotion } from "./useRailMotion"
 import { useScrollFade } from "../useScrollFade"
-import { WidgetContainer, type WidgetContainerSide } from "../WidgetContainer"
+import {
+  WidgetContainer,
+  type WidgetContainerSide,
+  type WidgetVirtualization,
+} from "../WidgetContainer"
 import {
   widgetTitle,
   type HomeRenderCtx,
@@ -204,6 +208,30 @@ export interface NewHomeLayoutProps {
    */
   editableWidgetContainers?: WidgetContainerSide[]
   /**
+   * Which containers keep ONLY THE WIDGETS YOU CAN SEE in the DOM. None by
+   * default: for a Home of a dozen widgets, mounting them all is what keeps a
+   * card's data, clock and animation alive across everything this layout does to
+   * it, and virtualizing would trade that away for nothing.
+   *
+   * Name a side once its widgets can outnumber a screen — a hundred cards is a
+   * hundred fetches and a hundred charts, and all but the three in view are work
+   * nobody asked for. Below `virtualization.threshold` widgets (12 by default) the
+   * column still renders them all, so naming a side here is a CEILING rather than
+   * a switch. What it costs is on `WidgetVirtualization`; in short, a widget that
+   * scrolls out is unmounted and comes back new, and only the cards in view get
+   * out of a dragged one's way.
+   *
+   * STACKED (below `md`) the rail's widgets belong to the main column, so "main"
+   * is what virtualizes them there.
+   */
+  virtualizedWidgetContainers?: WidgetContainerSide[]
+  /**
+   * Tuning for the above — the height a card is guessed at before it is measured,
+   * how many are kept past each edge, and the count it starts at. The scroll
+   * region is this layout's own, per side, and is not yours to set.
+   */
+  virtualization?: Omit<WidgetVirtualization, "scrollElement">
+  /**
    * Called with a widget id when its "Remove widget" menu item is used — the
    * three-dots menu in the widget's own header.
    */
@@ -279,6 +307,8 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       slotRenderers,
       renderWidget,
       editableWidgetContainers = ["main", "right"],
+      virtualizedWidgetContainers = [],
+      virtualization,
       onRemoveWidget,
       onChangeWidgetParams,
       renderWidgetPreview,
@@ -358,6 +388,27 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     // reached the end.
     const mainFade = useScrollFade()
     const railFade = useScrollFade()
+    // The COLLAPSED strip is a third scroll region — a tall enough one, once the
+    // rail holds more widgets than a screen of 40px glyphs.
+    const stripFade = useScrollFade()
+
+    /**
+     * WHAT A COLUMN IS ON SCREEN OF, for the sides that virtualize: its own
+     * scroll region, which is the box the fades are already watching. Handed over
+     * rather than left to be walked for, because this layout knows the answer —
+     * and the rail's is not the ancestor a walk would find while the rail is a
+     * floating panel.
+     */
+    const virtualizationFor = (
+      side: WidgetContainerSide
+    ): WidgetVirtualization | false =>
+      virtualizedWidgetContainers.includes(side)
+        ? {
+            ...virtualization,
+            scrollElement:
+              side === "main" ? mainFade.element : railFade.element,
+          }
+        : false
 
     const hasSide =
       aside != null || rightWidgets.length > 0 || onClickAddNewWidget != null
@@ -697,6 +748,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             slotRenderers={slotRenderers}
             renderWidget={renderWidget}
             ctx={ctx}
+            virtualized={virtualizationFor("main")}
             disableEdition={!canEditSide("main")}
             onReorder={
               onReorderWidgets
@@ -727,15 +779,20 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           {stacked || !sideReady || !collapsed ? null : (
             // The collapsed strip: one avatar per widget, the widget's own
             // catalog glyph. Hover/click floats the widget over the feed.
-            // NO FADE HERE: the strip is a short column of 40px glyphs, and a
-            // mask over those washes the glyphs themselves out rather than
-            // hinting at content past an edge. The fade belongs to the expanded
-            // rail, where the content is tall cards.
+            // IT FADES AT AN OVERFLOWING END, like both columns: a strip of
+            // enough widgets scrolls, and cut off at the edge with nothing to
+            // say so, the glyph you can half-see reads as the last one. The
+            // fade is scroll-aware (`useScrollFade`), so a strip that fits —
+            // which is most of them — is not masked at all, and the washing-out
+            // a static mask over 40px glyphs would be never happens.
             // `-m-1 p-1`: the hasUpdates dot pokes 2px past the 40px glyphs,
             // and the scrollport would clip it — bleed the scrollport out by
             // 4px (padding puts the glyphs back) so the dot stays inside it.
+            // The bleed is where the fade starts, too, so it opens on the gap
+            // above the first glyph rather than on the glyph itself.
             <motion.aside
               key="collapsed-strip"
+              ref={stripFade.ref}
               className={cn(
                 // `items-start` so a glyph is 40px wide whatever the column is
                 // doing: the strip lives in the rail's column, and that column
@@ -757,6 +814,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 // what lets the cards look like they are going INTO them.
                 width: "fit-content",
                 justifySelf: "end",
+                ...stripFade.style,
               }}
               initial={{ opacity: 1 }}
               animate={{ opacity: 1 }}
@@ -883,6 +941,13 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               slotRenderers={slotRenderers}
               renderWidget={renderWidget}
               ctx={ctx}
+              // The rail virtualizes only while it is a COLUMN — as a floating
+              // panel it is one card in a box of its own, and the container reads
+              // that off `visibleWidgetId` by itself, mounting only the card the
+              // panel shows. The setting stays put through the change: it decides
+              // how the widgets are drawn, and a prop that came and went would be
+              // one more thing moving mid-gesture.
+              virtualized={virtualizationFor("right")}
               // NOT gated on `collapsed`: whether the column is arrangeable
               // decides its tree's SHAPE (a draggable column is wrapped in a
               // DndContext), and a shape that changed when the rail collapsed

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 import { z } from "zod"
 
 import { Calendar, Clock } from "@/icons/app"
@@ -22,6 +22,73 @@ const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) => ({
 })
 
 const WIDGETS = [widget("clock"), widget("events")]
+
+/** A column of `count` widgets, named `widget-0`… in order. */
+const manyWidgets = (count: number) =>
+  Array.from({ length: count }, (_, index) => widget(`widget-${index}`))
+
+/**
+ * A scroll region around a column, the way a page gives it one — the box its
+ * widgets are on screen OF, and what a virtualized column looks for. The
+ * overflow is INLINE rather than a class: jsdom has no stylesheet, so a
+ * `overflow-y-auto` class is invisible to `getComputedStyle`.
+ */
+const Scroller = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ overflowY: "auto", height: 400 }}>{children}</div>
+)
+
+/**
+ * Which widgets are in the DOM, by id — read off the boxes a draggable column
+ * marks every widget's card with.
+ */
+const mountedIds = (container: HTMLElement) =>
+  [...container.querySelectorAll("[data-widget-id]")].map((el) =>
+    el.getAttribute("data-widget-id")
+  )
+
+/**
+ * GIVES JSDOM A LAYOUT, which is the one thing virtualization cannot do without:
+ * every box measures 0 there, and a column with no viewport has nothing on screen
+ * to keep. A placed card (`data-index`) is `card` tall and everything else —
+ * including the scroll region — is `viewport`.
+ *
+ * Both metrics, because the two measurements are taken differently: the scroll
+ * region is read from `offsetHeight` and a card from its client rect.
+ */
+const mockLayout = ({ viewport, card }: { viewport: number; card: number }) => {
+  const heightOf = (el: HTMLElement) =>
+    el.hasAttribute("data-index") ? card : viewport
+
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      const height = heightOf(this)
+      // Spelled out rather than a `DOMRect`: jsdom keeps a rect's fields on the
+      // prototype, so a spread one arrives with none of them and every offset
+      // taken from it comes out NaN.
+      return {
+        top: 0,
+        left: 0,
+        right: 400,
+        bottom: height,
+        width: 400,
+        height,
+        x: 0,
+        y: 0,
+        toJSON: () => ({}),
+      } as DOMRect
+    }
+  )
+  vi.spyOn(HTMLElement.prototype, "offsetHeight", "get").mockImplementation(
+    function (this: HTMLElement) {
+      return heightOf(this)
+    }
+  )
+  vi.spyOn(HTMLElement.prototype, "offsetWidth", "get").mockReturnValue(400)
+}
+
+/** The box that holds a virtualized column's cards, found through one of them. */
+const listOf = (container: HTMLElement) =>
+  container.querySelector("[data-index]")?.parentElement
 
 /** Opens the menu of the widget at `index` and returns its remove item. */
 const openMenu = async (index: number) => {
@@ -332,6 +399,137 @@ describe("WidgetContainer", () => {
       // The f0 `Widget`'s handle marks itself for gridstack; nothing here asks
       // for it.
       expect(container.querySelectorAll("[data-gs-handle]")).toHaveLength(0)
+    })
+  })
+
+  describe("virtualization", () => {
+    beforeEach(() => mockLayout({ viewport: 400, card: 200 }))
+    afterEach(() => vi.restoreAllMocks())
+
+    test("mounts only the widgets in view, not the hundred behind them", () => {
+      const widgets = manyWidgets(100)
+      const { container } = zeroRender(
+        <Scroller>
+          <WidgetContainer
+            widgets={widgets}
+            virtualized={{ estimateHeight: 200 }}
+            onReorder={() => {}}
+          />
+        </Scroller>
+      )
+
+      const mounted = mountedIds(container)
+      // A handful, from the top: the column is scrolled to 0, so the window is
+      // the two cards a 400px viewport holds and the overscan past them.
+      expect(mounted.length).toBeGreaterThan(0)
+      expect(mounted.length).toBeLessThan(widgets.length)
+      expect(mounted[0]).toBe("widget-0")
+      expect(mounted).not.toContain("widget-99")
+      expect(screen.queryByText("widget-99")).not.toBeInTheDocument()
+    })
+
+    test("holds the space of the widgets it did not mount", () => {
+      const { container } = zeroRender(
+        <Scroller>
+          <WidgetContainer
+            widgets={manyWidgets(100)}
+            virtualized={{ estimateHeight: 200 }}
+            onReorder={() => {}}
+          />
+        </Scroller>
+      )
+
+      // 100 cards of 200px, 24px apart — the whole column, so the scrollbar
+      // describes all of it and not the four cards that are mounted.
+      expect(listOf(container)?.style.height).toBe(`${100 * 200 + 99 * 24}px`)
+    })
+
+    test("places each mounted card where its absent neighbours would have", () => {
+      const { container } = zeroRender(
+        <Scroller>
+          <WidgetContainer
+            widgets={manyWidgets(100)}
+            virtualized={{ estimateHeight: 200 }}
+            onReorder={() => {}}
+          />
+        </Scroller>
+      )
+
+      const tops = [
+        ...container.querySelectorAll<HTMLElement>("[data-index]"),
+      ].map((el) => el.style.top)
+      // 200px cards, 24px apart, from the top of the list.
+      expect(tops.slice(0, 3)).toEqual(["0px", "224px", "448px"])
+    })
+
+    test("mounts them all below the threshold — a short column gains nothing", () => {
+      const { container } = zeroRender(
+        <Scroller>
+          <WidgetContainer
+            widgets={manyWidgets(4)}
+            virtualized={{ threshold: 5 }}
+            onReorder={() => {}}
+          />
+        </Scroller>
+      )
+
+      expect(mountedIds(container)).toHaveLength(4)
+    })
+
+    test("mounts them all with no scroll region to be clipped to", () => {
+      const { container } = zeroRender(
+        <WidgetContainer
+          widgets={manyWidgets(100)}
+          virtualized
+          onReorder={() => {}}
+        />
+      )
+
+      expect(mountedIds(container)).toHaveLength(100)
+    })
+
+    test("mounts ONLY the widget a panel floats — it is all there is to see", () => {
+      const { container } = zeroRender(
+        <Scroller>
+          <WidgetContainer
+            widgets={manyWidgets(100)}
+            virtualized
+            // The floating panel's filter. Unvirtualized this hides the other 99
+            // and keeps them mounted; virtualized, they are already unmounted the
+            // moment they scroll away, so there is nothing to preserve by keeping
+            // them.
+            visibleWidgetId="widget-80"
+            onReorder={() => {}}
+          />
+        </Scroller>
+      )
+
+      expect(mountedIds(container)).toEqual(["widget-80"])
+      expect(screen.getAllByText("widget-80").length).toBeGreaterThan(0)
+    })
+
+    test("an unvirtualized container still keeps every widget mounted for it", () => {
+      const { container } = zeroRender(
+        <Scroller>
+          <WidgetContainer
+            widgets={manyWidgets(100)}
+            visibleWidgetId="widget-80"
+            onReorder={() => {}}
+          />
+        </Scroller>
+      )
+
+      expect(mountedIds(container)).toHaveLength(100)
+    })
+
+    test("is off by default — nothing changes for a column that did not ask", () => {
+      const { container } = zeroRender(
+        <Scroller>
+          <WidgetContainer widgets={manyWidgets(100)} onReorder={() => {}} />
+        </Scroller>
+      )
+
+      expect(mountedIds(container)).toHaveLength(100)
     })
   })
 })

--- a/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Calendar, Clock } from "@/icons/app"
 
-import { type HomeWidgetItem, listSlot } from "../slotRenderers"
+import { type HomeWidgetItem, listSlot, widgetTitle } from "../slotRenderers"
 import { WidgetContainer } from "./index"
 
 const WIDGETS: HomeWidgetItem[] = [
@@ -88,4 +88,43 @@ export const EditingDisabled: Story = {
 /** The rail variant — a tighter gap between its widgets than the main column. */
 export const RightSide: Story = {
   args: { side: "right" },
+}
+
+/**
+ * A COLUMN LONGER THAN ITS SCROLL REGION, `virtualized`: 50 widgets, of which
+ * only the handful in view (plus the overscan) is in the DOM. Inspect the column
+ * while you scroll it — the cards ahead and behind are not hidden, they are not
+ * there, and the box they sit in holds the height of all 50 so the scrollbar
+ * still describes the whole column.
+ *
+ * The scroll region is the column's nearest scrollable ancestor, which here is
+ * the decorator's own box; `NewHomeLayout` hands its columns theirs.
+ *
+ * `estimateHeight` is what an unmounted card is assumed to be worth, and these
+ * are small ones — left at the 280px default the column would claim nearly twice
+ * its real height and the scrollbar would shrink under your thumb as the cards
+ * you scroll past get measured. Aim it at the cards you actually have.
+ */
+export const Virtualized: Story = {
+  args: {
+    widgets: Array.from({ length: 50 }, (_, index) => {
+      const source = WIDGETS[index % WIDGETS.length]!
+      return {
+        ...source,
+        id: `widget-${index}`,
+        header: {
+          ...source.header,
+          title: `${index + 1}. ${widgetTitle(source)}`,
+        },
+      }
+    }),
+    virtualized: { estimateHeight: 150 },
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-[480px] max-w-96 overflow-y-auto p-4">
+        <Story />
+      </div>
+    ),
+  ],
 }

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -46,7 +46,14 @@ import {
 import { SlotWidget } from "../SlotWidget"
 import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
 import { SortableWidget } from "./SortableWidget"
+import {
+  useWidgetVirtualizer,
+  type WidgetPlacement,
+  type WidgetVirtualization,
+} from "./useWidgetVirtualizer"
 import { WidgetMotion, type WidgetStow } from "./WidgetMotion"
+
+export type { WidgetVirtualization } from "./useWidgetVirtualizer"
 
 /**
  * WHAT CANNOT START A DRAG. The whole card is the drag surface — there is no
@@ -123,6 +130,14 @@ const widgetChrome = (widget: HomeWidgetItem) =>
 export type WidgetContainerSide = "main" | "right"
 
 /**
+ * The gap between a column's widgets, per side — the same numbers as the `gap-6`
+ * / `gap-4` classes below, which is why they are here rather than only there: a
+ * VIRTUALIZED column places its cards itself, so it needs the gap as a number.
+ * Keep the two in step.
+ */
+const GAP_PX: Record<WidgetContainerSide, number> = { main: 24, right: 16 }
+
+/**
  * One widget's place in the column, and the only thing that decides whether it
  * is SHOWN — never whether it exists.
  *
@@ -132,20 +147,54 @@ export type WidgetContainerSide = "main" | "right"
  * Hidden, plain `hidden` takes it out of sight AND out of the a11y tree — while
  * its render stays MOUNTED.
  *
- * It wraps every widget whether or not anything is being hidden: a wrapper that
- * came and went with the filtering would change the tree's shape, and changing
- * shape is what unmounts a render.
+ * VIRTUALIZED it is a real box instead, PLACED where the widget belongs in a
+ * column whose other cards are not mounted (`placement`), and the box the
+ * virtualizer measures this widget by. `display: contents` is not an option
+ * there: a card with no box of its own cannot be positioned, and cannot be
+ * measured either.
+ *
+ * It wraps every widget whether or not anything is being hidden or placed: a
+ * wrapper that came and went with the filtering would change the tree's shape,
+ * and changing shape is what unmounts a render.
  */
 const WidgetSlot = ({
   hidden,
+  placement,
+  measureRef,
   children,
 }: {
   hidden: boolean
+  /** Where this widget goes in a virtualized column, if it is one. */
+  placement?: WidgetPlacement
+  measureRef?: (node: HTMLElement | null) => void
   children: ReactNode
 }) => (
-  // No `display` of its own while hidden: `hidden` only means `display: none`
-  // for as long as nothing else sets one.
-  <div hidden={hidden} style={{ display: hidden ? undefined : "contents" }}>
+  <div
+    // Only the placed box is measured — an unplaced one is `display: contents`
+    // and has no size to report.
+    ref={placement ? measureRef : undefined}
+    // Which widget this box is, for the virtualizer to file its measurement
+    // under. Its own attribute, not ours: `indexAttribute` defaults to this.
+    data-index={placement?.index}
+    hidden={hidden}
+    style={
+      placement
+        ? {
+            // PLACED, NOT FLOWED, because its neighbours are not there to flow
+            // after: the list is one box as tall as the whole column would be,
+            // and each mounted card sits at the offset its absent neighbours
+            // would have pushed it to. The gap between them is the
+            // virtualizer's — a flex gap does not reach a positioned child.
+            position: "absolute",
+            top: placement.start,
+            left: 0,
+            width: "100%",
+          }
+        : // No `display` of its own while hidden: `hidden` only means
+          // `display: none` for as long as nothing else sets one.
+          { display: hidden ? undefined : "contents" }
+    }
+  >
     {children}
   </div>
 )
@@ -230,6 +279,19 @@ export interface WidgetContainerProps {
    */
   entrance?: false | { order?: number; delayMs?: number }
   /**
+   * KEEPS ONLY THE WIDGETS YOU CAN SEE IN THE DOM. `true` for the defaults, or an
+   * object to tune them; omitted (the default), every widget is mounted.
+   *
+   * For a column that can hold more widgets than fit on a screen — a hundred
+   * cards, each with its own data and its own chart, is a hundred fetches and a
+   * DOM the browser pays for on every frame. What it costs, and why it is not the
+   * default, is on `WidgetVirtualization`.
+   *
+   * Choose it ONCE for the life of the column: turning it on or off swaps how
+   * every card is laid out, which is a jump if anyone is looking.
+   */
+  virtualized?: boolean | WidgetVirtualization
+  /**
    * THE STOW: where this column's widgets go when the rail collapses. Each card
    * scales down onto its own glyph and fades, and grows back out of it when the
    * rail opens, so a card and its glyph read as one object rather than two
@@ -303,6 +365,7 @@ export function WidgetContainer({
   onReorder,
   visibleWidgetId,
   entrance = {},
+  virtualized = false,
   stow,
   addWidgetLabel,
   onChangeWidgetParams,
@@ -336,6 +399,36 @@ export function WidgetContainer({
   // same column is a fairground, not an explanation.
   const [flippedId, setFlippedId] = useState<string | null>(null)
   const columnRef = useRef<HTMLDivElement>(null)
+  /**
+   * WHICH WIDGETS ARE WORTH HAVING IN THE DOM — every one of them unless this
+   * column is virtualized. See `useWidgetVirtualizer`.
+   */
+  const virtual = useWidgetVirtualizer({
+    config: virtualized === true ? {} : virtualized,
+    count: widgets.length,
+    gap: GAP_PX[side],
+    // The card UNDER THE POINTER stays mounted for the whole gesture whatever the
+    // column scrolls past: dnd-kit holds the node it is dragging, and taking that
+    // out from under it mid-drag ends the drag rather than the drop.
+    pinned: activeId ? [widgets.findIndex((w) => w.id === activeId)] : [],
+    // A CONTAINER SHOWING ONE WIDGET IS NOT A COLUMN. `visibleWidgetId` is the
+    // floating panel, a box around a single card, so there is no viewport for the
+    // rest to be on screen of and nothing to place them against — the one widget
+    // it shows simply flows (see `panelOnly`).
+    paused: visibleWidgetId !== undefined,
+  })
+  /**
+   * PANEL MODE, IN A VIRTUALIZED COLUMN: the widget the panel floats is the only
+   * one there is to see, so it is the only one MOUNTED.
+   *
+   * An unvirtualized container keeps the rest mounted and merely hides them, which
+   * is what makes the collapsed rail lossless — hover a glyph and the card that
+   * comes out is the one that was already there, still loaded, still counting. A
+   * virtualized column has given that up by definition (scroll a card away and it
+   * unmounts), so keeping forty hidden cards in the DOM for a panel that shows one
+   * would be the cost of the guarantee without the guarantee.
+   */
+  const panelOnly = virtualized !== false && visibleWidgetId !== undefined
   /**
    * The LOCKED widget a drop was aiming at, if any — the reason it is about to be
    * refused.
@@ -574,6 +667,75 @@ export function WidgetContainer({
     )
   }
 
+  /**
+   * ONE WIDGET, wherever the column is drawing it. Both branches below render
+   * this, so becoming draggable (a second widget lands in the column) changes what
+   * is AROUND the widgets and not the widgets themselves.
+   */
+  const slot = (
+    widget: HomeWidgetItem,
+    order: number,
+    placement?: WidgetPlacement
+  ) => (
+    <WidgetSlot
+      key={widget.id}
+      hidden={isHidden(widget)}
+      placement={placement}
+      measureRef={virtual.measureRef}
+    >
+      {canDrag ? (
+        <SortableWidget id={widget.id} disabled={widget.locked}>
+          {/* The arrival wrapper sits INSIDE the sortable rather than around it:
+              dnd-kit measures the element it holds the ref to, and a transformed
+              ancestor would offset every rect it reads while a drag is in
+              flight. */}
+          {(state) => enter(order, render(widget, state), widget)}
+        </SortableWidget>
+      ) : (
+        enter(order, render(widget), widget)
+      )}
+    </WidgetSlot>
+  )
+
+  /**
+   * THE WIDGETS. Virtualized, the ones the window asks for, each placed where its
+   * unmounted neighbours would have put it, in a box as tall as the whole column;
+   * otherwise all of them, in flow.
+   *
+   * The element is THE SAME either way, down to its classes — which is what lets a
+   * container stop virtualizing (the panel opening) without remounting a card.
+   * Its own `gap` is inert while the cards are placed, and does the spacing while
+   * they are not.
+   */
+  const list = (
+    <div
+      ref={virtual.listRef}
+      className={cn("flex flex-col", side === "main" ? "gap-6" : "gap-4")}
+      style={
+        virtual.window
+          ? {
+              // THE HEIGHT OF THE COLUMN THAT WOULD BE, so the scrollbar
+              // describes all the widgets rather than the three that are
+              // mounted — and `relative` so the placed cards are placed from
+              // this box's top rather than the column's.
+              position: "relative",
+              height: virtual.window.totalSize,
+            }
+          : undefined
+      }
+    >
+      {virtual.window
+        ? virtual.window.placements.map((placement) =>
+            slot(widgets[placement.index], placement.index, placement)
+          )
+        : widgets.flatMap((widget, order) =>
+            panelOnly && widget.id !== visibleWidgetId
+              ? []
+              : [slot(widget, order)]
+          )}
+    </div>
+  )
+
   return (
     <div
       ref={columnRef}
@@ -602,30 +764,16 @@ export function WidgetContainer({
             handleDragEnd(event)
           }}
         >
+          {/* EVERY WIDGET'S ID, mounted or not: the order a drop commits is the
+              column's own, and a sortable that only knew about the cards in view
+              would reorder the slice instead of the list. dnd-kit takes the
+              missing ones in its stride — it has no rect for a card that isn't
+              there, so it moves the ones that are. */}
           <SortableContext
             items={widgets.map((widget) => widget.id)}
             strategy={verticalListSortingStrategy}
           >
-            {/* The same gap the static list uses, so a column that becomes
-                draggable (a second widget lands in it) doesn't reflow. */}
-            <div
-              className={cn(
-                "flex flex-col",
-                side === "main" ? "gap-6" : "gap-4"
-              )}
-            >
-              {widgets.map((widget, order) => (
-                <WidgetSlot key={widget.id} hidden={isHidden(widget)}>
-                  <SortableWidget id={widget.id} disabled={widget.locked}>
-                    {/* The arrival wrapper sits INSIDE the sortable rather than
-                        around it: dnd-kit measures the element it holds the ref
-                        to, and a transformed ancestor would offset every rect it
-                        reads while a drag is in flight. */}
-                    {(state) => enter(order, render(widget, state), widget)}
-                  </SortableWidget>
-                </WidgetSlot>
-              ))}
-            </div>
+            {list}
           </SortableContext>
           {/* The card that follows the pointer is a CLONE in an overlay — the
               in-list card hides meanwhile (SortableWidget). On release the
@@ -647,11 +795,7 @@ export function WidgetContainer({
           </DragOverlay>
         </DndContext>
       ) : (
-        widgets.map((widget, order) => (
-          <WidgetSlot key={widget.id} hidden={isHidden(widget)}>
-            {enter(order, render(widget), widget)}
-          </WidgetSlot>
-        ))
+        list
       )}
       {/* Adding, like removing and reordering, is always on offer.
           `disableEdition` columns never offer any of it. */}

--- a/packages/react/src/sds/Home/WidgetContainer/useWidgetVirtualizer.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/useWidgetVirtualizer.ts
@@ -1,0 +1,262 @@
+import {
+  defaultRangeExtractor,
+  useVirtualizer,
+  type Range,
+} from "@tanstack/react-virtual"
+import { useCallback, useLayoutEffect, useRef, useState } from "react"
+
+/**
+ * How many widgets it takes before mounting them all is worth avoiding. Below
+ * this a column renders every widget: virtualization buys nothing there and
+ * costs a measurement pass per card.
+ */
+const DEFAULT_THRESHOLD = 12
+/**
+ * The first guess at a card's height, before it has been measured. It is only a
+ * guess — every mounted card is measured and the guess is replaced — so what it
+ * has to be is CLOSE, not right: too small and a column of unmeasured widgets
+ * under-reports its height, so the scrollbar grows as you scroll it.
+ */
+const DEFAULT_ESTIMATE_PX = 280
+/**
+ * Cards kept mounted past each edge of the viewport. Two, because a widget is a
+ * card with data in it: the next one has to be there before it is scrolled to,
+ * or scrolling reads as a queue of cards loading.
+ */
+const DEFAULT_OVERSCAN = 2
+
+/** The `overflow-y` values that make an element a scroll region. */
+const SCROLLS = new Set(["auto", "scroll", "overlay"])
+
+/**
+ * The scroll region a column lives in — the box its widgets are on screen OF.
+ *
+ * Walked from the column rather than passed in, because a column does not know
+ * who is scrolling it: `NewHomeLayout` scrolls each of its columns in a box of
+ * its own, a page might scroll the lot in one, and a story just puts it in a
+ * `div`. The body is not an answer: virtualizing against the document needs a
+ * window virtualizer, and a column with no scroll region of any kind has no
+ * viewport to be clipped to — it renders everything (see `enabled` below).
+ */
+const scrollableAncestor = (from: HTMLElement): HTMLElement | null => {
+  let el = from.parentElement
+  while (el && el !== document.body && el !== document.documentElement) {
+    // `getPropertyValue`, not `.overflowY`: the property accessor is the one
+    // jsdom's computed style does not implement, and this is the API both it and
+    // every browser agree on.
+    if (SCROLLS.has(getComputedStyle(el).getPropertyValue("overflow-y")))
+      return el
+    el = el.parentElement
+  }
+  return null
+}
+
+/**
+ * VIRTUALIZATION — what a column does when it has more widgets than a screen.
+ *
+ * A widget is not a row: it is a card with its own data, its own chart, its own
+ * list of rows inside it. A hundred of them mounted is a hundred fetches, a
+ * hundred charts laid out and a DOM the browser spends every frame on, and all
+ * but the three you can see are work nobody asked for. So a virtualized column
+ * mounts ONLY the widgets in view (plus `overscan` past each edge) and holds the
+ * space of the rest open, so the scrollbar still describes the whole column.
+ *
+ * WHAT IT COSTS, and why it is opt-in rather than the default:
+ *
+ * - A widget that scrolls out is UNMOUNTED. Whatever it had loaded, timed or
+ *   animated is gone, and it starts again when it comes back — the opposite of
+ *   what the collapsed rail is built to guarantee. For a column of a few widgets
+ *   that trade is a bad one, which is what `threshold` is for.
+ * - Dragging still reorders correctly, but only the widgets that are MOUNTED
+ *   shuffle out of the way as you go: dnd-kit can't move a card that isn't
+ *   there. The dragged card itself is pinned into the DOM for the whole gesture.
+ * - `fullHeight` means nothing here. A virtualized column's height is the sum of
+ *   its cards, so there is no column height for a card to fill.
+ */
+export interface WidgetVirtualization {
+  /**
+   * Below this many widgets the column simply renders them all. Defaults to 12.
+   */
+  threshold?: number
+  /** First guess at a card's height in px, before it is measured. */
+  estimateHeight?: number
+  /** How many cards stay mounted past each edge of the viewport. */
+  overscan?: number
+  /**
+   * The scroll region to virtualize against. Defaults to the column's nearest
+   * scrollable ancestor — pass it when you already have the element (it saves
+   * the walk, and it is exact).
+   */
+  scrollElement?: HTMLElement | null
+}
+
+/** Where one on-screen widget goes, and how much room it takes. */
+export interface WidgetPlacement {
+  /** Its index in the column's full list of widgets. */
+  index: number
+  /** Its offset from the top of the list element, in px. */
+  start: number
+}
+
+export interface WidgetVirtualizer {
+  /** Goes on the element that holds the widgets. */
+  listRef: (node: HTMLDivElement | null) => void
+  /**
+   * The widgets to mount and where to put them — or `null`, meaning render
+   * every widget in normal flow (not virtualized, paused, below the threshold,
+   * or no scroll region to be clipped to).
+   */
+  window: {
+    placements: WidgetPlacement[]
+    /** The height the whole column would be, cards not mounted included. */
+    totalSize: number
+  } | null
+  /** Goes on every mounted widget's box, alongside its `data-index`. */
+  measureRef: (node: HTMLElement | null) => void
+}
+
+export interface UseWidgetVirtualizerOptions {
+  /** `false` — the column renders every widget, as an unvirtualized one does. */
+  config: WidgetVirtualization | false
+  /** How many widgets the column has in total. */
+  count: number
+  /**
+   * The column's gap in px. The virtualizer places the cards itself, so it needs
+   * the gap as a number as well as a class: placed cards are out of the flex
+   * flow, and a flex gap does not apply to them.
+   */
+  gap: number
+  /**
+   * Widgets that must stay mounted wherever the column is scrolled to, by index.
+   * The card under the pointer during a drag is the case this exists for:
+   * unmounting it mid-gesture takes dnd-kit's active node out from under it.
+   */
+  pinned?: number[]
+  /**
+   * Suspends virtualization: the column renders every widget in normal flow
+   * again, keeping the SAME elements it had. For a container that stops being a
+   * column — `NewHomeLayout`'s floating panel, which is one widget in a box of
+   * its own and has no viewport for the others to be measured against.
+   */
+  paused?: boolean
+}
+
+/**
+ * The window of widgets a column should have in the DOM.
+ *
+ * It is ALWAYS CALLED, virtualized or not, and it always returns the same shape:
+ * whether a column virtualizes decides how many widgets it draws and where, not
+ * what its tree looks like. A hook (or a wrapper element) that came and went
+ * with the setting would remount every widget in the column the moment it
+ * flipped — the panel opening, a widget being added past the threshold — which
+ * is exactly the cost virtualization is here to avoid paying twice.
+ */
+export function useWidgetVirtualizer({
+  config,
+  count,
+  gap,
+  pinned = [],
+  paused = false,
+}: UseWidgetVirtualizerOptions): WidgetVirtualizer {
+  const settings = config === false ? null : config
+  const [listEl, setListEl] = useState<HTMLDivElement | null>(null)
+  // The walked ancestor. In state, not a ref: it is found after the first
+  // render, and nothing else would re-render the column to use it.
+  const [ancestor, setAncestor] = useState<HTMLElement | null>(null)
+  const scrollElement = settings?.scrollElement ?? ancestor
+
+  const wanted = settings != null && !paused
+  const explicit = settings?.scrollElement != null
+
+  useLayoutEffect(() => {
+    if (!wanted || explicit || !listEl) return
+    setAncestor(scrollableAncestor(listEl))
+  }, [wanted, explicit, listEl])
+
+  /**
+   * HOW FAR DOWN THE SCROLL REGION THE WIDGETS START.
+   *
+   * A column is not only its widgets: the main one has a greeting, shortcuts and
+   * a feed above them, and all of that scrolls in the same box. So the offsets
+   * the virtualizer works in are measured from the scroll region's top, while the
+   * cards are placed inside the list element — the difference between the two is
+   * this, and it changes whenever the content above the widgets does.
+   */
+  const [scrollMargin, setScrollMargin] = useState(0)
+
+  useLayoutEffect(() => {
+    if (!wanted || !listEl || !scrollElement) return
+
+    const read = () => {
+      const offset =
+        listEl.getBoundingClientRect().top -
+        scrollElement.getBoundingClientRect().top +
+        scrollElement.scrollTop
+      // Sub-pixel differences are not a change: fractional scroll offsets and
+      // zoom leave remainders, and taking them would re-render on every observed
+      // frame — including the ones this very list's height caused.
+      setScrollMargin((prev) => (Math.abs(prev - offset) < 1 ? prev : offset))
+    }
+
+    read()
+    if (typeof ResizeObserver !== "function") return
+    const observer = new ResizeObserver(read)
+    observer.observe(scrollElement)
+    // The COLUMN, because what moves the widgets down is the content above them
+    // growing — the feed loading, a card appearing — and none of that resizes
+    // either the scroll region or the list.
+    if (listEl.parentElement) observer.observe(listEl.parentElement)
+    return () => observer.disconnect()
+  }, [wanted, listEl, scrollElement])
+
+  const enabled =
+    wanted &&
+    scrollElement != null &&
+    count >= (settings?.threshold ?? DEFAULT_THRESHOLD)
+
+  /**
+   * The window, PLUS whatever must be in the DOM regardless of where the column
+   * is scrolled to. Keyed by the pinned indexes rather than closing over them:
+   * the virtualizer memoizes its range on this function's identity, so a new pin
+   * has to be a new function or it would not be looked at until the next scroll.
+   */
+  const pinnedRef = useRef(pinned)
+  pinnedRef.current = pinned
+  const pinnedKey = pinned.join(",")
+  const rangeExtractor = useCallback(
+    (range: Range) => {
+      const indexes = new Set(defaultRangeExtractor(range))
+      for (const index of pinnedRef.current)
+        if (index >= 0 && index < range.count) indexes.add(index)
+      return [...indexes].sort((a, b) => a - b)
+    },
+    [pinnedKey]
+  )
+
+  const virtualizer = useVirtualizer({
+    enabled,
+    count,
+    gap,
+    scrollMargin,
+    rangeExtractor,
+    overscan: settings?.overscan ?? DEFAULT_OVERSCAN,
+    estimateSize: () => settings?.estimateHeight ?? DEFAULT_ESTIMATE_PX,
+    getScrollElement: () => scrollElement,
+  })
+
+  return {
+    listRef: setListEl,
+    measureRef: virtualizer.measureElement,
+    window: enabled
+      ? {
+          // `start` is measured from the SCROLL REGION's top and the cards are
+          // placed inside the list, so the offset to the list comes back off it.
+          placements: virtualizer.getVirtualItems().map(({ index, start }) => ({
+            index,
+            start: start - scrollMargin,
+          })),
+          totalSize: virtualizer.getTotalSize(),
+        }
+      : null,
+  }
+}

--- a/packages/react/src/sds/Home/useScrollFade.ts
+++ b/packages/react/src/sds/Home/useScrollFade.ts
@@ -67,5 +67,8 @@ export function useScrollFade(fade: number = SCROLL_FADE_PX) {
     return { maskImage: mask, WebkitMaskImage: mask }
   }, [ends, fade])
 
-  return { ref: setEl, style }
+  // `element` as well as the ref, because a scroll region is worth more than its
+  // own mask: whatever else needs to know what is on screen in it — a virtualized
+  // column, say — needs the element, and this hook already has it in state.
+  return { ref: setEl, style, element: el }
 }


### PR DESCRIPTION
## Description

A Home whose columns can hold more widgets than a screen mounted every one of them, so a hundred cards meant a hundred fetches, a hundred charts laid out and a DOM the browser paid for on every frame — for the three cards you can actually see. `WidgetContainer` now takes a `virtualized` prop and `NewHomeLayout` a `virtualizedWidgetContainers` one, per side, so a long column keeps only its on-screen widgets in the DOM while holding the space of the rest open; both are off by default, because mounting everything is what makes the collapsed rail lossless and a Home of a dozen widgets would trade that away for nothing.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Bug fix

## Screenshots (if applicable)

<!-- TODO: strip fade before/after — see `Home/NewHomeLayout → ManyWidgets` (100 widgets, with a badge counting the cards in the DOM) and `Home/WidgetContainer → Virtualized` -->

## Implementation details

- feat: add `virtualized` to `WidgetContainer` — `true` for the defaults, or `{ threshold, estimateHeight, overscan, scrollElement }`

  <details>
  <summary>What it costs, and why it is opt-in</summary>

  A widget that scrolls out is UNMOUNTED, so whatever it had loaded, timed or animated starts again when it comes back — the opposite of what the collapsed rail is built to guarantee. Dragging still commits the real order, but only the cards that are mounted shuffle out of a dragged one's way. And `fullHeight` means nothing in a virtualized column, whose height is the sum of its cards.

  Below `threshold` widgets (12 by default) a virtualized column still renders them all, so turning it on is a ceiling rather than a switch.
  </details>

- feat: add `virtualizedWidgetContainers` and `virtualization` to `NewHomeLayout`, which hands each named side its own scroll region
- feat: keep the tree's shape identical whether a column virtualizes or not

  <details>
  <summary>Why?</summary>

  The hook is always called and the list element is always the same element, down to its classes: virtualizing decides how many cards are drawn and where, never what the tree looks like. A wrapper — or a hook — that came and went with the setting would remount every widget in the column the moment it flipped, which is the cost virtualization is here to avoid paying twice.
  </details>

- feat: mount only the widget the floating panel shows, in a virtualized rail

  <details>
  <summary>Why?</summary>

  An unvirtualized container keeps the rest mounted and merely hides them, which is what makes hovering a glyph lossless. A virtualized column has already given that up by definition, so keeping forty hidden cards in the DOM for a panel that shows one would be the cost of the guarantee without the guarantee.
  </details>

- fix: fade the collapsed strip at an overflowing end, like both columns — enough glyphs and the strip scrolls, and cut off at the edge with nothing to say so, the glyph you can half-see reads as the last one. Scroll-aware, so a strip that fits is not masked at all
- feat: return the scroll region's `element` from `useScrollFade`, so a virtualized column can be told what it is on screen of instead of walking for it
- test: 11 unit tests — the window, the held-open height, the placements, the threshold, no-scroll-region, panel mode, and the strip's fade at each end
- chore: add `Home/NewHomeLayout → ManyWidgets` and `Home/WidgetContainer → Virtualized` stories

### Verification

Behaviour was checked in a real browser (Storybook), not only in jsdom: 100 widgets → 8–16 cards in the DOM at any scroll position in either column, correct offsets past the main column's freeform content, drag keeps its card mounted and the overlay intact, collapse leaves 40 glyphs and 0 rail cards, hovering one floats exactly one card. 6250 unit tests pass; `tsc` is clean.

`test-storybook` could not run here (no Playwright browsers in this worktree), so the axe pass on the two new stories is unverified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)