### PR TITLE
feat(ai): drop a dashboard widget into the chat to quote it

### DIFF
--- a/packages/react/src/kits/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/F0AiChat.tsx
@@ -247,6 +247,7 @@ const F0AiChatComponent = ({
           : undefined
       }
       exitStyle={splitPanel && open ? "hold" : "shrink"}
+      acceptsWidgetDrop={viewKey === "chat" && !overlay}
     >
       {/* Simultaneous crossfade: the outgoing view fades out while the next
           fades in (both briefly mounted, stacked via `absolute inset-0` over the

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
@@ -184,7 +184,7 @@ composer without changing the dashboard layout.
   the widget `id` and `title` without changing the built-in pending quote.
 - WHEN the pointer is released elsewhere, cancelled, or the dashboard unmounts
   → THEN the invitation closes without adding a quote.
-- WHEN chat is showing voice mode, hosted content, a host overlay, or a
+- WHEN chat is showing voice mode, hosted content, a host overlay, Pong, or a
   clarifying flow → THEN that surface is not a widget drop target.
 - Dragging is a pointer enhancement for editable dashboards. Use the widget
   menu's **Ask One** action as the keyboard and single-pointer alternative.

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
@@ -171,21 +171,21 @@ Use this pattern for chat-scoped discovery content with host-owned actions.
 
 In an editable, multi-item analytics dashboard, drag a widget by its reorder
 handle and release it over the visible One chat. The chat announces the drop
-target as soon as the gesture starts, then attaches the widget title to the
-composer without changing the dashboard layout.
+target as soon as the pointer moves far enough to become a drag, then attaches
+the widget title to the composer without changing the dashboard layout.
 
 <Canvas of={WidgetDropStories.DragWidgetToQuote} />
 
-- WHEN a titled widget drag starts → THEN the visible chat shows “Drop here to
-  discuss with One”.
+- WHEN a titled widget moves beyond the small click threshold → THEN the visible
+  chat shows “Drop here to discuss with One”; a plain grip click stays quiet.
 - WHEN the pointer is released over the chat → THEN the widget title becomes
   the pending quote and the dashboard does not reorder it.
 - WHEN the dashboard supplies `onAskAi` → THEN the drop calls the host with
   the widget `id` and `title` without changing the built-in pending quote.
 - WHEN the pointer is released elsewhere, cancelled, or the dashboard unmounts
   → THEN the invitation closes without adding a quote.
-- WHEN chat is showing voice mode, hosted content, a host overlay, Pong, or a
-  clarifying flow → THEN that surface is not a widget drop target.
+- WHEN chat is closing or showing voice mode, hosted content, a host overlay,
+  Pong, or a clarifying flow → THEN that surface is not a widget drop target.
 - Dragging is a pointer enhancement for editable dashboards. Use the widget
   menu's **Ask One** action as the keyboard and single-pointer alternative.
 - Dashboard dragging is disabled below the grid's 640 px editing breakpoint;

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
@@ -180,6 +180,8 @@ composer without changing the dashboard layout.
   discuss with One”.
 - WHEN the pointer is released over the chat → THEN the widget title becomes
   the pending quote and the dashboard does not reorder it.
+- WHEN the dashboard supplies `onAskAi` → THEN the drop calls the host with
+  the widget `id` and `title` without changing the built-in pending quote.
 - WHEN the pointer is released elsewhere, cancelled, or the dashboard unmounts
   → THEN the invitation closes without adding a quote.
 - WHEN chat is showing voice mode, hosted content, a host overlay, or a

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChat.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 import * as Stories from "./F0AiChat.stories"
+import * as WidgetDropStories from "./F0AiChatWidgetDrop.stories"
 
 <Meta of={Stories} />
 
@@ -166,6 +167,28 @@ Use this pattern for chat-scoped discovery content with host-owned actions.
 
 <Canvas of={Stories.WithHostOverlay} />
 
+### Discuss a dashboard widget
+
+In an editable, multi-item analytics dashboard, drag a widget by its reorder
+handle and release it over the visible One chat. The chat announces the drop
+target as soon as the gesture starts, then attaches the widget title to the
+composer without changing the dashboard layout.
+
+<Canvas of={WidgetDropStories.DragWidgetToQuote} />
+
+- WHEN a titled widget drag starts → THEN the visible chat shows “Drop here to
+  discuss with One”.
+- WHEN the pointer is released over the chat → THEN the widget title becomes
+  the pending quote and the dashboard does not reorder it.
+- WHEN the pointer is released elsewhere, cancelled, or the dashboard unmounts
+  → THEN the invitation closes without adding a quote.
+- WHEN chat is showing voice mode, hosted content, a host overlay, or a
+  clarifying flow → THEN that surface is not a widget drop target.
+- Dragging is a pointer enhancement for editable dashboards. Use the widget
+  menu's **Ask One** action as the keyboard and single-pointer alternative.
+- Dashboard dragging is disabled below the grid's 640 px editing breakpoint;
+  touch support depends on the host dashboard's reorder gesture.
+
 ## Accessibility
 
 Overlay content must provide its own semantic structure, accessible name,
@@ -189,6 +212,15 @@ they are unavailable to keyboard and assistive-technology navigation.
           <kbd>Tab</kbd>
         </td>
         <td>Moves focus among controls supplied by the host overlay.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Enter</kbd> / <kbd>Space</kbd>
+        </td>
+        <td>
+          Activates <strong>Ask One</strong> from a widget's actions menu as the
+          non-drag alternative to quoting it.
+        </td>
       </tr>
       <tr>
         <td>

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useEffect } from "react"
+
+import { F0AnalyticsDashboard } from "@/patterns/F0AnalyticsDashboard"
+import {
+  dashboardFilters,
+  dashboardPresets,
+  mixedItems,
+} from "@/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed"
+
+import { F0AiChat, F0AiChatProvider, useAiChat } from ".."
+
+import {
+  MockAiChatRuntimeProvider,
+  MockConnectedChatHeader,
+  MockConnectedChatInput,
+  MockConnectedMessagesContainer,
+} from "./_mock"
+
+/**
+ * Side-by-side harness: an editable dashboard on the left, the AI chat docked
+ * right — the arrangement the canvas mode produces in the real app, reduced to
+ * the two components the interaction spans.
+ */
+const WidgetDropLayout = () => {
+  const { setOpen } = useAiChat()
+
+  useEffect(() => {
+    setOpen(true)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    // `min-h-0` on both columns is load-bearing: flex items default to
+    // `min-height: auto`, so the tall dashboard would otherwise stretch the row
+    // (and with it the chat card) far past the viewport.
+    <div className="flex h-full w-full gap-2 overflow-hidden">
+      <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+        <F0AnalyticsDashboard
+          filters={dashboardFilters}
+          presets={dashboardPresets}
+          items={mixedItems}
+          editMode
+        />
+      </div>
+      <div className="flex min-h-0 w-[420px] shrink-0">
+        <F0AiChat
+          header={<MockConnectedChatHeader />}
+          messages={<MockConnectedMessagesContainer />}
+          input={<MockConnectedChatInput />}
+        />
+      </div>
+    </div>
+  )
+}
+
+const meta = {
+  title: "AI/F0AiChat/Widget drop",
+  component: F0AiChat,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["!autodocs", "experimental"],
+  decorators: [
+    (Story) => (
+      <div className="h-screen w-full overflow-hidden p-2">
+        <F0AiChatProvider enabled>
+          <MockAiChatRuntimeProvider>
+            <Story />
+          </MockAiChatRuntimeProvider>
+        </F0AiChatProvider>
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof F0AiChat>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/**
+ * Drag a widget into the chat to quote it.
+ *
+ * Grab a widget by the drag handle that appears to the left of its header on
+ * hover, then move the cursor over the chat panel: it swaps to a dashed drop
+ * state reading **"Drop here to discuss with One"**. Release, and the widget's
+ * title lands in the composer's quote chip, ready for a question.
+ *
+ * Two things worth watching while dragging over the chat: the dashboard's own
+ * drop indicator disappears (releasing there must not also reorder the grid),
+ * and leaving the panel without releasing cancels cleanly.
+ */
+export const DragWidgetToQuote: Story = {
+  render: () => <WidgetDropLayout />,
+}

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
@@ -114,12 +114,17 @@ export const DragWidgetToQuote: Story = {
     const clientX = dropRect.left + dropRect.width / 2
     const clientY = dropRect.top + dropRect.height / 2
 
-    await step("Show the chat invitation when widget dragging starts", () => {
-      fireEvent.pointerDown(grip, { button: 0 })
-      expect(
-        canvas.getByText("Drop here to discuss with One")
-      ).toBeInTheDocument()
-    })
+    await step(
+      "Show the chat invitation when widget dragging starts",
+      async () => {
+        fireEvent.pointerDown(grip, { button: 0 })
+        await waitFor(() =>
+          expect(
+            canvas.getByText("Drop here to discuss with One")
+          ).toBeInTheDocument()
+        )
+      }
+    )
 
     await step("Drop into chat without reordering the dashboard", async () => {
       fireEvent.pointerMove(ownerDocument, { clientX, clientY })

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, fireEvent, waitFor, within } from "storybook/test"
 
 import { useEffect } from "react"
 
@@ -61,7 +62,7 @@ const meta = {
   parameters: {
     layout: "fullscreen",
   },
-  tags: ["!autodocs", "experimental"],
+  tags: ["!autodocs", "experimental", "no-sidebar"],
   decorators: [
     (Story) => (
       <div className="h-screen w-full overflow-hidden p-2">
@@ -92,4 +93,46 @@ type Story = StoryObj<typeof meta>
  */
 export const DragWidgetToQuote: Story = {
   render: () => <WidgetDropLayout />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const ownerDocument = canvasElement.ownerDocument
+    const firstCard = await waitFor(() => {
+      const card = canvasElement.querySelector<HTMLElement>("[data-card-id]")
+      expect(card).toBeInTheDocument()
+      return card!
+    })
+    const originalFirstCardId = firstCard.dataset.cardId
+    const grip = (await canvas.findAllByLabelText("Drag to reorder"))[0]
+    const dropZone = await waitFor(() => {
+      const element = ownerDocument.querySelector<HTMLElement>(
+        "[data-ai-chat-dropzone]"
+      )
+      expect(element).toBeInTheDocument()
+      return element!
+    })
+    const dropRect = dropZone.getBoundingClientRect()
+    const clientX = dropRect.left + dropRect.width / 2
+    const clientY = dropRect.top + dropRect.height / 2
+
+    await step("Show the chat invitation when widget dragging starts", () => {
+      fireEvent.pointerDown(grip, { button: 0 })
+      expect(
+        canvas.getByText("Drop here to discuss with One")
+      ).toBeInTheDocument()
+    })
+
+    await step("Drop into chat without reordering the dashboard", async () => {
+      fireEvent.pointerMove(ownerDocument, { clientX, clientY })
+      fireEvent.pointerUp(dropZone, { clientX, clientY })
+
+      const removeQuote = await canvas.findByRole("button", {
+        name: "Remove quote",
+      })
+      await expect(removeQuote.parentElement).not.toHaveTextContent("")
+      await expect(
+        canvasElement.querySelector<HTMLElement>("[data-card-id]")?.dataset
+          .cardId
+      ).toBe(originalFirstCardId)
+    })
+  },
 }

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
@@ -89,7 +89,7 @@ type Story = StoryObj<typeof meta>
  *
  * Two things worth watching while dragging over the chat: the dashboard's own
  * drop indicator disappears (releasing there must not also reorder the grid),
- * and leaving the panel without releasing cancels cleanly.
+ * and releasing outside the panel cancels cleanly.
  */
 export const DragWidgetToQuote: Story = {
   render: () => <WidgetDropLayout />,
@@ -103,6 +103,9 @@ export const DragWidgetToQuote: Story = {
     })
     const originalFirstCardId = firstCard.dataset.cardId
     const grip = (await canvas.findAllByLabelText("Drag to reorder"))[0]
+    const gripRect = grip.getBoundingClientRect()
+    const dragStartX = gripRect.left + gripRect.width / 2
+    const dragStartY = gripRect.top + gripRect.height / 2
     const dropZone = await waitFor(() => {
       const element = ownerDocument.querySelector<HTMLElement>(
         "[data-ai-chat-dropzone]"
@@ -115,9 +118,16 @@ export const DragWidgetToQuote: Story = {
     const clientY = dropRect.top + dropRect.height / 2
 
     await step(
-      "Show the chat invitation when widget dragging starts",
+      "Show the chat invitation after meaningful pointer movement",
       async () => {
-        fireEvent.pointerDown(grip, { button: 0 })
+        fireEvent.pointerDown(grip, {
+          clientX: dragStartX,
+          clientY: dragStartY,
+        })
+        fireEvent.pointerMove(ownerDocument, {
+          clientX: dragStartX + 8,
+          clientY: dragStartY,
+        })
         await waitFor(() =>
           expect(
             canvas.getByText("Drop here to discuss with One")

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
@@ -128,7 +128,10 @@ export const DragWidgetToQuote: Story = {
       const removeQuote = await canvas.findByRole("button", {
         name: "Remove quote",
       })
-      await expect(removeQuote.parentElement).not.toHaveTextContent("")
+      await expect(removeQuote.parentElement).toHaveTextContent(
+        "Total Headcount"
+      )
+      await waitFor(() => expect(canvas.getByRole("textbox")).toHaveFocus())
       await expect(
         canvasElement.querySelector<HTMLElement>("[data-card-id]")?.dataset
           .cardId

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -19,8 +19,14 @@ import {
 } from "../providers/AiChatStateProvider"
 
 const Probe = () => {
-  const { setOpen, pendingQuote, setIsClarifying, setPanelContent, setMode } =
-    useAiChat()
+  const {
+    setOpen,
+    pendingQuote,
+    setIsClarifying,
+    setPanelContent,
+    setMode,
+    openGame,
+  } = useAiChat()
 
   return (
     <>
@@ -40,6 +46,9 @@ const Probe = () => {
       </button>
       <button type="button" onClick={() => setMode("voice")}>
         Start voice mode
+      </button>
+      <button type="button" onClick={() => openGame("pong")}>
+        Start Pong
       </button>
       <span data-testid="quote">{pendingQuote?.text ?? ""}</span>
     </>
@@ -232,6 +241,7 @@ describe("F0AiChat widget drop", () => {
     ],
     ["hosted panel", () => renderChat()],
     ["voice mode", () => renderChat()],
+    ["Pong", () => renderChat()],
   ])("does not expose a widget drop zone over %s", async (surface, setup) => {
     setup()
     await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
@@ -243,6 +253,8 @@ describe("F0AiChat widget drop", () => {
       await userEvent.click(
         screen.getByRole("button", { name: "Start voice mode" })
       )
+    } else if (surface === "Pong") {
+      await userEvent.click(screen.getByRole("button", { name: "Start Pong" }))
     }
 
     expect(document.querySelector("[data-ai-chat-dropzone]")).toBeNull()

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it } from "vitest"
+
+import {
+  act,
+  fireEvent,
+  screen,
+  userEvent,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { WIDGET_DRAG_END, WIDGET_DRAG_START } from "@/lib/dnd/widgetDragEvents"
+
+import { F0AiChat } from "../F0AiChat"
+import {
+  AiChatStateProvider,
+  useAiChat,
+} from "../providers/AiChatStateProvider"
+
+const Probe = () => {
+  const { setOpen, pendingQuote } = useAiChat()
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open chat
+      </button>
+      <span data-testid="quote">{pendingQuote?.text ?? ""}</span>
+    </>
+  )
+}
+
+/**
+ * No `fileAttachments`, so the file-drop path is off throughout — these tests
+ * also cover that the widget overlay isn't gated behind an upload handler.
+ */
+const renderChat = () =>
+  render(
+    <AiChatStateProvider
+      enabled
+      chatHeader={<button type="button">Header action</button>}
+      chatMessages={<div>Messages</div>}
+      chatInput={<button type="button">Send</button>}
+    >
+      <Probe />
+      <F0AiChat />
+    </AiChatStateProvider>
+  )
+
+/** Stands in for the dashboard grid announcing a drag. */
+const startWidgetDrag = (title: string) =>
+  act(() => {
+    window.dispatchEvent(
+      new CustomEvent(WIDGET_DRAG_START, { detail: { title } })
+    )
+  })
+
+const endWidgetDrag = () =>
+  act(() => {
+    window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
+  })
+
+const dropZone = () => {
+  const zone = document.querySelector("[data-ai-chat-dropzone]")
+  if (!(zone instanceof HTMLElement)) {
+    throw new Error("Expected the chat to expose a drop zone")
+  }
+  return zone
+}
+
+describe("F0AiChat widget drop", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it("invites the drop as soon as the drag starts, before the pointer arrives", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+
+    startWidgetDrag("Headcount by department")
+
+    // No pointer has touched the chat — the announcement alone is enough.
+    expect(
+      screen.getByText("Drop here to discuss with One")
+    ).toBeInTheDocument()
+  })
+
+  it("quotes the dragged widget's title when released over the chat", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    startWidgetDrag("Headcount by department")
+    fireEvent.pointerUp(dropZone())
+
+    expect(screen.getByTestId("quote")).toHaveTextContent(
+      "Headcount by department"
+    )
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+  })
+
+  it("withdraws the invitation when the drag ends away from the chat", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    startWidgetDrag("Headcount by department")
+    endWidgetDrag()
+
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+
+    // A later stray release must not retroactively quote the widget.
+    fireEvent.pointerUp(dropZone())
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
+  })
+
+  it("ignores a release over the chat with no drag in flight", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    fireEvent.pointerUp(dropZone())
+
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
+  })
+
+  /**
+   * Regression guard. A fast drag can deliver the start announcement and the
+   * release inside a single React batch, so no re-render separates them. A
+   * release handler closing over the *state* would still read the pre-drag
+   * `null` and silently drop the quote — which is exactly what the real
+   * browser did before the payload moved into a ref. Both events go in one
+   * `act` here to reproduce that batching.
+   */
+  it("still quotes when start and release land in the same React batch", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(WIDGET_DRAG_START, {
+          detail: { title: "Headcount by department" },
+        })
+      )
+      fireEvent.pointerUp(dropZone())
+    })
+
+    expect(screen.getByTestId("quote")).toHaveTextContent(
+      "Headcount by department"
+    )
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { ReactNode } from "react"
+import { useEffect, useRef } from "react"
 
 import {
   act,
@@ -45,6 +46,18 @@ const Probe = () => {
   )
 }
 
+const TestChatInput = () => {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const { setFocusChatInputFunction } = useAiChat()
+
+  useEffect(() => {
+    setFocusChatInputFunction(() => textareaRef.current?.focus())
+    return () => setFocusChatInputFunction(null)
+  }, [setFocusChatInputFunction])
+
+  return <textarea aria-label="Ask One" ref={textareaRef} />
+}
+
 /**
  * No `fileAttachments`, so the file-drop path is off throughout — these tests
  * also cover that the widget overlay isn't gated behind an upload handler.
@@ -55,7 +68,7 @@ const renderChat = ({ overlay }: { overlay?: ReactNode } = {}) =>
       enabled
       chatHeader={<button type="button">Header action</button>}
       chatMessages={<div>Messages</div>}
-      chatInput={<button type="button">Send</button>}
+      chatInput={<TestChatInput />}
       VoiceMode={() => <div>Voice content</div>}
     >
       <Probe />
@@ -67,7 +80,9 @@ const renderChat = ({ overlay }: { overlay?: ReactNode } = {}) =>
 const startWidgetDrag = (title: string) =>
   act(() => {
     window.dispatchEvent(
-      new CustomEvent(WIDGET_DRAG_START, { detail: { title } })
+      new CustomEvent(WIDGET_DRAG_START, {
+        detail: { id: "headcount", title },
+      })
     )
   })
 
@@ -115,6 +130,7 @@ describe("F0AiChat widget drop", () => {
     expect(screen.getByTestId("quote")).toHaveTextContent(
       "Headcount by department"
     )
+    expect(screen.getByRole("textbox", { name: "Ask One" })).toHaveFocus()
     expect(
       screen.queryByText("Drop here to discuss with One")
     ).not.toBeInTheDocument()
@@ -160,7 +176,10 @@ describe("F0AiChat widget drop", () => {
     act(() => {
       window.dispatchEvent(
         new CustomEvent(WIDGET_DRAG_START, {
-          detail: { title: "Headcount by department" },
+          detail: {
+            id: "headcount",
+            title: "Headcount by department",
+          },
         })
       )
       fireEvent.pointerUp(dropZone())
@@ -248,5 +267,30 @@ describe("F0AiChat widget drop", () => {
     expect(
       screen.queryByText("Drop here to discuss with One")
     ).not.toBeInTheDocument()
+  })
+
+  it("hands a dropped widget to the host without mutating the built-in quote", async () => {
+    const onAskAi = vi.fn()
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(WIDGET_DRAG_START, {
+          detail: {
+            id: "headcount",
+            title: "Headcount by department",
+            onAskAi,
+          },
+        })
+      )
+    })
+    fireEvent.pointerUp(dropZone())
+
+    expect(onAskAi).toHaveBeenCalledWith({
+      id: "headcount",
+      title: "Headcount by department",
+    })
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
   })
 })

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest"
+import type { ReactNode } from "react"
 
 import {
   act,
@@ -17,12 +18,27 @@ import {
 } from "../providers/AiChatStateProvider"
 
 const Probe = () => {
-  const { setOpen, pendingQuote } = useAiChat()
+  const { setOpen, pendingQuote, setIsClarifying, setPanelContent, setMode } =
+    useAiChat()
 
   return (
     <>
       <button type="button" onClick={() => setOpen(true)}>
         Open chat
+      </button>
+      <button type="button" onClick={() => setIsClarifying(true)}>
+        Start clarifying
+      </button>
+      <button
+        type="button"
+        onClick={() =>
+          setPanelContent({ id: "hosted", content: <div>Hosted content</div> })
+        }
+      >
+        Show hosted content
+      </button>
+      <button type="button" onClick={() => setMode("voice")}>
+        Start voice mode
       </button>
       <span data-testid="quote">{pendingQuote?.text ?? ""}</span>
     </>
@@ -33,16 +49,17 @@ const Probe = () => {
  * No `fileAttachments`, so the file-drop path is off throughout — these tests
  * also cover that the widget overlay isn't gated behind an upload handler.
  */
-const renderChat = () =>
+const renderChat = ({ overlay }: { overlay?: ReactNode } = {}) =>
   render(
     <AiChatStateProvider
       enabled
       chatHeader={<button type="button">Header action</button>}
       chatMessages={<div>Messages</div>}
       chatInput={<button type="button">Send</button>}
+      VoiceMode={() => <div>Voice content</div>}
     >
       <Probe />
-      <F0AiChat />
+      <F0AiChat overlay={overlay} />
     </AiChatStateProvider>
   )
 
@@ -152,5 +169,84 @@ describe("F0AiChat widget drop", () => {
     expect(screen.getByTestId("quote")).toHaveTextContent(
       "Headcount by department"
     )
+  })
+
+  it("ignores widget drags while a clarifying flow owns the composer", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+    await userEvent.click(
+      screen.getByRole("button", { name: "Start clarifying" })
+    )
+
+    startWidgetDrag("Headcount by department")
+
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+    fireEvent.pointerUp(dropZone())
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
+  })
+
+  it("retracts an active widget drag when clarifying starts", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+    startWidgetDrag("Headcount by department")
+    expect(
+      screen.getByText("Drop here to discuss with One")
+    ).toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Start clarifying" })
+    )
+
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+    fireEvent.pointerUp(dropZone())
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
+  })
+
+  it.each([
+    [
+      "host overlay",
+      () => renderChat({ overlay: <div>Blocking overlay</div> }),
+    ],
+    ["hosted panel", () => renderChat()],
+    ["voice mode", () => renderChat()],
+  ])("does not expose a widget drop zone over %s", async (surface, setup) => {
+    setup()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+    if (surface === "hosted panel") {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Show hosted content" })
+      )
+    } else if (surface === "voice mode") {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Start voice mode" })
+      )
+    }
+
+    expect(document.querySelector("[data-ai-chat-dropzone]")).toBeNull()
+    startWidgetDrag("Headcount by department")
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+  })
+
+  it("ignores malformed or blank widget drag announcements", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    startWidgetDrag("   ")
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent(WIDGET_DRAG_START))
+    })
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
   })
 })

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -33,6 +33,9 @@ const Probe = () => {
       <button type="button" onClick={() => setOpen(true)}>
         Open chat
       </button>
+      <button type="button" onClick={() => setOpen(false)}>
+        Close chat
+      </button>
       <button type="button" onClick={() => setIsClarifying(true)}>
         Start clarifying
       </button>
@@ -158,6 +161,24 @@ describe("F0AiChat widget drop", () => {
 
     // A later stray release must not retroactively quote the widget.
     fireEvent.pointerUp(dropZone())
+    expect(screen.getByTestId("quote")).toHaveTextContent("")
+  })
+
+  it("stops accepting widget drops as soon as the chat starts closing", async () => {
+    renderChat()
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+    const exitingCard = dropZone()
+
+    await userEvent.click(screen.getByRole("button", { name: "Close chat" }))
+
+    // AnimatePresence keeps the card mounted during its exit animation, but
+    // it must stop advertising and consuming drops immediately.
+    expect(exitingCard).not.toHaveAttribute("data-ai-chat-dropzone")
+    startWidgetDrag("Headcount by department")
+    expect(
+      screen.queryByText("Drop here to discuss with One")
+    ).not.toBeInTheDocument()
+    fireEvent.pointerUp(exitingCard)
     expect(screen.getByTestId("quote")).toHaveTextContent("")
   })
 

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -227,12 +227,12 @@ describe("F0AiChat widget drop", () => {
       screen.getByRole("button", { name: "Start clarifying" })
     )
 
+    expect(document.querySelector("[data-ai-chat-dropzone]")).toBeNull()
     startWidgetDrag("Headcount by department")
 
     expect(
       screen.queryByText("Drop here to discuss with One")
     ).not.toBeInTheDocument()
-    fireEvent.pointerUp(dropZone())
     expect(screen.getByTestId("quote")).toHaveTextContent("")
   })
 
@@ -243,6 +243,7 @@ describe("F0AiChat widget drop", () => {
     expect(
       screen.getByText("Drop here to discuss with One")
     ).toBeInTheDocument()
+    const previousDropZone = dropZone()
 
     await userEvent.click(
       screen.getByRole("button", { name: "Start clarifying" })
@@ -251,7 +252,9 @@ describe("F0AiChat widget drop", () => {
     expect(
       screen.queryByText("Drop here to discuss with One")
     ).not.toBeInTheDocument()
-    fireEvent.pointerUp(dropZone())
+    expect(previousDropZone).not.toHaveAttribute("data-ai-chat-dropzone")
+    expect(document.querySelector("[data-ai-chat-dropzone]")).toBeNull()
+    fireEvent.pointerUp(previousDropZone)
     expect(screen.getByTestId("quote")).toHaveTextContent("")
   })
 
@@ -262,6 +265,7 @@ describe("F0AiChat widget drop", () => {
     ],
     ["hosted panel", () => renderChat()],
     ["voice mode", () => renderChat()],
+    ["clarifying flow", () => renderChat()],
     ["Pong", () => renderChat()],
   ])("does not expose a widget drop zone over %s", async (surface, setup) => {
     setup()
@@ -273,6 +277,10 @@ describe("F0AiChat widget drop", () => {
     } else if (surface === "voice mode") {
       await userEvent.click(
         screen.getByRole("button", { name: "Start voice mode" })
+      )
+    } else if (surface === "clarifying flow") {
+      await userEvent.click(
+        screen.getByRole("button", { name: "Start clarifying" })
       )
     } else if (surface === "Pong") {
       await userEvent.click(screen.getByRole("button", { name: "Start Pong" }))

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -22,6 +22,7 @@ export const SidebarWindow = ({
   visible,
   side,
   exitStyle = "shrink",
+  acceptsWidgetDrop = false,
 }: {
   children?: ReactNode
   /** Overrides the context `open` as the mount condition — lets the frame
@@ -36,6 +37,8 @@ export const SidebarWindow = ({
    * the panels feel like they were always there.
    */
   exitStyle?: "shrink" | "hold"
+  /** Enables dashboard-widget quoting for the real chat/composer view only. */
+  acceptsWidgetDrop?: boolean
 }) => {
   const {
     open,
@@ -137,9 +140,10 @@ export const SidebarWindow = ({
   useEffect(() => {
     const onStart = (e: Event) => {
       // Same freeze as the file drop: a clarifying flow owns the panel.
-      if (isClarifying) return
+      if (!acceptsWidgetDrop || isClarifying) return
       const detail = (e as CustomEvent<WidgetDragStartDetail>).detail
-      setDragQuoteBoth(detail?.title ?? "")
+      if (typeof detail?.title !== "string" || !detail.title.trim()) return
+      setDragQuoteBoth(detail.title)
     }
     const onEnd = () => setDragQuoteBoth(null)
 
@@ -149,17 +153,28 @@ export const SidebarWindow = ({
       window.removeEventListener(WIDGET_DRAG_START, onStart)
       window.removeEventListener(WIDGET_DRAG_END, onEnd)
     }
-  }, [isClarifying, setDragQuoteBoth])
+  }, [acceptsWidgetDrop, isClarifying, setDragQuoteBoth])
+
+  // A view change, host overlay, or clarifying flow can take ownership of the
+  // shell while a pointer is still down. Retract the invitation immediately
+  // so releasing over non-chat content can never create an invisible quote.
+  useEffect(() => {
+    if (!acceptsWidgetDrop || isClarifying) setDragQuoteBoth(null)
+  }, [acceptsWidgetDrop, isClarifying, setDragQuoteBoth])
 
   // Releasing over the chat quotes the widget. This is a handler on the card,
   // so a release anywhere else simply never reaches it — the grid's own
   // `pointerup` clears the invitation via WIDGET_DRAG_END.
   const handlePointerUp = useCallback(() => {
+    if (!acceptsWidgetDrop || isClarifying) {
+      setDragQuoteBoth(null)
+      return
+    }
     const title = dragQuoteRef.current
     if (title === null) return
     setDragQuoteBoth(null)
     if (title) setPendingQuote({ text: title })
-  }, [setDragQuoteBoth, setPendingQuote])
+  }, [acceptsWidgetDrop, isClarifying, setDragQuoteBoth, setPendingQuote])
 
   const fullscreen = visualizationMode === "fullscreen"
   // Stays LOCAL: it gates this handle's document mousemove listener and its
@@ -273,7 +288,7 @@ export const SidebarWindow = ({
             // Marks this card as a drop target for pointer-driven drags
             // elsewhere in the app (the dashboard grid hit-tests for it to
             // suppress its own reorder while the cursor is over the chat).
-            data-ai-chat-dropzone=""
+            data-ai-chat-dropzone={acceptsWidgetDrop ? "" : undefined}
             onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
@@ -285,7 +300,7 @@ export const SidebarWindow = ({
             </div>
             {/* `canDrop` gates only the file drop — quoting a dragged widget
                 needs no upload handler, so it renders on its own. */}
-            {(canDrop || dragQuote !== null) && (
+            {(canDrop || (acceptsWidgetDrop && dragQuote !== null)) && (
               <DropOverlay
                 visible={(canDrop && fileDragOver) || dragQuote !== null}
                 mode={dragQuote !== null ? "discuss" : "files"}

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -62,7 +62,7 @@ export const SidebarWindow = ({
   } = useAiChat()
   const isVisible = visible ?? open
   const canAcceptWidgetDrop =
-    acceptsWidgetDrop && activeGame === null && isVisible
+    acceptsWidgetDrop && activeGame === null && isVisible && !isClarifying
   const canAcceptWidgetDropRef = useRef(canAcceptWidgetDrop)
   canAcceptWidgetDropRef.current = canAcceptWidgetDrop
   const widgetDropZoneRef = useRef<HTMLDivElement>(null)
@@ -157,8 +157,7 @@ export const SidebarWindow = ({
 
   useEffect(() => {
     const onStart = (e: Event) => {
-      // Same freeze as the file drop: a clarifying flow owns the panel.
-      if (!canAcceptWidgetDrop || isClarifying) return
+      if (!canAcceptWidgetDrop) return
       const detail = (e as CustomEvent<WidgetDragStartDetail>).detail
       if (
         typeof detail?.id !== "string" ||
@@ -177,20 +176,20 @@ export const SidebarWindow = ({
       window.removeEventListener(WIDGET_DRAG_START, onStart)
       window.removeEventListener(WIDGET_DRAG_END, onEnd)
     }
-  }, [canAcceptWidgetDrop, isClarifying, setDragQuoteBoth])
+  }, [canAcceptWidgetDrop, setDragQuoteBoth])
 
   // A view change, host overlay, or clarifying flow can take ownership of the
   // shell while a pointer is still down. Retract the invitation immediately
   // so releasing over non-chat content can never create an invisible quote.
   useEffect(() => {
-    if (!canAcceptWidgetDrop || isClarifying) setDragQuoteBoth(null)
-  }, [canAcceptWidgetDrop, isClarifying, setDragQuoteBoth])
+    if (!canAcceptWidgetDrop) setDragQuoteBoth(null)
+  }, [canAcceptWidgetDrop, setDragQuoteBoth])
 
   // Releasing over the chat quotes the widget. This is a handler on the card,
   // so a release anywhere else simply never reaches it — the grid's own
   // `pointerup` clears the invitation via WIDGET_DRAG_END.
   const handlePointerUp = useCallback(() => {
-    if (!canAcceptWidgetDropRef.current || isClarifying) {
+    if (!canAcceptWidgetDropRef.current) {
       setDragQuoteBoth(null)
       return
     }
@@ -203,13 +202,7 @@ export const SidebarWindow = ({
       setPendingQuote({ text: detail.title })
       focusChatInput()
     }
-  }, [
-    canAcceptWidgetDrop,
-    focusChatInput,
-    isClarifying,
-    setDragQuoteBoth,
-    setPendingQuote,
-  ])
+  }, [canAcceptWidgetDrop, focusChatInput, setDragQuoteBoth, setPendingQuote])
 
   const fullscreen = visualizationMode === "fullscreen"
   // Stays LOCAL: it gates this handle's document mousemove listener and its

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -55,6 +55,7 @@ export const SidebarWindow = ({
     setFileDragOver,
     processDroppedFiles,
     setPendingQuote,
+    focusChatInput,
     activeGame,
     closeGame,
     panelSide,
@@ -129,21 +130,30 @@ export const SidebarWindow = ({
   // The ref — not the state — is what the release reads, so a release that
   // lands in the same React batch as the state update still sees the title
   // instead of a stale `null`. The state exists to drive the overlay's render.
-  const dragQuoteRef = useRef<string | null>(null)
+  const dragQuoteRef = useRef<WidgetDragStartDetail | null>(null)
   const [dragQuote, setDragQuote] = useState<string | null>(null)
 
-  const setDragQuoteBoth = useCallback((title: string | null) => {
-    dragQuoteRef.current = title
-    setDragQuote(title)
-  }, [])
+  const setDragQuoteBoth = useCallback(
+    (detail: WidgetDragStartDetail | null) => {
+      dragQuoteRef.current = detail
+      setDragQuote(detail?.title ?? null)
+    },
+    []
+  )
 
   useEffect(() => {
     const onStart = (e: Event) => {
       // Same freeze as the file drop: a clarifying flow owns the panel.
       if (!acceptsWidgetDrop || isClarifying) return
       const detail = (e as CustomEvent<WidgetDragStartDetail>).detail
-      if (typeof detail?.title !== "string" || !detail.title.trim()) return
-      setDragQuoteBoth(detail.title)
+      if (
+        typeof detail?.id !== "string" ||
+        !detail.id ||
+        typeof detail.title !== "string" ||
+        !detail.title.trim()
+      )
+        return
+      setDragQuoteBoth(detail)
     }
     const onEnd = () => setDragQuoteBoth(null)
 
@@ -170,11 +180,22 @@ export const SidebarWindow = ({
       setDragQuoteBoth(null)
       return
     }
-    const title = dragQuoteRef.current
-    if (title === null) return
+    const detail = dragQuoteRef.current
+    if (detail === null) return
     setDragQuoteBoth(null)
-    if (title) setPendingQuote({ text: title })
-  }, [acceptsWidgetDrop, isClarifying, setDragQuoteBoth, setPendingQuote])
+    if (detail.onAskAi) {
+      detail.onAskAi({ id: detail.id, title: detail.title })
+    } else {
+      setPendingQuote({ text: detail.title })
+      focusChatInput()
+    }
+  }, [
+    acceptsWidgetDrop,
+    focusChatInput,
+    isClarifying,
+    setDragQuoteBoth,
+    setPendingQuote,
+  ])
 
   const fullscreen = visualizationMode === "fullscreen"
   // Stays LOCAL: it gates this handle's document mousemove listener and its

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -5,7 +5,10 @@ import { AnimatePresence, motion } from "motion/react"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useMediaQuery } from "usehooks-ts"
 
+import type { WidgetDragStartDetail } from "@/lib/dnd/widgetDragEvents"
+
 import { useReducedMotion } from "@/lib/a11y"
+import { WIDGET_DRAG_END, WIDGET_DRAG_START } from "@/lib/dnd/widgetDragEvents"
 import { cn } from "@/lib/utils"
 
 import { DropOverlay } from "../../../F0AiChatTextArea"
@@ -48,6 +51,7 @@ export const SidebarWindow = ({
     fileDragOver,
     setFileDragOver,
     processDroppedFiles,
+    setPendingQuote,
     activeGame,
     closeGame,
     panelSide,
@@ -111,6 +115,52 @@ export const SidebarWindow = ({
     },
     [setFileDragOver]
   )
+
+  // ─── Dashboard widget drag → quote ──────────────────────────
+  // A widget drag is a plain pointer gesture, not native HTML5 drag-and-drop,
+  // so it fires no `dragenter` and the file handlers above never see it. The
+  // grid announces the gesture on `window` instead, which lets the invitation
+  // appear the moment the drag starts rather than when the cursor finally
+  // arrives — the user can see where the widget can go before aiming for it.
+  //
+  // The ref — not the state — is what the release reads, so a release that
+  // lands in the same React batch as the state update still sees the title
+  // instead of a stale `null`. The state exists to drive the overlay's render.
+  const dragQuoteRef = useRef<string | null>(null)
+  const [dragQuote, setDragQuote] = useState<string | null>(null)
+
+  const setDragQuoteBoth = useCallback((title: string | null) => {
+    dragQuoteRef.current = title
+    setDragQuote(title)
+  }, [])
+
+  useEffect(() => {
+    const onStart = (e: Event) => {
+      // Same freeze as the file drop: a clarifying flow owns the panel.
+      if (isClarifying) return
+      const detail = (e as CustomEvent<WidgetDragStartDetail>).detail
+      setDragQuoteBoth(detail?.title ?? "")
+    }
+    const onEnd = () => setDragQuoteBoth(null)
+
+    window.addEventListener(WIDGET_DRAG_START, onStart)
+    window.addEventListener(WIDGET_DRAG_END, onEnd)
+    return () => {
+      window.removeEventListener(WIDGET_DRAG_START, onStart)
+      window.removeEventListener(WIDGET_DRAG_END, onEnd)
+    }
+  }, [isClarifying, setDragQuoteBoth])
+
+  // Releasing over the chat quotes the widget. This is a handler on the card,
+  // so a release anywhere else simply never reaches it — the grid's own
+  // `pointerup` clears the invitation via WIDGET_DRAG_END.
+  const handlePointerUp = useCallback(() => {
+    const title = dragQuoteRef.current
+    if (title === null) return
+    setDragQuoteBoth(null)
+    if (title) setPendingQuote({ text: title })
+  }, [setDragQuoteBoth, setPendingQuote])
+
   const fullscreen = visualizationMode === "fullscreen"
   // Stays LOCAL: it gates this handle's document mousemove listener and its
   // active style, and a split layout renders two windows — a shared gate would
@@ -220,22 +270,34 @@ export const SidebarWindow = ({
                   : "xs:rounded-r-xl"
                 : "xs:rounded-xl"
             )}
+            // Marks this card as a drop target for pointer-driven drags
+            // elsewhere in the app (the dashboard grid hit-tests for it to
+            // suppress its own reorder while the cursor is over the chat).
+            data-ai-chat-dropzone=""
             onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
             onDrop={handleDrop}
+            onPointerUp={handlePointerUp}
           >
             <div className="relative flex h-full w-full flex-col overflow-hidden">
               {children}
             </div>
-            {canDrop && (
+            {/* `canDrop` gates only the file drop — quoting a dragged widget
+                needs no upload handler, so it renders on its own. */}
+            {(canDrop || dragQuote !== null) && (
               <DropOverlay
-                visible={fileDragOver}
-                onFilesDropped={(files) => {
-                  dragCounterRef.current = 0
-                  setFileDragOver(false)
-                  processDroppedFiles(files)
-                }}
+                visible={(canDrop && fileDragOver) || dragQuote !== null}
+                mode={dragQuote !== null ? "discuss" : "files"}
+                onFilesDropped={
+                  canDrop
+                    ? (files) => {
+                        dragCounterRef.current = 0
+                        setFileDragOver(false)
+                        processDroppedFiles(files)
+                      }
+                    : undefined
+                }
               />
             )}
             {activeGame === "pong" && <F0AiPong onClose={closeGame} />}

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -60,13 +60,17 @@ export const SidebarWindow = ({
     closeGame,
     panelSide,
   } = useAiChat()
-  const canAcceptWidgetDrop = acceptsWidgetDrop && activeGame === null
+  const isVisible = visible ?? open
+  const canAcceptWidgetDrop =
+    acceptsWidgetDrop && activeGame === null && isVisible
+  const canAcceptWidgetDropRef = useRef(canAcceptWidgetDrop)
+  canAcceptWidgetDropRef.current = canAcceptWidgetDrop
+  const widgetDropZoneRef = useRef<HTMLDivElement>(null)
   const isCanvasMode = visualizationMode === "canvas"
   const reducedMotion = useReducedMotion()
   // Hosts dock the whole panel left for a chat-first experience (communications);
   // the default is right. The AI chat follows the panel side too.
   const isLeft = (side ?? panelSide) === "left"
-  const isVisible = visible ?? open
 
   // Was the panel already open on the previous committed render? A window
   // mounting while it was (a swap between the chat and hosted content on
@@ -79,6 +83,15 @@ export const SidebarWindow = ({
 
   const dragCounterRef = useRef(0)
   const canDrop = fileAttachments?.onUploadFiles != null && !isClarifying
+
+  // AnimatePresence retains the last rendered DOM props during exit. Remove
+  // the marker imperatively when visibility changes so a closing card cannot
+  // remain discoverable as a live drop zone for the duration of the animation.
+  useEffect(() => {
+    if (!canAcceptWidgetDrop) {
+      widgetDropZoneRef.current?.removeAttribute("data-ai-chat-dropzone")
+    }
+  }, [canAcceptWidgetDrop])
 
   const handleDragEnter = useCallback(
     (e: React.DragEvent) => {
@@ -177,7 +190,7 @@ export const SidebarWindow = ({
   // so a release anywhere else simply never reaches it — the grid's own
   // `pointerup` clears the invitation via WIDGET_DRAG_END.
   const handlePointerUp = useCallback(() => {
-    if (!canAcceptWidgetDrop || isClarifying) {
+    if (!canAcceptWidgetDropRef.current || isClarifying) {
       setDragQuoteBoth(null)
       return
     }
@@ -292,6 +305,7 @@ export const SidebarWindow = ({
             />
           )}
           <div
+            ref={widgetDropZoneRef}
             aria-hidden={!isVisible}
             className={cn(
               "relative flex h-full w-full flex-col overflow-hidden bg-f1-special-page border border-solid border-f1-border-secondary",

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -60,6 +60,7 @@ export const SidebarWindow = ({
     closeGame,
     panelSide,
   } = useAiChat()
+  const canAcceptWidgetDrop = acceptsWidgetDrop && activeGame === null
   const isCanvasMode = visualizationMode === "canvas"
   const reducedMotion = useReducedMotion()
   // Hosts dock the whole panel left for a chat-first experience (communications);
@@ -144,7 +145,7 @@ export const SidebarWindow = ({
   useEffect(() => {
     const onStart = (e: Event) => {
       // Same freeze as the file drop: a clarifying flow owns the panel.
-      if (!acceptsWidgetDrop || isClarifying) return
+      if (!canAcceptWidgetDrop || isClarifying) return
       const detail = (e as CustomEvent<WidgetDragStartDetail>).detail
       if (
         typeof detail?.id !== "string" ||
@@ -163,20 +164,20 @@ export const SidebarWindow = ({
       window.removeEventListener(WIDGET_DRAG_START, onStart)
       window.removeEventListener(WIDGET_DRAG_END, onEnd)
     }
-  }, [acceptsWidgetDrop, isClarifying, setDragQuoteBoth])
+  }, [canAcceptWidgetDrop, isClarifying, setDragQuoteBoth])
 
   // A view change, host overlay, or clarifying flow can take ownership of the
   // shell while a pointer is still down. Retract the invitation immediately
   // so releasing over non-chat content can never create an invisible quote.
   useEffect(() => {
-    if (!acceptsWidgetDrop || isClarifying) setDragQuoteBoth(null)
-  }, [acceptsWidgetDrop, isClarifying, setDragQuoteBoth])
+    if (!canAcceptWidgetDrop || isClarifying) setDragQuoteBoth(null)
+  }, [canAcceptWidgetDrop, isClarifying, setDragQuoteBoth])
 
   // Releasing over the chat quotes the widget. This is a handler on the card,
   // so a release anywhere else simply never reaches it — the grid's own
   // `pointerup` clears the invitation via WIDGET_DRAG_END.
   const handlePointerUp = useCallback(() => {
-    if (!acceptsWidgetDrop || isClarifying) {
+    if (!canAcceptWidgetDrop || isClarifying) {
       setDragQuoteBoth(null)
       return
     }
@@ -190,7 +191,7 @@ export const SidebarWindow = ({
       focusChatInput()
     }
   }, [
-    acceptsWidgetDrop,
+    canAcceptWidgetDrop,
     focusChatInput,
     isClarifying,
     setDragQuoteBoth,
@@ -309,7 +310,7 @@ export const SidebarWindow = ({
             // Marks this card as a drop target for pointer-driven drags
             // elsewhere in the app (the dashboard grid hit-tests for it to
             // suppress its own reorder while the cursor is over the chat).
-            data-ai-chat-dropzone={acceptsWidgetDrop ? "" : undefined}
+            data-ai-chat-dropzone={canAcceptWidgetDrop ? "" : undefined}
             onDragEnter={handleDragEnter}
             onDragOver={handleDragOver}
             onDragLeave={handleDragLeave}
@@ -321,7 +322,7 @@ export const SidebarWindow = ({
             </div>
             {/* `canDrop` gates only the file drop — quoting a dragged widget
                 needs no upload handler, so it renders on its own. */}
-            {(canDrop || (acceptsWidgetDrop && dragQuote !== null)) && (
+            {(canDrop || (canAcceptWidgetDrop && dragQuote !== null)) && (
               <DropOverlay
                 visible={(canDrop && fileDragOver) || dragQuote !== null}
                 mode={dragQuote !== null ? "discuss" : "files"}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/DropOverlay.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/DropOverlay.tsx
@@ -1,15 +1,26 @@
 import { F0Icon } from "@/components/F0Icon/F0Icon"
-import { Upload } from "@/icons/app"
+import { Messages, Upload } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
 interface DropOverlayProps {
   visible: boolean
-  onFilesDropped: (files: File[]) => void
+  /**
+   * Handles a native file drop. Omit for `mode="discuss"`, where the drag is a
+   * pointer gesture and carries no `dataTransfer`.
+   */
+  onFilesDropped?: (files: File[]) => void
+  /** Which drop the overlay is inviting. */
+  mode?: "files" | "discuss"
 }
 
-export const DropOverlay = ({ visible, onFilesDropped }: DropOverlayProps) => {
+export const DropOverlay = ({
+  visible,
+  onFilesDropped,
+  mode = "files",
+}: DropOverlayProps) => {
   const translation = useI18n()
+  const isDiscuss = mode === "discuss"
 
   return (
     <div
@@ -31,15 +42,18 @@ export const DropOverlay = ({ visible, onFilesDropped }: DropOverlayProps) => {
       }}
       onDrop={(e) => {
         e.preventDefault()
+        if (!onFilesDropped) return
         const files = Array.from(e.dataTransfer.files)
         if (files.length > 0) {
           onFilesDropped(files)
         }
       }}
     >
-      <F0Icon icon={Upload} size="lg" color="bold" />
+      <F0Icon icon={isDiscuss ? Messages : Upload} size="lg" color="bold" />
       <p className="text-base font-normal text-f1-foreground">
-        {translation.ai.dropFilesHere}
+        {isDiscuss
+          ? translation.ai.dropWidgetToDiscuss
+          : translation.ai.dropFilesHere}
       </p>
     </div>
   )

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/DropOverlay.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/DropOverlay.tsx
@@ -24,6 +24,9 @@ export const DropOverlay = ({
 
   return (
     <div
+      aria-hidden={!visible}
+      aria-live={visible ? "polite" : undefined}
+      role={visible ? "status" : undefined}
       className={cn(
         "absolute inset-1 z-50 flex flex-col items-center gap-2 justify-center rounded-[calc(theme(borderRadius.xl)-4px)] backdrop-blur bg-f1-background-tertiary/80 border border-dashed border-f1-border",
         "transition-opacity duration-150 ease-out motion-reduce:transition-none",

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/PendingQuoteChip.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/PendingQuoteChip.tsx
@@ -25,7 +25,7 @@ export const PendingQuoteChip = ({
   const translation = useI18n()
 
   return (
-    <div className="p-1">
+    <div aria-atomic="true" aria-live="polite" className="p-1" role="status">
       <div
         className={cn(
           "flex items-start gap-2 justify-center",

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
@@ -103,6 +103,7 @@ export const TextareaField = ({
         </p>
       )}
       <textarea
+        aria-label={resolvedDefaultPlaceholder}
         autoFocus={false}
         name="one-ai-input"
         rows={1}

--- a/packages/react/src/lib/dnd/widgetDragEvents.ts
+++ b/packages/react/src/lib/dnd/widgetDragEvents.ts
@@ -12,6 +12,10 @@ export const WIDGET_DRAG_START = "f0:widget-drag-start"
 export const WIDGET_DRAG_END = "f0:widget-drag-end"
 
 export type WidgetDragStartDetail = {
+  /** Stable dashboard item identifier passed to a host-owned Ask One action. */
+  id: string
   /** Human-readable widget title, used as the quoted text. */
   title: string
+  /** Host override for Ask One. When present, chat must not mutate its quote. */
+  onAskAi?: (item: { id: string; title: string }) => void
 }

--- a/packages/react/src/lib/dnd/widgetDragEvents.ts
+++ b/packages/react/src/lib/dnd/widgetDragEvents.ts
@@ -1,0 +1,17 @@
+/**
+ * Window events announcing a dashboard-widget drag, so drop targets elsewhere
+ * in the app can invite the drag from the moment it starts instead of waiting
+ * for the cursor to arrive.
+ *
+ * Deliberately plain DOM events rather than shared React state: the producer
+ * (`DashboardGrid`, a pattern) and the consumer (the AI chat panel, a kit)
+ * have no useful common ancestor to hang a context off, and neither needs to
+ * import the other. Promote this to context if a third party ever joins.
+ */
+export const WIDGET_DRAG_START = "f0:widget-drag-start"
+export const WIDGET_DRAG_END = "f0:widget-drag-end"
+
+export type WidgetDragStartDetail = {
+  /** Human-readable widget title, used as the quoted text. */
+  title: string
+}

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -494,6 +494,7 @@ export const defaultTranslations = {
       "Your message wasn't sent because one of the attachments failed to upload. Remove it or retry.",
     tooManyFilesError: "You can attach up to {{maxFiles}} files at once",
     dropFilesHere: "Drop your files here",
+    dropWidgetToDiscuss: "Drop here to discuss with One",
     reply: "Reply",
     removeQuote: "Remove quote",
     clarifyingQuestion: {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
 import * as Stories from "./index.stories"
 import * as AskOneStories from "./AskOne.stories"
+import * as WidgetDropStories from "@/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 <Meta of={Stories} />
@@ -140,6 +141,14 @@ real chat composer.
 
 <Canvas of={AskOneStories.WidgetQuotedInChat} />
 
+**Drag shortcut in edit mode**
+
+On a multi-item editable dashboard, dragging a titled widget into the visible
+chat is a pointer shortcut for the same action. The automated story finishes
+with the quote visible and the dashboard order unchanged.
+
+<Canvas of={WidgetDropStories.DragWidgetToQuote} />
+
 Pass `onAskAi` when the host needs to own the action instead of sending it to
 the mounted chat:
 
@@ -158,6 +167,10 @@ the mounted chat:
 - WHEN **Ask One** uses the built-in behavior → THEN the dashboard exits widget fullscreen, quotes the title, and opens the chat.
 - WHEN `onAskAi` is provided → THEN the action calls the host with the widget `id` and `title` without changing chat or fullscreen state.
 - WHEN a directly rendered widget has `onAskAi` but no `itemId` → THEN the action is hidden rather than sending an empty ID.
+- WHEN a widget is dropped on chat → THEN it follows the same built-in or
+  host-owned behavior as the menu action.
+- WHEN the pointer drag is cancelled or ends outside chat → THEN no quote or
+  host action is created.
 - WHEN a widget has no title → THEN the action is hidden because there is nothing to quote.
 
 ### Ask One from a chart point

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -169,6 +169,8 @@ the mounted chat:
 - WHEN a directly rendered widget has `onAskAi` but no `itemId` → THEN the action is hidden rather than sending an empty ID.
 - WHEN a widget is dropped on chat → THEN it follows the same built-in or
   host-owned behavior as the menu action.
+- WHEN the reorder grip is only clicked → THEN no drag invitation appears and
+  no widget action runs.
 - WHEN the pointer drag is cancelled or ends outside chat → THEN no quote or
   host action is created.
 - WHEN a widget has no title → THEN the action is hidden because there is nothing to quote.

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -413,6 +413,97 @@ describe("DashboardGrid", () => {
       chat.remove()
     })
 
+    it("does not reorder when the gesture ends over a later AI chat drop zone", () => {
+      const { container } = render(
+        <DashboardGrid items={makeCollectionItems(480)} filters={{}} editMode />
+      )
+      expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+
+      const firstChat = document.createElement("div")
+      firstChat.setAttribute("data-ai-chat-dropzone", "")
+      firstChat.getBoundingClientRect = () =>
+        ({ left: 800, right: 1000, top: 0, bottom: 600 }) as unknown as DOMRect
+      document.body.appendChild(firstChat)
+
+      const secondChat = document.createElement("div")
+      secondChat.setAttribute("data-ai-chat-dropzone", "")
+      secondChat.getBoundingClientRect = () =>
+        ({ left: 400, right: 700, top: 0, bottom: 600 }) as unknown as DOMRect
+      document.body.appendChild(secondChat)
+
+      const grip = container.querySelector('[aria-label="Drag to reorder"]')
+      if (!(grip instanceof HTMLElement)) {
+        throw new Error("Expected a grip to be rendered")
+      }
+
+      try {
+        fireEvent.pointerDown(grip, { button: 0 })
+        fireEvent(
+          document,
+          new MouseEvent("pointermove", {
+            clientX: 500,
+            clientY: 100,
+            bubbles: true,
+          })
+        )
+        fireEvent(
+          document,
+          new MouseEvent("pointerup", {
+            clientX: 500,
+            clientY: 100,
+            bubbles: true,
+          })
+        )
+
+        expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+      } finally {
+        firstChat.remove()
+        secondChat.remove()
+      }
+    })
+
+    it("uses the release position when the last move still pointed at the grid", () => {
+      const { container } = render(
+        <DashboardGrid items={makeCollectionItems(480)} filters={{}} editMode />
+      )
+      const chat = document.createElement("div")
+      chat.setAttribute("data-ai-chat-dropzone", "")
+      chat.getBoundingClientRect = () =>
+        ({ left: 400, right: 800, top: 0, bottom: 600 }) as unknown as DOMRect
+      document.body.appendChild(chat)
+
+      const grip = container.querySelector('[aria-label="Drag to reorder"]')
+      if (!(grip instanceof HTMLElement)) {
+        throw new Error("Expected a grip to be rendered")
+      }
+
+      try {
+        fireEvent.pointerDown(grip, { button: 0 })
+        // Cache a real grid target first.
+        fireEvent(
+          document,
+          new MouseEvent("pointermove", {
+            clientX: 0,
+            clientY: 100,
+            bubbles: true,
+          })
+        )
+        // No final pointermove reaches the document before release in chat.
+        fireEvent(
+          document,
+          new MouseEvent("pointerup", {
+            clientX: 500,
+            clientY: 100,
+            bubbles: true,
+          })
+        )
+
+        expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+      } finally {
+        chat.remove()
+      }
+    })
+
     describe("announcing the drag", () => {
       const listen = () => {
         const started: (string | undefined)[] = []

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -413,6 +413,106 @@ describe("DashboardGrid", () => {
       chat.remove()
     })
 
+    describe("announcing the drag", () => {
+      const listen = () => {
+        const started: (string | undefined)[] = []
+        let ended = 0
+        const onStart = (e: Event) =>
+          started.push((e as CustomEvent<{ title?: string }>).detail?.title)
+        const onEnd = () => {
+          ended += 1
+        }
+        window.addEventListener("f0:widget-drag-start", onStart)
+        window.addEventListener("f0:widget-drag-end", onEnd)
+        return {
+          started,
+          endCount: () => ended,
+          stop: () => {
+            window.removeEventListener("f0:widget-drag-start", onStart)
+            window.removeEventListener("f0:widget-drag-end", onEnd)
+          },
+        }
+      }
+
+      const grabFirstGrip = (container: HTMLElement) => {
+        const grip = container.querySelector('[aria-label="Drag to reorder"]')
+        if (!(grip instanceof HTMLElement)) {
+          throw new Error("Expected a grip to be rendered")
+        }
+        fireEvent.pointerDown(grip, { button: 0 })
+      }
+
+      it("stays quiet for a widget with no title", () => {
+        const items = makeCollectionItems(480).map((item) => ({
+          ...item,
+          title: "",
+        }))
+        const { container } = render(
+          <DashboardGrid items={items} filters={{}} editMode />
+        )
+        const events = listen()
+
+        try {
+          grabFirstGrip(container)
+          // The title is the quote. Announcing an empty one invites a drop
+          // that could only do nothing.
+          expect(events.started).toEqual([])
+        } finally {
+          events.stop()
+        }
+      })
+
+      it("retracts the invitation when the pointer is cancelled", () => {
+        const { container } = render(
+          <DashboardGrid
+            items={makeCollectionItems(480)}
+            filters={{}}
+            editMode
+          />
+        )
+        const events = listen()
+
+        try {
+          grabFirstGrip(container)
+          expect(events.started).toEqual(["Expenses"])
+
+          // No `pointerup` follows a cancel, so without handling it the chat
+          // would keep a full-panel drop overlay up for good.
+          fireEvent(
+            document,
+            new MouseEvent("pointercancel", { bubbles: true })
+          )
+
+          expect(events.endCount()).toBe(1)
+          // A cancelled gesture is not a drop: the order must not change.
+          expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+        } finally {
+          events.stop()
+        }
+      })
+
+      it("retracts the invitation when the grid unmounts mid-drag", () => {
+        const { container, unmount } = render(
+          <DashboardGrid
+            items={makeCollectionItems(480)}
+            filters={{}}
+            editMode
+          />
+        )
+        const events = listen()
+
+        try {
+          grabFirstGrip(container)
+          unmount()
+
+          // Otherwise the announcement outlives the grid that made it.
+          expect(events.endCount()).toBe(1)
+        } finally {
+          events.stop()
+        }
+      })
+    })
+
     it("renders no grip when not in edit mode", () => {
       const { container } = render(
         <DashboardGrid items={makeCollectionItems(480)} filters={{}} />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -370,6 +370,49 @@ describe("DashboardGrid", () => {
       expect(rowOrder(container)).toEqual(["category-totals", "expenses"])
     })
 
+    it("does not reorder when the gesture ends over the AI chat drop zone", () => {
+      const { container } = render(
+        <DashboardGrid items={makeCollectionItems(480)} filters={{}} editMode />
+      )
+      expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+
+      // Stand in for the chat panel. jsdom reports every rect as 0, so the
+      // zone has to report a real one for the containment check to mean
+      // anything — that zeroed default is also why the reorder test above is
+      // unaffected by this guard.
+      const chat = document.createElement("div")
+      chat.setAttribute("data-ai-chat-dropzone", "")
+      chat.getBoundingClientRect = () =>
+        ({ left: 400, right: 800, top: 0, bottom: 600 }) as unknown as DOMRect
+      document.body.appendChild(chat)
+
+      const grip = container.querySelector('[aria-label="Drag to reorder"]')
+      if (!(grip instanceof HTMLElement)) {
+        throw new Error("Expected a grip to be rendered")
+      }
+
+      fireEvent.pointerDown(grip, { button: 0 })
+      fireEvent(
+        document,
+        new MouseEvent("pointermove", {
+          clientX: 500,
+          clientY: 100,
+          bubbles: true,
+        })
+      )
+      fireEvent(
+        document,
+        new MouseEvent("pointerup", {
+          clientX: 500,
+          clientY: 100,
+          bubbles: true,
+        })
+      )
+
+      expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+      chat.remove()
+    })
+
     it("renders no grip when not in edit mode", () => {
       const { container } = render(
         <DashboardGrid items={makeCollectionItems(480)} filters={{}} />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -504,6 +504,51 @@ describe("DashboardGrid", () => {
       }
     })
 
+    it("rechecks chat eligibility on release before suppressing the reorder", () => {
+      const { container } = render(
+        <DashboardGrid items={makeCollectionItems(480)} filters={{}} editMode />
+      )
+      const chat = document.createElement("div")
+      chat.setAttribute("data-ai-chat-dropzone", "")
+      chat.getBoundingClientRect = () =>
+        ({ left: 400, right: 800, top: 0, bottom: 600 }) as unknown as DOMRect
+      document.body.appendChild(chat)
+
+      const grip = container.querySelector('[aria-label="Drag to reorder"]')
+      if (!(grip instanceof HTMLElement)) {
+        throw new Error("Expected a grip to be rendered")
+      }
+
+      try {
+        fireEvent.pointerDown(grip, { button: 0, clientX: 0, clientY: 0 })
+        fireEvent(
+          document,
+          new MouseEvent("pointermove", {
+            clientX: 10,
+            clientY: 0,
+            bubbles: true,
+          })
+        )
+
+        // The chat can become ineligible mid-gesture (clarifying, closing, or
+        // switching surfaces). Its stale pointerdown snapshot must not swallow
+        // a release that now belongs to the grid.
+        chat.removeAttribute("data-ai-chat-dropzone")
+        fireEvent(
+          document,
+          new MouseEvent("pointerup", {
+            clientX: 500,
+            clientY: 100,
+            bubbles: true,
+          })
+        )
+
+        expect(rowOrder(container)).toEqual(["category-totals", "expenses"])
+      } finally {
+        chat.remove()
+      }
+    })
+
     describe("announcing the drag", () => {
       const listen = () => {
         const started: (string | undefined)[] = []
@@ -530,8 +575,49 @@ describe("DashboardGrid", () => {
         if (!(grip instanceof HTMLElement)) {
           throw new Error("Expected a grip to be rendered")
         }
-        fireEvent.pointerDown(grip, { button: 0 })
+        fireEvent.pointerDown(grip, { button: 0, clientX: 0, clientY: 0 })
+        fireEvent(
+          document,
+          new MouseEvent("pointermove", {
+            clientX: 10,
+            clientY: 0,
+            bubbles: true,
+          })
+        )
       }
+
+      it("does not announce a drag for a plain grip click", () => {
+        const { container } = render(
+          <DashboardGrid
+            items={makeCollectionItems(480)}
+            filters={{}}
+            editMode
+          />
+        )
+        const events = listen()
+        const grip = container.querySelector('[aria-label="Drag to reorder"]')
+        if (!(grip instanceof HTMLElement)) {
+          throw new Error("Expected a grip to be rendered")
+        }
+
+        try {
+          fireEvent.pointerDown(grip, { button: 0, clientX: 0, clientY: 0 })
+          fireEvent(
+            document,
+            new MouseEvent("pointerup", {
+              clientX: 0,
+              clientY: 0,
+              bubbles: true,
+            })
+          )
+
+          expect(events.started).toEqual([])
+          expect(events.endCount()).toBe(0)
+          expect(rowOrder(container)).toEqual(["expenses", "category-totals"])
+        } finally {
+          events.stop()
+        }
+      })
 
       it("stays quiet for a widget with no title", () => {
         const items = makeCollectionItems(480).map((item) => ({

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -553,6 +553,48 @@ describe("DashboardGrid", () => {
         }
       })
 
+      it("announces the widget identity and host-owned Ask One action", () => {
+        const onAskAi = vi.fn()
+        const details: Array<{
+          id: string
+          title: string
+          onAskAi?: typeof onAskAi
+        }> = []
+        const onStart = (event: Event) => {
+          details.push(
+            (
+              event as CustomEvent<{
+                id: string
+                title: string
+                onAskAi?: typeof onAskAi
+              }>
+            ).detail
+          )
+        }
+        window.addEventListener("f0:widget-drag-start", onStart)
+        const { container } = render(
+          <DashboardGrid
+            items={makeCollectionItems(480)}
+            filters={{}}
+            editMode
+            onAskAi={onAskAi}
+          />
+        )
+
+        try {
+          grabFirstGrip(container)
+          expect(details).toEqual([
+            { id: "expenses", title: "Expenses", onAskAi },
+          ])
+          fireEvent(
+            document,
+            new MouseEvent("pointercancel", { bubbles: true })
+          )
+        } finally {
+          window.removeEventListener("f0:widget-drag-start", onStart)
+        }
+      })
+
       it("retracts the invitation when the pointer is cancelled", () => {
         const { container } = render(
           <DashboardGrid

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -25,6 +25,7 @@ import { MetricItem } from "../MetricItem/MetricItem"
 const GAP = 12
 const MAX_PER_ROW = 4
 const NARROW_THRESHOLD = 640
+const DRAG_START_THRESHOLD = 4
 
 /** Default row height in px, determined by the tallest item type. */
 const ROW_HEIGHTS: Record<string, number> = {
@@ -237,7 +238,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   const dropTargetRef = useRef<typeof dropTarget>(null)
   dropTargetRef.current = dropTarget
   const ghostRef = useRef<HTMLDivElement | null>(null)
-  /** AI chat drop zones, looked up once per drag rather than per move. */
+  /** AI chat drop zones, cached during movement and refreshed on release. */
   const chatDropZonesRef = useRef<Element[]>([])
   /** Teardown for the drag in flight, so an unmount can retract it. */
   const endDragRef = useRef<(() => void) | null>(null)
@@ -370,31 +371,40 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       e.preventDefault()
       e.stopPropagation()
 
+      const startX = e.clientX
+      const startY = e.clientY
+      let hasStartedDrag = false
       dragIdRef.current = id
       dropTargetRef.current = null
-      setDragId(id)
       setDropTarget(null)
-      chatDropZonesRef.current = Array.from(
-        document.querySelectorAll("[data-ai-chat-dropzone]")
-      )
-
-      // Announce the drag so other drop targets can invite it immediately,
-      // rather than waiting for the cursor to reach them. The AI chat listens
-      // for this to offer "discuss this widget" from the first moment of the
-      // gesture. Fired on `window` so the listener needs no shared ancestor.
-      //
-      // Nothing to announce without a title: the title *is* the quote, so the
-      // chat would invite a drop that could only do nothing.
-      const title = itemMapRef.current.get(id)?.title ?? ""
-      if (title) {
-        window.dispatchEvent(
-          new CustomEvent(WIDGET_DRAG_START, {
-            detail: { id, title, onAskAi },
-          })
-        )
-      }
 
       const move = (ev: PointerEvent) => {
+        if (!hasStartedDrag) {
+          if (
+            Math.hypot(ev.clientX - startX, ev.clientY - startY) <
+            DRAG_START_THRESHOLD
+          )
+            return
+
+          hasStartedDrag = true
+          setDragId(id)
+          chatDropZonesRef.current = Array.from(
+            document.querySelectorAll("[data-ai-chat-dropzone]")
+          )
+
+          // Invite other drop targets as soon as this becomes a real drag,
+          // while the pointer is still near the widget rather than waiting
+          // for it to reach the chat. A plain click on the grip stays quiet.
+          const title = itemMapRef.current.get(id)?.title ?? ""
+          if (title) {
+            window.dispatchEvent(
+              new CustomEvent(WIDGET_DRAG_START, {
+                detail: { id, title, onAskAi },
+              })
+            )
+          }
+        }
+
         const ghost = ghostRef.current
         if (ghost) {
           ghost.style.transform = `translate(${ev.clientX + 12}px, ${ev.clientY + 16}px)`
@@ -424,19 +434,27 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
 
         const draggedId = dragIdRef.current
         const target = dropTargetRef.current
-        if (commit && draggedId && target) commitDrop(draggedId, target)
+        if (commit && hasStartedDrag && draggedId && target)
+          commitDrop(draggedId, target)
         dragIdRef.current = null
         dropTargetRef.current = null
         chatDropZonesRef.current = []
         setDragId(null)
         setDropTarget(null)
-        window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
+        if (hasStartedDrag) {
+          window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
+        }
       }
       const up = (ev: PointerEvent) => {
         // The release is authoritative. A coalesced final move or a resized
         // panel can make the cached hover target stale; resolving once more
         // prevents a chat drop from also committing the old grid reorder.
-        dropTargetRef.current = resolveDropTarget(ev.clientX, ev.clientY)
+        if (hasStartedDrag) {
+          chatDropZonesRef.current = Array.from(
+            document.querySelectorAll("[data-ai-chat-dropzone]")
+          )
+          dropTargetRef.current = resolveDropTarget(ev.clientX, ev.clientY)
+        }
         endDrag(true)
       }
       const cancel = () => endDrag(false)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -237,6 +237,10 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   const dropTargetRef = useRef<typeof dropTarget>(null)
   dropTargetRef.current = dropTarget
   const ghostRef = useRef<HTMLDivElement | null>(null)
+  /** The AI chat's drop zone, looked up once per drag rather than per move. */
+  const chatDropZoneRef = useRef<Element | null>(null)
+  /** Teardown for the drag in flight, so an unmount can retract it. */
+  const endDragRef = useRef<(() => void) | null>(null)
 
   const commitDrop = useCallback(
     (draggedId: string, target: NonNullable<typeof dropTarget>) => {
@@ -292,7 +296,11 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       // that band, so without this the grid would paint a drop indicator
       // behind the chat's overlay and commit a reorder on release. Returning
       // null also makes `up`'s `if (draggedId && target)` skip `commitDrop`.
-      const chatEl = document.querySelector("[data-ai-chat-dropzone]")
+      //
+      // Found once when the drag starts, not on every move — this runs per
+      // `pointermove`. The rect is still read live, since the panel can be
+      // resized mid-drag.
+      const chatEl = chatDropZoneRef.current
       if (chatEl) {
         const c = chatEl.getBoundingClientRect()
         if (
@@ -367,16 +375,23 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       dropTargetRef.current = null
       setDragId(id)
       setDropTarget(null)
+      chatDropZoneRef.current = document.querySelector(
+        "[data-ai-chat-dropzone]"
+      )
 
       // Announce the drag so other drop targets can invite it immediately,
       // rather than waiting for the cursor to reach them. The AI chat listens
       // for this to offer "discuss this widget" from the first moment of the
       // gesture. Fired on `window` so the listener needs no shared ancestor.
-      window.dispatchEvent(
-        new CustomEvent(WIDGET_DRAG_START, {
-          detail: { title: itemMapRef.current.get(id)?.title ?? "" },
-        })
-      )
+      //
+      // Nothing to announce without a title: the title *is* the quote, so the
+      // chat would invite a drop that could only do nothing.
+      const title = itemMapRef.current.get(id)?.title ?? ""
+      if (title) {
+        window.dispatchEvent(
+          new CustomEvent(WIDGET_DRAG_START, { detail: { title } })
+        )
+      }
 
       const move = (ev: PointerEvent) => {
         const ghost = ghostRef.current
@@ -389,23 +404,48 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           setDropTarget(next)
         }
       }
-      const up = () => {
+
+      /**
+       * The single way out of a drag, whatever ends it.
+       *
+       * `commit` is false for the paths that aren't a deliberate release: a
+       * cancelled pointer (touch scroll takeover, the browser interrupting)
+       * and this grid unmounting mid-gesture. Both used to leave the listeners
+       * attached and, worse, never announce the end — so the chat kept its
+       * full-panel drop invitation up, and the next ordinary click inside it
+       * quoted a widget nobody was dragging.
+       */
+      const endDrag = (commit: boolean) => {
         document.removeEventListener("pointermove", move)
         document.removeEventListener("pointerup", up)
+        document.removeEventListener("pointercancel", cancel)
+        endDragRef.current = null
+
         const draggedId = dragIdRef.current
         const target = dropTargetRef.current
-        if (draggedId && target) commitDrop(draggedId, target)
+        if (commit && draggedId && target) commitDrop(draggedId, target)
         dragIdRef.current = null
         dropTargetRef.current = null
+        chatDropZoneRef.current = null
         setDragId(null)
         setDropTarget(null)
         window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
       }
+      const up = () => endDrag(true)
+      const cancel = () => endDrag(false)
+
+      endDragRef.current = () => endDrag(false)
       document.addEventListener("pointermove", move)
       document.addEventListener("pointerup", up)
+      document.addEventListener("pointercancel", cancel)
     },
     [commitDrop, resolveDropTarget]
   )
+
+  // A drag in flight when this unmounts (navigating away, switching
+  // dashboards) has to be retracted too, or the announcement outlives the grid
+  // that made it.
+  useEffect(() => () => endDragRef.current?.(), [])
 
   // ─── Row resize ─────────────────────────────────────────────
   const startResize = useCallback(

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -8,6 +8,7 @@ import type {
 
 import { F0Icon } from "@/components/F0Icon"
 import Handle from "@/icons/app/Handle"
+import { WIDGET_DRAG_END, WIDGET_DRAG_START } from "@/lib/dnd/widgetDragEvents"
 import { cn } from "@/lib/utils"
 
 import type {
@@ -286,6 +287,23 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   // over a chart canvas or a full-width row all the same.
   const resolveDropTarget = useCallback(
     (clientX: number, clientY: number): typeof dropTarget => {
+      // The AI chat panel is a drop target of its own (drop a widget to quote
+      // it in the composer). Rows are matched on Y alone, and the chat shares
+      // that band, so without this the grid would paint a drop indicator
+      // behind the chat's overlay and commit a reorder on release. Returning
+      // null also makes `up`'s `if (draggedId && target)` skip `commitDrop`.
+      const chatEl = document.querySelector("[data-ai-chat-dropzone]")
+      if (chatEl) {
+        const c = chatEl.getBoundingClientRect()
+        if (
+          clientX >= c.left &&
+          clientX <= c.right &&
+          clientY >= c.top &&
+          clientY <= c.bottom
+        )
+          return null
+      }
+
       const rowEls = containerRef.current
         ? Array.from(
             containerRef.current.querySelectorAll<HTMLElement>(
@@ -350,6 +368,16 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       setDragId(id)
       setDropTarget(null)
 
+      // Announce the drag so other drop targets can invite it immediately,
+      // rather than waiting for the cursor to reach them. The AI chat listens
+      // for this to offer "discuss this widget" from the first moment of the
+      // gesture. Fired on `window` so the listener needs no shared ancestor.
+      window.dispatchEvent(
+        new CustomEvent(WIDGET_DRAG_START, {
+          detail: { title: itemMapRef.current.get(id)?.title ?? "" },
+        })
+      )
+
       const move = (ev: PointerEvent) => {
         const ghost = ghostRef.current
         if (ghost) {
@@ -371,6 +399,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
         dropTargetRef.current = null
         setDragId(null)
         setDropTarget(null)
+        window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
       }
       document.addEventListener("pointermove", move)
       document.addEventListener("pointerup", up)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -237,8 +237,8 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   const dropTargetRef = useRef<typeof dropTarget>(null)
   dropTargetRef.current = dropTarget
   const ghostRef = useRef<HTMLDivElement | null>(null)
-  /** The AI chat's drop zone, looked up once per drag rather than per move. */
-  const chatDropZoneRef = useRef<Element | null>(null)
+  /** AI chat drop zones, looked up once per drag rather than per move. */
+  const chatDropZonesRef = useRef<Element[]>([])
   /** Teardown for the drag in flight, so an unmount can retract it. */
   const endDragRef = useRef<(() => void) | null>(null)
 
@@ -300,8 +300,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       // Found once when the drag starts, not on every move — this runs per
       // `pointermove`. The rect is still read live, since the panel can be
       // resized mid-drag.
-      const chatEl = chatDropZoneRef.current
-      if (chatEl) {
+      for (const chatEl of chatDropZonesRef.current) {
         const c = chatEl.getBoundingClientRect()
         if (
           clientX >= c.left &&
@@ -375,8 +374,8 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       dropTargetRef.current = null
       setDragId(id)
       setDropTarget(null)
-      chatDropZoneRef.current = document.querySelector(
-        "[data-ai-chat-dropzone]"
+      chatDropZonesRef.current = Array.from(
+        document.querySelectorAll("[data-ai-chat-dropzone]")
       )
 
       // Announce the drag so other drop targets can invite it immediately,
@@ -426,12 +425,18 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
         if (commit && draggedId && target) commitDrop(draggedId, target)
         dragIdRef.current = null
         dropTargetRef.current = null
-        chatDropZoneRef.current = null
+        chatDropZonesRef.current = []
         setDragId(null)
         setDropTarget(null)
         window.dispatchEvent(new CustomEvent(WIDGET_DRAG_END))
       }
-      const up = () => endDrag(true)
+      const up = (ev: PointerEvent) => {
+        // The release is authoritative. A coalesced final move or a resized
+        // panel can make the cached hover target stale; resolving once more
+        // prevents a chat drop from also committing the old grid reorder.
+        dropTargetRef.current = resolveDropTarget(ev.clientX, ev.clientY)
+        endDrag(true)
+      }
       const cancel = () => endDrag(false)
 
       endDragRef.current = () => endDrag(false)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -388,7 +388,9 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       const title = itemMapRef.current.get(id)?.title ?? ""
       if (title) {
         window.dispatchEvent(
-          new CustomEvent(WIDGET_DRAG_START, { detail: { title } })
+          new CustomEvent(WIDGET_DRAG_START, {
+            detail: { id, title, onAskAi },
+          })
         )
       }
 
@@ -444,7 +446,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       document.addEventListener("pointerup", up)
       document.addEventListener("pointercancel", cancel)
     },
-    [commitDrop, resolveDropTarget]
+    [commitDrop, onAskAi, resolveDropTarget]
   )
 
   // A drag in flight when this unmounts (navigating away, switching


### PR DESCRIPTION
## Description

Lets a reader drag an editable dashboard widget by its reorder grip and release it over the visible One chat. The widget title becomes a pending quote, the composer receives focus, and the dashboard keeps its original order.

The invitation appears on the first meaningful pointer movement, while the reader is still near the widget. A plain grip click stays quiet. Dragging remains a pointer enhancement; the widget menu's **Ask One** action is the keyboard and single-pointer equivalent.

**Final PR in the #5123 → #5124 → #5125 → #5126 stack.** This branch is based on #5125 because widget drops share its Ask One ownership and accessible-fallback contract.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Visual review

- [Interactive story — drag widget to quote](https://66a7a8d7d124220c363457cc-zvijnhlhyr.chromatic.com/?path=/story/kits-ai-f0aichat-widget-drop--drag-widget-to-quote): exercises meaningful movement → invitation → drop → quote → composer focus and asserts that widget order is unchanged.
- [MDX documentation — discuss a dashboard widget](https://66a7a8d7d124220c363457cc-zvijnhlhyr.chromatic.com/?path=/docs/kits-ai-f0aichat--documentation#discuss-a-dashboard-widget): behavior, click threshold, cancellation, host ownership, excluded/closing chat surfaces, responsive constraints, and the accessible alternative.

Review these states:

1. **Invitation while still over the dashboard:** move a reorder grip more than 4px. Chat offers **Drop here to discuss with One** before the pointer reaches it.
2. **Pointer over chat:** the dashboard reorder indicator disappears, so one release cannot both quote and reorder.
3. **Released:** the title is attached to the focused composer and the widget remains in its original slot.
4. **Plain click:** press and release the grip without moving; no chat overlay or drag-end action should fire.

https://github.com/user-attachments/assets/0e624143-3040-4d7f-af22-c75a60e07a56

**Invitation**

<img width="1546" alt="Dragging a widget over the dashboard while chat shows the drop invitation" src="https://github.com/user-attachments/assets/f5304b43-1f76-4e72-a8aa-c1dc099d32a7" />

**Pointer over chat**

<img width="1546" alt="Dragging over chat with the dashboard reorder indicator removed" src="https://github.com/user-attachments/assets/b239363f-049e-4768-884b-61ac327d0fff" />

**Quoted in the composer**

<img width="1546" alt="The widget title quoted in the focused composer without a dashboard reorder" src="https://github.com/user-attachments/assets/1af69389-e4c9-4a30-b627-7719eb0debfc" />

## Behavior and implementation

- The grid uses its existing pointer gesture and scoped `window` events; it does not pretend this is an HTML5 file drag.
- A 4px threshold separates a grip click from a real drag. The invitation is still early, but no longer flashes for a click.
- Chat eligibility is limited to the visible real composer: closing, voice, hosted content, host overlays, Pong, and clarifying flows cannot consume an invisible quote.
- Because `AnimatePresence` retains exiting DOM props, closing chat explicitly retracts the drop-zone marker and release reads the latest eligibility.
- The grid caches active chat zones while moving, then queries them again at pointer release. A chat that becomes ineligible mid-gesture cannot swallow the reorder.
- Final release coordinates are authoritative, and every active chat zone suppresses dashboard reorder.
- Host-owned drops call `onAskAi({ id, title })`; the built-in path quotes the title and focuses the composer.
- Pointer cancellation, producer unmount, surface changes, and game/clarifying transitions clear the active invitation.
- The invitation and completed quote are polite status messages. The widget menu's **Ask One** action provides the keyboard and reliable single-pointer route.

## Verification

Exact local candidate:

- Focused widget-drop, dashboard-grid, and widget-menu suites: **61/61 passed**.
- TypeScript, format check, targeted lint, diff check, and production Storybook build passed.
- Real Chrome completed the interaction story: `Total Headcount` quoted, textarea focused, invitation removed, first widget unchanged, and no console errors.
- Exact-head GitHub CI is green, including React unit tests, all eight Storybook shards, Chromatic, accessibility, code review, test coverage, API surface, lint, formatting, and the package build.

## Constraints

- Dashboard dragging is disabled below the grid's 640px editing breakpoint.
- Touch drag support depends on the host dashboard's existing reorder gesture.
- **Ask One** in the widget menu is the documented keyboard and reliable single-pointer alternative.

## Note for the bump

This adds `ai.dropWidgetToDiscuss`, so Factorial's `f0-provider.tsx` and `en.json` need `common.ai.drop_widget_to_discuss` before or with the version bump.

---

### The stack

| | PR | What it adds |
|---|---|---|
| 1 | #5123 | `F0DataChart` reports the selected mark |
| 2 | #5124 | Widget menu → **Ask One** |
| 3 | #5125 | Chart point → **Ask One** |
| 4 | #5126 | Drag a widget into chat |

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0
> - factorial-ci
> - factorial-pr


