### PR TITLE
feat(OneDataCollection): select a node on graph entry via initialSelectedNodeId

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
@@ -711,12 +711,15 @@ const DetailField = ({ label, value }: { label: string; value: string }) => (
 const OrgChartExample = ({
   defaultExpandDepth,
   focusOnEntry,
+  initialSelectedNodeId,
   graphLabel,
   tableLabel,
   lockedTagTypes,
 }: {
   defaultExpandDepth: number
   focusOnEntry?: string
+  /** Node marked as selected (the click ring) on entry — see the graph options. */
+  initialSelectedNodeId?: string
   /** Custom label for the graph chip; falls back to the localized "Graph". */
   graphLabel?: string
   /** Custom label for the table chip; falls back to the localized "Table". */
@@ -742,6 +745,7 @@ const OrgChartExample = ({
               defaultExpandDepth,
               revealNodeId: revealId,
               focusOnEntry,
+              initialSelectedNodeId,
               lockedTagTypes,
             },
           },
@@ -1119,6 +1123,23 @@ export const LiveUpdate: Story = {
  */
 export const FocusOnRoot: Story = {
   render: () => <OrgChartExample defaultExpandDepth={2} focusOnEntry="ceo-a" />,
+}
+
+/**
+ * Arrives with a node already **selected** (`initialSelectedNodeId: "ceo-a"`),
+ * paired with `focusOnEntry` on the same node so its branch is expanded and
+ * framed — the graph opens looking exactly the way a user click leaves it
+ * (selection ring + node actions), not just centered. Clicking any other node
+ * moves the selection normally.
+ */
+export const SelectedOnEntry: Story = {
+  render: () => (
+    <OrgChartExample
+      defaultExpandDepth={2}
+      focusOnEntry="ceo-a"
+      initialSelectedNodeId="ceo-a"
+    />
+  ),
 }
 
 /**

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.test.tsx
@@ -1,0 +1,165 @@
+import { act, waitFor } from "@testing-library/react"
+import { forwardRef } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  FiltersDefinition,
+  GroupingDefinition,
+  RecordType,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+import { zeroRender } from "@/testing/test-utils"
+
+import { DataCollectionSource } from "../../../hooks/useDataCollectionSource/types"
+import { ItemActionsDefinition } from "../../../item-actions"
+import { NavigationFiltersDefinition } from "../../../navigationFilters/types"
+import { DataCollectionSettingsProvider } from "../../../Settings/SettingsProvider"
+import { SummariesDefinition } from "../../../summary"
+import { GraphCollection } from "./index"
+import type { GraphVisualizationOptions } from "./types"
+
+// Stub F0Graph so we can read the props `GraphCollection` hands it — the entry
+// selection is wired here (controlled `selectedNodes` seeded with
+// `initialSelectedNodeId`, mirrored on change), which is what these tests cover.
+let latestF0GraphProps: Record<string, unknown> | null = null
+vi.mock("@/patterns/F0Graph", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/patterns/F0Graph")>()
+  return {
+    ...actual,
+    F0Graph: forwardRef((props: Record<string, unknown>, _ref) => {
+      latestF0GraphProps = props
+      return null
+    }),
+  }
+})
+
+type Employee = RecordType & { id: string; name: string; childrenCount: number }
+
+const ROOT_KEY = "ROOT"
+const employees = {
+  ceo: { id: "ceo", name: "Sofia", childrenCount: 2 },
+  vp1: { id: "vp1", name: "Marcus", childrenCount: 0 },
+  vp2: { id: "vp2", name: "Nina", childrenCount: 0 },
+} satisfies Record<string, Employee>
+
+const childrenByParent: Record<string, Employee[]> = {
+  [ROOT_KEY]: [employees.ceo],
+  ceo: [employees.vp1, employees.vp2],
+  vp1: [],
+  vp2: [],
+}
+
+const getParentKey = (options: { filters?: { parentId?: string[] } }): string =>
+  options.filters?.parentId?.[0] ?? ROOT_KEY
+
+const fetchByParent = (options: { filters?: { parentId?: string[] } }) => ({
+  records: childrenByParent[getParentKey(options)] ?? [],
+})
+
+const buildSource = () =>
+  ({
+    currentFilters: {},
+    setCurrentFilters: vi.fn(),
+    currentSortings: null,
+    setCurrentSortings: vi.fn(),
+    currentNavigationFilters: {},
+    setCurrentNavigationFilters: vi.fn(),
+    navigationFilters: undefined,
+    currentSearch: undefined,
+    debouncedCurrentSearch: undefined,
+    setCurrentSearch: vi.fn(),
+    isLoading: false,
+    setIsLoading: vi.fn(),
+    currentGrouping: undefined,
+    setCurrentGrouping: vi.fn(),
+    dataAdapter: { fetchData: vi.fn(fetchByParent) },
+    idProvider: (item: Employee) => item.id,
+    // eslint-disable-next-line no-type-assertion/no-type-assertion -- test scaffolding for a structurally complete source
+  }) as unknown as DataCollectionSource<
+    Employee,
+    FiltersDefinition,
+    SortingsDefinition,
+    SummariesDefinition,
+    ItemActionsDefinition<Employee>,
+    NavigationFiltersDefinition,
+    GroupingDefinition<Employee>
+  >
+
+const baseOptions = (
+  overrides: Partial<
+    GraphVisualizationOptions<Employee, FiltersDefinition, SortingsDefinition>
+  > = {}
+): GraphVisualizationOptions<
+  Employee,
+  FiltersDefinition,
+  SortingsDefinition
+> => ({
+  title: (employee) => employee.name,
+  getChildrenCount: (employee) => employee.childrenCount,
+  // eslint-disable-next-line no-type-assertion/no-type-assertion -- minimal filter shape for the mock adapter
+  childrenFilters: (parentId) =>
+    ({ parentId: [parentId ?? ROOT_KEY] }) as Partial<unknown>,
+  ...overrides,
+})
+
+const renderGraph = (
+  overrides: Partial<
+    GraphVisualizationOptions<Employee, FiltersDefinition, SortingsDefinition>
+  > = {}
+) =>
+  zeroRender(
+    <DataCollectionSettingsProvider>
+      <GraphCollection
+        source={buildSource()}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+        searchSelectionNonce={0}
+        {...baseOptions(overrides)}
+      />
+    </DataCollectionSettingsProvider>
+  )
+
+// F0Graph only mounts once the initial load settles.
+const waitForF0Graph = () =>
+  waitFor(() => expect(latestF0GraphProps).not.toBeNull())
+
+beforeEach(() => {
+  latestF0GraphProps = null
+})
+
+describe("GraphCollection — initialSelectedNodeId entry selection", () => {
+  it("seeds F0Graph's controlled selection with the entry node", async () => {
+    renderGraph({ initialSelectedNodeId: "ceo" })
+    await waitForF0Graph()
+
+    const selected = latestF0GraphProps?.selectedNodes as
+      | Set<string>
+      | undefined
+    expect(selected).toBeInstanceOf(Set)
+    expect([...(selected ?? [])]).toEqual(["ceo"])
+  })
+
+  it("leaves selection uncontrolled when no entry node is given", async () => {
+    renderGraph()
+    await waitForF0Graph()
+
+    // Uncontrolled: F0Graph keeps its own selection (prop stays undefined).
+    expect(latestF0GraphProps?.selectedNodes).toBeUndefined()
+  })
+
+  it("mirrors later selection changes so clicks keep moving the ring", async () => {
+    renderGraph({ initialSelectedNodeId: "ceo" })
+    await waitForF0Graph()
+
+    const onSelectedNodesChange = latestF0GraphProps?.onSelectedNodesChange as (
+      next: Set<string>
+    ) => void
+    act(() => onSelectedNodesChange(new Set(["vp1"])))
+
+    const selected = latestF0GraphProps?.selectedNodes as
+      | Set<string>
+      | undefined
+    expect([...(selected ?? [])]).toEqual(["vp1"])
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import {
   GroupingDefinition,
@@ -71,6 +71,7 @@ export const GraphCollection = <
   revealNodeId,
   searchSelectionNonce,
   focusOnEntry,
+  initialSelectedNodeId,
   loadNodePath,
   getParentId,
   loadNodeData,
@@ -142,6 +143,18 @@ export const GraphCollection = <
   // `focusedNode` prop only reacts to value changes), and dropping the click
   // selection when a reveal marks a node via `highlightedNodes` instead.
   const graphRef = useRef<F0GraphHandle>(null)
+
+  // Entry selection. When `initialSelectedNodeId` is set we run F0Graph's
+  // selection in CONTROLLED mode, seeded with that node so a deep link arrives
+  // already marked (the click-selection ring), and mirror every later change
+  // back into this state so clicks/keyboard keep moving the selection normally.
+  // The control mode is decided ONCE at mount (a stable boolean) so we never
+  // flip controlled/uncontrolled; consumers that omit the option keep the
+  // previous uncontrolled behavior (`selectedNodes` stays `undefined`).
+  const [controlSelection] = useState(() => initialSelectedNodeId !== undefined)
+  const [selectedNodes, setSelectedNodes] = useState<Set<string>>(() =>
+    initialSelectedNodeId ? new Set([initialSelectedNodeId]) : new Set()
+  )
 
   // Reveal + focus a node: load/expand it (declarative `focusedNode` handles
   // the first fly, with the right async + settle timing), then imperatively
@@ -249,14 +262,20 @@ export const GraphCollection = <
           initialFocusNodeId={focusOnEntry}
           highlightedNodes={highlightedNodes}
           selectionMode="single"
-          // Selecting a node marks it via the internal selection ring; drop the
-          // reveal highlight (search / "Find me") so only one node stays marked.
-          // Fires with the new set — a non-empty set means a real selection (an
-          // empty set is a pane click or our own `clearSelection()` on reveal,
-          // which must NOT wipe the highlight we just set). Centering lives on
-          // the node's own click (below) so a click on the empty canvas never
-          // re-centers.
+          // Controlled only when an entry selection was requested (see
+          // `controlSelection`); otherwise `undefined` keeps F0Graph's own
+          // uncontrolled selection, unchanged for existing consumers.
+          selectedNodes={controlSelection ? selectedNodes : undefined}
+          // Selecting a node marks it via the selection ring; drop the reveal
+          // highlight (search / "Find me") so only one node stays marked. Fires
+          // with the new set — a non-empty set means a real selection (an empty
+          // set is a pane click or our own `clearSelection()` on reveal, which
+          // must NOT wipe the highlight we just set). Centering lives on the
+          // node's own click (below) so a click on the empty canvas never
+          // re-centers. When controlled we also mirror the set so clicks keep
+          // moving the ring past the seeded entry selection.
           onSelectedNodesChange={(next) => {
+            if (controlSelection) setSelectedNodes(next)
             if (next.size > 0) clearFocus()
           }}
           showControls={showControls ?? true}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/types.ts
@@ -102,6 +102,18 @@ export type GraphVisualizationOptions<
    */
   focusOnEntry?: string
   /**
+   * Id of a node to mark as **selected on entry** — the click-selection ring, so
+   * a deep link lands on the graph looking the way a user's own click leaves it,
+   * not just framed. Seeded on the first render; the selection then follows
+   * normal clicks/keyboard (this is a one-shot entry seed, not a controlled
+   * value). Pair it with `focusOnEntry` (usually the same id) so the node's
+   * branch is expanded and framed — otherwise the ring isn't visible until its
+   * branch is opened. Unlike `revealNodeId` (search) it sets the selection, not
+   * the reveal highlight. Providing it puts the graph's selection in controlled
+   * mode; omitting it leaves selection uncontrolled (the default).
+   */
+  initialSelectedNodeId?: string
+  /**
    * Resolves the ancestor path (root → … → matched node) for a node so it can
    * be revealed, returning the records in root-first order. Required for
    * revealing nodes in branches that have not been expanded yet.


### PR DESCRIPTION
## Description

Add an opt-in `initialSelectedNodeId` option to the OneDataCollection **graph** visualization so a consumer can make the graph arrive with a node already **selected** (the click-selection ring), not just framed.

Until now the graph could frame a node on entry (`focusOnEntry`) and highlight a search reveal (`revealNodeId`), but there was no way to land in the `selected` state a user's own click leaves behind. Deep links (e.g. Job Catalog's "View Graph" from a node's detail page — FCT-60797) arrived framed but visually neutral, so it wasn't obvious which node the side panel belonged to.

## Type of change

- [x] Variant or improvement of existing pattern

## Implementation details

- **`collection/Graph/types.ts`** — new optional `initialSelectedNodeId?: string` on `GraphVisualizationOptions`, documented next to `focusOnEntry` (its viewport-framing sibling).
- **`collection/Graph/index.tsx`** — when the option is set, the graph runs F0Graph's selection in **controlled** mode, seeded with that node on the first render, and mirrors every later change back via `onSelectedNodesChange` so clicks/keyboard keep moving the selection normally. The control mode is decided **once at mount** (a stable boolean), so consumers that omit the option keep the previous **uncontrolled** behavior unchanged. No `F0Graph` changes — it already supports controlled `selectedNodes`/`onSelectedNodesChange`.
- **`__stories__/visualizations/graph.stories.tsx`** — new `SelectedOnEntry` story (paired with `focusOnEntry` on the same node).

Pair `initialSelectedNodeId` with `focusOnEntry` (same id) so the node's branch is expanded/framed and the ring is visible.

### Non-breaking

New **optional** prop; when omitted, `selectedNodes` stays `undefined` and selection is uncontrolled exactly as before. `check:api-surface` classifies this as SAFE.

### Verification

- oxfmt ✅ · oxlint ✅ · `tsc` clean for the edited files
- graph collection unit tests: 30/30 ✅

## Context

- Unblocks factorial **FCT-60797** ("[Job Catalog] Mark the deep-linked node as selected when arriving at the graph from View Graph"), the follow-up to FCT-60313.
