### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.32.2",
+  "packages/react": "6.33.0",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [6.32.2](https://github.com/factorialco/f0/compare/f0-react-v6.32.1...f0-react-v6.32.2) (2026-08-17)
+## [6.33.0](https://github.com/factorialco/f0/compare/f0-react-v6.32.1...f0-react-v6.33.0) (2026-08-17)
+
+
+### Features
+
+* **OneDataCollection:** permission-locked graph metadata toggle ([#5121](https://github.com/factorialco/f0/issues/5121)) ([460a3d2](https://github.com/factorialco/f0/commit/460a3d229f7c626e393e5fa903d654f09d5675fa))
 
 
 ### Bug Fixes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.32.2",
+  "version": "6.33.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.33.0</summary>

## [6.33.0](https://github.com/factorialco/f0/compare/f0-react-v6.32.1...f0-react-v6.33.0) (2026-08-17)


### Features

* **OneDataCollection:** permission-locked graph metadata toggle ([#5121](https://github.com/factorialco/f0/issues/5121)) ([460a3d2](https://github.com/factorialco/f0/commit/460a3d229f7c626e393e5fa903d654f09d5675fa))


### Bug Fixes

* **SortAndHideList:** add edge padding to first/last toggle rows ([#4767](https://github.com/factorialco/f0/issues/4767)) ([0cdc657](https://github.com/factorialco/f0/commit/0cdc657ff982e0f17a8eed8708e0cc57e23d2c14))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).