### PR TITLE
fix(ui/switch): meet the WCAG 2.2 target-size floor

### DIFF
--- a/packages/react/src/experimental/Forms/Fields/Switch/__tests__/Switch.test.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Switch/__tests__/Switch.test.tsx
@@ -30,4 +30,28 @@ describe("Switch (experimental)", () => {
     expect(label.className).toMatch(/!cursor-not-allowed/)
     expect(label.className).toMatch(/opacity-50/)
   })
+
+  // WCAG 2.2 SC 2.5.8 (Target Size, Minimum) requires an interactive target to
+  // be at least 24x24 CSS px unless it has 24px of clear space around it. The
+  // switch button used to be 20px tall (`h-5`), so it only conformed when the
+  // consumer's layout happened to isolate it — putting any other target within
+  // 24px (as a form row or a card footer does) turned it into a real AA
+  // failure that axe reports as `target-size`.
+  //
+  // Asserted on classes rather than measured: jsdom has no layout, so
+  // `getBoundingClientRect()` returns zeroes. The story-level axe test in
+  // `index.stories.tsx` (`AdjacentTargets`) is what checks the real geometry.
+  it("sizes the interactive box to the 24px WCAG target-size floor", () => {
+    render(<Switch title="Notifications" />)
+    const sw = screen.getByRole("switch")
+    expect(sw.className).toMatch(/\bh-6\b/)
+    expect(sw.className).not.toMatch(/\bh-5\b/)
+  })
+
+  it("keeps the visible pill at 20px so the design is unchanged", () => {
+    render(<Switch title="Notifications" />)
+    const track = screen.getByRole("switch").querySelector("[aria-hidden]")
+    expect(track).not.toBeNull()
+    expect(track?.className).toMatch(/\bh-5\b/)
+  })
 })

--- a/packages/react/src/experimental/Forms/Fields/Switch/index.stories.tsx
+++ b/packages/react/src/experimental/Forms/Fields/Switch/index.stories.tsx
@@ -93,3 +93,42 @@ export const NoLabel: Story = {
     return <Switch {...args} checked={checked} onCheckedChange={setChecked} />
   },
 }
+
+/**
+ * Regression guard for WCAG 2.2 SC 2.5.8 (Target Size, Minimum).
+ *
+ * Two switches sit 8px apart, closer than the 24px of clear space the spec's
+ * spacing exception needs. That leaves the switch's own box as the only way to
+ * satisfy the criterion, which is exactly the situation a form row or a card
+ * footer creates. With the 20px (`h-5`) switch this story failed axe with
+ * `target-size` on both controls; with the 24px hit area it passes on size
+ * regardless of how close the neighbours are.
+ *
+ * `a11y: { test: "error" }` makes it blocking — the global default in
+ * `.storybook/preview.tsx` is `todo`, which reports without failing.
+ */
+export const AdjacentTargets: Story = {
+  parameters: {
+    a11y: { test: "error" },
+  },
+  render: () => {
+    const [first, setFirst] = useState(false)
+    const [second, setSecond] = useState(true)
+    return (
+      <div className="flex flex-row gap-2">
+        <Switch
+          title="Email alerts"
+          hideLabel
+          checked={first}
+          onCheckedChange={setFirst}
+        />
+        <Switch
+          title="Push alerts"
+          hideLabel
+          checked={second}
+          onCheckedChange={setSecond}
+        />
+      </div>
+    )
+  },
+}

--- a/packages/react/src/ui/switch.tsx
+++ b/packages/react/src/ui/switch.tsx
@@ -2,7 +2,7 @@ import * as SwitchPrimitive from "@radix-ui/react-switch"
 import * as React from "react"
 import { useId } from "react"
 
-import { cn, focusRing } from "../lib/utils"
+import { cn } from "../lib/utils"
 
 const Switch = React.forwardRef<
   React.ElementRef<typeof SwitchPrimitive.Root>,
@@ -25,20 +25,40 @@ const Switch = React.forwardRef<
         name={switchId}
         aria-label={props.title ?? "Switch"}
         className={cn(
-          "relative h-5 w-[1.875rem] rounded-full bg-f1-border hover:bg-f1-border-hover data-[state=checked]:bg-f1-background-selected-bold",
+          // The interactive box is 24px tall to meet the WCAG 2.2 SC 2.5.8
+          // (Target Size, Minimum) 24x24 floor on its own. It used to be 20px
+          // (`h-5`), which only conformed via the spec's spacing exception —
+          // i.e. when a consumer happened to leave 24px of clear space around
+          // it. Any neighbouring target closer than that (a form row, a
+          // toolbar, a table cell) made it a genuine AA failure. The visible
+          // 20px pill is painted by the decorative track below, so the switch
+          // looks exactly the same as before.
+          "group relative flex h-6 w-[1.875rem] items-center bg-transparent",
           // `!cursor-not-allowed` defends against consumer CSS resets (e.g. ress.css)
           // that target `[disabled]` / `[aria-disabled='true']` with the same
           // specificity as `.cursor-not-allowed` and would otherwise win when
           // loaded after F0 styles.
           disabled && "!cursor-not-allowed opacity-50",
-          focusRing(),
+          "focus-visible:outline-none",
           className
         )}
         disabled={disabled}
       >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-x-0 top-1/2 h-5 -translate-y-1/2 rounded-full bg-f1-border transition-colors",
+            "group-hover:bg-f1-border-hover group-data-[state=checked]:bg-f1-background-selected-bold",
+            // Same ring as `focusRing()`, but driven by the parent's focus so
+            // the indicator keeps hugging the 20px pill instead of growing to
+            // the (now taller) hit area. Keep in sync with `focusRing()` in
+            // src/lib/utils.ts.
+            "group-focus-visible:ring-1 group-focus-visible:ring-f1-special-ring group-focus-visible:ring-offset-1"
+          )}
+        />
         <SwitchPrimitive.Thumb
           className={cn(
-            "block h-4 w-4 translate-x-[0.125rem] rounded-full bg-f1-background transition-transform duration-300 data-[state=checked]:translate-x-[0.75rem]"
+            "relative block h-4 w-4 translate-x-[0.125rem] rounded-full bg-f1-background transition-transform duration-300 data-[state=checked]:translate-x-[0.75rem]"
           )}
         />
       </SwitchPrimitive.Root>


### PR DESCRIPTION
## Description

The switch button was 20px tall, under the 24×24 CSS px minimum in WCAG 2.2 SC 2.5.8 (Target Size, Minimum). It passed only through the spec's spacing exception, which needs 24px of clear space around the target, so any control placed closer than that made it a Level AA failure. This gives the switch a 24px interactive box and leaves it looking the same. It turned up while auditing `Card` against the stable Definition of Done: the `WithInteractiveChildren` story failed axe on the switch, with a link sitting 11px away from it.

## Type of change

- [x] Bug fix

## Implementation details

- fix: give the switch a 24px interactive box, so it meets the target-size minimum on its own instead of depending on a consumer's spacing

  <details>
  <summary>How the design stays identical</summary>

  The interactive box and the painted box were the same element, so the pill's 20px height was also the target's height. They are now separate: `SwitchPrimitive.Root` is a transparent 30×24 hit area (`flex h-6 w-[1.875rem] items-center`), and the visible 20px pill is a decorative `aria-hidden` span inside it carrying the `bg-f1-border`, hover and `data-[state=checked]` colours. The thumb keeps `h-4 w-4` and both `translate-x` values.

  Measured the original build before changing it: root 30×20, thumb 16×16 inset 2px on every side. The new structure reproduces that, because the 16px thumb centres in the 24px box at offset 4 and the 20px pill centres at offset 2.

  </details>

- fix: keep the focus ring on the 20px pill rather than letting it grow with the taller hit area

  <details>
  <summary>Trade-off</summary>

  Driven from the parent's `focus-visible` state with `group-focus-visible:`, which duplicates the four utility classes in `focusRing()`. There is a comment on both sides to keep them in sync. The alternative was leaving `focusRing()` on the Root, which would have traced a 30×24 rect and changed the focus appearance.

  </details>

- test: add a regression test for the 24px floor, plus one asserting the pill stays 20px

  <details>
  <summary>Red-green evidence</summary>

  `pnpm check:bugfix-red-green` passes: both new tests fail on latest main and pass here. The CI job agrees.

  They assert on classes rather than measuring, because jsdom has no layout and `getBoundingClientRect()` returns zeroes. Real geometry is covered by the story below.

  </details>

- test: add an `AdjacentTargets` story that runs axe as blocking

  <details>
  <summary>What it reproduces</summary>

  Two switches 8px apart, closer than the spacing exception allows, which leaves the switch's own box as the only way to satisfy the criterion. That is the situation a form row or a card footer creates.

  It sets `a11y: { test: "error" }` because the global default in `.storybook/preview.tsx` is `todo`, which runs axe and reports without failing.

  Browse it in this PR's published Storybook: [Switch → Adjacent Targets](https://66a7a8d7d124220c363457cc-enrrfjccqq.chromatic.com/?path=/story/components-switch--adjacent-targets)

  </details>

One behaviour change beyond geometry: a consumer passing `className` now styles the hit area instead of the pill. Neither in-repo caller passes one (`experimental/Forms/Fields/Switch` and the `Card` story's demo content), but an external consumer overriding the switch background would see the difference.

No visual baselines moved. Chromatic passes, and no `withSnapshot` story renders a `Switch`. `tsc --noEmit`, `oxlint` and `oxfmt` are clean.
