### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.41.0",
+  "packages/react": "6.41.1",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.41.1](https://github.com/factorialco/f0/compare/f0-react-v6.41.0...f0-react-v6.41.1) (2026-08-19)
+
+
+### Bug Fixes
+
+* **F0ResourceHeader:** rename to clear stable DoD name-prefix check ([#5171](https://github.com/factorialco/f0/issues/5171)) ([de75230](https://github.com/factorialco/f0/commit/de75230fc458569df84c8cfce5a96e62e1bf8508))
+
 ## [6.41.0](https://github.com/factorialco/f0/compare/f0-react-v6.40.0...f0-react-v6.41.0) (2026-08-19)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.41.0",
+  "version": "6.41.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.41.1</summary>

## [6.41.1](https://github.com/factorialco/f0/compare/f0-react-v6.41.0...f0-react-v6.41.1) (2026-08-19)


### Bug Fixes

* **F0ResourceHeader:** rename to clear stable DoD name-prefix check ([#5171](https://github.com/factorialco/f0/issues/5171)) ([de75230](https://github.com/factorialco/f0/commit/de75230fc458569df84c8cfce5a96e62e1bf8508))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).