### PR TITLE
fix(F0Dialog): stop scrollable content from squeezing the tabs strip

### DIFF
--- a/packages/react/src/patterns/F0Dialog/__tests__/F0Dialog.tabs-strip.test.tsx
+++ b/packages/react/src/patterns/F0Dialog/__tests__/F0Dialog.tabs-strip.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0Dialog } from "../index"
+
+describe("patterns F0Dialog tabs strip", () => {
+  const tabs = [
+    { id: "pending", label: "Pending" },
+    { id: "acknowledged", label: "Acknowledged" },
+  ]
+
+  const renderWithTabs = () =>
+    render(
+      <F0Dialog
+        isOpen
+        onClose={vi.fn()}
+        title="Acknowledgements"
+        tabs={tabs}
+        activeTabId="pending"
+        setActiveTabId={vi.fn()}
+      >
+        <div>content</div>
+      </F0Dialog>
+    )
+
+  it("keeps the clipping wrapper unshrinkable so scrollable content cannot squeeze the tabs", () => {
+    renderWithTabs()
+
+    const strip = screen.getByRole("navigation").closest("div.overflow-hidden")
+
+    expect(strip).not.toBeNull()
+    expect(strip).toHaveClass("shrink-0")
+  })
+})

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
@@ -101,7 +101,7 @@ export const F0DialogHeader = ({
 
   const TabsStrip = () =>
     tabs ? (
-      <div className="overflow-hidden">
+      <div className="shrink-0 overflow-hidden">
         <div className="-mx-2">
           <Tabs
             tabs={tabs}


### PR DESCRIPTION
## 🚪 Why?

When an `F0Dialog` has `tabs` and the content is tall enough to scroll, the tab strip gets squeezed. The taller the content, the smaller the strip. With a long list it disappears and the list is drawn where the tabs used to be.

This is not app specific. On plain `main`, in this repo's own `Patterns/Dialog > With Person List Items` story:

<img width="782" height="318" alt="image" src="https://github.com/user-attachments/assets/b50e4775-34f0-4c2c-9e3f-453c76d3308c" />

## 🔑 What?

`shrink-0` on that div, so the strip keeps its height and the scroll area takes the overflow. The divider clipping from #4463 still works.

[FCT-61502]: https://factorialmakers.atlassian.net/browse/FCT-61502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Before

<img width="693" height="328" alt="image" src="https://github.com/user-attachments/assets/1c7ff2d9-0691-43ad-9d5e-6aeb712384ca" />

## After

<img width="702" height="274" alt="image" src="https://github.com/user-attachments/assets/62d170fb-868f-4544-8116-81975ab59d6f" />
