### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.35.0",
+  "packages/react": "6.36.0",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.36.0](https://github.com/factorialco/f0/compare/f0-react-v6.35.0...f0-react-v6.36.0) (2026-08-17)
+
+
+### Features
+
+* **OneDataCollection:** add defaultExpanded to nested tables ([#5045](https://github.com/factorialco/f0/issues/5045)) ([3d51401](https://github.com/factorialco/f0/commit/3d5140118b0c7d1cfb45834978f893f73c61fa12))
+
 ## [6.35.0](https://github.com/factorialco/f0/compare/f0-react-v6.34.0...f0-react-v6.35.0) (2026-08-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.35.0",
+  "version": "6.36.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.36.0</summary>

## [6.36.0](https://github.com/factorialco/f0/compare/f0-react-v6.35.0...f0-react-v6.36.0) (2026-08-17)


### Features

* **OneDataCollection:** add defaultExpanded to nested tables ([#5045](https://github.com/factorialco/f0/issues/5045)) ([3d51401](https://github.com/factorialco/f0/commit/3d5140118b0c7d1cfb45834978f893f73c61fa12))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).