### PR TITLE
ci(storybook): shard tests across 8 runners and fix the red table story

### DIFF
--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -9,27 +9,37 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  # Number of machines the ~2.3k stories are split across. MUST match the length
+  # of `strategy.matrix.shard` below — GitHub can't derive one from the other, so
+  # they are kept in sync by hand. Raising it shortens the run but every shard
+  # pays the same ~3.5min of fixed setup (checkout, install, Playwright,
+  # Storybook build), so the returns flatten quickly past ~4-6.
+  SHARD_TOTAL: 4
+
 jobs:
   # Detect which projects have changed
   detect-changes:
     uses: ./.github/workflows/_check-workspaces-changes.yaml
   test:
     needs: detect-changes
-    name: "[⚛️ REACT] Storybook Tests"
+    name: "[⚛️ REACT] Storybook Tests (${{ matrix.shard }}/4)"
     if: |
       needs.detect-changes.outputs.package_react == 'true' &&
       github.head_ref != 'release-please--branches--master' &&
       !contains(github.event.pull_request.labels.*.name, 'autorelease')
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
+    strategy:
+      # Every shard should report — a failure in one is not a reason to hide the
+      # results (or the a11y debt) found by the others.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
-        with:
-          # Full history so the a11y comment can diff changed files vs main.
-          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Get Playwright version
         id: playwright-version
@@ -53,30 +63,77 @@ jobs:
           pnpm --filter @factorialco/f0-core build
           pnpm --filter @factorialco/f0-react run build-storybook --quiet
 
+      # `--shard` is forwarded to Jest, which splits by *test file* (one file per
+      # CSF module). Balance is therefore approximate: the heaviest single suite
+      # is ~50s, so shards land within a few tens of seconds of each other.
       - name: Serve Storybook and run tests
         id: run_tests
-        env:
-          DEBUG: vite
-          VITEST_LOG_LEVEL: debug
         run: |
           pnpx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
              "pnpx http-server packages/react/storybook-static --port 6006 --silent" \
-             "pnpx wait-on http://localhost:6006 --timeout 60000 && sleep 2 && pnpm --filter @factorialco/f0-react test-storybook"
+             "pnpx wait-on http://localhost:6006 --timeout 60000 && sleep 2 && pnpm --filter @factorialco/f0-react test-storybook --shard=${{ matrix.shard }}/${{ env.SHARD_TOTAL }}"
 
-      # Turn the a11y violations captured during the run into a PR comment,
-      # scoped to the stories/components this PR changed. Runs whenever the
-      # tests actually executed (pass or fail — enforced failures still count),
-      # but not when Storybook failed to build (run_tests skipped).
+      # Each shard only sees the stories it ran, so the JSONL is partial. The
+      # a11y-comment job below stitches the shards back together.
+      - name: Upload a11y violations
+        if: always() && steps.run_tests.outcome != 'skipped'
+        uses: actions/upload-artifact@v4
+        with:
+          name: a11y-violations-${{ matrix.shard }}
+          path: packages/react/a11y-violations.jsonl
+          if-no-files-found: ignore
+          retention-days: 1
+
+  # Turn the a11y violations captured across all shards into a single PR
+  # comment, scoped to the stories/components this PR changed. Runs whenever the
+  # tests actually executed (pass or fail — enforced failures still count), but
+  # not when the test job was skipped entirely.
+  a11y-comment:
+    needs: [detect-changes, test]
+    name: "[⚛️ REACT] a11y PR comment"
+    if: >
+      always() && needs.test.result != 'skipped' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so the a11y comment can diff changed files vs main.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+      # No `merge-multiple` — every shard names its file `a11y-violations.jsonl`,
+      # so merging would have them overwrite each other. Downloading into
+      # per-artifact subdirectories keeps all four, and `cat` concatenates them
+      # (the format is one self-contained JSON object per line).
+      - name: Download a11y violations from all shards
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          pattern: a11y-violations-*
+          path: /tmp/a11y-shards
+      - name: Merge shard artifacts
+        run: |
+          shopt -s nullglob
+          files=(/tmp/a11y-shards/*/a11y-violations.jsonl)
+          if [ ${#files[@]} -eq 0 ]; then
+            echo "No a11y violation artifacts found — nothing to report."
+            exit 0
+          fi
+          cat "${files[@]}" > packages/react/a11y-violations.jsonl
+          echo "Merged ${#files[@]} shard(s), $(wc -l < packages/react/a11y-violations.jsonl) violating stories."
       - name: Build a11y comment for changed components
         id: a11y_comment
-        if: >
-          always() && steps.run_tests.outcome != 'skipped' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         run: |
+          [ -f packages/react/a11y-violations.jsonl ] || exit 0
           git fetch origin main --quiet || true
-          pnpm --filter @factorialco/f0-react exec tsx .scripts/check-a11y-comment.ts \
+          npx --yes tsx@4 packages/react/.scripts/check-a11y-comment.ts \
             --compare-commit origin/main > /tmp/a11y-output.txt 2>&1 || true
           LAST_JSON_LINE=$(grep -n '^{' /tmp/a11y-output.txt | tail -n 1 | cut -d: -f1)
           if [ -n "$LAST_JSON_LINE" ]; then
@@ -89,10 +146,7 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
       - name: Post a11y PR comment
-        if: >
-          always() && steps.a11y_comment.outputs.body != '' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
+        if: always() && steps.a11y_comment.outputs.body != ''
         continue-on-error: true
         uses: ./.github/actions/add-or-update-pr-comment
         with:

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -55,13 +55,21 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
+          # `-chromium` in the key: the cache now holds only the one browser we
+          # launch, so it must not restore an older all-browsers entry.
+          key: playwright-chromium-${{ steps.playwright-version.outputs.version }}-${{ runner.os }}
           restore-keys: |
-            playwright-browsers-${{ steps.playwright-version.outputs.version }}-
-            playwright-browsers-
+            playwright-chromium-${{ steps.playwright-version.outputs.version }}-
+            playwright-chromium-
+      # Chromium only. The test-runner never launches anything else (TEST_BROWSERS
+      # is unset, so it defaults to chromium), but a bare `install --with-deps`
+      # apt-installs the WebKit and Firefox system libraries too — the gstreamer
+      # /fluidsynth/rav1e pile. That apt step runs even on a browser-cache hit
+      # and was the least predictable part of the job, measured between 27s and
+      # 121s across the 8 shards of run 32146702636.
       - name: Install Playwright
         run: |
-          pnpx playwright@${{ steps.playwright-version.outputs.version }} install --with-deps
+          pnpx playwright@${{ steps.playwright-version.outputs.version }} install --with-deps chromium
       - name: Build Storybook
         run: |
           pnpm --filter @factorialco/f0-core build

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -12,10 +12,14 @@ concurrency:
 env:
   # Number of machines the ~2.3k stories are split across. MUST match the length
   # of `strategy.matrix.shard` below — GitHub can't derive one from the other, so
-  # they are kept in sync by hand. Raising it shortens the run but every shard
-  # pays the same ~3.5min of fixed setup (checkout, install, Playwright,
-  # Storybook build), so the returns flatten quickly past ~4-6.
-  SHARD_TOTAL: 4
+  # they are kept in sync by hand.
+  #
+  # 8 is about the end of the useful range. Every shard pays the same ~4.3min of
+  # fixed cost before it runs a single story (~90s install + ~40s Playwright +
+  # ~170s Storybook build), and at 8 shards the test step is already down to
+  # ~2min — so past here the build, not the tests, is what the job waits on.
+  # Measured at 4 shards: 236/245/277/172s of test time.
+  SHARD_TOTAL: 8
 
 jobs:
   # Detect which projects have changed
@@ -23,7 +27,7 @@ jobs:
     uses: ./.github/workflows/_check-workspaces-changes.yaml
   test:
     needs: detect-changes
-    name: "[⚛️ REACT] Storybook Tests (${{ matrix.shard }}/4)"
+    name: "[⚛️ REACT] Storybook Tests (${{ matrix.shard }}/8)"
     if: |
       needs.detect-changes.outputs.package_react == 'true' &&
       github.head_ref != 'release-please--branches--master' &&
@@ -35,7 +39,7 @@ jobs:
       # results (or the a11y debt) found by the others.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
     permissions:
       contents: read
     steps:
@@ -64,8 +68,11 @@ jobs:
           pnpm --filter @factorialco/f0-react run build-storybook --quiet
 
       # `--shard` is forwarded to Jest, which splits by *test file* (one file per
-      # CSF module). Balance is therefore approximate: the heaviest single suite
-      # is ~50s, so shards land within a few tens of seconds of each other.
+      # CSF module) using a hash of the file path — so shards get an even file
+      # *count*, not an even duration. The heaviest single suite is ~50s, which
+      # is the floor on how balanced this can get; at 8 shards that outlier is a
+      # visible fraction of a ~2min shard. Balancing by measured duration would
+      # need a custom Jest testSequencer.
       - name: Serve Storybook and run tests
         id: run_tests
         run: |
@@ -83,6 +90,40 @@ jobs:
           path: packages/react/a11y-violations.jsonl
           if-no-files-found: ignore
           retention-days: 1
+
+  # Single job to gate the branch on, so protection rules do not have to list
+  # every shard (and do not need editing when SHARD_TOTAL changes). It keeps the
+  # name the unsharded job used to have, so it is a drop-in for anything that
+  # already referenced "[⚛️ REACT] Storybook Tests".
+  #
+  # `if: always()` is load-bearing. Without it a failing shard makes this job
+  # *skipped* rather than *failed*, and a skipped check is not a red check — the
+  # gate would silently pass. So it always runs and inspects the results itself.
+  #
+  # `skipped` is deliberately accepted: detect-changes legitimately skips the
+  # whole matrix when the react package is untouched. Only failure/cancellation
+  # is fatal. a11y-comment is intentionally *not* gated on — it is a best-effort
+  # PR comment and is not worth blocking a merge over.
+  storybook-tests-passed:
+    needs: [detect-changes, test]
+    name: "[⚛️ REACT] Storybook Tests"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm every shard passed
+        env:
+          RESULTS: ${{ join(needs.*.result, ' ') }}
+        run: |
+          echo "Dependency results: $RESULTS"
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ]; then
+            echo "::error::At least one Storybook Tests shard failed."
+            exit 1
+          fi
+          if [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "::error::At least one Storybook Tests shard was cancelled."
+            exit 1
+          fi
+          echo "All Storybook Tests shards passed (or were skipped)."
 
   # Turn the a11y violations captured across all shards into a single PR
   # comment, scoped to the stories/components this PR changed. Runs whenever the

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -92,9 +92,8 @@ jobs:
           retention-days: 1
 
   # Single job to gate the branch on, so protection rules do not have to list
-  # every shard (and do not need editing when SHARD_TOTAL changes). It keeps the
-  # name the unsharded job used to have, so it is a drop-in for anything that
-  # already referenced "[⚛️ REACT] Storybook Tests".
+  # every shard, and does not need editing when SHARD_TOTAL changes. Named to
+  # match the "✅ …" gate every other PR workflow now exposes.
   #
   # `if: always()` is load-bearing. Without it a failing shard makes this job
   # *skipped* rather than *failed*, and a skipped check is not a red check — the
@@ -106,7 +105,7 @@ jobs:
   # PR comment and is not worth blocking a merge over.
   storybook-tests-passed:
     needs: [detect-changes, test]
-    name: "[⚛️ REACT] Storybook Tests"
+    name: "✅ Storybook Tests"
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/packages/react/.storybook/test-runner.ts
+++ b/packages/react/.storybook/test-runner.ts
@@ -270,23 +270,36 @@ const config: TestRunnerConfig = {
       // Apply story-level a11y rules
       await configureAxe(page, a11yConfig)
 
-      // Add a longer delay to ensure previous axe run is complete
-      await page.waitForTimeout(500)
+      // Let the story settle before scanning, then make sure no axe run is
+      // still in flight.
+      //
+      // This used to be a flat `page.waitForTimeout(500)` followed by a polling
+      // loop. At ~2.3k stories that fixed sleep was ~19 minutes of pure idling
+      // spread across the CI workers — around 40% of the whole job. Both waits
+      // are now deterministic and finish in a frame or two:
+      //
+      //  - two `requestAnimationFrame` ticks let layout/entry animations reach
+      //    their committed state, which is what the sleep was really buying us
+      //    (axe reads computed styles for contrast and target-size);
+      //  - `waitForFunction` on `axe.isRunning` replaces the hand-rolled 100ms
+      //    poll, so a concurrent run is awaited exactly as long as it needs.
+      //
+      // A11Y_SETTLE_MS restores an extra flat delay if a component turns out to
+      // need one, without another round-trip through this file.
+      await page.evaluate(
+        (extraMs) =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() =>
+              requestAnimationFrame(() =>
+                extraMs > 0 ? setTimeout(resolve, extraMs) : resolve()
+              )
+            )
+          }),
+        Number(process.env.A11Y_SETTLE_MS ?? 0)
+      )
 
-      // Ensure any previous axe runs are complete
-      await page.evaluate(() => {
-        if (window.axe?.isRunning) {
-          return new Promise((resolve) => {
-            const checkRunning = () => {
-              if (!window.axe?.isRunning) {
-                resolve(true)
-              } else {
-                setTimeout(checkRunning, 100)
-              }
-            }
-            checkRunning()
-          })
-        }
+      await page.waitForFunction(() => !window.axe?.isRunning, undefined, {
+        timeout: 10_000,
       })
 
       // Get violations without throwing an error. The rule scope is shared with

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1867,12 +1867,23 @@ export const CellsOfDifferentHeightsShareOneCenter: Story = {
         .map(firstLineCenter)
         .filter((center): center is number => center !== null)
 
-    /** The first data row of the table under the given caption. */
-    const rowUnder = async (caption: string) => {
-      const heading = await canvas.findByRole("heading", { name: caption })
-      const table = heading.parentElement!.querySelector("table")!
-      return within(table).getAllByRole("row")[1] as HTMLTableRowElement
-    }
+    /**
+     * The first data row of the table under the given caption.
+     *
+     * The heading renders on the first paint but the collection does not: while
+     * it loads, the table is an `aria-hidden` `role="presentation"` skeleton
+     * with no accessible rows. Awaiting the heading therefore proves nothing, so
+     * retry the row lookup (re-querying the table each time) until the real rows
+     * are there.
+     */
+    const rowUnder = (caption: string) =>
+      waitFor(async () => {
+        const heading = await canvas.findByRole("heading", { name: caption })
+        const table = heading.parentElement!.querySelector("table")!
+        const [, firstDataRow] = within(table).getAllByRole("row")
+        expect(firstDataRow).toBeInTheDocument()
+        return firstDataRow as HTMLTableRowElement
+      })
 
     const textOnly = await rowUnder("Text only")
     const withLongText = await rowUnder("With a long text")


### PR DESCRIPTION
## Description

The Storybook Tests job took ~20 minutes, 16 of them in a single test step, and `main` was red on top of that. This shards the run across 8 machines, collapses the shards back into one status check, and fixes the story that has been failing in CI since #5154. Measured end to end: **20m17s → 9m54s (−51%)**, with the test step itself down **−85%**.

## Implementation details

- fix: make the `CellsOfDifferentHeightsShareOneCenter` row lookup wait for loaded rows

  <details>
  <summary>Why it was failing</summary>

  `rowUnder` awaited the caption heading — present from the first paint — then ran a *synchronous* `getAllByRole("row")` on a table that is still an `aria-hidden` `role="presentation"` skeleton while the collection loads. So it threw `Unable to find an accessible element with the role "row"`.

  This has failed on **every CI run since #5154** ([`bc06d99a4`](https://github.com/factorialco/f0/commit/bc06d99a4)), including that PR's own run before it merged, so `main` has been red since. It passes locally, which is how it got through.

  Verified red→green by giving the story's adapter a 300ms delay: the old code reproduces the CI error verbatim, the new code gets past it. Confirmed on this PR's run — `PASS src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx (41.154 s)`.
  </details>

- ci: shard the run across 8 runners via `--shard=N/8`

  <details>
  <summary>Measured, and why 8 is the end of the useful range</summary>

  | | Job | Test step |
  |---|---|---|
  | Before (1 machine) | 20m 17s | 16m 12s |
  | 4 shards | 11m 18s | 172–277s |
  | 8 shards | **9m 54s** | **82–143s** |

  Jest shards by test file using a hash of the path, so shards get an even file *count*, not an even duration — hence the spread. `--shard` is forwarded straight to Jest and `JEST_SHARD` only gates coverage reporting, which this repo does not use.

  4→8 only bought ~1.4min because the test step is no longer the long pole: per shard it is now ~2min against a ~2.5min Storybook build plus ~1.5min of setup. Each shard builds its own Storybook on purpose — sharing one `storybook-static` artifact would serialise build→test and came out slower on these numbers.
  </details>

- ci: install only Chromium, the one browser the runner launches

  <details>
  <summary>Why</summary>

  `playwright install --with-deps` apt-installs the WebKit and Firefox system libraries too (the gstreamer/fluidsynth/rav1e pile), and that apt step runs even when the browser cache hits. Across the 8 shards it measured between 27s and 121s — the least predictable part of the job. The test-runner never launches anything else (`TEST_BROWSERS` is unset, so it defaults to chromium). The cache key gains a `-chromium` segment so it cannot restore an older all-browsers entry.
  </details>

- perf: replace the flat 500ms per-story sleep in `postVisit` with a double `requestAnimationFrame` + `waitForFunction` on `axe.isRunning`

  <details>
  <summary>Worth ~4%, not the 40% the worker-seconds suggested</summary>

  The sleep guarded nothing — `preVisit` re-evals the whole axe bundle before every story, so there is never a leftover run to wait for. What it bought was settle time, since axe reads computed styles for contrast and `target-size`; two rAF ticks give that deterministically in ~2ms measured against real Chromium.

  It looked like 1136 worker-seconds (2271 stories × 500ms, ~40% of the job's work), but it delivered only ~4%: per-test cost per machine went 0.425s → 0.408s. While one worker slept its Chromium sat idle and the other two got the CPU, so most of that idle was already being absorbed. Keeping the change because a deterministic wait beats a magic constant, but it is not where the win came from. `A11Y_SETTLE_MS` restores a flat delay if a component ever needs one.
  </details>

- ci: add a `✅ Storybook Tests` gate job so branch protection can require one check instead of 8 shards

  <details>
  <summary>`if: always()` is load-bearing</summary>

  Without it, a failing shard leaves the gate *skipped* rather than *failed*, and GitHub counts a skipped required check as satisfied — the gate would go green over a red build. This was confirmed accidentally: a push cancelled a run mid-flight and the gate correctly reported `Dependency results: success cancelled` → red.

  `skipped` is accepted deliberately, since `detect-changes` skips the matrix when the react package is untouched. `a11y-comment` is not gated on — it is a best-effort PR comment.
  </details>

- ci: upload `a11y-violations.jsonl` per shard and merge it in a downstream job

  <details>
  <summary>Why</summary>

  Each shard only visits its own stories, so its JSONL is partial and the comment would silently lose most of the picture. The new job concatenates all shards — deliberately without `merge-multiple`, since every shard names its file identically and merging would have them overwrite each other. Verified: `Merged 8 shard(s)`, comment posted. It runs the existing check script via `npx --yes tsx@4` rather than a full workspace install, keeping the serial tail to ~50s.
  </details>

- chore: drop the leftover `DEBUG: vite` / `VITEST_LOG_LEVEL: debug`, narrow the test job to a shallow checkout and `contents: read`, lower `timeout-minutes` 60 → 30

## Notes for the reviewer

Everything above is measured on this branch, not projected — baseline run [32135954686](https://github.com/factorialco/f0/actions/runs/32135954686), 8-shard run [32146702636](https://github.com/factorialco/f0/actions/runs/32146702636) (all 8 shards green).

The gate job is not enforced by this PR. It becomes a gate only once added to the ruleset's required status checks, which is a settings change — #5164 adds the equivalent gates to the other five PR workflows.

**The remaining bottleneck is the Storybook build, and most of it is one file.** `public/Big_Buck_Bunny_alt.webm` is 45MB in git, and copying it as a `staticDirs` entry took **33s on one run and 71s on another** out of a ~150s build, on every shard. Re-encoding it to a few MB would cut that from every Storybook build in the repo — chromatic and the deploy included — not just this job. It is a binary fixture change with its own risk (the a11y caption rule reads embedded tracks) so it is not in this PR.

Second remaining item: `injectAxe` re-reads and re-evals the 560KB axe bundle on *every* story (~22ms local) even though the page persists across stories within a file. Making it conditional is easy, but each story currently gets a fresh axe and `configureAxe` runs per-story, so skipping re-injection would leak one story's rule config into the next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)