### PR TITLE
feat(ComboChart): support stacked bars and dashed line series

### DIFF
--- a/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
@@ -178,3 +178,67 @@ export const Biaxial: Meta<typeof ComboChart<typeof departmentConfig>> = {
     legend: true,
   },
 }
+
+const headcountConfig = {
+  actuals: {
+    label: "Actuals",
+    color: "categorical-1",
+  },
+  incoming: {
+    label: "Incoming",
+    color: "categorical-4",
+  },
+  terminations: {
+    label: "Terminations",
+    color: "categorical-3",
+  },
+  planned: {
+    label: "Planned",
+    color: "categorical-2",
+    dashed: true,
+  },
+}
+
+export const StackedBySignWithLine: Meta<
+  typeof ComboChart<typeof headcountConfig>
+> = {
+  args: {
+    dataConfig: headcountConfig,
+    data: [
+      {
+        label: "January",
+        values: { actuals: 60, incoming: 12, terminations: 0, planned: 80 },
+      },
+      {
+        label: "February",
+        values: { actuals: 70, incoming: 0, terminations: -8, planned: 78 },
+      },
+      {
+        label: "March",
+        values: { actuals: 66, incoming: 24, terminations: 0, planned: 95 },
+      },
+      {
+        label: "April",
+        values: { actuals: 90, incoming: 0, terminations: -20, planned: 110 },
+      },
+    ],
+    bar: {
+      type: "stacked-by-sign",
+      categories: ["actuals", "incoming", "terminations"],
+    },
+    line: {
+      categories: ["planned"],
+      dot: true,
+      lineType: "linear",
+    },
+    xAxis: {
+      hide: false,
+      tickFormatter: (value: string) => value,
+    },
+    yAxis: {
+      hide: false,
+      tickFormatter: (value: string) => value,
+    },
+    legend: true,
+  },
+}

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -98,6 +98,16 @@ type ChartTypeConfig<K extends ChartConfig> = {
   axisPosition?: "left" | "right"
 }
 
+type BarChartTypeConfig<K extends ChartConfig> = ChartTypeConfig<K> & {
+  /**
+   * How multiple bar categories are laid out: side by side ("simple", the
+   * default), stacked into a single bar ("stacked"), or stacked with negative
+   * values hanging below the zero line ("stacked-by-sign"). Mirrors BarChart's
+   * `type` prop.
+   */
+  type?: "simple" | "stacked" | "stacked-by-sign"
+}
+
 type LineChartTypeConfig<K extends ChartConfig> = ChartTypeConfig<K> & {
   dot?: boolean
   lineType?: "natural" | "linear"
@@ -108,7 +118,7 @@ export type ComboChartProps<K extends ChartConfig = ChartConfig> =
     label?: boolean
     legend?: boolean
     showValueUnderLabel?: boolean
-    bar?: ChartTypeConfig<K>
+    bar?: BarChartTypeConfig<K>
     line?: LineChartTypeConfig<K>
     scatter?: ChartTypeConfig<K>
     onClick?: (data: ChartDataPoint<K>) => void
@@ -186,7 +196,7 @@ const _ComboChart = <K extends ChartConfig>(
           top: label ? 24 : 0,
           bottom: showValueUnderLabel ? 24 : 12,
         }}
-        stackOffset={undefined}
+        stackOffset={bar?.type === "stacked-by-sign" ? "sign" : undefined}
         onClick={(data) => {
           if (!onClick || !data.activeLabel || !data.activePayload) {
             return
@@ -321,12 +331,17 @@ const _ComboChart = <K extends ChartConfig>(
             key={`bar-${String(category)}`}
             isAnimationActive={false}
             dataKey={String(category)}
+            stackId={
+              bar?.type === "stacked" || bar?.type === "stacked-by-sign"
+                ? "stack"
+                : undefined
+            }
             fill={
               dataConfig[category].color
                 ? getColor(dataConfig[category].color)
                 : getCategoricalColor(index)
             }
-            radius={4}
+            radius={bar?.type === "stacked-by-sign" ? [4, 4, 0, 0] : 4}
             maxBarSize={32}
           >
             {label && (
@@ -352,6 +367,7 @@ const _ComboChart = <K extends ChartConfig>(
                 : getCategoricalColor(barCategories.length + index)
             }
             strokeWidth={2}
+            strokeDasharray={dataConfig[category].dashed ? "4 4" : undefined}
             dot={line?.dot ?? false}
             isAnimationActive={false}
             yAxisId={line?.axisPosition === "right" ? "right" : undefined}

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -5,6 +5,8 @@ import {
   ComposedChart,
   LabelList,
   Line,
+  Rectangle,
+  RectangleProps,
   Scatter,
   XAxis,
   YAxis,
@@ -77,6 +79,42 @@ const createScatter = (categoryKey: string) => {
 
   ScatterShape.displayName = `Scatter-${categoryKey}`
   return ScatterShape
+}
+
+type StackedBarShapeProps = RectangleProps & {
+  payload?: Record<string, unknown>
+}
+
+/**
+ * Rounds only the outer corners of a stacked bar: the top of the outermost
+ * positive segment and the bottom of the outermost negative one. Middle
+ * segments stay square so the stack reads as one continuous bar.
+ */
+const createStackedBarShape = (category: string, categories: string[]) => {
+  const StackedBarShape = (props: unknown) => {
+    const { payload, ...rest } = props as StackedBarShapeProps
+    const valueOf = (key: string) => {
+      const value = payload?.[key]
+      return typeof value === "number" ? value : 0
+    }
+
+    const value = valueOf(category)
+    const outermost = [...categories]
+      .reverse()
+      .find((key) => (value < 0 ? valueOf(key) < 0 : valueOf(key) > 0))
+    const isOutermost = value !== 0 && outermost === category
+
+    const radius: [number, number, number, number] = !isOutermost
+      ? [0, 0, 0, 0]
+      : value < 0
+        ? [0, 0, 4, 4]
+        : [4, 4, 0, 0]
+
+    return <Rectangle {...rest} radius={radius} />
+  }
+
+  StackedBarShape.displayName = `StackedBar-${category}`
+  return StackedBarShape
 }
 
 type ChartDataPoint<K extends ChartConfig> = {
@@ -341,7 +379,15 @@ const _ComboChart = <K extends ChartConfig>(
                 ? getColor(dataConfig[category].color)
                 : getCategoricalColor(index)
             }
-            radius={bar?.type === "stacked-by-sign" ? [4, 4, 0, 0] : 4}
+            radius={4}
+            shape={
+              bar?.type === "stacked" || bar?.type === "stacked-by-sign"
+                ? createStackedBarShape(
+                    String(category),
+                    barCategories.map(String)
+                  )
+                : undefined
+            }
             maxBarSize={32}
           >
             {label && (

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -104,11 +104,12 @@ const createStackedBarShape = (category: string, categories: string[]) => {
       .find((key) => (value < 0 ? valueOf(key) < 0 : valueOf(key) > 0))
     const isOutermost = value !== 0 && outermost === category
 
-    const radius: [number, number, number, number] = !isOutermost
-      ? [0, 0, 0, 0]
-      : value < 0
-        ? [0, 0, 4, 4]
-        : [4, 4, 0, 0]
+    // Segments below zero come in with a negative height and Rectangle mirrors
+    // the path for them, so the first two radius slots land on the bar tip on
+    // both sides of the axis.
+    const radius: [number, number, number, number] = isOutermost
+      ? [4, 4, 0, 0]
+      : [0, 0, 0, 0]
 
     return <Rectangle {...rest} radius={radius} />
   }

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -403,23 +403,27 @@ const _ComboChart = <K extends ChartConfig>(
           </Bar>
         ))}
 
-        {lineCategories.map((category, index) => (
-          <Line
-            key={`line-${String(category)}`}
-            type={line?.lineType ?? "natural"}
-            dataKey={String(category)}
-            stroke={
-              dataConfig[category].color
-                ? getColor(dataConfig[category].color)
-                : getCategoricalColor(barCategories.length + index)
-            }
-            strokeWidth={2}
-            strokeDasharray={dataConfig[category].dashed ? "4 4" : undefined}
-            dot={line?.dot ?? false}
-            isAnimationActive={false}
-            yAxisId={line?.axisPosition === "right" ? "right" : undefined}
-          />
-        ))}
+        {lineCategories.map((category, index) => {
+          const stroke = dataConfig[category].color
+            ? getColor(dataConfig[category].color)
+            : getCategoricalColor(barCategories.length + index)
+
+          return (
+            <Line
+              key={`line-${String(category)}`}
+              type={line?.lineType ?? "natural"}
+              dataKey={String(category)}
+              stroke={stroke}
+              strokeWidth={2}
+              strokeDasharray={dataConfig[category].dashed ? "4 4" : undefined}
+              // Solid dots in the series color; the default hollow white ones
+              // read as gaps over a dashed stroke.
+              dot={line?.dot ? { fill: stroke, stroke, r: 3 } : false}
+              isAnimationActive={false}
+              yAxisId={line?.axisPosition === "right" ? "right" : undefined}
+            />
+          )
+        })}
 
         {scatterCategories.map((category, index) => (
           <Scatter

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -23,6 +23,11 @@ export type ChartConfig = {
   [k in string]: {
     label?: React.ReactNode
     icon?: React.ComponentType
+    /**
+     * Render this series dashed where the chart draws it as a line, e.g. for
+     * projected or planned series. Ignored by bar-only series.
+     */
+    dashed?: boolean
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }


### PR DESCRIPTION
## Description

ComboChart can now stack its bar categories — including by sign, so negative series hang below the zero line — and draw individual line series dashed. Needed for Headcount Planning's evolution chart (stacked people series + terminations below zero + a dashed "planned" line), which no current chart covers: BarChart stacks but has no line, ComboChart had a line but no stacking.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Implementation details

- `bar.type?: "simple" | "stacked" | "stacked-by-sign"` on ComboChart, mirroring BarChart's `type` prop and reusing its exact recharts wiring (`stackOffset="sign"`, shared `stackId`, `[4,4,0,0]` radius).
- `dashed?: boolean` on `ChartConfig` entries, consumed by ComboChart's line series (`strokeDasharray="4 4"`) — the same per-series pattern LineChart/AreaChart already use via `LineChartConfig`; bar-only series ignore it.
- New `StackedBySignWithLine` story exercising both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="552" height="271" alt="Captura de pantalla 2026-08-14 a las 12 18 08" src="https://github.com/user-attachments/assets/957a8815-9676-49fe-ba29-8af81371123d" />
<img width="1668" height="789" alt="Captura de pantalla 2026-08-14 a las 12 22 53" src="https://github.com/user-attachments/assets/2c5ad70d-0fdc-42be-bce0-f670963c07d7" />

