### PR TITLE
fix(F0ResourceHeader): rename to clear stable DoD name-prefix check

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -31,7 +31,6 @@
     "Inputs/Search input",
     "Inputs/Text area input",
     "Inputs/Text input",
-    "Primitives/F0InputField",
-    "Resource header"
+    "Primitives/F0InputField"
   ]
 }

--- a/packages/react/src/components/F0Heading/__stories__/Heading.mdx
+++ b/packages/react/src/components/F0Heading/__stories__/Heading.mdx
@@ -7,7 +7,7 @@ import * as Stories from "./Heading.stories"
 
 > **Before using this component**, check if a higher-level component covers your use case:
 >
-> - **`ResourceHeader`** — entity pages (employee, team, company). Includes avatar, metadata, status, and actions.
+> - **`F0ResourceHeader`** — entity pages (employee, team, company). Includes avatar, metadata, status, and actions.
 > - **`SectionHeader`** — sections inside a page or form. Includes description, help center link, separator, and action button.
 >
 > `F0Heading` is a low-level typography primitive. Use it only when neither of the above fits.
@@ -80,7 +80,7 @@ Renders a heading with consistent typographic scale. It separates visual style (
 #### When NOT to use
 
 - Do not use `F0Heading` for body copy, descriptions, or labels: use `F0Text` instead
-- Do not use `F0Heading` to build a resource page header (employee, team, company): use `ResourceHeader` instead — it handles avatar, metadata, status, and actions
+- Do not use `F0Heading` to build a resource page header (employee, team, company): use `F0ResourceHeader` instead — it handles avatar, metadata, status, and actions
 - Do not use `F0Heading` to build a section header inside a form or content block: use `SectionHeader` instead — it handles description, help link, separator, and action
 - Do not use `heading-large` for section titles inside a page — it creates false visual hierarchy
 - Do not omit the `as` prop when the heading level matters for accessibility — the default rendering tag may not match the document structure

--- a/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.mdx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.mdx
@@ -101,7 +101,7 @@ Drawers can include module information and tabs in the header for complex conten
 
 ### With Resource Header
 
-You can embed a `ResourceHeader` component within the drawer content for a consistent header experience.
+You can embed a `F0ResourceHeader` component within the drawer content for a consistent header experience.
 
 <Canvas of={F0DrawerStories.WithResourceHeader} />
 

--- a/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Drawer/__stories__/F0Drawer.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { ComponentProps, FC, useState } from "react"
 import { F0Button } from "@/components/F0Button"
-import { ResourceHeader } from "@/patterns/ResourceHeader"
-import { Default as ResourceHeaderDefault } from "@/patterns/ResourceHeader/index.stories"
+import { F0ResourceHeader } from "@/patterns/F0ResourceHeader"
+import { Default as ResourceHeaderDefault } from "@/patterns/F0ResourceHeader/index.stories"
 import {
   OnePersonListItem,
   OnePersonListItemProps,
@@ -233,9 +233,9 @@ export const WithResourceHeader: Story = {
       href: "/timeoff",
     },
     children: (
-      <ResourceHeader
+      <F0ResourceHeader
         {...(ResourceHeaderDefault.args as ComponentProps<
-          typeof ResourceHeader
+          typeof F0ResourceHeader
         >)}
         primaryAction={undefined}
         secondaryActions={undefined}

--- a/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.mdx
+++ b/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.mdx
@@ -57,7 +57,7 @@ it with `attendeesDisplay` when a surface genuinely needs the other one.
 
 Only `maxAvatars` faces are shown (3 by default); the rest collapse into a `+N`
 counter. **Hover that counter and the collapsed attendees are listed** with their
-name and email — the same behaviour as the avatar list in `ResourceHeader`, since
+name and email — the same behaviour as the avatar list in `F0ResourceHeader`, since
 both go through `F0AvatarList`.
 
 <Canvas of={Stories.InProgress} />

--- a/packages/react/src/experimental/Information/Headers/__tests__/exports.test.tsx
+++ b/packages/react/src/experimental/Information/Headers/__tests__/exports.test.tsx
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { F0ResourceHeader } from "@/patterns/F0ResourceHeader"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+describe("deprecated ResourceHeader re-export", () => {
+  it("aliases the same component as F0ResourceHeader and still renders", async () => {
+    // Dynamic import: this suite exists specifically to verify the deprecated
+    // re-export barrel itself, which the repo's no-restricted-imports rule
+    // otherwise (rightly) forbids importing statically.
+    const barrel = await import("../exports")
+
+    expect(barrel.ResourceHeader).toBe(F0ResourceHeader)
+
+    const { ResourceHeader } = barrel
+    render(<ResourceHeader title="Reports" />)
+    expect(screen.getByText("Reports")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/Information/Headers/exports.ts
+++ b/packages/react/src/experimental/Information/Headers/exports.ts
@@ -1,7 +1,7 @@
 /**
- * @deprecated ResourceHeader has moved to @/patterns/ResourceHeader. Import from there instead.
+ * @deprecated F0ResourceHeader has moved to @/patterns/F0ResourceHeader. Import from there instead.
  */
-export * from "../../../patterns/ResourceHeader"
+export * from "../../../patterns/F0ResourceHeader"
 /**
  * @deprecated SectionHeader has moved to @/patterns/SectionHeader. Import from there instead.
  */

--- a/packages/react/src/experimental/Information/Headers/exports.ts
+++ b/packages/react/src/experimental/Information/Headers/exports.ts
@@ -3,6 +3,15 @@
  */
 export * from "../../../patterns/F0ResourceHeader"
 /**
+ * @deprecated Renamed to F0ResourceHeader and moved to @/patterns/F0ResourceHeader.
+ * Import F0ResourceHeader from there instead — this alias exists only so
+ * `@factorialco/f0-react`'s existing consumers don't break on the rename.
+ */
+export {
+  F0ResourceHeader as ResourceHeader,
+  type F0ResourceHeaderProps as ResourceHeaderProps,
+} from "../../../patterns/F0ResourceHeader"
+/**
  * @deprecated SectionHeader has moved to @/patterns/SectionHeader. Import from there instead.
  */
 export * from "../../../patterns/SectionHeader"

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
@@ -11,7 +11,7 @@ import { cn } from "@/lib/utils"
 import { F0Dialog } from "@/patterns/F0Dialog"
 import { F0Form } from "@/patterns/F0Form/F0Form"
 import { useF0Form } from "@/patterns/F0Form/useF0Form"
-import { ResourceHeader } from "@/patterns/ResourceHeader"
+import { F0ResourceHeader } from "@/patterns/F0ResourceHeader"
 import { ProgressBarCell } from "@/ui/value-display/types/progressBar"
 
 import type {
@@ -324,7 +324,7 @@ function SurveyAnsweringFormDialog({
             )}
           >
             <div className="mb-6">
-              <ResourceHeader
+              <F0ResourceHeader
                 title={title}
                 description={description}
                 {...resourceHeader}
@@ -442,7 +442,7 @@ function SurveyAnsweringFormInline({
       <div className="mx-auto flex w-full max-w-3xl flex-col">
         {!hideResourceHeader && (
           <div className="mb-6">
-            <ResourceHeader
+            <F0ResourceHeader
               title={title}
               description={description}
               {...resourceHeader}

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/types.ts
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/types.ts
@@ -2,7 +2,7 @@ import type { ModuleId } from "@/components/avatars/F0AvatarModule"
 import type { DialogPosition } from "@/patterns/F0Dialog/types"
 import type { UseFileUpload } from "@/patterns/F0Form/fields/file/types"
 import type { F0FormErrorTriggerMode } from "@/patterns/F0Form/types"
-import type { ResourceHeaderProps } from "@/patterns/ResourceHeader"
+import type { F0ResourceHeaderProps } from "@/patterns/F0ResourceHeader"
 
 import type {
   SurveyDatasets,
@@ -47,7 +47,7 @@ interface SurveyAnsweringFormSharedProps {
   elements: SurveyFormBuilderElement[]
   title: string
   description?: string
-  resourceHeader?: Omit<ResourceHeaderProps, "title" | "description">
+  resourceHeader?: Omit<F0ResourceHeaderProps, "title" | "description">
   defaultValues?: Partial<SurveyAnswers>
   loading?: boolean
   datasets?: SurveyDatasets
@@ -76,7 +76,7 @@ interface SurveyAnsweringFormDialogProps extends SurveyAnsweringFormSharedProps 
 interface SurveyAnsweringFormInlineProps extends SurveyAnsweringFormSharedProps {
   inline: true
   /**
-   * Hide the built-in ResourceHeader (title + description). Useful when the
+   * Hide the built-in F0ResourceHeader (title + description). Useful when the
    * embedding page already renders its own resource header above the form.
    */
   hideResourceHeader?: boolean

--- a/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
+++ b/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
@@ -44,7 +44,7 @@ import { Sidebar } from "@/patterns/Navigation/Sidebar/Sidebar"
 import * as SidebarStories from "@/patterns/Navigation/Sidebar/index.stories"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
-import { ResourceHeader } from "@/patterns/ResourceHeader"
+import { F0ResourceHeader } from "@/patterns/F0ResourceHeader"
 import { useAiChat } from "@/kits/ai/F0AiChat"
 import type { ClarifyingOption } from "@/kits/ai/F0ClarifyingPanel"
 import {
@@ -429,7 +429,7 @@ const templatesCanvasEntity: CanvasEntityDefinition<TemplatesCanvasContent> = {
   type: "templates",
   // Standard canvas header: title (from content) on the left, close on the
   // right — mirrors the design system's panel-header structure (no
-  // ResourceHeader chrome). Rendered as a component so closing can return to the
+  // F0ResourceHeader chrome). Rendered as a component so closing can return to the
   // first step of cocreation rather than just dismissing the canvas (see
   // `TemplatesCanvasHeader`); the framework `onClose` is intentionally dropped.
   renderHeader: ({ content }) => <TemplatesCanvasHeader content={content} />,
@@ -553,7 +553,7 @@ function useCloseTemplatesCanvas() {
 // story-specific (not part of the closed SDS `CanvasContent` union), so we keep
 // a local content type and cast at the `openCanvas` call site. `mode` selects
 // the surface: "preview" is the read-only `SurveyAnsweringForm` (template
-// browsing), while "edit" is the editable resource view — a `ResourceHeader` +
+// browsing), while "edit" is the editable resource view — a `F0ResourceHeader` +
 // Questions/Settings tabs over the interactive `SurveyFormBuilder` (see
 // `SurveyEditorCanvasHeader` / `SurveyEditorCanvasBody`).
 type SurveyCanvasContent = CanvasContentBase & {
@@ -637,7 +637,7 @@ const UNTITLED_SURVEY_NAME = "Untitled survey"
 // Build the canvas content for a blank survey opened by the "Empty survey"
 // welcome card (or the typed "Create" flow). Reuses the survey canvas entity
 // (mode "edit") but with no sample questions: it mirrors a real Survey resource
-// view — a `ResourceHeader` + Questions/Settings tab strip — with the
+// view — a `F0ResourceHeader` + Questions/Settings tab strip — with the
 // interactive `SurveyFormBuilder` (seeded empty) living under the "Questions"
 // tab (see `SurveyEditorCanvasHeader` / `SurveyEditorCanvasBody`). The
 // `surveyId` ties it to its entry in the multi-survey store.
@@ -1432,7 +1432,7 @@ function TemplatePreviewAlert() {
  * `FlowContent`'s `setBeforeClose`).
  * The framework `onClose` is intentionally ignored in favour of these. "Use this template"
  * swaps in the editable resource view (mode "edit"), carrying the template's
- * name and description so its `ResourceHeader` is populated. Defined as a
+ * name and description so its `F0ResourceHeader` is populated. Defined as a
  * component so it can read `openCanvas` / `setVisualizationMode` from context.
  */
 function SurveyCanvasHeader({ content }: { content: SurveyCanvasContent }) {
@@ -1902,7 +1902,7 @@ function countQuestions(elements: SurveyFormBuilderElement[]): number {
 
 /**
  * Header for the editable survey canvas. Mirrors a real Survey resource view: a
- * `ResourceHeader` (title, optional description, Draft status, Publish action,
+ * `F0ResourceHeader` (title, optional description, Draft status, Publish action,
  * "⋯" menu, metadata) stacked over the Questions / Settings tab strip — the
  * same chrome the split phase renders for a created survey. The "Questions"
  * metadata reflects the live question count from the shared canvas state.
@@ -1919,7 +1919,7 @@ function SurveyEditorCanvasHeader({
   const i18n = useI18n()
   return (
     <>
-      <ResourceHeader
+      <F0ResourceHeader
         title={name}
         description={content.description}
         status={{ label: "Status", text: "Draft", variant: "neutral" }}
@@ -2058,7 +2058,7 @@ const surveyCanvasEntity: CanvasEntityDefinition<SurveyCanvasContent> = {
   ),
   // "preview" is the read-only template browse view (its own thin header +
   // answering form); "edit" (incl. the empty survey) is the editable resource
-  // view — ResourceHeader + Questions/Settings tabs over the form builder.
+  // view — F0ResourceHeader + Questions/Settings tabs over the form builder.
   renderHeader: ({ content, onClose }) =>
     content.mode === "preview" ? (
       <SurveyCanvasHeader content={content} />

--- a/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
+++ b/packages/react/src/patterns/F0Dialog/__stories__/F0Modal.stories.tsx
@@ -6,8 +6,8 @@ import { expect, within } from "storybook/test"
 import { F0Button } from "@/components/F0Button"
 import { ApplicationFrame } from "@/patterns/ApplicationFrame"
 import ApplicationFrameStoryMeta from "@/patterns/ApplicationFrame/index.stories"
-import { ResourceHeader } from "@/patterns/ResourceHeader"
-import { Default as ResourceHeaderDefault } from "@/patterns/ResourceHeader/index.stories"
+import { F0ResourceHeader } from "@/patterns/F0ResourceHeader"
+import { Default as ResourceHeaderDefault } from "@/patterns/F0ResourceHeader/index.stories"
 import {
   OnePersonListItem,
   OnePersonListItemProps,
@@ -414,9 +414,9 @@ export const WithResourceHeader: Story = {
       href: "/timeoff",
     },
     children: (
-      <ResourceHeader
+      <F0ResourceHeader
         {...(ResourceHeaderDefault.args as ComponentProps<
-          typeof ResourceHeader
+          typeof F0ResourceHeader
         >)}
         primaryAction={undefined}
         secondaryActions={undefined}

--- a/packages/react/src/patterns/F0Dialog/internal-types.ts
+++ b/packages/react/src/patterns/F0Dialog/internal-types.ts
@@ -4,7 +4,7 @@ import { ModuleId } from "@/components/avatars/F0AvatarModule"
 import { DropdownInternalProps } from "@/experimental/Navigation/Dropdown/internal"
 import { NavigationProps } from "@/experimental/Navigation/Header/PageNavigation"
 import { TabsProps } from "@/patterns/Navigation/Tabs"
-import { ResourceHeaderProps } from "@/patterns/ResourceHeader"
+import { F0ResourceHeaderProps } from "@/patterns/F0ResourceHeader"
 
 import {
   DialogControls,
@@ -26,7 +26,7 @@ export type F0DialogHeaderProps = {
   }
   otherActions?: DropdownInternalProps["items"]
   navigation?: NavigationProps
-  resourceHeader?: ResourceHeaderProps
+  resourceHeader?: F0ResourceHeaderProps
   controls?: DialogControls
 } & Partial<Pick<TabsProps, "tabs" | "activeTabId" | "setActiveTabId">>
 

--- a/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
@@ -3,15 +3,15 @@ import { describe, expect, it, vi } from "vitest"
 import { Download } from "@/icons/app"
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 
-import { ResourceHeader } from "../index"
+import { F0ResourceHeader } from "../index"
 
-describe("ResourceHeader", () => {
+describe("F0ResourceHeader", () => {
   it("renders secondary dropdown actions and calls the selected actions", async () => {
     const user = userEvent.setup()
     const onExport = vi.fn()
 
     render(
-      <ResourceHeader
+      <F0ResourceHeader
         title="Reports"
         secondaryActions={[
           {

--- a/packages/react/src/patterns/F0ResourceHeader/index.mdx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.mdx
@@ -339,7 +339,7 @@ When hovering over a metadata field, one or more of these actions may be display
 ## Import
 
 ```tsx
-import { ResourceHeader } from "@factorialco/f0-react"
+import { F0ResourceHeader } from "@factorialco/f0-react"
 ```
 
 ## Examples

--- a/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
@@ -8,11 +8,11 @@ import * as Icon from "@/icons/app"
 import { Archive, Comment, Download, ExternalLink, Pencil } from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
-import { ResourceHeader } from "./index"
+import { F0ResourceHeader } from "./index"
 
-const meta: Meta<typeof ResourceHeader> = {
+const meta: Meta<typeof F0ResourceHeader> = {
   title: "Resource header",
-  component: ResourceHeader,
+  component: F0ResourceHeader,
   tags: ["stable"],
   parameters: {
     layout: "padded",
@@ -49,7 +49,7 @@ const meta: Meta<typeof ResourceHeader> = {
 
 export default meta
 
-type Story = StoryObj<typeof ResourceHeader>
+type Story = StoryObj<typeof F0ResourceHeader>
 
 // Hoisted so the play function has a type-safe handle on the spy: `args.primaryAction`
 // is a union (PrimaryActionButton | PrimaryDropdownAction) and has no `onClick` in common.
@@ -635,7 +635,7 @@ export const DeactivatedEmployee: Story = {
   },
 }
 
-type ResourceHeaderProps = ComponentProps<typeof ResourceHeader>
+type F0ResourceHeaderProps = ComponentProps<typeof F0ResourceHeader>
 
 export const Snapshot: Story = {
   tags: ["!dev"],
@@ -643,18 +643,20 @@ export const Snapshot: Story = {
   render: () => {
     return (
       <div>
-        <ResourceHeader {...(NoDescription.args as ResourceHeaderProps)} />
-        <ResourceHeader {...(Default.args as ResourceHeaderProps)} />
-        <ResourceHeader
-          {...(WithLongDescription.args as ResourceHeaderProps)}
+        <F0ResourceHeader {...(NoDescription.args as F0ResourceHeaderProps)} />
+        <F0ResourceHeader {...(Default.args as F0ResourceHeaderProps)} />
+        <F0ResourceHeader
+          {...(WithLongDescription.args as F0ResourceHeaderProps)}
         />
-        <ResourceHeader {...(WithDropdownAction.args as ResourceHeaderProps)} />
-        <ResourceHeader
-          {...(WithSecondaryDropdownAction.args as ResourceHeaderProps)}
+        <F0ResourceHeader
+          {...(WithDropdownAction.args as F0ResourceHeaderProps)}
         />
-        <ResourceHeader {...(PersonHeader.args as ResourceHeaderProps)} />
-        <ResourceHeader
-          {...(DeactivatedEmployee.args as ResourceHeaderProps)}
+        <F0ResourceHeader
+          {...(WithSecondaryDropdownAction.args as F0ResourceHeaderProps)}
+        />
+        <F0ResourceHeader {...(PersonHeader.args as F0ResourceHeaderProps)} />
+        <F0ResourceHeader
+          {...(DeactivatedEmployee.args as F0ResourceHeaderProps)}
         />
       </div>
     )

--- a/packages/react/src/patterns/F0ResourceHeader/index.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.tsx
@@ -24,7 +24,7 @@ type Props = {} & Pick<
  * Header for a resource detail page: avatar, title, description, status,
  * metadata and its primary, secondary and overflow actions.
  */
-export const ResourceHeader = ({
+export const F0ResourceHeader = ({
   avatar,
   title,
   description,
@@ -56,4 +56,4 @@ export const ResourceHeader = ({
   )
 }
 
-export type ResourceHeaderProps = Props
+export type F0ResourceHeaderProps = Props

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -9,7 +9,7 @@ import { ApplicationFrame } from "@/patterns/ApplicationFrame"
 import ApplicationFrameStoryMeta from "@/patterns/ApplicationFrame/index.stories"
 import { F0Dialog } from "@/patterns/F0Dialog"
 import { Page as NavigationPage } from "@/patterns/Navigation/Page"
-import { ResourceHeader } from "@/patterns/ResourceHeader"
+import { F0ResourceHeader } from "@/patterns/F0ResourceHeader"
 import { Sidebar } from "@/patterns/Navigation/Sidebar/Sidebar"
 import * as SidebarStories from "@/patterns/Navigation/Sidebar/index.stories"
 
@@ -64,7 +64,7 @@ function ResourcePageView({ resourcePage }: { resourcePage: Resource }) {
               module={CRUD_MODULE}
               breadcrumbs={[{ id: resourcePage.id, label: resourcePage.name }]}
             />
-            <ResourceHeader
+            <F0ResourceHeader
               title={resourcePage.name}
               description={resourcePage.summary}
               status={{

--- a/packages/react/src/sds/timeline/types.ts
+++ b/packages/react/src/sds/timeline/types.ts
@@ -42,7 +42,7 @@ export interface F0TimelineRowTaskProps extends F0TimelineRowBaseProps {
   icon?: IconType
   /** Description text (e.g., "Completed on 20/2025") */
   description?: string
-  /** Metadata items to display (assignees, tags, dates, etc.) using the same pattern as ResourceHeader */
+  /** Metadata items to display (assignees, tags, dates, etc.) using the same pattern as F0ResourceHeader */
   metadata?: (MetadataItem | undefined | boolean)[]
   /** Primary action button (displayed on the right after a divider) */
   primaryAction?: F0TimelineRowAction

--- a/packages/react/src/ui/ButtonGroup/variants.ts
+++ b/packages/react/src/ui/ButtonGroup/variants.ts
@@ -25,7 +25,7 @@ export const buttonGroupVariants = cva({
      * Orientation + responsive stacking, encoded as ONE axis:
      * - `none`: always a horizontal row.
      * - `sm` / `md`: stack as a column below the named *viewport* breakpoint and
-     *   become a row at/above it (matches Card footer `sm`, ResourceHeader `md`).
+     *   become a row at/above it (matches Card footer `sm`, F0ResourceHeader `md`).
      * - `container-md`: stack below the *container* `@md` breakpoint (28rem / 448px);
      *   requires an ancestor with `@container` (matches F0CardHorizontal).
      */


### PR DESCRIPTION
## Description

Resource header was cleared of every stable-DoD gap by #4989, but #5137 added a "F0" name-prefix check that its `ResourceHeader` folder/symbol never satisfied, so it regressed back onto `.scripts/stable-dod-debt.json`. This renames it to `F0ResourceHeader` (folder, exported symbol, and prop type) to match every other stable pattern's naming convention, and updates its internal consumers accordingly.

`ResourceHeader` is also exported publicly via the deprecated `@factorialco/f0-react/dist/experimental` barrel, and Factorial's frontend alone has **614 files** importing it from there (626 render sites) — pinned at `f0-react@6.8.3`, so the break wouldn't surface until that dependency is bumped. To avoid it, the deprecated barrel keeps re-exporting `ResourceHeader`/`ResourceHeaderProps` as aliases of the new names, with a regression test that verifies the alias directly (and fails if the alias is ever dropped — verified locally by reverting it and confirming the test catches it).

## Implementation details

- fix: rename `src/patterns/ResourceHeader` to `src/patterns/F0ResourceHeader`, and `ResourceHeader`/`ResourceHeaderProps` to `F0ResourceHeader`/`F0ResourceHeaderProps`
- fix: update all internal imports and JSX usages (`F0Dialog`, `F0Drawer`, `SurveyAnsweringForm`, `OneDataCollection`, `Cocreation` stories) and prose references in docs/comments
- fix: keep `ResourceHeader`/`ResourceHeaderProps` as deprecated aliases in the experimental barrel so existing `@factorialco/f0-react` consumers (Factorial's frontend) don't break on the next dependency bump, with a regression test for the alias
- chore: remove `Resource header` from `stable-dod-debt.json` now that it meets the full DoD again