### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.40.0",
+  "packages/react": "6.41.0",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.41.0](https://github.com/factorialco/f0/compare/f0-react-v6.40.0...f0-react-v6.41.0) (2026-08-19)
+
+
+### Features
+
+* **valueDisplay:** add neutral variant to tag cell ([#5081](https://github.com/factorialco/f0/issues/5081)) ([19e2da4](https://github.com/factorialco/f0/commit/19e2da4bb9d5bc24d6e623221cb54c9175418bf4))
+
 ## [6.40.0](https://github.com/factorialco/f0/compare/f0-react-v6.39.0...f0-react-v6.40.0) (2026-08-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.40.0",
+  "version": "6.41.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.41.0</summary>

## [6.41.0](https://github.com/factorialco/f0/compare/f0-react-v6.40.0...f0-react-v6.41.0) (2026-08-19)


### Features

* **valueDisplay:** add neutral variant to tag cell ([#5081](https://github.com/factorialco/f0/issues/5081)) ([19e2da4](https://github.com/factorialco/f0/commit/19e2da4bb9d5bc24d6e623221cb54c9175418bf4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).