### PR TITLE
feat(home): export HomeListItem and the tinted list glyph

### DIFF
--- a/packages/react/src/experimental/Widgets/Layout/exports.tsx
+++ b/packages/react/src/experimental/Widgets/Layout/exports.tsx
@@ -6,8 +6,15 @@
 // SlotWidget is public because a preview drawn any OTHER way is a preview that
 // can drift: an app that has to approximate a widget out of the content
 // components reproduces the frame, the seams and the spacing by hand, and the
-// first of those to fall out of step is silent. WidgetContainer and
-// HomeListItem stay internal — the layout draws columns from data.
+// first of those to fall out of step is silent. WidgetContainer stays internal
+// — the layout draws columns from data.
+//
+// HomeListItem is public for the same anti-drift reason, one level down: a
+// surface that drills INTO a widget (an overlay listing the tasks a grouped row
+// summarises) renders those rows outside any layout or slot, and they have to
+// match the rows the `list` slot drew. Prefer `listSlot` inside a widget; reach
+// for the row only for those Home-adjacent surfaces.
+export * from "../../../sds/Home/HomeListItem"
 export * from "../../../sds/Home/NewHomeLayout"
 export * from "../../../sds/Home/slotRenderers"
 export * from "../../../sds/Home/SlotWidget"

--- a/packages/react/src/sds/Home/HomeListItem/index.stories.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { F0Dialog } from "@/components/dialog-alike/F0Dialog"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
-import { Comment } from "@/icons/app"
+import { Comment, Money, PalmTree } from "@/icons/app"
+
+import { ListIconGlyph } from "../slotRenderers"
 
 import { HomeListItem } from "./index"
 
@@ -82,5 +85,50 @@ export const AvatarTypes: Story = {
         href="#"
       />
     </div>
+  ),
+}
+
+/**
+ * Rows rendered OUTSIDE a widget, in a dialog: the Home feed summarises several
+ * tasks in one row ("Approve 16 expenses"), and opening it lists the tasks it
+ * stands for. The rows have to match the ones the `list` slot drew in the
+ * widget, which is why the row is public — a slot can't reach in here.
+ */
+export const InsideADialog: Story = {
+  args: { title: "unused" },
+  parameters: { docs: { story: { height: "420px" } } },
+  render: () => (
+    <F0Dialog isOpen onClose={() => {}} title="Approve 16 expenses">
+      <div className="flex flex-col">
+        <HomeListItem
+          description="Overdue · 12 Aug 2026 · Client dinner"
+          left={<ListIconGlyph icon={Money} color="flubber" />}
+          href="#"
+          showChevron
+          title="Review Ada Lovelace's expense request"
+        />
+        <HomeListItem
+          description="Overdue · 12 Aug 2026 · Taxi to airport"
+          left={<ListIconGlyph icon={Money} color="flubber" />}
+          href="#"
+          showChevron
+          title="Review Grace Hopper's expense request"
+        />
+        <HomeListItem
+          description="Due tomorrow · 18 Aug 2026"
+          href="#"
+          left={<ListIconGlyph icon={PalmTree} color="viridian" />}
+          showChevron
+          title="Review Alan Turing's time off request"
+        />
+        <HomeListItem
+          description="Due tomorrow · 18 Aug 2026"
+          href="#"
+          left={<ListIconGlyph icon={Comment} color="lilac" />}
+          showChevron
+          title="Answer the engagement survey"
+        />
+      </div>
+    </F0Dialog>
   ),
 }

--- a/packages/react/src/sds/Home/HomeListItem/index.stories.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.stories.tsx
@@ -1,10 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { F0Dialog } from "@/components/dialog-alike/F0Dialog"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
-import { Comment, Money, PalmTree } from "@/icons/app"
-
-import { ListIconGlyph } from "../slotRenderers"
+import { Comment } from "@/icons/app"
 
 import { HomeListItem } from "./index"
 
@@ -85,50 +82,5 @@ export const AvatarTypes: Story = {
         href="#"
       />
     </div>
-  ),
-}
-
-/**
- * Rows rendered OUTSIDE a widget, in a dialog: the Home feed summarises several
- * tasks in one row ("Approve 16 expenses"), and opening it lists the tasks it
- * stands for. The rows have to match the ones the `list` slot drew in the
- * widget, which is why the row is public — a slot can't reach in here.
- */
-export const InsideADialog: Story = {
-  args: { title: "unused" },
-  parameters: { docs: { story: { height: "420px" } } },
-  render: () => (
-    <F0Dialog isOpen onClose={() => {}} title="Approve 16 expenses">
-      <div className="flex flex-col">
-        <HomeListItem
-          description="Overdue · 12 Aug 2026 · Client dinner"
-          left={<ListIconGlyph icon={Money} color="flubber" />}
-          href="#"
-          showChevron
-          title="Review Ada Lovelace's expense request"
-        />
-        <HomeListItem
-          description="Overdue · 12 Aug 2026 · Taxi to airport"
-          left={<ListIconGlyph icon={Money} color="flubber" />}
-          href="#"
-          showChevron
-          title="Review Grace Hopper's expense request"
-        />
-        <HomeListItem
-          description="Due tomorrow · 18 Aug 2026"
-          href="#"
-          left={<ListIconGlyph icon={PalmTree} color="viridian" />}
-          showChevron
-          title="Review Alan Turing's time off request"
-        />
-        <HomeListItem
-          description="Due tomorrow · 18 Aug 2026"
-          href="#"
-          left={<ListIconGlyph icon={Comment} color="lilac" />}
-          showChevron
-          title="Answer the engagement survey"
-        />
-      </div>
-    </F0Dialog>
   ),
 }

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -4,6 +4,7 @@ import { type z } from "zod"
 
 import { F0Avatar, type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { F0AvatarAlert } from "@/components/avatars/F0AvatarAlert"
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import {
   F0AvatarList,
   F0AvatarListProps,
@@ -253,28 +254,35 @@ const LIST_ICON_SIZE = {
  * colouring it is a Home decision, not a design-system one. Without a `color`
  * a row draws the plain `F0AvatarIcon` instead; this is the same box either way.
  */
-const ListIconGlyph = ({
+export const ListIconGlyph = ({
   icon,
-  tint,
-  size,
+  color,
+  size = "lg",
 }: {
   icon: IconType
-  tint: NonNullable<ReturnType<typeof listIconTint>>
-  size: ListGlyphSize
-}) => (
-  <div
-    className={cn(
-      "flex aspect-square items-center justify-center",
-      LIST_ICON_SIZE[size],
-      tint.className
-    )}
-    style={tint.style}
-  >
-    {/* No `color`: F0Icon defaults to `currentColor`, which the tile's own
-        `text-` class has already set to the hue. */}
-    <F0Icon icon={icon} size={size} />
-  </div>
-)
+  /** A palette name or `#rrggbb`; an unparseable value draws the plain tile. */
+  color: ListIconColor
+  size?: ListGlyphSize
+}) => {
+  const tint = listIconTint(color)
+
+  if (!tint) return <F0AvatarIcon icon={icon} size={size} />
+
+  return (
+    <div
+      className={cn(
+        "flex aspect-square items-center justify-center",
+        LIST_ICON_SIZE[size],
+        tint.className
+      )}
+      style={tint.style}
+    >
+      {/* No `color`: F0Icon defaults to `currentColor`, which the tile own
+          `text-` class has already set to the hue. */}
+      <F0Icon icon={icon} size={size} />
+    </div>
+  )
+}
 
 /**
  * What every row draws on its RIGHT: a counter, one avatar (e.g. the sender),
@@ -846,7 +854,11 @@ const listLeft = (
     if (tint)
       return {
         left: (
-          <ListIconGlyph icon={row.avatar.icon} tint={tint} size={avatarSize} />
+          <ListIconGlyph
+            icon={row.avatar.icon}
+            color={row.avatar.color}
+            size={avatarSize}
+          />
         ),
       }
   }


### PR DESCRIPTION
## 🚪 Why?

### Problem
A surface that drills **into** a Home widget has to render that widget's rows outside any layout or slot — and today it can't.

Concretely: the new Home's "Needs you" feed groups the inbox and summarises several tasks in one row ("Approve 16 expenses"). Opening that row lists the tasks it stands for, in an overlay. Those rows must look exactly like the ones the `list` slot drew in the widget, but `HomeListItem` and the tinted glyph are internal, so a consumer has to approximate them out of other components — the silent drift `SlotWidget` was made public to avoid, one level down.

## 🔑 What?

### Changes
- **`HomeListItem` is exported** from the Home kit, with the reasoning that already justifies `SlotWidget`. `WidgetContainer` stays internal; the guidance is unchanged — prefer `listSlot` inside a widget, reach for the row only for these Home-adjacent surfaces.
- **`ListIconGlyph` is exported** (the tinted tile a `list` row draws, previously internal). It now takes a `color: ListIconColor` instead of a pre-resolved tint object, so a consumer gets the same pastel category glyphs without rebuilding the tile. It falls back to the plain `F0AvatarIcon` when a colour can't be parsed; **the slot keeps deciding that fallback itself, so slot behaviour is unchanged.**

### Not covered
- No change to `listSlot`'s API or output; this only widens what a consumer may import.
- No story here: the drill-in surface that motivates it is still being built, so the export and the glyph change stand on their own.

## ✅ Verification

- `pnpm tsc`: clean.
- `pnpm lint`: 0 warnings, 0 errors.
- Pre-commit gates: no new circular dependencies, format, ownership all pass.
- Exercised locally in Storybook against a dialog rendering these rows (rows, tinted glyphs, hover actions, chevrons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)