### PR TITLE
docs(Card): meet the stable Definition of Done

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -14,7 +14,6 @@
     "Avatars/AvatarPerson",
     "Avatars/AvatarTeam",
     "BigNumber",
-    "Card",
     "Charts/RadarChart",
     "Checkbox",
     "DatePicker",

--- a/packages/react/src/components/F0Card/__stories__/Card.mdx
+++ b/packages/react/src/components/F0Card/__stories__/Card.mdx
@@ -1,0 +1,223 @@
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
+import * as Stories from "./Card.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { F0Card } from "../F0Card"
+import { I18nProvider, defaultTranslations } from "@/lib/providers/i18n"
+
+<Meta of={Stories} />
+
+# Card
+
+Summarises **one** resource — a person, a job posting, a project, a file — so it
+can be recognised and acted on without being opened. A card carries the
+resource's identity, a few supporting facts, and the actions available on it.
+
+For a list of many resources, reach for the
+[Data Collection card visualization](/docs/patterns-datacollection-visualizations-card--documentation)
+instead of assembling a grid by hand.
+
+## Anatomy
+
+{/* Canvas heights are set per story: the meta renders docs previews in a 320px iframe, which clips most of these cards. */}
+
+<Canvas of={Stories.Default} story={{ height: "380px" }} />
+
+<Controls of={Stories.Default} />
+
+The `avatar` and `title` carry identity, `description` adds a single line of
+context, and `metadata` holds the supporting facts as labelled rows. Actions
+split by prominence: `primaryAction` and `secondaryActions` sit in the footer,
+`otherActions` collapse into an overflow menu. Only `title` is really expected —
+every other region is optional and the layout closes up when it is absent.
+
+## Guidelines
+
+### When to use
+
+- The subject is **one** identifiable resource, and the reader needs enough of
+  it to decide whether to open it.
+- The same shape repeats across a set, so a scannable summary beats prose.
+- The resource has actions worth surfacing before it is opened, such as
+  approving, referring, or saving.
+
+### When not to use
+
+- **A collection.** Rendering many resources is
+  `OneDataCollection`'s job: it brings selection, search, filters, pagination and
+  the grid itself. Hand-rolling a grid of cards re-implements all of that and
+  drifts from it.
+- **A horizontal row.** Use `F0CardHorizontal` when the layout reads
+  left-to-right rather than top-down.
+- **A whole page.** A card summarises a resource; the resource's own page uses
+  `F0ResourceHeader` with page layout underneath.
+- **Transient feedback.** A card is a persistent object, not a message. Use a
+  toast for feedback and `F0Alert` for a standing condition on the page.
+
+### Do's and don'ts
+
+<DoDonts
+  stacked
+  do={{
+    description:
+      "Keep metadata to the few facts that support the decision the reader is about to make.",
+    guidelines: [
+      "Label every metadata row so the value is self-explanatory",
+      "Lead with the fact that most often decides the next action",
+      "Let the card close up when a region has no data, rather than padding it",
+    ],
+    children: (
+      <I18nProvider translations={defaultTranslations}>
+        <div className="w-[372px]">
+          <F0Card
+            avatar={{ type: "person", firstName: "Daniel", lastName: "Moreno" }}
+            title="Daniel Moreno"
+            description="Design Engineer"
+            metadata={[
+              {
+                property: {
+                  type: "text",
+                  label: "Job title",
+                  value: "Design Engineer",
+                },
+              },
+              {
+                property: {
+                  type: "status",
+                  label: "Status",
+                  value: { status: "positive", label: "Active" },
+                },
+              },
+            ]}
+          />
+        </div>
+      </I18nProvider>
+    ),
+  }}
+  dont={{
+    description:
+      "Don't turn the card into a record view by listing every field the resource has.",
+    guidelines: [
+      "Don't repeat the title inside the description",
+      "Don't stack more than a handful of metadata rows — link to the resource instead",
+      "Don't put a second resource's data in the same card",
+    ],
+    children: (
+      <I18nProvider translations={defaultTranslations}>
+        <div className="w-[372px]">
+          <F0Card
+            avatar={{ type: "person", firstName: "Daniel", lastName: "Moreno" }}
+            title="Daniel Moreno"
+            description="Daniel Moreno, Design Engineer at Factorial"
+            metadata={[
+              {
+                property: {
+                  type: "text",
+                  label: "Job title",
+                  value: "Design Engineer",
+                },
+              },
+              {
+                property: { type: "text", label: "Team", value: "Design" },
+              },
+              {
+                property: {
+                  type: "text",
+                  label: "Manager",
+                  value: "A. Prieto",
+                },
+              },
+              {
+                property: { type: "text", label: "Office", value: "Barcelona" },
+              },
+              {
+                property: { type: "text", label: "Start date", value: "2021" },
+              },
+              {
+                property: {
+                  type: "text",
+                  label: "Employee ID",
+                  value: "10924",
+                },
+              },
+            ]}
+          />
+        </div>
+      </I18nProvider>
+    ),
+  }}
+/>
+
+### Content best practices
+
+- **Title**: the resource's own name. No trailing period, no type prefix
+  ("Daniel Moreno", not "Employee: Daniel Moreno").
+- **Description**: one line that adds something the title does not.
+- **Metadata labels**: consistent across every card in the same set, so a column
+  of cards reads as a column.
+- **Action labels**: verb-first and specific ("Refer", "Approve"), never "Click
+  here".
+
+### Behavior
+
+- With `link`, the whole card navigates. Footer actions, the overflow menu and
+  interactive `children` keep their own behaviour instead of triggering
+  navigation, so a card can be both a link and a small control surface.
+- `selectable` turns the card into a selection target, with `selected` and
+  `onSelect` controlled by the consumer.
+- `bookmark` adds a save toggle that appears on hover and stays visible while
+  saved, so the saved state reads at a glance.
+- `F0Card.Skeleton` mirrors the loaded layout — pass `compact` so the placeholder
+  matches the density of the card that replaces it.
+
+## Variants
+
+Images accept a fit and a size, or a fixed `imageAspectRatio` when the ratio
+matters more than the height. `blurredBackground` fills the leftover space when
+the image does not cover its container.
+
+<Canvas of={Stories.WithImage} story={{ height: "500px" }} />
+
+`compact` tightens the layout to a single row of identity plus actions, for
+dense lists and side panels.
+
+<Canvas of={Stories.Compact} story={{ height: "380px" }} />
+
+## Usage
+
+### Actions
+
+`primaryAction` is the one thing you expect to be done; `secondaryActions` are
+alternatives, and accept either buttons or a single link.
+
+<Canvas of={Stories.WithActions} story={{ height: "440px" }} />
+
+### Alerts
+
+`alert` puts a coloured strip above the card for a condition that applies to
+that resource — an expiring document, a failed sync. It takes either an action
+or a dismiss affordance, not both.
+
+<Canvas of={Stories.WithAlert} story={{ height: "460px" }} />
+
+## Accessibility
+
+- When `link` is set the card renders one full-bleed anchor labelled with the
+  card's `title`, so the whole surface is a single keyboard target with a visible
+  focus ring — rather than a mouse-only click handler.
+- Clicks inside the body forward to that anchor, except on nested `a[href]`,
+  `input`, `select`, `textarea` and menu triggers, which keep their own
+  behaviour. That is what makes interactive `children` safe inside a linked card.
+- On an interactive card the header exposes `role="button"` with the title as its
+  accessible name and responds to both <kbd>Enter</kbd> and <kbd>Space</kbd>.
+- `image` is described by the card's `title`; the blurred backdrop behind it is
+  `aria-hidden`, so it is never announced twice.
+- `alert` announces itself according to severity: `role="alert"` for `critical`
+  and `warning`, `role="status"` for `info` and `positive`. Pick the variant by
+  urgency, not by colour.
+- `bookmark.label` names the toggle for screen readers and falls back to the
+  card's `title`.
+- The skeleton marks itself `aria-busy` in a polite live region, so a loading
+  card is announced once rather than as it fills in.
+- Interactive `children` are yours to size: every control needs a 24×24 CSS px
+  target, or 24px of clear space around it, to satisfy WCAG 2.2 SC 2.5.8. A bare
+  text link in a card footer usually needs padding to get there.

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -57,7 +57,15 @@ const InteractiveChildrenContent = () => {
         This card has a link, but the children are interactive.
       </p>
       <div className="flex items-center justify-between">
-        <F0Link href="https://google.com" target="_blank">
+        {/*
+         * `py-0.5` takes the link from its 20px line box to a 24px target so it
+         * satisfies WCAG 2.2 SC 2.5.8 (Target Size, Minimum) on its own. A bare
+         * text link would only pass via the spacing exception, and the switch
+         * sits 11px away — well inside the 24px that exception needs. The
+         * inline exception does not apply either: this is a standalone action,
+         * not a link inside a sentence.
+         */}
+        <F0Link href="https://google.com" target="_blank" className="py-0.5">
           Click me (goes to Google)
         </F0Link>
         <Switch
@@ -85,8 +93,12 @@ const meta = {
     docs: {
       story: { inline: false, height: "320px" },
     },
+    a11y: { test: "error" },
   },
-  tags: ["autodocs", "stable"],
+  // `!autodocs` because Card.mdx is the docs page — the same pairing every other
+  // MDX-documented stable component uses (F0Button, F0Avatar, F0AvatarList,
+  // F0Alert, F0Icon).
+  tags: ["stable", "!autodocs"],
   argTypes: {
     imageFit: {
       control: "select",


### PR DESCRIPTION
## Description

`Card` was tagged `stable` but sat on the DoD debt list, missing MDX docs, the "good" docs tier and enforced axe. It now clears the bar and comes off the list, which takes `pnpm check:stable-dod` from 9 to 10 truly-stable components. Turning axe on also uncovered a WCAG 2.2 target-size failure that the story file had been carrying unreported: the link half is fixed here, the switch half in #5173.

> **Stacked on #5173.** Base is `fix/switch-target-size`. Merge that one first, then this diff reduces to the three Card files.

Rendered docs page in this PR's published Storybook: [Components → Card → Documentation](https://66a7a8d7d124220c363457cc-zgeduirnex.chromatic.com/?path=/docs/components-card--documentation)

## Type of change

- [x] Documentation only
- [x] Bug fix

## Implementation details

- docs: add `__stories__/Card.mdx` at the gold tier

  <details>
  <summary>What it covers</summary>

  Modelled on `F0Alert.mdx`: anatomy with `<Controls>`, when to use and when not to use, do's and don'ts on metadata restraint, content and behaviour guidance, and five story canvases.

  The "when not to use" section routes people away from the wrong tool: a collection of cards is `OneDataCollection`'s job, a horizontal one is `F0CardHorizontal`, a resource's own page is `F0ResourceHeader`, and transient feedback is a toast.

  The accessibility section describes what the component actually does: the full-bleed anchor labelled by `title`, the nested-interactive bail-out (`a[href]`, `input`, `select`, `textarea`, menu triggers) that makes interactive `children` safe inside a linked card, `role="button"` plus Enter and Space on an interactive header, the `aria-hidden` blurred backdrop, the polite `aria-busy` skeleton, and `role="alert"` versus `role="status"` by alert variant.

  </details>

- fix: enforce axe on the Card stories with `a11y: { test: "error" }`

  <details>
  <summary>Why it was passing before</summary>

  `.storybook/preview.tsx` sets a global `a11y: { test: "todo" }`, which runs axe and reports without failing. `Card` therefore showed green while `WithInteractiveChildren` carried a serious Level AA violation.

  </details>

- fix: give the standalone link in the `WithInteractiveChildren` demo content a 24px target

  <details>
  <summary>The two failing nodes</summary>

  | Node | Measured | Fixed by |
  |---|---|---|
  | Standalone link | 187.2 × 20 px, `padding: 0` | `py-0.5` here |
  | Switch | 30 × 20 px | #5173, at source |

  Neither could fall back on an exception. The two controls sit 11px apart, well inside the 24px the spacing exception needs, and the link is a standalone action rather than a link inside a sentence.

  </details>

- chore: set the story tags to `["stable", "!autodocs"]` now that the MDX is the docs page, matching F0Button, F0Avatar, F0AvatarList, F0Alert and F0Icon

- docs: set Canvas heights per story so the previews stop clipping

  <details>
  <summary>Numbers</summary>

  The meta renders docs previews in a 320px iframe and these cards are 323 to 428px tall, so every canvas was cut off. Measured each preview iframe after the change: no overflow.

  </details>

- chore: remove `Card` from `.scripts/stable-dod-debt.json`

  <details>
  <summary>Gate output</summary>

  ```
  $ pnpm check:stable-dod
  Stable-tagged: 41 · meeting the bar: 10 · in debt: 31
  ✔ Truly stable (tagged + meets the full DoD): Alert, Avatars/Avatar, Avatars/AvatarList,
    Button/Button, Button/ButtonDropdown, Card, Icon, Link, AI/F0AiChatHeader, Forms/F0Form
  ✔ Stable DoD ratchet holds.
  ```

  Card's computed status: `{ tier: "gold", a11y: "enforced", mdx: true, play: true, snap: true, tests: true }`.

  The test-runner over the 29 Card stories passes with axe blocking, and `a11y-violations.jsonl` comes out empty where it previously recorded the two `target-size` nodes. `tsc --noEmit`, `oxlint` and `oxfmt` are clean, and the 34 existing Card unit tests still pass.

  </details>

The docs content is the part that needs judgement: the mechanics are gated by `check:stable-dod`, but whether the "when not to use" guidance matches how you want teams to choose between `Card` and `OneDataCollection` is your call.
