### PR TITLE
ci: add one aggregate gate job per PR workflow

### DIFF
--- a/.github/workflows/api-surface.yaml
+++ b/.github/workflows/api-surface.yaml
@@ -180,3 +180,32 @@ jobs:
                 core.info(`Label "${label}" not present; nothing to remove`);
               }
             }
+
+  # Single check to gate the branch on. It collapses this workflow's jobs into
+  # one status, so branch protection lists one stable name and never needs
+  # editing when jobs are added, removed, renamed or sharded.
+  #
+  # `if: always()` is load-bearing. Without it a failing dependency leaves this
+  # job *skipped* rather than *failed*, and GitHub counts a skipped required
+  # check as satisfied — the gate would go green over a red build.
+  #
+  # `skipped` is accepted on purpose: detect-changes skips the jobs for a
+  # package that this PR did not touch. Only failure/cancellation is fatal.
+  api-surface-passed:
+    needs: [detect-changes, build-dts, api-diff]
+    name: "✅ API Surface"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm every API Surface check passed
+        run: |
+          echo "Dependency results: ${{ join(needs.*.result, ' ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::A API Surface check failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::A API Surface check was cancelled."
+            exit 1
+          fi
+          echo "All API Surface checks passed (or were skipped as not applicable)."

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -53,3 +53,32 @@ jobs:
           review-url: ${{ steps.chromatic.outputs.url }}
           build-url: ${{ steps.chromatic.outputs.buildUrl }}
           storybook-url: ${{ steps.chromatic.outputs.storybookUrl }}
+
+  # Single check to gate the branch on. It collapses this workflow's jobs into
+  # one status, so branch protection lists one stable name and never needs
+  # editing when jobs are added, removed, renamed or sharded.
+  #
+  # `if: always()` is load-bearing. Without it a failing dependency leaves this
+  # job *skipped* rather than *failed*, and GitHub counts a skipped required
+  # check as satisfied — the gate would go green over a red build.
+  #
+  # `skipped` is accepted on purpose: detect-changes skips the jobs for a
+  # package that this PR did not touch. Only failure/cancellation is fatal.
+  chromatic-passed:
+    needs: [detect-changes, chromatic]
+    name: "✅ Chromatic"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm every Chromatic check passed
+        run: |
+          echo "Dependency results: ${{ join(needs.*.result, ' ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::A Chromatic check failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::A Chromatic check was cancelled."
+            exit 1
+          fi
+          echo "All Chromatic checks passed (or were skipped as not applicable)."

--- a/.github/workflows/ownership.yaml
+++ b/.github/workflows/ownership.yaml
@@ -21,3 +21,32 @@ jobs:
         run: pnpm install --filter @factorialco/f0-ownership --ignore-scripts
       - name: Run ownership checks
         run: pnpm --filter @factorialco/f0-ownership run check
+
+  # Single check to gate the branch on. It collapses this workflow's jobs into
+  # one status, so branch protection lists one stable name and never needs
+  # editing when jobs are added, removed, renamed or sharded.
+  #
+  # `if: always()` is load-bearing. Without it a failing dependency leaves this
+  # job *skipped* rather than *failed*, and GitHub counts a skipped required
+  # check as satisfied — the gate would go green over a red build.
+  #
+  # `skipped` is accepted on purpose: detect-changes skips the jobs for a
+  # package that this PR did not touch. Only failure/cancellation is fatal.
+  ownership-passed:
+    needs: [check]
+    name: "✅ Ownership"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm every Ownership check passed
+        run: |
+          echo "Dependency results: ${{ join(needs.*.result, ' ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::A Ownership check failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::A Ownership check was cancelled."
+            exit 1
+          fi
+          echo "All Ownership checks passed (or were skipped as not applicable)."

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -279,3 +279,32 @@ jobs:
           comment-type: cycle_dependency
           github-token: ${{ secrets.GITHUB_TOKEN }}
           comment-body: ${{ steps.comment.outputs.body }}
+
+  # Single check to gate the branch on. It collapses this workflow's jobs into
+  # one status, so branch protection lists one stable name and never needs
+  # editing when jobs are added, removed, renamed or sharded.
+  #
+  # `if: always()` is load-bearing. Without it a failing dependency leaves this
+  # job *skipped* rather than *failed*, and GitHub counts a skipped required
+  # check as satisfied — the gate would go green over a red build.
+  #
+  # `skipped` is accepted on purpose: detect-changes skips the jobs for a
+  # package that this PR did not touch. Only failure/cancellation is fatal.
+  quality-passed:
+    needs: [detect-changes, format, format-react-native, lint, lint-react-native, stable-dod, new-component-dod, cycle-dependencies]
+    name: "✅ Quality"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm every Quality check passed
+        run: |
+          echo "Dependency results: ${{ join(needs.*.result, ' ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::A Quality check failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::A Quality check was cancelled."
+            exit 1
+          fi
+          echo "All Quality checks passed (or were skipped as not applicable)."

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -112,3 +112,32 @@ jobs:
         run: pnpm --filter @factorialco/f0-core build
       - name: Run tests
         run: pnpm --filter @factorialco/f0-react-native run test:ci
+
+  # Single check to gate the branch on. It collapses this workflow's jobs into
+  # one status, so branch protection lists one stable name and never needs
+  # editing when jobs are added, removed, renamed or sharded.
+  #
+  # `if: always()` is load-bearing. Without it a failing dependency leaves this
+  # job *skipped* rather than *failed*, and GitHub counts a skipped required
+  # check as satisfied — the gate would go green over a red build.
+  #
+  # `skipped` is accepted on purpose: detect-changes skips the jobs for a
+  # package that this PR did not touch. Only failure/cancellation is fatal.
+  unit-tests-passed:
+    needs: [detect-changes, test, bugfix-red-green, test-react-native]
+    name: "✅ Unit Tests"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm every Unit Tests check passed
+        run: |
+          echo "Dependency results: ${{ join(needs.*.result, ' ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::A Unit Tests check failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::A Unit Tests check was cancelled."
+            exit 1
+          fi
+          echo "All Unit Tests checks passed (or were skipped as not applicable)."


### PR DESCRIPTION
## Description

Branch protection on `main` currently requires no status checks at all — the `Main` ruleset only enforces pull requests and linear history. Requiring the individual jobs would mean listing ~22 names in the ruleset and editing it every time a job is added, removed or sharded, which just became concrete: sharding the Storybook workflow turned one check into eight. Each PR workflow now exposes a single `✅ …` job that collapses its own jobs into one status, so the ruleset only needs six stable names that never change again.

## Implementation details

- ci: add `✅ Quality`, `✅ Unit Tests`, `✅ API Surface`, `✅ Chromatic` and `✅ Ownership` gate jobs

  <details>
  <summary>Why one per workflow rather than one for the repo?</summary>

  `needs:` cannot cross workflow boundaries, so a single repo-wide gate would have to poll the Checks API for the PR's SHA and wait for the other workflows to conclude. That needs a hand-maintained list of what to wait for — and silently passes when a workflow it should have waited on has not started yet — as well as burning runner minutes idling. One native `needs:` gate per workflow avoids all of that.

  The six workflows covered are the ones that fire on a new commit to a PR. The other PR-triggered workflows are deliberately left alone: `pr-name` (re-runs on title *edit*), `review-policy` (also `pull_request_review`, `labeled`/`unlabeled`), `agentic-checks` (`ready_for_review`), `build-and-publish-alpha` (also `issue_comment`), `remove-pr-alpha-versions` (`types: [closed]`) and `pr-package-labels` (writes labels — automation, not a check).
  </details>

- ci: gate on `always()` and inspect `needs.*.result` explicitly

  <details>
  <summary>Why not the plain `needs:`-only form?</summary>

  This is the part that is easy to get wrong. With a bare `needs: [a, b]` and no `if:`, a *failing* dependency does not fail the aggregator — it leaves it **skipped**, and GitHub counts a skipped required check as satisfied. The gate would then report green over a red build, which is worse than having no gate at all, because it looks like it is protecting you.

  So each gate runs unconditionally and fails itself on `contains(needs.*.result, 'failure')` or `'cancelled'`. `skipped` is accepted on purpose: `detect-changes` legitimately skips the jobs for a package the PR did not touch, and those are not failures.
  </details>

## Notes for the reviewer

Nothing is enforced by this PR on its own — a gate job only becomes a gate once it is added to the ruleset's required status checks, which is a repo-settings change. GitHub also only offers a check name in that UI after it has appeared on at least one run, so this needs to merge (or at least run once) first. The six names to add:

```
✅ Quality
✅ Unit Tests
✅ API Surface
✅ Chromatic
✅ Ownership
✅ Storybook Tests
```

The last one ships in #5162, not here.

`✅ Ownership` is admittedly a formality — that workflow has a single unconditional job, so requiring it directly would be equivalent. It is included so the required-check list is one uniform pattern and stays correct if that workflow ever grows a second job.

This PR's own run exercises all five gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)