### PR TITLE
fix(F0Select): keep one trigger node across selection changes

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -1177,7 +1177,7 @@ const F0SelectComponent = forwardRef(function Select<
    * selection lists what is chosen, which is what the trigger's "N selected"
    * cannot.
    *
-   * Nothing selected, nothing to explain: no tooltip at all.
+   * Nothing selected, nothing to explain: empty, and nothing opens on hover.
    */
   const selectedTooltipText = getDisplayItemsForSelection
     .map((item) => item.selectedLabel ?? item.label)
@@ -1208,15 +1208,18 @@ const F0SelectComponent = forwardRef(function Select<
       </div>
     )
 
-    return selectedTooltipText ? (
+    /**
+     * Always mounted, empty description and all: wrapping the trigger only once
+     * there was something to say remounted it on the first selection, dropping
+     * its focus mid-interaction. An empty tooltip opens nothing.
+     */
+    return (
       <TooltipInternal
         label={hideLabel ? label : undefined}
         description={selectedTooltipText}
       >
         {box}
       </TooltipInternal>
-    ) : (
-      box
     )
   }
 

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -964,7 +964,7 @@ describe("Select", () => {
         expect(tooltipWrapper()).toHaveAttribute("data-state", "closed")
       })
 
-      it("is not wired at all when nothing is selected", () => {
+      it("stays wired when nothing is selected", () => {
         render(
           <F0Select
             {...defaultSelectProps}
@@ -974,8 +974,11 @@ describe("Select", () => {
           />
         )
 
-        // Nothing selected, nothing to explain.
-        expect(tooltipWrapper()).toBeNull()
+        // Wired but silent: nothing selected means nothing to explain, and an
+        // empty tooltip never opens (`Tooltip.emptyContent.test.tsx`). Dropping
+        // the wiring instead would change the element type above the trigger and
+        // remount it (`F0Select.triggerIdentity.test.tsx`).
+        expect(tooltipWrapper()).toHaveAttribute("data-state", "closed")
       })
     })
   })

--- a/packages/react/src/components/F0Select/__tests__/F0Select.triggerIdentity.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.triggerIdentity.test.tsx
@@ -1,0 +1,83 @@
+import { screen } from "@testing-library/react"
+import "@testing-library/jest-dom/vitest"
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0Select } from "../index"
+
+const OPTIONS = [
+  { value: "tokens", label: "Tokens" },
+  { value: "flows", label: "Flows" },
+]
+
+/**
+ * The trigger's DOM node must SURVIVE a selection change. Wrapping it in the
+ * tooltip only once there was something to say changed the element type above
+ * it, so React discarded the trigger and mounted a fresh one — dropping focus
+ * mid-interaction, and detaching any node a caller had already captured.
+ */
+describe("F0Select trigger identity", () => {
+  it("keeps the same trigger node when a selection arrives", () => {
+    const { rerender } = render(
+      <F0Select label="Project" options={OPTIONS} onChange={() => {}} />
+    )
+
+    const trigger = screen.getByRole("combobox")
+
+    rerender(
+      <F0Select
+        label="Project"
+        value="tokens"
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    expect(trigger).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBe(trigger)
+  })
+
+  it("keeps the same trigger node when the selection is cleared", () => {
+    const { rerender } = render(
+      <F0Select
+        label="Project"
+        value="tokens"
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    const trigger = screen.getByRole("combobox")
+
+    rerender(<F0Select label="Project" options={OPTIONS} onChange={() => {}} />)
+
+    expect(trigger).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBe(trigger)
+  })
+
+  it("keeps the same trigger node when the selection changes", () => {
+    const { rerender } = render(
+      <F0Select
+        label="Project"
+        value="tokens"
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    const trigger = screen.getByRole("combobox")
+
+    rerender(
+      <F0Select
+        label="Project"
+        value="flows"
+        options={OPTIONS}
+        onChange={() => {}}
+      />
+    )
+
+    expect(trigger).toBeInTheDocument()
+    expect(screen.getByRole("combobox")).toBe(trigger)
+  })
+})

--- a/packages/react/src/components/F0Select/__tests__/F0Select.triggerTooltip.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.triggerTooltip.test.tsx
@@ -85,7 +85,7 @@ describe("F0Select trigger tooltip content", () => {
     expect(screen.getByTestId("tooltip-description")).toHaveTextContent("Flows")
   })
 
-  it("wires no tooltip when nothing is selected", () => {
+  it("has nothing to say when nothing is selected", () => {
     render(
       <F0Select
         label="Select project"
@@ -95,6 +95,8 @@ describe("F0Select trigger tooltip content", () => {
       />
     )
 
-    expect(screen.queryByTestId("tooltip-description")).not.toBeInTheDocument()
+    // The tooltip stays mounted so the trigger below it survives the first
+    // selection — see F0Select.triggerIdentity.test.tsx. Empty opens nothing.
+    expect(screen.getByTestId("tooltip-description")).toHaveTextContent("")
   })
 })

--- a/packages/react/src/experimental/Overlays/Tooltip/__tests__/Tooltip.emptyContent.test.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/__tests__/Tooltip.emptyContent.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import "@testing-library/jest-dom/vitest"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { TooltipInternal } from "../index"
+
+/**
+ * `instant` shortens Radix's open timer to 100ms, which a real-timer wait can
+ * outlast — fake timers deadlock `user.hover`.
+ */
+const OPEN_DELAY_MARGIN_MS = 400
+
+const settleOpenDelay = () =>
+  new Promise((resolve) => setTimeout(resolve, OPEN_DELAY_MARGIN_MS))
+
+describe("TooltipInternal with nothing to say", () => {
+  it("does not open on hover when the description is empty", async () => {
+    const user = userEvent.setup()
+    render(
+      <TooltipInternal instant description="">
+        <button>Trigger</button>
+      </TooltipInternal>
+    )
+
+    await user.hover(screen.getByRole("button", { name: "Trigger" }))
+    await settleOpenDelay()
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument()
+  })
+
+  it("does not report an open when there is nothing to open", async () => {
+    const user = userEvent.setup()
+    const onOpen = vi.fn()
+    render(
+      <TooltipInternal instant description="" onOpen={onOpen}>
+        <button>Trigger</button>
+      </TooltipInternal>
+    )
+
+    await user.hover(screen.getByRole("button", { name: "Trigger" }))
+    await settleOpenDelay()
+
+    expect(onOpen).not.toHaveBeenCalled()
+  })
+
+  it("still opens once there is a description", async () => {
+    const user = userEvent.setup()
+    render(
+      <TooltipInternal instant description="Tokens — Design system">
+        <button>Trigger</button>
+      </TooltipInternal>
+    )
+
+    await user.hover(screen.getByRole("button", { name: "Trigger" }))
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Tokens — Design system"
+    )
+  })
+})

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -51,6 +51,13 @@ export function TooltipInternal({
 
   const openDelayMs = useMemo(() => (instant ? 100 : delay), [delay, instant])
 
+  /**
+   * A tooltip with nothing to say must not open. Deciding it here lets callers
+   * whose text can be empty keep it mounted — unmounting it instead changes the
+   * element type above the trigger, and React then remounts the trigger.
+   */
+  const hasContent = Boolean(label || description || shortcut)
+
   const clearOpenTimeout = useCallback(() => {
     if (openTimeoutRef.current) {
       clearTimeout(openTimeoutRef.current)
@@ -64,10 +71,11 @@ export function TooltipInternal({
   }, [clearOpenTimeout])
 
   const scheduleOpen = useCallback(() => {
+    if (!hasContent) return
     onOpen?.()
     clearOpenTimeout()
     openTimeoutRef.current = setTimeout(() => setOpen(true), openDelayMs)
-  }, [clearOpenTimeout, onOpen, openDelayMs])
+  }, [clearOpenTimeout, hasContent, onOpen, openDelayMs])
 
   useEffect(() => close, [close])
 
@@ -86,7 +94,7 @@ export function TooltipInternal({
         disableHoverableContent={instant}
       >
         <TooltipPrimitive
-          open={open}
+          open={hasContent && open}
           onOpenChange={(nextOpen) => {
             // We control when the tooltip opens so it doesn't show on mouse click
             // focus/programmatic focus. Still allow Radix to request closing (e.g. escape).
@@ -103,6 +111,7 @@ export function TooltipInternal({
             onPointerLeave={() => close()}
             onPointerDown={() => close()}
             onFocus={(e) => {
+              if (!hasContent) return
               if (isFocusVisible(e.currentTarget)) {
                 onOpen?.()
                 setOpen(true)


### PR DESCRIPTION
## Description

F0Select's trigger tooltip is derived from the selection, and since 6.18.0 the tooltip was mounted only once there was something to say. That changed the element type above the trigger on the first selection, so React discarded the trigger and mounted a fresh one — a focused trigger lost focus mid-interaction, and any node a caller had already captured was silently detached from the document. The tooltip now stays mounted with an empty description instead, and `TooltipInternal` refuses to open when it has nothing to say, so no call site has to trade a stable tree for an empty bubble.

## Impact

**This regression is blocking the f0 upgrade in the monorepo.** In [factorialco/factorial#110119](https://github.com/factorialco/factorial/pull/110119) (`@factorialco/f0-react` 6.17.0 → 6.33.0) it fails **14 tests across 8 spec files, in all 5 frontend spec shards**. Every one of them asserts against an `F0Select` whose value arrives asynchronously — a form default or a query response — which is the normal shape of a `fieldType: 'select'` F0Form field:

| Spec file | Failing | Symptom |
| --- | --- | --- |
| `employees/.../TaxResidence/BasicForm` | 3 | `findByLabelText` → detached |
| `goals/.../MetricConfigField` | 3 | `findByText` → detached |
| `employees/.../BankInfo` | 2 | `findByLabelText` → detached |
| `contracts/.../EditAdditionalCompensationWizardModal` | 2 | detached + stale text on the old node |
| `employees/.../EmployeeRetirementRegime` | 1 | `findByLabelText` → detached |
| `expenses/.../F0PerDiemDetail/TripInfoSection` | 1 | `findByLabelText` → detached |
| `ats/.../JobPostingSettings/BasicInformation` | 1 | `findByLabelText` → detached |
| `ats/.../ScheduleInterview` | 1 | `toBeVisible` → *"element is not in the document"* |

That last one is the clearest evidence of the mechanism, because the log prints the orphaned node itself — the F0Select trigger, alive and fully rendered, just no longer attached:

```
Received element is not visible (element is not in the document):
  <button role="combobox" aria-expanded="false" name="interviewType" value="online"
          aria-label="ats.schedule_interview.steps.team_location.interview_type" ... />
```

The tests are the messenger, not the victim: **the same remount drops keyboard focus from a real user's trigger** the moment their first selection lands, so this is worth fixing regardless of CI.

## Type of change

- [x] Bug fix

## Implementation details

- fix: keep F0Select's trigger tooltip mounted regardless of selection, so the trigger's DOM node survives a selection arriving, changing, or being cleared

  <details>
  <summary>Why the wrapper cannot be conditional</summary>

  React reconciles by element type and position. Adding `TooltipInternal` above the trigger once `selectedTooltipText` becomes non-empty changes the type at that position, and React answers by unmounting the whole subtree — including Radix's `SelectTrigger` button — and mounting a new one. Nothing above the trigger can appear or disappear at runtime without costing the trigger its identity, so the only fix is to keep the chain stable.
  </details>

- fix: `TooltipInternal` no longer opens, and no longer reports an open via `onOpen`, when it has no label, description or shortcut

  <details>
  <summary>Why this belongs in the tooltip</summary>

  Callers derive tooltip text from state that can legitimately be empty. Without this, each one has to choose between an empty bubble on hover and a conditional mount that remounts its trigger. Deciding it once in the tooltip removes that trade-off for every call site — `ui/Action` has the same conditional shape today.
  </details>

- test: add `F0Select.triggerIdentity.test.tsx` pinning that the trigger node survives a selection arriving, changing, and being cleared
- test: add `Tooltip.emptyContent.test.tsx` covering that an empty tooltip stays shut and a populated one still opens
- test: update the two existing expectations that asserted the tooltip was absent with no selection — it is now mounted and silent
