### PR TITLE
feat(F0DataChart): report the clicked mark via onPointClick

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -9,6 +9,7 @@ import * as HeatmapStories from "./Heatmap.stories"
 import * as ScatterStories from "./Scatter.stories"
 import * as SkeletonsStories from "./Skeletons.stories"
 import * as EmptyStatesStories from "./EmptyStates.stories"
+import * as PointClickStories from "./PointClick.stories"
 
 <Meta title="F0DataChart/Overview" />
 
@@ -367,6 +368,56 @@ import {
 ---
 
 ## Customization
+
+### Point click
+
+Pass `onPointClick` when a host needs to respond to the chart mark a reader
+selects. Without the callback, chart clicks remain inert.
+
+```tsx
+<F0DataChart
+  type="bar"
+  categories={["Barcelona", "Madrid"]}
+  series={[{ name: "Headcount", data: [39, 43] }]}
+  onPointClick={(point) => {
+    console.log(point.category, point.seriesName, point.value)
+  }}
+/>
+```
+
+The callback includes the category, series, raw numeric value, configured
+indices, and viewport coordinates for anchoring a host-owned action. `values`
+keeps the complete numeric tuple for chart types such as scatter and heatmap;
+`series` keeps every resolved series when a line click represents a whole
+category.
+
+**Mark-sized targets**
+
+Bar segments, slices, cells, and points respond only when the mark itself is
+clicked. Use this story to compare the visible value with the callback payload.
+
+<Canvas of={PointClickStories.OnAMark} />
+
+**Line plot targets**
+
+Lines are too thin to target reliably, so the complete plot column is
+clickable. The nearest series becomes the headline value and `series` contains
+all visible values at the resolved category, matching the axis tooltip.
+
+<Canvas of={PointClickStories.AnywhereInAPlotArea} />
+
+**Multi-measure points**
+
+For scatter charts, read `values` rather than only `value`: the tuple preserves
+both measures that define the point.
+
+<Canvas of={PointClickStories.BothMeasuresOfAScatterPoint} />
+
+- WHEN `onPointClick` is omitted → THEN clicking the chart produces no callback or visual change.
+- WHEN a bar, pie, funnel, gauge, heatmap, radar, or scatter mark is clicked → THEN the callback reports that ECharts series item.
+- WHEN a line plot column is clicked → THEN the callback reports the nearest visible series as the headline and every visible series at that category in `series`.
+- WHEN a value is `null`, `undefined`, empty, or non-numeric → THEN the click is ignored; a genuine zero is still reported.
+- WHEN a successful pick is reported → THEN the chart dismisses its hover tooltip so the host can present one action at the same anchor.
 
 ### Value & Category Formatters
 

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -389,7 +389,16 @@ The callback includes the category, series, raw numeric value, configured
 indices, `source: "pointer"`, and viewport coordinates for anchoring a host-owned action. `values`
 keeps the complete numeric tuple for chart types such as scatter and heatmap;
 `series` keeps every resolved series when a line click represents a whole
-category.
+category. `category` is the clicked mark's ECharts name—an axis category, pie
+slice, funnel stage, scatter label, or gauge/radar item name—and can be empty.
+`seriesName` is the configured series name and can also be empty when ECharts
+does not report one.
+
+This callback is intentionally pointer-only. ECharts renders marks into one
+canvas rather than focusable DOM nodes. Hosts using this callback must provide
+an equivalent keyboard-accessible data or action surface outside the canvas. A
+future keyboard path can add another `source` value without breaking pointer
+consumers.
 
 **Mark-sized targets**
 
@@ -402,7 +411,9 @@ clicked. Use this story to compare the visible value with the callback payload.
 
 Lines are too thin to target reliably, so the complete plot column is
 clickable. The nearest series becomes the headline value and `series` contains
-all visible values at the resolved category, matching the axis tooltip.
+all visible values at the resolved category, matching the axis tooltip. When a
+handler is present, the pointer cursor identifies the clickable plot; axis
+labels retain the default cursor because they are not point targets.
 
 <Canvas of={PointClickStories.AnywhereInAPlotArea} />
 
@@ -418,6 +429,18 @@ both measures that define the point.
 - WHEN a line plot column is clicked → THEN the callback reports the nearest visible series as the headline and every visible series at that category in `series`.
 - WHEN any value in a point tuple is `null`, `undefined`, empty, or non-numeric → THEN the click is ignored; a genuine zero is still reported.
 - WHEN a successful pick is reported → THEN the chart dismisses its hover tooltip so the host can present one action at the same anchor.
+
+### Legend selection changes
+
+Legend-bearing charts (`bar`, `line`, `funnel`, `pie`, `radar`, and `scatter`)
+accept `onLegendSelectionChange`. After a reader toggles a legend item, the
+callback reports the final `{ [legendName]: visible }` mapping, including the
+chart's isolate and restore behavior. Companion data or action surfaces can use
+that mapping to stay aligned with what remains visible on the canvas. Gauge has
+no legend, and heatmap uses a visual scale rather than an interactive legend,
+so neither variant accepts this prop.
+
+<Canvas of={PointClickStories.LegendSelectionChanges} />
 
 ### Value & Category Formatters
 

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -386,7 +386,7 @@ selects. Without the callback, chart clicks remain inert.
 ```
 
 The callback includes the category, series, raw numeric value, configured
-indices, and viewport coordinates for anchoring a host-owned action. `values`
+indices, `source: "pointer"`, and viewport coordinates for anchoring a host-owned action. `values`
 keeps the complete numeric tuple for chart types such as scatter and heatmap;
 `series` keeps every resolved series when a line click represents a whole
 category.
@@ -416,7 +416,7 @@ both measures that define the point.
 - WHEN `onPointClick` is omitted → THEN clicking the chart produces no callback or visual change.
 - WHEN a bar, pie, funnel, gauge, heatmap, radar, or scatter mark is clicked → THEN the callback reports that ECharts series item.
 - WHEN a line plot column is clicked → THEN the callback reports the nearest visible series as the headline and every visible series at that category in `series`.
-- WHEN a value is `null`, `undefined`, empty, or non-numeric → THEN the click is ignored; a genuine zero is still reported.
+- WHEN any value in a point tuple is `null`, `undefined`, empty, or non-numeric → THEN the click is ignored; a genuine zero is still reported.
 - WHEN a successful pick is reported → THEN the chart dismisses its hover tooltip so the host can present one action at the same anchor.
 
 ### Value & Category Formatters

--- a/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
@@ -47,6 +47,10 @@ const Readout = ({ point }: { point: F0DataChartPointClick | null }) => {
       <Row label="category" value={point.category || "(empty)"} />
       <Row label="value" value={String(point.value)} />
       <Row label="values" value={`[${point.values.join(", ")}]`} />
+      <Row
+        label="series"
+        value={point.series.map((s) => `${s.name}: ${s.value}`).join("  ·  ")}
+      />
       <Row label="dataIndex" value={String(point.dataIndex)} />
       <Row label="seriesIndex" value={String(point.seriesIndex)} />
       <Row
@@ -159,22 +163,27 @@ export const OnAMark: Story = {
 }
 
 /**
- * Lines get a wider hit area: anywhere inside the plot area counts, and the
- * click resolves to the nearest point — nearest category horizontally, then
- * the series nearest to the cursor vertically.
+ * Lines get a wider hit area: anywhere inside the plot area counts. The click
+ * resolves to the nearest category horizontally and answers with **every**
+ * series there — the same rows the tooltip shows on hover, in `series`.
  *
  * A line is a few pixels wide, so requiring a hit on it asks the user to miss.
  * The tooltip here already made that concession (it is axis-triggered rather
- * than item-triggered), and clicking now agrees with it.
+ * than item-triggered), and clicking now agrees with it on both counts: same
+ * target, same answer.
  *
- * Worth trying: click well above every line, and then hide a series from the
- * legend and click where it used to be — a hidden series is never the answer.
+ * `seriesName` and `value` still name one series — the one nearest the cursor
+ * vertically — so anything that wants a headline has one.
+ *
+ * Worth trying: click high and then low in the same column. `series` doesn't
+ * change, the headline does. Then hide a series from the legend and click
+ * where it used to be — a hidden series is neither, and nor is a gap.
  */
 export const AnywhereInAPlotArea: Story = {
   render: () => (
     <ClickDemo
       chart={REVENUE}
-      hint="Click anywhere in the plot area — you do not have to hit a line. The nearest point answers."
+      hint="Click anywhere in the plot area — you do not have to hit a line. The whole column answers."
     />
   ),
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
@@ -15,7 +15,7 @@ import { F0DataChart } from "../index"
 const meta = {
   component: F0DataChart,
   title: "F0DataChart/Point click",
-  tags: ["autodocs", "experimental"],
+  tags: ["experimental", "!autodocs", "no-sidebar"],
 } satisfies Meta<typeof F0DataChart>
 
 export default meta

--- a/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
@@ -43,6 +43,7 @@ const Readout = ({ point }: { point: F0DataChartPointClick | null }) => {
 
   return (
     <dl className="grid grid-cols-[110px_1fr] gap-x-4 gap-y-1 rounded-xl bg-f1-background-tertiary p-3 font-mono text-xs">
+      <Row label="source" value={point.source} />
       <Row label="seriesName" value={point.seriesName || "(empty)"} />
       <Row label="category" value={point.category || "(empty)"} />
       <Row label="value" value={String(point.value)} />
@@ -81,6 +82,36 @@ const ClickDemo = ({
   )
 }
 
+const LegendSelectionDemo = () => {
+  const [selection, setSelection] = useState<Record<string, boolean> | null>(
+    null
+  )
+
+  return (
+    <div className="flex w-[600px] flex-col gap-3">
+      <p className="text-sm text-f1-foreground-secondary">
+        Click a legend item to isolate it, then click it again to restore every
+        series.
+      </p>
+      <div className="h-[320px] w-full rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-3">
+        <F0DataChart {...REVENUE} onLegendSelectionChange={setSelection} />
+      </div>
+      <dl className="grid grid-cols-[110px_1fr] gap-x-4 gap-y-1 rounded-xl bg-f1-background-tertiary p-3 font-mono text-xs">
+        <Row
+          label="selected"
+          value={
+            selection
+              ? Object.entries(selection)
+                  .map(([name, visible]) => `${name}: ${visible}`)
+                  .join("  ·  ")
+              : "No legend change yet."
+          }
+        />
+      </dl>
+    </div>
+  )
+}
+
 // ---------------------------------------------------------------------------
 // Data
 // ---------------------------------------------------------------------------
@@ -99,7 +130,7 @@ const HEADCOUNT: F0DataChartProps = {
 
 const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
 
-const REVENUE: F0DataChartProps = {
+const REVENUE = {
   type: "line",
   categories: MONTHS,
   series: [
@@ -107,7 +138,7 @@ const REVENUE: F0DataChartProps = {
     { name: "Design", data: [1.8, 2.0, 2.2, 2.4, 2.6, 2.5] },
     { name: "Sales", data: [3.0, 3.1, 3.0, 2.9, 2.8, 3.4] },
   ],
-}
+} satisfies F0DataChartProps
 
 /**
  * A handful of employees, plus the two anomalies a scatter exists to reveal:
@@ -203,4 +234,12 @@ export const BothMeasuresOfAScatterPoint: Story = {
       hint="Click the outlier at the top right. `values` keeps the salary that `value` alone would lose."
     />
   ),
+}
+
+/**
+ * The observer receives the final legend state after the chart's isolate,
+ * restore, or ordinary toggle behavior has completed.
+ */
+export const LegendSelectionChanges: Story = {
+  render: () => <LegendSelectionDemo />,
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/PointClick.stories.tsx
@@ -1,0 +1,197 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+
+import type { F0DataChartPointClick, F0DataChartProps } from "../types"
+
+import { F0DataChart } from "../index"
+
+/**
+ * `onPointClick` reports the single mark the user picked. These stories are
+ * for trying it by hand — each one renders a chart and prints the payload it
+ * last produced, so what the chart says and what a consumer receives can be
+ * compared side by side.
+ */
+const meta = {
+  component: F0DataChart,
+  title: "F0DataChart/Point click",
+  tags: ["autodocs", "experimental"],
+} satisfies Meta<typeof F0DataChart>
+
+export default meta
+type Story = StoryObj<typeof F0DataChart>
+
+// ---------------------------------------------------------------------------
+// Harness
+// ---------------------------------------------------------------------------
+
+const Row = ({ label, value }: { label: string; value: string }) => (
+  <>
+    <dt className="text-f1-foreground-secondary">{label}</dt>
+    <dd className="text-f1-foreground">{value}</dd>
+  </>
+)
+
+const Readout = ({ point }: { point: F0DataChartPointClick | null }) => {
+  if (!point) {
+    return (
+      <p className="rounded-xl bg-f1-background-tertiary p-3 text-sm text-f1-foreground-secondary">
+        Nothing picked yet.
+      </p>
+    )
+  }
+
+  return (
+    <dl className="grid grid-cols-[110px_1fr] gap-x-4 gap-y-1 rounded-xl bg-f1-background-tertiary p-3 font-mono text-xs">
+      <Row label="seriesName" value={point.seriesName || "(empty)"} />
+      <Row label="category" value={point.category || "(empty)"} />
+      <Row label="value" value={String(point.value)} />
+      <Row label="values" value={`[${point.values.join(", ")}]`} />
+      <Row label="dataIndex" value={String(point.dataIndex)} />
+      <Row label="seriesIndex" value={String(point.seriesIndex)} />
+      <Row
+        label="client x/y"
+        value={`${Math.round(point.clientX)}, ${Math.round(point.clientY)}`}
+      />
+    </dl>
+  )
+}
+
+const ClickDemo = ({
+  chart,
+  hint,
+}: {
+  chart: F0DataChartProps
+  hint: string
+}) => {
+  const [picked, setPicked] = useState<F0DataChartPointClick | null>(null)
+
+  return (
+    <div className="flex w-[600px] flex-col gap-3">
+      <p className="text-sm text-f1-foreground-secondary">{hint}</p>
+      <div className="h-[320px] w-full rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-3">
+        <F0DataChart {...chart} onPointClick={setPicked} />
+      </div>
+      <Readout point={picked} />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Data
+// ---------------------------------------------------------------------------
+
+const WORKPLACES = ["Barcelona", "Madrid", "Lisbon", "Tokyo"]
+
+const HEADCOUNT: F0DataChartProps = {
+  type: "bar",
+  categories: WORKPLACES,
+  series: [
+    { name: "Male", data: [18, 24, 9, 6] },
+    { name: "Female", data: [21, 19, 12, 7] },
+  ],
+  stacked: true,
+}
+
+const MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun"]
+
+const REVENUE: F0DataChartProps = {
+  type: "line",
+  categories: MONTHS,
+  series: [
+    { name: "Engineering", data: [2.4, 2.8, 3.0, 2.7, 2.5, 2.9] },
+    { name: "Design", data: [1.8, 2.0, 2.2, 2.4, 2.6, 2.5] },
+    { name: "Sales", data: [3.0, 3.1, 3.0, 2.9, 2.8, 3.4] },
+  ],
+}
+
+/**
+ * A handful of employees, plus the two anomalies a scatter exists to reveal:
+ * someone paid well above their tenure, and someone long-serving whose salary
+ * never caught up.
+ */
+const SALARY_VS_TENURE: F0DataChartProps = {
+  type: "scatter",
+  series: [
+    {
+      name: "Engineering",
+      data: [
+        { x: 52000, y: 3.2, label: "Ana Ruiz" },
+        { x: 61000, y: 5.4, label: "Marc Vidal" },
+        { x: 74000, y: 8.1, label: "Júlia Serra" },
+        { x: 128000, y: 0.6, label: "Roser Nogué" },
+        { x: 37000, y: 13.8, label: "Bernat Illa" },
+      ],
+    },
+    {
+      name: "Design",
+      data: [
+        { x: 44000, y: 2.1, label: "Pau Bosch" },
+        { x: 58000, y: 6.3, label: "Laia Roca" },
+        { x: 96000, y: 1.4, label: "Ivet Prat" },
+      ],
+    },
+  ],
+  xAxisName: "salary",
+  yAxisName: "tenure",
+  xValueFormatter: (v: number) => `€${Math.round(v / 1000)}k`,
+  valueFormatter: (v: number) => `${v} yrs`,
+  xTooltipValueFormatter: (v: number) => `€${v.toLocaleString()}`,
+  tooltipValueFormatter: (v: number) => `${v} yrs`,
+}
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/**
+ * The default hit area. A click has to land on the mark itself — which is
+ * fine for a bar, since a bar is a large target. Clicking the gaps, the axis
+ * labels or the legend reports nothing.
+ */
+export const OnAMark: Story = {
+  render: () => (
+    <ClickDemo
+      chart={HEADCOUNT}
+      hint="Click a bar segment. Clicking between the bars does nothing — the mark is the target."
+    />
+  ),
+}
+
+/**
+ * Lines get a wider hit area: anywhere inside the plot area counts, and the
+ * click resolves to the nearest point — nearest category horizontally, then
+ * the series nearest to the cursor vertically.
+ *
+ * A line is a few pixels wide, so requiring a hit on it asks the user to miss.
+ * The tooltip here already made that concession (it is axis-triggered rather
+ * than item-triggered), and clicking now agrees with it.
+ *
+ * Worth trying: click well above every line, and then hide a series from the
+ * legend and click where it used to be — a hidden series is never the answer.
+ */
+export const AnywhereInAPlotArea: Story = {
+  render: () => (
+    <ClickDemo
+      chart={REVENUE}
+      hint="Click anywhere in the plot area — you do not have to hit a line. The nearest point answers."
+    />
+  ),
+}
+
+/**
+ * A scatter point is the relationship between two measures, so `value` alone
+ * cannot describe it — `values` carries both, in `[x, y]` order.
+ *
+ * Click **Roser Nogué**, the point at the top right: `value` is `0.6` (the
+ * tenure), while `values` is `[128000, 0.6]`. Quoting only `value` would drop
+ * the salary, which is the number that makes the point interesting.
+ */
+export const BothMeasuresOfAScatterPoint: Story = {
+  render: () => (
+    <ClickDemo
+      chart={SALARY_VS_TENURE}
+      hint="Click the outlier at the top right. `values` keeps the salary that `value` alone would lose."
+    />
+  ),
+}

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -2087,6 +2087,28 @@ describe("BarChart — legend isolation", () => {
     expect(isolated).toBeLessThan(full as number)
   })
 
+  it("reports the final legend visibility to companion surfaces", () => {
+    const onLegendSelectionChange = vi.fn()
+    render(
+      <F0DataChart
+        {...stacked}
+        onLegendSelectionChange={onLegendSelectionChange}
+      />
+    )
+
+    emitChartEvent("legendselectchanged", {
+      name: "Women",
+      selected: { Women: false, Men: true },
+    })
+
+    // The first click isolates the chosen series under F0's legend behavior,
+    // regardless of ECharts' intermediate default-toggle state.
+    expect(onLegendSelectionChange).toHaveBeenLastCalledWith({
+      Women: true,
+      Men: false,
+    })
+  })
+
   it("restores the full total when the legend is fully selected again", () => {
     render(<F0DataChart {...stacked} />)
     emitChartEvent("legendselectchanged", {

--- a/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
@@ -5,6 +5,7 @@ import { zeroRender as render } from "@/testing/test-utils"
 import { F0DataChart } from "../F0DataChart"
 
 const setOptionMock = vi.fn()
+const chartEventHandlers: Record<string, ((params: unknown) => void)[]> = {}
 
 vi.mock("echarts", () => ({
   init: vi.fn(() => ({
@@ -12,8 +13,18 @@ vi.mock("echarts", () => ({
     resize: vi.fn(),
     dispose: vi.fn(),
     getDom: vi.fn(() => document.createElement("div")),
-    on: vi.fn(),
-    off: vi.fn(),
+    on: vi.fn((event: string, handler: (params: unknown) => void) => {
+      chartEventHandlers[event] = [
+        ...(chartEventHandlers[event] ?? []),
+        handler,
+      ]
+    }),
+    off: vi.fn((event: string, handler: (params: unknown) => void) => {
+      chartEventHandlers[event] = (chartEventHandlers[event] ?? []).filter(
+        (candidate) => candidate !== handler
+      )
+    }),
+    dispatchAction: vi.fn(),
   })),
   use: vi.fn(),
   getInstanceByDom: vi.fn(),
@@ -64,8 +75,43 @@ const funnelProps = {
 
 beforeEach(() => {
   setOptionMock.mockClear()
+  for (const event of Object.keys(chartEventHandlers)) {
+    delete chartEventHandlers[event]
+  }
   containerSize.width = 800
   containerSize.height = 320
+})
+
+describe("FunnelChart — legend visibility", () => {
+  it("reports the final stage selection to companion surfaces", () => {
+    const onLegendSelectionChange = vi.fn()
+    render(
+      <F0DataChart
+        {...funnelProps}
+        showLegend
+        onLegendSelectionChange={onLegendSelectionChange}
+      />
+    )
+
+    chartEventHandlers.legendselectchanged?.forEach((handler) =>
+      handler({
+        name: "Applied",
+        selected: {
+          Applied: false,
+          Screened: true,
+          Interviewed: true,
+          Hired: true,
+        },
+      })
+    )
+
+    expect(onLegendSelectionChange).toHaveBeenLastCalledWith({
+      Applied: true,
+      Screened: false,
+      Interviewed: false,
+      Hired: false,
+    })
+  })
 })
 
 // The formatter runs inside ECharts on hover, so it only gets exercised by

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -15,6 +15,7 @@ import { F0DataChart } from "../F0DataChart"
 const setOptionMock = vi.fn()
 const onMock = vi.fn()
 const zrOnMock = vi.fn()
+const zrSetCursorStyleMock = vi.fn()
 
 vi.mock("echarts", () => ({
   init: vi.fn(() => ({
@@ -22,9 +23,15 @@ vi.mock("echarts", () => ({
     resize: vi.fn(),
     dispose: vi.fn(),
     getDom: vi.fn(() => document.createElement("div")),
+    getOption: getLatestOption,
+    containPixel: vi.fn(() => false),
     on: onMock,
     off: vi.fn(),
-    getZr: vi.fn(() => ({ on: zrOnMock, off: vi.fn() })),
+    getZr: vi.fn(() => ({
+      on: zrOnMock,
+      off: vi.fn(),
+      setCursorStyle: zrSetCursorStyleMock,
+    })),
     isDisposed: vi.fn(() => false),
   })),
   use: vi.fn(),
@@ -69,6 +76,7 @@ beforeEach(() => {
   setOptionMock.mockClear()
   onMock.mockClear()
   zrOnMock.mockClear()
+  zrSetCursorStyleMock.mockClear()
   containerSize.width = 800
   containerSize.height = 320
 })
@@ -90,7 +98,45 @@ describe("LineChart — click hit area", () => {
     )
 
     expect(zrOnMock).toHaveBeenCalledWith("click", expect.any(Function))
+    expect(zrOnMock).toHaveBeenCalledWith("mousemove", expect.any(Function))
+    expect(zrOnMock).toHaveBeenCalledWith("globalout", expect.any(Function))
     expect(onMock).not.toHaveBeenCalledWith("click", expect.any(Function))
+  })
+
+  it("keeps axis labels distinct from the clickable plot", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["Jan", "Feb", "Mar"]}
+        series={[{ name: "Revenue", data: [1, 2, 3] }]}
+        onPointClick={vi.fn()}
+      />
+    )
+
+    const axisMouseOver = onMock.mock.calls.find(
+      ([event]) => event === "mouseover"
+    )?.[1] as ((params: Record<string, unknown>) => void) | undefined
+
+    axisMouseOver?.({
+      componentType: "xAxis",
+      componentIndex: 0,
+      value: "Jan",
+      event: { offsetX: 40, offsetY: 240 },
+    })
+
+    expect(zrSetCursorStyleMock).toHaveBeenCalledWith("default")
+
+    zrSetCursorStyleMock.mockClear()
+    zrOnMock.mock.calls
+      .filter(([event]) => event === "mousemove")
+      .forEach(([, handler]) =>
+        (handler as (params: Record<string, unknown>) => void)({
+          offsetX: 40,
+          offsetY: 240,
+        })
+      )
+
+    expect(zrSetCursorStyleMock).toHaveBeenCalledWith("default")
   })
 })
 

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -13,6 +13,8 @@ import { F0DataChart } from "../F0DataChart"
 // ---------------------------------------------------------------------------
 
 const setOptionMock = vi.fn()
+const onMock = vi.fn()
+const zrOnMock = vi.fn()
 
 vi.mock("echarts", () => ({
   init: vi.fn(() => ({
@@ -20,8 +22,10 @@ vi.mock("echarts", () => ({
     resize: vi.fn(),
     dispose: vi.fn(),
     getDom: vi.fn(() => document.createElement("div")),
-    on: vi.fn(),
+    on: onMock,
     off: vi.fn(),
+    getZr: vi.fn(() => ({ on: zrOnMock, off: vi.fn() })),
+    isDisposed: vi.fn(() => false),
   })),
   use: vi.fn(),
   getInstanceByDom: vi.fn(),
@@ -63,8 +67,31 @@ function getLatestOption() {
 
 beforeEach(() => {
   setOptionMock.mockClear()
+  onMock.mockClear()
+  zrOnMock.mockClear()
   containerSize.width = 800
   containerSize.height = 320
+})
+
+describe("LineChart — click hit area", () => {
+  /**
+   * Pins the wiring, not the resolution (which `usePointClick`'s own tests
+   * cover): a line is too thin to require a hit on it, so this chart has to
+   * listen at the canvas level and must NOT take the mark-only path.
+   */
+  it("listens for clicks across the plot area, not on the marks", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["Jan", "Feb", "Mar"]}
+        series={[{ name: "Revenue", data: [1, 2, 3] }]}
+        onPointClick={vi.fn()}
+      />
+    )
+
+    expect(zrOnMock).toHaveBeenCalledWith("click", expect.any(Function))
+    expect(onMock).not.toHaveBeenCalledWith("click", expect.any(Function))
+  })
 })
 
 describe("LineChart — area mode", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
@@ -34,20 +34,73 @@ function makeChartStub() {
   }
 }
 
+/**
+ * Stand-in for a line chart, which resolves clicks itself instead of being
+ * handed a mark: the grid spans x 40–440 and y 20–220, categories sit every
+ * 100px from x=40, and the value axis runs 0 at the bottom to 100 at the top.
+ */
+function makeLineChartStub(option: {
+  series?: { name?: string; data?: unknown[] }[]
+  xAxis?: { data?: unknown[] }[]
+  legend?: { selected?: Record<string, boolean> }[]
+}) {
+  const zrHandlers: ((ev: unknown) => void)[] = []
+  const dispatched: { type: string }[] = []
+  let disposed = false
+  return {
+    zrHandlers,
+    dispatched,
+    dispose: () => {
+      disposed = true
+    },
+    instance: {
+      getZr: () => ({
+        on: (_event: string, fn: (ev: unknown) => void) => {
+          zrHandlers.push(fn)
+        },
+        off: (_event: string, fn: (ev: unknown) => void) => {
+          const i = zrHandlers.indexOf(fn)
+          if (i >= 0) zrHandlers.splice(i, 1)
+        },
+      }),
+      containPixel: (_finder: string, [x, y]: [number, number]) =>
+        x >= 40 && x <= 440 && y >= 20 && y <= 220,
+      convertFromPixel: (_finder: unknown, [x, y]: [number, number]) => [
+        (x - 40) / 100,
+        (220 - y) / 2,
+      ],
+      getOption: () => option,
+      isDisposed: () => disposed,
+      dispatchAction: (action: { type: string }) => {
+        dispatched.push(action)
+      },
+    } as unknown as echarts.ECharts,
+  }
+}
+
 const Harness = ({
   chart,
   onPointClick,
+  hitArea,
 }: {
   chart: echarts.ECharts
   onPointClick?: (point: F0DataChartPointClick) => void
+  hitArea?: "mark" | "plot"
 }) => {
   const ref = useRef<echarts.ECharts | null>(chart)
-  usePointClick(ref, onPointClick)
+  usePointClick(ref, onPointClick, hitArea)
   return null
 }
 
 const fire = (stub: ReturnType<typeof makeChartStub>, params: unknown) =>
   stub.handlers["click"]?.forEach((h) => h(params))
+
+const clickPlot = (
+  stub: ReturnType<typeof makeLineChartStub>,
+  offsetX: number,
+  offsetY: number,
+  event?: unknown
+) => stub.zrHandlers.forEach((h) => h({ offsetX, offsetY, event }))
 
 describe("usePointClick", () => {
   it("reports the clicked mark, normalised", () => {
@@ -249,5 +302,170 @@ describe("usePointClick", () => {
     // nothing. Only the absence of a throw is meaningful here.
     stub.dispose()
     expect(() => unmount()).not.toThrow()
+  })
+})
+
+describe("usePointClick — plot hit area (line charts)", () => {
+  const lineOption = {
+    xAxis: [{ data: ["Jan", "Feb", "Mar", "Apr", "May"] }],
+    series: [
+      { name: "Headcount", data: [10, 30, 50, 70, 90] },
+      { name: "Attrition", data: [5, 8, null, 12, 15] },
+    ],
+  }
+
+  const renderLine = (
+    stub: ReturnType<typeof makeLineChartStub>,
+    onPointClick = vi.fn()
+  ) => {
+    render(
+      <Harness
+        chart={stub.instance}
+        onPointClick={onPointClick}
+        hitArea="plot"
+      />
+    )
+    return onPointClick
+  }
+
+  it("answers a click that misses the line entirely", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    // x=140 is "Feb"; y=164 reads as 28 on the value axis — well off the line
+    // at 30, which is the whole point: a line is too thin to ask for a hit.
+    clickPlot(stub, 140, 164)
+
+    expect(onPointClick).toHaveBeenCalledWith({
+      seriesName: "Headcount",
+      category: "Feb",
+      value: 30,
+      values: [30],
+      dataIndex: 1,
+      seriesIndex: 0,
+      clientX: 0,
+      clientY: 0,
+    })
+  })
+
+  it("picks the series the click was aimed at, not the first one", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    // Same category, but low — nearer Attrition (8) than Headcount (30).
+    clickPlot(stub, 140, 208)
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ seriesName: "Attrition", value: 8 })
+    )
+  })
+
+  it("skips a series with a gap at that category", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    // "Mar" is null for Attrition. Aiming low there must not quote the gap as
+    // a zero — the only answer left is Headcount.
+    clickPlot(stub, 240, 208)
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ seriesName: "Headcount", value: 50 })
+    )
+  })
+
+  it("ignores a series the legend has switched off", () => {
+    const stub = makeLineChartStub({
+      ...lineOption,
+      legend: [{ selected: { Headcount: false, Attrition: true } }],
+    })
+    const onPointClick = renderLine(stub)
+
+    // Aimed at where Headcount would be, but it isn't on screen.
+    clickPlot(stub, 140, 164)
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ seriesName: "Attrition" })
+    )
+  })
+
+  it("rounds to the nearest category", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    clickPlot(stub, 189, 100) // 1.49 → Feb
+    clickPlot(stub, 191, 100) // 1.51 → Mar
+
+    expect(onPointClick.mock.calls.map(([p]) => p.category)).toEqual([
+      "Feb",
+      "Mar",
+    ])
+  })
+
+  it("ignores clicks outside the plot area", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    clickPlot(stub, 10, 100) // left of the grid, over the axis labels
+    clickPlot(stub, 200, 260) // below the grid, over the legend
+
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("stays quiet when no series has a value at that category", () => {
+    const stub = makeLineChartStub({
+      xAxis: [{ data: ["Jan"] }],
+      series: [{ name: "Headcount", data: [null] }],
+    })
+    const onPointClick = renderLine(stub)
+
+    clickPlot(stub, 40, 100)
+
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("carries the click position, from the touch when there is one", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    clickPlot(stub, 140, 164, { clientX: 500, clientY: 300 })
+    clickPlot(stub, 140, 164, {
+      changedTouches: [{ clientX: 120, clientY: 340 }],
+    })
+
+    expect(
+      onPointClick.mock.calls.map(([p]) => [p.clientX, p.clientY])
+    ).toEqual([
+      [500, 300],
+      [120, 340],
+    ])
+  })
+
+  it("dismisses the hover tooltip on a pick, and only on a pick", () => {
+    const stub = makeLineChartStub(lineOption)
+    renderLine(stub)
+
+    clickPlot(stub, 10, 100) // outside the plot — no pick
+    expect(stub.dispatched).toEqual([])
+
+    clickPlot(stub, 140, 164)
+    expect(stub.dispatched).toEqual([{ type: "hideTip" }])
+  })
+
+  it("detaches on unmount", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = vi.fn()
+    const { unmount } = render(
+      <Harness
+        chart={stub.instance}
+        onPointClick={onPointClick}
+        hitArea="plot"
+      />
+    )
+
+    unmount()
+
+    expect(stub.zrHandlers).toHaveLength(0)
+    clickPlot(stub, 140, 164)
+    expect(onPointClick).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
@@ -1,0 +1,214 @@
+import type * as echarts from "echarts"
+import { useRef } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import type { F0DataChartPointClick } from "../types"
+
+import { usePointClick } from "../utils/usePointClick"
+
+/** Minimal stand-in for an ECharts instance: records handlers so tests can fire them. */
+function makeChartStub() {
+  const handlers: Record<string, ((params: unknown) => void)[]> = {}
+  const dispatched: { type: string }[] = []
+  let disposed = false
+  return {
+    handlers,
+    dispatched,
+    dispose: () => {
+      disposed = true
+    },
+    instance: {
+      on: (event: string, fn: (params: unknown) => void) => {
+        handlers[event] = [...(handlers[event] ?? []), fn]
+      },
+      off: (event: string, fn: (params: unknown) => void) => {
+        handlers[event] = (handlers[event] ?? []).filter((h) => h !== fn)
+      },
+      isDisposed: () => disposed,
+      dispatchAction: (action: { type: string }) => {
+        dispatched.push(action)
+      },
+    } as unknown as echarts.ECharts,
+  }
+}
+
+const Harness = ({
+  chart,
+  onPointClick,
+}: {
+  chart: echarts.ECharts
+  onPointClick?: (point: F0DataChartPointClick) => void
+}) => {
+  const ref = useRef<echarts.ECharts | null>(chart)
+  usePointClick(ref, onPointClick)
+  return null
+}
+
+const fire = (stub: ReturnType<typeof makeChartStub>, params: unknown) =>
+  stub.handlers["click"]?.forEach((h) => h(params))
+
+describe("usePointClick", () => {
+  it("reports the clicked mark, normalised", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Male",
+      seriesIndex: 1,
+      dataIndex: 0,
+      name: "Barcelona office",
+      value: 18,
+      event: { event: { clientX: 420, clientY: 260 } },
+    })
+
+    expect(onPointClick).toHaveBeenCalledWith({
+      seriesName: "Male",
+      category: "Barcelona office",
+      value: 18,
+      dataIndex: 0,
+      seriesIndex: 1,
+      clientX: 420,
+      clientY: 260,
+    })
+  })
+
+  it("takes the measure from the last entry of a tuple value (scatter)", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Salary vs tenure",
+      seriesIndex: 0,
+      dataIndex: 4,
+      name: "",
+      value: [3, 52000],
+    })
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 52000, category: "" })
+    )
+  })
+
+  it("dismisses the hover tooltip on a pick", () => {
+    const stub = makeChartStub()
+    render(<Harness chart={stub.instance} onPointClick={vi.fn()} />)
+
+    // Otherwise the tooltip and whatever answers the click stack over one mark.
+    fire(stub, { componentType: "series", seriesName: "Male", value: 18 })
+
+    expect(stub.dispatched).toEqual([{ type: "hideTip" }])
+  })
+
+  it("leaves the tooltip alone when the click is not a pick", () => {
+    const stub = makeChartStub()
+    render(<Harness chart={stub.instance} onPointClick={vi.fn()} />)
+
+    fire(stub, { componentType: "legend", name: "Male" })
+    fire(stub, { componentType: "series", seriesName: "Male", value: null })
+
+    expect(stub.dispatched).toEqual([])
+  })
+
+  it("falls back to 0,0 when the event carries no position", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, { componentType: "series", seriesName: "Male", value: 18 })
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ clientX: 0, clientY: 0 })
+    )
+  })
+
+  it("ignores clicks that are not on a series", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    // Axis labels and legend entries raise `click` too, and carry no value.
+    fire(stub, { componentType: "xAxis", value: "Barcelona office" })
+    fire(stub, { componentType: "legend", name: "Male" })
+
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("ignores a series click with no usable value", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    // A gap in the data must not be quoted. `Number(null)` and `Number("")`
+    // are both 0, so these would read as a real zero without an explicit guard.
+    fire(stub, { componentType: "series", seriesName: "Male", value: null })
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Male",
+      value: undefined,
+    })
+    fire(stub, { componentType: "series", seriesName: "Male", value: "" })
+    fire(stub, { componentType: "series", seriesName: "Male", value: "n/a" })
+
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("still reports a genuine zero", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Not specified",
+      name: "Tokyo office",
+      value: 0,
+    })
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 0 })
+    )
+  })
+
+  it("does nothing when no handler is supplied", () => {
+    const stub = makeChartStub()
+    render(<Harness chart={stub.instance} />)
+
+    // Binding still happens, so the listener must tolerate an absent handler.
+    expect(() =>
+      fire(stub, { componentType: "series", seriesName: "Male", value: 1 })
+    ).not.toThrow()
+  })
+
+  it("detaches on unmount", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    const { unmount } = render(
+      <Harness chart={stub.instance} onPointClick={onPointClick} />
+    )
+
+    unmount()
+
+    expect(stub.handlers["click"]).toHaveLength(0)
+    fire(stub, { componentType: "series", seriesName: "Male", value: 1 })
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it("unmounts cleanly when the instance was already disposed", () => {
+    const stub = makeChartStub()
+    const { unmount } = render(
+      <Harness chart={stub.instance} onPointClick={vi.fn()} />
+    )
+
+    // `off` throws on a disposed instance, so cleanup has to skip it. The
+    // listener is left attached, which is harmless: a disposed chart emits
+    // nothing. Only the absence of a throw is meaningful here.
+    stub.dispose()
+    expect(() => unmount()).not.toThrow()
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
@@ -44,23 +44,39 @@ function makeLineChartStub(option: {
   xAxis?: { data?: unknown[] }[]
   legend?: { selected?: Record<string, boolean> }[]
 }) {
-  const zrHandlers: ((ev: unknown) => void)[] = []
+  const zrHandlers: Record<string, ((ev: unknown) => void)[]> = {}
+  const chartHandlers: Record<string, ((params: unknown) => void)[]> = {}
+  const cursorStyles: string[] = []
   const dispatched: { type: string }[] = []
   let disposed = false
   return {
     zrHandlers,
+    chartHandlers,
+    cursorStyles,
     dispatched,
     dispose: () => {
       disposed = true
     },
     instance: {
+      on: (event: string, fn: (params: unknown) => void) => {
+        chartHandlers[event] = [...(chartHandlers[event] ?? []), fn]
+      },
+      off: (event: string, fn: (params: unknown) => void) => {
+        chartHandlers[event] = (chartHandlers[event] ?? []).filter(
+          (handler) => handler !== fn
+        )
+      },
       getZr: () => ({
-        on: (_event: string, fn: (ev: unknown) => void) => {
-          zrHandlers.push(fn)
+        on: (event: string, fn: (ev: unknown) => void) => {
+          zrHandlers[event] = [...(zrHandlers[event] ?? []), fn]
         },
-        off: (_event: string, fn: (ev: unknown) => void) => {
-          const i = zrHandlers.indexOf(fn)
-          if (i >= 0) zrHandlers.splice(i, 1)
+        off: (event: string, fn: (ev: unknown) => void) => {
+          zrHandlers[event] = (zrHandlers[event] ?? []).filter(
+            (handler) => handler !== fn
+          )
+        },
+        setCursorStyle: (cursor: string) => {
+          cursorStyles.push(cursor)
         },
       }),
       containPixel: (_finder: string, [x, y]: [number, number]) =>
@@ -100,7 +116,30 @@ const clickPlot = (
   offsetX: number,
   offsetY: number,
   event?: unknown
-) => stub.zrHandlers.forEach((h) => h({ offsetX, offsetY, event }))
+) =>
+  stub.zrHandlers.click?.forEach((handler) =>
+    handler({ offsetX, offsetY, event })
+  )
+
+const hoverPlot = (
+  stub: ReturnType<typeof makeLineChartStub>,
+  offsetX: number,
+  offsetY: number
+) =>
+  stub.zrHandlers.mousemove?.forEach((handler) => handler({ offsetX, offsetY }))
+
+const leavePlot = (stub: ReturnType<typeof makeLineChartStub>) =>
+  stub.zrHandlers.globalout?.forEach((handler) => handler({}))
+
+const enterAxis = (stub: ReturnType<typeof makeLineChartStub>) =>
+  stub.chartHandlers.mouseover?.forEach((handler) =>
+    handler({ componentType: "xAxis" })
+  )
+
+const leaveAxis = (stub: ReturnType<typeof makeLineChartStub>) =>
+  stub.chartHandlers.mouseout?.forEach((handler) =>
+    handler({ componentType: "xAxis" })
+  )
 
 describe("usePointClick", () => {
   it("reports the clicked mark, normalised", () => {
@@ -542,6 +581,49 @@ describe("usePointClick — plot hit area (line charts)", () => {
     expect(onPointClick).not.toHaveBeenCalled()
   })
 
+  it("adds a pointer cursor inside the plot without overriding native targets", () => {
+    const stub = makeLineChartStub(lineOption)
+    renderLine(stub)
+
+    hoverPlot(stub, 140, 100)
+    hoverPlot(stub, 10, 100)
+    hoverPlot(stub, 200, 260)
+
+    expect(stub.cursorStyles).toEqual(["pointer"])
+  })
+
+  it("keeps the default cursor when the plot has no click handler", () => {
+    const stub = makeLineChartStub(lineOption)
+    render(<Harness chart={stub.instance} hitArea="plot" />)
+
+    hoverPlot(stub, 140, 100)
+
+    expect(stub.cursorStyles).toEqual([])
+  })
+
+  it("restores the default cursor after leaving the chart", () => {
+    const stub = makeLineChartStub(lineOption)
+    renderLine(stub)
+
+    hoverPlot(stub, 140, 100)
+    leavePlot(stub)
+
+    expect(stub.cursorStyles).toEqual(["pointer", "default"])
+  })
+
+  it("keeps axis labels default without overriding the legend", () => {
+    const stub = makeLineChartStub(lineOption)
+    renderLine(stub)
+
+    enterAxis(stub)
+    hoverPlot(stub, 10, 100)
+    hoverPlot(stub, 10, 100)
+    leaveAxis(stub)
+    hoverPlot(stub, 200, 260)
+
+    expect(stub.cursorStyles).toEqual(["default", "default", "default"])
+  })
+
   it("stays quiet when no series has a value at that category", () => {
     const stub = makeLineChartStub({
       xAxis: [{ data: ["Jan"] }],
@@ -595,7 +677,9 @@ describe("usePointClick — plot hit area (line charts)", () => {
 
     unmount()
 
-    expect(stub.zrHandlers).toHaveLength(0)
+    expect(Object.values(stub.zrHandlers).flat()).toHaveLength(0)
+    expect(Object.values(stub.chartHandlers).flat()).toHaveLength(0)
+    expect(stub.cursorStyles.at(-1)).toBe("default")
     clickPlot(stub, 140, 164)
     expect(onPointClick).not.toHaveBeenCalled()
   })

--- a/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
@@ -119,6 +119,7 @@ describe("usePointClick", () => {
     })
 
     expect(onPointClick).toHaveBeenCalledWith({
+      source: "pointer",
       seriesName: "Male",
       category: "Barcelona office",
       value: 18,
@@ -153,6 +154,37 @@ describe("usePointClick", () => {
     )
   })
 
+  it("rejects a tuple when any measure is not finite", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Engineering",
+      value: [Number.NaN, 0.6],
+    })
+
+    expect(onPointClick).not.toHaveBeenCalled()
+  })
+
+  it.each([null, undefined, ""])(
+    "rejects a tuple when an earlier measure is %s",
+    (invalid) => {
+      const stub = makeChartStub()
+      const onPointClick = vi.fn()
+      render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+      fire(stub, {
+        componentType: "series",
+        seriesName: "Engineering",
+        value: [invalid, 0.6],
+      })
+
+      expect(onPointClick).not.toHaveBeenCalled()
+    }
+  )
+
   it("keeps the whole tuple of a heatmap cell", () => {
     const stub = makeChartStub()
     const onPointClick = vi.fn()
@@ -167,6 +199,55 @@ describe("usePointClick", () => {
 
     expect(onPointClick).toHaveBeenCalledWith(
       expect.objectContaining({ value: 37, values: [2, 4, 37] })
+    )
+  })
+
+  it.each([
+    {
+      name: "radar",
+      params: {
+        componentType: "series",
+        name: "Team A",
+        value: [8, 7],
+        dataIndex: 1,
+        seriesIndex: 0,
+      },
+      expected: {
+        seriesName: "",
+        category: "Team A",
+        value: 7,
+        values: [8, 7],
+        dataIndex: 1,
+        seriesIndex: 0,
+      },
+    },
+    {
+      name: "gauge",
+      params: {
+        componentType: "series",
+        name: "Goal",
+        value: 72,
+        dataIndex: 0,
+        seriesIndex: 0,
+      },
+      expected: {
+        seriesName: "",
+        category: "Goal",
+        value: 72,
+        values: [72],
+        dataIndex: 0,
+        seriesIndex: 0,
+      },
+    },
+  ])("normalizes $name item semantics", ({ params, expected }) => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    fire(stub, params)
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ source: "pointer", ...expected })
     )
   })
 
@@ -339,6 +420,7 @@ describe("usePointClick — plot hit area (line charts)", () => {
     clickPlot(stub, 140, 164)
 
     expect(onPointClick).toHaveBeenCalledWith({
+      source: "pointer",
       seriesName: "Headcount",
       category: "Feb",
       value: 30,

--- a/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
@@ -123,6 +123,8 @@ describe("usePointClick", () => {
       category: "Barcelona office",
       value: 18,
       values: [18],
+      // A mark is one series, so the list holds exactly it.
+      series: [{ name: "Male", seriesIndex: 1, value: 18 }],
       dataIndex: 0,
       seriesIndex: 1,
       clientX: 420,
@@ -341,11 +343,49 @@ describe("usePointClick — plot hit area (line charts)", () => {
       category: "Feb",
       value: 30,
       values: [30],
+      series: [
+        { name: "Headcount", seriesIndex: 0, value: 30 },
+        { name: "Attrition", seriesIndex: 1, value: 8 },
+      ],
       dataIndex: 1,
       seriesIndex: 0,
       clientX: 0,
       clientY: 0,
     })
+  })
+
+  it("reports every series at the category, in configured order", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    // The tooltip here is axis-triggered: hovering "Feb" lists both series.
+    // A click covers the same column, so it answers with the same rows —
+    // wherever in the column it landed.
+    clickPlot(stub, 140, 30)
+    clickPlot(stub, 140, 210)
+
+    const columns = onPointClick.mock.calls.map(([p]) => p.series)
+    expect(columns[0]).toEqual(columns[1])
+    expect(columns[0]).toEqual([
+      { name: "Headcount", seriesIndex: 0, value: 30 },
+      { name: "Attrition", seriesIndex: 1, value: 8 },
+    ])
+  })
+
+  it("still names the nearest series as the headline", () => {
+    const stub = makeLineChartStub(lineOption)
+    const onPointClick = renderLine(stub)
+
+    // Same column, opposite ends: the list is identical, the headline is not.
+    clickPlot(stub, 140, 30) // high — near Headcount
+    clickPlot(stub, 140, 210) // low — near Attrition
+
+    expect(
+      onPointClick.mock.calls.map(([p]) => [p.seriesName, p.value])
+    ).toEqual([
+      ["Headcount", 30],
+      ["Attrition", 8],
+    ])
   })
 
   it("picks the series the click was aimed at, not the first one", () => {
@@ -365,11 +405,16 @@ describe("usePointClick — plot hit area (line charts)", () => {
     const onPointClick = renderLine(stub)
 
     // "Mar" is null for Attrition. Aiming low there must not quote the gap as
-    // a zero — the only answer left is Headcount.
+    // a zero — and the gap must not appear as a row either, since the tooltip
+    // doesn't show one.
     clickPlot(stub, 240, 208)
 
     expect(onPointClick).toHaveBeenCalledWith(
-      expect.objectContaining({ seriesName: "Headcount", value: 50 })
+      expect.objectContaining({
+        seriesName: "Headcount",
+        value: 50,
+        series: [{ name: "Headcount", seriesIndex: 0, value: 50 }],
+      })
     )
   })
 
@@ -380,11 +425,15 @@ describe("usePointClick — plot hit area (line charts)", () => {
     })
     const onPointClick = renderLine(stub)
 
-    // Aimed at where Headcount would be, but it isn't on screen.
+    // Aimed at where Headcount would be, but it isn't on screen — so it is
+    // neither the headline nor a row.
     clickPlot(stub, 140, 164)
 
     expect(onPointClick).toHaveBeenCalledWith(
-      expect.objectContaining({ seriesName: "Attrition" })
+      expect.objectContaining({
+        seriesName: "Attrition",
+        series: [{ name: "Attrition", seriesIndex: 1, value: 8 }],
+      })
     )
   })
 

--- a/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/usePointClick.test.tsx
@@ -69,6 +69,7 @@ describe("usePointClick", () => {
       seriesName: "Male",
       category: "Barcelona office",
       value: 18,
+      values: [18],
       dataIndex: 0,
       seriesIndex: 1,
       clientX: 420,
@@ -76,22 +77,41 @@ describe("usePointClick", () => {
     })
   })
 
-  it("takes the measure from the last entry of a tuple value (scatter)", () => {
+  it("keeps both measures of a scatter point, not just the last", () => {
     const stub = makeChartStub()
     const onPointClick = vi.fn()
     render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
 
     fire(stub, {
       componentType: "series",
-      seriesName: "Salary vs tenure",
+      seriesName: "Engineering",
       seriesIndex: 0,
       dataIndex: 4,
-      name: "",
-      value: [3, 52000],
+      name: "Roser Nogué",
+      value: [128000, 0.6],
+    })
+
+    // A scatter point *is* the relationship between its two measures, so
+    // reporting only `value` would quote the tenure and drop the salary.
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ value: 0.6, values: [128000, 0.6] })
+    )
+  })
+
+  it("keeps the whole tuple of a heatmap cell", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    // `[xIndex, yIndex, value]` — here the last entry really is the measure.
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Office activity",
+      value: [2, 4, 37],
     })
 
     expect(onPointClick).toHaveBeenCalledWith(
-      expect.objectContaining({ value: 52000, category: "" })
+      expect.objectContaining({ value: 37, values: [2, 4, 37] })
     )
   })
 
@@ -113,6 +133,25 @@ describe("usePointClick", () => {
     fire(stub, { componentType: "series", seriesName: "Male", value: null })
 
     expect(stub.dispatched).toEqual([])
+  })
+
+  it("takes the position from the touch on a touch device", () => {
+    const stub = makeChartStub()
+    const onPointClick = vi.fn()
+    render(<Harness chart={stub.instance} onPointClick={onPointClick} />)
+
+    // A TouchEvent has no `clientX` of its own — it lives on the touch. Without
+    // reading it the popover would anchor to the viewport corner.
+    fire(stub, {
+      componentType: "series",
+      seriesName: "Male",
+      value: 18,
+      event: { event: { changedTouches: [{ clientX: 120, clientY: 340 }] } },
+    })
+
+    expect(onPointClick).toHaveBeenCalledWith(
+      expect.objectContaining({ clientX: 120, clientY: 340 })
+    )
   })
 
   it("falls back to 0,0 when the event carries no position", () => {

--- a/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
@@ -32,7 +32,7 @@ export const BarChart = (props: F0DataChartBarProps) => {
   usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
-  useLegendInteraction(chartRef)
+  useLegendInteraction(chartRef, props.onLegendSelectionChange)
   useLegendSelection(
     chartRef,
     useCallback(

--- a/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
@@ -7,6 +7,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useLegendSelection } from "../../utils/useLegendSelection"
 import {
@@ -28,6 +29,7 @@ export const BarChart = (props: F0DataChartBarProps) => {
   > | null>(null)
   const options = useBarChartOptions(ref, props, size, legendSelection)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef)

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -10,6 +10,7 @@ import type {
 
 import { formatPercent } from "../../utils/formatters"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useFunnelChartOptions } from "./useFunnelChartOptions"
 
@@ -37,6 +38,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
   const ref = useRef<HTMLDivElement>(null)
   const options = useFunnelChartOptions(ref, props)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   useLegendInteraction(chartRef)
 
   const sorted = sortFunnelData(series.data ?? [], sort)

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -39,7 +39,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
   const options = useFunnelChartOptions(ref, props)
   const chartRef = useEChartsInstance(ref, options)
   usePointClick(chartRef, props.onPointClick)
-  useLegendInteraction(chartRef)
+  useLegendInteraction(chartRef, props.onLegendSelectionChange)
 
   const sorted = sortFunnelData(series.data ?? [], sort)
   const firstValue = sorted[0]?.value ?? 0

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
@@ -5,6 +5,7 @@ import type { F0DataChartGaugeProps } from "../../types"
 import { resolveChartSize } from "../../utils/responsive"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useGaugeChartOptions } from "./useGaugeChartOptions"
 
 export const GaugeChart = (props: F0DataChartGaugeProps) => {
@@ -12,7 +13,8 @@ export const GaugeChart = (props: F0DataChartGaugeProps) => {
   const { width } = useContainerSize(ref)
   const size = resolveChartSize(width)
   const options = useGaugeChartOptions(ref, props, size)
-  useEChartsInstance(ref, options)
+  const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
 
   return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
@@ -9,6 +9,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useHeatmapChartOptions } from "./useHeatmapChartOptions"
 
 export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
@@ -18,6 +19,7 @@ export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
   const size = resolveChartSize(width)
   const options = useHeatmapChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
 

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -23,7 +23,7 @@ export const LineChart = (props: F0DataChartLineProps) => {
   usePointClick(chartRef, props.onPointClick, "plot")
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
-  useLegendInteraction(chartRef)
+  useLegendInteraction(chartRef, props.onLegendSelectionChange)
 
   // ECharts (zrender) sets `cursor: pointer` on the canvas element via inline
   // style whenever an axis label has `triggerEvent: true` (which we need for

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -25,18 +25,5 @@ export const LineChart = (props: F0DataChartLineProps) => {
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef, props.onLegendSelectionChange)
 
-  // ECharts (zrender) sets `cursor: pointer` on the canvas element via inline
-  // style whenever an axis label has `triggerEvent: true` (which we need for
-  // the truncation tooltip). `axisLabel.cursor` is ignored for canvas-rendered
-  // labels, so `useAxisLabelTooltip` toggles `data-axis-hover="true"` on the
-  // container while the cursor is over an axis label, and the Tailwind
-  // arbitrary variant below scopes the `cursor: default !important` reset to
-  // exactly that window — leaving the rest of the chart with its normal
-  // pointer cursor over data points.
-  return (
-    <div
-      ref={ref}
-      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
-    />
-  )
+  return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -17,7 +17,10 @@ export const LineChart = (props: F0DataChartLineProps) => {
   const size = resolveChartSize(width)
   const options = useLineChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
-  usePointClick(chartRef, props.onPointClick)
+  // "plot", not "mark": a line is a few pixels wide, so requiring a hit on the
+  // line itself makes the action unusable. Same reason the tooltip here is
+  // axis-triggered — the whole column is one target.
+  usePointClick(chartRef, props.onPointClick, "plot")
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef)

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -7,6 +7,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useLineChartOptions } from "./useLineChartOptions"
 
@@ -16,6 +17,7 @@ export const LineChart = (props: F0DataChartLineProps) => {
   const size = resolveChartSize(width)
   const options = useLineChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef)

--- a/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
@@ -5,6 +5,7 @@ import type { F0DataChartPieProps } from "../../types"
 import { resolveChartSize } from "../../utils/responsive"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { usePieChartOptions } from "./usePieChartOptions"
 
@@ -14,6 +15,7 @@ export const PieChart = (props: F0DataChartPieProps) => {
   const size = resolveChartSize(width)
   const options = usePieChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   useLegendInteraction(chartRef)
 
   return <div ref={ref} className="h-full w-full" />

--- a/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
@@ -16,7 +16,7 @@ export const PieChart = (props: F0DataChartPieProps) => {
   const options = usePieChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
   usePointClick(chartRef, props.onPointClick)
-  useLegendInteraction(chartRef)
+  useLegendInteraction(chartRef, props.onLegendSelectionChange)
 
   return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
@@ -5,6 +5,7 @@ import type { F0DataChartRadarProps } from "../../types"
 import { resolveChartSize } from "../../utils/responsive"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useRadarChartOptions } from "./useRadarChartOptions"
 
@@ -14,6 +15,7 @@ export const RadarChart = (props: F0DataChartRadarProps) => {
   const size = resolveChartSize(width)
   const options = useRadarChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   useLegendInteraction(chartRef)
 
   return <div ref={ref} className="h-full w-full" />

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
@@ -16,7 +16,7 @@ export const RadarChart = (props: F0DataChartRadarProps) => {
   const options = useRadarChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
   usePointClick(chartRef, props.onPointClick)
-  useLegendInteraction(chartRef)
+  useLegendInteraction(chartRef, props.onLegendSelectionChange)
 
   return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/ScatterChart/ScatterChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/ScatterChart/ScatterChart.tsx
@@ -7,6 +7,7 @@ import { useAxisLabelTooltip } from "../../utils/useAxisLabelTooltip"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
 import { useEChartsInstance } from "../../utils/useEChartsInstance"
+import { usePointClick } from "../../utils/usePointClick"
 import { useLegendInteraction } from "../../utils/useLegendInteraction"
 import { useScatterChartOptions } from "./useScatterChartOptions"
 
@@ -16,6 +17,7 @@ export const ScatterChart = (props: F0DataChartScatterProps) => {
   const size = resolveChartSize(width)
   const options = useScatterChartOptions(ref, props, size)
   const chartRef = useEChartsInstance(ref, options)
+  usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
   useLegendInteraction(chartRef)

--- a/packages/react/src/kits/F0DataChart/components/ScatterChart/ScatterChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/ScatterChart/ScatterChart.tsx
@@ -20,7 +20,7 @@ export const ScatterChart = (props: F0DataChartScatterProps) => {
   usePointClick(chartRef, props.onPointClick)
   const theme = useChartTheme(ref)
   useAxisLabelTooltip(chartRef, ref, theme)
-  useLegendInteraction(chartRef)
+  useLegendInteraction(chartRef, props.onLegendSelectionChange)
 
   // The Y axis carries a `maxLabelWidth`, so it sets `triggerEvent: true` for
   // the truncation tooltip — which makes zrender put `cursor: pointer` on the

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -20,6 +20,7 @@ export type {
   F0DataChartPieProps,
   F0DataChartPieSeries,
   F0DataChartPointClick,
+  F0DataChartPointClickSeries,
   F0DataChartProps,
   F0DataChartRadarIndicator,
   F0DataChartRadarProps,

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -19,6 +19,7 @@ export type {
   F0DataChartPieDataPoint,
   F0DataChartPieProps,
   F0DataChartPieSeries,
+  F0DataChartPointClick,
   F0DataChartProps,
   F0DataChartRadarIndicator,
   F0DataChartRadarProps,

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -46,6 +46,17 @@ export interface F0DataChartPointClick {
   category: string
   /** Raw, unformatted value. Consumers apply their own formatting. */
   value: number
+  /**
+   * Every number the mark carries, in series order: `[42]` for a bar or a
+   * slice, `[x, y]` for a scatter point, `[xIndex, yIndex, value]` for a
+   * heatmap cell.
+   *
+   * {@link value} is the last entry, which is the measure for every type
+   * except scatter — there both entries are measures, and quoting only the
+   * last one drops half the point. Read this when the chart type has more
+   * than one number to say.
+   */
+  values: number[]
   /** Index of the clicked mark within its series. */
   dataIndex: number
   /** Index of the series the mark belongs to. */
@@ -53,7 +64,8 @@ export interface F0DataChartPointClick {
   /**
    * Where the click landed, in viewport coordinates — enough to anchor a
    * floating element without the consumer having to reach for the chart's own
-   * geometry. Both are 0 if the event carried no position.
+   * geometry. Taken from the touch on a touch device, where the event itself
+   * carries no coordinates. Both are 0 if neither did.
    */
   clientX: number
   clientY: number

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -34,7 +34,7 @@ export interface F0DataChartEmptyStateProps {
 
 /** One series' value at the category a click resolved to. */
 export interface F0DataChartPointClickSeries {
-  /** Series name, as shown in the legend ("Male"). */
+  /** Configured series name. Empty when ECharts does not report one. */
   name: string
   /** Index of the series in the chart's own series list. */
   seriesIndex: number
@@ -53,10 +53,13 @@ export interface F0DataChartPointClickSeries {
  */
 export interface F0DataChartPointClick {
   /** Interaction surface that resolved the point. */
-  source: "pointer" | "keyboard"
-  /** Series the mark belongs to, as shown in the legend ("Male"). */
+  source: "pointer"
+  /** Configured series name for the mark. Empty when ECharts does not report one. */
   seriesName: string
-  /** Category the mark sits at ("Barcelona office"). Empty for chart types with no category axis. */
+  /**
+   * Mark name reported by ECharts: an axis category, pie slice, funnel stage,
+   * scatter label, or gauge/radar item name. Empty when the mark has no name.
+   */
   category: string
   /** Raw, unformatted value. Consumers apply their own formatting. */
   value: number
@@ -89,8 +92,8 @@ export interface F0DataChartPointClick {
    * Where a pointer click landed, in viewport coordinates — enough to anchor a
    * floating element without the consumer having to reach for the chart's own
    * geometry. Taken from the touch on a touch device, where the event itself
-   * carries no coordinates. Both are 0 for a keyboard-resolved point or if a
-   * pointer event carried no coordinates; use {@link source} to distinguish.
+   * carries no coordinates. Both are 0 if the pointer event carried no
+   * coordinates.
    */
   clientX: number
   clientY: number
@@ -103,12 +106,6 @@ interface F0DataChartCommonProps {
   /** Customize or opt out of the empty state shown when data is empty. */
   emptyState?: F0DataChartEmptyStateProps
   /**
-   * Reports the chart's live legend visibility after an interactive toggle.
-   * Primarily used by accessible companion surfaces that must expose the same
-   * data currently shown on the canvas.
-   */
-  onLegendSelectionChange?: (selected: Record<string, boolean>) => void
-  /**
    * Called when the user clicks a single mark (bar segment, slice, point).
    * Omit to leave clicks inert, which is the default for every chart.
    *
@@ -118,6 +115,16 @@ interface F0DataChartCommonProps {
    * {@link F0DataChartPointClick.series}, matching what the tooltip showed.
    */
   onPointClick?: (point: F0DataChartPointClick) => void
+}
+
+/** Props shared only by variants with an interactive legend. */
+interface F0DataChartLegendInteractionProps {
+  /**
+   * Reports the chart's live legend visibility after an interactive toggle.
+   * Primarily used by accessible companion surfaces that must expose the same
+   * data currently shown on the canvas.
+   */
+  onLegendSelectionChange?: (selected: Record<string, boolean>) => void
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +196,8 @@ export interface F0DataChartLineSeries {
 // Shared base props
 // ---------------------------------------------------------------------------
 
-interface F0DataChartBaseProps extends F0DataChartCommonProps {
+interface F0DataChartBaseProps
+  extends F0DataChartCommonProps, F0DataChartLegendInteractionProps {
   /** Labels for the category axis (one per data point) */
   categories: string[]
 
@@ -372,7 +380,8 @@ export interface F0DataChartFunnelSeries {
  * Funnels do NOT use category/value axes — stage names come from the data
  * points themselves. This interface is separate from `F0DataChartBaseProps`.
  */
-export interface F0DataChartFunnelProps extends F0DataChartCommonProps {
+export interface F0DataChartFunnelProps
+  extends F0DataChartCommonProps, F0DataChartLegendInteractionProps {
   /** Chart type */
   type: "funnel"
   /** The funnel series to render */
@@ -450,7 +459,8 @@ export interface F0DataChartPieSeries {
  * Pies do NOT use category/value axes — segment names come from the data
  * points themselves. This interface is separate from `F0DataChartBaseProps`.
  */
-export interface F0DataChartPieProps extends F0DataChartCommonProps {
+export interface F0DataChartPieProps
+  extends F0DataChartCommonProps, F0DataChartLegendInteractionProps {
   /** Chart type */
   type: "pie"
   /** The pie series to render */
@@ -511,7 +521,8 @@ export interface F0DataChartRadarSeries {
  *
  * Radar charts use a polar coordinate system — no cartesian axes.
  */
-export interface F0DataChartRadarProps extends F0DataChartCommonProps {
+export interface F0DataChartRadarProps
+  extends F0DataChartCommonProps, F0DataChartLegendInteractionProps {
   /** Chart type */
   type: "radar"
   /** Axes of the radar — defines the dimensions to compare */
@@ -664,7 +675,8 @@ export interface F0DataChartScatterSeries {
  * continuous — so this interface is separate from `F0DataChartBaseProps`.
  * Pass multiple `series` to color-split the points by a group dimension.
  */
-export interface F0DataChartScatterProps extends F0DataChartCommonProps {
+export interface F0DataChartScatterProps
+  extends F0DataChartCommonProps, F0DataChartLegendInteractionProps {
   /** Chart type */
   type: "scatter"
   /** One or more point groups. Multiple series render as a color split. */

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -32,12 +32,24 @@ export interface F0DataChartEmptyStateProps {
   disabled?: boolean
 }
 
+/** One series' value at the category a click resolved to. */
+export interface F0DataChartPointClickSeries {
+  /** Series name, as shown in the legend ("Male"). */
+  name: string
+  /** Index of the series in the chart's own series list. */
+  seriesIndex: number
+  /** Raw, unformatted value at this category. */
+  value: number
+}
+
 /**
- * The single mark a click landed on — one bar segment, one slice, one point.
+ * What a click resolved to — one bar segment, one slice, one point, or (for a
+ * line, where the click can land anywhere in the plot area) a whole category.
  *
- * Note this is narrower than what an axis-triggered tooltip displays: hovering
- * a category reveals every series at it, while a click can only ever identify
- * the one mark under the cursor.
+ * The top-level fields always name a single series, so a consumer that wants
+ * one number has one. {@link F0DataChartPointClick.series} carries everything
+ * the click resolved, which for a line is every series at that category — the
+ * same rows its tooltip shows.
  */
 export interface F0DataChartPointClick {
   /** Series the mark belongs to, as shown in the legend ("Male"). */
@@ -57,6 +69,16 @@ export interface F0DataChartPointClick {
    * than one number to say.
    */
   values: number[]
+  /**
+   * Every series the click resolved, in the order they are configured.
+   *
+   * A line chart accepts a click anywhere in its plot area, so this is the
+   * whole category — one entry per series that has a value there and is
+   * switched on in the legend, exactly the rows its axis tooltip shows.
+   * Everywhere else a click identifies one mark and this holds that one entry,
+   * matching {@link seriesName} and {@link value}.
+   */
+  series: F0DataChartPointClickSeries[]
   /** Index of the clicked mark within its series. */
   dataIndex: number
   /** Index of the series the mark belongs to. */
@@ -81,10 +103,10 @@ interface F0DataChartCommonProps {
    * Called when the user clicks a single mark (bar segment, slice, point).
    * Omit to leave clicks inert, which is the default for every chart.
    *
-   * Line charts accept a click anywhere in the plot area and answer with the
-   * nearest point, since a line is too thin to hit — the same allowance their
-   * axis-triggered tooltip already makes. What arrives here is identical
-   * either way.
+   * Line charts accept a click anywhere in the plot area, since a line is too
+   * thin to hit — the same allowance their axis-triggered tooltip already
+   * makes — and answer with the whole category in
+   * {@link F0DataChartPointClick.series}, matching what the tooltip showed.
    */
   onPointClick?: (point: F0DataChartPointClick) => void
 }

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -52,6 +52,8 @@ export interface F0DataChartPointClickSeries {
  * same rows its tooltip shows.
  */
 export interface F0DataChartPointClick {
+  /** Interaction surface that resolved the point. */
+  source: "pointer" | "keyboard"
   /** Series the mark belongs to, as shown in the legend ("Male"). */
   seriesName: string
   /** Category the mark sits at ("Barcelona office"). Empty for chart types with no category axis. */
@@ -84,10 +86,11 @@ export interface F0DataChartPointClick {
   /** Index of the series the mark belongs to. */
   seriesIndex: number
   /**
-   * Where the click landed, in viewport coordinates — enough to anchor a
+   * Where a pointer click landed, in viewport coordinates — enough to anchor a
    * floating element without the consumer having to reach for the chart's own
    * geometry. Taken from the touch on a touch device, where the event itself
-   * carries no coordinates. Both are 0 if neither did.
+   * carries no coordinates. Both are 0 for a keyboard-resolved point or if a
+   * pointer event carried no coordinates; use {@link source} to distinguish.
    */
   clientX: number
   clientY: number
@@ -99,6 +102,12 @@ export interface F0DataChartPointClick {
 interface F0DataChartCommonProps {
   /** Customize or opt out of the empty state shown when data is empty. */
   emptyState?: F0DataChartEmptyStateProps
+  /**
+   * Reports the chart's live legend visibility after an interactive toggle.
+   * Primarily used by accessible companion surfaces that must expose the same
+   * data currently shown on the canvas.
+   */
+  onLegendSelectionChange?: (selected: Record<string, boolean>) => void
   /**
    * Called when the user clicks a single mark (bar segment, slice, point).
    * Omit to leave clicks inert, which is the default for every chart.

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -33,11 +33,43 @@ export interface F0DataChartEmptyStateProps {
 }
 
 /**
+ * The single mark a click landed on — one bar segment, one slice, one point.
+ *
+ * Note this is narrower than what an axis-triggered tooltip displays: hovering
+ * a category reveals every series at it, while a click can only ever identify
+ * the one mark under the cursor.
+ */
+export interface F0DataChartPointClick {
+  /** Series the mark belongs to, as shown in the legend ("Male"). */
+  seriesName: string
+  /** Category the mark sits at ("Barcelona office"). Empty for chart types with no category axis. */
+  category: string
+  /** Raw, unformatted value. Consumers apply their own formatting. */
+  value: number
+  /** Index of the clicked mark within its series. */
+  dataIndex: number
+  /** Index of the series the mark belongs to. */
+  seriesIndex: number
+  /**
+   * Where the click landed, in viewport coordinates — enough to anchor a
+   * floating element without the consumer having to reach for the chart's own
+   * geometry. Both are 0 if the event carried no position.
+   */
+  clientX: number
+  clientY: number
+}
+
+/**
  * Props shared by every `F0DataChart` variant.
  */
 interface F0DataChartCommonProps {
   /** Customize or opt out of the empty state shown when data is empty. */
   emptyState?: F0DataChartEmptyStateProps
+  /**
+   * Called when the user clicks a single mark (bar segment, slice, point).
+   * Omit to leave clicks inert, which is the default for every chart.
+   */
+  onPointClick?: (point: F0DataChartPointClick) => void
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -80,6 +80,11 @@ interface F0DataChartCommonProps {
   /**
    * Called when the user clicks a single mark (bar segment, slice, point).
    * Omit to leave clicks inert, which is the default for every chart.
+   *
+   * Line charts accept a click anywhere in the plot area and answer with the
+   * nearest point, since a line is too thin to hit — the same allowance their
+   * axis-triggered tooltip already makes. What arrives here is identical
+   * either way.
    */
   onPointClick?: (point: F0DataChartPointClick) => void
 }

--- a/packages/react/src/kits/F0DataChart/utils/useLegendInteraction.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useLegendInteraction.ts
@@ -13,10 +13,13 @@ import { type RefObject, useEffect, useRef } from "react"
  * state from ECharts' `legendselectchanged` event.
  */
 export function useLegendInteraction(
-  chartRef: RefObject<echarts.ECharts | null>
+  chartRef: RefObject<echarts.ECharts | null>,
+  onSelectionChange?: (selected: Record<string, boolean>) => void
 ) {
   // Track the previous selected state so we know what changed
   const prevSelectedRef = useRef<Record<string, boolean> | null>(null)
+  const onSelectionChangeRef = useRef(onSelectionChange)
+  onSelectionChangeRef.current = onSelectionChange
 
   useEffect(() => {
     const chart = chartRef.current
@@ -47,6 +50,7 @@ export function useLegendInteraction(
           next[name] = name === clickedName
         }
         prevSelectedRef.current = next
+        onSelectionChangeRef.current?.(next)
         chart!.dispatchAction({ type: "legendSelect", name: clickedName })
         for (const name of allNames) {
           if (name !== clickedName) {
@@ -64,11 +68,13 @@ export function useLegendInteraction(
           chart!.dispatchAction({ type: "legendSelect", name })
         }
         prevSelectedRef.current = next
+        onSelectionChangeRef.current?.(next)
         return
       }
 
       // Default: accept ECharts' toggle
       prevSelectedRef.current = { ...echartsSelected }
+      onSelectionChangeRef.current?.({ ...echartsSelected })
     }
 
     chart.on(

--- a/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
+++ b/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
@@ -4,6 +4,87 @@ import { type RefObject, useEffect, useRef } from "react"
 import type { F0DataChartPointClick } from "../types"
 
 /**
+ * Where a click has to land to count as a pick.
+ *
+ * - `"mark"` — on the mark itself. Right for bars, slices and points, which
+ *   are big enough to hit.
+ * - `"plot"` — anywhere inside the plot area, resolved to the nearest mark.
+ *   For lines, which are too thin to click reliably — the same reason they
+ *   already use an axis-triggered tooltip rather than an item one.
+ */
+export type F0DataChartHitArea = "mark" | "plot"
+
+type NativePosition =
+  | {
+      clientX?: number
+      clientY?: number
+      changedTouches?: ArrayLike<{ clientX: number; clientY: number }>
+    }
+  | undefined
+
+/**
+ * Viewport coordinates of a click. A `TouchEvent` carries no `clientX` of its
+ * own — it lives on the touch — so anything anchored to the click would end up
+ * in the viewport corner without this.
+ */
+function positionOf(native: NativePosition) {
+  const touch = native?.changedTouches?.[0]
+  return {
+    clientX: touch?.clientX ?? native?.clientX ?? 0,
+    clientY: touch?.clientY ?? native?.clientY ?? 0,
+  }
+}
+
+type PlotSeries = { name?: string; data?: unknown[] }
+
+/**
+ * The series whose value at `dataIndex` sits closest to `yValue` — the line the
+ * user was aiming at when they clicked in the plot area.
+ *
+ * Skips gaps and anything the legend has switched off, so a click never quotes
+ * a series that isn't on screen. Null when no series has a value here.
+ */
+function pickNearestSeries(
+  series: PlotSeries[],
+  dataIndex: number,
+  yValue: number,
+  selected?: Record<string, boolean>
+): { seriesIndex: number; seriesName: string; value: number } | null {
+  let best: {
+    seriesIndex: number
+    seriesName: string
+    value: number
+    distance: number
+  } | null = null
+
+  series.forEach((entry, seriesIndex) => {
+    const seriesName = String(entry.name ?? "")
+    if (selected?.[seriesName] === false) return
+
+    const point = entry.data?.[dataIndex]
+    // A series that styles one of its points sends `{ value }` instead of a
+    // bare number for that entry.
+    const raw =
+      point !== null && typeof point === "object" && "value" in point
+        ? (point as { value?: unknown }).value
+        : point
+    if (raw === null || raw === undefined || raw === "") return
+
+    const value = Number(raw)
+    if (!Number.isFinite(value)) return
+
+    const distance = Math.abs(value - yValue)
+    if (!best || distance < best.distance) {
+      best = { seriesIndex, seriesName, value, distance }
+    }
+  })
+
+  if (!best) return null
+  const { seriesIndex, seriesName, value } = best
+  return { seriesIndex, seriesName, value }
+}
+
+/**
  * Reports the single mark the user clicked — one bar segment, one slice, one
  * point — normalised into {@link F0DataChartPointClick}.
  *
@@ -11,10 +92,16 @@ import type { F0DataChartPointClick } from "../types"
  * same fields regardless of series type, so this binds once at the instance
  * level rather than needing a variant per chart.
  *
+ * With `hitArea: "plot"` it instead listens at the canvas level and resolves
+ * the click itself: nearest category on the x axis, nearest series by value.
+ * A line is a few pixels wide, so asking the user to hit one is asking them to
+ * miss; the axis tooltip already treats the whole column as one target and this
+ * makes clicking agree with it. What gets reported is unchanged — one series,
+ * one value — so consumers can't tell the two paths apart.
+ *
  * Deliberately narrower than the hover tooltip: an axis-triggered tooltip shows
- * every series at a category, but a click can only identify the mark under the
- * cursor. Reconstructing the full category would mean reading back the option's
- * series, which is a different feature.
+ * every series at a category, but a click can only answer with the one the
+ * user was pointing at.
  *
  * Dismisses the hover tooltip on a successful pick: the click is answered by
  * something anchored at the same spot, and leaving the tooltip up would stack
@@ -22,7 +109,8 @@ import type { F0DataChartPointClick } from "../types"
  */
 export function usePointClick(
   chartRef: RefObject<echarts.ECharts | null>,
-  onPointClick: ((point: F0DataChartPointClick) => void) | undefined
+  onPointClick: ((point: F0DataChartPointClick) => void) | undefined,
+  hitArea: F0DataChartHitArea = "mark"
 ): void {
   // Kept in a ref so a consumer passing an inline arrow doesn't detach and
   // rebind the listener on every render.
@@ -31,7 +119,86 @@ export function usePointClick(
 
   useEffect(() => {
     const chart = chartRef.current
-    if (!chart || typeof chart.on !== "function") return
+    if (!chart) return
+
+    // ─── "plot": resolve the click from the canvas ──────────────
+    if (hitArea === "plot") {
+      if (typeof chart.getZr !== "function") return
+      const zr = chart.getZr()
+      if (!zr) return
+
+      const onPlotClick = (ev: unknown) => {
+        const handler = handlerRef.current
+        if (!handler) return
+
+        const e = ev as {
+          offsetX?: number
+          offsetY?: number
+          event?: NativePosition
+        }
+        if (typeof e.offsetX !== "number" || typeof e.offsetY !== "number")
+          return
+
+        const pixel: [number, number] = [e.offsetX, e.offsetY]
+        // The plot area only: clicks on the legend, the axes or the margins
+        // aren't picks, and this is exactly the region the tooltip covers.
+        if (!chart.containPixel("grid", pixel)) return
+
+        const coords = chart.convertFromPixel({ gridIndex: 0 }, pixel) as
+          | number[]
+          | undefined
+        const xValue = coords?.[0]
+        const yValue = coords?.[1]
+        if (typeof xValue !== "number" || !Number.isFinite(xValue)) return
+        if (typeof yValue !== "number" || !Number.isFinite(yValue)) return
+
+        const option = chart.getOption() as {
+          series?: PlotSeries[]
+          xAxis?: { data?: unknown[] }[]
+          legend?: { selected?: Record<string, boolean> }[]
+        }
+        const categories = option.xAxis?.[0]?.data ?? []
+        // On a category axis this is the fractional index; rounding lands on
+        // the nearest tick. Clamped because `boundaryGap: false` puts the
+        // first and last category on the grid edges, where the fraction can
+        // fall just outside the range.
+        const dataIndex = Math.min(
+          Math.max(Math.round(xValue), 0),
+          Math.max(categories.length - 1, 0)
+        )
+
+        const nearest = pickNearestSeries(
+          option.series ?? [],
+          dataIndex,
+          yValue,
+          option.legend?.[0]?.selected
+        )
+        if (!nearest) return
+
+        // `hideTip` is safe to fire even with no tooltip showing.
+        chart.dispatchAction({ type: "hideTip" })
+
+        handler({
+          seriesName: nearest.seriesName,
+          category: String(categories[dataIndex] ?? ""),
+          value: nearest.value,
+          values: [nearest.value],
+          dataIndex,
+          seriesIndex: nearest.seriesIndex,
+          ...positionOf(e.event),
+        })
+      }
+
+      zr.on("click", onPlotClick)
+      return () => {
+        // `off` throws on a disposed instance, which happens when the chart
+        // unmounts before this cleanup runs.
+        if (!chart.isDisposed?.()) zr.off("click", onPlotClick)
+      }
+    }
+
+    // ─── "mark": ECharts names the mark for us ──────────────────
+    if (typeof chart.on !== "function") return
 
     const onClick = (params: unknown) => {
       const handler = handlerRef.current
@@ -47,13 +214,7 @@ export function usePointClick(
         // ECharts wraps the native event; `event.event` is the DOM original,
         // which is a TouchEvent on touch — where the position lives on the
         // touch, not on the event.
-        event?: {
-          event?: {
-            clientX?: number
-            clientY?: number
-            changedTouches?: ArrayLike<{ clientX: number; clientY: number }>
-          }
-        }
+        event?: { event?: NativePosition }
       }
 
       // Axis labels, legend entries and the like also raise `click`; only marks
@@ -72,9 +233,6 @@ export function usePointClick(
       const value = Number(raw)
       if (!Number.isFinite(value)) return
 
-      const native = p.event?.event
-      const touch = native?.changedTouches?.[0]
-
       // `hideTip` is safe to fire even with no tooltip showing.
       chart.dispatchAction({ type: "hideTip" })
 
@@ -85,8 +243,7 @@ export function usePointClick(
         values: list.map(Number),
         dataIndex: p.dataIndex ?? 0,
         seriesIndex: p.seriesIndex ?? 0,
-        clientX: touch?.clientX ?? native?.clientX ?? 0,
-        clientY: touch?.clientY ?? native?.clientY ?? 0,
+        ...positionOf(p.event?.event),
       })
     }
 
@@ -96,5 +253,5 @@ export function usePointClick(
       // unmounts before this cleanup runs.
       if (!chart.isDisposed?.()) chart.off("click", onClick)
     }
-  }, [chartRef])
+  }, [chartRef, hitArea])
 }

--- a/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
+++ b/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
@@ -1,7 +1,10 @@
 import type * as echarts from "echarts"
 import { type RefObject, useEffect, useRef } from "react"
 
-import type { F0DataChartPointClick } from "../types"
+import type {
+  F0DataChartPointClick,
+  F0DataChartPointClickSeries,
+} from "../types"
 
 /**
  * Where a click has to land to count as a pick.
@@ -38,28 +41,30 @@ function positionOf(native: NativePosition) {
 type PlotSeries = { name?: string; data?: unknown[] }
 
 /**
- * The series whose value at `dataIndex` sits closest to `yValue` — the line the
- * user was aiming at when they clicked in the plot area.
+ * Every series that has a value at `dataIndex`, in configured order — the same
+ * rows the axis tooltip shows — plus the one nearest `yValue`, which is the
+ * line the user was aiming at.
  *
- * Skips gaps and anything the legend has switched off, so a click never quotes
- * a series that isn't on screen. Null when no series has a value here.
+ * Skips gaps and anything the legend has switched off, so a click never
+ * reports a series that isn't on screen. Null when the whole category is
+ * empty.
  */
-function pickNearestSeries(
+function resolveColumn(
   series: PlotSeries[],
   dataIndex: number,
   yValue: number,
   selected?: Record<string, boolean>
-): { seriesIndex: number; seriesName: string; value: number } | null {
-  let best: {
-    seriesIndex: number
-    seriesName: string
-    value: number
-    distance: number
-  } | null = null
+): {
+  series: F0DataChartPointClickSeries[]
+  nearest: F0DataChartPointClickSeries
+} | null {
+  const entries: F0DataChartPointClickSeries[] = []
+  let nearest: F0DataChartPointClickSeries | null = null
+  let nearestDistance = Infinity
 
   series.forEach((entry, seriesIndex) => {
-    const seriesName = String(entry.name ?? "")
-    if (selected?.[seriesName] === false) return
+    const name = String(entry.name ?? "")
+    if (selected?.[name] === false) return
 
     const point = entry.data?.[dataIndex]
     // A series that styles one of its points sends `{ value }` instead of a
@@ -73,15 +78,17 @@ function pickNearestSeries(
     const value = Number(raw)
     if (!Number.isFinite(value)) return
 
+    const resolved = { name, seriesIndex, value }
+    entries.push(resolved)
+
     const distance = Math.abs(value - yValue)
-    if (!best || distance < best.distance) {
-      best = { seriesIndex, seriesName, value, distance }
+    if (distance < nearestDistance) {
+      nearestDistance = distance
+      nearest = resolved
     }
   })
 
-  if (!best) return null
-  const { seriesIndex, seriesName, value } = best
-  return { seriesIndex, seriesName, value }
+  return nearest ? { series: entries, nearest } : null
 }
 
 /**
@@ -93,15 +100,15 @@ function pickNearestSeries(
  * level rather than needing a variant per chart.
  *
  * With `hitArea: "plot"` it instead listens at the canvas level and resolves
- * the click itself: nearest category on the x axis, nearest series by value.
- * A line is a few pixels wide, so asking the user to hit one is asking them to
- * miss; the axis tooltip already treats the whole column as one target and this
- * makes clicking agree with it. What gets reported is unchanged — one series,
- * one value — so consumers can't tell the two paths apart.
+ * the click itself: nearest category on the x axis, then every series that has
+ * a value there. A line is a few pixels wide, so asking the user to hit one is
+ * asking them to miss; the axis tooltip already treats the whole column as one
+ * target, and this makes clicking agree with it — the click answers with the
+ * same rows the hover did.
  *
- * Deliberately narrower than the hover tooltip: an axis-triggered tooltip shows
- * every series at a category, but a click can only answer with the one the
- * user was pointing at.
+ * `seriesName` and `value` still name a single series: the one nearest the
+ * click, so anything that wants a headline has one. `series` carries the whole
+ * column beside it.
  *
  * Dismisses the hover tooltip on a successful pick: the click is answered by
  * something anchored at the same spot, and leaving the tooltip up would stack
@@ -167,24 +174,25 @@ export function usePointClick(
           Math.max(categories.length - 1, 0)
         )
 
-        const nearest = pickNearestSeries(
+        const column = resolveColumn(
           option.series ?? [],
           dataIndex,
           yValue,
           option.legend?.[0]?.selected
         )
-        if (!nearest) return
+        if (!column) return
 
         // `hideTip` is safe to fire even with no tooltip showing.
         chart.dispatchAction({ type: "hideTip" })
 
         handler({
-          seriesName: nearest.seriesName,
+          seriesName: column.nearest.name,
           category: String(categories[dataIndex] ?? ""),
-          value: nearest.value,
-          values: [nearest.value],
+          value: column.nearest.value,
+          values: [column.nearest.value],
+          series: column.series,
           dataIndex,
-          seriesIndex: nearest.seriesIndex,
+          seriesIndex: column.nearest.seriesIndex,
           ...positionOf(e.event),
         })
       }
@@ -236,13 +244,19 @@ export function usePointClick(
       // `hideTip` is safe to fire even with no tooltip showing.
       chart.dispatchAction({ type: "hideTip" })
 
+      const seriesName = String(p.seriesName ?? "")
+      const seriesIndex = p.seriesIndex ?? 0
+
       handler({
-        seriesName: String(p.seriesName ?? ""),
+        seriesName,
         category: String(p.name ?? ""),
         value,
         values: list.map(Number),
+        // A mark identifies exactly one series, so the list has one entry.
+        // Only a line click resolves a whole column.
+        series: [{ name: seriesName, seriesIndex, value }],
         dataIndex: p.dataIndex ?? 0,
-        seriesIndex: p.seriesIndex ?? 0,
+        seriesIndex,
         ...positionOf(p.event?.event),
       })
     }

--- a/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
+++ b/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
@@ -186,6 +186,7 @@ export function usePointClick(
         chart.dispatchAction({ type: "hideTip" })
 
         handler({
+          source: "pointer",
           seriesName: column.nearest.name,
           category: String(categories[dataIndex] ?? ""),
           value: column.nearest.value,
@@ -234,12 +235,19 @@ export function usePointClick(
       // but a scatter point *is* both numbers, so the whole tuple is reported
       // alongside it rather than discarded here.
       const list = Array.isArray(p.value) ? p.value : [p.value]
-      const raw = list[list.length - 1]
       // `Number(null)` is 0 and `Number("")` is 0, so a gap in the data would
       // otherwise be reported as a real zero.
-      if (raw === null || raw === undefined || raw === "") return
-      const value = Number(raw)
-      if (!Number.isFinite(value)) return
+      if (
+        list.some(
+          (entry) => entry === null || entry === undefined || entry === ""
+        )
+      )
+        return
+      const values = list.map(Number)
+      // Every tuple member is semantic data: a finite Y cannot make a broken
+      // scatter X or heatmap index safe to quote.
+      if (values.some((entry) => !Number.isFinite(entry))) return
+      const value = values[values.length - 1]
 
       // `hideTip` is safe to fire even with no tooltip showing.
       chart.dispatchAction({ type: "hideTip" })
@@ -248,10 +256,11 @@ export function usePointClick(
       const seriesIndex = p.seriesIndex ?? 0
 
       handler({
+        source: "pointer",
         seriesName,
         category: String(p.name ?? ""),
         value,
-        values: list.map(Number),
+        values,
         // A mark identifies exactly one series, so the list has one entry.
         // Only a line click resolves a whole column.
         series: [{ name: seriesName, seriesIndex, value }],

--- a/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
+++ b/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
@@ -1,0 +1,87 @@
+import type * as echarts from "echarts"
+import { type RefObject, useEffect, useRef } from "react"
+
+import type { F0DataChartPointClick } from "../types"
+
+/**
+ * Reports the single mark the user clicked — one bar segment, one slice, one
+ * point — normalised into {@link F0DataChartPointClick}.
+ *
+ * Works for every chart type because ECharts' item-level click params carry the
+ * same fields regardless of series type, so this binds once at the instance
+ * level rather than needing a variant per chart.
+ *
+ * Deliberately narrower than the hover tooltip: an axis-triggered tooltip shows
+ * every series at a category, but a click can only identify the mark under the
+ * cursor. Reconstructing the full category would mean reading back the option's
+ * series, which is a different feature.
+ *
+ * Dismisses the hover tooltip on a successful pick: the click is answered by
+ * something anchored at the same spot, and leaving the tooltip up would stack
+ * two floating panels over one mark.
+ */
+export function usePointClick(
+  chartRef: RefObject<echarts.ECharts | null>,
+  onPointClick: ((point: F0DataChartPointClick) => void) | undefined
+): void {
+  // Kept in a ref so a consumer passing an inline arrow doesn't detach and
+  // rebind the listener on every render.
+  const handlerRef = useRef(onPointClick)
+  handlerRef.current = onPointClick
+
+  useEffect(() => {
+    const chart = chartRef.current
+    if (!chart || typeof chart.on !== "function") return
+
+    const onClick = (params: unknown) => {
+      const handler = handlerRef.current
+      if (!handler) return
+
+      const p = params as {
+        componentType?: string
+        seriesName?: string
+        seriesIndex?: number
+        dataIndex?: number
+        name?: string
+        value?: unknown
+        // ECharts wraps the native event; `event.event` is the DOM original.
+        event?: { event?: { clientX?: number; clientY?: number } }
+      }
+
+      // Axis labels, legend entries and the like also raise `click`; only marks
+      // belonging to a series carry a value worth quoting.
+      if (p.componentType !== "series") return
+
+      // Bars and lines give a bare number; scatter and some stacked shapes give
+      // a tuple whose last entry is the measure.
+      const raw = Array.isArray(p.value) ? p.value[p.value.length - 1] : p.value
+      // `Number(null)` is 0 and `Number("")` is 0, so a gap in the data would
+      // otherwise be reported as a real zero.
+      if (raw === null || raw === undefined || raw === "") return
+      const value = Number(raw)
+      if (!Number.isFinite(value)) return
+
+      const native = p.event?.event
+
+      // `hideTip` is safe to fire even with no tooltip showing.
+      chart.dispatchAction({ type: "hideTip" })
+
+      handler({
+        seriesName: String(p.seriesName ?? ""),
+        category: String(p.name ?? ""),
+        value,
+        dataIndex: p.dataIndex ?? 0,
+        seriesIndex: p.seriesIndex ?? 0,
+        clientX: native?.clientX ?? 0,
+        clientY: native?.clientY ?? 0,
+      })
+    }
+
+    chart.on("click", onClick)
+    return () => {
+      // `off` throws on a disposed instance, which happens when the chart
+      // unmounts before this cleanup runs.
+      if (!chart.isDisposed?.()) chart.off("click", onClick)
+    }
+  }, [chartRef])
+}

--- a/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
+++ b/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
@@ -44,17 +44,28 @@ export function usePointClick(
         dataIndex?: number
         name?: string
         value?: unknown
-        // ECharts wraps the native event; `event.event` is the DOM original.
-        event?: { event?: { clientX?: number; clientY?: number } }
+        // ECharts wraps the native event; `event.event` is the DOM original,
+        // which is a TouchEvent on touch — where the position lives on the
+        // touch, not on the event.
+        event?: {
+          event?: {
+            clientX?: number
+            clientY?: number
+            changedTouches?: ArrayLike<{ clientX: number; clientY: number }>
+          }
+        }
       }
 
       // Axis labels, legend entries and the like also raise `click`; only marks
       // belonging to a series carry a value worth quoting.
       if (p.componentType !== "series") return
 
-      // Bars and lines give a bare number; scatter and some stacked shapes give
-      // a tuple whose last entry is the measure.
-      const raw = Array.isArray(p.value) ? p.value[p.value.length - 1] : p.value
+      // Bars and lines give a bare number; a scatter point gives `[x, y]` and a
+      // heatmap cell `[xIndex, yIndex, value]`. The measure is the last entry —
+      // but a scatter point *is* both numbers, so the whole tuple is reported
+      // alongside it rather than discarded here.
+      const list = Array.isArray(p.value) ? p.value : [p.value]
+      const raw = list[list.length - 1]
       // `Number(null)` is 0 and `Number("")` is 0, so a gap in the data would
       // otherwise be reported as a real zero.
       if (raw === null || raw === undefined || raw === "") return
@@ -62,6 +73,7 @@ export function usePointClick(
       if (!Number.isFinite(value)) return
 
       const native = p.event?.event
+      const touch = native?.changedTouches?.[0]
 
       // `hideTip` is safe to fire even with no tooltip showing.
       chart.dispatchAction({ type: "hideTip" })
@@ -70,10 +82,11 @@ export function usePointClick(
         seriesName: String(p.seriesName ?? ""),
         category: String(p.name ?? ""),
         value,
+        values: list.map(Number),
         dataIndex: p.dataIndex ?? 0,
         seriesIndex: p.seriesIndex ?? 0,
-        clientX: native?.clientX ?? 0,
-        clientY: native?.clientY ?? 0,
+        clientX: touch?.clientX ?? native?.clientX ?? 0,
+        clientY: touch?.clientY ?? native?.clientY ?? 0,
       })
     }
 

--- a/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
+++ b/packages/react/src/kits/F0DataChart/utils/usePointClick.ts
@@ -133,6 +133,51 @@ export function usePointClick(
       if (typeof chart.getZr !== "function") return
       const zr = chart.getZr()
       if (!zr) return
+      let isAxisHover = false
+
+      const pointOf = (ev: unknown): [number, number] | null => {
+        const { offsetX, offsetY } = ev as {
+          offsetX?: number
+          offsetY?: number
+        }
+        return typeof offsetX === "number" && typeof offsetY === "number"
+          ? [offsetX, offsetY]
+          : null
+      }
+
+      const onPlotMouseMove = (ev: unknown) => {
+        if (isAxisHover) {
+          zr.setCursorStyle("default")
+          return
+        }
+
+        const pixel = pointOf(ev)
+        if (handlerRef.current && pixel && chart.containPixel("grid", pixel)) {
+          zr.setCursorStyle("pointer")
+        }
+      }
+
+      const onPlotGlobalOut = () => {
+        isAxisHover = false
+        zr.setCursorStyle("default")
+      }
+
+      const onAxisMouseOver = (params: unknown) => {
+        const componentType = (params as { componentType?: string })
+          .componentType
+        if (componentType === "xAxis" || componentType === "yAxis") {
+          isAxisHover = true
+          zr.setCursorStyle("default")
+        }
+      }
+
+      const onAxisMouseOut = (params: unknown) => {
+        const componentType = (params as { componentType?: string })
+          .componentType
+        if (componentType === "xAxis" || componentType === "yAxis") {
+          isAxisHover = false
+        }
+      }
 
       const onPlotClick = (ev: unknown) => {
         const handler = handlerRef.current
@@ -143,10 +188,8 @@ export function usePointClick(
           offsetY?: number
           event?: NativePosition
         }
-        if (typeof e.offsetX !== "number" || typeof e.offsetY !== "number")
-          return
-
-        const pixel: [number, number] = [e.offsetX, e.offsetY]
+        const pixel = pointOf(e)
+        if (!pixel) return
         // The plot area only: clicks on the legend, the axes or the margins
         // aren't picks, and this is exactly the region the tooltip covers.
         if (!chart.containPixel("grid", pixel)) return
@@ -199,10 +242,21 @@ export function usePointClick(
       }
 
       zr.on("click", onPlotClick)
+      zr.on("mousemove", onPlotMouseMove)
+      zr.on("globalout", onPlotGlobalOut)
+      chart.on("mouseover", onAxisMouseOver)
+      chart.on("mouseout", onAxisMouseOut)
       return () => {
         // `off` throws on a disposed instance, which happens when the chart
         // unmounts before this cleanup runs.
-        if (!chart.isDisposed?.()) zr.off("click", onPlotClick)
+        if (!chart.isDisposed?.()) {
+          zr.off("click", onPlotClick)
+          zr.off("mousemove", onPlotMouseMove)
+          zr.off("globalout", onPlotGlobalOut)
+          chart.off("mouseover", onAxisMouseOver)
+          chart.off("mouseout", onAxisMouseOut)
+          zr.setCursorStyle("default")
+        }
       }
     }
 


### PR DESCRIPTION
## Description

Adds `onPointClick` to `F0DataChart`, so a host can respond to the exact chart mark a reader selected: one bar segment, slice, cell, radar value, scatter point, gauge value, or line category.

Nothing changes visually unless a handler is passed. The callback is deliberately mark-level rather than tooltip-level: it reports the selected datum, raw numeric payload, chart indices, the literal `pointer` source, and viewport coordinates a host can use to anchor its own action.

The canvas interaction is intentionally pointer-only. Any host that exposes `onPointClick` must provide an equivalent keyboard-accessible data/action surface outside the ECharts canvas. A keyboard source can be added later without breaking this contract.

**Split out of #5104.** First in the stack; #5124 and #5125 build on this public chart contract.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Visual review

<img width="644" height="452" alt="Point click payload after selecting a chart mark" src="https://github.com/user-attachments/assets/a2fc5e4c-ffe2-4190-a86f-fba94bba2915" />

<img width="633" height="516" alt="Line chart point click payload" src="https://github.com/user-attachments/assets/4b8b9035-9c9b-43e4-b4fc-72318ca2b8ca" />

- [Interactive story - mark-sized target](https://66a7a8d7d124220c363457cc-tfxtqdfoix.chromatic.com/?path=/story/kits-f0datachart-point-click--on-a-mark): click a bar segment and compare the visible value with the emitted payload. Clicking between bars must keep **Nothing picked yet**.
- [Interactive story - line plot target](https://66a7a8d7d124220c363457cc-tfxtqdfoix.chromatic.com/?path=/story/kits-f0datachart-point-click--anywhere-in-a-plot-area): move across the plot, axes, and legend. Only the clickable plot uses the pointer cursor; axis labels stay default and the legend keeps its native pointer. Click a plot column and inspect every visible series at that category.
- [Interactive story - scatter tuple](https://66a7a8d7d124220c363457cc-tfxtqdfoix.chromatic.com/?path=/story/kits-f0datachart-point-click--both-measures-of-a-scatter-point): verify that both measures survive in `values`.
- **Legend callback:** the current-head Storybook deployment adds `kits-f0datachart-point-click--legend-selection-changes`. Isolate a legend item, restore it, and compare the full `selected` mapping printed below the chart. Chromatic publishes the exact deployment link in this PR once the current build finishes.
- [MDX documentation - F0DataChart point click](https://66a7a8d7d124220c363457cc-tfxtqdfoix.chromatic.com/?path=/docs/kits-f0datachart-overview--documentation#point-click): public contract, code example, chart-specific behavior, accessibility limitation, cursor behavior, legend support matrix, and linked Canvas stories.

This PR intentionally has no resting visual change. The useful screenshots are the story before selection and after selecting one mark, because the review target is the callback payload and hit area rather than new chrome.

## Implementation details

- **Pointer-only public source:** `F0DataChartPointClick.source` is the literal `"pointer"`; the unreachable `"keyboard"` union member and keyboard-coordinate wording were removed.
- **Truthful payload semantics:** `category` documents the ECharts mark name across category, pie, funnel, scatter, gauge, and radar charts. `seriesName` documents the configured series name and its possible empty fallback.
- **Grid-aware line affordance:** zrender adds a pointer only inside a handler-backed grid. Axis labels remain default across repeated movement, while legends and other native ECharts targets keep their own cursor. All added listeners and cursor state are cleaned up on global-out and unmount.
- **Scoped legend observer:** `onLegendSelectionChange` is accepted only by the six variants that wire interactive legends: bar, line, funnel, pie, radar, and scatter. Gauge and heatmap do not advertise an unsupported prop.
- **Normalized payload:** genuine `0` is reported, while `null`, `undefined`, blank, non-numeric, and non-finite tuple entries are rejected. `values` preserves scatter and heatmap tuples, and `series` preserves every visible line-series value at one category.
- **Host-owned action placement:** pointer coordinates let a host anchor an action beside the selected mark; a successful pick dismisses the tooltip so both surfaces do not compete.

## Verification

- 84/84 focused point-click, line, scatter, and heatmap tests passed.
- 2/2 focused bar/funnel legend callback tests passed.
- TypeScript, formatting, targeted lint, cycle-dependency hook, and diff checks passed.
- Production Storybook build passed.
- Exact Chrome check passed: plot pointer, persistent default axis cursor, native legend pointer, `source: pointer` payload, and legend selection readout.
- Two independent correctness/accessibility reviews found no remaining blockers.
- Exact-head GitHub CI is green, including React unit tests, all eight Storybook shards, Chromatic, accessibility, API surface, lint, formatting, and package build.

---

### The stack

| | PR | What it adds |
|---|---|---|
| 1 | #5123 | `F0DataChart` reports the selected mark - kit API, no resting visual change |
| 2 | #5124 | Widget menu -> **Ask One** |
| 3 | #5125 | Chart point -> **Ask One** |
| 4 | #5126 | Drag a widget into chat |

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0
> - factorial-ci
> - factorial-pr



