### PR TITLE
feat(NewHomeLayout): add rail actions to collapsed widget glyphs

### DIFF
--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
@@ -5,6 +5,7 @@ import { F0Button } from "@/components/F0Button"
 import { F0Select } from "@/components/F0Select"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { SolidPause, SolidPlay, SolidStop } from "@/icons/app"
+import { useReducedMotion } from "@/lib/a11y"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { cn } from "@/lib/utils"
 
@@ -57,6 +58,40 @@ export type ClockInControlsVariant = "default" | "horizontal-bar"
  */
 const FIELD_WITHOUT_FILL =
   "[&_[data-testid=input-field-wrapper]]:bg-transparent"
+
+/**
+ * THE DAY'S PULSE, beside the status it belongs to: the dot in the state's own
+ * colour, with a halo ticking out of it and fading, once every second and a half.
+ *
+ * BOTH VARIANTS draw it. The bar variant used to leave it out on the grounds that
+ * its own bar is coloured by the same state — but a bar says what the day HAS
+ * been, and this says the day is still going: it is the only thing on the tile
+ * that moves when the clock is running.
+ *
+ * Reduced motion keeps the dot and drops the halo. The halo repeats forever, and
+ * a signal you cannot pause is exactly the kind that has to be able to hold still.
+ */
+const StatusPulse = ({ color }: { color: string }) => {
+  const reducedMotion = useReducedMotion()
+
+  return (
+    <div className="relative aspect-square h-4 shrink-0 self-center">
+      {!reducedMotion && (
+        <motion.div
+          className="absolute inset-0 rounded-full opacity-20"
+          style={{ backgroundColor: color }}
+          initial={{ scale: 0.5, opacity: 0.6 }}
+          animate={{ scale: 1.6, opacity: 0 }}
+          transition={{ duration: 1.5, repeat: Infinity, repeatDelay: 1 }}
+        />
+      )}
+      <div
+        className="absolute inset-[3px] rounded-full"
+        style={{ backgroundColor: color }}
+      />
+    </div>
+  )
+}
 
 /** Everything both variants take, on the same terms. */
 interface ClockInControlsBaseProps {
@@ -561,9 +596,7 @@ export function ClockInControls({
       <div className="flex flex-col gap-2">
         {/* The state and the running total, one line, ONE type size: they are
             two halves of one fact ("clocked out, nothing tracked yet"), so
-            neither is made subordinate to the other. No status dot here — the
-            bar below is coloured by that same state, and the total has the
-            place the dot holds in the default variant. */}
+            neither is made subordinate to the other. */}
         <div className="flex flex-row items-end justify-between gap-2">
           <div className="flex min-w-0 flex-row items-baseline gap-1.5">
             {/* `shrink-0`: the STATE is the headline and must read in full — left
@@ -571,6 +604,10 @@ export function ClockInControls({
             <span className="line-clamp-1 shrink-0 text-xl font-semibold text-f1-foreground">
               {statusText}
             </span>
+            {/* The same pulse the default variant carries, beside the same words.
+                The row is `items-baseline` for the text; the dot centres itself
+                against it (`self-center`) rather than sitting on the baseline. */}
+            <StatusPulse color={statusColor} />
             {/* WHICH break, next to the fact that you're on one — it belongs to
                 the status, not to the controls. Break names are consumer copy and
                 can run long ("Lunch break — canteen, second shift"), so it
@@ -647,27 +684,7 @@ export function ClockInControls({
                 <span className="line-clamp-1 text-2xl font-semibold text-f1-foreground">
                   {statusText}
                 </span>
-                <div className="relative aspect-square h-4">
-                  <motion.div
-                    className="absolute inset-0 rounded-full opacity-20"
-                    style={{
-                      backgroundColor: statusColor,
-                    }}
-                    initial={{ scale: 0.5, opacity: 0.6 }}
-                    animate={{ scale: 1.6, opacity: 0 }}
-                    transition={{
-                      duration: 1.5,
-                      repeat: Infinity,
-                      repeatDelay: 1,
-                    }}
-                  />
-                  <div
-                    className="absolute inset-[3px] rounded-full"
-                    style={{
-                      backgroundColor: statusColor,
-                    }}
-                  />
-                </div>
+                <StatusPulse color={statusColor} />
               </div>
               {subtitle && (
                 <p className="line-clamp-1 text-f1-foreground-secondary">

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -437,18 +437,27 @@ describe("NewHomeLayout", () => {
        * BUTTON STAYS EXACTLY AS IT WAS: hover is when you are aiming at it, and a
        * control that repaints itself mid-aim is one you cannot hit.
        */
-      test("hands the width back while the widget floats, button unchanged", async () => {
+      test("hands the width back while the widget floats, button unrepainted", async () => {
         renderLayout(1000, { rightWidgets: TICKING_RAIL })
 
         const button = () =>
           screen.getByRole("button", { name: "Take a break, clock" })
-        const before = button().className
+        /** Everything about the button EXCEPT whether its border is showing. */
+        const paint = () =>
+          button()
+            .className.split(" ")
+            .filter((c) => c !== "ring-1")
+
+        const before = paint()
 
         await userEvent.hover(button())
 
         expect(screen.getByText("tracked today")).toBeVisible()
         expect(pill()).not.toHaveTextContent("7:12")
-        expect(button().className).toBe(before)
+        // Same fill, same icon colour, same size — only the border came on, and
+        // that is the one thing hover is allowed to change.
+        expect(paint()).toEqual(before)
+        expect(button().className).toContain("ring-1")
       })
 
       test("blinks the separator once a second, digits held still", () => {
@@ -531,6 +540,10 @@ describe("NewHomeLayout", () => {
         const hoverFills = classes.filter((c) => c.startsWith("hover:bg-"))
 
         expect(hoverFills).toEqual(["hover:bg-f1-background"])
+        // The border answers the GLYPH's hover, not the button's own — pointing
+        // at the reading is pointing at the thing the button belongs to.
+        expect(classes).toContain("group-hover:ring-1")
+        expect(classes).not.toContain("hover:ring-1")
       })
 
       test("keeps the dark slab and the accent button by default", () => {

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -396,7 +396,7 @@ describe("NewHomeLayout", () => {
     })
 
     /**
-     * A `time` turns the glyph into a pill: the reading, then the button. It is
+     * A `text` turns the glyph into a pill: the reading, then the button. It is
      * the STOWED widget's stand-in, so it gives its width back the moment the card
      * itself is out.
      */
@@ -413,7 +413,7 @@ describe("NewHomeLayout", () => {
           railAction: {
             icon: markedIcon("action"),
             label: "Take a break",
-            time: "7:12",
+            text: "7:12",
             ticking: true,
             onClick: () => resumes++,
           },

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
-import { useEffect, useState } from "react"
+import { forwardRef, useEffect, useState, type SVGProps } from "react"
 
+import { type IconType } from "@/components/F0Icon"
 import { Calendar, Clock } from "@/icons/app"
 import {
   act,
@@ -55,6 +56,18 @@ const RAIL = [
   widget("clock", { locked: true }),
   widget("events", { hasUpdates: true }),
 ]
+
+/**
+ * An icon a test can NAME. The real ones are anonymous paths, and a glyph that
+ * flashes between two of them is only testable if the two can be told apart.
+ */
+const markedIcon = (mark: string): IconType =>
+  forwardRef<SVGSVGElement, SVGProps<SVGSVGElement>>((props, ref) => (
+    <svg {...props} ref={ref} data-icon={mark} />
+  )) as IconType
+
+/** How many times the rail action has been run. */
+let resumes = 0
 
 const renderLayout = (width: number, props = {}) => {
   layoutWidth = width
@@ -141,6 +154,7 @@ beforeEach(() => {
   })
   resizeCallbacks = []
   clockMounts = 0
+  resumes = 0
   // jsdom has no ResizeObserver. This one keeps its callback so a test can fire
   // it (`resizeLayoutTo`) instead of only serving the initial read.
   vi.stubGlobal(
@@ -238,6 +252,219 @@ describe("NewHomeLayout", () => {
       expect(
         screen.getByRole("button", { name: "clock" }).querySelector(dot)
       ).toBeNull()
+    })
+  })
+
+  /**
+   * A widget's `railAction` turns its glyph into that action's button. The glyph
+   * is still the way to the widget — hover, or focus — but the CLICK is the
+   * action's, which is the whole point of putting it there.
+   */
+  describe("a glyph that is an action", () => {
+    const ACTION_RAIL = [
+      widget("clock", {
+        icon: markedIcon("module"),
+        // A body only this widget has, so "is the card floating?" doesn't have to
+        // be asked of a word the header carries too.
+        slots: [
+          {
+            visualization: "indicators",
+            params: { items: [{ label: "tracked today", content: "1" }] },
+          },
+        ],
+        railAction: {
+          icon: markedIcon("action"),
+          label: "Resume",
+          flashing: true,
+          onClick: () => resumes++,
+        },
+      }),
+      widget("events"),
+    ]
+
+    /** Which icon the glyph is wearing right now. */
+    const face = (button: HTMLElement) =>
+      button.querySelector("[data-icon]")?.getAttribute("data-icon")
+
+    const glyph = () =>
+      screen.getByRole("button", { name: "Resume, clock" }) as HTMLElement
+
+    test("names itself after the action AND the widget it belongs to", () => {
+      renderLayout(1000, { rightWidgets: ACTION_RAIL })
+
+      expect(glyph()).toBeInTheDocument()
+      // The plain glyph's name is gone: there is one control here, not two.
+      expect(
+        screen.queryByRole("button", { name: "clock" })
+      ).not.toBeInTheDocument()
+    })
+
+    test("runs the action on every click — it never toggles the panel", async () => {
+      renderLayout(1000, { rightWidgets: ACTION_RAIL })
+
+      await userEvent.click(glyph())
+      await userEvent.click(glyph())
+
+      // A plain glyph's second click would have PUT THE WIDGET BACK. This one
+      // does what it says twice, and the panel stays out.
+      expect(resumes).toBe(2)
+      expect(screen.getByText("tracked today")).toBeVisible()
+    })
+
+    test("still floats its widget on hover, like any other glyph", async () => {
+      renderLayout(1000, { rightWidgets: ACTION_RAIL })
+
+      await userEvent.hover(glyph())
+
+      expect(screen.getByText("tracked today")).toBeVisible()
+      expect(resumes).toBe(0)
+    })
+
+    test("floats its widget on FOCUS too — the click is spoken for", () => {
+      renderLayout(1000, { rightWidgets: ACTION_RAIL })
+
+      act(() => glyph().focus())
+
+      expect(screen.getByText("tracked today")).toBeVisible()
+    })
+
+    test("flashing alternates the two icons once a second", () => {
+      vi.useFakeTimers()
+      try {
+        renderLayout(1000, { rightWidgets: ACTION_RAIL })
+
+        // It starts on the action's face: whatever happens, the glyph opens by
+        // saying what it does.
+        expect(face(glyph())).toBe("action")
+        act(() => vi.advanceTimersByTime(1000))
+        expect(face(glyph())).toBe("module")
+        act(() => vi.advanceTimersByTime(1000))
+        expect(face(glyph())).toBe("action")
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    test("settles on the action's face while the widget is floating", async () => {
+      renderLayout(1000, { rightWidgets: ACTION_RAIL })
+
+      await userEvent.hover(glyph())
+
+      vi.useFakeTimers()
+      try {
+        act(() => vi.advanceTimersByTime(3000))
+        expect(face(glyph())).toBe("action")
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    test("holds still when the state stops asking", () => {
+      vi.useFakeTimers()
+      try {
+        renderLayout(1000, {
+          rightWidgets: [
+            widget("clock", {
+              icon: markedIcon("module"),
+              railAction: {
+                icon: markedIcon("action"),
+                label: "Clock out",
+                onClick: () => {},
+              },
+            }),
+          ],
+        })
+
+        const button = screen.getByRole("button", {
+          name: "Clock out, clock",
+        }) as HTMLElement
+        expect(face(button)).toBe("action")
+        act(() => vi.advanceTimersByTime(3000))
+        expect(face(button)).toBe("action")
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
+    test("is the COLLAPSED rail's affordance only", () => {
+      renderLayout(1400, { rightWidgets: ACTION_RAIL })
+
+      // Expanded, the card's own footer is where a call to action belongs.
+      expect(
+        screen.queryByRole("button", { name: "Resume, clock" })
+      ).not.toBeInTheDocument()
+    })
+
+    /**
+     * A `time` turns the glyph into a pill: the reading, then the button. It is
+     * the STOWED widget's stand-in, so it gives its width back the moment the card
+     * itself is out.
+     */
+    describe("with a live reading on it", () => {
+      const TICKING_RAIL = [
+        widget("clock", {
+          icon: markedIcon("module"),
+          slots: [
+            {
+              visualization: "indicators",
+              params: { items: [{ label: "tracked today", content: "1" }] },
+            },
+          ],
+          railAction: {
+            icon: markedIcon("action"),
+            label: "Take a break",
+            time: "7:12",
+            ticking: true,
+            onClick: () => resumes++,
+          },
+        }),
+      ]
+
+      const pill = () =>
+        screen.getByRole("button", { name: "Take a break, clock" })
+          .parentElement as HTMLElement
+
+      test("draws the reading beside the button", () => {
+        renderLayout(1000, { rightWidgets: TICKING_RAIL })
+
+        // Whole and unsplit: a screen reader reads "7:12", not "7 12".
+        expect(pill()).toHaveTextContent("7:12")
+      })
+
+      test("hands the width back while the widget is floating", async () => {
+        renderLayout(1000, { rightWidgets: TICKING_RAIL })
+
+        await userEvent.hover(
+          screen.getByRole("button", { name: "Take a break, clock" })
+        )
+
+        // The card is out with the same numbers in full — the pill would only be
+        // an overhang repeating them.
+        expect(screen.getByText("tracked today")).toBeVisible()
+        expect(pill()).not.toHaveTextContent("7:12")
+      })
+
+      test("blinks the separator once a second, digits held still", () => {
+        vi.useFakeTimers()
+        try {
+          renderLayout(1000, { rightWidgets: TICKING_RAIL })
+
+          const separator = () =>
+            [...pill().querySelectorAll("span")].find(
+              (span) => span.textContent === ":"
+            ) as HTMLElement
+
+          expect(separator().style.opacity).toBe("1")
+          act(() => vi.advanceTimersByTime(1000))
+          expect(separator().style.opacity).not.toBe("1")
+          // The reading itself never changes — only the app's clock moves it.
+          expect(pill()).toHaveTextContent("7:12")
+          act(() => vi.advanceTimersByTime(1000))
+          expect(separator().style.opacity).toBe("1")
+        } finally {
+          vi.useRealTimers()
+        }
+      })
     })
   })
 

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -299,6 +299,28 @@ describe("NewHomeLayout", () => {
       ).not.toBeInTheDocument()
     })
 
+    /**
+     * The tooltip is the only place the action's NAME is written — the glyph is
+     * an icon — so it opens INSTANTLY. On the default wait it was a name you had
+     * to stop and ask for, on a control you point at on your way past.
+     */
+    test("names the action without a wait", () => {
+      vi.useFakeTimers()
+      try {
+        renderLayout(1000, { rightWidgets: ACTION_RAIL })
+
+        // `fireEvent`, not `userEvent`: the tooltip is a TIMER, and userEvent's
+        // own waiting deadlocks against fake ones.
+        fireEvent.pointerEnter(glyph(), { pointerType: "mouse" })
+        // Well past the instant 100ms, and well inside the default 700ms.
+        act(() => vi.advanceTimersByTime(200))
+
+        expect(screen.getByRole("tooltip")).toHaveTextContent("Resume")
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+
     test("runs the action on every click — it never toggles the panel", async () => {
       renderLayout(1000, { rightWidgets: ACTION_RAIL })
 

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -431,17 +431,24 @@ describe("NewHomeLayout", () => {
         expect(pill()).toHaveTextContent("7:12")
       })
 
-      test("hands the width back while the widget is floating", async () => {
+      /**
+       * The pill goes when the card comes out — it would only be an overhang
+       * repeating what the card says in full, over the panel it belongs to. THE
+       * BUTTON STAYS EXACTLY AS IT WAS: hover is when you are aiming at it, and a
+       * control that repaints itself mid-aim is one you cannot hit.
+       */
+      test("hands the width back while the widget floats, button unchanged", async () => {
         renderLayout(1000, { rightWidgets: TICKING_RAIL })
 
-        await userEvent.hover(
+        const button = () =>
           screen.getByRole("button", { name: "Take a break, clock" })
-        )
+        const before = button().className
 
-        // The card is out with the same numbers in full — the pill would only be
-        // an overhang repeating them.
+        await userEvent.hover(button())
+
         expect(screen.getByText("tracked today")).toBeVisible()
         expect(pill()).not.toHaveTextContent("7:12")
+        expect(button().className).toBe(before)
       })
 
       test("blinks the separator once a second, digits held still", () => {
@@ -464,6 +471,78 @@ describe("NewHomeLayout", () => {
         } finally {
           vi.useRealTimers()
         }
+      })
+
+      /**
+       * A `tone` is ONE decision for the whole chip: the pill takes the colour and
+       * the button becomes a plain chip carrying it in the icon, so the two halves
+       * never put two strong hues beside each other.
+       */
+      test("paints the pill and the button from one tone", () => {
+        renderLayout(1000, {
+          rightWidgets: [
+            widget("clock", {
+              icon: markedIcon("module"),
+              railAction: {
+                icon: markedIcon("action"),
+                label: "Resume",
+                text: "0:20",
+                tone: "warning",
+                onClick: () => {},
+              },
+            }),
+          ],
+        })
+
+        const button = screen.getByRole("button", { name: "Resume, clock" })
+        const pill = button.parentElement as HTMLElement
+
+        expect(pill.className).toContain("bg-f1-background-warning-bold")
+        // Not the tone again on the button — a plain chip, tone in the icon.
+        expect(button.className).toContain("bg-f1-background")
+        expect(button.className).not.toContain("warning")
+      })
+
+      /**
+       * The chip's `hover:` fill is its RESTING fill, on purpose: `tailwind-merge`
+       * settles classes per variant, so a plain `bg-*` leaves the button variant's
+       * own `hover:bg-*` standing — and the page's hover tint over a bold pill
+       * reads as the button going see-through.
+       */
+      test("does not let anything repaint the chip on hover", () => {
+        renderLayout(1000, {
+          rightWidgets: [
+            widget("clock", {
+              icon: markedIcon("module"),
+              railAction: {
+                icon: markedIcon("action"),
+                label: "Resume",
+                text: "0:20",
+                tone: "critical",
+                onClick: () => {},
+              },
+            }),
+          ],
+        })
+
+        const classes = screen
+          .getByRole("button", { name: "Resume, clock" })
+          .className.split(" ")
+        const hoverFills = classes.filter((c) => c.startsWith("hover:bg-"))
+
+        expect(hoverFills).toEqual(["hover:bg-f1-background"])
+      })
+
+      test("keeps the dark slab and the accent button by default", () => {
+        renderLayout(1000, { rightWidgets: TICKING_RAIL })
+
+        const button = screen.getByRole("button", {
+          name: "Take a break, clock",
+        })
+        expect((button.parentElement as HTMLElement).className).toContain(
+          "bg-f1-background-inverse"
+        )
+        expect(button.className).toContain("bg-f1-background-accent-bold")
       })
     })
   })
@@ -532,6 +611,34 @@ describe("NewHomeLayout", () => {
       await renderDeferredRail(1000)
 
       expect(screen.getByText("08:00")).not.toBeVisible()
+    })
+
+    /**
+     * THE FLOATING CARD IS OVER THE FEED, and it has to win that on the layout's
+     * terms rather than by out-bidding whatever the feed contains — Home's own
+     * Ask-AI composer is `z-20`, and the next thing an app puts in the column is
+     * not this layout's to know.
+     *
+     * The contract is three classes, which is what this asserts: the main column
+     * ISOLATES (so every z-index inside it is settled within the column, not
+     * against the panel), the panel sits above it, and the strip sits above the
+     * panel — a glyph is what the card came out of, so it stays in front.
+     *
+     * Asserted as classes because jsdom has no Tailwind: it can tell you the
+     * class is there, never what it paints. The real check is the Storybook story.
+     */
+    test("layers the floating card over the column, and the strip over both", () => {
+      const { container } = renderLayout(1000)
+
+      const main = container.querySelector(
+        ".overflow-y-auto.min-h-0, .min-h-0.overflow-y-auto"
+      ) as HTMLElement
+      const strip = container.querySelector("aside.-m-1") as HTMLElement
+      const panel = container.querySelector("aside.absolute") as HTMLElement
+
+      expect(main.className).toContain("isolate")
+      expect(panel.className).toContain("z-10")
+      expect(strip.className).toContain("z-20")
     })
 
     test("hovering a glyph floats THAT widget, and only it", async () => {

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -36,6 +36,7 @@ import {
   SolidPause,
   SolidPlay,
   Target,
+  Timer,
 } from "@/icons/app"
 import { F0AiChatTextArea } from "@/kits/ai/F0AiChatTextArea"
 import { type WelcomeScreenSuggestion } from "@/kits/ai/F0AiChat/types"
@@ -1373,9 +1374,10 @@ const clockInDay = (
  * - **Clocked in.** A `positive` pill — `--positive-50`, the tile's own green —
  *   with the running total in HOURS AND MINUTES, its separator blinking once a
  *   second the way a clock does (`ticking`), and "Take a break" as a plain chip at
- *   the end of it. Nothing is being asked of you, so the icon holds still.
+ *   the end of it. The face turns over on the same second (`flashing`), between
+ *   the timer and the break it offers.
  * - **On a break.** A `promote` pill — `--promote-50`, the tile's amber — counting
- *   the BREAK, and the button FLASHES between the clock's own icon and the play
+ *   the BREAK, and the button FLASHES between the timer icon and the play
  *   triangle: the colour says paused, the flash asks you to do something about it.
  *
  * Hover any of them and the card floats out as ever — the pill gives its width
@@ -1418,6 +1420,10 @@ const ClockGlyphActionHome = () => {
           // one colour.
           tone: "positive",
           ticking: true,
+          // Ticking as well as counting: the icon turns over between the timer
+          // and what the button does, so a running day says so twice — the
+          // separator's blink and the face's turn, on the same second.
+          flashing: true,
           onClick: () => {
             setOnBreak(0)
             setStatus("break")
@@ -1449,7 +1455,13 @@ const ClockGlyphActionHome = () => {
 
   const [clock, ...rest] = RIGHT_WIDGETS
   const day = clockInDay(status, worked, onBreak, new Date())
-  const rail: HomeWidgetItem[] = [{ ...clock, railAction }, ...rest]
+  // `Timer`, not the catalog's plain `Clock`: this icon is the OTHER FACE of the
+  // flash, so it is read a second at a time next to a running total — a stopwatch
+  // says which clock is meant, where a wall clock would just say "time".
+  const rail: HomeWidgetItem[] = [
+    { ...clock, icon: Timer, railAction },
+    ...rest,
+  ]
 
   return (
     // Capped BELOW what two columns need (712 + 16 + 396), so the rail is in its

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -33,6 +33,8 @@ import {
   Receipt,
   Search,
   Settings,
+  SolidPause,
+  SolidPlay,
   Target,
 } from "@/icons/app"
 import { F0AiChatTextArea } from "@/kits/ai/F0AiChatTextArea"
@@ -43,10 +45,12 @@ import {
   ClockInControls,
   type ClockInProject,
 } from "../ClockIn/ClockInControls"
+import { type ClockInStatus } from "../ClockIn/ClockInGraph"
 import {
   fromParams,
   homeSlot,
   type HomeWidgetItem,
+  type HomeWidgetRailAction,
   listSlot,
   resolveWidgetHeader,
   type SlotRenderers,
@@ -510,7 +514,23 @@ const CLOCK_IN_PROJECTS: ClockInProject[] = [
  * this same render rather than a hand-built stand-in that has to be kept in
  * step with it.
  */
-const ClockInTile = ({ loading }: { loading?: boolean }) => {
+const ClockInTile = ({
+  loading,
+  day,
+  onClockIn,
+  onClockOut,
+  onBreak,
+}: {
+  loading?: boolean
+  /**
+   * The day the tile is showing. `ClockInControls` reads its own status off the
+   * LAST entry's `variant`, so the day is the state — see `clockInDay` below.
+   */
+  day?: ClockInDay
+  onClockIn?: () => void
+  onClockOut?: () => void
+  onBreak?: () => void
+}) => {
   const [locationId, setLocationId] = useState("remote")
   const [projectId, setProjectId] = useState<string | undefined>()
 
@@ -519,8 +539,8 @@ const ClockInTile = ({ loading }: { loading?: boolean }) => {
       variant="horizontal-bar"
       loading={loading}
       labels={CLOCK_IN_LABELS}
-      data={[]}
-      trackedMinutes={0}
+      data={day?.data ?? []}
+      trackedMinutes={day?.trackedMinutes ?? 0}
       remainingMinutes={8 * 60}
       locations={CLOCK_IN_LOCATIONS}
       locationId={locationId}
@@ -528,8 +548,10 @@ const ClockInTile = ({ loading }: { loading?: boolean }) => {
       projects={CLOCK_IN_PROJECTS}
       projectId={projectId}
       onChangeProjectId={setProjectId}
-      onClockIn={() => {}}
-      onClockOut={() => {}}
+      canShowBreakButton
+      onClockIn={onClockIn ?? (() => {})}
+      onClockOut={onClockOut ?? (() => {})}
+      onBreak={onBreak}
     />
   )
 }
@@ -1282,6 +1304,172 @@ export const Loading: Story = {
       </NewHomeLayout>
     </div>
   ),
+}
+
+/* ============================= glyph actions ============================= */
+
+/**
+ * HOURS AND MINUTES, as a glyph shows them: `7:04`. Seconds are what a stopwatch
+ * counts; a working day is read in hours, and the blinking separator is what says
+ * it is running — not a digit changing sixty times a minute.
+ */
+const hhmm = (seconds: number) => {
+  const minutes = Math.floor(seconds / 60)
+  return `${Math.floor(minutes / 60)}:${String(minutes % 60).padStart(2, "0")}`
+}
+
+/** What `ClockInControls` needs to draw the day — and to know which state it is in. */
+type ClockInDay = {
+  data: { from: Date; to: Date; variant: ClockInStatus }[]
+  trackedMinutes: number
+}
+
+/**
+ * THE DAY as the three states leave it. `ClockInControls` derives its status from
+ * the LAST entry's variant, so "on a break" is a worked stretch followed by a break
+ * stretch — the tile then says "On a break" on its own, with no status prop to keep
+ * in step with the rail.
+ *
+ * The clock started `worked + onBreak` seconds ago, so the two readings and the bar
+ * describe the same day.
+ */
+const clockInDay = (
+  status: ClockInStatus,
+  worked: number,
+  onBreak: number,
+  now: Date
+): ClockInDay => {
+  const at = (secondsAgo: number) => new Date(now.getTime() - secondsAgo * 1000)
+  const trackedMinutes = Math.floor(worked / 60)
+
+  if (status === "clocked-out") return { data: [], trackedMinutes: 0 }
+  if (status === "clocked-in")
+    return {
+      data: [{ from: at(worked), to: now, variant: "clocked-in" }],
+      trackedMinutes,
+    }
+  return {
+    data: [
+      { from: at(worked + onBreak), to: at(onBreak), variant: "clocked-in" },
+      { from: at(onBreak), to: now, variant: "break" },
+    ],
+    trackedMinutes,
+  }
+}
+
+/**
+ * THE RAIL'S ONE-CLICK STATE, as time tracking uses it: the clock's glyph is the
+ * clock's button, and the day decides which button that is. Click the glyph — or
+ * the tile's own controls, which drive the same state — to move between all three.
+ *
+ * - **Clocked out.** Nothing is running, so the glyph is a quiet `neutral` play:
+ *   the day is on offer, not overdue.
+ * - **Clocked in.** The glyph is a PILL — the running total in HOURS AND MINUTES,
+ *   its separator blinking once a second the way a clock does (`ticking`), with
+ *   "Take a break" at the end of it. Nothing is being asked of you, so the icon
+ *   holds still.
+ * - **On a break.** Still a pill, now counting the BREAK, and the button FLASHES
+ *   between the clock's own icon and the play triangle: the one state that is
+ *   asking to be acted on.
+ *
+ * Hover any of them and the card floats out as ever — the pill gives its width
+ * back while it does, since the card says all of it in full.
+ *
+ * Both readings are HOURS AND MINUTES on a real clock, so they change once a
+ * minute. What says "this is running" second to second is the blink, not a digit.
+ */
+const ClockGlyphActionHome = () => {
+  const [status, setStatus] = useState<ClockInStatus>("clocked-in")
+  /** Seconds worked today, and seconds into the CURRENT break. */
+  const [worked, setWorked] = useState((7 * 60 + 12) * 60)
+  const [onBreak, setOnBreak] = useState(0)
+
+  // The story's own clock, whichever counter the state says is running — REAL
+  // TIME, a second a second. It is kept in seconds so the day's bar and the
+  // tile's total stay in step with the pill, but nothing ever shows them: the
+  // glyph is read in hours and minutes, and a figure that moved every second in
+  // the corner of the page would be a stopwatch, not a day. In the real Home
+  // this is all the app's; the rail only draws the string it is handed.
+  useEffect(() => {
+    if (status === "clocked-out") return
+    const tick = setInterval(() => {
+      if (status === "clocked-in") setWorked((seconds) => seconds + 1)
+      else setOnBreak((seconds) => seconds + 1)
+    }, 1000)
+    return () => clearInterval(tick)
+  }, [status])
+
+  const railAction: HomeWidgetRailAction =
+    status === "clocked-in"
+      ? {
+          icon: SolidPause,
+          label: "Take a break",
+          time: hhmm(worked),
+          ticking: true,
+          onClick: () => {
+            setOnBreak(0)
+            setStatus("break")
+          },
+        }
+      : status === "break"
+        ? {
+            icon: SolidPlay,
+            label: "Resume",
+            time: hhmm(onBreak),
+            ticking: true,
+            // The state is asking to be acted on — a day left on a break.
+            flashing: true,
+            onClick: () => setStatus("clocked-in"),
+          }
+        : {
+            icon: SolidPlay,
+            label: "Clock in",
+            variant: "neutral",
+            onClick: () => {
+              setWorked(0)
+              setStatus("clocked-in")
+            },
+          }
+
+  const [clock, ...rest] = RIGHT_WIDGETS
+  const day = clockInDay(status, worked, onBreak, new Date())
+  const rail: HomeWidgetItem[] = [{ ...clock, railAction }, ...rest]
+
+  return (
+    // Capped BELOW what two columns need (712 + 16 + 396), so the rail is in its
+    // collapsed strip — the only presentation that draws glyphs at all.
+    <div className="mx-auto h-full w-full max-w-[1000px] p-6">
+      <NewHomeLayout
+        rightWidgets={rail}
+        // The tile and the glyph are the SAME state: clocking in from the card
+        // grows the pill in the rail, and vice versa.
+        slotRenderers={{
+          "clock-in": {
+            render: () => (
+              <ClockInTile
+                day={day}
+                onClockIn={() => setStatus("clocked-in")}
+                onClockOut={() => setStatus("clocked-out")}
+                onBreak={() => {
+                  setOnBreak(0)
+                  setStatus("break")
+                }}
+              />
+            ),
+            skeleton: () => <ClockInTile loading />,
+          },
+        }}
+      >
+        {mainColumnBlocks()}
+      </NewHomeLayout>
+    </div>
+  )
+}
+
+export const GlyphAction: Story = {
+  // A story with a clock in it: every snapshot of it would differ from the last.
+  parameters: { chromatic: { disableSnapshot: true } },
+  render: () => <ClockGlyphActionHome />,
 }
 
 /* ============================== virtualization ============================== */

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1404,7 +1404,7 @@ const ClockGlyphActionHome = () => {
       ? {
           icon: SolidPause,
           label: "Take a break",
-          time: hhmm(worked),
+          text: hhmm(worked),
           ticking: true,
           onClick: () => {
             setOnBreak(0)
@@ -1415,7 +1415,7 @@ const ClockGlyphActionHome = () => {
         ? {
             icon: SolidPlay,
             label: "Resume",
-            time: hhmm(onBreak),
+            text: hhmm(onBreak),
             ticking: true,
             // The state is asking to be acted on — a day left on a break.
             flashing: true,

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1362,24 +1362,27 @@ const clockInDay = (
  * clock's button, and the day decides which button that is. Click the glyph — or
  * the tile's own controls, which drive the same state — to move between all three.
  *
- * Each state has its own COLOUR, which is what `tone` is for — one word paints the
- * pill and the button together, so the rail says which state you are in before
- * you have read the number.
+ * Each state has its own COLOUR, and it is the colour the TILE already uses for
+ * it — `CLOCK_IN_COLORS`, the same values its status dot pulses and its bar is
+ * drawn in. One word (`tone`) paints the pill and the button together, so the
+ * rail says which state you are in before you have read the number, and says it
+ * in the same green the card does.
  *
- * - **Clocked out.** No reading to show, so no pill: just the accent play button.
- *   The day is on offer, not overdue.
- * - **Clocked in.** An `accent` PILL — the running total in HOURS AND MINUTES, its
- *   separator blinking once a second the way a clock does (`ticking`), with "Take
- *   a break" as a plain chip at the end of it. Nothing is being asked of you, so
- *   the icon holds still.
- * - **On a break.** A `warning` pill counting the BREAK, and the button FLASHES
- *   between the clock's own icon and the play triangle: amber says paused, the
- *   flash asks you to do something about it.
+ * - **Clocked out.** The dark slab (`neutral`), holding what the day came to, with
+ *   the accent play button on it. Nothing is running, so nothing blinks.
+ * - **Clocked in.** A `positive` pill — `--positive-50`, the tile's own green —
+ *   with the running total in HOURS AND MINUTES, its separator blinking once a
+ *   second the way a clock does (`ticking`), and "Take a break" as a plain chip at
+ *   the end of it. Nothing is being asked of you, so the icon holds still.
+ * - **On a break.** A `promote` pill — `--promote-50`, the tile's amber — counting
+ *   the BREAK, and the button FLASHES between the clock's own icon and the play
+ *   triangle: the colour says paused, the flash asks you to do something about it.
  *
  * Hover any of them and the card floats out as ever — the pill gives its width
- * back while it does, since the card says all of it in full.
+ * back while it does, since the card says all of it in full, and the button it
+ * leaves behind is the same button it always was.
  *
- * Both readings are HOURS AND MINUTES on a real clock, so they change once a
+ * Every reading is HOURS AND MINUTES on a real clock, so they change once a
  * minute. What says "this is running" second to second is the blink, not a digit.
  */
 const ClockGlyphActionHome = () => {
@@ -1409,8 +1412,11 @@ const ClockGlyphActionHome = () => {
           icon: SolidPause,
           label: "Take a break",
           text: hhmm(worked),
-          // The day is RUNNING: the accent pill, and the clock's own blink.
-          tone: "accent",
+          // THE SAME GREEN THE TILE PULSES: `positive` is `--positive-50`, which
+          // is exactly what `CLOCK_IN_COLORS["clocked-in"]` paints the status dot
+          // and the day's bar. The glyph and the card are one state, so they are
+          // one colour.
+          tone: "positive",
           ticking: true,
           onClick: () => {
             setOnBreak(0)
@@ -1422,9 +1428,10 @@ const ClockGlyphActionHome = () => {
             icon: SolidPlay,
             label: "Resume",
             text: hhmm(onBreak),
-            // A DIFFERENT COLOUR for a different state — amber says paused
-            // without saying broken, and the flashing icon does the asking.
-            tone: "warning",
+            // …and the same amber, `--promote-50`, that the tile pulses on a
+            // break (`CLOCK_IN_COLORS.break`) — not `warning`, which is a
+            // different yellow and would say something the tile isn't saying.
+            tone: "promote",
             ticking: true,
             flashing: true,
             onClick: () => setStatus("clocked-in"),
@@ -1432,10 +1439,12 @@ const ClockGlyphActionHome = () => {
         : {
             icon: SolidPlay,
             label: "Clock in",
-            onClick: () => {
-              setWorked(0)
-              setStatus("clocked-in")
-            },
+            // STILL A READING, on the dark slab: what the day came to so far. The
+            // clock has stopped, so nothing blinks — the tone is what says the
+            // difference between a total that is still moving and one that isn't.
+            text: hhmm(worked),
+            tone: "neutral",
+            onClick: () => setStatus("clocked-in"),
           }
 
   const [clock, ...rest] = RIGHT_WIDGETS

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1362,15 +1362,19 @@ const clockInDay = (
  * clock's button, and the day decides which button that is. Click the glyph — or
  * the tile's own controls, which drive the same state — to move between all three.
  *
- * - **Clocked out.** Nothing is running, so the glyph is a quiet `neutral` play:
- *   the day is on offer, not overdue.
- * - **Clocked in.** The glyph is a PILL — the running total in HOURS AND MINUTES,
- *   its separator blinking once a second the way a clock does (`ticking`), with
- *   "Take a break" at the end of it. Nothing is being asked of you, so the icon
- *   holds still.
- * - **On a break.** Still a pill, now counting the BREAK, and the button FLASHES
- *   between the clock's own icon and the play triangle: the one state that is
- *   asking to be acted on.
+ * Each state has its own COLOUR, which is what `tone` is for — one word paints the
+ * pill and the button together, so the rail says which state you are in before
+ * you have read the number.
+ *
+ * - **Clocked out.** No reading to show, so no pill: just the accent play button.
+ *   The day is on offer, not overdue.
+ * - **Clocked in.** An `accent` PILL — the running total in HOURS AND MINUTES, its
+ *   separator blinking once a second the way a clock does (`ticking`), with "Take
+ *   a break" as a plain chip at the end of it. Nothing is being asked of you, so
+ *   the icon holds still.
+ * - **On a break.** A `warning` pill counting the BREAK, and the button FLASHES
+ *   between the clock's own icon and the play triangle: amber says paused, the
+ *   flash asks you to do something about it.
  *
  * Hover any of them and the card floats out as ever — the pill gives its width
  * back while it does, since the card says all of it in full.
@@ -1405,6 +1409,8 @@ const ClockGlyphActionHome = () => {
           icon: SolidPause,
           label: "Take a break",
           text: hhmm(worked),
+          // The day is RUNNING: the accent pill, and the clock's own blink.
+          tone: "accent",
           ticking: true,
           onClick: () => {
             setOnBreak(0)
@@ -1416,15 +1422,16 @@ const ClockGlyphActionHome = () => {
             icon: SolidPlay,
             label: "Resume",
             text: hhmm(onBreak),
+            // A DIFFERENT COLOUR for a different state — amber says paused
+            // without saying broken, and the flashing icon does the asking.
+            tone: "warning",
             ticking: true,
-            // The state is asking to be acted on — a day left on a break.
             flashing: true,
             onClick: () => setStatus("clocked-in"),
           }
         : {
             icon: SolidPlay,
             label: "Clock in",
-            variant: "neutral",
             onClick: () => {
               setWorked(0)
               setStatus("clocked-in")

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -141,20 +141,27 @@ const useFlash = (running: boolean) => {
 }
 
 /**
- * A rail action's live reading, BLINKING LIKE A CLOCK: the digits stand still and
- * the separators go dim for half of every second, which is what says the number is
- * counting rather than parked.
+ * A rail action's reading, and — while it is `ticking` — BLINKING LIKE A CLOCK:
+ * the characters stand still and the separators go dim for half of every second,
+ * which is what says the number is counting rather than parked. A reading with
+ * nothing to separate is simply drawn.
  *
  * Opacity only, and the string is never taken apart in the accessibility tree — a
  * screen reader still reads "0:42", not "0 42". `tabular-nums` so a digit rolling
  * over doesn't move the pill.
  */
-const TickingTime = ({ time, ticking }: { time: string; ticking: boolean }) => {
+const GlyphReading = ({
+  text,
+  ticking,
+}: {
+  text: string
+  ticking: boolean
+}) => {
   const lit = useFlash(ticking)
 
   return (
     <span className="whitespace-nowrap px-2 text-2xl font-semibold tabular-nums">
-      {time.split(":").map((part, index) => (
+      {text.split(":").map((part, index) => (
         <Fragment key={index}>
           {index > 0 ? (
             <span
@@ -211,7 +218,7 @@ const CollapsedGlyph = ({
    * on top of it, saying it again — so the glyph gives the room back and is simply
    * its button again.
    */
-  const time = action?.time && !open ? action.time : undefined
+  const text = action?.text && !open ? action.text : undefined
 
   /** The genie, identical whichever face the glyph wears. */
   const glyphMotion = {
@@ -244,8 +251,8 @@ const CollapsedGlyph = ({
     // and FOCUS opens it too, so reaching the glyph by keyboard still gets you
     // to the widget's own controls — they are the next thing in the tab order.
     //
-    // With a `time` the whole thing becomes a PILL: the reading, then the button
-    // inset in it at 32px. The pill keeps the strip's 40px HEIGHT — the one
+    // With a `text` the whole thing becomes a PILL: the reading, then the same
+    // button at the end of it. The pill keeps the strip's 40px HEIGHT — the one
     // dimension the strip's rhythm and the cards' stow are built on — and takes
     // the width it needs off the left, out over the feed.
     return (
@@ -261,7 +268,7 @@ const CollapsedGlyph = ({
             // `rounded-lg` — one step up from the button's `rounded-md`, which is
             // what the radius scale says a container holding an `lg` control
             // takes. Nothing here is a shape the strip doesn't already use.
-            time
+            text
               ? "flex flex-row items-center gap-1 rounded-lg bg-f1-background-inverse p-1 text-f1-foreground-inverse -mr-1"
               : "rounded-lg"
           )}
@@ -269,7 +276,9 @@ const CollapsedGlyph = ({
           onFocus={(event) => onOpen(widget.id, event.currentTarget)}
           {...glyphMotion}
         >
-          {time ? <TickingTime time={time} ticking={!!action.ticking} /> : null}
+          {text ? (
+            <GlyphReading text={text} ticking={!!action.ticking} />
+          ) : null}
           <Action
             type="button"
             variant={action.variant ?? "default"}
@@ -976,7 +985,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 // doing: the strip lives in the rail's column, and that column
                 // spends the collapse on its way DOWN from the full rail width —
                 // stretched, the glyphs would start card-wide and shrink. END
-                // rather than start because a `railAction` with a time is a PILL
+                // rather than start because a `railAction` with a reading is a PILL
                 // wider than the column: the box grows to it and hangs out over
                 // the feed to the LEFT (`justifySelf: end` below), and the 40px
                 // glyphs have to stay on the rail's edge while it does.

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -207,53 +207,60 @@ const RAIL_ACTION_TONES = {
   neutral: {
     pill: "bg-f1-background-inverse text-f1-foreground-inverse",
     button:
-      "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+      "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover",
     icon: "inverse",
-    solo: "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    ring: "ring-f1-border-inverse",
+    solo: "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover",
     soloIcon: "inverse",
+    soloRing: "ring-f1-border-inverse",
   },
   accent: {
     pill: "bg-f1-background-accent-bold text-f1-foreground-inverse",
-    button:
-      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    button: "bg-f1-background hover:bg-f1-background",
     icon: "accent",
-    solo: "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    ring: "ring-f1-border-secondary",
+    solo: "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover",
     soloIcon: "inverse",
+    soloRing: "ring-f1-border-inverse",
   },
   critical: {
     pill: "bg-f1-background-critical-bold text-f1-foreground-inverse",
-    button:
-      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    button: "bg-f1-background hover:bg-f1-background",
     icon: "critical",
-    solo: "bg-f1-background-critical-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    ring: "ring-f1-border-secondary",
+    solo: "bg-f1-background-critical-bold",
     soloIcon: "inverse",
+    soloRing: "ring-f1-border-inverse",
   },
   warning: {
     pill: "bg-f1-background-warning-bold text-f1-foreground-inverse",
-    button:
-      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    button: "bg-f1-background hover:bg-f1-background",
     icon: "warning",
-    solo: "bg-f1-background-warning-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    ring: "ring-f1-border-secondary",
+    solo: "bg-f1-background-warning-bold",
     soloIcon: "inverse",
+    soloRing: "ring-f1-border-inverse",
   },
   // The amber `--promote-50`, which is also the colour a clock-in tile pulses on
   // a break: a rail action that mirrors a widget's own status should be able to
   // mirror its colour exactly, not approximate it with `warning`.
   promote: {
     pill: "bg-f1-background-promote-bold text-f1-foreground-inverse",
-    button:
-      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    button: "bg-f1-background hover:bg-f1-background",
     icon: "promote",
-    solo: "bg-f1-background-promote-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    ring: "ring-f1-border-secondary",
+    solo: "bg-f1-background-promote-bold",
     soloIcon: "inverse",
+    soloRing: "ring-f1-border-inverse",
   },
   positive: {
     pill: "bg-f1-background-positive-bold text-f1-foreground-inverse",
-    button:
-      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    button: "bg-f1-background hover:bg-f1-background",
     icon: "positive",
-    solo: "bg-f1-background-positive-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    ring: "ring-f1-border-secondary",
+    solo: "bg-f1-background-positive-bold",
     soloIcon: "inverse",
+    soloRing: "ring-f1-border-inverse",
   },
 } as const satisfies Record<
   RailActionTone,
@@ -261,8 +268,10 @@ const RAIL_ACTION_TONES = {
     pill: string
     button: string
     icon: F0IconProps["color"]
+    ring: string
     solo: string
     soloIcon: F0IconProps["color"]
+    soloRing: string
   }
 >
 
@@ -364,7 +373,10 @@ const CollapsedGlyph = ({
             // `pointer-events-auto` against the strip's `none`: a pill is wider
             // than the rail's column, and the box holding it must not become a
             // 100px dead margin down the side of the feed.
-            "pointer-events-auto relative shrink-0",
+            //
+            // `group` so the BUTTON can answer this whole box's hover — see its
+            // border below.
+            "group pointer-events-auto relative shrink-0",
             // The pill is the GLYPH'S OWN geometry, grown sideways: the 40px
             // height every glyph has, the button unchanged inside it, and
             // `rounded-lg` — one step up from the button's `rounded-md`, which is
@@ -394,15 +406,25 @@ const CollapsedGlyph = ({
             // whether it is standing alone as the glyph or sitting at the end of
             // a pill. A reading beside it doesn't make it a different control.
             size="lg"
-            compact
             // FLAT, like every other glyph in the strip. A button's elevation
             // chrome — the drop shadow and the `::after` top highlight — is for a
             // control raised off a page; here it reads as a border, and the
             // highlight's own radius is a step tighter than an `lg` button's, so
             // it cuts a visible arc across each corner. The strip is tiles.
             className={cn(
-              "size-10 shadow-none after:hidden hover:shadow-none active:shadow-none",
-              action.text ? tone.button : tone.solo
+              // `[&_.main]:px-0` — the button is 40px of icon, not a label with
+              // room around it, and an `lg` button's own padding would squeeze a
+              // 24px glyph out of a 40px box. The tile centres it instead.
+              "size-10 shadow-none after:hidden hover:shadow-none active:shadow-none [&_.main]:px-0",
+              action.text ? tone.button : tone.solo,
+              // THE BORDER ANSWERS THE WHOLE GLYPH, not just its 40px: the pill is
+              // one object, and pointing at the reading is pointing at the thing
+              // the button belongs to. It stays for as long as the widget is out
+              // (`open`), so crossing from the glyph into the card it opened
+              // doesn't switch the button off behind you.
+              "ring-inset group-hover:ring-1",
+              open && "ring-1",
+              action.text ? tone.ring : tone.soloRing
             )}
             // "Resume" on its own doesn't say which glyph this is; the tooltip
             // can lean on the strip for that, an accessible name can't.
@@ -410,7 +432,10 @@ const CollapsedGlyph = ({
             onClick={() => action.onClick()}
           >
             <F0Icon
-              size="md"
+              // The strip's own glyph size: `F0AvatarIcon` at `lg` draws its icon
+              // at 24px, and an action glyph that drew a smaller one read as a
+              // different KIND of tile rather than the same tile doing something.
+              size="lg"
               // `color` rather than a text class: it marks the svg
               // `data-has-color`, which is what stops the button variant's own
               // icon rules from painting over the tone.

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -236,6 +236,17 @@ const RAIL_ACTION_TONES = {
     solo: "bg-f1-background-warning-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
     soloIcon: "inverse",
   },
+  // The amber `--promote-50`, which is also the colour a clock-in tile pulses on
+  // a break: a rail action that mirrors a widget's own status should be able to
+  // mirror its colour exactly, not approximate it with `warning`.
+  promote: {
+    pill: "bg-f1-background-promote-bold text-f1-foreground-inverse",
+    button:
+      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    icon: "promote",
+    solo: "bg-f1-background-promote-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    soloIcon: "inverse",
+  },
   positive: {
     pill: "bg-f1-background-positive-bold text-f1-foreground-inverse",
     button:

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion } from "motion/react"
 import {
   Children,
   type CSSProperties,
@@ -11,21 +12,19 @@ import {
   useState,
 } from "react"
 
-import { AnimatePresence, motion } from "motion/react"
-
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
-import Menu from "@/icons/app/Menu"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 // No `Pencil`/`Check`: there is no edit mode to toggle any more.
 import { Plus } from "@/icons/app"
-import { Tooltip } from "@/experimental/Overlays/Tooltip"
-import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
-import { SidebarIconSvg } from "@/patterns/Navigation/Sidebar/Icon"
-import { Action } from "@/ui/Action"
+import Menu from "@/icons/app/Menu"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
+import { SidebarIconSvg } from "@/patterns/Navigation/Sidebar/Icon"
+import { Action } from "@/ui/Action"
 
 import {
   entranceDelay,
@@ -44,14 +43,6 @@ import {
   RIGHT_AREA_DELAY_MS,
   withReducedMotion,
 } from "../home-motion"
-import { SlotWidget } from "../SlotWidget"
-import { useRailMotion } from "./useRailMotion"
-import { useScrollFade } from "../useScrollFade"
-import {
-  WidgetContainer,
-  type WidgetContainerSide,
-  type WidgetVirtualization,
-} from "../WidgetContainer"
 import {
   widgetTitle,
   type HomeRenderCtx,
@@ -59,6 +50,14 @@ import {
   type SlotRenderers,
   type WidgetParams,
 } from "../slotRenderers"
+import { SlotWidget } from "../SlotWidget"
+import { useScrollFade } from "../useScrollFade"
+import {
+  WidgetContainer,
+  type WidgetContainerSide,
+  type WidgetVirtualization,
+} from "../WidgetContainer"
+import { useRailMotion } from "./useRailMotion"
 
 /**
  * The DaytimePage gradient wash, by period — the same stops and the same 8%
@@ -109,8 +108,73 @@ const CONTENT_WIDTH = 712
 const GLYPH_GAP_PX = 8
 
 /**
+ * THE GLYPH'S SECOND — how long each face of a flashing glyph is up, and how long
+ * a ticking readout's separator stays lit. One period, not two half-periods: a
+ * faster alternation reads as a fault rather than as a request, and a clock that
+ * blinks twice a second isn't a clock.
+ */
+const GLYPH_FLASH_MS = 1000
+
+/**
+ * The one-second beat both the flashing icon and the ticking readout are drawn
+ * on: `true` for the first half of it, `false` for the second.
+ *
+ * It rests on `true` whenever it isn't running, so every way of stopping — reduced
+ * motion, the widget floating under the pointer, a state that stopped asking for
+ * anything — leaves the glyph in the state that says the most: the action's icon,
+ * the separator lit.
+ */
+const useFlash = (running: boolean) => {
+  const reducedMotion = useReducedMotion()
+  const [lit, setLit] = useState(true)
+
+  useEffect(() => {
+    if (!running || reducedMotion) {
+      setLit(true)
+      return
+    }
+    const beat = setInterval(() => setLit((was) => !was), GLYPH_FLASH_MS)
+    return () => clearInterval(beat)
+  }, [running, reducedMotion])
+
+  return lit
+}
+
+/**
+ * A rail action's live reading, BLINKING LIKE A CLOCK: the digits stand still and
+ * the separators go dim for half of every second, which is what says the number is
+ * counting rather than parked.
+ *
+ * Opacity only, and the string is never taken apart in the accessibility tree — a
+ * screen reader still reads "0:42", not "0 42". `tabular-nums` so a digit rolling
+ * over doesn't move the pill.
+ */
+const TickingTime = ({ time, ticking }: { time: string; ticking: boolean }) => {
+  const lit = useFlash(ticking)
+
+  return (
+    <span className="whitespace-nowrap px-2 text-2xl font-semibold tabular-nums">
+      {time.split(":").map((part, index) => (
+        <Fragment key={index}>
+          {index > 0 ? (
+            <span
+              className="transition-opacity duration-200"
+              style={{ opacity: lit ? 1 : 0.24 }}
+            >
+              :
+            </span>
+          ) : null}
+          {part}
+        </Fragment>
+      ))}
+    </span>
+  )
+}
+
+/**
  * One widget as the collapsed strip shows it: its own catalog glyph, standing in
- * for the whole card.
+ * for the whole card — or, when the widget carries a `railAction`, that action's
+ * button wearing the same 40px.
  *
  * It ARRIVES FROM LARGER THAN LIFE — the card that just shrank into it — and
  * leaves the other way, blooming back out into the card it becomes. While its
@@ -135,6 +199,108 @@ const CollapsedGlyph = ({
   onClose: () => void
 }) => {
   const reducedMotion = useReducedMotion()
+  const action = widget.railAction
+  // The flash pauses while the widget is FLOATING, because the panel is open for
+  // exactly one reason — the pointer (or the focus ring) is on the glyph — and a
+  // face that changed under the pointer would make the click a coin toss about
+  // which icon was pressed.
+  const actionFace = useFlash(!!action?.flashing && !open)
+  /**
+   * THE PILL IS FOR THE STOWED WIDGET. Floating, the card itself is out with the
+   * same reading in full context — and the pill would be a 100px overhang sitting
+   * on top of it, saying it again — so the glyph gives the room back and is simply
+   * its button again.
+   */
+  const time = action?.time && !open ? action.time : undefined
+
+  /** The genie, identical whichever face the glyph wears. */
+  const glyphMotion = {
+    initial: {
+      opacity: 0,
+      scale: reducedMotion ? 1 : GENIE_GLYPH_ENTER_SCALE,
+    },
+    animate: { opacity: 1, scale: open ? GENIE_GLYPH_OPEN_SCALE : 1 },
+    exit: { opacity: 0, scale: reducedMotion ? 1 : GENIE_GLYPH_EXIT_SCALE },
+    whileHover: reducedMotion ? undefined : { scale: GENIE_GLYPH_HOVER_SCALE },
+    whileTap: reducedMotion ? undefined : { scale: GENIE_GLYPH_TAP_SCALE },
+    transition: withReducedMotion(
+      { ...glyphTransition, delay: entranceDelay(order, delayMs) },
+      reducedMotion
+    ),
+  }
+
+  /* Same accent dot HomeListItem draws for unread rows — the ring keeps it
+     legible over any glyph, action button included. */
+  const updatesDot = widget.hasUpdates ? (
+    <span className="pointer-events-none absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
+  ) : null
+
+  if (action) {
+    // The action's button IS the glyph — one control, so nothing is nested in
+    // anything and the strip's geometry is untouched (`size-10` + `compact`
+    // hold the button to the 40px every other glyph is).
+    //
+    // Which means the panel can't be a click any more: hover opens it as ever,
+    // and FOCUS opens it too, so reaching the glyph by keyboard still gets you
+    // to the widget's own controls — they are the next thing in the tab order.
+    //
+    // With a `time` the whole thing becomes a PILL: the reading, then the button
+    // inset in it at 32px. The pill keeps the strip's 40px HEIGHT — the one
+    // dimension the strip's rhythm and the cards' stow are built on — and takes
+    // the width it needs off the left, out over the feed.
+    return (
+      <Tooltip label={action.label}>
+        <motion.div
+          className={cn(
+            // `pointer-events-auto` against the strip's `none`: a pill is wider
+            // than the rail's column, and the box holding it must not become a
+            // 100px dead margin down the side of the feed.
+            "pointer-events-auto relative shrink-0",
+            // The pill is the GLYPH'S OWN geometry, grown sideways: the 40px
+            // height every glyph has, the button unchanged inside it, and
+            // `rounded-lg` — one step up from the button's `rounded-md`, which is
+            // what the radius scale says a container holding an `lg` control
+            // takes. Nothing here is a shape the strip doesn't already use.
+            time
+              ? "flex flex-row items-center gap-1 rounded-lg bg-f1-background-inverse p-1 text-f1-foreground-inverse -mr-1"
+              : "rounded-lg"
+          )}
+          onMouseEnter={(event) => onOpen(widget.id, event.currentTarget)}
+          onFocus={(event) => onOpen(widget.id, event.currentTarget)}
+          {...glyphMotion}
+        >
+          {time ? <TickingTime time={time} ticking={!!action.ticking} /> : null}
+          <Action
+            type="button"
+            variant={action.variant ?? "default"}
+            // THE SAME BUTTON either way — 40px at the strip's own radius,
+            // whether it is standing alone as the glyph or sitting at the end of
+            // a pill. A reading beside it doesn't make it a different control.
+            size="lg"
+            compact
+            // FLAT, like every other glyph in the strip. A button's elevation
+            // chrome — the drop shadow and the `::after` top highlight — is for a
+            // control raised off a page; here it reads as a border, and the
+            // highlight's own radius is a step tighter than an `lg` button's, so
+            // it cuts a visible arc across each corner. The strip is tiles.
+            className="size-10 shadow-none after:hidden active:shadow-none"
+            // "Resume" on its own doesn't say which glyph this is; the tooltip
+            // can lean on the strip for that, an accessible name can't.
+            aria-label={`${action.label}, ${widgetTitle(widget)}`}
+            onClick={() => action.onClick()}
+          >
+            <F0Icon
+              size="md"
+              // No widget icon means no second face to flash to — the action's
+              // is the only one there is.
+              icon={actionFace || !widget.icon ? action.icon : widget.icon}
+            />
+          </Action>
+          {updatesDot}
+        </motion.div>
+      </Tooltip>
+    )
+  }
 
   return (
     <motion.button
@@ -147,23 +313,10 @@ const CollapsedGlyph = ({
       onClick={(event) =>
         open ? onClose() : onOpen(widget.id, event.currentTarget)
       }
-      className="rounded-lg"
-      initial={{
-        opacity: 0,
-        scale: reducedMotion ? 1 : GENIE_GLYPH_ENTER_SCALE,
-      }}
-      animate={{ opacity: 1, scale: open ? GENIE_GLYPH_OPEN_SCALE : 1 }}
-      exit={{ opacity: 0, scale: reducedMotion ? 1 : GENIE_GLYPH_EXIT_SCALE }}
-      whileHover={
-        reducedMotion ? undefined : { scale: GENIE_GLYPH_HOVER_SCALE }
-      }
-      whileTap={reducedMotion ? undefined : { scale: GENIE_GLYPH_TAP_SCALE }}
-      transition={withReducedMotion(
-        { ...glyphTransition, delay: entranceDelay(order, delayMs) },
-        reducedMotion
-      )}
+      // See the strip: it takes no pointer events, so each glyph takes its own.
+      className="pointer-events-auto rounded-lg"
+      {...glyphMotion}
     >
-      {/* Same accent dot HomeListItem uses for unread rows. */}
       <span className="relative inline-flex">
         {widget.icon ? (
           <F0AvatarIcon icon={widget.icon} size="lg" />
@@ -172,11 +325,7 @@ const CollapsedGlyph = ({
             {widgetTitle(widget).charAt(0)}
           </span>
         )}
-        {widget.hasUpdates ? (
-          // Same dot HomeListItem draws for unread rows — the ring keeps it
-          // legible over any glyph.
-          <span className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-f1-background-accent-bold ring-2 ring-f1-background" />
-        ) : null}
+        {updatesDot}
       </span>
     </motion.button>
   )
@@ -823,11 +972,21 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               key="collapsed-strip"
               ref={stripFade.ref}
               className={cn(
-                // `items-start` so a glyph is 40px wide whatever the column is
+                // `items-end` so a glyph is its own 40px whatever the column is
                 // doing: the strip lives in the rail's column, and that column
                 // spends the collapse on its way DOWN from the full rail width —
-                // stretched, the glyphs would start card-wide and shrink.
-                "-m-1 flex min-h-0 flex-col items-start gap-2 overflow-y-auto p-1",
+                // stretched, the glyphs would start card-wide and shrink. END
+                // rather than start because a `railAction` with a time is a PILL
+                // wider than the column: the box grows to it and hangs out over
+                // the feed to the LEFT (`justifySelf: end` below), and the 40px
+                // glyphs have to stay on the rail's edge while it does.
+                //
+                // Which is also why the box itself takes NO pointer events: at a
+                // pill's width it would otherwise be a dead margin down the side
+                // of the feed, eating clicks meant for the cards under it. Each
+                // glyph turns them back on for its own 40px (`pointer-events-auto`).
+                "-m-1 flex min-h-0 flex-col items-end gap-2 overflow-y-auto p-1",
+                "pointer-events-none",
                 SCROLLBAR_HIDDEN
               )}
               style={{
@@ -877,7 +1036,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                     type="button"
                     aria-label={t.widgets.addWidget}
                     onClick={() => onClickAddNewWidget("right")}
-                    className="flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
+                    className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
                     initial={{ opacity: 0 }}
                     animate={{ opacity: 1 }}
                     exit={{ opacity: 0 }}

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -14,7 +14,7 @@ import {
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
-import { F0Icon } from "@/components/F0Icon"
+import { F0Icon, type F0IconProps } from "@/components/F0Icon"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 // No `Pencil`/`Check`: there is no edit mode to toggle any more.
 import { Plus } from "@/icons/app"
@@ -31,8 +31,6 @@ import {
   entranceTransition,
   GENIE_GLYPH_ENTER_SCALE,
   GENIE_GLYPH_EXIT_SCALE,
-  GENIE_GLYPH_HOVER_SCALE,
-  GENIE_GLYPH_OPEN_SCALE,
   GENIE_GLYPH_TAP_SCALE,
   GENIE_ORIGIN,
   GENIE_RETRACTED_OFFSET_PX,
@@ -47,6 +45,7 @@ import {
   widgetTitle,
   type HomeRenderCtx,
   type HomeWidgetItem,
+  type RailActionTone,
   type SlotRenderers,
   type WidgetParams,
 } from "../slotRenderers"
@@ -140,11 +139,14 @@ const useFlash = (running: boolean) => {
   return lit
 }
 
+/** How far a blinking reading goes down on the off beat. */
+const TICK_DIM = 0.24
+
 /**
- * A rail action's reading, and — while it is `ticking` — BLINKING LIKE A CLOCK:
- * the characters stand still and the separators go dim for half of every second,
- * which is what says the number is counting rather than parked. A reading with
- * nothing to separate is simply drawn.
+ * A rail action's reading, BLINKING LIKE A CLOCK while it is `ticking`: the
+ * figures stand still and the separators go dim for half of every second, which
+ * is what says the number is counting rather than parked. The figures never
+ * blink — a reading you cannot read at a glance is not a reading.
  *
  * Opacity only, and the string is never taken apart in the accessibility tree — a
  * screen reader still reads "0:42", not "0 42". `tabular-nums` so a digit rolling
@@ -166,7 +168,7 @@ const GlyphReading = ({
           {index > 0 ? (
             <span
               className="transition-opacity duration-200"
-              style={{ opacity: lit ? 1 : 0.24 }}
+              style={{ opacity: lit ? 1 : TICK_DIM }}
             >
               :
             </span>
@@ -177,6 +179,81 @@ const GlyphReading = ({
     </span>
   )
 }
+
+/**
+ * WHAT A TONE PAINTS. One entry per tone, and each says the same three things:
+ * the pill's fill, the button's fill, and what colour the button's icon takes.
+ *
+ * The pairing is the point. `neutral` is the dark slab with the accent button on
+ * it — a chip that isn't saying anything in particular. Every OTHER tone colours
+ * the pill and turns the button into a plain chip carrying that colour in its
+ * icon, so the two halves never put two strong hues side by side. Without a
+ * reading there is no pill, and `solo` is what the button wears on its own.
+ *
+ * THE CHIP KEEPS ITS FILL ON HOVER — `hover:` set to the SAME colour, which is
+ * not redundant: `tailwind-merge` only settles classes within one variant, so a
+ * plain `bg-*` never displaces the button variant's `hover:bg-*`, and the chip
+ * was repainting itself with the page's hover tint the moment you pointed at it.
+ * Over a bold pill that reads as the button going see-through rather than
+ * lighting up. What the chip does instead is take a BORDER — the glyphs no longer
+ * scale under the pointer (see `glyphMotion`), so the ring is the feedback: a
+ * hairline on the plain chips, and the inverse one on the solid buttons, which is
+ * the only border that shows on a bold fill.
+ *
+ * Literal class strings, one per tone: Tailwind reads source text, so a class
+ * built from a variable never reaches the stylesheet.
+ */
+const RAIL_ACTION_TONES = {
+  neutral: {
+    pill: "bg-f1-background-inverse text-f1-foreground-inverse",
+    button:
+      "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    icon: "inverse",
+    solo: "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    soloIcon: "inverse",
+  },
+  accent: {
+    pill: "bg-f1-background-accent-bold text-f1-foreground-inverse",
+    button:
+      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    icon: "accent",
+    solo: "bg-f1-background-accent-bold hover:bg-f1-background-accent-bold-hover hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    soloIcon: "inverse",
+  },
+  critical: {
+    pill: "bg-f1-background-critical-bold text-f1-foreground-inverse",
+    button:
+      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    icon: "critical",
+    solo: "bg-f1-background-critical-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    soloIcon: "inverse",
+  },
+  warning: {
+    pill: "bg-f1-background-warning-bold text-f1-foreground-inverse",
+    button:
+      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    icon: "warning",
+    solo: "bg-f1-background-warning-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    soloIcon: "inverse",
+  },
+  positive: {
+    pill: "bg-f1-background-positive-bold text-f1-foreground-inverse",
+    button:
+      "bg-f1-background hover:bg-f1-background hover:ring-1 hover:ring-inset hover:ring-f1-border-secondary",
+    icon: "positive",
+    solo: "bg-f1-background-positive-bold hover:ring-1 hover:ring-inset hover:ring-f1-border-inverse",
+    soloIcon: "inverse",
+  },
+} as const satisfies Record<
+  RailActionTone,
+  {
+    pill: string
+    button: string
+    icon: F0IconProps["color"]
+    solo: string
+    soloIcon: F0IconProps["color"]
+  }
+>
 
 /**
  * One widget as the collapsed strip shows it: its own catalog glyph, standing in
@@ -213,22 +290,36 @@ const CollapsedGlyph = ({
   // which icon was pressed.
   const actionFace = useFlash(!!action?.flashing && !open)
   /**
-   * THE PILL IS FOR THE STOWED WIDGET. Floating, the card itself is out with the
-   * same reading in full context — and the pill would be a 100px overhang sitting
-   * on top of it, saying it again — so the glyph gives the room back and is simply
-   * its button again.
+   * THE PILL IS FOR THE STOWED WIDGET. Floating, the card is out with the same
+   * reading in full context, so the pill goes and leaves the button it was built
+   * around — which also takes the overhang out of the panel's way.
+   *
+   * THE BUTTON ITSELF DOES NOT CHANGE while that happens. Its colours come from
+   * whether the action HAS a reading, not from whether the pill is drawn right
+   * now (`action.text`, not this) — a control that repaints under the pointer is
+   * one you cannot aim at, and hover is exactly when you are aiming.
    */
   const text = action?.text && !open ? action.text : undefined
+  /** What the state's colour paints — the pill, the button, and its icon. */
+  const tone = RAIL_ACTION_TONES[action?.tone ?? "neutral"]
 
-  /** The genie, identical whichever face the glyph wears. */
+  /**
+   * The genie, identical whichever face the glyph wears.
+   *
+   * EVERY SCALE HERE IS TRANSIENT — arriving, leaving, the press — and none of
+   * them is HELD. A held fractional scale is rasterized once and then stretched:
+   * the glyph's icon and a pill's figures go soft, and they stay soft for as long
+   * as you keep the pointer there, which is exactly when they are being read. The
+   * hover and open states say what they have to say with the panel they open, the
+   * tooltip, and the button's own hover border.
+   */
   const glyphMotion = {
     initial: {
       opacity: 0,
       scale: reducedMotion ? 1 : GENIE_GLYPH_ENTER_SCALE,
     },
-    animate: { opacity: 1, scale: open ? GENIE_GLYPH_OPEN_SCALE : 1 },
+    animate: { opacity: 1, scale: 1 },
     exit: { opacity: 0, scale: reducedMotion ? 1 : GENIE_GLYPH_EXIT_SCALE },
-    whileHover: reducedMotion ? undefined : { scale: GENIE_GLYPH_HOVER_SCALE },
     whileTap: reducedMotion ? undefined : { scale: GENIE_GLYPH_TAP_SCALE },
     transition: withReducedMotion(
       { ...glyphTransition, delay: entranceDelay(order, delayMs) },
@@ -269,7 +360,10 @@ const CollapsedGlyph = ({
             // what the radius scale says a container holding an `lg` control
             // takes. Nothing here is a shape the strip doesn't already use.
             text
-              ? "flex flex-row items-center gap-1 rounded-lg bg-f1-background-inverse p-1 text-f1-foreground-inverse -mr-1"
+              ? cn(
+                  "-mr-1 flex flex-row items-center gap-1 rounded-lg p-1",
+                  tone.pill
+                )
               : "rounded-lg"
           )}
           onMouseEnter={(event) => onOpen(widget.id, event.currentTarget)}
@@ -281,7 +375,10 @@ const CollapsedGlyph = ({
           ) : null}
           <Action
             type="button"
-            variant={action.variant ?? "default"}
+            // `ghost` and then painted: the tone decides this button's fill and
+            // its icon TOGETHER with the pill's, and a variant would bring a
+            // second opinion about both.
+            variant="ghost"
             // THE SAME BUTTON either way — 40px at the strip's own radius,
             // whether it is standing alone as the glyph or sitting at the end of
             // a pill. A reading beside it doesn't make it a different control.
@@ -292,7 +389,10 @@ const CollapsedGlyph = ({
             // control raised off a page; here it reads as a border, and the
             // highlight's own radius is a step tighter than an `lg` button's, so
             // it cuts a visible arc across each corner. The strip is tiles.
-            className="size-10 shadow-none after:hidden active:shadow-none"
+            className={cn(
+              "size-10 shadow-none after:hidden hover:shadow-none active:shadow-none",
+              action.text ? tone.button : tone.solo
+            )}
             // "Resume" on its own doesn't say which glyph this is; the tooltip
             // can lean on the strip for that, an accessible name can't.
             aria-label={`${action.label}, ${widgetTitle(widget)}`}
@@ -300,6 +400,10 @@ const CollapsedGlyph = ({
           >
             <F0Icon
               size="md"
+              // `color` rather than a text class: it marks the svg
+              // `data-has-color`, which is what stops the button variant's own
+              // icon rules from painting over the tone.
+              color={action.text ? tone.icon : tone.soloIcon}
               // No widget icon means no second face to flash to — the action's
               // is the only one there is.
               icon={actionFace || !widget.icon ? action.icon : widget.icon}
@@ -906,7 +1010,18 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             screen instead of being cut short inside the page. */}
         <div
           ref={mainFade.ref}
-          className={cn("relative min-h-0 overflow-y-auto", SCROLLBAR_HIDDEN)}
+          className={cn(
+            // `isolate` — A STACKING CONTEXT OF ITS OWN, and the reason the
+            // floating panel is not buried by the feed. Without it the column is
+            // `relative` at `z-index: auto`, which is no context at all: every
+            // z-index INSIDE it competes at the layout's level, and the content a
+            // Home puts here brings its own (the Ask-AI composer is `z-20`, and
+            // whatever a card does next is not this layout's to know). Isolated,
+            // the whole column is one layer that the panel's `z-10` clears, no
+            // matter what its contents bid.
+            "relative isolate min-h-0 overflow-y-auto",
+            SCROLLBAR_HIDDEN
+          )}
           style={{
             // Placed rather than flowed, because the strip and the rail body
             // BOTH want this row's second column and for a moment mid-collapse
@@ -995,7 +1110,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 // of the feed, eating clicks meant for the cards under it. Each
                 // glyph turns them back on for its own 40px (`pointer-events-auto`).
                 "-m-1 flex min-h-0 flex-col items-end gap-2 overflow-y-auto p-1",
-                "pointer-events-none",
+                // ABOVE THE PANEL (`z-10`): a glyph is what the floating card
+                // came out of, so it stays in front of it — and a pill overhangs
+                // far enough to be half-covered otherwise.
+                "pointer-events-none z-20",
                 SCROLLBAR_HIDDEN
               )}
               style={{

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -366,8 +366,13 @@ const CollapsedGlyph = ({
     // button at the end of it. The pill keeps the strip's 40px HEIGHT — the one
     // dimension the strip's rhythm and the cards' stow are built on — and takes
     // the width it needs off the left, out over the feed.
+    //
+    // The tooltip is `instant`: it is the only place the action's NAME is
+    // written, and the glyph is a control you point at on your way past. The
+    // default 700ms wait is for a label that merely confirms what you can
+    // already read — here it withheld the whole thing.
     return (
-      <Tooltip label={action.label}>
+      <Tooltip label={action.label} instant>
         <motion.div
           className={cn(
             // `pointer-events-auto` against the strip's `none`: a pill is wider

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -13,7 +13,7 @@ import {
   type ModuleId,
 } from "@/components/avatars/F0AvatarModule"
 import type { AvatarSize } from "@/components/avatars/internal/BaseAvatar"
-import { F0Button } from "@/components/F0Button"
+import { F0Button, type F0ButtonProps } from "@/components/F0Button"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { cn } from "@/lib/utils"
 import { Counter } from "@/ui/Counter"
@@ -614,6 +614,66 @@ export const widgetParamsAreComplete = (
   params: WidgetParams | undefined
 ): boolean => (schema ? schema.safeParse(params ?? {}).success : true)
 
+/**
+ * A DIRECT ACTION on a widget's collapsed glyph: the one thing the widget can be
+ * told to do without being opened — resume a paused timer, clock out, join the
+ * call that starts now.
+ *
+ * The glyph BECOMES the button, because 40px is one control's worth of room. So
+ * the widget is still one hover away (hovering or focusing the glyph floats it
+ * over the feed, as any glyph does) and the CLICK is the action's rather than the
+ * panel's.
+ *
+ * Only the COLLAPSED rail draws it. Expanded, the card's own footer button
+ * (`action`) is where a widget's call to action belongs, and stacked (below `md`)
+ * there is no glyph to put it on.
+ */
+export type HomeWidgetRailAction = {
+  /** The action's own glyph — `Play` to resume, `Pause` for a running timer. */
+  icon: IconType
+  /**
+   * What it does, in the imperative ("Resume"): the glyph's tooltip, and half of
+   * its accessible name — the widget's title is the other half, since "Resume"
+   * alone says nothing about which of the strip's glyphs it is.
+   */
+  label: string
+  onClick: () => void
+  /** The button's colour. The accent (`default`) unless you say otherwise. */
+  variant?: F0ButtonProps["variant"]
+  /**
+   * A LIVE READING to put beside the button — the running total, the break you
+   * are on, the minutes left. The glyph grows into a dark PILL to hold it,
+   * overflowing its 40px column leftwards, and the whole strip right-aligns
+   * behind it.
+   *
+   * It is only shown while the widget is STOWED. Hovering floats the card, which
+   * has the same number in full context, so the pill shrinks back to its button
+   * rather than sitting on top of the card repeating itself.
+   *
+   * Keep it SHORT — "7:12" hours and minutes, "0:20" into a break. This is a
+   * glyph, not a status bar, and a digit that changes every second in the corner
+   * of the page is a distraction rather than a reading.
+   */
+  time?: string
+  /**
+   * The reading is COUNTING: its separators blink once a second, the way a clock
+   * does, so a stowed timer is visibly running rather than merely displayed.
+   * Reduced motion holds them lit.
+   */
+  ticking?: boolean
+  /**
+   * THE STATE IS ASKING TO BE ACTED ON — a timer left on a break, a shift you
+   * never clocked out of. The glyph alternates once a second between the
+   * widget's own icon and the action's, so the strip can say which module wants
+   * something AND what it wants without growing a second control.
+   *
+   * It settles on the action's icon while the widget is floating, so what you
+   * click is never the face that happened to be up. Reduced motion is honoured:
+   * the glyph simply stays the button.
+   */
+  flashing?: boolean
+}
+
 /** A widget as handed to the layout: header + an ordered list of slots. */
 export type HomeWidgetItem = HomeWidgetChrome & {
   id: string
@@ -648,6 +708,11 @@ export type HomeWidgetItem = HomeWidgetChrome & {
    * "Add widget" picker, so the strip can never drift from the catalog.
    */
   icon?: IconType
+  /**
+   * The one thing the widget can do FROM THE COLLAPSED RAIL, drawn on its glyph
+   * instead of the catalog `icon`. See `HomeWidgetRailAction`.
+   */
+  railAction?: HomeWidgetRailAction
   /**
    * PINNED: the widget stays put. It offers no "Remove widget" in its menu, it
    * cannot be dragged, and no other widget can displace it — for widgets a user

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -624,6 +624,7 @@ export const railActionTones = [
   "accent",
   "critical",
   "warning",
+  "promote",
   "positive",
 ] as const
 
@@ -661,11 +662,18 @@ export type HomeWidgetRailAction = {
    *
    * - `"neutral"` (the default) — the dark slab, with the accent button on it.
    *   Nothing about the state is remarkable; it is simply running.
-   * - `"accent"`, `"critical"`, `"warning"`, `"positive"` — the pill takes that
-   *   colour and the button becomes a plain chip carrying it in its icon, so the
-   *   two never fight over the same hue.
+   * - `"accent"`, `"critical"`, `"warning"`, `"promote"`, `"positive"` — the pill
+   *   takes that colour and the button becomes a plain chip carrying it in its
+   *   icon, so the two never fight over the same hue.
    *
    * Without a `text` there is no pill, and the tone paints the button itself.
+   *
+   * PICK THE ONE THE WIDGET ALREADY USES. A rail action stands in for a state the
+   * card is also showing, and the semantic tones are the same values that state
+   * is drawn with elsewhere — a clock-in tile pulses `--positive-50` while it
+   * runs and `--promote-50` on a break, which is exactly `"positive"` and
+   * `"promote"` here. Two names for one state is how a glyph ends up a different
+   * green from the card it came out of.
    */
   tone?: RailActionTone
   /**

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -641,24 +641,24 @@ export type HomeWidgetRailAction = {
   /** The button's colour. The accent (`default`) unless you say otherwise. */
   variant?: F0ButtonProps["variant"]
   /**
-   * A LIVE READING to put beside the button — the running total, the break you
-   * are on, the minutes left. The glyph grows into a dark PILL to hold it,
-   * overflowing its 40px column leftwards, and the whole strip right-aligns
-   * behind it.
+   * A READING to put beside the button — a clock's running total or the break
+   * you are on today, but any short string the state can be summed up in. The
+   * glyph grows into a dark PILL to hold it, overflowing its 40px column
+   * leftwards, and the whole strip right-aligns behind it.
    *
    * It is only shown while the widget is STOWED. Hovering floats the card, which
-   * has the same number in full context, so the pill shrinks back to its button
+   * says the same thing in full context, so the pill shrinks back to its button
    * rather than sitting on top of the card repeating itself.
    *
-   * Keep it SHORT — "7:12" hours and minutes, "0:20" into a break. This is a
-   * glyph, not a status bar, and a digit that changes every second in the corner
-   * of the page is a distraction rather than a reading.
+   * Keep it SHORT — "7:12", "0:20", "3 left". This is a glyph, not a status bar,
+   * and anything that has to be read twice does not belong on one.
    */
-  time?: string
+  text?: string
   /**
-   * The reading is COUNTING: its separators blink once a second, the way a clock
-   * does, so a stowed timer is visibly running rather than merely displayed.
-   * Reduced motion holds them lit.
+   * The reading is COUNTING: the separators in `text` blink once a second, the
+   * way a clock does, so a stowed timer is visibly running rather than merely
+   * displayed. Reduced motion holds them lit, and a `text` with nothing to
+   * separate simply stands still.
    */
   ticking?: boolean
   /**

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -13,7 +13,7 @@ import {
   type ModuleId,
 } from "@/components/avatars/F0AvatarModule"
 import type { AvatarSize } from "@/components/avatars/internal/BaseAvatar"
-import { F0Button, type F0ButtonProps } from "@/components/F0Button"
+import { F0Button } from "@/components/F0Button"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { cn } from "@/lib/utils"
 import { Counter } from "@/ui/Counter"
@@ -615,6 +615,21 @@ export const widgetParamsAreComplete = (
 ): boolean => (schema ? schema.safeParse(params ?? {}).success : true)
 
 /**
+ * The colours a rail action's chip can take, by what the state MEANS rather than
+ * by hue: the same five a tag or a banner picks from, so a red pill in the rail
+ * is red for the same reason a red tag is.
+ */
+export const railActionTones = [
+  "neutral",
+  "accent",
+  "critical",
+  "warning",
+  "positive",
+] as const
+
+export type RailActionTone = (typeof railActionTones)[number]
+
+/**
  * A DIRECT ACTION on a widget's collapsed glyph: the one thing the widget can be
  * told to do without being opened — resume a paused timer, clock out, join the
  * call that starts now.
@@ -638,17 +653,30 @@ export type HomeWidgetRailAction = {
    */
   label: string
   onClick: () => void
-  /** The button's colour. The accent (`default`) unless you say otherwise. */
-  variant?: F0ButtonProps["variant"]
+  /**
+   * WHAT COLOUR THE STATE IS. One tone paints the whole chip — the pill behind
+   * the reading and the button at the end of it — because they are one object,
+   * and two colours picked separately is how you end up with a red button on an
+   * amber pill.
+   *
+   * - `"neutral"` (the default) — the dark slab, with the accent button on it.
+   *   Nothing about the state is remarkable; it is simply running.
+   * - `"accent"`, `"critical"`, `"warning"`, `"positive"` — the pill takes that
+   *   colour and the button becomes a plain chip carrying it in its icon, so the
+   *   two never fight over the same hue.
+   *
+   * Without a `text` there is no pill, and the tone paints the button itself.
+   */
+  tone?: RailActionTone
   /**
    * A READING to put beside the button — a clock's running total or the break
    * you are on today, but any short string the state can be summed up in. The
    * glyph grows into a dark PILL to hold it, overflowing its 40px column
    * leftwards, and the whole strip right-aligns behind it.
    *
-   * It is only shown while the widget is STOWED. Hovering floats the card, which
-   * says the same thing in full context, so the pill shrinks back to its button
-   * rather than sitting on top of the card repeating itself.
+   * It is only drawn while the widget is STOWED. Hovering floats the card, which
+   * says the same thing in full context, so the pill gives its width back and
+   * leaves the button — the one part of it you can act on.
    *
    * Keep it SHORT — "7:12", "0:20", "3 left". This is a glyph, not a status bar,
    * and anything that has to be read twice does not belong on one.


### PR DESCRIPTION
## Description

A rail widget can now carry a `railAction`, and the collapsed strip draws that action's button as its glyph — so a paused timer can be resumed, or a break taken, without opening the card. The action can bring a short reading with it, which grows the glyph into a pill; a `tone` paints that pill and its button together, so the state has a colour before its number has been read; and `flashing` alternates the icon once a second for a state that is asking to be acted on. All three come from the time-tracking rail design, but the layout stays generic: it draws the icon, label, reading, colour and two flags it is handed.

## Adding it to a widget you already have

Nothing about an existing widget changes — you add one field to the `HomeWidgetItem` you already pass to `rightWidgets`, and derive it from whatever state the widget's own tile is driven by:

```tsx
const clockIn: HomeWidgetItem = {
  id: "clock-in",
  icon: Clock, // still the catalog glyph, and the flash's other face
  header: { title: "Clock in" },
  slots: [{ visualization: "clock-in", params: {} }],

  // ↓ the only new part
  railAction:
    status === "break"
      ? {
          icon: SolidPlay,
          label: "Resume", // tooltip, and half the accessible name
          onClick: () => resume(),
          text: hhmm(onBreak), // a reading → the glyph becomes a pill
          ticking: true, // blink its separator like a clock
          tone: "promote", // the tile's own amber, on the pill and in the icon
          flashing: true, // a state asking to be acted on
        }
      : {
          icon: SolidPause,
          label: "Take a break",
          onClick: () => takeABreak(),
          text: hhmm(worked),
          ticking: true,
          tone: "positive", // the tile's own green
        },
}
```

Worth knowing when you wire one up:

- **It is drawn only in the COLLAPSED rail.** Expanded, the card's own footer `action` is where a call to action belongs; stacked (below `md`) there is no glyph at all. Nothing else about the widget changes.
- **The click stops opening the panel** — hover and focus still float the card, so the widget is never more than a hover away. The pill gives its width back while the card is out; the button does not change.
- **The app owns the clock.** `text` is just a short string the rail draws — a clock reading is only the first use of it. Keep it to hours and minutes (`"7:12"`), not seconds; the blink is what says it is running.
- **`tone`** is one decision for the whole chip: `"neutral"` (default) is the dark slab with an accent button, and `"accent"` / `"critical"` / `"warning"` / `"promote"` / `"positive"` colour the pill and leave the button a plain chip carrying that colour in its icon. **Pick the one the widget already uses** — the semantic tones are the same values the card draws that state with, so a clock-in glyph is the same green as the tile beside it.
- Omit `railAction` and the glyph is exactly what it is today.

## Implementation details

- feat: add `HomeWidgetRailAction` (`icon`, `label`, `onClick`) on `HomeWidgetItem` — the collapsed glyph becomes that action's button

  <details>
  <summary>Why the glyph BECOMES the button</summary>

  40px is one control's worth of room, and nesting a button inside the glyph button would be invalid markup. So there is one control: hover and focus still float the widget over the feed, and the click is the action's rather than the panel's. Focus was added as an opener precisely because the click is now spoken for — a keyboard user reaching the glyph still gets to the card's own controls, which are next in the tab order.
  </details>

- feat: add `text` + `ticking` — the glyph grows into a pill holding a short reading, its separators blinking once a second like a clock

  <details>
  <summary>Geometry and pointer events</summary>

  The pill keeps the strip's 40px height — the dimension the glyph rhythm and the cards' stow animation are built on — and takes its width off the left, out over the feed. The strip therefore right-aligns and takes no pointer events, with each glyph turning them back on for its own 40px, so a pill's overhang never becomes a dead margin eating clicks meant for the feed.

  The blink is opacity only, so the string stays whole in the accessibility tree ("7:12", not "7 12"), and the reading is `tabular-nums` so a digit rolling over doesn't jog the pill.
  </details>

- feat: add `tone` — one word paints the pill and its button, by what the state means

  <details>
  <summary>Why one prop rather than two colours</summary>

  The pill and the button are one object. Picked separately, they are how you end up with a red button on an amber pill. Each tone therefore says three things at once: the pill's fill, the button's fill, and the icon's colour — and every coloured tone turns the button into a plain chip carrying the colour in its icon, so the two halves never put two strong hues side by side.

  The set is the semantic one (`accent`, `critical`, `warning`, `promote`, `positive`) rather than a palette, so a rail action can take the exact colour its own widget already uses for that state — `promote` is in the table because a clock-in tile pulses `--promote-50` on a break, and an approximate `warning` would have been a different yellow from the card two centimetres away.
  </details>

- feat: add `flashing` — the glyph alternates once a second between the widget's icon and the action's, settling on the action's face while the card floats and never alternating under `prefers-reduced-motion`
- feat: `ClockInControls` draws its status pulse in the `horizontal-bar` variant too, beside the same words

  <details>
  <summary>Why the bar variant should have had it</summary>

  It was left out on the grounds that the bar below carries the same colour — but a bar says what the day HAS been, and the pulse says it is still going. It is the only thing on the tile that moves while the clock runs, and the rail's glyph is not always in view to say it instead. Both variants now draw one `StatusPulse`; it keeps the dot and drops the halo under `prefers-reduced-motion`, since a signal that repeats forever is exactly the kind that has to be able to hold still.
  </details>

- fix: keep the floating card above the main column — the column now isolates, so a widget's internals cannot out-bid the panel

  <details>
  <summary>What was wrong</summary>

  The column was `relative` at `z-index: auto`, which is no stacking context at all: every z-index inside it competed at the layout's level, and Home's own Ask-AI composer is `z-20` against the panel's `z-10`, so the card came out underneath the feed. Isolated, the whole column is one layer the panel clears — and the strip clears the panel, since a glyph is what the card came out of.
  </details>

- fix: stop the chip repainting itself on hover — `tailwind-merge` settles classes per variant, so a plain `bg-*` left the button variant's `hover:bg-*` standing and the page's hover tint over a bold pill read as the button going see-through
- fix: nothing scales under the pointer any more — a held fractional scale is rasterized once and stretched, so the glyph's icon and the pill's figures stayed soft for as long as you pointed at them; the hover border is the feedback instead, in the strip's own `f1-border-secondary`
- fix: drop the action button's elevation chrome in the strip — the drop shadow and the `::after` top highlight read as a border, and that highlight's radius is a step tighter than an `lg` button's, cutting an arc across each corner
- test: cover the action glyph (naming, click vs. panel, hover/focus, flash cadence, collapsed-only), the pill (reading, width handed back on hover with the button unchanged, separator blink), the tones, the pinned hover fill, and the three-layer stacking contract
- docs: add the `Glyph Action` story — clocked in (green), on a break (amber), clocked out (the dark slab holding the day's total), driven from either the glyph or the tile's own controls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
