### PR TITLE
feat(F0AvatarPerson): add pending state for roles to be filled

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarPerson/F0AvatarPerson.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/F0AvatarPerson.tsx
@@ -1,4 +1,4 @@
-import { PersonNegative } from "@/icons/app"
+import { PersonNegative, SearchPerson } from "@/icons/app"
 
 import { BaseAvatar } from "../internal/BaseAvatar"
 import { F0AvatarPersonProps } from "./types"
@@ -12,7 +12,14 @@ export const F0AvatarPerson = ({
   "aria-labelledby": ariaLabelledby,
   badge,
   deactivated,
+  pending,
 }: F0AvatarPersonProps) => {
+  const stateIcon = deactivated
+    ? PersonNegative
+    : pending
+      ? SearchPerson
+      : undefined
+
   return (
     <BaseAvatar
       type="rounded"
@@ -23,9 +30,7 @@ export const F0AvatarPerson = ({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
       badge={badge}
-      icon={
-        deactivated ? { icon: PersonNegative, color: "secondary" } : undefined
-      }
+      icon={stateIcon ? { icon: stateIcon, color: "secondary" } : undefined}
     />
   )
 }

--- a/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.mdx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.mdx
@@ -15,7 +15,7 @@ The avatar for an individual — an employee, user or contact.
 
 - Represent a specific person consistently across the interface
 - Help distinguish people at a glance in lists, headers and assignments
-- Convey a person's state, such as deactivated
+- Convey a person's state, such as deactivated or pending
 
 ### Anatomy
 
@@ -34,6 +34,13 @@ A person can be shown as deactivated, which replaces the content with a muted
 person icon to signal that the account is no longer active.
 
 <Canvas of={PersonStories.Deactivated} />
+
+A person can also be shown as pending, which replaces the content with a muted
+search-person icon to signal a position that is planned but still to be filled —
+for example an open role in headcount planning. `deactivated` and `pending` are
+mutually exclusive; if both are set, `deactivated` wins.
+
+<Canvas of={PersonStories.Pending} />
 
 ---
 

--- a/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/__stories__/F0AvatarPerson.stories.tsx
@@ -69,6 +69,13 @@ export const Deactivated: Story = {
   },
 }
 
+export const Pending: Story = {
+  args: {
+    ...Default.args,
+    pending: true,
+  },
+}
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
@@ -125,6 +132,20 @@ export const Snapshot: Story = {
               key={size}
               size={size}
               deactivated
+              firstName="Juanito"
+              lastName="Perez"
+            />
+          ))}
+        </div>
+      </section>
+      <section>
+        <h4 className="text-lg font-semibold">Pending</h4>
+        <div className="flex flex-row gap-2">
+          {avatarSizes.map((size) => (
+            <F0AvatarPerson
+              key={size}
+              size={size}
+              pending
               firstName="Juanito"
               lastName="Perez"
             />

--- a/packages/react/src/components/avatars/F0AvatarPerson/__tests__/F0AvatarPerson.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarPerson/__tests__/F0AvatarPerson.test.tsx
@@ -29,4 +29,21 @@ describe("F0AvatarPerson", () => {
 
     expect(screen.getByText("JS")).toBeInTheDocument()
   })
+
+  it("replaces the initials with an icon when pending", () => {
+    zeroRender(
+      <F0AvatarPerson
+        firstName="Jane"
+        lastName="Smith"
+        size="md"
+        pending
+        aria-label="Open position"
+      />
+    )
+
+    expect(screen.queryByText("JS")).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("img", { name: "Open position" })
+    ).toBeInTheDocument()
+  })
 })

--- a/packages/react/src/components/avatars/F0AvatarPerson/types.ts
+++ b/packages/react/src/components/avatars/F0AvatarPerson/types.ts
@@ -24,6 +24,18 @@ export type F0AvatarPersonProps = {
   badge?: AvatarBadge
   /**
    * Whether the person is deactivated. If true, the avatar will display an icon instead of the person's name or picture.
+   *
+   * Mutually exclusive with `pending`: they represent opposite ends of the
+   * employee lifecycle. If both are set, `deactivated` takes precedence.
    */
   deactivated?: boolean
+  /**
+   * Whether the position is still to be filled — a person who is planned but
+   * not hired yet (e.g. an open role in headcount planning). If true, the
+   * avatar will display a search-person icon instead of the person's name or
+   * picture.
+   *
+   * Mutually exclusive with `deactivated`.
+   */
+  pending?: boolean
 } & Pick<BaseAvatarProps, "aria-label" | "aria-labelledby">


### PR DESCRIPTION
## Description

Person avatars can now represent a role that is planned but not filled yet. Headcount Planning lists positions before anyone is hired, and until now the only non-default person state was `deactivated`, which reads as "no longer active" — the opposite meaning. The new `pending` state reuses the same ring and background as `deactivated` and only swaps the icon, so the two read as states of one component rather than two unrelated treatments.

## Screenshots

Storybook: `Avatars/AvatarPerson` → `Pending`, and the `Snapshot` story for all six sizes next to `Deactivated`.
<img width="317" height="111" alt="image" src="https://github.com/user-attachments/assets/760dd3cd-add9-4f6b-a146-70d1d3a6af0a" />


## Implementation details

- feat: add a `pending` prop to `F0AvatarPerson` that renders a muted `SearchPerson` icon in place of the initials or picture
- docs: document the pending state and its exclusivity with `deactivated` in the MDX Variants section
- test: cover that `pending` replaces the initials while keeping the accessible name

  <details>
  <summary>Why the states are exclusive rather than an enum</summary>

  `deactivated` and `pending` sit at opposite ends of the employee lifecycle, so
  they can never be true at once. They are kept as two booleans (with
  `deactivated` taking precedence) rather than a single state enum because
  `deactivated` is already public API and several consumers — `F0Avatar`,
  `Chip` — build their props with `Omit<F0AvatarPersonProps, …>`, which collapses
  a discriminated union and would break those call sites.
  </details>