### PR TITLE
feat(SlotWidget): export its content, frameless

### DIFF
--- a/packages/react/src/experimental/Widgets/Layout/exports.tsx
+++ b/packages/react/src/experimental/Widgets/Layout/exports.tsx
@@ -6,8 +6,11 @@
 // SlotWidget is public because a preview drawn any OTHER way is a preview that
 // can drift: an app that has to approximate a widget out of the content
 // components reproduces the frame, the seams and the spacing by hand, and the
-// first of those to fall out of step is silent. WidgetContainer and
-// HomeListItem stay internal — the layout draws columns from data.
+// first of those to fall out of step is silent. `SlotWidgetContent` is the same
+// guarantee WITHOUT the frame, for a surface that is already a surface (an
+// overlay drilling into a widget) and would otherwise be a card inside a card.
+// WidgetContainer and HomeListItem stay internal — the layout draws columns
+// from data.
 export * from "../../../sds/Home/NewHomeLayout"
 export * from "../../../sds/Home/slotRenderers"
 export * from "../../../sds/Home/SlotWidget"

--- a/packages/react/src/sds/Home/SlotWidget/index.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.tsx
@@ -107,6 +107,81 @@ const FLIP_EASING = "cubic-bezier(0.4, 0, 0.1, 1)"
 /** How far the card lifts toward you at the top of the jump. */
 const FLIP_JUMP = 1.04
 
+/**
+ * A widget's CONTENT: the slot stack, with the dividers between slots and the
+ * skeletons while it loads — everything `SlotWidget` draws, minus the card.
+ *
+ * Public because the frame is not always wanted. A surface that drills into a
+ * widget (an overlay listing the tasks one of its grouped rows summarises) is
+ * already a surface: wrapped in a `Widget` it would be a card inside a card,
+ * with two borders and two paddings. Rendering the slots here keeps the rows
+ * IDENTICAL to the widget's — same slots, same renderers — which composing them
+ * by hand would not.
+ *
+ * Inside a card, prefer `SlotWidget`: it is this plus the frame.
+ */
+export function SlotWidgetContent({
+  slots,
+  loading = false,
+  slotRenderers,
+  ctx = {},
+}: Pick<SlotWidgetProps, "slots" | "loading" | "slotRenderers" | "ctx">) {
+  const renderers = slotRenderers
+    ? { ...defaultSlotRenderers, ...slotRenderers }
+    : defaultSlotRenderers
+
+  return (
+    // ONE child, so a Widget frame's internal `gap-4` applies once to the whole
+    // slot stack instead of around every slot AND every divider.
+    <div
+      className="flex flex-col"
+      {...(loading
+        ? { "aria-busy": true, "aria-live": "polite" as const }
+        : {})}
+    >
+      {slots.map((slot, index) => {
+        const entry = resolveSlotRenderer(renderers[slot.visualization])
+        const slotCtx = {
+          ...ctx,
+          isLastSlot: index === slots.length - 1,
+        }
+        return (
+          <Fragment key={index}>
+            {/* Wrapped rather than passing className: Separator spreads its
+                rest props AFTER its own classes, so a className would replace
+                them (and its 1px height) instead of adding the margin. */}
+            {index > 0 ? (
+              <div className="my-3">
+                <Separator bare />
+              </div>
+            ) : null}
+            {loading ? (
+              // A placeholder says nothing worth reading out — the stack
+              // above already announces that the widget is busy.
+              <div aria-hidden="true">
+                {/* A visualization with no skeleton of its own (a bespoke
+                    renderer passed as a bare function, an unregistered one)
+                    still gets a placeholder rather than the dashed notice. */}
+                {(entry?.skeleton ?? defaultSlotSkeleton)(slot.params, {
+                  ...slotCtx,
+                  expectedItemsCount:
+                    slot.expectedItemsCount ?? DEFAULT_EXPECTED_ITEMS_COUNT,
+                })}
+              </div>
+            ) : entry ? (
+              entry.render(slot.params, slotCtx)
+            ) : (
+              <div className="rounded-md border border-dashed border-f1-border p-2 text-f1-foreground-secondary">
+                {`No renderer for slot "${slot.visualization}"`}
+              </div>
+            )}
+          </Fragment>
+        )
+      })}
+    </div>
+  )
+}
+
 export function SlotWidget({
   header,
   params,
@@ -142,10 +217,6 @@ export function SlotWidget({
     const landed = setTimeout(() => setJumping(false), FLIP_MS)
     return () => clearTimeout(landed)
   }, [flipped, shouldReduceMotion])
-  const renderers = slotRenderers
-    ? { ...defaultSlotRenderers, ...slotRenderers }
-    : defaultSlotRenderers
-
   // Everything the params decide (title, info) is resolved first, so from here
   // down the header is the plain one the frame takes. The LINK stays in it: the
   // frame draws it as the title itself.
@@ -171,54 +242,12 @@ export function SlotWidget({
       {...(alert ? { alert } : { status })}
       isDragging={isDragging}
     >
-      {/* ONE child, so the Widget frame's internal `gap-4` applies once to the
-          whole slot stack instead of around every slot AND every divider. */}
-      <div
-        className="flex flex-col"
-        {...(loading
-          ? { "aria-busy": true, "aria-live": "polite" as const }
-          : {})}
-      >
-        {slots.map((slot, index) => {
-          const entry = resolveSlotRenderer(renderers[slot.visualization])
-          const slotCtx = {
-            ...ctx,
-            isLastSlot: index === slots.length - 1,
-          }
-          return (
-            <Fragment key={index}>
-              {/* Wrapped rather than passing className: Separator spreads its
-                  rest props AFTER its own classes, so a className would replace
-                  them (and its 1px height) instead of adding the margin. */}
-              {index > 0 ? (
-                <div className="my-3">
-                  <Separator bare />
-                </div>
-              ) : null}
-              {loading ? (
-                // A placeholder says nothing worth reading out — the stack
-                // above already announces that the widget is busy.
-                <div aria-hidden="true">
-                  {/* A visualization with no skeleton of its own (a bespoke
-                      renderer passed as a bare function, an unregistered one)
-                      still gets a placeholder rather than the dashed notice. */}
-                  {(entry?.skeleton ?? defaultSlotSkeleton)(slot.params, {
-                    ...slotCtx,
-                    expectedItemsCount:
-                      slot.expectedItemsCount ?? DEFAULT_EXPECTED_ITEMS_COUNT,
-                  })}
-                </div>
-              ) : entry ? (
-                entry.render(slot.params, slotCtx)
-              ) : (
-                <div className="rounded-md border border-dashed border-f1-border p-2 text-f1-foreground-secondary">
-                  {`No renderer for slot "${slot.visualization}"`}
-                </div>
-              )}
-            </Fragment>
-          )
-        })}
-      </div>
+      <SlotWidgetContent
+        ctx={ctx}
+        loading={loading}
+        slotRenderers={slotRenderers}
+        slots={slots}
+      />
     </Widget>
   )
 


### PR DESCRIPTION
## 🚪 Why?

### Problem
`SlotWidget` is the canonical way to draw a `HomeWidgetItem` — but it is a **card**.

A surface that drills *into* a widget is already a surface. The new Home's "Needs you" feed summarises several tasks in one row ("Approve 16 expenses"); opening that row lists the tasks it stands for, in an overlay. Drawn with `SlotWidget`, that overlay gets a card inside a card — two borders, two backgrounds, two paddings (`ui/Card`: `rounded-xl border ... p-4 shadow`).

The alternative — composing the rows by hand out of `HomeListItem` and the tinted glyph — is exactly the silent drift `SlotWidget` was made public to prevent.

## 🔑 What?

### Changes
- Extract the slot stack `SlotWidget` already drew into **`SlotWidgetContent`**, and export it: same slots, same renderers, same dividers and loading skeletons — just no frame.
- `SlotWidget` now renders `SlotWidgetContent`, so there is **one implementation** and the two cannot drift.
- Guidance in the Home kit's export barrel: inside a card use `SlotWidget`; reach for `SlotWidgetContent` only for a surface that is already a surface.

Behaviour inside a widget is unchanged — this is a pure extraction plus an export.

### Not covered
- No story: `SlotWidgetContent` deliberately doesn't get its own Storybook entry. It is the same content `SlotWidget`'s stories already cover, and the surface that motivates it is still being built.

## ✅ Verification

- `pnpm tsc`: clean.
- `pnpm lint`: 0 warnings, 0 errors.
- Pre-commit gates: no new circular dependencies, format, file sizes, ownership all pass.
- Exercised locally (uncommitted story) rendering the drill-in overlay: rows, tinted category glyphs and hover actions identical to the widget's, and no card chrome inside the dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)