### PR TITLE
fix(SlotWidget): view-more button steps up with the card

### DIFF
--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -463,6 +463,42 @@ describe("list slot schema", () => {
 
       expect(container.querySelectorAll(".size-10")).toHaveLength(2)
     })
+
+    const truncatedList = (
+      <SlotWidget
+        slots={[
+          listSlot(
+            { left: "person", descriptionRequired: true, maxVisibleItems: 2 },
+            Array.from({ length: 5 }, (_, i) => ({
+              id: String(i),
+              title: `Person ${i}`,
+              description: `Detail ${i}`,
+              avatar: { firstName: "Ada", lastName: "Lovelace" },
+            }))
+          ),
+        ]}
+      />
+    )
+
+    test("in the rail View more keeps its ghost size", () => {
+      withCardWidth(396)
+      zeroRender(truncatedList)
+
+      // The chosen size lands on the button's INNER box — the same assertion
+      // the frame's footer-button spec makes.
+      expect(
+        screen.getByRole("button", { name: "View more (3)" }).className
+      ).toContain("[&_.main]:h-6")
+    })
+
+    test("past 480px View more steps up with the card — md, like the footer button", () => {
+      withCardWidth(600)
+      zeroRender(truncatedList)
+
+      expect(
+        screen.getByRole("button", { name: "View more (3)" }).className
+      ).toContain("[&_.main]:h-8")
+    })
   })
 
   describe("items coming and going", () => {

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -859,10 +859,15 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
         <div className="mt-1 self-start">
           {/* `neutral`, the same button a widget's own call to action is (the
               frame's `action`): "View more" is something you press, and a ghost
-              button under a dense list of rows reads as another row. */}
+              button under a dense list of rows reads as another row. Past the
+              width threshold it takes the SAME step every card-sized control
+              takes (`WIDE_WIDGET_PX`) — `md`, and `outline` rather than
+              `neutral`, exactly like the frame's footer button — so a wide
+              card doesn't grow its rows and its footer around a button still
+              drawn at rail size. */}
           <F0Button
-            variant="neutral"
-            size="sm"
+            variant={isWide ? "outline" : "neutral"}
+            size={isWide ? "md" : "sm"}
             label={
               expanded ? "View less" : `View more (${allRows.length - max})`
             }


### PR DESCRIPTION
## Description

Past the width threshold, everything a card sizes for itself steps up one (#5108) — **except the `list` slot's own "View more" button**, which stayed hardcoded at `neutral`/`sm`. In a wide card (e.g. a feed widget in the new Home's main column) the rows' glyphs, the trailing faces and the frame's footer button all grew around a button still drawn at rail size.

## Type of change

- [x] Bug fix

## Implementation details

`ListSlot` already asks `useWidgetIsWide()` for its glyph sizes; the View more button now takes the same answer — `md`, and `outline` rather than `neutral`, exactly the step the frame's footer button takes past `WIDE_WIDGET_PX`. In the rail nothing changes.

Two specs pin both sides, using the same `clientWidth`-mock + `[&_.main]:h-*` assertions the frame's footer-button spec established.

## Checklist

- [x] Specs added (rail keeps ghost size, wide steps up)
- [x] `oxfmt` / `oxlint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)