### PR TITLE
feat(F0AnalyticsDashboard): offer Ask One in the widget menu

### DIFF
--- a/packages/react/src/kits/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/kits/ai/F0AiChat/internal-types.ts
@@ -186,6 +186,10 @@ export type AiChatProviderReturnValue = {
   processDroppedFiles: (files: File[]) => void
   /** @internal Registers the processFiles callback owned by ChatTextarea */
   setProcessDroppedFilesFunction: (fn: ((files: File[]) => void) | null) => void
+  /** Move focus into the mounted chat composer, or queue it until mount. */
+  focusChatInput: () => void
+  /** @internal Registers the focus callback owned by ChatTextarea. */
+  setFocusChatInputFunction: (fn: (() => void) | null) => void
   /**
    * Pre-loaded context shown as an empty state in the chat.
    * Prepended to the first user message as `<pending-context>`.

--- a/packages/react/src/kits/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/kits/ai/F0AiChat/internal-types.ts
@@ -186,8 +186,11 @@ export type AiChatProviderReturnValue = {
   processDroppedFiles: (files: File[]) => void
   /** @internal Registers the processFiles callback owned by ChatTextarea */
   setProcessDroppedFilesFunction: (fn: ((files: File[]) => void) | null) => void
-  /** Move focus into the mounted chat composer, or queue it until mount. */
-  focusChatInput: () => void
+  /**
+   * Move focus into the mounted chat composer, or queue it until mount.
+   * Returns whether focus moved synchronously.
+   */
+  focusChatInput: () => boolean
   /** @internal Registers the focus callback owned by ChatTextarea. */
   setFocusChatInputFunction: (fn: (() => void) | null) => void
   /**

--- a/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -216,12 +216,14 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   // request as soon as it becomes available.
   const focusChatInputRef = useRef<(() => void) | null>(null)
   const pendingChatInputFocusRef = useRef(false)
-  const focusChatInput = useCallback(() => {
+  const focusChatInput = useCallback((): boolean => {
     if (focusChatInputRef.current) {
       focusChatInputRef.current()
-    } else {
-      pendingChatInputFocusRef.current = true
+      return true
     }
+
+    pendingChatInputFocusRef.current = true
+    return false
   }, [])
   const setFocusChatInputFunction = useCallback((fn: (() => void) | null) => {
     focusChatInputRef.current = fn
@@ -241,6 +243,10 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
 
   useEffect(() => {
     if (!open) {
+      // A focus request belongs to the interaction that opened the panel.
+      // Once that panel closes, replaying it on a later mount would steal
+      // focus from whatever the user moved on to.
+      pendingChatInputFocusRef.current = false
       setCanvasContent(null)
       setVisualizationMode("sidepanel")
       const prefersReducedMotion = window.matchMedia(
@@ -502,6 +508,7 @@ const REAL_VALUES: Partial<AiChatProviderReturnValue> = {
   placeholders: [],
   welcomeScreenSuggestions: [],
   welcomeScreenCards: [],
+  focusChatInput: () => false,
 }
 
 const NO_PROVIDER_CONTEXT = new Proxy({} as AiChatProviderReturnValue, {

--- a/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -211,6 +211,26 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     []
   )
 
+  // Focus bridge — callers can request focus before the chat has mounted.
+  // The textarea registers its local ref callback and consumes one buffered
+  // request as soon as it becomes available.
+  const focusChatInputRef = useRef<(() => void) | null>(null)
+  const pendingChatInputFocusRef = useRef(false)
+  const focusChatInput = useCallback(() => {
+    if (focusChatInputRef.current) {
+      focusChatInputRef.current()
+    } else {
+      pendingChatInputFocusRef.current = true
+    }
+  }, [])
+  const setFocusChatInputFunction = useCallback((fn: (() => void) | null) => {
+    focusChatInputRef.current = fn
+    if (fn && pendingChatInputFocusRef.current) {
+      pendingChatInputFocusRef.current = false
+      fn()
+    }
+  }, [])
+
   const resetChatWidth = () => {
     setChatWidth(DEFAULT_CHAT_WIDTH)
   }
@@ -399,6 +419,8 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
         setFileDragOver,
         processDroppedFiles,
         setProcessDroppedFilesFunction,
+        focusChatInput,
+        setFocusChatInputFunction,
         pendingContext,
         setPendingContext,
         pendingQuote,

--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -111,7 +111,7 @@ export const F0AiChatTextArea = ({
   // hosts only need to wire the `onSuggestionClick` business action.
   // When the textarea is rendered outside an `F0AiChatProvider` the
   // tracking ref resolves to a no-op via the provider fallback.
-  const { tracking } = useAiChat()
+  const { tracking, setFocusChatInputFunction } = useAiChat()
   const handleSuggestionClick = useCallback(
     (item: WelcomeScreenSuggestionItem, group: WelcomeScreenSuggestion) => {
       tracking?.onWelcomeSuggestionClick?.({
@@ -187,6 +187,13 @@ export const F0AiChatTextArea = ({
       textareaRef.current?.focus()
     }
   }, [])
+
+  useEffect(() => {
+    setFocusChatInputFunction(() => {
+      textareaRef.current?.focus()
+    })
+    return () => setFocusChatInputFunction(null)
+  }, [setFocusChatInputFunction])
 
   // Expose the file-drop handler to parents that own a wider drop zone
   // (e.g. the whole chat window). The handler is stable for the lifetime

--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -189,11 +189,16 @@ export const F0AiChatTextArea = ({
   }, [])
 
   useEffect(() => {
+    if (isClarifying) {
+      setFocusChatInputFunction(null)
+      return
+    }
+
     setFocusChatInputFunction(() => {
       textareaRef.current?.focus()
     })
     return () => setFocusChatInputFunction(null)
-  }, [setFocusChatInputFunction])
+  }, [isClarifying, setFocusChatInputFunction])
 
   // Expose the file-drop handler to parents that own a wider drop zone
   // (e.g. the whole chat window). The handler is stable for the lifetime

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
@@ -1,0 +1,63 @@
+import { useState } from "react"
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import {
+  AiChatStateProvider,
+  useAiChat,
+} from "../../F0AiChat/providers/AiChatStateProvider"
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+const FocusHarness = () => {
+  const [showInput, setShowInput] = useState(false)
+  const { focusChatInput } = useAiChat()
+
+  return (
+    <>
+      <button type="button" onClick={focusChatInput}>
+        Focus composer
+      </button>
+      <button type="button" onClick={() => setShowInput(true)}>
+        Mount composer
+      </button>
+      {showInput && <F0AiChatTextArea onSubmit={vi.fn()} />}
+    </>
+  )
+}
+
+describe("F0AiChatTextArea focus bridge", () => {
+  it("buffers a focus request until the composer mounts", async () => {
+    const user = userEvent.setup()
+    render(
+      <AiChatStateProvider enabled>
+        <FocusHarness />
+      </AiChatStateProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Focus composer" }))
+    await user.click(screen.getByRole("button", { name: "Mount composer" }))
+
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
+  })
+
+  it("focuses a composer that is already mounted", async () => {
+    const user = userEvent.setup()
+    render(
+      <AiChatStateProvider enabled>
+        <FocusHarness />
+      </AiChatStateProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mount composer" }))
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
+
+    const focusButton = screen.getByRole("button", { name: "Focus composer" })
+    focusButton.focus()
+    expect(focusButton).toHaveFocus()
+
+    await user.click(focusButton)
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
@@ -13,12 +13,24 @@ import { F0AiChatTextArea } from "../F0AiChatTextArea"
 const FocusHarness = () => {
   const [showInput, setShowInput] = useState(false)
   const [isClarifying, setIsClarifying] = useState(false)
-  const { focusChatInput } = useAiChat()
+  const { focusChatInput, setOpen } = useAiChat()
 
   return (
     <>
       <button type="button" onClick={focusChatInput}>
         Focus composer
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          setOpen(true)
+          focusChatInput()
+        }}
+      >
+        Open and focus composer
+      </button>
+      <button type="button" onClick={() => setOpen(false)}>
+        Close chat
       </button>
       <button type="button" onClick={() => setShowInput(true)}>
         Mount composer
@@ -101,5 +113,24 @@ describe("F0AiChatTextArea focus bridge", () => {
     await user.click(screen.getByRole("button", { name: "Restore composer" }))
 
     await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
+  })
+
+  it("discards a buffered focus request when the chat closes", async () => {
+    const user = userEvent.setup()
+    render(
+      <AiChatStateProvider enabled>
+        <FocusHarness />
+      </AiChatStateProvider>
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Open and focus composer" })
+    )
+    await user.click(screen.getByRole("button", { name: "Close chat" }))
+    const mountButton = screen.getByRole("button", { name: "Mount composer" })
+    await user.click(mountButton)
+
+    expect(screen.getByRole("textbox")).not.toHaveFocus()
+    expect(mountButton).toHaveFocus()
   })
 })

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { userEvent } from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
 
@@ -12,6 +12,7 @@ import { F0AiChatTextArea } from "../F0AiChatTextArea"
 
 const FocusHarness = () => {
   const [showInput, setShowInput] = useState(false)
+  const [isClarifying, setIsClarifying] = useState(false)
   const { focusChatInput } = useAiChat()
 
   return (
@@ -22,12 +23,33 @@ const FocusHarness = () => {
       <button type="button" onClick={() => setShowInput(true)}>
         Mount composer
       </button>
-      {showInput && <F0AiChatTextArea onSubmit={vi.fn()} />}
+      <button type="button" onClick={() => setIsClarifying(true)}>
+        Show clarifying panel
+      </button>
+      <button type="button" onClick={() => setIsClarifying(false)}>
+        Restore composer
+      </button>
+      {showInput && (
+        <F0AiChatTextArea
+          onSubmit={vi.fn()}
+          clarifyingUI={
+            isClarifying ? <div>Choose a reporting period</div> : undefined
+          }
+        />
+      )}
     </>
   )
 }
 
 describe("F0AiChatTextArea focus bridge", () => {
+  beforeEach(() => {
+    window.history.replaceState(null, "", "#focus-bridge-test")
+  })
+
+  afterEach(() => {
+    window.history.replaceState(null, "", window.location.pathname)
+  })
+
   it("buffers a focus request until the composer mounts", async () => {
     const user = userEvent.setup()
     render(
@@ -51,13 +73,33 @@ describe("F0AiChatTextArea focus bridge", () => {
     )
 
     await user.click(screen.getByRole("button", { name: "Mount composer" }))
-    await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
+    expect(screen.getByRole("textbox")).not.toHaveFocus()
 
     const focusButton = screen.getByRole("button", { name: "Focus composer" })
     focusButton.focus()
     expect(focusButton).toHaveFocus()
 
     await user.click(focusButton)
+    await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
+  })
+
+  it("buffers focus while a clarifying panel replaces the composer", async () => {
+    const user = userEvent.setup()
+    render(
+      <AiChatStateProvider enabled>
+        <FocusHarness />
+      </AiChatStateProvider>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Mount composer" }))
+    await user.click(
+      screen.getByRole("button", { name: "Show clarifying panel" })
+    )
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Focus composer" }))
+    await user.click(screen.getByRole("button", { name: "Restore composer" }))
+
     await waitFor(() => expect(screen.getByRole("textbox")).toHaveFocus())
   })
 })

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -453,6 +453,13 @@ export const defaultTranslations = {
       exporting: "Exporting…",
     },
     dashboardItem: {
+      /**
+       * Deliberately not `ai.ask` ("Ask One" by default here, but hosts
+       * override it — factorial renders it as plain "Ask" for the widget and
+       * insight-card buttons). This menu entry needs the product name spelled
+       * out, so it owns its own key.
+       */
+      askOne: "Ask One",
       chartType: "Chart type",
       errorTitle: "Error loading data",
       retry: "Retry",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
@@ -49,6 +49,7 @@ export const F0AnalyticsDashboard = <
   onExportReady,
   resetKey,
   onTransformChart,
+  onAskAi,
   navigationFilters,
   filtersLoading,
 }: F0AnalyticsDashboardProps<Filters>) => {
@@ -172,6 +173,7 @@ export const F0AnalyticsDashboard = <
           editMode={editMode}
           onLayoutChange={onLayoutChange}
           onTransformChart={onTransformChart}
+          onAskAi={onAskAi}
           resetKey={resetKey}
           onFullscreenChange={setIsItemFullscreen}
         />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
@@ -9,6 +9,7 @@ import {
   MockConnectedChatInput,
   MockConnectedMessagesContainer,
 } from "@/kits/ai/F0AiChat/__stories__/_mock"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0AnalyticsDashboard } from "../index"
 import { mixedItems } from "./mockDataMixed"
@@ -85,6 +86,7 @@ type Story = StoryObj<typeof meta>
  */
 export const WidgetMenuAction: Story = {
   render: () => <AskOneLayout />,
+  parameters: withSnapshot({}),
   play: async ({ canvasElement, step }) => {
     await step("Open the widget actions menu", async () => {
       const { menu } = await openAskOneMenu(canvasElement)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
@@ -1,0 +1,136 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { expect, userEvent, waitFor, within } from "storybook/test"
+
+import { F0AiChat, F0AiChatProvider } from "@/kits/ai/F0AiChat"
+import {
+  MockAiChatRuntimeProvider,
+  MockConnectedChatHeader,
+  MockConnectedChatInput,
+  MockConnectedMessagesContainer,
+} from "@/kits/ai/F0AiChat/__stories__/_mock"
+
+import { F0AnalyticsDashboard } from "../index"
+import { mixedItems } from "./mockDataMixed"
+
+const widget = mixedItems.filter((item) => item.id === "headcount")
+
+const AskOneLayout = () => {
+  return (
+    <div className="flex h-full w-full gap-2 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+        <F0AnalyticsDashboard items={widget} />
+      </div>
+      <div className="flex min-h-0 w-[420px] shrink-0">
+        <F0AiChat
+          header={<MockConnectedChatHeader />}
+          messages={<MockConnectedMessagesContainer />}
+          input={<MockConnectedChatInput />}
+        />
+      </div>
+    </div>
+  )
+}
+
+const openAskOneMenu = async (canvasElement: HTMLElement) => {
+  const canvas = within(canvasElement)
+  const trigger = await canvas.findByRole("button", { name: "Other actions" })
+
+  await userEvent.click(trigger)
+
+  const menuId = trigger.getAttribute("aria-controls")
+  if (!menuId) throw new Error("The widget menu trigger has no aria-controls")
+
+  const menu = await waitFor(() => {
+    const element = canvasElement.ownerDocument.getElementById(menuId)
+    expect(element).toBeInTheDocument()
+    return element!
+  })
+
+  return { canvas, menu: within(menu) }
+}
+
+const meta = {
+  title: "AnalyticsDashboard/Ask One",
+  component: F0AnalyticsDashboard,
+  parameters: {
+    layout: "fullscreen",
+    docs: { story: { autoplay: true, inline: false, height: "720px" } },
+  },
+  tags: ["experimental", "!autodocs", "no-sidebar"],
+  args: { items: widget },
+  beforeEach: () => {
+    window.localStorage.removeItem("ONE-ai-chat-open")
+    window.localStorage.removeItem("ONE-ai-chat-visualization-mode")
+  },
+  decorators: [
+    (Story) => (
+      <div className="h-screen w-full overflow-hidden p-2">
+        <F0AiChatProvider enabled>
+          <MockAiChatRuntimeProvider>
+            <Story />
+          </MockAiChatRuntimeProvider>
+        </F0AiChatProvider>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof F0AnalyticsDashboard>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * The widget menu exposes Ask One only when a chat or a host handler can answer
+ * it. This story leaves the menu open so the action can be reviewed in context.
+ */
+export const WidgetMenuAction: Story = {
+  render: () => <AskOneLayout />,
+  play: async ({ canvasElement, step }) => {
+    await step("Open the widget actions menu", async () => {
+      const { menu } = await openAskOneMenu(canvasElement)
+      await expect(
+        await menu.findByRole("menuitem", { name: "Ask One" })
+      ).toBeInTheDocument()
+    })
+  },
+}
+
+/**
+ * Choosing Ask One copies the widget title into the real chat composer and
+ * opens the panel. The completed interaction stays visible for visual review.
+ */
+export const WidgetQuotedInChat: Story = {
+  render: () => <AskOneLayout />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    let menu: ReturnType<typeof within> | undefined
+
+    await step("Open the widget actions menu", async () => {
+      menu = (await openAskOneMenu(canvasElement)).menu
+    })
+
+    if (!menu) throw new Error("The widget actions menu did not open")
+
+    await step("Ask One about the widget", async () => {
+      await userEvent.click(
+        await menu.findByRole("menuitem", { name: "Ask One" })
+      )
+      await waitFor(() =>
+        expect(
+          menu.queryByRole("menuitem", { name: "Ask One" })
+        ).not.toBeInTheDocument()
+      )
+    })
+
+    await step("Verify the quoted widget in the focused composer", async () => {
+      const removeQuote = await canvas.findByRole("button", {
+        name: "Remove quote",
+      })
+      await expect(removeQuote.parentElement).toHaveTextContent(
+        "Headcount by Department"
+      )
+      const textbox = await canvas.findByRole("textbox")
+      await waitFor(() => expect(textbox).toHaveFocus())
+    })
+  },
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -153,9 +153,11 @@ the mounted chat:
 ```
 
 - WHEN an enabled AI chat is mounted and a widget has a title → THEN its actions menu includes **Ask One**.
+- WHEN a widget is in an error state but still has a title → THEN **Ask One** remains available from its error header.
 - WHEN no chat is available and `onAskAi` is omitted → THEN the action is hidden instead of offering a dead command.
 - WHEN **Ask One** uses the built-in behavior → THEN the dashboard exits widget fullscreen, quotes the title, and opens the chat.
 - WHEN `onAskAi` is provided → THEN the action calls the host with the widget `id` and `title` without changing chat or fullscreen state.
+- WHEN a directly rendered widget has `onAskAi` but no `itemId` → THEN the action is hidden rather than sending an empty ID.
 - WHEN a widget has no title → THEN the action is hidden because there is nothing to quote.
 
 ### Report filters

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -1,5 +1,6 @@
 import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
 import * as Stories from "./index.stories"
+import * as AskOneStories from "./AskOne.stories"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 <Meta of={Stories} />
@@ -118,6 +119,44 @@ so the new affordance can be compared with the unchanged header.
 - WHEN `info` is omitted → THEN the header layout and interaction remain unchanged.
 - WHEN the widget is in an error state → THEN the information trigger remains available to explain what the failed widget was meant to measure.
 - WHEN the title is long → THEN it truncates around the fixed-size trigger instead of pushing the trigger out of the header.
+
+### Ask One from a widget
+
+When an enabled AI chat is mounted, each titled widget adds **Ask One** to its
+actions menu. Choosing it opens the chat and places the widget title in the
+composer's quote chip, ready for a question.
+
+**Menu action**
+
+The story leaves the widget menu open so the action, icon, and placement can be
+reviewed directly.
+
+<Canvas of={AskOneStories.WidgetMenuAction} />
+
+**Quoted in the chat**
+
+This story completes the action and leaves the resulting quote visible in the
+real chat composer.
+
+<Canvas of={AskOneStories.WidgetQuotedInChat} />
+
+Pass `onAskAi` when the host needs to own the action instead of sending it to
+the mounted chat:
+
+```tsx
+<F0AnalyticsDashboard
+  items={items}
+  onAskAi={({ id, title }) => {
+    openProductChat({ widgetId: id, quote: title })
+  }}
+/>
+```
+
+- WHEN an enabled AI chat is mounted and a widget has a title → THEN its actions menu includes **Ask One**.
+- WHEN no chat is available and `onAskAi` is omitted → THEN the action is hidden instead of offering a dead command.
+- WHEN **Ask One** uses the built-in behavior → THEN the dashboard exits widget fullscreen, quotes the title, and opens the chat.
+- WHEN `onAskAi` is provided → THEN the action calls the host with the widget `id` and `title` without changing chat or fullscreen state.
+- WHEN a widget has no title → THEN the action is hidden because there is nothing to quote.
 
 ### Report filters
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
 import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
 
+import {
+  AiChatStateProvider,
+  useAiChat,
+} from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
+
 import { DashboardItem } from "../components/DashboardItem/DashboardItem"
 
 describe("DashboardItem", () => {
@@ -166,6 +171,59 @@ describe("DashboardItem — description action", () => {
       screen.getByRole("button", { name: "Show less" })
     ).toBeInTheDocument()
     expect(screen.queryByText("·")).not.toBeInTheDocument()
+  })
+
+  describe("Ask One", () => {
+    const QuoteProbe = () => {
+      const { pendingQuote, open } = useAiChat()
+      return (
+        <span
+          data-testid="probe"
+          data-quote={pendingQuote?.text ?? ""}
+          data-open={String(open)}
+        />
+      )
+    }
+
+    const openMenu = async () =>
+      userEvent.click(screen.getByLabelText("Other actions"))
+
+    it("offers the action and hands the widget to the chat", async () => {
+      render(
+        <AiChatStateProvider enabled>
+          <QuoteProbe />
+          <DashboardItem title="Headcount by workplace" isLoading={false}>
+            <div>Content</div>
+          </DashboardItem>
+        </AiChatStateProvider>
+      )
+
+      await openMenu()
+      await userEvent.click(screen.getByText("Ask One"))
+
+      const probe = screen.getByTestId("probe")
+      expect(probe).toHaveAttribute("data-quote", "Headcount by workplace")
+      // Opens the chat too — otherwise the quote lands somewhere unseen.
+      expect(probe).toHaveAttribute("data-open", "true")
+    })
+
+    it("is absent without a chat provider, where the setters are inert", async () => {
+      render(
+        <DashboardItem
+          title="Headcount by workplace"
+          isLoading={false}
+          actions={[{ label: "CSV", onClick: vi.fn() }]}
+        >
+          <div>Content</div>
+        </DashboardItem>
+      )
+
+      await openMenu()
+
+      expect(screen.queryByText("Ask One")).not.toBeInTheDocument()
+      // The rest of the menu is untouched.
+      expect(screen.getByText("Download")).toBeInTheDocument()
+    })
   })
 })
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
@@ -194,10 +194,16 @@ describe("DashboardItem — description action", () => {
       userEvent.click(screen.getByLabelText("Other actions"))
 
     it("offers the action and hands the widget to the chat", async () => {
+      const onFullscreenChange = vi.fn()
       render(
         <AiChatStateProvider enabled>
           <QuoteProbe />
-          <DashboardItem title="Headcount by workplace" isLoading={false}>
+          <DashboardItem
+            title="Headcount by workplace"
+            isLoading={false}
+            isFullscreen
+            onFullscreenChange={onFullscreenChange}
+          >
             <div>Content</div>
           </DashboardItem>
         </AiChatStateProvider>
@@ -210,6 +216,7 @@ describe("DashboardItem — description action", () => {
       expect(probe).toHaveAttribute("data-quote", "Headcount by workplace")
       // Opens the chat too — otherwise the quote lands somewhere unseen.
       expect(probe).toHaveAttribute("data-open", "true")
+      expect(onFullscreenChange).toHaveBeenCalledWith(false)
     })
 
     it("is absent without a chat provider, where the setters are inert", async () => {
@@ -232,6 +239,7 @@ describe("DashboardItem — description action", () => {
 
     it("hands the widget to the host instead, when it takes the action", async () => {
       const onAskAi = vi.fn()
+      const onFullscreenChange = vi.fn()
       render(
         <AiChatStateProvider enabled>
           <QuoteProbe />
@@ -239,7 +247,9 @@ describe("DashboardItem — description action", () => {
             title="Headcount by workplace"
             itemId="headcount"
             isLoading={false}
+            isFullscreen
             onAskAi={onAskAi}
+            onFullscreenChange={onFullscreenChange}
           >
             <div>Content</div>
           </DashboardItem>
@@ -258,6 +268,7 @@ describe("DashboardItem — description action", () => {
       const probe = screen.getByTestId("probe")
       expect(probe).toHaveAttribute("data-quote", "")
       expect(probe).toHaveAttribute("data-open", "false")
+      expect(onFullscreenChange).not.toHaveBeenCalled()
     })
 
     it("offers the action with no chat mounted, once the host answers it", async () => {
@@ -277,6 +288,25 @@ describe("DashboardItem — description action", () => {
       await userEvent.click(screen.getByText("Ask One"))
 
       expect(onAskAi).toHaveBeenCalledTimes(1)
+    })
+
+    it("hides the action when the title cannot produce a quote", async () => {
+      render(
+        <AiChatStateProvider enabled>
+          <DashboardItem
+            title="   "
+            isLoading={false}
+            actions={[{ label: "CSV", onClick: vi.fn() }]}
+          >
+            <div>Content</div>
+          </DashboardItem>
+        </AiChatStateProvider>
+      )
+
+      await openMenu()
+
+      expect(screen.queryByText("Ask One")).not.toBeInTheDocument()
+      expect(screen.getByText("Download")).toBeInTheDocument()
     })
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
 
 import {
@@ -174,6 +174,11 @@ describe("DashboardItem — description action", () => {
   })
 
   describe("Ask One", () => {
+    // The chat's open state is persisted, so without this a test inherits
+    // whatever the previous one left behind — and "did the click open it?"
+    // stops meaning anything.
+    beforeEach(() => localStorage.clear())
+
     const QuoteProbe = () => {
       const { pendingQuote, open } = useAiChat()
       return (
@@ -223,6 +228,55 @@ describe("DashboardItem — description action", () => {
       expect(screen.queryByText("Ask One")).not.toBeInTheDocument()
       // The rest of the menu is untouched.
       expect(screen.getByText("Download")).toBeInTheDocument()
+    })
+
+    it("hands the widget to the host instead, when it takes the action", async () => {
+      const onAskAi = vi.fn()
+      render(
+        <AiChatStateProvider enabled>
+          <QuoteProbe />
+          <DashboardItem
+            title="Headcount by workplace"
+            itemId="headcount"
+            isLoading={false}
+            onAskAi={onAskAi}
+          >
+            <div>Content</div>
+          </DashboardItem>
+        </AiChatStateProvider>
+      )
+
+      await openMenu()
+      await userEvent.click(screen.getByText("Ask One"))
+
+      expect(onAskAi).toHaveBeenCalledWith({
+        id: "headcount",
+        title: "Headcount by workplace",
+      })
+      // The chat is left alone entirely — the host may not even be sending the
+      // widget there, so quoting into it would be a second, unasked-for action.
+      const probe = screen.getByTestId("probe")
+      expect(probe).toHaveAttribute("data-quote", "")
+      expect(probe).toHaveAttribute("data-open", "false")
+    })
+
+    it("offers the action with no chat mounted, once the host answers it", async () => {
+      const onAskAi = vi.fn()
+      render(
+        <DashboardItem
+          title="Headcount by workplace"
+          itemId="headcount"
+          isLoading={false}
+          onAskAi={onAskAi}
+        >
+          <div>Content</div>
+        </DashboardItem>
+      )
+
+      await openMenu()
+      await userEvent.click(screen.getByText("Ask One"))
+
+      expect(onAskAi).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
@@ -1,5 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
+import {
+  screen,
+  userEvent,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
 
 import {
   AiChatStateProvider,
@@ -190,8 +195,11 @@ describe("DashboardItem — description action", () => {
       )
     }
 
-    const openMenu = async () =>
-      userEvent.click(screen.getByLabelText("Other actions"))
+    const openMenu = async () => {
+      const trigger = screen.getByLabelText("Other actions")
+      await userEvent.click(trigger)
+      return trigger
+    }
 
     it("offers the action and hands the widget to the chat", async () => {
       const onFullscreenChange = vi.fn()
@@ -209,7 +217,7 @@ describe("DashboardItem — description action", () => {
         </AiChatStateProvider>
       )
 
-      await openMenu()
+      const trigger = await openMenu()
       await userEvent.click(screen.getByText("Ask One"))
 
       const probe = screen.getByTestId("probe")
@@ -217,6 +225,10 @@ describe("DashboardItem — description action", () => {
       // Opens the chat too — otherwise the quote lands somewhere unseen.
       expect(probe).toHaveAttribute("data-open", "true")
       expect(onFullscreenChange).toHaveBeenCalledWith(false)
+      // The composer is not mounted in this harness. Radix must keep its
+      // normal restoration instead of dropping focus on document.body while
+      // the provider buffers the request.
+      await waitFor(() => expect(trigger).toHaveFocus())
     })
 
     it("is absent without a chat provider, where the setters are inert", async () => {
@@ -287,7 +299,49 @@ describe("DashboardItem — description action", () => {
       await openMenu()
       await userEvent.click(screen.getByText("Ask One"))
 
-      expect(onAskAi).toHaveBeenCalledTimes(1)
+      expect(onAskAi).toHaveBeenCalledWith({
+        id: "headcount",
+        title: "Headcount by workplace",
+      })
+    })
+
+    it("hides a host-owned action when a direct item has no ID", () => {
+      render(
+        <DashboardItem
+          title="Headcount by workplace"
+          isLoading={false}
+          onAskAi={vi.fn()}
+        >
+          <div>Content</div>
+        </DashboardItem>
+      )
+
+      expect(
+        screen.queryByRole("button", { name: "Other actions" })
+      ).not.toBeInTheDocument()
+    })
+
+    it("keeps Ask One available when the widget data failed", async () => {
+      render(
+        <AiChatStateProvider enabled>
+          <QuoteProbe />
+          <DashboardItem
+            title="Headcount by workplace"
+            isLoading={false}
+            error={new Error("Failed to load")}
+          >
+            <div>Content</div>
+          </DashboardItem>
+        </AiChatStateProvider>
+      )
+
+      await openMenu()
+      await userEvent.click(screen.getByText("Ask One"))
+
+      expect(screen.getByTestId("probe")).toHaveAttribute(
+        "data-quote",
+        "Headcount by workplace"
+      )
     })
 
     it("hides the action when the title cannot produce a quote", async () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
@@ -212,6 +212,30 @@ describe("F0AnalyticsDashboard report filters", () => {
   })
 })
 
+describe("F0AnalyticsDashboard Ask One", () => {
+  it("passes the public host handler through to a rendered widget", async () => {
+    const user = userEvent.setup()
+    const onAskAi = vi.fn()
+
+    render(
+      <F0AnalyticsDashboard
+        items={[metricItem(vi.fn().mockResolvedValue({ value: 42 }))]}
+        onAskAi={onAskAi}
+      />
+    )
+
+    await user.click(
+      await screen.findByRole("button", { name: "Other actions" })
+    )
+    await user.click(screen.getByRole("menuitem", { name: "Ask One" }))
+
+    expect(onAskAi).toHaveBeenCalledWith({
+      id: "headcount",
+      title: "Headcount",
+    })
+  })
+})
+
 describe("F0AnalyticsDashboard — unrenderable chart config", () => {
   // A host app that maps a wire chart type it has no case for yields
   // `undefined`. Every type switch here lacks a default, so without a guard

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -470,6 +470,7 @@ interface ChartItemProps<Filters extends FiltersDefinition> {
   actions?: DropdownItem[]
   editMode?: boolean
   handleDelete?: (itemId: string) => void
+  onAskAi?: (item: { id: string; title: string }) => void
   onTransformChart?: (
     itemId: string,
     newType: string,
@@ -485,6 +486,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
   actions,
   editMode,
   handleDelete,
+  onAskAi,
   onTransformChart,
   isFullscreen,
   onFullscreenChange,
@@ -692,6 +694,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       actions={allActions}
       editMode={editMode}
       handleDelete={handleDelete}
+      onAskAi={onAskAi}
       itemId={item.id}
       chartTypeOptions={chartTypeOptions}
       isFullscreen={isFullscreen}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -21,6 +21,7 @@ interface CollectionItemProps<Filters extends FiltersDefinition> {
   actions?: DropdownItem[]
   editMode?: boolean
   handleDelete?: (itemId: string) => void
+  onAskAi?: (item: { id: string; title: string }) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }
@@ -39,6 +40,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
   actions,
   editMode,
   handleDelete,
+  onAskAi,
   isFullscreen,
   onFullscreenChange,
 }: CollectionItemProps<Filters>) {
@@ -125,6 +127,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
       actions={allActions}
       editMode={editMode}
       handleDelete={handleDelete}
+      onAskAi={onAskAi}
       itemId={item.id}
       isFullscreen={isFullscreen}
       onFullscreenChange={onFullscreenChange}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -60,6 +60,8 @@ interface DashboardGridProps<Filters extends FiltersDefinition> {
     newType: string,
     orientation?: "vertical" | "horizontal"
   ) => void
+  /** Overrides the built-in "Ask One" action on a widget. See `F0AnalyticsDashboardProps.onAskAi`. */
+  onAskAi?: (item: { id: string; title: string }) => void
   /**
    * Notifies the parent when the grid enters/exits a "fill height" mode —
    * triggered by click-to-fullscreen on a multi-item dashboard. The parent
@@ -86,6 +88,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   onLayoutChange,
   resetKey,
   onTransformChart,
+  onAskAi,
   onFullscreenChange,
 }: DashboardGridProps<Filters>) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -444,6 +447,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           editMode={editMode}
           onDelete={handleDelete}
           onTransformChart={onTransformChart}
+          onAskAi={onAskAi}
           isFullscreen
         />
       </div>
@@ -482,6 +486,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
             editMode={editMode}
             onDelete={handleDelete}
             onTransformChart={onTransformChart}
+            onAskAi={onAskAi}
             isFullscreen
             onFullscreenChange={(fs) =>
               setFullscreenItemId(fs ? fullscreenItemId : null)
@@ -568,6 +573,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                       editMode={editMode}
                       onDelete={handleDelete}
                       onTransformChart={onTransformChart}
+                      onAskAi={onAskAi}
                       onFullscreenChange={(fs) =>
                         setFullscreenItemId(fs ? id : null)
                       }
@@ -977,6 +983,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
   editMode,
   onDelete,
   onTransformChart,
+  onAskAi,
   isFullscreen,
   onFullscreenChange,
 }: {
@@ -990,6 +997,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
     newType: string,
     orientation?: "vertical" | "horizontal"
   ) => void
+  onAskAi?: (item: { id: string; title: string }) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }) {
@@ -1002,6 +1010,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           actions={actions}
           editMode={editMode}
           handleDelete={onDelete}
+          onAskAi={onAskAi}
           onTransformChart={onTransformChart}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
@@ -1015,6 +1024,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           actions={actions}
           editMode={editMode}
           handleDelete={onDelete}
+          onAskAi={onAskAi}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
         />
@@ -1027,6 +1037,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           actions={actions}
           editMode={editMode}
           handleDelete={onDelete}
+          onAskAi={onAskAi}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
         />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -18,6 +18,8 @@ import {
   InfoCircleLine,
 } from "@/icons/app"
 import { InfoHint, type InfoHintContent } from "@/lib/InfoHint"
+import { One as OneIcon } from "@/icons/ai"
+import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -130,6 +132,11 @@ export function DashboardItem({
    */
   const [isExplanationView, setIsExplanationView] = useState(false)
   const translations = useI18n()
+  const {
+    enabled: aiEnabled,
+    setPendingQuote,
+    setOpen: setAiChatOpen,
+  } = useAiChat()
 
   const handleDropdownOpenChange = (open: boolean) => {
     setIsDropdownOpen(open)
@@ -146,7 +153,13 @@ export function DashboardItem({
   const hasChartTypes = chartTypeOptions && chartTypeOptions.length > 0
   const hasExplanation = !!explanation && explanation.trim().length > 0
   const hasFullscreen = !!onFullscreenChange
-  const showMenu = hasDownloads || hasDelete || hasChartTypes || hasExplanation
+  // Keyboard-reachable twin of dragging the widget onto the chat. Gated on the
+  // chat actually being available: with no provider mounted `useAiChat()`
+  // returns an inert context whose setters are no-ops, so offering the action
+  // would do nothing.
+  const hasAskOne = aiEnabled && title.trim().length > 0
+  const showMenu =
+    hasAskOne || hasDownloads || hasDelete || hasChartTypes || hasExplanation
 
   if (error) {
     return (
@@ -352,6 +365,28 @@ export function DashboardItem({
                             <F0Icon icon={InfoCircleLine} />
                             <span className="flex-1">
                               {translations.ai.dashboardItem.dataExplanation}
+                            </span>
+                          </div>
+                        </DropdownMenuItem>
+                      </DropdownMenuGroup>
+                    )}
+
+                    {hasAskOne && (
+                      <DropdownMenuGroup>
+                        <DropdownMenuItem
+                          onClick={() => {
+                            // Fullscreen covers the chat, so step out of it
+                            // before handing the widget over — same reason the
+                            // delete action does.
+                            if (isFullscreen) onFullscreenChange?.(false)
+                            setPendingQuote({ text: title })
+                            setAiChatOpen(true)
+                          }}
+                        >
+                          <div className="flex w-full flex-row items-center gap-2">
+                            <F0Icon icon={OneIcon} />
+                            <span className="flex-1">
+                              {translations.ai.dashboardItem.askOne}
                             </span>
                           </div>
                         </DropdownMenuItem>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react"
+import { useRef, useState, type ReactNode } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0ButtonToggleGroup } from "@/components/F0ButtonToggleGroup"
@@ -129,6 +129,7 @@ export function DashboardItem({
   onFullscreenChange,
 }: DashboardItemProps) {
   const [isDropdownOpen, setIsDropdownOpen] = useState(false)
+  const shouldFocusChatAfterMenuRef = useRef(false)
   /**
    * When true, the dropdown menu's content is swapped from the action list
    * to a markdown rendering of `explanation`. The dropdown trigger stays
@@ -143,6 +144,7 @@ export function DashboardItem({
     enabled: aiEnabled,
     setPendingQuote,
     setOpen: setAiChatOpen,
+    focusChatInput,
   } = useAiChat()
 
   const handleDropdownOpenChange = (open: boolean) => {
@@ -324,6 +326,12 @@ export function DashboardItem({
               <DropdownMenuContent
                 align="end"
                 className={cn("py-1", isExplanationView && "w-96 max-w-[90vw]")}
+                onCloseAutoFocus={(event) => {
+                  if (!shouldFocusChatAfterMenuRef.current) return
+                  event.preventDefault()
+                  shouldFocusChatAfterMenuRef.current = false
+                  focusChatInput()
+                }}
               >
                 {isExplanationView && hasExplanation ? (
                   <div className="px-3 py-2 text-base text-f1-foreground [&>div]:flex [&>div]:flex-col [&>div]:gap-2">
@@ -393,6 +401,7 @@ export function DashboardItem({
                             // before handing the widget over — same reason the
                             // delete action does.
                             if (isFullscreen) onFullscreenChange?.(false)
+                            shouldFocusChatAfterMenuRef.current = true
                             setPendingQuote({ text: title })
                             setAiChatOpen(true)
                           }}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -56,6 +56,12 @@ interface DashboardItemProps {
   editMode?: boolean
   /** Called when the user clicks the delete action */
   handleDelete?: (itemId: string) => void
+  /**
+   * Overrides the built-in "Ask One" action. Given it, this component stops
+   * touching the chat and the host answers instead — and the entry no longer
+   * needs a chat to be mounted at all.
+   */
+  onAskAi?: (item: { id: string; title: string }) => void
   /** Item ID — required when editMode is true for the delete callback */
   itemId?: string
   /** Chart type transform options — rendered as a toggle group in the dropdown */
@@ -113,6 +119,7 @@ export function DashboardItem({
   actions = [],
   editMode,
   handleDelete,
+  onAskAi,
   itemId,
   chartTypeOptions,
   explanation,
@@ -153,11 +160,11 @@ export function DashboardItem({
   const hasChartTypes = chartTypeOptions && chartTypeOptions.length > 0
   const hasExplanation = !!explanation && explanation.trim().length > 0
   const hasFullscreen = !!onFullscreenChange
-  // Keyboard-reachable twin of dragging the widget onto the chat. Gated on the
-  // chat actually being available: with no provider mounted `useAiChat()`
-  // returns an inert context whose setters are no-ops, so offering the action
-  // would do nothing.
-  const hasAskOne = aiEnabled && title.trim().length > 0
+  // Keyboard-reachable twin of dragging the widget onto the chat. Gated on
+  // something being able to answer it: a host handler, or failing that a
+  // mounted chat — with no provider `useAiChat()` returns an inert context
+  // whose setters are no-ops, so offering the action would do nothing.
+  const hasAskOne = (!!onAskAi || aiEnabled) && title.trim().length > 0
   const showMenu =
     hasAskOne || hasDownloads || hasDelete || hasChartTypes || hasExplanation
 
@@ -375,6 +382,13 @@ export function DashboardItem({
                       <DropdownMenuGroup>
                         <DropdownMenuItem
                           onClick={() => {
+                            if (onAskAi) {
+                              // The host answers this one. Nothing else here
+                              // applies: it may not open the chat at all, so
+                              // leaving fullscreen would be a guess.
+                              onAskAi({ id: itemId ?? "", title })
+                              return
+                            }
                             // Fullscreen covers the chat, so step out of it
                             // before handing the widget over — same reason the
                             // delete action does.

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -166,33 +166,99 @@ export function DashboardItem({
   // something being able to answer it: a host handler, or failing that a
   // mounted chat — with no provider `useAiChat()` returns an inert context
   // whose setters are no-ops, so offering the action would do nothing.
-  const hasAskOne = (!!onAskAi || aiEnabled) && title.trim().length > 0
+  const hasAskOne = title.trim().length > 0 && (onAskAi ? !!itemId : aiEnabled)
   const showMenu =
     hasAskOne || hasDownloads || hasDelete || hasChartTypes || hasExplanation
+
+  const handleAskOne = () => {
+    if (onAskAi) {
+      // The host answers this one. Nothing else here applies: it may not open
+      // the chat at all, so leaving fullscreen would be a guess. `hasAskOne`
+      // guarantees the public payload has a real widget ID.
+      if (!itemId) return
+      onAskAi({ id: itemId, title })
+      return
+    }
+
+    // Fullscreen covers the chat, so step out of it before handing the widget
+    // over — same reason the delete action does.
+    if (isFullscreen) onFullscreenChange?.(false)
+    shouldFocusChatAfterMenuRef.current = true
+    setPendingQuote({ text: title })
+    setAiChatOpen(true)
+  }
+
+  const handleAskOneMenuCloseAutoFocus = (event: Event) => {
+    if (!shouldFocusChatAfterMenuRef.current) return
+    shouldFocusChatAfterMenuRef.current = false
+
+    // Keep Radix's normal trigger restoration while the composer is still
+    // mounting. The buffered request moves focus once registration completes.
+    if (focusChatInput()) event.preventDefault()
+  }
+
+  const askOneMenuItem = hasAskOne ? (
+    <DropdownMenuGroup>
+      <DropdownMenuItem onClick={handleAskOne}>
+        <div className="flex w-full flex-row items-center gap-2">
+          <F0Icon icon={OneIcon} />
+          <span className="flex-1">{translations.ai.dashboardItem.askOne}</span>
+        </div>
+      </DropdownMenuItem>
+    </DropdownMenuGroup>
+  ) : null
 
   if (error) {
     return (
       <div className="flex h-full flex-col overflow-hidden rounded-lg border border-solid border-f1-border-secondary">
-        <div className="flex shrink-0 flex-col p-4">
+        <div className="flex shrink-0 items-start gap-2 p-4">
           {/* The help copy survives the failure: a reader looking at an error
               is exactly the one asking what the widget was meant to show.
               `items-start`, not `items-center`: this heading doesn't truncate,
               so a long title wraps and centring would float the ⓘ against the
               middle of the block instead of its first line. */}
-          <div className="flex min-w-0 items-start gap-1">
-            <h3 className="text-base font-medium text-f1-foreground">
-              {title}
-            </h3>
-            {info && (
-              <div className="flex shrink-0 items-center text-f1-foreground-secondary">
-                <InfoHint info={info} />
-              </div>
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="flex min-w-0 items-start gap-1">
+              <h3 className="text-base font-medium text-f1-foreground">
+                {title}
+              </h3>
+              {info && (
+                <div className="flex shrink-0 items-center text-f1-foreground-secondary">
+                  <InfoHint info={info} />
+                </div>
+              )}
+            </div>
+            {description && (
+              <p className="text-base text-f1-foreground-secondary">
+                {description}
+              </p>
             )}
           </div>
-          {description && (
-            <p className="text-base text-f1-foreground-secondary">
-              {description}
-            </p>
+          {hasAskOne && (
+            <DropdownMenu
+              open={isDropdownOpen}
+              onOpenChange={handleDropdownOpenChange}
+            >
+              <DropdownMenuTrigger asChild>
+                <ButtonInternal
+                  label={translations.actions.other}
+                  icon={Ellipsis}
+                  variant="ghost"
+                  size="md"
+                  hideLabel
+                  pressed={isDropdownOpen}
+                  compact
+                  onClick={(event: React.MouseEvent) => event.stopPropagation()}
+                />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                align="end"
+                className="py-1"
+                onCloseAutoFocus={handleAskOneMenuCloseAutoFocus}
+              >
+                {askOneMenuItem}
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
         </div>
         <div className="min-h-0 flex-1 overflow-auto">
@@ -326,12 +392,7 @@ export function DashboardItem({
               <DropdownMenuContent
                 align="end"
                 className={cn("py-1", isExplanationView && "w-96 max-w-[90vw]")}
-                onCloseAutoFocus={(event) => {
-                  if (!shouldFocusChatAfterMenuRef.current) return
-                  event.preventDefault()
-                  shouldFocusChatAfterMenuRef.current = false
-                  focusChatInput()
-                }}
+                onCloseAutoFocus={handleAskOneMenuCloseAutoFocus}
               >
                 {isExplanationView && hasExplanation ? (
                   <div className="px-3 py-2 text-base text-f1-foreground [&>div]:flex [&>div]:flex-col [&>div]:gap-2">
@@ -386,35 +447,7 @@ export function DashboardItem({
                       </DropdownMenuGroup>
                     )}
 
-                    {hasAskOne && (
-                      <DropdownMenuGroup>
-                        <DropdownMenuItem
-                          onClick={() => {
-                            if (onAskAi) {
-                              // The host answers this one. Nothing else here
-                              // applies: it may not open the chat at all, so
-                              // leaving fullscreen would be a guess.
-                              onAskAi({ id: itemId ?? "", title })
-                              return
-                            }
-                            // Fullscreen covers the chat, so step out of it
-                            // before handing the widget over — same reason the
-                            // delete action does.
-                            if (isFullscreen) onFullscreenChange?.(false)
-                            shouldFocusChatAfterMenuRef.current = true
-                            setPendingQuote({ text: title })
-                            setAiChatOpen(true)
-                          }}
-                        >
-                          <div className="flex w-full flex-row items-center gap-2">
-                            <F0Icon icon={OneIcon} />
-                            <span className="flex-1">
-                              {translations.ai.dashboardItem.askOne}
-                            </span>
-                          </div>
-                        </DropdownMenuItem>
-                      </DropdownMenuGroup>
-                    )}
+                    {askOneMenuItem}
 
                     {hasDownloads && (
                       <DropdownMenuGroup>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -26,6 +26,7 @@ interface MetricItemProps<Filters extends FiltersDefinition> {
   actions?: import("@/experimental/Navigation/Dropdown").DropdownItem[]
   editMode?: boolean
   handleDelete?: (itemId: string) => void
+  onAskAi?: (item: { id: string; title: string }) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }
@@ -187,6 +188,7 @@ export function MetricItem<Filters extends FiltersDefinition>({
   actions,
   editMode,
   handleDelete,
+  onAskAi,
 }: MetricItemProps<Filters>) {
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -209,6 +211,7 @@ export function MetricItem<Filters extends FiltersDefinition>({
       actions={actions}
       editMode={editMode}
       handleDelete={handleDelete}
+      onAskAi={onAskAi}
       itemId={item.id}
     >
       {data && (

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -528,6 +528,20 @@ export interface F0AnalyticsDashboardProps<
     orientation?: "vertical" | "horizontal"
   ) => void
   /**
+   * Called when the user picks "Ask One" on a widget, replacing what the entry
+   * does by default (quote the widget in the mounted AI chat, then open it).
+   *
+   * Pass this to own the action — send the widget somewhere else, add
+   * tracking, ask for confirmation first. The entry then appears whether or
+   * not an AI chat is mounted, since the host is answering it. Its label stays
+   * `ai.dashboardItem.askOne`, which hosts already override, so the copy is
+   * yours either way.
+   *
+   * Without it the entry appears only where an AI chat is mounted and enabled,
+   * and drives that chat directly.
+   */
+  onAskAi?: (item: { id: string; title: string }) => void
+  /**
    * Navigation filter definitions (e.g. date-navigator).
    * Rendered above the grid alongside the regular filter bar.
    */


### PR DESCRIPTION
## Description

Adds **Ask One** to a dashboard widget's actions menu. Choosing it lets a reader carry the widget context into One without retyping the title: the built-in path exits widget fullscreen, opens the chat, attaches the title as a quote, and focuses the composer.

The action is only offered when it can work. A host can provide `onAskAi` to own the handoff; otherwise an enabled F0 AI chat handles it. Untitled widgets and standalone dashboards without either responder remain unchanged.

**Split out of #5104.** Second in the stack, based on #5123.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots (if applicable)

- [Interactive story - menu action](https://66a7a8d7d124220c363457cc-wpapwoctjg.chromatic.com/?path=/story/patterns-analyticsdashboard-ask-one--widget-menu-action): leaves the widget menu open so reviewers can inspect the label, icon, and placement.
- [Interactive story - completed handoff](https://66a7a8d7d124220c363457cc-wpapwoctjg.chromatic.com/?path=/story/patterns-analyticsdashboard-ask-one--widget-quoted-in-chat): selects **Ask One** and leaves the real chat open with the widget quote visible and the composer focused.
- [MDX documentation - Ask One from a widget](https://66a7a8d7d124220c363457cc-wpapwoctjg.chromatic.com/?path=/docs/patterns-analyticsdashboard--documentation#ask-one-from-a-widget): usage, host-owned API, behavioral rules, and both linked Canvas stories.

**Menu action** - **Ask One** appears with the existing widget actions only when a chat or host handler is available.

<img width="532" height="243" alt="Widget actions menu with Ask One between provenance and delete actions" src="https://github.com/user-attachments/assets/233c350d-8617-42ce-8195-e77f15a8bfd9" />

<img width="763" height="753" alt="image" src="https://github.com/user-attachments/assets/aa84b699-f011-4056-8bbe-0eb6885bb975" />


## Implementation details

- feat: expose **Ask One** from every titled dashboard widget when an enabled chat or `onAskAi` responder is available

  <details>
  <summary>Why is it gated?</summary>

  `F0AnalyticsDashboard` is also used without the AI shell. Showing a command backed only by inert context setters would create a dead action, and an untitled widget has no context to quote. Both cases therefore keep the previous menu unchanged.
  </details>

- feat: support built-in and host-owned handoffs

  <details>
  <summary>Who owns which state?</summary>

  The built-in action exits widget fullscreen, attaches the title, opens the chat, and transfers focus after the Radix menu closes. When `onAskAi` is supplied, the host receives `{ id, title }` and F0 does not mutate chat or fullscreen state or steal host-managed focus.
  </details>

- feat: preserve safe focus while the real textarea mounts

  <details>
  <summary>Why?</summary>

  Opening the chat and mounting its composer are separate React steps. While the composer is absent, Radix restores focus to the widget trigger and the bridge queues the intended transfer. Closing the chat cancels that request so a later, unrelated mount cannot steal focus.
  </details>

- chore: add the `ai.dashboardItem.askOne` translation key and document the Factorial-side override required with the package bump
- fix: keep Ask One available in widget error headers, and hide host-owned actions when a directly rendered item has no ID rather than emitting an empty ID\n- test: cover provider, title, ID, and error-state gating; built-in quote/open/fullscreen/focus behavior; stale-focus cancellation; host ownership; public callback propagation; and the real Storybook menu-to-composer flow\n- story: opt the open-menu review state into Chromatic snapshots

## Verification

- Focused Ask One, dashboard, and focus-bridge suites: 35/35 passed.
- TypeScript, targeted lint, format, and production Storybook build passed.
- Production Storybook and exact Chrome checks passed for the open-menu and completed quote/focus stories. Exact-head GitHub CI is green, including React unit tests, all eight Storybook shards, Chromatic, and the package build.

## Note for the bump

This adds an F0 translation key, so Factorial's `f0-provider.tsx` and `en.json` need `common.ai.dashboard_item.ask_one` before or with the version bump. Overridden translation sections are exhaustive.

---

### The stack

| | PR | What it adds |
|---|---|---|
| 1 | #5123 | `F0DataChart` reports the selected mark |
| 2 | #5124 | Widget menu -> **Ask One** |
| 3 | #5125 | Chart point -> **Ask One** |
| 4 | #5126 | Drag a widget into chat |

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0
> - factorial-ci
> - factorial-pr


