### PR TITLE
feat(SlotWidget): export it and draw previews from data

### DIFF
--- a/packages/react/src/experimental/Widgets/Content/CalendarEventList/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Content/CalendarEventList/index.spec.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import { type CalendarEventProps } from "../CalendarEvent"
+import { CalendarEventList } from "./index"
+
+const EVENTS: CalendarEventProps[] = [
+  {
+    title: "Standup",
+    description: "09:30",
+    color: "#5596F6",
+    isPending: false,
+  },
+  {
+    title: "Design review",
+    description: "11:00",
+    color: "#5596F6",
+    isPending: false,
+  },
+]
+
+/** The box the events are laid out in — `showAllItems`' own container. */
+const listOf = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>(".flex.flex-col")
+
+describe("CalendarEventList", () => {
+  describe("showAllItems", () => {
+    test("spaces its events by the same default the overflow path uses", () => {
+      const { container } = zeroRender(
+        <CalendarEventList events={EVENTS} showAllItems />
+      )
+
+      // 8px, not nothing. This container used to have no gap at all, and its
+      // `gap` prop reached only the overflow path — so every consumer of this
+      // path silently lost the spacing and had to put it back by hand.
+      expect(listOf(container)).toHaveStyle({ gap: "8px" })
+    })
+
+    test("takes a gap of its own", () => {
+      const { container } = zeroRender(
+        <CalendarEventList events={EVENTS} showAllItems gap={16} />
+      )
+
+      expect(listOf(container)).toHaveStyle({ gap: "16px" })
+    })
+  })
+
+  test("draws nothing for no events", () => {
+    const { container } = zeroRender(
+      <CalendarEventList events={[]} showAllItems />
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/packages/react/src/experimental/Widgets/Content/CalendarEventList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/CalendarEventList/index.tsx
@@ -6,6 +6,10 @@ import { CalendarEvent, CalendarEventProps } from "../CalendarEvent"
 
 export interface CalendarEventListProps {
   events: CalendarEventProps[]
+  /**
+   * The space between events, in px. Applies to BOTH paths — the overflow list
+   * and `showAllItems` — so a list that stops overflowing keeps its rhythm.
+   */
   gap?: number
   showAllItems?: boolean
   minSize?: number
@@ -22,8 +26,12 @@ export const CalendarEventList: FC<CalendarEventListProps> = ({
   }
 
   if (showAllItems) {
+    // The SAME `gap` the overflow path hands `VerticalOverflowList`. It used to
+    // be missing here, which made "show them all" quietly mean "show them with
+    // no space between them" — and left every consumer of this path to discover
+    // the spacing was gone and put it back by hand.
     return (
-      <div className="flex flex-col">
+      <div className="flex flex-col" style={{ gap: `${gap}px` }}>
         {events.map((item) => (
           <CalendarEvent key={item.title} {...item} />
         ))}

--- a/packages/react/src/experimental/Widgets/Layout/exports.tsx
+++ b/packages/react/src/experimental/Widgets/Layout/exports.tsx
@@ -1,10 +1,16 @@
 // The Home kit's PUBLIC surface is deliberately small: the layout, the
-// "Add widget" picker, and the slot vocabulary (types + `listSlot`/`homeSlot`
-// builders) that feeds them. SlotWidget, WidgetContainer and HomeListItem are
-// internal building blocks — the layout draws widgets from data, so nothing
-// outside needs to render one by hand.
+// "Add widget" picker, the slot vocabulary (types + `listSlot`/`homeSlot`
+// builders) that feeds them — and `SlotWidget`, the one canonical way to draw a
+// `HomeWidgetItem`.
+//
+// SlotWidget is public because a preview drawn any OTHER way is a preview that
+// can drift: an app that has to approximate a widget out of the content
+// components reproduces the frame, the seams and the spacing by hand, and the
+// first of those to fall out of step is silent. WidgetContainer and
+// HomeListItem stay internal — the layout draws columns from data.
 export * from "../../../sds/Home/NewHomeLayout"
 export * from "../../../sds/Home/slotRenderers"
+export * from "../../../sds/Home/SlotWidget"
 export * from "../../../sds/Home/WidgetCatalog"
 // Named by NewHomeLayoutProps (`editableWidgetContainers`, the add callback,
 // `virtualization`), so the types are public even though the component is not.

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -41,6 +41,7 @@ import {
   homeSlot,
   type HomeWidgetItem,
   listSlot,
+  resolveWidgetHeader,
   type SlotRenderers,
   widgetTitle,
 } from "../slotRenderers"

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -36,13 +36,11 @@ import {
   ClockInControls,
   type ClockInProject,
 } from "../ClockIn/ClockInControls"
-import { SlotWidget } from "../SlotWidget"
 import {
   fromParams,
   homeSlot,
   type HomeWidgetItem,
   listSlot,
-  resolveWidgetHeader,
   type SlotRenderers,
   widgetTitle,
 } from "../slotRenderers"
@@ -694,8 +692,9 @@ const LOADING_RIGHT_WIDGETS: HomeWidgetItem[] = RIGHT_WIDGETS.map((widget) => ({
 /* ============================ add-widget catalog ============================ */
 
 /**
- * The catalog the picker offers. Every preview is the REAL widget — the same
- * `SlotWidget` render the rail makes — so what you preview is what gets added.
+ * The catalog the picker offers. Every preview is the WIDGET ITSELF, handed over
+ * as data — the picker draws it through the same `SlotWidget` the rail uses, so
+ * what you preview is what gets added, down to the spacing.
  */
 const CATALOG_ITEMS = [
   ...RIGHT_WIDGETS.map((widget) => ({
@@ -703,66 +702,55 @@ const CATALOG_ITEMS = [
     // `widgetTitle` rather than the header's own: a configurable widget's title
     // can be a function of its params, and a catalog row needs the text.
     title: widgetTitle(widget),
-    // The same sentence the widget's info side shows, under the preview.
-    info: resolveWidgetHeader(widget.header, widget.params)?.info,
     icon: widget.icon!,
-    preview: (
-      <SlotWidget
-        header={widget.header}
-        params={widget.params}
-        slots={widget.slots}
-        slotRenderers={SLOT_RENDERERS}
-      />
-    ),
+    // The rail's own widget, unchanged. Its `info` comes with it.
+    preview: widget,
   })),
   {
     id: "time-off",
     title: "Time off",
     icon: PalmTree,
-    preview: (
-      <SlotWidget
-        header={{ title: "Time off" }}
-        slots={[
-          {
-            visualization: "indicators",
-            params: { items: [{ label: "Days left", content: "12" }] },
-          },
-        ]}
-      />
-    ),
+    preview: {
+      id: "time-off",
+      header: { title: "Time off" },
+      slots: [
+        {
+          visualization: "indicators",
+          params: { items: [{ label: "Days left", content: "12" }] },
+        },
+      ],
+    },
   },
   {
     id: "tasks",
     title: "Tasks",
     icon: File,
-    preview: (
-      <SlotWidget
-        header={{ title: "Tasks", count: 3 }}
-        slots={[
-          listSlot({ clickBehavior: "link" }, [
-            { id: "1", title: "Sign the Q3 addendum", href: "/tasks/1" },
-            { id: "2", title: "Review expense report", href: "/tasks/2" },
-            { id: "3", title: "Approve time off", href: "/tasks/3" },
-          ]),
-        ]}
-      />
-    ),
+    preview: {
+      id: "tasks",
+      header: { title: "Tasks", count: 3 },
+      slots: [
+        listSlot({ clickBehavior: "link" }, [
+          { id: "1", title: "Sign the Q3 addendum", href: "/tasks/1" },
+          { id: "2", title: "Review expense report", href: "/tasks/2" },
+          { id: "3", title: "Approve time off", href: "/tasks/3" },
+        ]),
+      ],
+    },
   },
   {
     id: "goals",
     title: "Goals",
     icon: Target,
-    preview: (
-      <SlotWidget
-        header={{ title: "Goals" }}
-        slots={[
-          {
-            visualization: "indicators",
-            params: { items: [{ label: "On track", content: "4/5" }] },
-          },
-        ]}
-      />
-    ),
+    preview: {
+      id: "goals",
+      header: { title: "Goals" },
+      slots: [
+        {
+          visualization: "indicators",
+          params: { items: [{ label: "On track", content: "4/5" }] },
+        },
+      ],
+    },
   },
   // The schema showcase: each of these leans on a different `list` schema —
   // what you preview here is exactly what the slot vocabulary can say.
@@ -770,150 +758,146 @@ const CATALOG_ITEMS = [
     id: "team",
     title: "Team",
     icon: Person,
-    preview: (
-      <SlotWidget
-        header={{ title: "Team", count: 6 }}
-        slots={[
-          // Alert left + the people themselves trailing: two-line rows (md).
-          listSlot(
+    preview: {
+      id: "team",
+      header: { title: "Team", count: 6 },
+      slots: [
+        // Alert left + the people themselves trailing: two-line rows (md).
+        listSlot(
+          {
+            left: "alert",
+            right: "person-list",
+            descriptionRequired: true,
+            clickBehavior: "link",
+          },
+          [
             {
-              left: "alert",
-              right: "person-list",
-              descriptionRequired: true,
-              clickBehavior: "link",
+              id: "in",
+              title: "Clocked in",
+              description: "4 people",
+              alert: "positive",
+              avatars: [
+                { firstName: "Ada", lastName: "Lovelace" },
+                { firstName: "Alan", lastName: "Turing" },
+              ],
+              remainingCount: 2,
+              href: "/attendance",
             },
-            [
-              {
-                id: "in",
-                title: "Clocked in",
-                description: "4 people",
-                alert: "positive",
-                avatars: [
-                  { firstName: "Ada", lastName: "Lovelace" },
-                  { firstName: "Alan", lastName: "Turing" },
-                ],
-                remainingCount: 2,
-                href: "/attendance",
-              },
-              {
-                id: "away",
-                title: "Away",
-                description: "2 people",
-                alert: "warning",
-                avatars: [{ firstName: "Grace", lastName: "Hopper" }],
-                href: "/attendance/away",
-              },
-            ]
-          ),
-        ]}
-      />
-    ),
+            {
+              id: "away",
+              title: "Away",
+              description: "2 people",
+              alert: "warning",
+              avatars: [{ firstName: "Grace", lastName: "Hopper" }],
+              href: "/attendance/away",
+            },
+          ]
+        ),
+      ],
+    },
   },
   {
     id: "people",
     title: "People",
     icon: Person,
-    preview: (
-      <SlotWidget
-        header={{ title: "New joiners", count: 7 }}
-        slots={[
-          // maxVisibleItems: 3 of 7 rows, the rest behind "View more (4)".
-          listSlot(
-            {
-              left: "person",
-              subtitleRequired: true,
-              clickBehavior: "link",
-              maxVisibleItems: 3,
+    preview: {
+      id: "people",
+      header: { title: "New joiners", count: 7 },
+      slots: [
+        // maxVisibleItems: 3 of 7 rows, the rest behind "View more (4)".
+        listSlot(
+          {
+            left: "person",
+            subtitleRequired: true,
+            clickBehavior: "link",
+            maxVisibleItems: 3,
+          },
+          [
+            "Ada Lovelace",
+            "Alan Turing",
+            "Grace Hopper",
+            "Katherine Johnson",
+            "Margaret Hamilton",
+            "Annie Easley",
+            "Mary Jackson",
+          ].map((name, index) => ({
+            id: String(index),
+            title: name,
+            subtitle: "Engineering",
+            avatar: {
+              firstName: name.split(" ")[0],
+              lastName: name.split(" ")[1],
             },
-            [
-              "Ada Lovelace",
-              "Alan Turing",
-              "Grace Hopper",
-              "Katherine Johnson",
-              "Margaret Hamilton",
-              "Annie Easley",
-              "Mary Jackson",
-            ].map((name, index) => ({
-              id: String(index),
-              title: name,
-              subtitle: "Engineering",
-              avatar: {
-                firstName: name.split(" ")[0],
-                lastName: name.split(" ")[1],
-              },
-              href: `/employees/${index}`,
-            }))
-          ),
-        ]}
-      />
-    ),
+            href: `/employees/${index}`,
+          }))
+        ),
+      ],
+    },
   },
   {
     id: "documents",
     title: "Documents",
     icon: File,
-    preview: (
-      <SlotWidget
-        header={{ title: "Documents" }}
-        alert="2 documents need signing"
-        action={{ label: "Sign now", onClick: () => {} }}
-        slots={[
-          // File avatars, two-line rows (md).
-          listSlot(
-            { left: "file", descriptionRequired: true, clickBehavior: "link" },
-            [
-              {
-                id: "1",
-                title: "Q3 addendum.pdf",
-                description: "Needs your signature",
-                avatar: {
-                  file: { name: "q3-addendum.pdf", type: "application/pdf" },
-                },
-                href: "/documents/1",
+    preview: {
+      id: "documents",
+      header: { title: "Documents" },
+      alert: "2 documents need signing",
+      action: { label: "Sign now", onClick: () => {} },
+      slots: [
+        // File avatars, two-line rows (md).
+        listSlot(
+          { left: "file", descriptionRequired: true, clickBehavior: "link" },
+          [
+            {
+              id: "1",
+              title: "Q3 addendum.pdf",
+              description: "Needs your signature",
+              avatar: {
+                file: { name: "q3-addendum.pdf", type: "application/pdf" },
               },
-              {
-                id: "2",
-                title: "Remote policy.pdf",
-                description: "Needs your signature",
-                avatar: {
-                  file: { name: "remote-policy.pdf", type: "application/pdf" },
-                },
-                href: "/documents/2",
+              href: "/documents/1",
+            },
+            {
+              id: "2",
+              title: "Remote policy.pdf",
+              description: "Needs your signature",
+              avatar: {
+                file: { name: "remote-policy.pdf", type: "application/pdf" },
               },
-            ]
-          ),
-        ]}
-      />
-    ),
+              href: "/documents/2",
+            },
+          ]
+        ),
+      ],
+    },
   },
   {
     id: "offices",
     title: "Offices",
     icon: Building,
-    preview: (
-      <SlotWidget
-        header={{ title: "Offices" }}
-        slots={[
-          // Flag left + counter right: one-line rows (sm).
-          listSlot({ left: "flag", right: "counter", clickBehavior: "link" }, [
-            {
-              id: "es",
-              title: "Spain",
-              avatar: { flag: "es" },
-              count: 24,
-              href: "/offices/es",
-            },
-            {
-              id: "pt",
-              title: "Portugal",
-              avatar: { flag: "pt" },
-              count: 9,
-              href: "/offices/pt",
-            },
-          ]),
-        ]}
-      />
-    ),
+    preview: {
+      id: "offices",
+      header: { title: "Offices" },
+      slots: [
+        // Flag left + counter right: one-line rows (sm).
+        listSlot({ left: "flag", right: "counter", clickBehavior: "link" }, [
+          {
+            id: "es",
+            title: "Spain",
+            avatar: { flag: "es" },
+            count: 24,
+            href: "/offices/es",
+          },
+          {
+            id: "pt",
+            title: "Portugal",
+            avatar: { flag: "pt" },
+            count: 9,
+            href: "/offices/pt",
+          },
+        ]),
+      ],
+    },
   },
 ]
 
@@ -981,14 +965,10 @@ const Home = () => {
         }}
         // The preview rebuilds the widget the same way the rail does, so the
         // dialog shows the events the params will really produce — not just the
-        // title following along.
-        renderWidgetPreview={(widget, params) =>
-          widget.id === "events" ? (
-            <SlotWidget
-              {...eventsWidget(params as EventsParams)}
-              slotRenderers={SLOT_RENDERERS}
-            />
-          ) : null
+        // title following along. It hands back the WIDGET; the layout draws it
+        // through the same `SlotWidget` the rail uses.
+        rebuildWidget={(widget, params) =>
+          widget.id === "events" ? eventsWidget(params as EventsParams) : widget
         }
         onReorderWidgets={(_, ids) =>
           setRail((w) => ids.flatMap((id) => w.filter((x) => x.id === id)))
@@ -1007,6 +987,9 @@ const Home = () => {
         groups={CATALOG_GROUPS}
         onAdd={() => setOpen(false)}
         previewWidth={side === "right" ? 396 : 768}
+        // The same map the layout gets — a preview drawn without it would show
+        // "No renderer for slot …" for every bespoke visualization.
+        slotRenderers={SLOT_RENDERERS}
       />
     </div>
   )

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -245,10 +245,22 @@ export interface NewHomeLayoutProps {
    */
   onChangeWidgetParams?: (id: string, params: WidgetParams) => void
   /**
-   * Draws a widget for params being tried out in that dialog, before they are
-   * saved. Defaults to the widget with those params swapped in — which is
-   * already live for everything they derive (title, info); supply this to
-   * rebuild its slots as well.
+   * REBUILDS a widget for params being tried out in that dialog, before they are
+   * saved — the same widget with slots that follow the new params, which only
+   * the app can produce. It hands back DATA, and f0 draws it through the same
+   * `SlotWidget` the column uses, so the preview cannot drift from the card.
+   *
+   * Without it the preview is the widget with those params swapped in — already
+   * live for everything they derive (title, info), just not for its slots.
+   */
+  rebuildWidget?: (
+    widget: HomeWidgetItem,
+    params: WidgetParams
+  ) => HomeWidgetItem
+  /**
+   * @deprecated Use `rebuildWidget`. A preview the app renders has to reproduce
+   * `SlotWidget` by hand and drifts from the column the moment either side
+   * changes. Ignored when `rebuildWidget` is given.
    */
   renderWidgetPreview?: (
     widget: HomeWidgetItem,
@@ -311,6 +323,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       virtualization,
       onRemoveWidget,
       onChangeWidgetParams,
+      rebuildWidget,
       renderWidgetPreview,
       onClickAddNewWidget,
       onReorderWidgets,
@@ -757,6 +770,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             }
             onRemoveWidget={onRemoveWidget}
             onChangeWidgetParams={onChangeWidgetParams}
+            rebuildWidget={rebuildWidget}
             renderWidgetPreview={renderWidgetPreview}
             paramsPreviewWidth={mainWidth}
             onClickAddNewWidget={
@@ -961,6 +975,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               }
               onRemoveWidget={onRemoveWidget}
               onChangeWidgetParams={onChangeWidgetParams}
+              rebuildWidget={rebuildWidget}
               renderWidgetPreview={renderWidgetPreview}
               paramsPreviewWidth={asideWidth}
               // Not from the panel: collapsed, the strip carries the add

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -149,6 +149,43 @@ What the params CAN'T do by themselves is rebuild the widget's slots — only th
 app knows where that data comes from. Persist what `onChangeWidgetParams` hands
 you, pass it back as the widget's `params`, and rebuild the slots from it.
 
+## Previews: hand over the widget, not a render of it
+
+A widget is previewed twice — in the "Add widget" catalog and in "Edit params" —
+and both previews are the **same card the column draws**, because both take the
+widget as **data** and render it through this component.
+
+```tsx
+// The catalog: `preview` IS the widget.
+<WidgetCatalog
+  widgets={[{ id: "events", title: "Events", icon: Calendar, preview: eventsWidget }]}
+  slotRenderers={SLOT_RENDERERS}   // the same map the layout gets
+  onAdd={add}
+  isOpen={open}
+  onClose={close}
+/>
+
+// "Edit params": hand back the WIDGET for the params being tried out.
+<NewHomeLayout
+  rightWidgets={widgets}
+  slotRenderers={SLOT_RENDERERS}
+  onChangeWidgetParams={save}
+  rebuildWidget={(widget, params) =>
+    widget.id === "events" ? eventsWidget(params) : widget
+  }
+/>
+```
+
+Its `info` comes with it: a catalog item that declares none shows the widget's
+own `header.info` under the preview, the same sentence its info side carries.
+
+**Don't assemble a preview out of the content components.** A hand-built
+approximation has to reproduce the frame, the seams and the spacing — and the
+first of those to fall out of step does so silently, so a widget previews one
+way and lands on the page another. Passing a `ReactNode` still works, for a
+widget the app draws its own way (`renderWidget`); a `HomeWidgetItem` is the
+form that cannot drift.
+
 ## Loading
 
 `loading` swaps every slot's content for that visualization's **skeleton**,

--- a/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
@@ -3,6 +3,7 @@ import { describe, expect, test, vi } from "vitest"
 import { Calendar, Clock, File } from "@/icons/app"
 import { screen, userEvent, zeroRender } from "@/testing/test-utils"
 
+import { EVENT_LIST_GAP, homeSlot, type HomeWidgetItem } from "../slotRenderers"
 import { WidgetCatalog, type WidgetCatalogGroup } from "./index"
 
 const GROUPS: WidgetCatalogGroup[] = [
@@ -36,6 +37,16 @@ const listed = () =>
     .getAllByRole("button")
     .map((el) => el.textContent?.trim())
     .filter((text) => text && TITLES.includes(text))
+
+/**
+ * The nearest box holding both elements — the one whose own layout is what puts
+ * space between them.
+ */
+const boxAround = (a: HTMLElement, b: HTMLElement) => {
+  let node: HTMLElement | null = a
+  while (node && !node.contains(b)) node = node.parentElement
+  return node
+}
 
 const render = (props = {}) =>
   zeroRender(
@@ -104,5 +115,109 @@ describe("WidgetCatalog", () => {
     await userEvent.click(screen.getByRole("button", { name: "Add widget" }))
 
     expect(onAdd).toHaveBeenCalledWith("time-off")
+  })
+
+  describe("a preview handed over as DATA", () => {
+    const eventsWidget: HomeWidgetItem = {
+      id: "events",
+      header: { title: "Events", info: "The next events this week." },
+      slots: [
+        homeSlot("event-list", {
+          showAllItems: true,
+          events: [
+            {
+              title: "Standup",
+              description: "09:30",
+              color: "#5596F6",
+              isPending: false,
+            },
+            {
+              title: "Design review",
+              description: "11:00",
+              color: "#5596F6",
+              isPending: false,
+            },
+          ],
+        }),
+      ],
+    }
+    const asData = [
+      { id: "events", title: "Events", icon: Calendar, preview: eventsWidget },
+    ]
+
+    test("is drawn through SlotWidget, not left to the app to approximate", () => {
+      render({ widgets: asData, groups: undefined })
+
+      // The title three times over — the row that selected it, the card's
+      // header, and the card's BACK, which keeps the title. That third one is
+      // the tell: the preview is the whole `SlotWidget`, flip side and all.
+      expect(screen.getAllByText("Events")).toHaveLength(3)
+      expect(screen.getByText("Standup")).toBeInTheDocument()
+      expect(screen.getByText("Design review")).toBeInTheDocument()
+    })
+
+    test("keeps the spacing the column gives it", () => {
+      render({ widgets: asData, groups: undefined })
+
+      // THE REGRESSION THIS GUARDS: an approximated preview reached for
+      // `CalendarEventList showAllItems` and lost `EVENT_LIST_GAP`, so catalog
+      // rows sat flush while the same widget on the rail was spaced 8px. The
+      // box holding BOTH events is the slot's own container, and the gap is on
+      // it — nothing between it and the events lays them out.
+      expect(
+        boxAround(
+          screen.getByText("Standup"),
+          screen.getByText("Design review")
+        )
+      ).toHaveClass(EVENT_LIST_GAP)
+    })
+
+    test("says what the widget says, without being told twice", () => {
+      render({ widgets: asData, groups: undefined })
+
+      // The item declared no `info`: the pane takes the widget's own. Twice
+      // over, because the card carries the same sentence on its back.
+      expect(screen.getAllByText("The next events this week.")).toHaveLength(2)
+    })
+
+    test("an item's own info still wins", () => {
+      render({
+        widgets: [{ ...asData[0], info: "Only the ones you are invited to." }],
+        groups: undefined,
+      })
+
+      expect(
+        screen.getByText("Only the ones you are invited to.")
+      ).toBeInTheDocument()
+    })
+
+    test("a bespoke visualization needs the layout's renderers", () => {
+      const bespoke: HomeWidgetItem = {
+        id: "clock-in",
+        header: { title: "Clock in" },
+        slots: [{ visualization: "clock-in", params: {} }],
+      }
+      const widgets = [
+        { id: "clock-in", title: "Clock in", icon: Clock, preview: bespoke },
+      ]
+
+      const { unmount } = render({ widgets, groups: undefined })
+      // Unrendered without the map — the same notice a column would show.
+      expect(screen.getByText(/No renderer for slot/)).toBeInTheDocument()
+      unmount()
+
+      render({
+        widgets,
+        groups: undefined,
+        slotRenderers: { "clock-in": () => <p>clocked in</p> },
+      })
+      expect(screen.getByText("clocked in")).toBeInTheDocument()
+    })
+
+    test("a ReactNode preview is still passed through as given", () => {
+      render({ widgets: WIDGETS, groups: undefined })
+
+      expect(screen.getByText("clock")).toBeInTheDocument()
+    })
   })
 })

--- a/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
@@ -4,7 +4,11 @@ import { Calendar, Clock, File, PalmTree, Receipt, Target } from "@/icons/app"
 
 import { homeSlot, listSlot } from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
-import { WidgetCatalog, type WidgetCatalogGroup } from "./index"
+import {
+  WidgetCatalog,
+  type WidgetCatalogGroup,
+  type WidgetCatalogItem,
+} from "./index"
 
 /**
  * Beyond its header and slots, a widget may carry the `Widget` frame's own
@@ -16,95 +20,113 @@ const CHROME_CATALOG = [
     id: "payroll",
     title: "Payroll",
     icon: Receipt,
-    preview: (
-      <SlotWidget
-        header={{
-          title: "Payroll",
-          subtitle: "June",
-          count: 3,
-          info: "Gross, before deductions.",
-        }}
-        status={{ text: "Approved", variant: "positive" }}
-        summaries={[
-          { label: "Gross", value: "3,200", postfixUnit: "€" },
-          { label: "Net", value: "2,480", postfixUnit: "€" },
-        ]}
-        slots={[
-          listSlot({ clickBehavior: "link" }, [
-            { id: "1", title: "June payslip", href: "/payroll/june" },
-          ]),
-        ]}
-      />
-    ),
+    preview: {
+      id: "payroll",
+      header: {
+        title: "Payroll",
+        subtitle: "June",
+        count: 3,
+        info: "Gross, before deductions.",
+      },
+      status: { text: "Approved", variant: "positive" as const },
+      summaries: [
+        { label: "Gross", value: "3,200", postfixUnit: "€" },
+        { label: "Net", value: "2,480", postfixUnit: "€" },
+      ],
+      slots: [
+        listSlot({ clickBehavior: "link" }, [
+          { id: "1", title: "June payslip", href: "/payroll/june" },
+        ]),
+      ],
+    },
   },
   {
     id: "documents",
     title: "Documents",
     icon: File,
-    preview: (
-      <SlotWidget
-        header={{ title: "Documents" }}
-        alert="2 documents need signing"
-        action={{ label: "Sign now", onClick: () => {} }}
-        slots={[
-          listSlot({ clickBehavior: "link" }, [
-            { id: "1", title: "Q3 addendum", href: "/docs/1" },
-          ]),
-        ]}
-      />
-    ),
+    preview: {
+      id: "documents",
+      header: { title: "Documents" },
+      alert: "2 documents need signing",
+      action: { label: "Sign now", onClick: () => {} },
+      slots: [
+        listSlot({ clickBehavior: "link" }, [
+          { id: "1", title: "Q3 addendum", href: "/docs/1" },
+        ]),
+      ],
+    },
   },
 ]
 
-const CATALOG = [
+const CATALOG: WidgetCatalogItem[] = [
   ...CHROME_CATALOG,
   {
     id: "time-off",
     title: "Time off",
     icon: PalmTree,
-    preview: (
-      <SlotWidget
-        header={{ title: "Time off" }}
-        slots={[
-          homeSlot("indicators", {
-            items: [{ label: "Days left", content: "12" }],
-          }),
-        ]}
-      />
-    ),
+    preview: {
+      id: "time-off",
+      header: { title: "Time off" },
+      slots: [
+        homeSlot("indicators", {
+          items: [{ label: "Days left", content: "12" }],
+        }),
+      ],
+    },
   },
   {
     id: "events",
     title: "Events",
     icon: Calendar,
-    preview: (
-      <SlotWidget
-        header={{ title: "Events", count: 2 }}
-        slots={[
-          listSlot({ clickBehavior: "link" }, [
-            { id: "1", title: "Design sync", href: "/calendar/1" },
-            { id: "2", title: "All hands", href: "/calendar/2" },
-          ]),
-        ]}
-      />
-    ),
+    // AN `event-list`, deliberately: its rows are the ones whose 8px
+    // `EVENT_LIST_GAP` an approximated preview used to drop. Handed over as
+    // data, the picker draws it through the same `SlotWidget` the rail does, so
+    // this preview and the card on the page are one render.
+    preview: {
+      id: "events",
+      header: { title: "Events", count: 2, info: "The next events this week." },
+      slots: [
+        homeSlot("event-list", {
+          showAllItems: true,
+          events: [
+            {
+              title: "Design sync",
+              description: "Weekly, 30 min",
+              color: "#5596F6",
+              isPending: false,
+              fromDate: new Date("2026-07-24T09:30:00"),
+            },
+            {
+              title: "All hands",
+              description: "Q3 roadmap update",
+              color: "#10B881",
+              isPending: false,
+              fromDate: new Date("2026-07-30T16:00:00"),
+            },
+          ],
+        }),
+      ],
+    },
   },
   {
     id: "goals",
     title: "Goals",
     icon: Target,
-    preview: (
-      <SlotWidget
-        header={{ title: "Goals" }}
-        slots={[
-          homeSlot("indicators", {
-            items: [{ label: "On track", content: "4/5" }],
-          }),
-        ]}
-      />
-    ),
+    preview: {
+      id: "goals",
+      header: { title: "Goals" },
+      slots: [
+        homeSlot("indicators", {
+          items: [{ label: "On track", content: "4/5" }],
+        }),
+      ],
+    },
   },
   {
+    // The ESCAPE HATCH, kept in the catalog so it stays exercised: a `ReactNode`
+    // preview, for a widget the app draws its own way (`renderWidget`). Every
+    // other entry here hands over the widget itself, which is the form that
+    // cannot drift.
     id: "clock-in",
     title: "Clock in",
     icon: Clock,

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode, useMemo, useState } from "react"
+import { Fragment, isValidElement, ReactNode, useMemo, useState } from "react"
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import {
@@ -12,6 +12,13 @@ import { cn } from "@/lib/utils"
 import { useI18n } from "@/lib/providers/i18n"
 import { F0Dialog } from "@/patterns/F0Dialog"
 
+import {
+  resolveWidgetHeader,
+  widgetChrome,
+  type HomeWidgetItem,
+  type SlotRenderers,
+} from "../slotRenderers"
+import { SlotWidget } from "../SlotWidget"
 import { useWidgetDialogLayout, WidgetPreviewPane } from "../WidgetPreview"
 
 /** One entry in the widget catalog dialog. */
@@ -20,14 +27,25 @@ export interface WidgetCatalogItem {
   title: string
   icon: IconType
   /**
-   * The LIVE PREVIEW of the widget — the same node the Home renders (e.g. a
-   * `SlotWidget`), so the preview can't drift from what gets added.
+   * The LIVE PREVIEW of the widget.
+   *
+   * GIVE IT THE WIDGET ITSELF — the same `HomeWidgetItem` the layout would be
+   * handed — and the catalog draws it through `SlotWidget`, exactly as the
+   * column will. That is the only form that cannot drift: a preview assembled
+   * out of content components reproduces the frame, the seams and the spacing
+   * by hand, and the first of those to fall out of step is silent.
+   *
+   * A `ReactNode` is still accepted, for a widget the app draws its own way
+   * (`renderWidget`) or for something that isn't a widget at all.
    */
-  preview: ReactNode
+  preview: HomeWidgetItem | ReactNode
   /**
    * What this widget is telling you — the widget's own `header.info`, shown under
    * the preview. Deciding whether to add a widget is exactly the moment that
    * sentence is worth reading, so the picker says it without being asked.
+   *
+   * Taken from the widget's own header when `preview` is a `HomeWidgetItem`, so
+   * for those it is usually nothing to pass.
    */
   info?: string
   /**
@@ -75,8 +93,63 @@ export interface WidgetCatalogProps {
    * to it, so a rail-bound widget previews at rail width.
    */
   previewWidth?: number
+  /**
+   * Per-visualization renderers for the previews this dialog draws itself,
+   * MERGED OVER the kit's `defaultSlotRenderers`. Pass the SAME map the layout
+   * gets: a widget whose visualization is bespoke would otherwise preview as
+   * "No renderer for slot …" and then render properly once added.
+   */
+  slotRenderers?: SlotRenderers
   title?: string
 }
+
+/**
+ * Which of the two things a `preview` is. A `HomeWidgetItem` is a plain object
+ * with `slots`; every `ReactNode` that is an object at all is an element, a
+ * portal or an iterable — so `isValidElement` and the shape between them tell
+ * the union apart without asking the caller to say which they meant.
+ */
+const isWidgetItem = (
+  preview: WidgetCatalogItem["preview"]
+): preview is HomeWidgetItem =>
+  typeof preview === "object" &&
+  preview !== null &&
+  !isValidElement(preview) &&
+  Array.isArray((preview as HomeWidgetItem).slots)
+
+/**
+ * One catalog preview. A widget handed over as DATA is drawn here through the
+ * same `SlotWidget` a column uses — which is the whole point of taking data: the
+ * preview and the card it previews are one render, so they cannot come out
+ * differently. Anything else is passed through as given.
+ */
+const CatalogPreview = ({
+  preview,
+  slotRenderers,
+}: {
+  preview: WidgetCatalogItem["preview"]
+  slotRenderers?: SlotRenderers
+}) => {
+  if (!isWidgetItem(preview)) return <>{preview}</>
+  return (
+    <SlotWidget
+      {...widgetChrome(preview)}
+      header={preview.header}
+      params={preview.params}
+      fullHeight={preview.fullHeight}
+      slots={preview.slots}
+      loading={preview.loading}
+      slotRenderers={slotRenderers}
+    />
+  )
+}
+
+/** The sentence under a preview: the item's own, else the widget's. */
+const previewInfo = (item: WidgetCatalogItem) =>
+  item.info ??
+  (isWidgetItem(item.preview)
+    ? resolveWidgetHeader(item.preview.header, item.preview.params)?.info
+    : undefined)
 
 /**
  * A section's heading: its glyph and its name.
@@ -118,6 +191,7 @@ export function WidgetCatalog({
   onAdd,
   groups,
   previewWidth = 396,
+  slotRenderers,
   title = "Add widget",
 }: WidgetCatalogProps) {
   const t = useI18n()
@@ -241,10 +315,15 @@ export function WidgetCatalog({
             down the list, so each row you land on announces its widget. */}
         <WidgetPreviewPane
           previewKey={selected?.id}
-          info={selected?.info}
+          info={selected ? previewInfo(selected) : undefined}
           previewWidth={previewWidth}
         >
-          {selected?.preview}
+          {selected ? (
+            <CatalogPreview
+              preview={selected.preview}
+              slotRenderers={slotRenderers}
+            />
+          ) : null}
         </WidgetPreviewPane>
       </div>
     </F0Dialog>

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -5,7 +5,7 @@ import { Calendar, Clock } from "@/icons/app"
 import { f0FormField } from "@/patterns/F0Form"
 import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
 
-import { type HomeWidgetItem } from "../slotRenderers"
+import { type HomeWidgetItem, type WidgetParams } from "../slotRenderers"
 import { WidgetContainer } from "./index"
 
 const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) => ({
@@ -341,6 +341,74 @@ describe("WidgetContainer", () => {
       expect(
         screen.queryByRole("menuitem", { name: "Remove widget" })
       ).not.toBeInTheDocument()
+    })
+
+    describe("the params dialog's preview", () => {
+      const schema = z.object({
+        limit: f0FormField(z.number(), { label: "Limit" }),
+      })
+      const configurable = widget("clock", {
+        paramsSchema: schema,
+        params: { limit: 3 },
+      })
+      /** Slots the plain widget never has, so a preview can be told apart. */
+      const rebuilt = (_: HomeWidgetItem, params: WidgetParams) => ({
+        ...configurable,
+        slots: [
+          {
+            visualization: "indicators",
+            params: {
+              items: [{ label: "Showing", content: `${params.limit} rows` }],
+            },
+          },
+        ],
+      })
+      const openParams = async () => {
+        await userEvent.click(screen.getByRole("button", { name: "Actions" }))
+        await userEvent.click(
+          screen.getByRole("menuitem", { name: "Edit params" })
+        )
+      }
+
+      test("is the widget the app REBUILDS, drawn by the column itself", async () => {
+        zeroRender(
+          <WidgetContainer
+            widgets={[configurable]}
+            onChangeWidgetParams={() => {}}
+            rebuildWidget={rebuilt}
+          />
+        )
+
+        // Nothing rebuilt while the dialog is shut.
+        expect(screen.queryByText("Showing")).not.toBeInTheDocument()
+
+        await openParams()
+
+        // The slots follow the params — and they are drawn through the same
+        // `SlotWidget` the column uses, so the preview cannot drift from it.
+        await waitFor(() =>
+          expect(screen.getByText("Showing")).toBeInTheDocument()
+        )
+        expect(screen.getByText("3 rows")).toBeInTheDocument()
+      })
+
+      test("prefers rebuildWidget over the deprecated render function", async () => {
+        zeroRender(
+          <WidgetContainer
+            widgets={[configurable]}
+            onChangeWidgetParams={() => {}}
+            rebuildWidget={rebuilt}
+            renderWidgetPreview={() => <p>hand-rendered</p>}
+          />
+        )
+
+        await openParams()
+
+        await waitFor(() =>
+          expect(screen.getByText("Showing")).toBeInTheDocument()
+        )
+        expect(screen.queryByText("hand-rendered")).not.toBeInTheDocument()
+      })
     })
   })
 

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -36,9 +36,9 @@ import { cn } from "@/lib/utils"
 import { arrivalWindowMs, useElapsed } from "../home-motion"
 import {
   resolveWidgetHeader,
+  widgetChrome,
   widgetTitle,
   type HomeRenderCtx,
-  type HomeWidgetChrome,
   type HomeWidgetItem,
   type SlotRenderers,
   type WidgetParams,
@@ -111,20 +111,6 @@ const DROP_ANIMATION = {
   duration: 450,
   easing: "cubic-bezier(0.4, 0, 0.1, 1)",
 }
-
-/** The `Widget` chrome an item carries, ready to spread onto `SlotWidget`. */
-const widgetChrome = (widget: HomeWidgetItem) =>
-  ("alert" in widget && widget.alert !== undefined
-    ? {
-        action: widget.action,
-        summaries: widget.summaries,
-        alert: widget.alert,
-      }
-    : {
-        action: widget.action,
-        summaries: widget.summaries,
-        status: "status" in widget ? widget.status : undefined,
-      }) as HomeWidgetChrome
 
 /** Which column a container is: the growing main one, or the fixed side rail. */
 export type WidgetContainerSide = "main" | "right"
@@ -314,10 +300,28 @@ export interface WidgetContainerProps {
    */
   onChangeWidgetParams?: (id: string, params: WidgetParams) => void
   /**
-   * Draws a widget for params the user is trying out in that dialog, before they
-   * are saved. Defaults to the widget as it is with those params swapped in —
-   * enough for everything the params DERIVE (its title, its info); supply this
-   * to rebuild its slots too, which only the app can do.
+   * REBUILDS a widget for params the user is trying out in that dialog, before
+   * they are saved — the same widget with slots that follow the new params,
+   * which only the app can produce (it knows where their data comes from).
+   *
+   * It hands back DATA, not a rendered node, so the preview is drawn by this
+   * column through the same `SlotWidget` the column itself uses: a preview and
+   * the card it is previewing cannot come out differently, because they are the
+   * same render.
+   *
+   * Without it the preview is the widget as it is with those params swapped in
+   * — already live for everything the params DERIVE (its title, its info), just
+   * not for its slots.
+   */
+  rebuildWidget?: (
+    widget: HomeWidgetItem,
+    params: WidgetParams
+  ) => HomeWidgetItem
+  /**
+   * @deprecated Use `rebuildWidget`, which returns the widget as DATA and lets
+   * f0 draw it — a preview rendered by the app has to reproduce `SlotWidget` by
+   * hand, and drifts from the column the moment either side changes. Ignored
+   * when `rebuildWidget` is given.
    */
   renderWidgetPreview?: (
     widget: HomeWidgetItem,
@@ -369,6 +373,7 @@ export function WidgetContainer({
   stow,
   addWidgetLabel,
   onChangeWidgetParams,
+  rebuildWidget,
   renderWidgetPreview,
   paramsPreviewWidth,
   removeLabel,
@@ -825,10 +830,16 @@ export function WidgetContainer({
           // The preview is the WIDGET, drawn with the params being tried out —
           // so whatever they derive (its title, its info) is what you watch
           // change. Its slots can only follow if the app rebuilds them.
+          //
+          // Every branch ends in this column's OWN `render`, so the preview is
+          // the card: `rebuildWidget` only changes what data goes in. The
+          // deprecated `renderWidgetPreview` is the one that steps outside it.
           renderPreview={(params) =>
-            renderWidgetPreview
-              ? renderWidgetPreview(editingParams, params)
-              : render(editingParams, undefined, params)
+            rebuildWidget
+              ? render(rebuildWidget(editingParams, params), undefined, params)
+              : renderWidgetPreview
+                ? renderWidgetPreview(editingParams, params)
+                : render(editingParams, undefined, params)
           }
           onSave={(params) => onChangeWidgetParams(editingParams.id, params)}
         />

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -668,6 +668,29 @@ export type HomeWidgetItem = HomeWidgetChrome & {
 }
 
 /**
+ * The `Widget` chrome an item carries, ready to spread onto `SlotWidget`.
+ *
+ * `alert` and `status` are mutually exclusive on the frame, and which one an
+ * item means is decided by whether it declares an `alert` at all — so the two
+ * are never handed over together.
+ *
+ * Public because drawing a `HomeWidgetItem` yourself is public (`SlotWidget`),
+ * and this is the one part of that spread with a rule in it.
+ */
+export const widgetChrome = (widget: HomeWidgetItem): HomeWidgetChrome =>
+  ("alert" in widget && widget.alert !== undefined
+    ? {
+        action: widget.action,
+        summaries: widget.summaries,
+        alert: widget.alert,
+      }
+    : {
+        action: widget.action,
+        summaries: widget.summaries,
+        status: "status" in widget ? widget.status : undefined,
+      }) as HomeWidgetChrome
+
+/**
  * Row-based slots cancel their rows' own padding so the rows sit flush with the
  * widget's content box — every list-like slot carries this. `indicators`
  * doesn't: it isn't rows and has no padding to cancel.
@@ -879,10 +902,11 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
  * for the same reason `ListSlot` is one: the churn animation asks whether this
  * render is a bulk replacement, and that is a hook.
  *
- * The events are drawn here rather than through `CalendarEventList` for one
- * reason: that component's `showAllItems` container has no gap, and its `gap`
- * prop only reaches the overflow path — so `EVENT_LIST_GAP` has to sit on the
- * DIRECT parent of the event items, which is this container.
+ * The events are drawn here rather than through `CalendarEventList` because the
+ * churn needs its own wrapper AROUND each event (`HomeSlotItem`), and that
+ * component owns the space between its items — there is nowhere to put one.
+ * `EVENT_LIST_GAP` therefore sits on this container, the direct parent of the
+ * event items, and matches that component's own 8px default.
  */
 function EventListSlot({
   params,
@@ -1104,10 +1128,9 @@ export const defaultSlotRenderers: SlotRenderers = {
       />
     ),
   },
-  // The events are rendered here rather than through `CalendarEventList` for one
-  // reason: that component's `showAllItems` container has no gap, and its `gap`
-  // prop only reaches the overflow path — so `EVENT_LIST_GAP` has to sit on the
-  // DIRECT parent of the event items, which is this container.
+  // The events are rendered here rather than through `CalendarEventList`
+  // because each one is wrapped for the CHURN (see `EventListSlot`), which asks
+  // for a per-item wrapper that component has no way to put in.
   "event-list": {
     render: (params, ctx) => (
       <EventListSlot params={params as EventListParams} ctx={ctx} />


### PR DESCRIPTION
## Description

Widget previews rendered by apps drifted from the real widget render: in factorial's new Home, `event-list` rows in the "Add widget" catalog and in the Edit-params dialog sat flush while the same widget on the rail showed the correct 8px `EVENT_LIST_GAP`. The cause was that `SlotWidget` — the one component that renders a `HomeWidgetItem` canonically — was not exported, so apps had to approximate a widget out of the content components and silently lost the spacing. This exports it, lets both dialogs draw previews from widget DATA through f0's own `SlotWidget` so a preview cannot drift by construction, and hardens `CalendarEventList` so the naive path isn't punished either.

## Implementation details

- feat: export `SlotWidget` (and its props) from `dist/experimental`

  <details>
  <summary>Why?</summary>

  `WidgetCatalog` took `preview: ReactNode` and `renderWidgetPreview` was app-supplied, so an app needing its previews to follow the tried params had to render a `HomeWidgetItem` itself — with no canonical way to do it. The `NewHomeLayout` story already used `SlotWidget` for its own catalog previews; apps just couldn't. This alone lets factorial delete `frontend/src/modules/dashboard/components/Widgets/HomeWidgetPreview.tsx` and its three `eslint-disable`d casts.
  </details>

- feat: `WidgetCatalogItem.preview` accepts a `HomeWidgetItem`, drawn by the catalog through `SlotWidget`, plus a `slotRenderers` prop on `WidgetCatalog`

  <details>
  <summary>Why?</summary>

  Handing over the widget as data is the only form that cannot drift — the preview and the card become one render. `ReactNode` is still accepted for a widget the app draws its own way (`renderWidget`). An item that declares no `info` now inherits the widget's own `header.info`, and `slotRenderers` is needed so a bespoke visualization previews as itself rather than as the "No renderer for slot …" notice.
  </details>

- feat: `WidgetContainer` and `NewHomeLayout` take `rebuildWidget?: (widget, params) => HomeWidgetItem`, deprecating `renderWidgetPreview`

  <details>
  <summary>Why?</summary>

  It returns data rather than a rendered node, so the Edit-params preview is drawn by the column through the same `SlotWidget` the column itself uses. `renderWidgetPreview` still works and is ignored when `rebuildWidget` is given. `WidgetUpdateDialog.renderPreview` is unchanged: that dialog is not exported and is only reachable through `WidgetContainer`, so a second widget-drawing path there would duplicate the wiring for no public caller.
  </details>

- fix: `CalendarEventList` applies its `gap` on the `showAllItems` path, not only on the overflow path
- chore: export `widgetChrome` next to `HomeWidgetItem` — the one part of spreading a widget onto `SlotWidget` that carries a rule (`alert` and `status` are exclusive)
- docs: add a "Previews: hand over the widget, not a render of it" section to `SlotWidget.mdx`; correct the `event-list` renderer comments, which cited the (now fixed) missing gap rather than the real reason it draws `CalendarEvent`s itself — the churn animation needs a `HomeSlotItem` wrapper per event
- test: cover the catalog drawing data previews with the right spacing and inherited info, `rebuildWidget` driving the params preview, and `CalendarEventList`'s gap on both paths