### PR TITLE
feat(F0AiChatTextArea): add padding prop to drop the chat gutter

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -87,6 +87,7 @@ export const F0AiChatTextArea = ({
   onSuggestionClick,
   welcomeScreenSuggestionsPlacement = "above",
   welcomeScreenCards,
+  padding = "default",
   ref,
 }: F0AiChatTextAreaProps) => {
   const translation = useI18n()
@@ -403,7 +404,10 @@ export const F0AiChatTextArea = ({
     <motion.div
       ref={ref}
       className={cn(
-        "flex flex-col items-center gap-2 px-4 pb-3 pt-2",
+        "flex flex-col items-center gap-2",
+        // The chat window's gutter. `padding="none"` hands it to the host —
+        // see the prop's doc for what the host takes on with it.
+        padding === "default" && "px-4 pb-3 pt-2",
         isFullscreenWelcome && "min-h-0 flex-1 justify-start -mt-20"
       )}
       {...(fullscreen ? composerReveal : {})}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -265,6 +265,7 @@ type WrapperProps = {
   fullscreen?: boolean
   inProgress?: boolean
   toolbarStart?: React.ReactNode
+  padding?: "default" | "none"
 }
 
 const Wrapper = ({
@@ -285,6 +286,7 @@ const Wrapper = ({
   fullscreen,
   inProgress,
   toolbarStart,
+  padding,
 }: WrapperProps) => {
   const [pendingContext, setPendingContext] = useState<PendingContext | null>(
     initialPendingContext
@@ -360,6 +362,7 @@ const Wrapper = ({
         welcomeScreenCards={cardsWithBehavior}
         isWelcomeScreen={isWelcomeScreen}
         fullscreen={fullscreen}
+        padding={padding}
       />
       {submissions.length > 0 && (
         <div className="rounded-md border border-f1-border p-3 text-sm">
@@ -424,6 +427,23 @@ export const TransitionDemo: Story = {
       </div>
     )
   },
+}
+
+// The composer with no inset of its own, for hosts that already own the
+// spacing (a home hero, a card). The dashed frame stands in for that host:
+// note the field now runs edge to edge, and the focus glow needs the host to
+// leave it a few pixels of room and not clip overflow.
+export const NoPadding: Story = {
+  args: {
+    padding: "none",
+  },
+  decorators: [
+    (Story) => (
+      <div className="rounded-md border border-dashed border-f1-border p-6">
+        <Story />
+      </div>
+    ),
+  ],
 }
 
 export const WithRotatingPlaceholders: Story = {

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.padding.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.padding.test.tsx
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+const GUTTER = ["px-4", "pb-3", "pt-2"]
+
+/** The composer's root — the rendered element that owns the gutter. */
+const renderComposer = (padding?: "default" | "none") => {
+  const { container } = render(
+    <F0AiChatTextArea onSubmit={vi.fn()} padding={padding} />
+  )
+  return container.firstElementChild as HTMLElement
+}
+
+describe("F0AiChatTextArea padding", () => {
+  it("applies the chat gutter by default", () => {
+    expect(renderComposer()).toHaveClass(...GUTTER)
+  })
+
+  it('drops the gutter with padding="none"', () => {
+    const root = renderComposer("none")
+
+    GUTTER.forEach((cls) => expect(root).not.toHaveClass(cls))
+    // The stack itself is untouched — only the outer inset goes away.
+    expect(root).toHaveClass("flex", "flex-col", "items-center", "gap-2")
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/types.ts
@@ -192,6 +192,26 @@ export type F0AiChatTextAreaProps = {
   welcomeScreenCards?: F0AiChatWelcomeCard[]
 
   /**
+   * The composer's own inset against whatever contains it.
+   *
+   * - `"default"` — the gutter the chat layouts expect (16px sides, 8px top,
+   *   12px bottom). It is what keeps the field off the chat window's edges and
+   *   leaves room for the focus glow, which bleeds a few pixels outside the
+   *   field's border box.
+   *
+   * - `"none"` — no inset, for hosts that place the composer inside a container
+   *   that already owns the spacing (a landing/home hero, a card). The host then
+   *   owns BOTH sides of that bargain: give the composer some room of your own,
+   *   and don't clip overflow around it, or the focus glow gets cut at the edge.
+   *
+   * Only the outer inset changes; the gap between the composer and the blocks
+   * below it (suggestions, cards, footer, disclaimer) is unaffected.
+   *
+   * @default "default"
+   */
+  padding?: "default" | "none"
+
+  /**
    * When true on the welcome screen, the composer adopts the fullscreen
    * layout: the input slot grows to claim the bottom half (so the textarea
    * rises toward the vertical center) and the welcome cards render below it.


### PR DESCRIPTION
## Description

`F0AiChatTextArea`'s root carries the chat window's gutter (`px-4 pb-3 pt-2`), which is right for the chat layouts it was built for but wrong for hosts that place the composer inside a container that already owns the spacing — a home hero, a card. Since F0 public components take no `className`, those hosts had no way out except negative margins at the call site. This adds `padding?: "default" | "none"`, defaulting to the current behavior, so nothing existing shifts.

## Implementation details

- feat: add `padding` prop to `F0AiChatTextArea`; `"none"` drops the outer inset and hands the spacing to the host

  <details>
  <summary>Why only the outer inset?</summary>

  The root does two separate jobs: it stacks the composer's sibling blocks (suggestions row, welcome cards, footer, disclaimer — each capped at `max-w-content`) and it insets the whole thing from the chat window's edges. Only the second is the host's business, so `flex flex-col items-center gap-2` stays unconditional and the internal rhythm is untouched.

  Worth knowing for anyone reaching for `"none"`: the form's focus glow (`after:inset-0.5 after:blur-[6px]`) renders a few pixels outside the field's border box. The default gutter is what gives it room. A host that opts out takes on both sides of that — leave the composer some space, and don't clip overflow around it.
  </details>

- test: cover both values on the rendered root
- docs: add a `NoPadding` story, framed by a dashed host container so the "host owns the spacing" contract is visible

## Notes for reviewers

The prop is additive and defaults to today's behavior, so no consumer changes. If Foundations would rather express this as a layout variant than a `padding` prop, happy to rename before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)