### PR TITLE
fix(F0AiChatTextArea): keep inside-suggestions popover open on click

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.suggestionsInside.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.suggestionsInside.test.tsx
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { ChartVerticalBars } from "@/icons/app"
-import { zeroRender as render, screen } from "@/testing/test-utils"
+import { userEvent, zeroRender as render, screen } from "@/testing/test-utils"
 
 import { type WelcomeScreenSuggestion } from "../../F0AiChat/types"
 
@@ -133,6 +133,32 @@ describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
     // The send button did NOT come back with it.
     expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
     expect(textarea().parentElement?.contains(sendButton())).toBe(true)
+  })
+
+  it("opens the group popover on click without submitting the form", async () => {
+    // Inside the form a chip's implicit `type="submit"` submits it, and the
+    // submit handler's textarea refocus reads to Radix as an outside
+    // interaction — closing the popover in the same click that opened it.
+    const user = userEvent.setup()
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    const form = textarea().closest("form")!
+    const onFormSubmit = vi.fn()
+    form.addEventListener("submit", onFormSubmit)
+
+    await user.click(trigger())
+
+    expect(onFormSubmit).not.toHaveBeenCalled()
+    expect(trigger()).toHaveAttribute("aria-expanded", "true")
+    expect(screen.getByText("April leave summary")).toBeInTheDocument()
   })
 
   it("keeps the send button inline once the welcome screen is gone", () => {

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -136,6 +136,12 @@ export const WelcomeScreenSuggestionsRow = ({
             {suggestions.map((group, index) => (
               <ButtonInternal
                 key={`${group.label}-${index}`}
+                // The `inside` placement mounts this row within the composer's
+                // <form>, where a button's implicit `type="submit"` submits it —
+                // and the submit handler refocuses the textarea, which Radix
+                // takes as an outside interaction and closes the popover the
+                // same click just opened.
+                type="button"
                 variant="outline"
                 label={group.label}
                 icon={group.icon}


### PR DESCRIPTION
## Description

In the `welcomeScreenSuggestionsPlacement="inside"` layout, clicking a welcome-suggestion chip appeared to do nothing: the group popover opened and closed within the same click, so the suggestions never showed. The chips render through `Action`, whose native `<button>` sets no `type` attribute and therefore defaults to `type="submit"` — and the inside placement is the only one that mounts the chips within the composer's `<form>`. The click submitted the form, the submit handler's `textareaRef.focus()` moved focus outside the popover, and Radix dismissed it as an outside interaction. The chips now pass `type="button"`, the same treatment `SubmitButton` (explicit `type="submit"`) and `EntitiesListView` (`suppressImplicitSubmit`) already give this footgun.

## Implementation details

- fix: pass `type="button"` to the welcome-suggestion group chips so they no longer implicitly submit the composer form

  <details>
  <summary>How the popover closed itself</summary>

  Event sequence captured on the deployed Storybook docs page:

  1. `click` on chip → popover mounts (state logic was correct)
  2. `submit` on the composer form — the chip's implicit `type="submit"`
  3. `handleSubmit` ends with `textareaRef.current?.focus()` (runs on every submit)
  4. Radix Popover treats the focus move as an interact-outside → popover unmounts ~20ms after mounting

  Programmatic `.click()` didn't reproduce it, which is why unit tests and play functions missed it.
  </details>

- test: add a regression test clicking a chip inside the form — asserts no submit event fires and the popover opens and stays open (verified to fail without the fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)