### PR TITLE
perf(storybook): shrink the 45MB sample video and guard against regressions

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -9,6 +9,20 @@ jobs:
   # Detect which projects have changed
   detect-changes:
     uses: ./.github/workflows/_check-workspaces-changes.yaml
+  # Intentionally NOT gated on detect-changes: a big file can land anywhere in
+  # the repo, including paths no package filter watches, and this check is a
+  # couple of seconds. It needs no pnpm install either — just git and tsx.
+  file-sizes:
+    name: "File sizes"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+      - name: Check no tracked file is oversized
+        run: npx --yes tsx@4 scripts/check-file-sizes.ts
+
   format:
     needs: detect-changes
     # Prevents running on the release-please branch

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -29,6 +29,9 @@ pre-commit:
       run: pnpm --filter @factorialco/f0-react-native prettier --write {staged_files}
       stage_fixed: true
 
+    file-sizes:
+      run: pnpm exec tsx scripts/check-file-sizes.ts --staged
+
     cycle-dependencies:
       run: pnpm exec tsx packages/react/.scripts/check-cycle-dependencies.ts --pre-commit
 

--- a/scripts/check-file-sizes.ts
+++ b/scripts/check-file-sizes.ts
@@ -1,0 +1,118 @@
+#!/usr/bin/env tsx
+/**
+ * check-file-sizes.ts
+ *
+ * Fails when a tracked file is larger than MAX_BYTES.
+ *
+ * Why this exists: `packages/react/public` and `.storybook/static` are Storybook
+ * `staticDirs` entries, so every Storybook build copies them wholesale. A single
+ * 45MB sample video (`Big_Buck_Bunny_alt.webm`, since re-encoded) was costing
+ * 33–71s of copy time in *every* build — on all 8 Storybook Tests shards, plus
+ * Chromatic and the deploy. Large files are also paid on every clone and every
+ * CI checkout, forever, because git history keeps them even after deletion.
+ *
+ * Usage:
+ *   tsx scripts/check-file-sizes.ts            # all tracked files (CI)
+ *   tsx scripts/check-file-sizes.ts --staged   # staged files only (pre-commit)
+ */
+import { execFileSync } from "node:child_process"
+import { statSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+
+/**
+ * The ceiling. Set just above the largest asset the repo legitimately carries
+ * (the `.storybook/static` landscape JPEGs, ~2.5MB) so it catches a new order of
+ * magnitude rather than relitigating what is already here.
+ */
+const MAX_BYTES = 3 * 1024 * 1024
+
+/**
+ * Deliberate exceptions: path → reason. Keep this empty if you can. Adding an
+ * entry means every clone and every CI checkout of this repo pays for that file
+ * from now on, so it needs a reason better than "the asset I had was big".
+ *
+ * Generated text files that grow monotonically (pnpm-lock.yaml, CHANGELOGs) are
+ * the likeliest first entries — they are well under the limit today, so they are
+ * intentionally NOT pre-listed.
+ */
+const ALLOWLIST: Record<string, string> = {}
+
+const mb = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(2)}MB`
+
+function trackedFiles(stagedOnly: boolean): string[] {
+  const args = stagedOnly
+    ? ["diff", "--cached", "--name-only", "--diff-filter=ACMR", "-z"]
+    : ["ls-files", "-z"]
+  return execFileSync("git", args, { cwd: REPO_ROOT, maxBuffer: 64 * 1024 * 1024 })
+    .toString("utf-8")
+    .split("\0")
+    .filter(Boolean)
+}
+
+const stagedOnly = process.argv.includes("--staged")
+
+const oversized: { file: string; size: number }[] = []
+for (const file of trackedFiles(stagedOnly)) {
+  if (file in ALLOWLIST) continue
+  let size: number
+  try {
+    size = statSync(join(REPO_ROOT, file)).size
+  } catch {
+    // Deleted or renamed away between listing and stat — nothing to weigh.
+    continue
+  }
+  if (size > MAX_BYTES) oversized.push({ file, size })
+}
+
+// Flag allowlist entries that no longer need to be there, so the list shrinks on
+// its own instead of quietly outliving the problem it documented.
+const stale = Object.keys(ALLOWLIST).filter((file) => {
+  try {
+    return statSync(join(REPO_ROOT, file)).size <= MAX_BYTES
+  } catch {
+    return true // gone entirely
+  }
+})
+
+if (oversized.length === 0 && stale.length === 0) {
+  const scope = stagedOnly ? "staged" : "tracked"
+  console.log(`✓ No ${scope} file exceeds ${mb(MAX_BYTES)}.`)
+  process.exit(0)
+}
+
+if (oversized.length > 0) {
+  console.error(
+    `\n✖ ${oversized.length} file(s) exceed the ${mb(MAX_BYTES)} limit:\n`
+  )
+  for (const { file, size } of oversized.sort((a, b) => b.size - a.size)) {
+    console.error(`    ${mb(size).padStart(9)}  ${file}`)
+  }
+  console.error(
+    `\n  Files this size are copied on every Storybook build (public/ and\n` +
+      `  .storybook/static are staticDirs) and live in git history forever, so\n` +
+      `  deleting one later does not give the space back.\n\n` +
+      `  Options, best first:\n` +
+      `    • Compress it. Images → WebP/AVIF. Video → scale to the size it is\n` +
+      `      actually displayed at and trim to the length the story needs;\n` +
+      `      \`ffmpeg -i in.webm -t 60 -vf scale=640:360 -c:v libvpx-vp9 -crf 36\n` +
+      `      -b:v 0 -c:a libopus -b:a 48k out.webm\` took one 45MB sample to 2.5MB.\n` +
+      `    • Do you need a real asset? A fixture only has to be plausible.\n` +
+      `    • If it genuinely must ship at this size, add it to ALLOWLIST in\n` +
+      `      scripts/check-file-sizes.ts with the reason.\n`
+  )
+}
+
+if (stale.length > 0) {
+  console.error(
+    `\n✖ ${stale.length} stale ALLOWLIST entry/entries in ` +
+      `scripts/check-file-sizes.ts — these are now under the limit or gone, so ` +
+      `delete them:\n`
+  )
+  for (const file of stale) console.error(`    ${file}`)
+  console.error("")
+}
+
+process.exit(1)


### PR DESCRIPTION
## Description

`packages/react/public` is a Storybook `staticDirs` entry, so every build copies the whole directory — and 45 of its 46MB was one file, `Big_Buck_Bunny_alt.webm`. That copy was measured at **33s on one CI run and 71s on another**, out of a ~150s Storybook build. It is now paid on all 8 Storybook Tests shards, plus Chromatic and the deploy. Re-encoding the fixture takes `public/` from 46MB to 3.1MB.

## Implementation details

- perf: re-encode the sample video to 640×360 and trim 298s → 60s (45.10MB → 2.50MB)

  <details>
  <summary>Why these numbers</summary>

  **640×360** because the stories render the player inside a `w-[640px]` frame (`Frame` in `F0VideoPlayer.stories.tsx`), so this is 1:1 rather than downscaled-on-display 720p. VP9/Opus in WebM as before, stereo audio kept — the docs note "the sample has audio" and the `silent` prop is only set on one story to illustrate the no-audio state.

  **60s** is the interesting constraint. The inline WebVTT cues in `bigBuckBunnyCaptions.ts` run to `00:00:53.541`, so anything shorter breaks the captions stories — you would see one partial cue and nothing else. Trimming from 0 keeps every cue aligned with exactly the footage it described before.

  Estimated copy time at the ~1MB/s the runner was actually managing:

  | variant | size | est. copy |
  |---|---|---|
  | current (298s, 720p) | 45.10 MB | ~45s |
  | **this PR (60s, 640×360)** | **2.50 MB** | **~2.5s** |
  | 5s @ 640×360 | 0.14 MB | ~0.1s |

  A 5s clip would save ~2s more and cost the captions stories plus any meaningful scrub/speed/`restrictForwardSeek` demo, so it is not worth it.
  </details>

## Notes for the reviewer

The path and filename are unchanged, so all nine references keep working — `F0VideoPlayer.stories.tsx`, `ApplicationFrame/index.stories.tsx` (which asserts the `src` string), `F0Chat.stories.tsx` and `F0Chat/mocks/mockSeeds.ts`.

**Verified in a real browser, not just with `ffprobe`.** Served from a Storybook dev server and run through the test-runner:

| suite | result |
|---|---|
| `F0VideoPlayer.stories.tsx` | 13/13 pass |
| `ApplicationFrame/index.stories.tsx` (incl. `CommunicationsVideoAttachments`) | 11/11 pass |
| `F0Chat.stories.tsx` | 15/15 pass |

axe checks included. I had initially worried the a11y captions rule might read embedded tracks, which would have made this risky — it does not: `data-video-captions` is derived from the `captions` prop and `silent` in `F0VideoPlayer/internal.tsx`, and the original file had no embedded subtitle track anyway.

Two things to expect:

- **Chromatic will show diffs** on stories that display the player. The poster (`/video-poster.webp`) is unchanged so the pre-playback frame is identical, but the duration label goes `4:58` → `1:00` and the seekbar scale changes.
- **This does not shrink the repo.** The 45MB blob stays in history; git gains a second, smaller blob. What it shrinks is every checkout's working tree and every `staticDirs` copy from here on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Added: a check so this cannot come back

`ci: fail when a tracked file exceeds 3MB` — `scripts/check-file-sizes.ts`.

3MB sits just above the largest asset the repo legitimately carries (the ~2.5MB `.storybook/static` landscape JPEGs), so it catches a new order of magnitude rather than relitigating what is already here. `ALLOWLIST` starts empty, and the script also fails on *stale* allowlist entries so the list shrinks on its own rather than outliving the problem it documented.

Verified red/green: with the 45MB original restored it exits 1 and prints the size plus the `ffmpeg` recipe; with the 2.5MB version it exits 0.

It runs in two places:

- **lefthook `pre-commit`**, `--staged` only, so it stays instant locally.
- **An ungated `file-sizes` job in `quality.yaml`.** This is the part worth reviewing. Every other job in that workflow is gated on `detect-changes`, which only watches `packages/**` — so a large file added anywhere else would sail past. This job therefore has no `needs:` and no `if:`, and needs no `pnpm install`: just git and tsx, ~3s.

### Merge-order note for #5164

#5164 adds a `quality-passed` gate that lists its dependencies explicitly. Once both PRs are in, `file-sizes` must be appended to that `needs:` list, or the gate can report green while the size check is red. I did not add it preemptively because a `needs:` entry for a job that does not exist yet makes the workflow invalid. Whichever merges second gets the one-line follow-up; noted on #5164 as well.
