### PR TITLE
ci(storybook): stop a stalled apt mirror timing out shards

### DIFF
--- a/.github/workflows/_check-workspaces-changes.yaml
+++ b/.github/workflows/_check-workspaces-changes.yaml
@@ -11,6 +11,13 @@ on:
       package_core:
         description: "Changes in the core package"
         value: ${{ jobs.changes.outputs.package_core }}
+      # Scoped deliberately to the one workflow file rather than folded into
+      # package_react: eight workflows consume this one, and a change to the
+      # Storybook Tests workflow is no reason to re-run Chromatic, the unit
+      # tests or an alpha publish. Only storybook-tests.yaml reads this.
+      workflow_storybook_tests:
+        description: "Changes to the Storybook Tests workflow itself"
+        value: ${{ jobs.changes.outputs.workflow_storybook_tests }}
 
 jobs:
   # Detect which projects have changed
@@ -21,6 +28,7 @@ jobs:
       package_react: ${{ steps.changes.outputs.package_react }}
       package_react_native: ${{ steps.changes.outputs.package_react_native }}
       package_core: ${{ steps.changes.outputs.package_core }}
+      workflow_storybook_tests: ${{ steps.changes.outputs.workflow_storybook_tests }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
@@ -35,3 +43,5 @@ jobs:
               - 'packages/react-native/**'
             package_core: 
               - 'packages/core/**'
+            workflow_storybook_tests:
+              - '.github/workflows/storybook-tests.yaml'

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -61,15 +61,55 @@ jobs:
           restore-keys: |
             playwright-chromium-${{ steps.playwright-version.outputs.version }}-
             playwright-chromium-
-      # Chromium only. The test-runner never launches anything else (TEST_BROWSERS
-      # is unset, so it defaults to chromium), but a bare `install --with-deps`
-      # apt-installs the WebKit and Firefox system libraries too — the gstreamer
-      # /fluidsynth/rav1e pile. That apt step runs even on a browser-cache hit
-      # and was the least predictable part of the job, measured between 27s and
-      # 121s across the 8 shards of run 32146702636.
+      # Chromium only, and deliberately *without* `--with-deps`. The test-runner
+      # never launches anything else (TEST_BROWSERS is unset, so it defaults to
+      # chromium), and every shared library chromium needs is already on the
+      # ubuntu-latest image — on a passing shard `--with-deps` reported all of
+      # them "already the newest version" and installed nothing but the nine font
+      # packages the next step now handles.
+      #
+      # What `--with-deps` did buy was an unconditional `apt-get update`, which
+      # was the least predictable part of this job (27s–121s across the 8 shards
+      # of run 32146702636) and then its worst failure mode outright: when the
+      # runner's azure.archive.ubuntu.com mirror is unreachable, apt falls back to
+      # archive.ubuntu.com and can stall indefinitely fetching the package
+      # indices. apt sets no timeout there by default, and neither did this step,
+      # so the stall consumed the entire 30-minute job budget before a single
+      # story ran — 4 of 8 shards in run 32230793617, then 7 of 8 in 32233463322.
+      #
+      # With the browser cache warm this step now touches no apt mirror at all.
       - name: Install Playwright
+        timeout-minutes: 5
         run: |
-          pnpx playwright@${{ steps.playwright-version.outputs.version }} install --with-deps chromium
+          pnpx playwright@${{ steps.playwright-version.outputs.version }} install chromium
+
+      # The font packages `--with-deps` used to pull (CJK/Thai/Cyrillic coverage
+      # plus freefont), installed on their own so a slow or unreachable apt mirror
+      # can no longer take the whole job down with it:
+      #
+      #   * `timeout-minutes` bounds a stall at 3 minutes instead of 30,
+      #   * `continue-on-error` keeps a mirror outage from failing the shard, and
+      #   * the Acquire::* options stop apt hanging on a dead mirror in the first
+      #     place — by default it has neither a timeout nor a retry limit.
+      #
+      # Non-fatal is the right call because nothing in this job depends on these
+      # fonts today: no story contains CJK, Thai or Cyrillic text, and the
+      # test-runner makes no pixel assertions (axe + play functions only — visual
+      # diffing lives in Chromatic, which sets up its own browser). They are kept
+      # so a future story with international text renders real glyphs rather than
+      # tofu, not because the suite needs them to pass.
+      - name: Install browser fonts
+        timeout-minutes: 3
+        continue-on-error: true
+        run: |
+          APT_OPTS=(-o Acquire::Retries=3
+                    -o Acquire::http::Timeout=15
+                    -o Acquire::https::Timeout=15)
+          sudo apt-get "${APT_OPTS[@]}" update
+          sudo apt-get "${APT_OPTS[@]}" install -y --no-install-recommends \
+            fonts-freefont-ttf fonts-ipafont-gothic fonts-tlwg-loma-otf \
+            fonts-unifont fonts-wqy-zenhei xfonts-cyrillic xfonts-encodings \
+            xfonts-scalable xfonts-utils
       - name: Build Storybook
         run: |
           pnpm --filter @factorialco/f0-core build

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -28,8 +28,15 @@ jobs:
   test:
     needs: detect-changes
     name: "[⚛️ REACT] Storybook Tests (${{ matrix.shard }}/8)"
+    # A change to this workflow runs the matrix too. Without it the shards are
+    # skipped whenever a PR touches only .github/ — and because the gate below
+    # deliberately treats "skipped" as passing, a change to the Storybook Tests
+    # workflow could not be validated before merging it: the gate went green
+    # having run nothing. That is how the apt stall this workflow now guards
+    # against reached main in the first place.
     if: |
-      needs.detect-changes.outputs.package_react == 'true' &&
+      (needs.detect-changes.outputs.package_react == 'true' ||
+       needs.detect-changes.outputs.workflow_storybook_tests == 'true') &&
       github.head_ref != 'release-please--branches--master' &&
       !contains(github.event.pull_request.labels.*.name, 'autorelease')
     timeout-minutes: 30


### PR DESCRIPTION
## Description

`playwright install --with-deps` runs an unconditional `apt-get update` at the top of every shard, and when the runner's `azure.archive.ubuntu.com` mirror is unreachable apt falls back to `archive.ubuntu.com` and stalls fetching the package indices — with no timeout or retry limit of its own, and none on the step, so the stall consumed the entire 30-minute job budget before a single story ran. It took out 4 of 8 shards in [run 32230793617](https://github.com/factorialco/f0/actions/runs/32230793617) (a push to `main`) and 7 of 8 in [32233463322](https://github.com/factorialco/f0/actions/runs/32233463322), and was still hanging 6 of 8 shards on unrelated PRs while this fix was written. No test ever failed — the shards died in setup.

## Implementation details

- fix: drop `--with-deps` from the Playwright install, so a warm browser cache means the step touches no apt mirror at all

  <details>
  <summary>Why this is safe</summary>

  Every shared library chromium needs is already present on the `ubuntu-latest` image. On a shard that got a responsive mirror, `--with-deps` reported all of them "already the newest version" and finished with `0 upgraded, 9 newly installed` — and all nine of those were font packages (`fonts-ipafont-gothic`, `fonts-wqy-zenhei`, `fonts-tlwg-loma-otf`, `xfonts-cyrillic`, …), which the new step below installs directly. The cache key is unchanged, so the cache stays warm across this change.
  </details>

- fix: install the nine font packages in their own step, which a mirror outage can no longer fail the shard with

  <details>
  <summary>Why non-fatal</summary>

  `continue-on-error: true` plus `timeout-minutes: 3` caps a mirror outage at 3 minutes and a warning instead of a red 30-minute build, and `Acquire::Retries` / `Acquire::{http,https}::Timeout` stop apt hanging on a dead mirror in the first place — by default it has neither.

  Nothing in this job depends on these fonts today: no story in the repo contains CJK, Thai or Cyrillic text, and the test-runner makes no pixel assertions (axe + play functions only — visual diffing runs in Chromatic via `chromaui/action`, which renders on Chromatic's own infra). They are kept so a future story with international text renders real glyphs rather than tofu, not because the suite needs them to pass.
  </details>

- chore: add `timeout-minutes` to both setup steps, so a hang in either surfaces as a fast failure instead of silently eating the job budget

- fix: run the shards when this workflow itself changes, via a new scoped `workflow_storybook_tests` output on the shared `detect-changes` filter

  <details>
  <summary>Why this was needed to validate the fix at all</summary>

  `detect-changes` only fires `package_react` on `packages/react/**` and `packages/core/**`, so the first push of this PR — touching only `.github/` — skipped the entire matrix. And because the aggregate gate deliberately accepts `skipped` as passing, `✅ Storybook Tests` [went green having run nothing](https://github.com/factorialco/f0/actions/runs/32237960320). A change to the Storybook Tests workflow could not be validated before merging it, which is how an unguarded apt stall reached `main` in the first place.

  Scoped to a new output rather than folded into `package_react` because eight workflows consume that shared filter, and editing this one is no reason to re-run Chromatic, the unit tests or an alpha publish.
  </details>

## Verification

[Run 32238464121](https://github.com/factorialco/f0/actions/runs/32238464121) on this branch — all 8 shards green in 4.9–7.2m, and `Install Playwright` is now **2s on every shard**, down from the 27–121s it measured when the mirror answered (and unbounded when it didn't):

| shard | total | Install Playwright | Install browser fonts |
| --- | --- | --- | --- |
| 1 | 6.3m | 2s | 20s |
| 2 | 6.7m | 2s | 39s |
| 3 | 7.2m | 2s | 123s |
| 4 | 6.5m | 2s | 14s |
| 5 | 6.1m | 2s | 15s |
| 6 | 6.8m | 2s | 35s |
| 7 | 6.4m | 2s | 33s |
| 8 | 4.9m | 2s | 27s |

Shard 3's 123s on the fonts step is the mirror still being slow — worth noting that under the old arrangement that latency sat on the critical path, and past 3 minutes it would now be a warning rather than a red build.

## Notes for reviewers

No regression unit test accompanies this: the failure is an apt-mirror stall on the GitHub runner, not something reproducible from a unit test. The run above is the regression evidence.

The same skip-means-pass gap still exists for the other seven consumers of `_check-workspaces-changes.yaml` — a PR editing `chromatic.yml`, `test.yaml` or `quality.yaml` likewise cannot validate itself. Left alone here to keep this PR scoped to the outage; happy to follow up if you want it closed across the board.