### PR TITLE
feat(F0AnalyticsDashboard): offer Ask One on a clicked chart mark

### DIFF
--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
@@ -12,15 +12,32 @@ import {
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0AnalyticsDashboard } from "../index"
+import type { DashboardItem } from "../types"
 import { mixedItems } from "./mockDataMixed"
 
 const widget = mixedItems.filter((item) => item.id === "headcount")
+const pointWidget = [
+  {
+    id: "point-headcount",
+    title: "Headcount by Department",
+    description: "Click the bar to mention this value in chat",
+    type: "chart",
+    chart: {
+      type: "bar",
+      tooltipValueFormatter: (value: number) => `${value} people`,
+    },
+    fetchData: async () => ({
+      categories: ["Engineering"],
+      series: [{ name: "Headcount", data: [145] }],
+    }),
+  },
+] satisfies DashboardItem[]
 
-const AskOneLayout = () => {
+const AskOneLayout = ({ items = widget }: { items?: DashboardItem[] }) => {
   return (
     <div className="flex h-full w-full gap-2 overflow-hidden">
       <div className="min-h-0 min-w-0 flex-1 overflow-auto">
-        <F0AnalyticsDashboard items={widget} />
+        <F0AnalyticsDashboard items={items} />
       </div>
       <div className="flex min-h-0 w-[420px] shrink-0">
         <F0AiChat
@@ -134,5 +151,60 @@ export const WidgetQuotedInChat: Story = {
       const textbox = await canvas.findByRole("textbox")
       await waitFor(() => expect(textbox).toHaveFocus())
     })
+  },
+}
+
+/**
+ * Click the Engineering bar, then choose Ask One from the anchored action. The
+ * complete category, series, and formatted value appear in the real composer.
+ */
+export const ChartPointFlow: Story = {
+  render: () => <AskOneLayout items={pointWidget} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Click the Engineering bar to reveal the anchored Ask One action, or Tab to the chart's Ask One trigger to open the keyboard point menu. Choose the point to review the complete quote in the focused chat composer.",
+      },
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step("Open the keyboard point menu", async () => {
+      const trigger = await canvas.findByRole("button", {
+        name: "Ask One: Headcount by Department",
+      })
+      trigger.focus()
+      await expect(trigger).toHaveFocus()
+      await userEvent.keyboard("{Enter}")
+      const menuId = trigger.getAttribute("aria-controls")
+      if (!menuId)
+        throw new Error("The point menu trigger has no aria-controls")
+
+      const menu = await waitFor(() => {
+        const element = canvasElement.ownerDocument.getElementById(menuId)
+        expect(element).toBeInTheDocument()
+        return within(element!)
+      })
+      await userEvent.click(
+        await menu.findByRole("menuitem", {
+          name: "Headcount by Department — Engineering, Headcount: 145 people",
+        })
+      )
+    })
+
+    await step(
+      "Verify the formatted point in the focused composer",
+      async () => {
+        const removeQuote = await canvas.findByRole("button", {
+          name: "Remove quote",
+        })
+        await expect(removeQuote.parentElement).toHaveTextContent(
+          "Headcount by Department — Engineering Headcount: 145 people"
+        )
+        await waitFor(() => expect(canvas.getByRole("textbox")).toHaveFocus())
+      }
+    )
   },
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -197,6 +197,7 @@ no pointer position to anchor to.
 - WHEN a scatter point is quoted → THEN both the X and Y measures are included with their axis names and formatters.
 - WHEN a line category is quoted → THEN every visible series at that category is included, matching the axis tooltip.
 - WHEN `onAskAi` owns the action → THEN it receives the raw point and the built-in chat state remains unchanged.
+- WHEN the chart has no title → THEN pointer and keyboard point actions are hidden because there is no widget context to quote.
 - WHEN the chart moves because of scrolling or resizing, or the reader presses <kbd>Escape</kbd> or clicks elsewhere → THEN the anchored action closes.
 - WHEN a screen reader reaches the point action → THEN its trigger is named **Ask One: _chart title_** and each menu item exposes the complete formatted point context.
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -160,6 +160,46 @@ the mounted chat:
 - WHEN a directly rendered widget has `onAskAi` but no `itemId` → THEN the action is hidden rather than sending an empty ID.
 - WHEN a widget has no title → THEN the action is hidden because there is nothing to quote.
 
+### Ask One from a chart point
+
+Charts with an available chat or `onAskAi` handler let the reader click a mark
+before choosing **Ask One**. The intermediate action is intentional: ordinary
+chart exploration must not open the chat on every click.
+
+**Interactive point flow**
+
+In this story, click the Engineering bar to reveal the anchored action. Choose
+**Ask One** to review the category, series, and formatted value in the focused
+chat composer.
+
+<Canvas of={AskOneStories.ChartPointFlow} />
+
+The host-owned callback receives the raw point as `point`, in addition to the
+widget `id` and `title`. `point.values` preserves every measure carried by one
+mark, while `point.series` preserves every visible series resolved by a line
+chart click. `point.source` distinguishes `"pointer"` from `"keyboard"`;
+keyboard-resolved points use `0` for both viewport coordinates because there is
+no pointer position to anchor to.
+
+```tsx
+<F0AnalyticsDashboard
+  items={items}
+  onAskAi={({ id, title, point }) => {
+    openProductChat({ widgetId: id, quote: title, point })
+  }}
+/>
+```
+
+- WHEN a pointer user clicks a chart mark → THEN **Ask One** appears beside that mark without opening the chat yet.
+- WHEN a keyboard user tabs to the chart's point action → THEN a visible **Ask One** trigger opens a menu containing every currently visible point, with the same formatted context as pointer selection.
+- WHEN a chart contains more than 100 points → THEN the keyboard menu pages them with **Previous** and **Next** actions instead of mounting the entire dataset at once.
+- WHEN the built-in action is chosen → THEN the quote keeps the chart title, visible point context, and tooltip-formatted values, opens the chat, and focuses its composer.
+- WHEN a scatter point is quoted → THEN both the X and Y measures are included with their axis names and formatters.
+- WHEN a line category is quoted → THEN every visible series at that category is included, matching the axis tooltip.
+- WHEN `onAskAi` owns the action → THEN it receives the raw point and the built-in chat state remains unchanged.
+- WHEN the chart moves because of scrolling or resizing, or the reader presses <kbd>Escape</kbd> or clicks elsewhere → THEN the anchored action closes.
+- WHEN a screen reader reaches the point action → THEN its trigger is named **Ask One: _chart title_** and each menu item exposes the complete formatted point context.
+
 ### Report filters
 
 Report filters are one applied state shared by every participating item. Pass `filtersValue` with `onFiltersChange` to own that state — for example to hydrate a saved report and persist each committed change — or pass only `defaultFilters` to let the dashboard own it.
@@ -258,7 +298,22 @@ The filter bar remains usable when valid report filters return empty chart data.
         <td>
           <kbd>Escape</kbd>
         </td>
-        <td>Closes the filter dialog and rolls back temporary selections.</td>
+        <td>Closes the filter dialog or an anchored chart-point action.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>, then <kbd>Enter</kbd> / <kbd>Space</kbd>
+        </td>
+        <td>
+          Reaches and reveals the chart's <strong>Ask One</strong> trigger, then
+          opens its keyboard-accessible data-point menu.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>ArrowUp</kbd> / <kbd>ArrowDown</kbd>
+        </td>
+        <td>Moves through data points in the open chart action menu.</td>
       </tr>
     </tbody>
   </table>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import {
@@ -7,14 +8,27 @@ import {
   zeroRender as render,
 } from "@/testing/test-utils"
 
-import type { F0DataChartPointClick } from "@/kits/F0DataChart"
+import type {
+  F0DataChartPointClick,
+  F0DataChartProps,
+} from "@/kits/F0DataChart"
+import {
+  AiChatStateProvider,
+  useAiChat,
+} from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 
 import type { DashboardChartItem } from "../types"
 
-import { ChartItem } from "../components/ChartItem/ChartItem"
+import {
+  buildPointQuoteText,
+  buildAccessibleChartPoints,
+  buildChartProps,
+  ChartItem,
+} from "../components/ChartItem/ChartItem"
 
 /** The mark a click lands on, as `usePointClick` would report it. */
 const POINT: F0DataChartPointClick = {
+  source: "pointer",
   seriesName: "Male",
   category: "Barcelona office",
   value: 18,
@@ -64,10 +78,46 @@ const pickAMark = async () => {
   await userEvent.click(screen.getByRole("button", { name: "Ask One" }))
 }
 
+const ChatProbe = () => {
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const { pendingQuote, open, setFocusChatInputFunction } = useAiChat()
+
+  useEffect(() => {
+    setFocusChatInputFunction(() => inputRef.current?.focus())
+    return () => setFocusChatInputFunction(null)
+  }, [setFocusChatInputFunction])
+
+  return (
+    <>
+      <span
+        data-testid="probe"
+        data-quote={pendingQuote?.text ?? ""}
+        data-open={String(open)}
+      />
+      <textarea ref={inputRef} aria-label="Chat question" />
+    </>
+  )
+}
+
 describe("ChartItem — asking about a mark", () => {
   it("hands the host the mark, not a sentence built from it", async () => {
-    const onAskAi = vi.fn()
-    render(<ChartItem item={item} filters={{}} onAskAi={onAskAi} />)
+    const onAskAi = vi.fn(() =>
+      screen.getByRole("button", { name: "Host chat" }).focus()
+    )
+    const onFullscreenChange = vi.fn()
+    render(
+      <AiChatStateProvider enabled>
+        <button type="button" aria-label="Host chat" />
+        <ChatProbe />
+        <ChartItem
+          item={item}
+          filters={{}}
+          onAskAi={onAskAi}
+          isFullscreen
+          onFullscreenChange={onFullscreenChange}
+        />
+      </AiChatStateProvider>
+    )
 
     await pickAMark()
 
@@ -78,6 +128,15 @@ describe("ChartItem — asking about a mark", () => {
       title: "Headcount by workplace",
       point: POINT,
     })
+    expect(screen.getByTestId("probe")).toHaveAttribute("data-quote", "")
+    expect(screen.getByTestId("probe")).toHaveAttribute("data-open", "false")
+    expect(
+      screen.getByRole("textbox", { name: "Chat question" })
+    ).not.toHaveFocus()
+    expect(onFullscreenChange).not.toHaveBeenCalled()
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Host chat" })).toHaveFocus()
+    )
   })
 
   it("offers the click with no chat mounted, once the host answers it", async () => {
@@ -89,5 +148,610 @@ describe("ChartItem — asking about a mark", () => {
     await pickAMark()
 
     expect(onAskAi).toHaveBeenCalledTimes(1)
+  })
+
+  it("preserves host-owned focus after keyboard point selection", async () => {
+    let hostButton: HTMLButtonElement | null = null
+    const onAskAi = vi.fn(() => hostButton?.focus())
+    render(
+      <>
+        <button
+          ref={(element) => {
+            hostButton = element
+          }}
+          type="button"
+          aria-label="Host chat"
+        />
+        <ChartItem item={item} filters={{}} onAskAi={onAskAi} />
+      </>
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by workplace",
+    })
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    await userEvent.click(
+      await screen.findByRole("menuitem", {
+        name: "Headcount by workplace — Barcelona office, Male: 18",
+      })
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Host chat" })).toHaveFocus()
+    )
+    expect(onAskAi).toHaveBeenCalledWith(
+      expect.objectContaining({
+        point: expect.objectContaining({ source: "keyboard" }),
+      })
+    )
+  })
+
+  it("puts the visible mark in the built-in chat", async () => {
+    const onFullscreenChange = vi.fn()
+
+    render(
+      <AiChatStateProvider enabled>
+        <ChatProbe />
+        <ChartItem
+          item={item}
+          filters={{}}
+          isFullscreen
+          onFullscreenChange={onFullscreenChange}
+        />
+      </AiChatStateProvider>
+    )
+
+    await pickAMark()
+
+    expect(screen.getByTestId("probe")).toHaveAttribute(
+      "data-quote",
+      "Headcount by workplace — Barcelona office\nMale: 18"
+    )
+    expect(screen.getByTestId("probe")).toHaveAttribute("data-open", "true")
+    expect(screen.getByRole("textbox", { name: "Chat question" })).toHaveFocus()
+    expect(onFullscreenChange).toHaveBeenCalledWith(false)
+  })
+
+  it("offers every mark through a keyboard-reachable menu", async () => {
+    render(
+      <AiChatStateProvider enabled>
+        <ChatProbe />
+        <ChartItem item={item} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by workplace",
+    })
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+
+    const point = await screen.findByRole("menuitem", {
+      name: "Headcount by workplace — Barcelona office, Male: 18",
+    })
+    await userEvent.click(point)
+
+    expect(screen.getByTestId("probe")).toHaveAttribute(
+      "data-quote",
+      "Headcount by workplace — Barcelona office\nMale: 18"
+    )
+    expect(screen.getByRole("textbox", { name: "Chat question" })).toHaveFocus()
+  })
+
+  it("returns focus to the point trigger when its keyboard menu closes", async () => {
+    render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={item} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by workplace",
+    })
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    await screen.findByRole("menuitem", {
+      name: "Headcount by workplace — Barcelona office, Male: 18",
+    })
+
+    await userEvent.keyboard("{Escape}")
+
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+
+  it("pages large point sets instead of mounting every menu item", async () => {
+    const categories = Array.from(
+      { length: 101 },
+      (_, index) => `Team ${index}`
+    )
+    const largeItem: DashboardChartItem = {
+      ...item,
+      fetchData: () =>
+        Promise.resolve({
+          categories,
+          series: [
+            {
+              name: "Headcount",
+              data: categories.map((_, index) => index),
+            },
+          ],
+        }),
+    }
+    render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={largeItem} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by workplace",
+    })
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+
+    expect(await screen.findAllByRole("menuitem")).toHaveLength(101)
+    await userEvent.click(screen.getByRole("menuitem", { name: "Next" }))
+
+    const lastPoint = await screen.findByRole("menuitem", {
+      name: "Headcount by workplace — Team 100, Headcount: 100",
+    })
+    await waitFor(() => expect(lastPoint).toHaveFocus())
+    expect(screen.getAllByRole("menuitem")).toHaveLength(2)
+    expect(
+      screen.getByRole("menuitem", { name: "Previous" })
+    ).toBeInTheDocument()
+  })
+
+  it("returns focus to the keyboard point trigger after Escape", async () => {
+    render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={item} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByRole("button", { name: "mark" }))
+    const pointAction = await screen.findByRole("button", { name: "Ask One" })
+    await waitFor(() => expect(pointAction).toHaveFocus())
+
+    await userEvent.keyboard("{Escape}")
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "Ask One: Headcount by workplace",
+        })
+      ).toHaveFocus()
+    )
+  })
+
+  it("clears a picked mark when a filter refetch starts", async () => {
+    let resolveRefresh:
+      | ((value: {
+          categories: string[]
+          series: { name: string; data: number[] }[]
+        }) => void)
+      | undefined
+    const fetchData = vi
+      .fn()
+      .mockResolvedValueOnce({
+        categories: ["Barcelona office"],
+        series: [{ name: "Male", data: [18] }],
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve
+          })
+      )
+    const refreshItem = { ...item, fetchData }
+    const view = render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={refreshItem} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByRole("button", { name: "mark" }))
+    expect(
+      await screen.findByRole("button", { name: "Ask One" })
+    ).toBeInTheDocument()
+
+    view.rerender(
+      <AiChatStateProvider enabled>
+        <ChartItem item={refreshItem} filters={{ department: ["Design"] }} />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() => expect(fetchData).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Ask One" })
+      ).not.toBeInTheDocument()
+    )
+
+    resolveRefresh?.({
+      categories: ["Madrid office"],
+      series: [{ name: "Female", data: [22] }],
+    })
+  })
+
+  it("clears a picked mark when the chart transformation changes", async () => {
+    const view = render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={item} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByRole("button", { name: "mark" }))
+    expect(
+      await screen.findByRole("button", { name: "Ask One" })
+    ).toBeInTheDocument()
+
+    view.rerender(
+      <AiChatStateProvider enabled>
+        <ChartItem item={{ ...item, chart: { type: "line" } }} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Ask One" })
+      ).not.toBeInTheDocument()
+    )
+  })
+})
+
+describe("buildPointQuoteText", () => {
+  it("keeps and independently formats both scatter measures", () => {
+    expect(
+      buildPointQuoteText(
+        item.title,
+        {
+          type: "scatter",
+          series: [],
+          xAxisName: "salary",
+          yAxisName: "tenure",
+          xTooltipValueFormatter: (value) => `€${value.toLocaleString("en")}`,
+          tooltipValueFormatter: (value) => `${value} yrs`,
+        },
+        {
+          ...POINT,
+          seriesName: "Engineering",
+          category: "Roser Nogué",
+          value: 0.6,
+          values: [128000, 0.6],
+          series: [{ name: "Engineering", seriesIndex: 0, value: 0.6 }],
+        }
+      )
+    ).toBe(
+      "Headcount by workplace — Roser Nogué\nEngineering\nsalary: €128,000\ntenure: 0.6 yrs"
+    )
+  })
+
+  it("keeps every visible line series at the picked category", () => {
+    expect(
+      buildPointQuoteText(
+        item.title,
+        {
+          type: "line",
+          categories: ["Feb"],
+          series: [],
+          categoryFormatter: (category) => category.toUpperCase(),
+          tooltipValueFormatter: (value) => `${value}%`,
+        },
+        {
+          ...POINT,
+          category: "Feb",
+          value: 30,
+          values: [30],
+          series: [
+            { name: "Headcount", seriesIndex: 0, value: 30 },
+            { name: "Attrition", seriesIndex: 1, value: 8 },
+          ],
+        }
+      )
+    ).toBe("Headcount by workplace — FEB\nHeadcount: 30%\nAttrition: 8%")
+  })
+
+  it("names every radar indicator carried by the point", () => {
+    expect(
+      buildPointQuoteText(
+        item.title,
+        {
+          type: "radar",
+          indicators: [{ name: "Performance" }, { name: "Engagement" }],
+          series: [],
+          tooltipValueFormatter: (value) => `${value}/10`,
+        },
+        {
+          ...POINT,
+          seriesName: "Team A",
+          category: "Team A",
+          value: 7,
+          values: [8, 7],
+        }
+      )
+    ).toBe(
+      "Headcount by workplace — Team A\nPerformance: 8/10\nEngagement: 7/10"
+    )
+  })
+
+  it("resolves heatmap tuple indexes to the visible row and column", () => {
+    expect(
+      buildPointQuoteText(
+        item.title,
+        {
+          type: "heatmap",
+          xCategories: ["09:00", "10:00"],
+          yCategories: ["Monday", "Tuesday"],
+          data: [],
+          tooltipValueFormatter: (value) => `${value} people`,
+        },
+        {
+          ...POINT,
+          seriesName: "",
+          category: "",
+          value: 37,
+          values: [1, 0, 37],
+        }
+      )
+    ).toBe("Headcount by workplace — Monday — 10:00\n37 people")
+  })
+
+  it("uses the same localized-number fallback as the tooltip", () => {
+    expect(
+      buildPointQuoteText(
+        item.title,
+        { type: "gauge", value: 128000 },
+        { ...POINT, seriesName: "", category: "", value: 128000 }
+      )
+    ).toBe(`Headcount by workplace\n${(128000).toLocaleString()}`)
+  })
+
+  it("quotes every indicator synthesized by a chart transformation", () => {
+    const transformed = buildChartProps(
+      { ...item, chart: { type: "radar" } },
+      {
+        categories: ["Performance", "Engagement"],
+        series: [{ name: "Team A", data: [8, 7] }],
+      }
+    )
+    expect(transformed.type).toBe("radar")
+    if (transformed.type !== "radar") throw new Error("Expected radar props")
+
+    const [point] = buildAccessibleChartPoints(transformed)
+    expect(
+      point &&
+        buildPointQuoteText(item.title, transformed, point.point)
+          .split("\n")
+          .join(", ")
+    ).toBe("Headcount by workplace — Team A, Performance: 8, Engagement: 7")
+  })
+})
+
+describe("buildAccessibleChartPoints", () => {
+  const keyboardPosition = {
+    source: "keyboard" as const,
+    clientX: 0,
+    clientY: 0,
+  }
+
+  const cases: Array<{
+    name: string
+    chart: F0DataChartProps
+    expected: F0DataChartPointClick[]
+  }> = [
+    {
+      name: "line categories with their complete finite series column",
+      chart: {
+        type: "line",
+        categories: ["Jan", "Feb"],
+        series: [
+          { name: "Headcount", data: [30, { value: 31 }] },
+          { name: "Attrition", data: [8, Number.NaN] },
+        ],
+      },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "Headcount",
+          category: "Jan",
+          value: 30,
+          values: [30],
+          series: [
+            { name: "Headcount", seriesIndex: 0, value: 30 },
+            { name: "Attrition", seriesIndex: 1, value: 8 },
+          ],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+        {
+          ...keyboardPosition,
+          seriesName: "Headcount",
+          category: "Feb",
+          value: 31,
+          values: [31],
+          series: [{ name: "Headcount", seriesIndex: 0, value: 31 }],
+          dataIndex: 1,
+          seriesIndex: 0,
+        },
+      ],
+    },
+    {
+      name: "finite funnel stages",
+      chart: {
+        type: "funnel",
+        series: {
+          name: "Candidates",
+          data: [
+            { name: "Applied", value: 100 },
+            { name: "Hired", value: Number.NaN },
+          ],
+        },
+      },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "Candidates",
+          category: "Applied",
+          value: 100,
+          values: [100],
+          series: [{ name: "Candidates", seriesIndex: 0, value: 100 }],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+      ],
+    },
+    {
+      name: "finite visible pie segments",
+      chart: {
+        type: "pie",
+        series: {
+          name: "Headcount",
+          data: [
+            { name: "Engineering", value: 60 },
+            { name: "Sales", value: Number.POSITIVE_INFINITY },
+          ],
+        },
+      },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "Headcount",
+          category: "Engineering",
+          value: 60,
+          values: [60],
+          series: [{ name: "Headcount", seriesIndex: 0, value: 60 }],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+      ],
+    },
+    {
+      name: "the gauge datum using ECharts item semantics",
+      chart: { type: "gauge", name: "Goal", value: 72 },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "",
+          category: "Goal",
+          value: 72,
+          values: [72],
+          series: [{ name: "", seriesIndex: 0, value: 72 }],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+      ],
+    },
+    {
+      name: "finite heatmap tuples with their axis indexes",
+      chart: {
+        type: "heatmap",
+        xCategories: ["09:00", "10:00"],
+        yCategories: ["Monday"],
+        data: [
+          [1, 0, 37],
+          [Number.NaN, 0, 9],
+        ],
+      },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "",
+          category: "",
+          value: 37,
+          values: [1, 0, 37],
+          series: [{ name: "", seriesIndex: 0, value: 37 }],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+      ],
+    },
+    {
+      name: "finite scatter tuples with their point identity",
+      chart: {
+        type: "scatter",
+        series: [
+          {
+            name: "Engineering",
+            data: [
+              { x: 128000, y: 0.6, label: "Roser Nogué" },
+              { x: Number.NaN, y: 1, label: "Broken" },
+            ],
+          },
+        ],
+      },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "Engineering",
+          category: "Roser Nogué",
+          value: 0.6,
+          values: [128000, 0.6],
+          series: [{ name: "Engineering", seriesIndex: 0, value: 0.6 }],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+      ],
+    },
+  ]
+
+  it.each(cases)("synthesizes $name", ({ chart, expected }) => {
+    expect(buildAccessibleChartPoints(chart).map(({ point }) => point)).toEqual(
+      expected
+    )
+  })
+
+  it("keeps keyboard points aligned with the live legend selection", () => {
+    const chart: F0DataChartProps = {
+      type: "bar",
+      categories: ["Engineering"],
+      series: [
+        { name: "Women", data: [70] },
+        { name: "Men", data: [75] },
+      ],
+    }
+
+    expect(
+      buildAccessibleChartPoints(chart, { Women: false }).map(
+        ({ point }) => point.seriesName
+      )
+    ).toEqual(["Men"])
+
+    expect(
+      buildAccessibleChartPoints(
+        {
+          type: "funnel",
+          series: {
+            name: "Candidates",
+            data: [
+              { name: "Applied", value: 100 },
+              { name: "Hired", value: 20 },
+            ],
+          },
+        },
+        { Applied: false }
+      ).map(({ point }) => point.category)
+    ).toEqual(["Hired"])
+  })
+
+  it.each([
+    { type: "gauge", value: Number.NaN } as const,
+    {
+      type: "radar",
+      indicators: [{ name: "Performance" }],
+      series: [{ name: "Team A", data: [Number.NaN] }],
+    } as const,
+  ])("does not expose malformed $type data", (chart) => {
+    expect(buildAccessibleChartPoints(chart)).toEqual([])
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -24,6 +24,7 @@ import {
   buildAccessibleChartPoints,
   buildChartProps,
   ChartItem,
+  hasAccessibleChartPoint,
 } from "../components/ChartItem/ChartItem"
 
 /** The mark a click lands on, as `usePointClick` would report it. */
@@ -150,6 +151,30 @@ describe("ChartItem — asking about a mark", () => {
     expect(onAskAi).toHaveBeenCalledTimes(1)
   })
 
+  it("clears a picked mark when its responder becomes unavailable", async () => {
+    const onAskAi = vi.fn()
+    const view = render(
+      <ChartItem item={item} filters={{}} onAskAi={onAskAi} />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByRole("button", { name: "mark" }))
+    expect(
+      await screen.findByRole("button", { name: "Ask One" })
+    ).toBeInTheDocument()
+
+    view.rerender(<ChartItem item={item} filters={{}} />)
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: "Ask One" })
+      ).not.toBeInTheDocument()
+    )
+    expect(onAskAi).not.toHaveBeenCalled()
+  })
+
   it("preserves host-owned focus after keyboard point selection", async () => {
     let hostButton: HTMLButtonElement | null = null
     const onAskAi = vi.fn(() => hostButton?.focus())
@@ -260,6 +285,60 @@ describe("ChartItem — asking about a mark", () => {
     await waitFor(() => expect(trigger).toHaveFocus())
   })
 
+  it("closes the keyboard point menu when refreshed data replaces its actions", async () => {
+    let resolveRefresh:
+      | ((value: {
+          categories: string[]
+          series: { name: string; data: number[] }[]
+        }) => void)
+      | undefined
+    const fetchData = vi
+      .fn()
+      .mockResolvedValueOnce({
+        categories: ["Barcelona office"],
+        series: [{ name: "Male", data: [18] }],
+      })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveRefresh = resolve
+          })
+      )
+    const refreshItem = { ...item, fetchData }
+    const view = render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={refreshItem} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by workplace",
+    })
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    expect(
+      await screen.findByRole("menuitem", {
+        name: "Headcount by workplace — Barcelona office, Male: 18",
+      })
+    ).toBeInTheDocument()
+
+    view.rerender(
+      <AiChatStateProvider enabled>
+        <ChartItem item={refreshItem} filters={{ department: ["Design"] }} />
+      </AiChatStateProvider>
+    )
+    await waitFor(() => expect(fetchData).toHaveBeenCalledTimes(2))
+
+    resolveRefresh?.({
+      categories: ["Madrid office"],
+      series: [{ name: "Female", data: [22] }],
+    })
+
+    await waitFor(() =>
+      expect(screen.queryByRole("menu")).not.toBeInTheDocument()
+    )
+  })
+
   it("pages large point sets instead of mounting every menu item", async () => {
     const categories = Array.from(
       { length: 101 },
@@ -318,6 +397,31 @@ describe("ChartItem — asking about a mark", () => {
     await waitFor(() => expect(pointAction).toHaveFocus())
 
     await userEvent.keyboard("{Escape}")
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("button", {
+          name: "Ask One: Headcount by workplace",
+        })
+      ).toHaveFocus()
+    )
+  })
+
+  it("returns focus to the keyboard point trigger after viewport movement", async () => {
+    render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={item} filters={{}} />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByRole("button", { name: "mark" }))
+    const pointAction = await screen.findByRole("button", { name: "Ask One" })
+    await waitFor(() => expect(pointAction).toHaveFocus())
+
+    window.dispatchEvent(new Event("resize"))
 
     await waitFor(() =>
       expect(
@@ -751,7 +855,14 @@ describe("buildAccessibleChartPoints", () => {
       indicators: [{ name: "Performance" }],
       series: [{ name: "Team A", data: [Number.NaN] }],
     } as const,
+    {
+      type: "heatmap",
+      xCategories: ["09:00"],
+      yCategories: ["Monday"],
+      data: [[0, 0] as unknown as [number, number, number]],
+    } as const,
   ])("does not expose malformed $type data", (chart) => {
     expect(buildAccessibleChartPoints(chart)).toEqual([])
+    expect(hasAccessibleChartPoint(chart)).toBe(false)
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  screen,
+  userEvent,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import type { F0DataChartPointClick } from "@/kits/F0DataChart"
+
+import type { DashboardChartItem } from "../types"
+
+import { ChartItem } from "../components/ChartItem/ChartItem"
+
+/** The mark a click lands on, as `usePointClick` would report it. */
+const POINT: F0DataChartPointClick = {
+  seriesName: "Male",
+  category: "Barcelona office",
+  value: 18,
+  values: [18],
+  series: [{ name: "Male", seriesIndex: 0, value: 18 }],
+  dataIndex: 0,
+  seriesIndex: 0,
+  clientX: 400,
+  clientY: 300,
+}
+
+// Standing in for the chart itself: jsdom can't render a canvas, and what
+// matters here is only what ChartItem does with a reported mark.
+vi.mock("@/kits/F0DataChart", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/kits/F0DataChart")>()
+  return {
+    ...actual,
+    F0DataChart: ({
+      onPointClick,
+    }: {
+      onPointClick?: (point: F0DataChartPointClick) => void
+    }) => (
+      <button type="button" onClick={() => onPointClick?.(POINT)}>
+        mark
+      </button>
+    ),
+  }
+})
+
+const item: DashboardChartItem = {
+  id: "headcount",
+  title: "Headcount by workplace",
+  type: "chart",
+  chart: { type: "bar" },
+  fetchData: () =>
+    Promise.resolve({
+      categories: ["Barcelona office"],
+      series: [{ name: "Male", data: [18] }],
+    }),
+}
+
+const pickAMark = async () => {
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+  )
+  await userEvent.click(screen.getByRole("button", { name: "mark" }))
+  await userEvent.click(screen.getByRole("button", { name: "Ask One" }))
+}
+
+describe("ChartItem — asking about a mark", () => {
+  it("hands the host the mark, not a sentence built from it", async () => {
+    const onAskAi = vi.fn()
+    render(<ChartItem item={item} filters={{}} onAskAi={onAskAi} />)
+
+    await pickAMark()
+
+    // The raw point, so the host phrases it — it owns the copy and has the
+    // formatters. `point` is what separates this from the ⋯ menu's ask.
+    expect(onAskAi).toHaveBeenCalledWith({
+      id: "headcount",
+      title: "Headcount by workplace",
+      point: POINT,
+    })
+  })
+
+  it("offers the click with no chat mounted, once the host answers it", async () => {
+    const onAskAi = vi.fn()
+    render(<ChartItem item={item} filters={{}} onAskAi={onAskAi} />)
+
+    // No AiChatStateProvider anywhere: without a handler the chart would be
+    // inert, since nothing could answer the click.
+    await pickAMark()
+
+    expect(onAskAi).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 
 import type { DashboardChartItem } from "../types"
+import type { F0AnalyticsDashboardPointClick } from "../types"
 
 import {
   buildPointQuoteText,
@@ -70,6 +71,13 @@ const item: DashboardChartItem = {
       series: [{ name: "Male", data: [18] }],
     }),
 }
+
+const filters = {}
+
+const rebuildItem = (): DashboardChartItem => ({
+  ...item,
+  chart: { type: "bar" },
+})
 
 const pickAMark = async () => {
   await waitFor(() =>
@@ -173,6 +181,89 @@ describe("ChartItem — asking about a mark", () => {
       ).not.toBeInTheDocument()
     )
     expect(onAskAi).not.toHaveBeenCalled()
+  })
+
+  it("keeps a picked mark through an unrelated inline-config rerender", async () => {
+    let revision = 0
+    const onAskAi = vi.fn()
+    const renderInlineItem = () => (
+      <ChartItem
+        item={rebuildItem()}
+        filters={filters}
+        onAskAi={(target) => onAskAi(revision, target)}
+      />
+    )
+    const view = render(renderInlineItem())
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByRole("button", { name: "mark" }))
+    expect(
+      await screen.findByRole("button", { name: "Ask One" })
+    ).toBeInTheDocument()
+
+    revision = 1
+    view.rerender(renderInlineItem())
+
+    const pointAction = screen.getByRole("button", { name: "Ask One" })
+    expect(pointAction).toBeInTheDocument()
+    await userEvent.click(pointAction)
+    expect(onAskAi).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({ point: POINT })
+    )
+  })
+
+  it("keeps the keyboard point menu through an unrelated inline-config rerender", async () => {
+    let revision = 0
+    const onAskAi = vi.fn()
+    const renderInlineItem = () => (
+      <ChartItem
+        item={rebuildItem()}
+        filters={filters}
+        onAskAi={(target) => onAskAi(revision, target)}
+      />
+    )
+    const view = render(renderInlineItem())
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by workplace",
+    })
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    const pointAction = await screen.findByRole("menuitem", {
+      name: "Headcount by workplace — Barcelona office, Male: 18",
+    })
+
+    revision = 1
+    view.rerender(renderInlineItem())
+
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    await userEvent.click(pointAction)
+    expect(onAskAi).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        point: expect.objectContaining({ source: "keyboard" }),
+      })
+    )
+  })
+
+  it("does not expose point actions for a chart without a title", async () => {
+    render(
+      <AiChatStateProvider enabled>
+        <ChartItem item={{ ...item, title: "   " }} filters={filters} />
+      </AiChatStateProvider>
+    )
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "mark" })).toBeInTheDocument()
+    )
+    await userEvent.click(screen.getByRole("button", { name: "mark" }))
+
+    expect(
+      screen.queryByRole("button", { name: /Ask One/ })
+    ).not.toBeInTheDocument()
   })
 
   it("preserves host-owned focus after keyboard point selection", async () => {
@@ -652,7 +743,7 @@ describe("buildAccessibleChartPoints", () => {
   const cases: Array<{
     name: string
     chart: F0DataChartProps
-    expected: F0DataChartPointClick[]
+    expected: F0AnalyticsDashboardPointClick[]
   }> = [
     {
       name: "line categories with their complete finite series column",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
@@ -15,6 +15,16 @@ import type {
 import { F0AnalyticsDashboard } from "../F0AnalyticsDashboard"
 import type { DashboardMetricItem } from "../types"
 
+// Keep this dashboard integration test at the chart boundary: jsdom has no
+// canvas context, while ChartItem's keyboard point surface is ordinary DOM.
+vi.mock("@/kits/F0DataChart", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/kits/F0DataChart")>()
+  return {
+    ...actual,
+    F0DataChart: () => <div aria-label="Chart" role="img" />,
+  }
+})
+
 const filters = {
   department: {
     type: "in",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
@@ -234,6 +234,58 @@ describe("F0AnalyticsDashboard Ask One", () => {
       title: "Headcount",
     })
   })
+
+  it("passes a keyboard-selected chart point through the public handler", async () => {
+    const user = userEvent.setup()
+    const onAskAi = vi.fn()
+
+    render(
+      <F0AnalyticsDashboard
+        items={[
+          {
+            id: "headcount-chart",
+            title: "Headcount by department",
+            type: "chart",
+            chart: { type: "bar" },
+            fetchData: () =>
+              Promise.resolve({
+                categories: ["Engineering"],
+                series: [{ name: "Headcount", data: [145] }],
+              }),
+          },
+        ]}
+        onAskAi={onAskAi}
+      />
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by department",
+    })
+    trigger.focus()
+    await user.keyboard("{Enter}")
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "Headcount by department — Engineering, Headcount: 145",
+      })
+    )
+
+    expect(onAskAi).toHaveBeenCalledWith({
+      id: "headcount-chart",
+      title: "Headcount by department",
+      point: {
+        source: "keyboard",
+        seriesName: "Headcount",
+        category: "Engineering",
+        value: 145,
+        values: [145],
+        series: [{ name: "Headcount", seriesIndex: 0, value: 145 }],
+        dataIndex: 0,
+        seriesIndex: 0,
+        clientX: 0,
+        clientY: 0,
+      },
+    })
+  })
 })
 
 describe("F0AnalyticsDashboard — unrenderable chart config", () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/PointActionPopover.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/PointActionPopover.test.tsx
@@ -75,6 +75,43 @@ describe("PointActionPopover", () => {
     expect(onDismiss).not.toHaveBeenCalled()
   })
 
+  it("dismisses when a scroll container moves the mark", () => {
+    const onDismiss = vi.fn()
+    render(
+      <PointActionPopover
+        anchor={anchor}
+        onAsk={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    )
+
+    // Not the window — the dashboard scrolls inside its own containers, and
+    // `scroll` doesn't bubble, so only a capture-phase listener sees this.
+    const scroller = document.createElement("div")
+    document.body.appendChild(scroller)
+    try {
+      fireEvent.scroll(scroller)
+      expect(onDismiss).toHaveBeenCalledTimes(1)
+    } finally {
+      scroller.remove()
+    }
+  })
+
+  it("dismisses on resize, which moves every mark at once", () => {
+    const onDismiss = vi.fn()
+    render(
+      <PointActionPopover
+        anchor={anchor}
+        onAsk={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    )
+
+    fireEvent.resize(window)
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
   it("portals out of the widget so the card cannot clip it", () => {
     const { container } = render(
       <PointActionPopover anchor={anchor} onAsk={vi.fn()} onDismiss={vi.fn()} />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/PointActionPopover.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/PointActionPopover.test.tsx
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  fireEvent,
+  screen,
+  userEvent,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { PointActionPopover } from "../components/ChartItem/PointActionPopover"
+
+const anchor = { clientX: 400, clientY: 300 }
+
+describe("PointActionPopover", () => {
+  it("renders nothing without an anchor", () => {
+    render(
+      <PointActionPopover anchor={null} onAsk={vi.fn()} onDismiss={vi.fn()} />
+    )
+
+    expect(screen.queryByRole("button")).not.toBeInTheDocument()
+  })
+
+  it("offers the single action and reports it", async () => {
+    const onAsk = vi.fn()
+    render(
+      <PointActionPopover anchor={anchor} onAsk={onAsk} onDismiss={vi.fn()} />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Ask One" }))
+
+    expect(onAsk).toHaveBeenCalledTimes(1)
+  })
+
+  it("dismisses on Escape", () => {
+    const onDismiss = vi.fn()
+    render(
+      <PointActionPopover
+        anchor={anchor}
+        onAsk={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    )
+
+    fireEvent.keyDown(document, { key: "Escape" })
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("dismisses on a pointer press outside", () => {
+    const onDismiss = vi.fn()
+    render(
+      <PointActionPopover
+        anchor={anchor}
+        onAsk={vi.fn()}
+        onDismiss={onDismiss}
+      />
+    )
+
+    fireEvent.pointerDown(document.body)
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it("survives a press on the action itself without dismissing first", () => {
+    const onDismiss = vi.fn()
+    const onAsk = vi.fn()
+    render(
+      <PointActionPopover anchor={anchor} onAsk={onAsk} onDismiss={onDismiss} />
+    )
+
+    // The outside-press listener is capture-phase, so it would otherwise fire
+    // before the button's own click and tear the popover down mid-gesture.
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Ask One" }))
+
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it("portals out of the widget so the card cannot clip it", () => {
+    const { container } = render(
+      <PointActionPopover anchor={anchor} onAsk={vi.fn()} onDismiss={vi.fn()} />
+    )
+
+    // Charts live inside `overflow-hidden` cards and scroll containers.
+    expect(container).toBeEmptyDOMElement()
+    expect(screen.getByRole("button", { name: "Ask One" })).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef, useState } from "react"
+
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { One as OneIcon } from "@/icons/ai"
+import { cn } from "@/lib/utils"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/ui/dropdown-menu"
+
+export type AccessiblePointAction = {
+  key: string
+  getLabel: () => string
+  onSelect: () => void
+}
+
+type AccessiblePointActionsProps = {
+  hasActions: boolean
+  getActions: () => AccessiblePointAction[]
+  label: string
+  triggerLabel: string
+  previousLabel: string
+  nextLabel: string
+  setTrigger: (element: HTMLButtonElement | null) => void
+  focusChatAfterSelect: boolean
+  focusChatInput: () => void
+}
+
+/**
+ * Keyboard and screen-reader surface for canvas marks. It stays visually quiet
+ * until its trigger receives focus, then exposes the same point actions in a
+ * native Radix menu with arrow-key navigation.
+ */
+export function AccessiblePointActions({
+  hasActions,
+  getActions,
+  label,
+  triggerLabel,
+  previousLabel,
+  nextLabel,
+  setTrigger,
+  focusChatAfterSelect,
+  focusChatInput,
+}: AccessiblePointActionsProps) {
+  const [open, setOpen] = useState(false)
+  const [actions, setActions] = useState<AccessiblePointAction[] | null>(null)
+  const [page, setPage] = useState(0)
+  const shouldFocusChatRef = useRef(false)
+  const selectedActionRef = useRef(false)
+  const pendingActionRef = useRef<(() => void) | null>(null)
+  const triggerRef = useRef<HTMLButtonElement | null>(null)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const shouldFocusPageRef = useRef(false)
+  const shouldFocusInitialActionRef = useRef(false)
+
+  useEffect(() => {
+    setActions(null)
+    setPage(0)
+  }, [getActions])
+
+  useEffect(() => {
+    if (!shouldFocusPageRef.current) return
+    shouldFocusPageRef.current = false
+    let focusFrame = 0
+    const frame = requestAnimationFrame(() => {
+      // Radix moves focus back to the content after an item prevents close.
+      // Run one frame later so the new page's first data action wins.
+      focusFrame = requestAnimationFrame(() => {
+        contentRef.current
+          ?.querySelector<HTMLElement>("[data-point-action]")
+          ?.focus()
+      })
+    })
+    return () => {
+      cancelAnimationFrame(frame)
+      cancelAnimationFrame(focusFrame)
+    }
+  }, [page])
+
+  useEffect(() => {
+    if (!open || actions === null || !shouldFocusInitialActionRef.current)
+      return
+    shouldFocusInitialActionRef.current = false
+    let focusFrame = 0
+    const frame = requestAnimationFrame(() => {
+      focusFrame = requestAnimationFrame(() => {
+        contentRef.current
+          ?.querySelector<HTMLElement>("[data-point-action]")
+          ?.focus()
+      })
+    })
+    return () => {
+      cancelAnimationFrame(frame)
+      cancelAnimationFrame(focusFrame)
+    }
+  }, [actions, open])
+
+  if (!hasActions) return null
+
+  const pageSize = 100
+  const loadedActions = actions ?? []
+  const start = page * pageSize
+  const pageActions = loadedActions.slice(start, start + pageSize)
+  const hasPrevious = page > 0
+  const hasNext = start + pageSize < loadedActions.length
+
+  const changePage = (nextPage: number) => {
+    shouldFocusPageRef.current = true
+    setPage(nextPage)
+  }
+
+  return (
+    <div
+      className={cn(
+        "absolute bottom-2 left-2 z-10 transition-opacity",
+        open
+          ? "pointer-events-auto opacity-100"
+          : "pointer-events-none opacity-0 focus-within:pointer-events-auto focus-within:opacity-100"
+      )}
+    >
+      <DropdownMenu
+        open={open}
+        onOpenChange={(nextOpen) => {
+          if (nextOpen && actions === null) {
+            shouldFocusInitialActionRef.current = true
+            setActions(getActions())
+          }
+          setOpen(nextOpen)
+        }}
+      >
+        <DropdownMenuTrigger asChild>
+          <ButtonInternal
+            ref={(element) => {
+              const trigger =
+                element instanceof HTMLButtonElement ? element : null
+              triggerRef.current = trigger
+              setTrigger(trigger)
+            }}
+            type="button"
+            variant="outline"
+            size="sm"
+            label={label}
+            aria-label={triggerLabel}
+            icon={OneIcon}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          ref={contentRef}
+          align="start"
+          side="top"
+          className="max-h-80 max-w-[min(32rem,90vw)] overflow-y-auto"
+          onCloseAutoFocus={(event) => {
+            if (!selectedActionRef.current) return
+            event.preventDefault()
+            selectedActionRef.current = false
+            const action = pendingActionRef.current
+            pendingActionRef.current = null
+            action?.()
+            if (!shouldFocusChatRef.current) {
+              requestAnimationFrame(() => {
+                const activeElement = document.activeElement
+                if (
+                  !activeElement ||
+                  activeElement === document.body ||
+                  !activeElement.isConnected
+                ) {
+                  triggerRef.current?.focus()
+                }
+              })
+              return
+            }
+            shouldFocusChatRef.current = false
+            focusChatInput()
+          }}
+        >
+          {hasPrevious && (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault()
+                changePage(page - 1)
+              }}
+            >
+              {previousLabel}
+            </DropdownMenuItem>
+          )}
+          {pageActions.map((action) => (
+            <DropdownMenuItem
+              key={action.key}
+              data-point-action=""
+              onSelect={() => {
+                selectedActionRef.current = true
+                shouldFocusChatRef.current = focusChatAfterSelect
+                // Run after Radix has closed its modal focus scope. A host may
+                // open and focus its own chat or dialog; doing that while the
+                // menu is still modal would bounce focus back into this menu.
+                pendingActionRef.current = action.onSelect
+              }}
+            >
+              {action.getLabel()}
+            </DropdownMenuItem>
+          ))}
+          {hasNext && (
+            <DropdownMenuItem
+              onSelect={(event) => {
+                event.preventDefault()
+                changePage(page + 1)
+              }}
+            >
+              {nextLabel}
+            </DropdownMenuItem>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  )
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
@@ -19,6 +19,15 @@ export type AccessiblePointAction = {
 type AccessiblePointActionsProps = {
   hasActions: boolean
   getActions: () => AccessiblePointAction[]
+  /** Semantic inputs that make a cached point action stale. */
+  resetOn: {
+    data: unknown
+    isLoading: boolean
+    chartType: string
+    legendSelection: Record<string, boolean> | undefined
+    owner: "host" | "chat" | "none"
+    title: string
+  }
   label: string
   triggerLabel: string
   previousLabel: string
@@ -36,6 +45,7 @@ type AccessiblePointActionsProps = {
 export function AccessiblePointActions({
   hasActions,
   getActions,
+  resetOn,
   label,
   triggerLabel,
   previousLabel,
@@ -54,12 +64,16 @@ export function AccessiblePointActions({
   const contentRef = useRef<HTMLDivElement>(null)
   const shouldFocusPageRef = useRef(false)
   const shouldFocusInitialActionRef = useRef(false)
+  const getActionsRef = useRef(getActions)
+  getActionsRef.current = getActions
+
+  const { data, isLoading, chartType, legendSelection, owner, title } = resetOn
 
   useEffect(() => {
     setActions(null)
     setPage(0)
     setOpen(false)
-  }, [getActions])
+  }, [data, isLoading, chartType, legendSelection, owner, title])
 
   useEffect(() => {
     if (!shouldFocusPageRef.current) return
@@ -126,7 +140,7 @@ export function AccessiblePointActions({
         onOpenChange={(nextOpen) => {
           if (nextOpen && actions === null) {
             shouldFocusInitialActionRef.current = true
-            setActions(getActions())
+            setActions(getActionsRef.current())
           }
           setOpen(nextOpen)
         }}
@@ -196,7 +210,15 @@ export function AccessiblePointActions({
                 // Run after Radix has closed its modal focus scope. A host may
                 // open and focus its own chat or dialog; doing that while the
                 // menu is still modal would bounce focus back into this menu.
-                pendingActionRef.current = action.onSelect
+                pendingActionRef.current = () => {
+                  // The host may replace its callback during an unrelated
+                  // render while this menu is open. Resolve the same stable
+                  // point key against the latest action set at selection time.
+                  getActionsRef
+                    .current()
+                    .find((latestAction) => latestAction.key === action.key)
+                    ?.onSelect()
+                }
               }}
             >
               {action.getLabel()}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
@@ -58,6 +58,7 @@ export function AccessiblePointActions({
   useEffect(() => {
     setActions(null)
     setPage(0)
+    setOpen(false)
   }, [getActions])
 
   useEffect(() => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -1,9 +1,12 @@
-import { useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 
 import type { IconType } from "@/components/F0Icon"
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import type { RecordType } from "@/hooks/datasource"
-import type { F0DataChartProps } from "@/kits/F0DataChart"
+import type {
+  F0DataChartPointClick,
+  F0DataChartProps,
+} from "@/kits/F0DataChart"
 import type {
   FiltersDefinition,
   FiltersState,
@@ -28,6 +31,7 @@ import {
   RadarChartSkeleton,
   ScatterChartSkeleton,
 } from "@/kits/F0DataChart"
+import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import { useI18n } from "@/lib/providers/i18n"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
@@ -50,6 +54,7 @@ import {
 } from "../../utils/chartDataAdapter"
 import { chartDataToTabular } from "../../utils/chartDataToTabular"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
+import { PointActionPopover } from "./PointActionPopover"
 
 // ---------------------------------------------------------------------------
 // Chart type option registry
@@ -493,6 +498,44 @@ export function ChartItem<Filters extends FiltersDefinition>({
 }: ChartItemProps<Filters>) {
   const translations = useI18n()
   const [viewMode, setViewMode] = useState<"chart" | "table">("chart")
+  const {
+    enabled: aiEnabled,
+    setPendingQuote,
+    setOpen: setAiChatOpen,
+  } = useAiChat()
+
+  /**
+   * The mark the user last clicked, held until they either choose the action or
+   * dismiss it. Clicking a chart offers to quote rather than quoting outright —
+   * charts get clicked while reading, and hijacking every click to open the
+   * chat would make exploring one hostile.
+   */
+  const [pickedPoint, setPickedPoint] = useState<F0DataChartPointClick | null>(
+    null
+  )
+
+  const handleAskAboutPoint = useCallback(() => {
+    if (!pickedPoint) return
+    const chart = item.chart
+    // Format through the chart's own formatter so the quoted number reads
+    // exactly as the tooltip did — a raw value can differ wildly from what was
+    // on screen (currency, compact notation, percentages).
+    const format =
+      ("tooltipValueFormatter" in chart && chart.tooltipValueFormatter) ||
+      ("valueFormatter" in chart && chart.valueFormatter) ||
+      null
+    const value = format ? format(pickedPoint.value) : String(pickedPoint.value)
+    const heading = pickedPoint.category
+      ? `${item.title} — ${pickedPoint.category}`
+      : item.title
+
+    setPendingQuote({
+      text: `${heading}\n${pickedPoint.seriesName}: ${value}`,
+    })
+    // Without this the quote would land in a panel the user cannot see.
+    setAiChatOpen(true)
+    setPickedPoint(null)
+  }, [item, pickedPoint, setPendingQuote, setAiChatOpen])
 
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -708,6 +751,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
           <div ref={chartContainerRef} className="h-full w-full px-4 py-3">
             <F0DataChart
               {...chartProps}
+              onPointClick={aiEnabled ? setPickedPoint : undefined}
               // Windowing rows is only offered where the reader can get them
               // back: this widget puts the count and a "show all" link in its
               // description. Without an expand handler there is nowhere for that
@@ -725,6 +769,11 @@ export function ChartItem<Filters extends FiltersDefinition>({
               // horizontal bar chart drops its row window and draws every
               // category at a fixed row height, growing the widget.
               {...(fitContent ? { showAllCategories: true } : {})}
+            />
+            <PointActionPopover
+              anchor={pickedPoint}
+              onAsk={handleAskAboutPoint}
+              onDismiss={() => setPickedPoint(null)}
             />
           </div>
         )

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import type { IconType } from "@/components/F0Icon"
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
@@ -21,6 +21,7 @@ import {
   Table as TableIcon,
 } from "@/icons/app"
 import { DataChartEmptyStateView, F0DataChart } from "@/kits/F0DataChart"
+import { tooltipValueFormat } from "@/kits/F0DataChart/utils/options"
 import {
   BarChartSkeleton,
   FunnelChartSkeleton,
@@ -55,6 +56,10 @@ import {
 } from "../../utils/chartDataAdapter"
 import { chartDataToTabular } from "../../utils/chartDataToTabular"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
+import {
+  AccessiblePointActions,
+  type AccessiblePointAction,
+} from "./AccessiblePointActions"
 import { PointActionPopover } from "./PointActionPopover"
 
 // ---------------------------------------------------------------------------
@@ -113,6 +118,325 @@ function buildChartTypeOptions(
       type: "table",
     },
   ]
+}
+
+function formatPointValue(
+  chart: F0DataChartProps,
+  value: number,
+  axis: "x" | "y" = "y"
+): string {
+  return axis === "x" && chart.type === "scatter"
+    ? tooltipValueFormat(
+        chart.xTooltipValueFormatter,
+        chart.xValueFormatter
+      )(value)
+    : tooltipValueFormat(
+        chart.tooltipValueFormatter,
+        chart.valueFormatter
+      )(value)
+}
+
+/** @internal Exported for focused quote-contract tests. */
+export function buildPointQuoteText(
+  title: string,
+  chart: F0DataChartProps,
+  point: F0DataChartPointClick
+): string {
+  if (chart.type === "scatter" && point.values.length >= 2) {
+    const heading = point.category ? `${title} — ${point.category}` : title
+    const xLabel = chart.xAxisName ?? "X"
+    const yLabel = chart.yAxisName ?? "Y"
+    const series = point.seriesName ? `${point.seriesName}\n` : ""
+
+    return `${heading}\n${series}${xLabel}: ${formatPointValue(chart, point.values[0], "x")}\n${yLabel}: ${formatPointValue(chart, point.values[1])}`
+  }
+
+  if (chart.type === "line" && point.series.length > 1) {
+    const category = chart.categoryFormatter
+      ? chart.categoryFormatter(point.category)
+      : point.category
+    const heading = category ? `${title} — ${category}` : title
+    const rows = point.series.map(
+      ({ name, value }) => `${name}: ${formatPointValue(chart, value)}`
+    )
+
+    return `${heading}\n${rows.join("\n")}`
+  }
+
+  if (
+    chart.type === "radar" &&
+    chart.indicators.length &&
+    point.values.length > 1
+  ) {
+    const heading = point.category ? `${title} — ${point.category}` : title
+    const rows = chart.indicators
+      .slice(0, point.values.length)
+      .map(
+        ({ name }, index) =>
+          `${name}: ${formatPointValue(chart, point.values[index])}`
+      )
+
+    return `${heading}\n${rows.join("\n")}`
+  }
+
+  if (chart.type === "heatmap" && point.values.length >= 3) {
+    const xCategory = chart.xCategories[point.values[0]]
+    const yCategory = chart.yCategories[point.values[1]]
+    const context = [yCategory, xCategory].filter(Boolean).join(" — ")
+    const heading = context ? `${title} — ${context}` : title
+
+    return `${heading}\n${formatPointValue(chart, point.value)}`
+  }
+
+  const category =
+    "categoryFormatter" in chart && chart.categoryFormatter
+      ? chart.categoryFormatter(point.category)
+      : point.category
+  const heading = category ? `${title} — ${category}` : title
+  const label = point.seriesName ? `${point.seriesName}: ` : ""
+
+  return `${heading}\n${label}${formatPointValue(chart, point.value)}`
+}
+
+type AccessibleChartPoint = {
+  key: string
+  point: F0DataChartPointClick
+}
+
+function numericPointValue(point: unknown): number | null {
+  const raw =
+    typeof point === "object" && point !== null && "value" in point
+      ? point.value
+      : point
+  if (raw === null || raw === undefined || raw === "") return null
+  const value = Number(raw)
+  return Number.isFinite(value) ? value : null
+}
+
+function accessiblePoint(
+  key: string,
+  point: F0DataChartPointClick
+): AccessibleChartPoint {
+  return { key, point }
+}
+
+/** @internal Exported for keyboard-surface contract tests. */
+export function buildAccessibleChartPoints(
+  chart: F0DataChartProps,
+  selected: Record<string, boolean> = {}
+): AccessibleChartPoint[] {
+  const keyboardContext = {
+    source: "keyboard" as const,
+    clientX: 0,
+    clientY: 0,
+  }
+
+  switch (chart.type) {
+    case "bar":
+      return chart.series.flatMap((series, seriesIndex) => {
+        if (selected[series.name] === false) return []
+        return series.data.flatMap((entry, dataIndex) => {
+          const value = numericPointValue(entry)
+          if (value === null) return []
+          const point: F0DataChartPointClick = {
+            seriesName: series.name,
+            category: chart.categories[dataIndex] ?? "",
+            value,
+            values: [value],
+            series: [{ name: series.name, seriesIndex, value }],
+            dataIndex,
+            seriesIndex,
+            ...keyboardContext,
+          }
+          return [accessiblePoint(`bar-${seriesIndex}-${dataIndex}`, point)]
+        })
+      })
+    case "line":
+      return chart.categories.flatMap((category, dataIndex) => {
+        const series = chart.series.flatMap((entry, seriesIndex) => {
+          if (selected[entry.name] === false) return []
+          const value = numericPointValue(entry.data[dataIndex])
+          return value === null
+            ? []
+            : [{ name: entry.name, seriesIndex, value }]
+        })
+        const first = series[0]
+        if (!first) return []
+        const point: F0DataChartPointClick = {
+          seriesName: first.name,
+          category,
+          value: first.value,
+          values: [first.value],
+          series,
+          dataIndex,
+          seriesIndex: first.seriesIndex,
+          ...keyboardContext,
+        }
+        return [accessiblePoint(`line-${dataIndex}`, point)]
+      })
+    case "funnel":
+      return chart.series.data.flatMap((entry, dataIndex) => {
+        if (selected[entry.name] === false) return []
+        const value = numericPointValue(entry.value)
+        if (value === null) return []
+        const point: F0DataChartPointClick = {
+          seriesName: chart.series.name,
+          category: entry.name,
+          value,
+          values: [value],
+          series: [{ name: chart.series.name, seriesIndex: 0, value }],
+          dataIndex,
+          seriesIndex: 0,
+          ...keyboardContext,
+        }
+        return [accessiblePoint(`funnel-${dataIndex}`, point)]
+      })
+    case "pie":
+      return chart.series.data.flatMap((entry, dataIndex) => {
+        if (selected[entry.name] === false) return []
+        const value = numericPointValue(entry.value)
+        if (value === null) return []
+        const point: F0DataChartPointClick = {
+          seriesName: chart.series.name,
+          category: entry.name,
+          value,
+          values: [value],
+          series: [{ name: chart.series.name, seriesIndex: 0, value }],
+          dataIndex,
+          seriesIndex: 0,
+          ...keyboardContext,
+        }
+        return [accessiblePoint(`pie-${dataIndex}`, point)]
+      })
+    case "radar":
+      return chart.series.flatMap((series, seriesIndex) => {
+        if (selected[series.name] === false) return []
+        const values = series.data
+        if (
+          values.length === 0 ||
+          values.some((value) => !Number.isFinite(value))
+        ) {
+          return []
+        }
+        const value = values.at(-1)
+        if (value === undefined) return []
+        const point: F0DataChartPointClick = {
+          seriesName: "",
+          category: series.name,
+          value,
+          values,
+          series: [{ name: "", seriesIndex: 0, value }],
+          dataIndex: seriesIndex,
+          seriesIndex: 0,
+          ...keyboardContext,
+        }
+        return [accessiblePoint(`radar-${seriesIndex}`, point)]
+      })
+    case "gauge": {
+      const value = numericPointValue(chart.value)
+      if (value === null) return []
+      const point: F0DataChartPointClick = {
+        seriesName: "",
+        category: chart.name ?? "",
+        value,
+        values: [value],
+        series: [{ name: "", seriesIndex: 0, value }],
+        dataIndex: 0,
+        seriesIndex: 0,
+        ...keyboardContext,
+      }
+      return [accessiblePoint("gauge-0", point)]
+    }
+    case "heatmap":
+      return chart.data.flatMap(([x, y, value], dataIndex) => {
+        if (![x, y, value].every(Number.isFinite)) return []
+        const point: F0DataChartPointClick = {
+          seriesName: "",
+          category: "",
+          value,
+          values: [x, y, value],
+          series: [{ name: "", seriesIndex: 0, value }],
+          dataIndex,
+          seriesIndex: 0,
+          ...keyboardContext,
+        }
+        return [accessiblePoint(`heatmap-${dataIndex}`, point)]
+      })
+    case "scatter":
+      return chart.series.flatMap((series, seriesIndex) => {
+        if (selected[series.name] === false) return []
+        return series.data.flatMap((entry, dataIndex) => {
+          const [x, y] = Array.isArray(entry) ? entry : [entry.x, entry.y]
+          if (![x, y].every(Number.isFinite)) return []
+          const category = Array.isArray(entry) ? "" : (entry.label ?? "")
+          const point: F0DataChartPointClick = {
+            seriesName: series.name,
+            category,
+            value: y,
+            values: [x, y],
+            series: [{ name: series.name, seriesIndex, value: y }],
+            dataIndex,
+            seriesIndex,
+            ...keyboardContext,
+          }
+          return [accessiblePoint(`scatter-${seriesIndex}-${dataIndex}`, point)]
+        })
+      })
+  }
+}
+
+function hasAccessibleChartPoint(
+  chart: F0DataChartProps,
+  selected: Record<string, boolean> = {}
+): boolean {
+  switch (chart.type) {
+    case "bar":
+      return chart.series.some(
+        (series) =>
+          selected[series.name] !== false &&
+          series.data.some((entry) => numericPointValue(entry) !== null)
+      )
+    case "line":
+      return chart.categories.some((_, dataIndex) =>
+        chart.series.some(
+          (series) =>
+            selected[series.name] !== false &&
+            numericPointValue(series.data[dataIndex]) !== null
+        )
+      )
+    case "funnel":
+      return chart.series.data.some(
+        (entry) =>
+          selected[entry.name] !== false &&
+          numericPointValue(entry.value) !== null
+      )
+    case "pie":
+      return chart.series.data.some(
+        (entry) =>
+          selected[entry.name] !== false &&
+          numericPointValue(entry.value) !== null
+      )
+    case "radar":
+      return chart.series.some(
+        (series) =>
+          selected[series.name] !== false &&
+          series.data.length > 0 &&
+          series.data.every(Number.isFinite)
+      )
+    case "gauge":
+      return numericPointValue(chart.value) !== null
+    case "heatmap":
+      return chart.data.some((tuple) => tuple.every(Number.isFinite))
+    case "scatter":
+      return chart.series.some(
+        (series) =>
+          selected[series.name] !== false &&
+          series.data.some((entry) => {
+            const [x, y] = Array.isArray(entry) ? entry : [entry.x, entry.y]
+            return [x, y].every(Number.isFinite)
+          })
+      )
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -503,6 +827,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
     enabled: aiEnabled,
     setPendingQuote,
     setOpen: setAiChatOpen,
+    focusChatInput,
   } = useAiChat()
 
   // An item can arrive with a chart config this build cannot render — most
@@ -522,49 +847,80 @@ export function ChartItem<Filters extends FiltersDefinition>({
   const [pickedPoint, setPickedPoint] = useState<F0DataChartPointClick | null>(
     null
   )
-
-  const handleAskAboutPoint = useCallback(() => {
-    if (!pickedPoint) return
-
-    if (onAskAi) {
-      // The host answers this the same way it answers the ⋯ menu, with the
-      // mark attached. It gets the raw point rather than the sentence built
-      // below: it owns the phrasing, and it has the formatters too.
-      onAskAi({ id: item.id, title: item.title, point: pickedPoint })
-      setPickedPoint(null)
-      return
-    }
-
-    // `safeChart`, not `item.chart`: the same guarded config the rest of the
-    // component uses. `"x" in undefined` throws, and an item can arrive
-    // without a renderable chart.
-    const chart = safeChart
-    // Format through the chart's own formatter so the quoted number reads
-    // exactly as the tooltip did — a raw value can differ wildly from what was
-    // on screen (currency, compact notation, percentages).
-    const format =
-      ("tooltipValueFormatter" in chart && chart.tooltipValueFormatter) ||
-      ("valueFormatter" in chart && chart.valueFormatter) ||
-      null
-    const value = format ? format(pickedPoint.value) : String(pickedPoint.value)
-    const heading = pickedPoint.category
-      ? `${item.title} — ${pickedPoint.category}`
-      : item.title
-
-    setPendingQuote({
-      text: `${heading}\n${pickedPoint.seriesName}: ${value}`,
-    })
-    // Without this the quote would land in a panel the user cannot see.
-    setAiChatOpen(true)
-    setPickedPoint(null)
-  }, [item, safeChart, onAskAi, pickedPoint, setPendingQuote, setAiChatOpen])
-
+  const [legendSelection, setLegendSelection] = useState<
+    Record<string, boolean> | undefined
+  >()
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
     Filters,
     DashboardChartData
   >(item.fetchData, filters, enabled)
   const chartContainerRef = useRef<HTMLDivElement>(null)
+  const keyboardPointTriggerRef = useRef<HTMLButtonElement | null>(null)
+
+  // Keep the data used for quoting identical to the data actually rendered.
+  // In particular, transformed radar charts synthesize indicators here that
+  // do not exist in the raw fetch result.
+  const chartProps = useMemo(
+    () =>
+      data && !unrenderableChart
+        ? buildChartProps(item as DashboardChartItem, data)
+        : undefined,
+    [item, data, unrenderableChart]
+  )
+
+  // A point belongs to one exact render. A filter/config/refetch transition
+  // can retain old data while loading; never let that stale mark reappear or
+  // resolve its tuple indexes against the next result.
+  useEffect(() => {
+    setPickedPoint(null)
+    setLegendSelection(undefined)
+  }, [data, isLoading, item.chart])
+
+  const handleAskAboutPoint = useCallback(
+    (point: F0DataChartPointClick) => {
+      if (onAskAi) {
+        // The host answers this the same way it answers the ⋯ menu, with the
+        // mark attached. It gets the raw point rather than the sentence built
+        // below: it owns the phrasing, and it has the formatters too.
+        onAskAi({ id: item.id, title: item.title, point })
+        setPickedPoint(null)
+        requestAnimationFrame(() => {
+          const activeElement = document.activeElement
+          if (
+            !activeElement ||
+            activeElement === document.body ||
+            !activeElement.isConnected
+          ) {
+            keyboardPointTriggerRef.current?.focus()
+          }
+        })
+        return
+      }
+
+      if (!chartProps) return
+
+      setPendingQuote({
+        text: buildPointQuoteText(item.title, chartProps, point),
+      })
+      // Fullscreen covers the chat, matching the widget-level Ask One action.
+      if (isFullscreen) onFullscreenChange?.(false)
+      // Without this the quote would land in a panel the user cannot see.
+      setAiChatOpen(true)
+      focusChatInput()
+      setPickedPoint(null)
+    },
+    [
+      item,
+      chartProps,
+      onAskAi,
+      isFullscreen,
+      onFullscreenChange,
+      setPendingQuote,
+      setAiChatOpen,
+      focusChatInput,
+    ]
+  )
 
   const CHART_TYPE_OPTIONS = useMemo(
     () => buildChartTypeOptions(translations),
@@ -583,20 +939,43 @@ export function ChartItem<Filters extends FiltersDefinition>({
     [actions, downloadActions]
   )
 
+  const hasAccessiblePointActions = useMemo(
+    () =>
+      !!chartProps &&
+      !!(aiEnabled || onAskAi) &&
+      hasAccessibleChartPoint(chartProps, legendSelection),
+    [chartProps, aiEnabled, onAskAi, legendSelection]
+  )
+
+  const getAccessiblePointActions = useCallback<() => AccessiblePointAction[]>(
+    () =>
+      chartProps
+        ? buildAccessibleChartPoints(chartProps, legendSelection).map(
+            ({ key, point }) => ({
+              key,
+              getLabel: () =>
+                buildPointQuoteText(item.title, chartProps, point)
+                  .split("\n")
+                  .join(", "),
+              onSelect: () => handleAskAboutPoint(point),
+            })
+          )
+        : [],
+    [chartProps, item.title, legendSelection, handleAskAboutPoint]
+  )
+
+  const dismissPointAction = useCallback(
+    (reason: "escape" | "outside" | "viewport") => {
+      setPickedPoint(null)
+      if (reason === "escape") {
+        requestAnimationFrame(() => keyboardPointTriggerRef.current?.focus())
+      }
+    },
+    []
+  )
+
   // No fabricated error when data is absent — `F0DataChart` (or the explicit
   // fallback below for `!data`) renders a proper empty state instead.
-
-  // Memoized so the chart receives identity-stable props across unrelated
-  // re-renders. Fresh props objects would rebuild the ECharts options and
-  // trigger a full `setOption(notMerge)` — which recreates the tooltip and
-  // hides it mid-hover — on every parent render.
-  const chartProps = useMemo(
-    () =>
-      data && !unrenderableChart
-        ? buildChartProps(item as DashboardChartItem, data)
-        : undefined,
-    [item, data, unrenderableChart]
-  )
 
   // Determine which chart type options are available for this chart
   const currentOrientation =
@@ -762,9 +1141,13 @@ export function ChartItem<Filters extends FiltersDefinition>({
         viewMode === "table" ? (
           <ChartTableView config={safeChart} data={data} />
         ) : (
-          <div ref={chartContainerRef} className="h-full w-full px-4 py-3">
+          <div
+            ref={chartContainerRef}
+            className="relative h-full w-full px-4 py-3"
+          >
             <F0DataChart
               {...chartProps}
+              onLegendSelectionChange={setLegendSelection}
               // Something has to be able to answer the click: the host, or
               // failing that a mounted chat.
               onPointClick={aiEnabled || onAskAi ? setPickedPoint : undefined}
@@ -786,10 +1169,25 @@ export function ChartItem<Filters extends FiltersDefinition>({
               // category at a fixed row height, growing the widget.
               {...(fitContent ? { showAllCategories: true } : {})}
             />
+            <AccessiblePointActions
+              hasActions={hasAccessiblePointActions}
+              getActions={getAccessiblePointActions}
+              label={translations.ai.dashboardItem.askOne}
+              triggerLabel={`${translations.ai.dashboardItem.askOne}: ${item.title}`}
+              previousLabel={translations.navigation.previous}
+              nextLabel={translations.navigation.next}
+              setTrigger={(element) => {
+                keyboardPointTriggerRef.current = element
+              }}
+              focusChatAfterSelect={!onAskAi}
+              focusChatInput={focusChatInput}
+            />
             <PointActionPopover
               anchor={pickedPoint}
-              onAsk={handleAskAboutPoint}
-              onDismiss={() => setPickedPoint(null)}
+              onAsk={() => {
+                if (pickedPoint) handleAskAboutPoint(pickedPoint)
+              }}
+              onDismiss={dismissPointAction}
             />
           </div>
         )

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -385,7 +385,8 @@ export function buildAccessibleChartPoints(
   }
 }
 
-function hasAccessibleChartPoint(
+/** @internal Exported for keyboard-surface contract tests. */
+export function hasAccessibleChartPoint(
   chart: F0DataChartProps,
   selected: Record<string, boolean> = {}
 ): boolean {
@@ -426,7 +427,9 @@ function hasAccessibleChartPoint(
     case "gauge":
       return numericPointValue(chart.value) !== null
     case "heatmap":
-      return chart.data.some((tuple) => tuple.every(Number.isFinite))
+      return chart.data.some(([x, y, value]) =>
+        [x, y, value].every(Number.isFinite)
+      )
     case "scatter":
       return chart.series.some(
         (series) =>
@@ -877,6 +880,15 @@ export function ChartItem<Filters extends FiltersDefinition>({
     setLegendSelection(undefined)
   }, [data, isLoading, item.chart])
 
+  const pointAskOwner = onAskAi ? "host" : aiEnabled ? "chat" : "none"
+
+  // A pending point belongs to the responder that was available when it was
+  // picked. Do not let a later host/chat ownership change redirect that action
+  // or leave a dead popover behind.
+  useEffect(() => {
+    setPickedPoint(null)
+  }, [pointAskOwner])
+
   const handleAskAboutPoint = useCallback(
     (point: F0DataChartPointClick) => {
       if (onAskAi) {
@@ -967,7 +979,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
   const dismissPointAction = useCallback(
     (reason: "escape" | "outside" | "viewport") => {
       setPickedPoint(null)
-      if (reason === "escape") {
+      if (reason !== "outside") {
         requestAnimationFrame(() => keyboardPointTriggerRef.current?.focus())
       }
     },

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -3,10 +3,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { IconType } from "@/components/F0Icon"
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import type { RecordType } from "@/hooks/datasource"
-import type {
-  F0DataChartPointClick,
-  F0DataChartProps,
-} from "@/kits/F0DataChart"
+import type { F0DataChartProps } from "@/kits/F0DataChart"
 import type {
   FiltersDefinition,
   FiltersState,
@@ -42,6 +39,7 @@ import type {
   DashboardChartData,
   DashboardChartItem,
   F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardPointClick,
 } from "../../types"
 
 import { useChartDownloadActions } from "../../hooks/useChartDownloadActions"
@@ -140,7 +138,7 @@ function formatPointValue(
 export function buildPointQuoteText(
   title: string,
   chart: F0DataChartProps,
-  point: F0DataChartPointClick
+  point: F0AnalyticsDashboardPointClick
 ): string {
   if (chart.type === "scatter" && point.values.length >= 2) {
     const heading = point.category ? `${title} — ${point.category}` : title
@@ -200,7 +198,7 @@ export function buildPointQuoteText(
 
 type AccessibleChartPoint = {
   key: string
-  point: F0DataChartPointClick
+  point: F0AnalyticsDashboardPointClick
 }
 
 function numericPointValue(point: unknown): number | null {
@@ -215,7 +213,7 @@ function numericPointValue(point: unknown): number | null {
 
 function accessiblePoint(
   key: string,
-  point: F0DataChartPointClick
+  point: F0AnalyticsDashboardPointClick
 ): AccessibleChartPoint {
   return { key, point }
 }
@@ -238,7 +236,7 @@ export function buildAccessibleChartPoints(
         return series.data.flatMap((entry, dataIndex) => {
           const value = numericPointValue(entry)
           if (value === null) return []
-          const point: F0DataChartPointClick = {
+          const point: F0AnalyticsDashboardPointClick = {
             seriesName: series.name,
             category: chart.categories[dataIndex] ?? "",
             value,
@@ -262,7 +260,7 @@ export function buildAccessibleChartPoints(
         })
         const first = series[0]
         if (!first) return []
-        const point: F0DataChartPointClick = {
+        const point: F0AnalyticsDashboardPointClick = {
           seriesName: first.name,
           category,
           value: first.value,
@@ -279,7 +277,7 @@ export function buildAccessibleChartPoints(
         if (selected[entry.name] === false) return []
         const value = numericPointValue(entry.value)
         if (value === null) return []
-        const point: F0DataChartPointClick = {
+        const point: F0AnalyticsDashboardPointClick = {
           seriesName: chart.series.name,
           category: entry.name,
           value,
@@ -296,7 +294,7 @@ export function buildAccessibleChartPoints(
         if (selected[entry.name] === false) return []
         const value = numericPointValue(entry.value)
         if (value === null) return []
-        const point: F0DataChartPointClick = {
+        const point: F0AnalyticsDashboardPointClick = {
           seriesName: chart.series.name,
           category: entry.name,
           value,
@@ -320,7 +318,7 @@ export function buildAccessibleChartPoints(
         }
         const value = values.at(-1)
         if (value === undefined) return []
-        const point: F0DataChartPointClick = {
+        const point: F0AnalyticsDashboardPointClick = {
           seriesName: "",
           category: series.name,
           value,
@@ -335,7 +333,7 @@ export function buildAccessibleChartPoints(
     case "gauge": {
       const value = numericPointValue(chart.value)
       if (value === null) return []
-      const point: F0DataChartPointClick = {
+      const point: F0AnalyticsDashboardPointClick = {
         seriesName: "",
         category: chart.name ?? "",
         value,
@@ -350,7 +348,7 @@ export function buildAccessibleChartPoints(
     case "heatmap":
       return chart.data.flatMap(([x, y, value], dataIndex) => {
         if (![x, y, value].every(Number.isFinite)) return []
-        const point: F0DataChartPointClick = {
+        const point: F0AnalyticsDashboardPointClick = {
           seriesName: "",
           category: "",
           value,
@@ -369,7 +367,7 @@ export function buildAccessibleChartPoints(
           const [x, y] = Array.isArray(entry) ? entry : [entry.x, entry.y]
           if (![x, y].every(Number.isFinite)) return []
           const category = Array.isArray(entry) ? "" : (entry.label ?? "")
-          const point: F0DataChartPointClick = {
+          const point: F0AnalyticsDashboardPointClick = {
             seriesName: series.name,
             category,
             value: y,
@@ -847,9 +845,8 @@ export function ChartItem<Filters extends FiltersDefinition>({
    * charts get clicked while reading, and hijacking every click to open the
    * chat would make exploring one hostile.
    */
-  const [pickedPoint, setPickedPoint] = useState<F0DataChartPointClick | null>(
-    null
-  )
+  const [pickedPoint, setPickedPoint] =
+    useState<F0AnalyticsDashboardPointClick | null>(null)
   const [legendSelection, setLegendSelection] = useState<
     Record<string, boolean> | undefined
   >()
@@ -872,15 +869,19 @@ export function ChartItem<Filters extends FiltersDefinition>({
     [item, data, unrenderableChart]
   )
 
-  // A point belongs to one exact render. A filter/config/refetch transition
+  // A point belongs to one exact data render. A filter/type/refetch transition
   // can retain old data while loading; never let that stale mark reappear or
-  // resolve its tuple indexes against the next result.
+  // resolve its tuple indexes against the next result. Do not key this on the
+  // host's item/chart object identity: inline dashboard configs are normally
+  // rebuilt on every parent render even when their semantics are unchanged.
   useEffect(() => {
     setPickedPoint(null)
     setLegendSelection(undefined)
-  }, [data, isLoading, item.chart])
+  }, [data, isLoading, safeChart.type])
 
   const pointAskOwner = onAskAi ? "host" : aiEnabled ? "chat" : "none"
+  const canAskAboutPoint =
+    pointAskOwner !== "none" && item.title.trim().length > 0
 
   // A pending point belongs to the responder that was available when it was
   // picked. Do not let a later host/chat ownership change redirect that action
@@ -890,7 +891,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
   }, [pointAskOwner])
 
   const handleAskAboutPoint = useCallback(
-    (point: F0DataChartPointClick) => {
+    (point: F0AnalyticsDashboardPointClick) => {
       if (onAskAi) {
         // The host answers this the same way it answers the ⋯ menu, with the
         // mark attached. It gets the raw point rather than the sentence built
@@ -954,9 +955,9 @@ export function ChartItem<Filters extends FiltersDefinition>({
   const hasAccessiblePointActions = useMemo(
     () =>
       !!chartProps &&
-      !!(aiEnabled || onAskAi) &&
+      canAskAboutPoint &&
       hasAccessibleChartPoint(chartProps, legendSelection),
-    [chartProps, aiEnabled, onAskAi, legendSelection]
+    [chartProps, canAskAboutPoint, legendSelection]
   )
 
   const getAccessiblePointActions = useCallback<() => AccessiblePointAction[]>(
@@ -1159,10 +1160,14 @@ export function ChartItem<Filters extends FiltersDefinition>({
           >
             <F0DataChart
               {...chartProps}
-              onLegendSelectionChange={setLegendSelection}
+              {...(chartProps.type !== "gauge" && chartProps.type !== "heatmap"
+                ? { onLegendSelectionChange: setLegendSelection }
+                : {})}
               // Something has to be able to answer the click: the host, or
               // failing that a mounted chat.
-              onPointClick={aiEnabled || onAskAi ? setPickedPoint : undefined}
+              onPointClick={
+                canAskAboutPoint ? (point) => setPickedPoint(point) : undefined
+              }
               // Windowing rows is only offered where the reader can get them
               // back: this widget puts the count and a "show all" link in its
               // description. Without an expand handler there is nowhere for that
@@ -1184,6 +1189,14 @@ export function ChartItem<Filters extends FiltersDefinition>({
             <AccessiblePointActions
               hasActions={hasAccessiblePointActions}
               getActions={getAccessiblePointActions}
+              resetOn={{
+                data,
+                isLoading,
+                chartType: safeChart.type,
+                legendSelection,
+                owner: pointAskOwner,
+                title: item.title,
+              }}
               label={translations.ai.dashboardItem.askOne}
               triggerLabel={`${translations.ai.dashboardItem.askOne}: ${item.title}`}
               previousLabel={translations.navigation.previous}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -505,6 +505,14 @@ export function ChartItem<Filters extends FiltersDefinition>({
     setOpen: setAiChatOpen,
   } = useAiChat()
 
+  // An item can arrive with a chart config this build cannot render — most
+  // plausibly when a host app maps a wire type it has no case for and yields
+  // `undefined`. Every path below switches on `chart.type` without a default,
+  // so rendering it would throw and take the whole dashboard with it. Detect
+  // it once and degrade to this item's own error state.
+  const unrenderableChart = !isRenderableChart(item.chart)
+  const safeChart = unrenderableChart ? FALLBACK_CHART_CONFIG : item.chart
+
   /**
    * The mark the user last clicked, held until they either choose the action or
    * dismiss it. Clicking a chart offers to quote rather than quoting outright —
@@ -527,7 +535,10 @@ export function ChartItem<Filters extends FiltersDefinition>({
       return
     }
 
-    const chart = item.chart
+    // `safeChart`, not `item.chart`: the same guarded config the rest of the
+    // component uses. `"x" in undefined` throws, and an item can arrive
+    // without a renderable chart.
+    const chart = safeChart
     // Format through the chart's own formatter so the quoted number reads
     // exactly as the tooltip did — a raw value can differ wildly from what was
     // on screen (currency, compact notation, percentages).
@@ -546,7 +557,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
     // Without this the quote would land in a panel the user cannot see.
     setAiChatOpen(true)
     setPickedPoint(null)
-  }, [item, onAskAi, pickedPoint, setPendingQuote, setAiChatOpen])
+  }, [item, safeChart, onAskAi, pickedPoint, setPendingQuote, setAiChatOpen])
 
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -559,14 +570,6 @@ export function ChartItem<Filters extends FiltersDefinition>({
     () => buildChartTypeOptions(translations),
     [translations]
   )
-
-  // An item can arrive with a chart config this build cannot render — most
-  // plausibly when a host app maps a wire type it has no case for and yields
-  // `undefined`. Every path below switches on `chart.type` without a default,
-  // so rendering it would throw and take the whole dashboard with it. Detect
-  // it once and degrade to this item's own error state.
-  const unrenderableChart = !isRenderableChart(item.chart)
-  const safeChart = unrenderableChart ? FALLBACK_CHART_CONFIG : item.chart
 
   const downloadActions = useChartDownloadActions({
     chartContainerRef,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -40,6 +40,7 @@ import type {
   DashboardChartConfig,
   DashboardChartData,
   DashboardChartItem,
+  F0AnalyticsDashboardAskAiTarget,
 } from "../../types"
 
 import { useChartDownloadActions } from "../../hooks/useChartDownloadActions"
@@ -475,7 +476,7 @@ interface ChartItemProps<Filters extends FiltersDefinition> {
   actions?: DropdownItem[]
   editMode?: boolean
   handleDelete?: (itemId: string) => void
-  onAskAi?: (item: { id: string; title: string }) => void
+  onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
   onTransformChart?: (
     itemId: string,
     newType: string,
@@ -516,6 +517,16 @@ export function ChartItem<Filters extends FiltersDefinition>({
 
   const handleAskAboutPoint = useCallback(() => {
     if (!pickedPoint) return
+
+    if (onAskAi) {
+      // The host answers this the same way it answers the ⋯ menu, with the
+      // mark attached. It gets the raw point rather than the sentence built
+      // below: it owns the phrasing, and it has the formatters too.
+      onAskAi({ id: item.id, title: item.title, point: pickedPoint })
+      setPickedPoint(null)
+      return
+    }
+
     const chart = item.chart
     // Format through the chart's own formatter so the quoted number reads
     // exactly as the tooltip did — a raw value can differ wildly from what was
@@ -535,7 +546,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
     // Without this the quote would land in a panel the user cannot see.
     setAiChatOpen(true)
     setPickedPoint(null)
-  }, [item, pickedPoint, setPendingQuote, setAiChatOpen])
+  }, [item, onAskAi, pickedPoint, setPendingQuote, setAiChatOpen])
 
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -751,7 +762,9 @@ export function ChartItem<Filters extends FiltersDefinition>({
           <div ref={chartContainerRef} className="h-full w-full px-4 py-3">
             <F0DataChart
               {...chartProps}
-              onPointClick={aiEnabled ? setPickedPoint : undefined}
+              // Something has to be able to answer the click: the host, or
+              // failing that a mounted chat.
+              onPointClick={aiEnabled || onAskAi ? setPickedPoint : undefined}
               // Windowing rows is only offered where the reader can get them
               // back: this widget puts the count and a "show all" link in its
               // description. Without an expand handler there is nowhere for that

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
@@ -21,7 +21,7 @@ export type PointActionPopoverProps = {
   /** Called when the action is chosen. */
   onAsk: () => void
   /** Called when the popover should close without acting. */
-  onDismiss: () => void
+  onDismiss: (reason: "escape" | "outside" | "viewport") => void
 }
 
 /**
@@ -77,13 +77,17 @@ export function PointActionPopover({
   useEffect(() => {
     if (!anchor) return
 
+    const focusFrame = requestAnimationFrame(() => {
+      containerRef.current?.querySelector<HTMLButtonElement>("button")?.focus()
+    })
+
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onDismiss()
+      if (e.key === "Escape") onDismiss("escape")
     }
     const onPointerDown = (e: PointerEvent) => {
       const el = containerRef.current
       if (el && e.target instanceof Node && el.contains(e.target)) return
-      onDismiss()
+      onDismiss("outside")
     }
 
     document.addEventListener("keydown", onKeyDown)
@@ -94,10 +98,11 @@ export function PointActionPopover({
     // entirely, and a popover that follows it out would be worse than one
     // that goes away. Capture, because the dashboard scrolls inside its own
     // containers and `scroll` doesn't bubble.
-    const onViewportChange = () => onDismiss()
+    const onViewportChange = () => onDismiss("viewport")
     window.addEventListener("scroll", onViewportChange, true)
     window.addEventListener("resize", onViewportChange)
     return () => {
+      cancelAnimationFrame(focusFrame)
       document.removeEventListener("keydown", onKeyDown)
       document.removeEventListener("pointerdown", onPointerDown, true)
       window.removeEventListener("scroll", onViewportChange, true)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
@@ -88,9 +88,20 @@ export function PointActionPopover({
 
     document.addEventListener("keydown", onKeyDown)
     document.addEventListener("pointerdown", onPointerDown, true)
+    // Anchored to a viewport position taken at click time, so anything that
+    // moves the mark underneath leaves this pointing at nothing. Dismiss
+    // rather than re-measure: the mark may have scrolled out of the widget
+    // entirely, and a popover that follows it out would be worse than one
+    // that goes away. Capture, because the dashboard scrolls inside its own
+    // containers and `scroll` doesn't bubble.
+    const onViewportChange = () => onDismiss()
+    window.addEventListener("scroll", onViewportChange, true)
+    window.addEventListener("resize", onViewportChange)
     return () => {
       document.removeEventListener("keydown", onKeyDown)
       document.removeEventListener("pointerdown", onPointerDown, true)
+      window.removeEventListener("scroll", onViewportChange, true)
+      window.removeEventListener("resize", onViewportChange)
     }
   }, [anchor, onDismiss])
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/PointActionPopover.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { One as OneIcon } from "@/icons/ai"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+
+const GAP = 8
+const MIN_MARGIN = 8
+
+export type PointActionAnchor = {
+  /** Viewport coordinates of the click that opened this. */
+  clientX: number
+  clientY: number
+}
+
+export type PointActionPopoverProps = {
+  /** Click position; null hides the popover. */
+  anchor: PointActionAnchor | null
+  /** Called when the action is chosen. */
+  onAsk: () => void
+  /** Called when the popover should close without acting. */
+  onDismiss: () => void
+}
+
+/**
+ * Floating single-action menu anchored to a clicked chart mark — the same shape
+ * as the "Reply" affordance over a text selection in the chat, so quoting works
+ * the same way wherever the user starts.
+ *
+ * Portalled to `document.body`: the widget clips its content (`overflow-hidden`
+ * on the card, and charts sit inside scroll containers), which would cut a
+ * popover positioned within the tree.
+ */
+export function PointActionPopover({
+  anchor,
+  onAsk,
+  onDismiss,
+}: PointActionPopoverProps) {
+  const translations = useI18n()
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [coords, setCoords] = useState<{ top: number; left: number } | null>(
+    null
+  )
+
+  // Sit above the click, flipping below when that would overflow the viewport
+  // top, and clamp horizontally so the button never hangs off-screen.
+  useLayoutEffect(() => {
+    if (!anchor) {
+      setCoords(null)
+      return
+    }
+    const el = containerRef.current
+    if (!el) return
+
+    const { offsetWidth: width, offsetHeight: height } = el
+    let top = anchor.clientY - height - GAP
+    if (top < MIN_MARGIN) top = anchor.clientY + GAP
+    top = Math.min(
+      Math.max(top, MIN_MARGIN),
+      window.innerHeight - height - MIN_MARGIN
+    )
+
+    const centered = anchor.clientX - width / 2
+    const left = Math.min(
+      Math.max(centered, MIN_MARGIN),
+      window.innerWidth - width - MIN_MARGIN
+    )
+
+    setCoords({ top, left })
+  }, [anchor])
+
+  // Dismiss on Escape or on a pointer press anywhere outside. The press is
+  // captured so it closes even when the click lands on another chart mark,
+  // which would otherwise re-anchor and re-open in the same gesture.
+  useEffect(() => {
+    if (!anchor) return
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onDismiss()
+    }
+    const onPointerDown = (e: PointerEvent) => {
+      const el = containerRef.current
+      if (el && e.target instanceof Node && el.contains(e.target)) return
+      onDismiss()
+    }
+
+    document.addEventListener("keydown", onKeyDown)
+    document.addEventListener("pointerdown", onPointerDown, true)
+    return () => {
+      document.removeEventListener("keydown", onKeyDown)
+      document.removeEventListener("pointerdown", onPointerDown, true)
+    }
+  }, [anchor, onDismiss])
+
+  if (typeof document === "undefined") return null
+  if (!anchor) return null
+
+  return createPortal(
+    <div
+      ref={containerRef}
+      style={{
+        position: "fixed",
+        top: coords?.top ?? -9999,
+        left: coords?.left ?? -9999,
+        visibility: coords ? "visible" : "hidden",
+      }}
+      className={cn(
+        "z-50 rounded-md bg-f1-background p-1 border border-solid border-f1-border-secondary",
+        "drop-shadow"
+      )}
+    >
+      <ButtonInternal
+        type="button"
+        variant="ghost"
+        label={translations.ai.dashboardItem.askOne}
+        icon={OneIcon}
+        onClick={onAsk}
+      />
+    </div>,
+    document.body
+  )
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -10,7 +10,10 @@ import type { RecordType } from "@/hooks/datasource"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
 
-import type { DashboardCollectionItem } from "../../types"
+import type {
+  DashboardCollectionItem,
+  F0AnalyticsDashboardAskAiTarget,
+} from "../../types"
 
 import { useCollectionDownloadActions } from "../../hooks/useCollectionDownloadActions"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
@@ -21,7 +24,7 @@ interface CollectionItemProps<Filters extends FiltersDefinition> {
   actions?: DropdownItem[]
   editMode?: boolean
   handleDelete?: (itemId: string) => void
-  onAskAi?: (item: { id: string; title: string }) => void
+  onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils"
 import type {
   DashboardItem as DashboardItemType,
   DashboardItemLayout,
+  F0AnalyticsDashboardAskAiTarget,
 } from "../../types"
 
 import { ChartItem, chartItemFitsContent } from "../ChartItem/ChartItem"
@@ -61,7 +62,7 @@ interface DashboardGridProps<Filters extends FiltersDefinition> {
     orientation?: "vertical" | "horizontal"
   ) => void
   /** Overrides the built-in "Ask One" action on a widget. See `F0AnalyticsDashboardProps.onAskAi`. */
-  onAskAi?: (item: { id: string; title: string }) => void
+  onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
   /**
    * Notifies the parent when the grid enters/exits a "fill height" mode —
    * triggered by click-to-fullscreen on a multi-item dashboard. The parent
@@ -997,7 +998,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
     newType: string,
     orientation?: "vertical" | "horizontal"
   ) => void
-  onAskAi?: (item: { id: string; title: string }) => void
+  onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }) {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -1,5 +1,7 @@
 import { useRef, useState, type ReactNode } from "react"
 
+import type { F0AnalyticsDashboardAskAiTarget } from "../../types"
+
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0ButtonToggleGroup } from "@/components/F0ButtonToggleGroup"
 import { F0Icon, type IconType } from "@/components/F0Icon"
@@ -61,7 +63,7 @@ interface DashboardItemProps {
    * touching the chat and the host answers instead — and the entry no longer
    * needs a chat to be mounted at all.
    */
-  onAskAi?: (item: { id: string; title: string }) => void
+  onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
   /** Item ID — required when editMode is true for the delete callback */
   itemId?: string
   /** Chart type transform options — rendered as a toggle group in the dropdown */

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -13,6 +13,7 @@ import { cn, focusRing } from "@/lib/utils"
 import type {
   DashboardMetricData,
   DashboardMetricItem,
+  F0AnalyticsDashboardAskAiTarget,
   MetricFormat,
 } from "../../types"
 
@@ -26,7 +27,7 @@ interface MetricItemProps<Filters extends FiltersDefinition> {
   actions?: import("@/experimental/Navigation/Dropdown").DropdownItem[]
   editMode?: boolean
   handleDelete?: (itemId: string) => void
-  onAskAi?: (item: { id: string; title: string }) => void
+  onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
@@ -12,6 +12,7 @@ export type {
   DashboardItemBase,
   DashboardMetricData,
   DashboardMetricItem,
+  F0AnalyticsDashboardAskAiTarget,
   F0AnalyticsDashboardProps,
   FunnelChartConfig,
   GaugeChartConfig,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
@@ -13,6 +13,7 @@ export type {
   DashboardMetricData,
   DashboardMetricItem,
   F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardPointClick,
   F0AnalyticsDashboardProps,
   FunnelChartConfig,
   GaugeChartConfig,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -443,16 +443,14 @@ export type DashboardItemLayout = {
 // Root component props
 // ---------------------------------------------------------------------------
 
-/**
- * Props for the F0AnalyticsDashboard component.
- *
- * The entire dashboard is defined declaratively via `filters` (optional shared
- * filter definitions), `presets`, and `items` (an ordered array of chart /
- * collection configs).
- *
- * An LLM can generate the full `items` array as JSON (minus the `fetchData`
- * functions) to build dashboards on the fly.
- */
+/** A point selected from either the chart canvas or its keyboard companion. */
+export type F0AnalyticsDashboardPointClick = Omit<
+  F0DataChartPointClick,
+  "source"
+> & {
+  source: "pointer" | "keyboard"
+}
+
 /**
  * What the user asked about: a whole widget, or one mark inside it.
  *
@@ -463,9 +461,19 @@ export type DashboardItemLayout = {
 export interface F0AnalyticsDashboardAskAiTarget {
   id: string
   title: string
-  point?: F0DataChartPointClick
+  point?: F0AnalyticsDashboardPointClick
 }
 
+/**
+ * Props for the F0AnalyticsDashboard component.
+ *
+ * The entire dashboard is defined declaratively via `filters` (optional shared
+ * filter definitions), `presets`, and `items` (an ordered array of chart /
+ * collection configs).
+ *
+ * An LLM can generate the full `items` array as JSON (minus the `fetchData`
+ * functions) to build dashboards on the fly.
+ */
 export interface F0AnalyticsDashboardProps<
   Filters extends FiltersDefinition = FiltersDefinition,
 > {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -4,6 +4,7 @@ import type {
   F0DataChartFunnelSeries,
   F0DataChartLineSeries,
   F0DataChartPieSeries,
+  F0DataChartPointClick,
   F0DataChartRadarIndicator,
   F0DataChartRadarSeries,
   F0DataChartScatterSeries,
@@ -452,6 +453,19 @@ export type DashboardItemLayout = {
  * An LLM can generate the full `items` array as JSON (minus the `fetchData`
  * functions) to build dashboards on the fly.
  */
+/**
+ * What the user asked about: a whole widget, or one mark inside it.
+ *
+ * `point` is absent when the ask came from the widget's ⋯ menu and present
+ * when it came from clicking a mark, which is the only thing that tells the
+ * two apart.
+ */
+export interface F0AnalyticsDashboardAskAiTarget {
+  id: string
+  title: string
+  point?: F0DataChartPointClick
+}
+
 export interface F0AnalyticsDashboardProps<
   Filters extends FiltersDefinition = FiltersDefinition,
 > {
@@ -539,8 +553,12 @@ export interface F0AnalyticsDashboardProps<
    *
    * Without it the entry appears only where an AI chat is mounted and enabled,
    * and drives that chat directly.
+   *
+   * `point` is set when the ask came from a clicked mark rather than the
+   * widget menu, so one handler answers both without the host having to tell
+   * them apart by anything other than its presence.
    */
-  onAskAi?: (item: { id: string; title: string }) => void
+  onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
   /**
    * Navigation filter definitions (e.g. date-navigator).
    * Rendered above the grid alongside the regular filter bar.


### PR DESCRIPTION
## Description

Extends **Ask One** from widget-level context to one selected chart point. A pointer user clicks a mark and confirms the anchored action; a keyboard or screen-reader user opens the chart's named **Ask One** trigger and chooses the same formatted point from a menu.

The confirmation step is intentional: chart clicks are common during exploration, so selecting a mark must not open chat by itself. The built-in action quotes the chart title, category, series, and displayed value, then opens chat and focuses the composer. Hosts using `onAskAi` receive the raw point instead.

**Third PR in the #5123 → #5124 → #5125 stack.**

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Visual review

<img width="1207" height="763" alt="Chart point Ask One flow" src="https://github.com/user-attachments/assets/39cb8432-0397-4728-be24-852c4407765b" />

- [Interactive story — complete chart-point flow](https://66a7a8d7d124220c363457cc-cekxzmvkdt.chromatic.com/?path=/story/patterns-analyticsdashboard-ask-one--chart-point-flow): the play function uses the keyboard route and leaves the formatted point quote visible in the focused composer. Reset it to exercise the pointer route by clicking the Engineering bar.
- [MDX documentation — Ask One from a chart point](https://66a7a8d7d124220c363457cc-cekxzmvkdt.chromatic.com/?path=/docs/patterns-analyticsdashboard--documentation#ask-one-from-a-chart-point): pointer and keyboard behavior, host ownership, formatting, pagination, dismissal, title requirements, and screen-reader naming.

Review these states:

1. **Pointer confirmation:** click the Engineering bar. The anchored **Ask One** action appears beside the mark and chat stays closed.
2. **Keyboard point picker:** reset, Tab to **Ask One: Headcount by Department**, then press Enter. The menu exposes complete formatted point context.
3. **Completed handoff:** choose Engineering. The quote contains title, category, series, and formatted value; focus lands in the composer.
4. **Ordinary host rerender:** while the anchored action or keyboard menu is open, an unrelated parent render must not dismiss it.

## Behavior and implementation

- Chart selection is a two-step offer, so ordinary exploration cannot unexpectedly open One.
- Quotes use the chart's tooltip/value formatters, including scatter axes, heatmap labels, and all visible line series at a category.
- The pointer action portals above clipped widgets and dismisses on Escape, outside press, scroll, resize, or genuinely stale data.
- The keyboard companion is named **Ask One: chart title**, exposes the same visible/legend-filtered points, and pages large charts at 100 items.
- `F0DataChart` remains truthfully pointer-only. The dashboard's real keyboard companion adds `source: "keyboard"` through `F0AnalyticsDashboardPointClick`; keyboard points use zero viewport coordinates because they have no pointer anchor.
- Host callbacks own chat/focus/fullscreen state and receive `{ id, title, point }`; the built-in action exits fullscreen, quotes, opens chat, and focuses its composer.
- Inline host config and callback identities may change on normal React renders. Point actions reset only for semantic invalidation, and an open action resolves the latest host callback when selected.
- Charts with blank titles expose neither pointer nor keyboard point actions, matching widget-level Ask One.
- The public props JSDoc remains attached to `F0AnalyticsDashboardProps`.

## Verification

Exact local candidate:

- Focused point-click, point-action, dashboard integration, and public callback suites: **84/84 passed**.
- TypeScript, format check, targeted lint, diff check, and production Storybook build passed.
- Real Chrome completed the point story with the formatted quote visible and the textarea focused.
- The pre-push changed-path run passed 245 tests; its six failures are inherited BarChart font-metric assertions reproduced on the exact lower stack and untouched by this PR.
- Exact-head GitHub CI is green, including React unit tests, all eight Storybook shards, Chromatic, accessibility, and the package build.

---

### The stack

| | PR | What it adds |
|---|---|---|
| 1 | #5123 | `F0DataChart` reports the selected mark |
| 2 | #5124 | Widget menu → **Ask One** |
| 3 | #5125 | Chart point → **Ask One** |
| 4 | #5126 | Drag a widget into chat |

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0
> - factorial-ci
> - factorial-pr


