### PR TITLE
feat(OneDataCollection): permission-locked graph metadata toggle

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
@@ -2,14 +2,15 @@ import { Meta, StoryObj } from "@storybook/react-vite"
 import "@xyflow/react/dist/style.css"
 import { useRef, useState } from "react"
 
+import type { F0GraphNodeTag } from "@/patterns/F0Graph"
+
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
 import { F0Button } from "@/components/F0Button"
+import { Calendar, Office } from "@/icons/app"
 import { F0Dialog } from "@/patterns/F0Dialog"
-import type { F0GraphNodeTag } from "@/patterns/F0Graph"
 
 import { useDataCollectionSource } from "../../hooks/useDataCollectionSource"
 import { OneDataCollection } from "../../index"
-import { Calendar, Office } from "@/icons/app"
 
 type Employee = {
   id: string
@@ -712,6 +713,7 @@ const OrgChartExample = ({
   focusOnEntry,
   graphLabel,
   tableLabel,
+  lockedTagTypes,
 }: {
   defaultExpandDepth: number
   focusOnEntry?: string
@@ -719,6 +721,8 @@ const OrgChartExample = ({
   graphLabel?: string
   /** Custom label for the table chip; falls back to the localized "Table". */
   tableLabel?: string
+  /** Tag columns locked (OFF + disabled + tooltip) in the settings, per reason. */
+  lockedTagTypes?: Partial<Record<(typeof NODE_TAG_TYPES)[number], string>>
 }) => {
   const [selected, setSelected] = useState<EmployeeNode | null>(null)
   const [revealId, setRevealId] = useState<string | undefined>(undefined)
@@ -738,6 +742,7 @@ const OrgChartExample = ({
               defaultExpandDepth,
               revealNodeId: revealId,
               focusOnEntry,
+              lockedTagTypes,
             },
           },
           { ...tableVisualization, label: tableLabel },
@@ -800,6 +805,24 @@ export const OrgChart: Story = {
  */
 export const PreExpanded: Story = {
   render: () => <OrgChartExample defaultExpandDepth={2} />,
+}
+
+/**
+ * A metadata column the viewer isn't allowed to see is **locked** rather than
+ * dropped: open the settings and the "Legal entity" toggle is still listed, but
+ * switched off and disabled, with a tooltip explaining why. It never renders on
+ * a node (the consumer omits its tag). Unlike a pinned column, there is no lock
+ * icon — the disabled switch + tooltip is the affordance.
+ */
+export const LockedMetadata: Story = {
+  render: () => (
+    <OrgChartExample
+      defaultExpandDepth={1}
+      lockedTagTypes={{
+        legalEntity: "You don't have permission to see this metadata",
+      }}
+    />
+  ),
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -62,6 +62,7 @@ export const GraphCollection = <
   nodeTagTypes,
   defaultVisibleTagTypes,
   pinnedTagTypes,
+  lockedTagTypes,
   currentUserNodeId,
   getNodeId,
   getChildrenCount,
@@ -200,6 +201,9 @@ export const GraphCollection = <
   const allTagTypes = nodeTagTypes ? [...nodeTagTypes] : []
   const defaultVisibleSet = new Set(defaultVisibleTagTypes ?? allTagTypes)
   const pinnedSet = new Set<string>(pinnedTagTypes ?? [])
+  // Columns the actor can't see: never rendered on a node, whatever the saved
+  // visibility says (their settings toggle is locked OFF + disabled too).
+  const lockedSet = new Set<string>(Object.keys(lockedTagTypes ?? {}))
   const hiddenSet = new Set(
     graphSettings?.hidden ??
       allTagTypes.filter((type) => !defaultVisibleSet.has(type))
@@ -211,7 +215,8 @@ export const GraphCollection = <
       (order.indexOf(b) === -1 ? Infinity : order.indexOf(b))
   )
   const visibleTagTypes = orderedTagTypes.filter(
-    (type) => pinnedSet.has(type) || !hiddenSet.has(type)
+    (type) =>
+      !lockedSet.has(type) && (pinnedSet.has(type) || !hiddenSet.has(type))
   )
 
   // Reorder each node's tags to match the configured metadata order.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/settings/SettingsRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/settings/SettingsRenderer.tsx
@@ -1,12 +1,14 @@
-import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+import type { F0GraphNodeTagColumn } from "@/patterns/F0Graph"
+
 import { RecordType } from "@/hooks/datasource"
 import { SortingsDefinition } from "@/hooks/datasource/types/sortings.typings"
-import type { F0GraphNodeTagColumn } from "@/patterns/F0Graph"
+import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+
+import type { SortAndHideListItem } from "../../Table/components/SortAndHideList/types"
+import type { GraphVisualizationOptions } from "../types"
 
 import { useDataCollectionSettings } from "../../../../Settings/SettingsProvider"
 import { SortAndHideSettings } from "../../../../Settings/SortAndHideSettings"
-import type { SortAndHideListItem } from "../../Table/components/SortAndHideList/types"
-import type { GraphVisualizationOptions } from "../types"
 
 export type GraphVisualizationSettings = {
   /** Metadata order (tag-type ids), matching the table column settings shape. */
@@ -20,6 +22,7 @@ type GraphSettingsProps = {
   labels?: Partial<Record<F0GraphNodeTagColumn, string>>
   defaultVisibleTagTypes?: ReadonlyArray<F0GraphNodeTagColumn>
   pinnedTagTypes?: ReadonlyArray<F0GraphNodeTagColumn>
+  lockedTagTypes?: Partial<Record<F0GraphNodeTagColumn, string>>
 }
 
 /**
@@ -32,12 +35,14 @@ const GraphSettings = ({
   labels,
   defaultVisibleTagTypes,
   pinnedTagTypes,
+  lockedTagTypes,
 }: GraphSettingsProps) => {
   const { settings } = useDataCollectionSettings()
   const graphSettings = settings.visualization.graph ?? {}
 
   const defaultVisible = new Set(defaultVisibleTagTypes ?? tagTypes)
   const pinned = new Set<string>(pinnedTagTypes ?? [])
+  const locked = lockedTagTypes ?? {}
   const hidden = new Set(
     graphSettings.hidden ?? tagTypes.filter((type) => !defaultVisible.has(type))
   )
@@ -51,15 +56,31 @@ const GraphSettings = ({
     ...tagTypes.filter((type) => !savedOrder.includes(type)),
   ]
 
-  const items: SortAndHideListItem[] = orderedTypes.map((type) => ({
-    id: type,
-    label: labels?.[type as F0GraphNodeTagColumn] ?? type,
-    // Pinned tags can't be reordered or hidden — shown with a lock icon, just
-    // like frozen columns in the table settings.
-    sortable: !pinned.has(type),
-    canHide: !pinned.has(type),
-    visible: pinned.has(type) || !hidden.has(type),
-  }))
+  const items: SortAndHideListItem[] = orderedTypes.map((type) => {
+    const lockReason = locked[type as F0GraphNodeTagColumn]
+    // Locked by permission takes precedence over pinned/default: the row is
+    // forced OFF + disabled with the reason in a tooltip (no lock icon).
+    if (lockReason !== undefined) {
+      return {
+        id: type,
+        label: labels?.[type as F0GraphNodeTagColumn] ?? type,
+        sortable: false,
+        canHide: false,
+        visible: false,
+        disabledReason: lockReason,
+      }
+    }
+
+    return {
+      id: type,
+      label: labels?.[type as F0GraphNodeTagColumn] ?? type,
+      // Pinned tags can't be reordered or hidden — shown with a lock icon, just
+      // like frozen columns in the table settings.
+      sortable: !pinned.has(type),
+      canHide: !pinned.has(type),
+      visible: pinned.has(type) || !hidden.has(type),
+    }
+  })
 
   return (
     <SortAndHideSettings
@@ -88,6 +109,7 @@ export const SettingsRenderer = <
       labels={props.nodeTagTypeLabels}
       defaultVisibleTagTypes={props.defaultVisibleTagTypes}
       pinnedTagTypes={props.pinnedTagTypes}
+      lockedTagTypes={props.lockedTagTypes}
     />
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/settings/__tests__/SettingsRenderer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/settings/__tests__/SettingsRenderer.test.tsx
@@ -3,8 +3,9 @@ import { describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render } from "@/testing/test-utils"
 
-import { DataCollectionSettingsProvider } from "../../../../../Settings/SettingsProvider"
 import type { GraphVisualizationOptions } from "../../types"
+
+import { DataCollectionSettingsProvider } from "../../../../../Settings/SettingsProvider"
 import { SettingsRenderer } from "../SettingsRenderer"
 
 vi.stubGlobal(
@@ -71,5 +72,27 @@ describe("Graph SettingsRenderer", () => {
     const switches = screen.getAllByRole("switch")
     const disabled = switches.filter((s) => s.hasAttribute("disabled"))
     expect(disabled.length).toBe(1)
+  })
+
+  it("renders a locked tag as OFF + disabled, and locked wins over pinned", () => {
+    renderSettings({
+      ...baseOptions,
+      // 'status' is pinned in baseOptions; locking it too must win (OFF, not the
+      // pinned ON). 'company' is locked but not pinned.
+      lockedTagTypes: {
+        company: "No permission",
+        status: "No permission",
+      },
+    } as unknown as Options)
+
+    const switchFor = (label: string) => {
+      const row = screen.getByText(label).closest("li") as HTMLElement
+      return within(row).getByRole("switch")
+    }
+
+    expect(switchFor("Legal entity")).toBeDisabled()
+    expect(switchFor("Legal entity")).toHaveAttribute("aria-checked", "false")
+    expect(switchFor("Reports")).toBeDisabled()
+    expect(switchFor("Reports")).toHaveAttribute("aria-checked", "false")
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -56,6 +56,15 @@ export type GraphVisualizationOptions<
   /** Tag columns that are always visible and cannot be hidden in the settings. */
   pinnedTagTypes?: ReadonlyArray<F0GraphNodeTagColumn>
   /**
+   * Tag columns the actor is not allowed to see, mapped to the reason. Each is
+   * still listed in the settings but with its toggle forced OFF and disabled,
+   * and the given (already-translated) text shown in a tooltip. Unlike
+   * `pinnedTagTypes` (locked ON, drawn with a lock icon), these render no lock
+   * icon — the disabled switch + tooltip is the affordance. The caller should
+   * also omit these columns' tags from `tags(record)`.
+   */
+  lockedTagTypes?: Partial<Record<F0GraphNodeTagColumn, string>>
+  /**
    * Floating toolbar shown above a node while it is selected. Provide the
    * action buttons (e.g. `<F0Button size="sm" … />`) for the given record.
    */

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.test.tsx
@@ -2,8 +2,9 @@ import { describe, expect, it, vi } from "vitest"
 
 import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
 
-import { SortAndHideList } from "./SortAndHideList"
 import type { SortAndHideListItem } from "./types"
+
+import { SortAndHideList } from "./SortAndHideList"
 
 const items: SortAndHideListItem[] = [
   { id: "name", label: "Name", sortable: false, canHide: false, visible: true },
@@ -72,5 +73,69 @@ describe("SortAndHideList remove affordance", () => {
     expect(
       screen.queryByRole("button", { name: "Remove column" })
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("SortAndHideList disabledReason (locked entry)", () => {
+  const lockedItems: SortAndHideListItem[] = [
+    // Pinned: locked ON (disabled + checked), with a lock icon.
+    {
+      id: "name",
+      label: "Name",
+      sortable: false,
+      canHide: false,
+      visible: true,
+    },
+    // Locked by permission: OFF + disabled, no lock icon, tooltip reason.
+    {
+      id: "devices",
+      label: "Devices",
+      sortable: false,
+      canHide: false,
+      visible: false,
+      disabledReason: "You don't have permission to see this",
+    },
+  ]
+
+  it("renders a locked entry as an OFF, disabled switch", () => {
+    render(<SortAndHideList items={lockedItems} allowSorting allowHiding />)
+
+    const switches = screen.getAllByRole("switch")
+    // Pinned "Name" stays ON; the locked "Devices" is forced OFF.
+    expect(switches[0]).toBeDisabled()
+    expect(switches[0]).toHaveAttribute("aria-checked", "true")
+    expect(switches[1]).toBeDisabled()
+    expect(switches[1]).toHaveAttribute("aria-checked", "false")
+  })
+
+  it("wraps the locked switch so its tooltip can trigger despite the disabled control", () => {
+    const { container } = render(
+      <SortAndHideList items={lockedItems} allowSorting allowHiding />
+    )
+    // The disabled switch sits inside a non-disabled wrapper (the tooltip
+    // trigger) — a disabled control fires no pointer events of its own.
+    expect(container.querySelector(".cursor-not-allowed")).not.toBeNull()
+  })
+
+  it("does not force other rows off when one entry is locked", () => {
+    render(
+      <SortAndHideList
+        items={[
+          ...lockedItems,
+          {
+            id: "role",
+            label: "Role",
+            sortable: true,
+            canHide: true,
+            visible: true,
+          },
+        ]}
+        allowSorting
+        allowHiding
+      />
+    )
+    const switches = screen.getAllByRole("switch")
+    expect(switches[2]).not.toBeDisabled()
+    expect(switches[2]).toHaveAttribute("aria-checked", "true")
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
@@ -2,10 +2,11 @@ import { Reorder, useDragControls } from "motion/react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
-import { OneEllipsis } from "@/lib/OneEllipsis"
-import { useI18n } from "@/lib/providers/i18n"
 import { Switch } from "@/experimental/Forms/Fields/Switch"
 import { Delete, Handle, LockLocked } from "@/icons/app"
+import { OneEllipsis } from "@/lib/OneEllipsis"
+import { useI18n } from "@/lib/providers/i18n"
+import { TooltipWrapper } from "@/lib/tooltip-wrapper"
 import { cn } from "@/lib/utils"
 
 import { SortAndHideListItem } from "./types"
@@ -47,7 +48,7 @@ const Item = ({
         >
           {item.sortable ? (
             <F0Icon icon={Handle} size="xs" />
-          ) : (
+          ) : item.disabledReason ? null : (
             <F0Icon icon={LockLocked} size="sm" />
           )}
         </div>
@@ -73,20 +74,31 @@ const Item = ({
           />
         </div>
       )}
-      {allowHiding && (
-        <Switch
-          checked={item.visible}
-          onCheckedChange={(checked) => {
-            onChangeVisibility({
-              ...item,
-              visible: checked,
-            })
-          }}
-          title={item.label}
-          hideLabel
-          disabled={!item.canHide}
-        />
-      )}
+      {allowHiding &&
+        (item.disabledReason ? (
+          // Locked by the caller (e.g. no permission): forced OFF + disabled,
+          // with the reason in a tooltip. The switch is wrapped in a span so the
+          // tooltip still triggers on hover — a disabled control fires no pointer
+          // events of its own (same idiom as the disabled Dropdown menu item).
+          <TooltipWrapper tooltip={item.disabledReason}>
+            <span className="inline-flex cursor-not-allowed">
+              <Switch checked={false} title={item.label} hideLabel disabled />
+            </span>
+          </TooltipWrapper>
+        ) : (
+          <Switch
+            checked={item.visible}
+            onCheckedChange={(checked) => {
+              onChangeVisibility({
+                ...item,
+                visible: checked,
+              })
+            }}
+            title={item.label}
+            hideLabel
+            disabled={!item.canHide}
+          />
+        ))}
     </div>
   )
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/types.ts
@@ -10,4 +10,11 @@ export type SortAndHideListItem = {
    * list has an `onRemove` handler, a trash affordance is revealed on hover.
    */
   removable?: boolean
+  /**
+   * When set, the entry is locked: its switch renders forced OFF and disabled,
+   * wrapped in a tooltip showing this text (e.g. a missing-permission reason).
+   * Distinct from a non-hideable (`canHide: false`) row — that draws a lock icon
+   * and stays ON; a `disabledReason` row shows no lock icon and stays OFF.
+   */
+  disabledReason?: string
 }


### PR DESCRIPTION
## What

Adds a **permission-locked** state for graph metadata toggles ("Graph settings"). A tag column the actor is not allowed to see stays **listed** in the settings but with its toggle **switched off and disabled**, plus a **tooltip** explaining why — instead of silently vanishing, so the user learns the data exists. The column's tags are also never rendered on a node.

Distinct from a **pinned** column (`pinnedTagTypes`), which is locked *on* and drawn with a 🔒 lock icon. A locked column shows **no lock icon** — the disabled switch + tooltip is the affordance.

<img width="479" height="232" alt="Screenshot 2026-08-14 at 11 37 58" src="https://github.com/user-attachments/assets/8a53c78f-9aa6-4456-92c5-ebbfb286e04c" />


## How

- **`SortAndHideListItem.disabledReason?: string`** — when set, the row's `Switch` renders OFF + `disabled`, wrapped in `TooltipWrapper` (via a non-disabled `<span>` so the tooltip still triggers over a disabled control), and the leading slot shows no lock icon. Additive: unset for every existing caller, so table column settings and current graph toggles are unchanged.
- **`GraphVisualizationOptions.lockedTagTypes?: Partial<Record<F0GraphNodeTagColumn, string>>`** — tag column → tooltip text.
  - `Graph/settings/SettingsRenderer.tsx` maps a locked type to `{ sortable: false, canHide: false, visible: false, disabledReason }`. **Locked wins over pinned/default.**
  - `Graph/index.tsx` also excludes locked columns from `visibleTagTypes`, so a locked column's tag never renders on a node even if the consumer forgets to omit it (defense in depth).

The consumer keeps declaring the column in `nodeTagTypes` (so the row appears) and omits its tags from `tags(record)` when the actor lacks permission.

## Tests / docs

- `SortAndHideList.test.tsx`: locked row renders OFF + disabled, is wrapped for its tooltip, and does not force other rows off.
- Graph `SettingsRenderer.test.tsx`: locked tag renders OFF + disabled, and locked wins over pinned.
- Storybook: new `LockedMetadata` story under *Data Collection / Visualizations / Graph*.

## Consumer

First consumer: Job Catalog Competencies / Devices behind `SeeAttributes` — factorial **FCT-61230** (this is **FCT-61293**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)