### PR TITLE
fix(OneDataCollection): center table cell content in a 24px band

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1694,3 +1694,111 @@ export const RowActionsKeepTagListHoverable: Story = {
     expect(popover).toBeInTheDocument()
   },
 }
+
+/**
+ * Cells of different intrinsic heights in the same row: plain text (a 20px line),
+ * a person avatar (20px) and a tag (26px).
+ *
+ * Cells are `align-top`, so before the content band each of these sat flush with the
+ * cell's top padding: the tag alone set the row's height (42px) and the text and
+ * avatar beside it ended up 3px above its center. They now share one center, because
+ * cell content is centered inside a 32px band rather than pinned to the cell's top
+ * edge — which also holds the row at its intended 48px. See
+ * `ui/value-display/const.ts`.
+ */
+export const CellsOfDifferentHeightsShareOneCenter: Story = {
+  render: () => {
+    const records = [
+      {
+        id: 1,
+        firstName: "Dani",
+        lastName: "Smith",
+        role: "Senior Engineer",
+        department: "Engineering",
+      },
+      {
+        id: 2,
+        firstName: "Desirée",
+        lastName: "Johnson",
+        role: "Product Manager",
+        department: "Product",
+      },
+    ]
+
+    const source = useDataCollectionSource({
+      dataAdapter: { fetchData: async () => ({ records }) },
+    })
+
+    return (
+      <OneDataCollection
+        source={source}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: [
+                {
+                  label: "Name",
+                  render: (item) => ({
+                    type: "person",
+                    value: {
+                      firstName: item.firstName,
+                      lastName: item.lastName,
+                    },
+                  }),
+                },
+                { label: "Role", render: (item) => item.role },
+                {
+                  label: "Department",
+                  render: (item) => ({
+                    type: "tag",
+                    value: { label: item.department },
+                  }),
+                },
+              ],
+            },
+          },
+        ]}
+      />
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const roleCell = await canvas.findByText("Senior Engineer")
+    const row = roleCell.closest("tr")!
+
+    /** Vertical center of a cell's first line of text, relative to the cell. */
+    const firstLineCenter = (cell: HTMLTableCellElement) => {
+      const cellRect = cell.getBoundingClientRect()
+      const walker = document.createTreeWalker(cell, NodeFilter.SHOW_TEXT)
+      let node: Node | null
+      while ((node = walker.nextNode())) {
+        if (!node.textContent?.trim()) continue
+        const range = document.createRange()
+        range.selectNodeContents(node)
+        const [line] = [...range.getClientRects()].filter((r) => r.height > 0)
+        if (line) return (line.top + line.bottom) / 2 - cellRect.top
+      }
+      return null
+    }
+
+    const cells = [...row.querySelectorAll("td")].filter(
+      (cell) => cell.getBoundingClientRect().height > 0
+    )
+    const rowCenter = row.getBoundingClientRect().height / 2
+
+    await waitFor(() => {
+      // The tag is the tallest content here, and it does not push the row past
+      // the 48px floor — so the band is the whole row and every value display
+      // lines up on its center.
+      expect(row.getBoundingClientRect().height).toBe(48)
+
+      for (const cell of cells) {
+        const center = firstLineCenter(cell)
+        if (center === null) continue
+        expect(Math.abs(center - rowCenter)).toBeLessThanOrEqual(1)
+      }
+    })
+  },
+}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1885,10 +1885,11 @@ export const CellsOfDifferentHeightsShareOneCenter: Story = {
     const TOLERANCE = 1.5
 
     await waitFor(() => {
-      // Rows keep the height their own content asks for: the band sets it at 40px
-      // when every value is a line of text, and the taller tag sets it at 42px.
-      expect(textOnly.getBoundingClientRect().height).toBe(40)
-      expect(withTags.getBoundingClientRect().height).toBe(42)
+      // Rows keep the height their own content asks for: the band sets it at 41px
+      // when every value is a line of text, and the taller tag sets it at 43px.
+      // Both include the 1px the row spends on its own separator.
+      expect(textOnly.getBoundingClientRect().height).toBe(41)
+      expect(withTags.getBoundingClientRect().height).toBe(43)
 
       for (const row of [textOnly, withTags]) {
         for (const center of firstLineCenters(row)) {

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
-import { useState, useMemo } from "react"
+import { useState, useMemo, type ReactNode } from "react"
 import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
@@ -1695,78 +1695,156 @@ export const RowActionsKeepTagListHoverable: Story = {
   },
 }
 
+const ALIGNMENT_PEOPLE = [
+  {
+    id: 1,
+    firstName: "Dani",
+    lastName: "Smith",
+    role: "Senior Engineer",
+    department: "Engineering",
+    notes:
+      "Leads the payroll integrations squad and is the main point of contact for the quarterly compliance review.",
+  },
+  {
+    id: 2,
+    firstName: "Desirée",
+    lastName: "Johnson",
+    role: "Product Manager",
+    department: "Product",
+    notes: "Owns the onboarding funnel.",
+  },
+]
+
+const AlignmentCase = ({
+  caption,
+  children,
+}: {
+  caption: string
+  children: ReactNode
+}) => (
+  <section>
+    <h3 className="mb-2 font-medium text-f1-foreground">{caption}</h3>
+    {children}
+  </section>
+)
+
 /**
- * Cells of different intrinsic heights in the same row: plain text (a 20px line),
- * a person avatar (20px) and a tag (26px).
+ * The three shapes a row can take, so the effect of the content band is visible
+ * side by side:
  *
- * Cells are `align-top`, so before the content band each of these sat flush with the
- * cell's top padding: the tag alone set the row's height (42px) and the text and
- * avatar beside it ended up 3px above its center. They now share one center, because
- * cell content is centered inside a 32px band rather than pinned to the cell's top
- * edge — which also holds the row at its intended 48px. See
+ * 1. **Text only** — every value is a 20px line, so the 24px band sets the row: 40px,
+ *    the same height the cell's loading skeleton reserves.
+ * 2. **With a long text** — the wrapped value stretches the row well past the band.
+ *    The single-line cells stay beside its *first* line rather than drifting to the
+ *    middle of a much taller row, which is what `align-top` buys us.
+ * 3. **With tags** — a 26px tag and a 20px avatar next to 20px text. The tag is taller
+ *    than the band, so it still sets the row height (42px, unchanged), but the text
+ *    beside it now lands on its center instead of 3px above it.
+ *
+ * Cells are `align-top`, so without the band each value sits flush with the cell's
+ * top padding and lands on a different vertical center. See
  * `ui/value-display/const.ts`.
  */
 export const CellsOfDifferentHeightsShareOneCenter: Story = {
   render: () => {
-    const records = [
-      {
-        id: 1,
-        firstName: "Dani",
-        lastName: "Smith",
-        role: "Senior Engineer",
-        department: "Engineering",
-      },
-      {
-        id: 2,
-        firstName: "Desirée",
-        lastName: "Johnson",
-        role: "Product Manager",
-        department: "Product",
-      },
-    ]
-
-    const source = useDataCollectionSource({
-      dataAdapter: { fetchData: async () => ({ records }) },
-    })
+    const dataAdapter = {
+      fetchData: async () => ({ records: ALIGNMENT_PEOPLE }),
+    }
+    const textOnlySource = useDataCollectionSource({ dataAdapter })
+    const longTextSource = useDataCollectionSource({ dataAdapter })
+    const tagsSource = useDataCollectionSource({ dataAdapter })
 
     return (
-      <OneDataCollection
-        source={source}
-        visualizations={[
-          {
-            type: "table",
-            options: {
-              columns: [
-                {
-                  label: "Name",
-                  render: (item) => ({
-                    type: "person",
-                    value: {
-                      firstName: item.firstName,
-                      lastName: item.lastName,
+      <div className="flex flex-col gap-8">
+        <AlignmentCase caption="Text only">
+          <OneDataCollection
+            source={textOnlySource}
+            visualizations={[
+              {
+                type: "table",
+                options: {
+                  columns: [
+                    {
+                      label: "Name",
+                      render: (item) => `${item.firstName} ${item.lastName}`,
                     },
-                  }),
+                    { label: "Role", render: (item) => item.role },
+                    {
+                      label: "Department",
+                      render: (item) => item.department,
+                    },
+                  ],
                 },
-                { label: "Role", render: (item) => item.role },
-                {
-                  label: "Department",
-                  render: (item) => ({
-                    type: "tag",
-                    value: { label: item.department },
-                  }),
+              },
+            ]}
+          />
+        </AlignmentCase>
+
+        <AlignmentCase caption="With a long text">
+          <OneDataCollection
+            source={longTextSource}
+            visualizations={[
+              {
+                type: "table",
+                options: {
+                  columns: [
+                    {
+                      label: "Name",
+                      render: (item) => `${item.firstName} ${item.lastName}`,
+                    },
+                    { label: "Role", render: (item) => item.role },
+                    {
+                      label: "Notes",
+                      width: 260,
+                      render: (item) => ({
+                        type: "longText",
+                        value: { text: item.notes, lines: 3 },
+                      }),
+                    },
+                  ],
                 },
-              ],
-            },
-          },
-        ]}
-      />
+              },
+            ]}
+          />
+        </AlignmentCase>
+
+        <AlignmentCase caption="With tags">
+          <OneDataCollection
+            source={tagsSource}
+            visualizations={[
+              {
+                type: "table",
+                options: {
+                  columns: [
+                    {
+                      label: "Name",
+                      render: (item) => ({
+                        type: "person",
+                        value: {
+                          firstName: item.firstName,
+                          lastName: item.lastName,
+                        },
+                      }),
+                    },
+                    { label: "Role", render: (item) => item.role },
+                    {
+                      label: "Department",
+                      render: (item) => ({
+                        type: "tag",
+                        value: { label: item.department },
+                      }),
+                    },
+                  ],
+                },
+              },
+            ]}
+          />
+        </AlignmentCase>
+      </div>
     )
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
-
-    const roleCell = await canvas.findByText("Senior Engineer")
-    const row = roleCell.closest("tr")!
 
     /** Vertical center of a cell's first line of text, relative to the cell. */
     const firstLineCenter = (cell: HTMLTableCellElement) => {
@@ -1783,21 +1861,49 @@ export const CellsOfDifferentHeightsShareOneCenter: Story = {
       return null
     }
 
-    const cells = [...row.querySelectorAll("td")].filter(
-      (cell) => cell.getBoundingClientRect().height > 0
-    )
-    const rowCenter = row.getBoundingClientRect().height / 2
+    const firstLineCenters = (row: HTMLTableRowElement) =>
+      [...row.querySelectorAll("td")]
+        .filter((cell) => cell.getBoundingClientRect().height > 0)
+        .map(firstLineCenter)
+        .filter((center): center is number => center !== null)
+
+    /** The first data row of the table under the given caption. */
+    const rowUnder = async (caption: string) => {
+      const heading = await canvas.findByRole("heading", { name: caption })
+      const table = heading.parentElement!.querySelector("table")!
+      return within(table).getAllByRole("row")[1] as HTMLTableRowElement
+    }
+
+    const textOnly = await rowUnder("Text only")
+    const withLongText = await rowUnder("With a long text")
+    const withTags = await rowUnder("With tags")
+
+    // The band is 24px and the cell's `py-2` adds 8px above and below it.
+    const BAND_CENTER = 20
+    // The 26px tag overshoots the band by 1px on each side, so its own center sits
+    // 1px below everything else's — the widest gap this layout allows.
+    const TOLERANCE = 1.5
 
     await waitFor(() => {
-      // The tag is the tallest content here, and it does not push the row past
-      // the 48px floor — so the band is the whole row and every value display
-      // lines up on its center.
-      expect(row.getBoundingClientRect().height).toBe(48)
+      // Rows keep the height their own content asks for: the band sets it at 40px
+      // when every value is a line of text, and the taller tag sets it at 42px.
+      expect(textOnly.getBoundingClientRect().height).toBe(40)
+      expect(withTags.getBoundingClientRect().height).toBe(42)
 
-      for (const cell of cells) {
-        const center = firstLineCenter(cell)
-        if (center === null) continue
-        expect(Math.abs(center - rowCenter)).toBeLessThanOrEqual(1)
+      for (const row of [textOnly, withTags]) {
+        for (const center of firstLineCenters(row)) {
+          expect(Math.abs(center - BAND_CENTER)).toBeLessThanOrEqual(TOLERANCE)
+        }
+      }
+
+      // The wrapped value stretches the row, but the band stays pinned to the
+      // top — so every cell, the long one included, still puts its first line on
+      // the band's center rather than the row's.
+      const longRowHeight = withLongText.getBoundingClientRect().height
+      expect(longRowHeight).toBeGreaterThan(48)
+      for (const center of firstLineCenters(withLongText)) {
+        expect(Math.abs(center - BAND_CENTER)).toBeLessThanOrEqual(TOLERANCE)
+        expect(Math.abs(center - longRowHeight / 2)).toBeGreaterThan(TOLERANCE)
       }
     })
   },

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -34,6 +34,7 @@ import { PagesPagination } from "@/patterns/OneDataCollection/components/PagesPa
 import { useDataCollectionSettings } from "@/patterns/OneDataCollection/Settings/SettingsProvider"
 import { GroupHeader } from "@/ui/GroupHeader/index"
 import { Skeleton } from "@/ui/skeleton.tsx"
+import { tableCellContentClassName } from "@/ui/value-display/const"
 
 import type {
   TableCustomizationProps,
@@ -988,7 +989,8 @@ export const TableCollection = <
                             <div
                               className={cn(
                                 column.align === "right" ? "justify-end" : "",
-                                "flex"
+                                "flex",
+                                tableCellContentClassName
                               )}
                             >
                               {(() => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -3232,7 +3232,7 @@ describe("TableCollection", () => {
     /**
      * Cells are `align-top`, so a value shorter than the row sticks to the cell's
      * top padding rather than its center. Every cell's value is wrapped in a
-     * centering band (`min-h-8 items-center`) so values of different intrinsic
+     * centering band (`min-h-6 items-center`) so values of different intrinsic
      * heights — a 20px line of text, a 20px avatar, a 26px tag — share one center
      * at the row's natural height, while the band stays pinned to the top when a
      * tall value stretches the row.
@@ -3269,7 +3269,7 @@ describe("TableCollection", () => {
       expect(cells.length).toBeGreaterThan(0)
 
       for (const cell of cells) {
-        const band = cell.querySelector(".min-h-8.items-center")
+        const band = cell.querySelector(".min-h-6.items-center")
         expect(band).not.toBeNull()
         expect(band).toContainElement(
           cell.querySelector<HTMLElement>(".truncate, span")

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -3276,5 +3276,41 @@ describe("TableCollection", () => {
         )
       }
     })
+
+    it("pads the cell to offset the separator the row paints over it", async () => {
+      // TableRow draws its 1px rule on its own last pixel (`after:bottom-0`), so a
+      // symmetric `py` leaves the gap below the value a pixel shorter than the gap
+      // above it. The bottom padding carries that pixel back.
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createTestSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      const SEPARATOR_PX = 1
+      const cell = screen.getAllByRole("cell")[0]
+
+      const top = /(?:^| )pt-(\d+(?:\.\d+)?)(?: |$)/.exec(cell.className)
+      const bottom = /(?:^| )pb-\[(\d+)px\](?: |$)/.exec(cell.className)
+      expect(top).not.toBeNull()
+      expect(bottom).not.toBeNull()
+      expect(Number(bottom![1])).toBe(Number(top![1]) * 4 + SEPARATOR_PX)
+    })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -3227,4 +3227,54 @@ describe("TableCollection", () => {
       expect(onSelectItems.mock.calls.length).toBe(callCountAfterRender)
     })
   })
+
+  describe("cell content alignment", () => {
+    /**
+     * Cells are `align-top`, so a value shorter than the row sticks to the cell's
+     * top padding rather than its center. Every cell's value is wrapped in a
+     * centering band (`min-h-8 items-center`) so values of different intrinsic
+     * heights — a 20px line of text, a 20px avatar, a 26px tag — share one center
+     * at the row's natural height, while the band stays pinned to the top when a
+     * tall value stretches the row.
+     *
+     * Asserted on the class rather than on measured geometry because jsdom does
+     * not lay out: `getBoundingClientRect()` returns zeroes for every element.
+     * The rendered positions are covered by the
+     * `CellsOfDifferentHeightsShareOneCenter` story's play function.
+     */
+    it("wraps every cell value in the centering band", async () => {
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={createTestSource()}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      const cells = screen.getAllByRole("cell")
+      expect(cells.length).toBeGreaterThan(0)
+
+      for (const cell of cells) {
+        const band = cell.querySelector(".min-h-8.items-center")
+        expect(band).not.toBeNull()
+        expect(band).toContainElement(
+          cell.querySelector<HTMLElement>(".truncate, span")
+        )
+      }
+    })
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -24,6 +24,7 @@ import { renderProperty } from "@/patterns/OneDataCollection/property-render"
 import { SummariesDefinition } from "@/patterns/OneDataCollection/summary"
 import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 import { Checkbox } from "@/ui/checkbox"
+import { tableCellContentClassName } from "@/ui/value-display/const"
 
 import type {
   CellRendererProps,
@@ -361,7 +362,8 @@ const RowComponentInner = <
           <div
             className={cn(
               column.align === "right" ? "justify-end" : "",
-              "flex"
+              "flex",
+              tableCellContentClassName
             )}
           >
             {renderCell(item, column)}

--- a/packages/react/src/ui/table.tsx
+++ b/packages/react/src/ui/table.tsx
@@ -97,8 +97,12 @@ const TableCell = React.forwardRef<
   <td
     ref={ref}
     className={cn(
-      "relative min-h-[48px] whitespace-nowrap px-3 py-2 align-top first:pl-6 last:pr-6",
-      "[&:has([role=checkbox])]:px-2 [&:has([role=checkbox])]:py-2",
+      // `pb` is 1px larger than `pt` on purpose: the row paints its separator on
+      // its own last pixel (`after:bottom-0` on TableRow), so a symmetric `py`
+      // leaves content looking 1px high — the gap below it is a pixel shorter
+      // than the gap above once the rule is drawn over it.
+      "relative min-h-[48px] whitespace-nowrap px-3 pb-[9px] pt-2 align-top first:pl-6 last:pr-6",
+      "[&:has([role=checkbox])]:px-2",
       className
     )}
     {...props}

--- a/packages/react/src/ui/value-display/const.test.ts
+++ b/packages/react/src/ui/value-display/const.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  TABLE_CELL_BAND_PX,
+  TABLE_CELL_LINE_PX,
+  tableCellContentClassName,
+  tableDisplayClassNames,
+} from "./const"
+
+/** Tailwind's spacing scale: `min-h-6` → 24px, `pt-0.5` → 2px. */
+const spacingPx = (className: string, prefix: string): number | null => {
+  const match = new RegExp(`(?:^| )${prefix}-(\\d+(?:\\.\\d+)?)(?: |$)`).exec(
+    className
+  )
+  return match ? Number(match[1]) * 4 : null
+}
+
+/**
+ * These guard the *relationships* between the alignment classes, which is what a
+ * future change is liable to break silently: resizing the band without moving the
+ * multiline offset with it, or re-adding a per-type padding nudge, both leave cells
+ * on different vertical centers again while every existing test still passes.
+ *
+ * The rendered geometry is covered by the `CellsOfDifferentHeightsShareOneCenter`
+ * story's play function — jsdom does not lay out, so it can't be asserted here.
+ */
+describe("table cell alignment constants", () => {
+  it("spells the band out as the height the cell reserves", () => {
+    expect(spacingPx(tableCellContentClassName, "min-h")).toBe(
+      TABLE_CELL_BAND_PX
+    )
+  })
+
+  it("centers content in the band", () => {
+    // Without this, a value shorter than the band sits at the band's top edge and
+    // the whole fix is inert.
+    expect(tableCellContentClassName).toContain("items-center")
+  })
+
+  it("offsets wrapping values by half the band's slack", () => {
+    // A wrapping value is taller than the band, so centering can't place its first
+    // line: it is pinned to the top and nudged down by whatever centering would
+    // have added. Resize the band and this offset has to move with it.
+    expect(spacingPx(tableDisplayClassNames.multiline, "pt")).toBe(
+      (TABLE_CELL_BAND_PX - TABLE_CELL_LINE_PX) / 2
+    )
+    expect(tableDisplayClassNames.multiline).toContain("self-start")
+  })
+
+  it.each(["text", "avatar", "avatarList"] as const)(
+    "gives %s no padding of its own",
+    (type) => {
+      // Regression guard for #4887: a per-type `pt-*` makes that cell taller than
+      // its siblings, which grows the row and leaves the shorter cells with uneven
+      // gaps. The band supplies the offset without adding height, so single-line
+      // types must stay flush.
+      expect(tableDisplayClassNames[type]).not.toMatch(/\bp[trblxy]?-/)
+    }
+  )
+})

--- a/packages/react/src/ui/value-display/const.ts
+++ b/packages/react/src/ui/value-display/const.ts
@@ -7,25 +7,42 @@
  * too, and because `min-height` does not apply to `display: table-cell`, the
  * `min-h-[48px]` on the cell never held the row open either: the row collapsed onto
  * its tallest value and every other value hugged the top padding above it. A row of
- * plain text came out 36px tall, the same row with a 26px tag 42px, and each value
- * landed on a different center — text 3px above the tag's, an action button 5px
- * below it.
+ * plain text came out 36px tall, the same row with a 26px tag 42px, and in that
+ * second row the text sat 3px above the tag's center.
  *
- * The fix is a fixed-height band rather than a per-type padding nudge (an earlier
+ * The fix is a fixed-height band rather than a per-type padding nudge (a bare
  * `pt-0.5` on text made that cell taller than its avatar-only siblings, which grew
- * the row and left the shorter cells with uneven gaps). Cell content is centered
- * inside a 32px band — the intended 48px row minus the cell's `py-2` — which both
- * restores that row height and gives every value display one shared center. When a
- * tall value stretches the row the band stays pinned to the top, so the short cells
- * keep sitting beside that value's first line instead of drifting to the middle of a
- * much taller row.
+ * the row and left the shorter cells with uneven gaps — the band adds the same
+ * offset without adding height). Cell content is centered inside a 24px band, so
+ * every value display shares one center. When a value is taller than the band the
+ * row grows around it, but the band stays pinned to the top, so the short cells keep
+ * sitting beside that value's first line instead of drifting to the middle of a much
+ * taller row.
+ *
+ * 24px is the content height a cell's own loading state reserves (`min-h-[24px]` in
+ * `experimental/OneTable/TableCell`), so a row does not change height when its data
+ * arrives. It also leaves a row's height set by its own content: text-only rows come
+ * out at 40px and a row with a tag at 42px, rather than every row being padded up to
+ * a uniform floor.
  */
 
 /**
- * Applied by the table visualization to the wrapper around every cell's value.
- * `min-h-8` is the 32px band; keep it in sync with `min-h-[48px]` in `ui/table.tsx`.
+ * Height of the band. The Tailwind classes below have to spell out values derived
+ * from this one — they can't be built at runtime, since Tailwind only emits classes
+ * it can see literally. `const.test.ts` holds the two in sync.
  */
-export const tableCellContentClassName = "min-h-8 items-center"
+export const TABLE_CELL_BAND_PX = 24
+
+/** Line box of `text-base`, the single line every cell's value aligns on. */
+export const TABLE_CELL_LINE_PX = 20
+
+/**
+ * Applied by the table visualization to the wrapper around every cell's value.
+ * `min-h-6` is {@link TABLE_CELL_BAND_PX}; keep it in sync with the skeleton's
+ * `min-h-[24px]` in `experimental/OneTable/TableCell`, or rows change height when
+ * their data arrives.
+ */
+export const tableCellContentClassName = "min-h-6 items-center"
 
 export const tableDisplayClassNames = {
   text: "",
@@ -35,8 +52,8 @@ export const tableDisplayClassNames = {
    * Values that wrap can't be centered in the band: once they are taller than it,
    * centering is a no-op and their first line would sit above the single-line
    * cells beside them. Pinning them to the top of the band and offsetting by half
-   * its slack — `(32 - 20) / 2` = 6px, one line of `text-base` — puts their first
-   * line on the same baseline as every other cell, wrapped or not.
+   * its slack — `(24 - 20) / 2` = 2px, against one line of `text-base` — puts their
+   * first line on the same baseline as every other cell, wrapped or not.
    */
-  multiline: "self-start pt-1.5",
+  multiline: "self-start pt-0.5",
 }

--- a/packages/react/src/ui/value-display/const.ts
+++ b/packages/react/src/ui/value-display/const.ts
@@ -1,17 +1,42 @@
 /**
- * Class names applied to value-display content when rendered inside a table cell.
+ * Vertical alignment of value displays rendered inside a table cell.
  *
- * Table cells are `align-top` so that tall, multi-line values (e.g. longText) align
- * to the top of the row instead of floating in its vertical center. Single-line
- * values must NOT receive an extra top padding: a per-type nudge (previously
- * `pt-0.5` on text) makes that cell taller than its avatar-only siblings, so the
- * row grows and the shorter cells end up with uneven top/bottom gaps — most visible
- * on square (team) avatars. Keeping every single-line type flush with the cell
- * padding makes all of them the same height, so the row is symmetric while
- * multi-line values still top-align.
+ * Table cells are `align-top` (see `ui/table.tsx`) so that a value tall enough to
+ * stretch the row — a wrapped `longText` — starts at the top of it instead of
+ * floating in the middle. The side effect is that *short* values stick to the top
+ * too, and because `min-height` does not apply to `display: table-cell`, the
+ * `min-h-[48px]` on the cell never held the row open either: the row collapsed onto
+ * its tallest value and every other value hugged the top padding above it. A row of
+ * plain text came out 36px tall, the same row with a 26px tag 42px, and each value
+ * landed on a different center — text 3px above the tag's, an action button 5px
+ * below it.
+ *
+ * The fix is a fixed-height band rather than a per-type padding nudge (an earlier
+ * `pt-0.5` on text made that cell taller than its avatar-only siblings, which grew
+ * the row and left the shorter cells with uneven gaps). Cell content is centered
+ * inside a 32px band — the intended 48px row minus the cell's `py-2` — which both
+ * restores that row height and gives every value display one shared center. When a
+ * tall value stretches the row the band stays pinned to the top, so the short cells
+ * keep sitting beside that value's first line instead of drifting to the middle of a
+ * much taller row.
  */
+
+/**
+ * Applied by the table visualization to the wrapper around every cell's value.
+ * `min-h-8` is the 32px band; keep it in sync with `min-h-[48px]` in `ui/table.tsx`.
+ */
+export const tableCellContentClassName = "min-h-8 items-center"
+
 export const tableDisplayClassNames = {
   text: "",
   avatar: "",
   avatarList: "",
+  /**
+   * Values that wrap can't be centered in the band: once they are taller than it,
+   * centering is a no-op and their first line would sit above the single-line
+   * cells beside them. Pinning them to the top of the band and offsetting by half
+   * its slack — `(32 - 20) / 2` = 6px, one line of `text-base` — puts their first
+   * line on the same baseline as every other cell, wrapped or not.
+   */
+  multiline: "self-start pt-1.5",
 }

--- a/packages/react/src/ui/value-display/const.ts
+++ b/packages/react/src/ui/value-display/const.ts
@@ -22,8 +22,9 @@
  * 24px is the content height a cell's own loading state reserves (`min-h-[24px]` in
  * `experimental/OneTable/TableCell`), so a row does not change height when its data
  * arrives. It also leaves a row's height set by its own content: text-only rows come
- * out at 40px and a row with a tag at 42px, rather than every row being padded up to
- * a uniform floor.
+ * out at 41px and a row with a tag at 43px, rather than every row being padded up to
+ * a uniform floor. (Each includes the 1px the row spends on its own separator; see
+ * the cell padding in `ui/table.tsx`.)
  */
 
 /**

--- a/packages/react/src/ui/value-display/types/longText/longText.test.tsx
+++ b/packages/react/src/ui/value-display/types/longText/longText.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender as render } from "@/testing/test-utils"
+
+import { tableDisplayClassNames } from "../../const"
+import { ValueDisplayRendererContext } from "../../renderers"
+import { LongTextCell } from "./longText"
+
+const TEXT = "Leads the payroll integrations squad."
+
+describe("LongTextCell", () => {
+  /**
+   * A wrapping value is the one case the table's centering band can't place: once
+   * it is taller than the band, centering is a no-op and its first line would sit
+   * above the single-line cells beside it. It opts out of centering and takes the
+   * offset as padding instead — see `ui/value-display/const.ts`.
+   */
+  it("takes the multiline offset inside a table", () => {
+    render(
+      LongTextCell(TEXT, {
+        visualization: "table",
+      } satisfies ValueDisplayRendererContext)
+    )
+
+    expect(screen.getByText(TEXT)).toHaveClass(
+      ...tableDisplayClassNames.multiline.split(" ")
+    )
+  })
+
+  it("takes no table offset in other visualizations", () => {
+    // Outside a table there is no band and no row to align against, so the offset
+    // would just push the value off-center.
+    render(
+      LongTextCell(TEXT, {
+        visualization: "card",
+      } satisfies ValueDisplayRendererContext)
+    )
+
+    expect(screen.getByText(TEXT)).not.toHaveClass("self-start")
+    expect(screen.getByText(TEXT).className).not.toMatch(/\bp[trblxy]?-/)
+  })
+})

--- a/packages/react/src/ui/value-display/types/longText/longText.tsx
+++ b/packages/react/src/ui/value-display/types/longText/longText.tsx
@@ -57,7 +57,7 @@ export const LongTextCell = (
       className={cn(
         "whitespace-pre-wrap break-words text-f1-foreground",
         shouldShowPlaceholderStyling && "text-f1-foreground-secondary",
-        meta.visualization === "table" && tableDisplayClassNames.text
+        meta.visualization === "table" && tableDisplayClassNames.multiline
       )}
       lines={lines}
       disabled={fullText}


### PR DESCRIPTION
## Description

Table cells are `align-top` (since #2627, so a wrapped `longText` starts at the top of the row rather than floating in its middle), which also pinned every *short* value to the cell's top padding. And because `min-height` does not apply to `display: table-cell`, the `min-h-[48px]` on the cell never held the row open either — the row collapsed onto its tallest value and each value display landed on a different vertical center. In a row with a person avatar, plain text and a tag, the row came out 42px tall with the text and avatar sitting 3px above the tag's center. This centers cell content inside a 24px band, so every value display shares one center, while the band stays pinned to the top when a tall value stretches the row — short cells keep sitting beside that value's first line instead of drifting to the middle of a much taller row.

## Implementation details

- fix: center every table cell's value inside a 24px content band, so text, avatars and tags share one vertical center instead of each hugging the cell's top padding

  <details>
  <summary>Why a band instead of a per-type padding nudge?</summary>

  A bare `pt-*` on text was tried before and reverted in #4887: real padding grows the cell, which grows the row, which leaves the shorter cells with uneven gaps. It also under-corrects — the offset depends on the sibling value's height, not one constant. Centering inside a band applies the same offset without adding height, and is self-correcting for any content height.
  </details>

  <details>
  <summary>Why 24px?</summary>

  It is the content height a cell's own loading state already reserves (`min-h-[24px]` in `experimental/OneTable/TableCell`), so a row does not change height when its data arrives. It also leaves each row's height set by its own content rather than padding every row up to a uniform floor: a text-only row is 40px and a row with a 26px tag stays at its natural 42px.
  </details>

- fix: offset a wrapped `longText`'s first line by half the band's slack so it shares the same baseline as the single-line cells beside it, in both the short and the wrapped case
- test: add unit tests for the invariants that keep cells centered — the band class must encode the band height, the multiline offset must stay half the band's slack, and single-line types must carry no padding of their own (red on main, green here)
- test: add a `CellsOfDifferentHeightsShareOneCenter` story covering the three row shapes — text only, with a wrapped long text, and with tags — whose play function asserts each row's height and that every cell's first line lands on the band's center

### Notes for reviewers

- **Row heights.** Text-only rows go 36px → 40px. Rows whose tallest value already exceeded the band (a 26px tag → 42px) are unchanged. Rows with a wrapped `longText` grow 2px.
- **One residual.** A tag is 26px, 1px taller than the band on each side, so in a tag row its center sits 1px below the text's. Closing that would mean sizing the band to the tag (26px) and pushing every text-only row to 42px — worth a design opinion.