### PR TITLE
fix(OneDataCollection): make the all-items-selected label visible on the dark action bar

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
@@ -145,7 +145,7 @@ export const OneDataCollectionActionBar = forwardRef<
         {!!displayedSelectedNumber && (
           <div className="dark flex h-8 w-full items-center justify-between gap-3 px-2 sm:h-auto sm:w-fit sm:justify-start sm:pl-2 sm:pr-0">
             {showAllItemsSelected ? (
-              <span className="font-medium tabular-nums">
+              <span className="font-medium tabular-nums text-f1-foreground">
                 {t("status.selected.allItemsSelected", {
                   total: totalItems ?? 0,
                 })}

--- a/packages/react/src/patterns/OneDataCollection/components/ActionBar/__tests__/OneDataCollectionActionBar.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/ActionBar/__tests__/OneDataCollectionActionBar.test.tsx
@@ -1,0 +1,26 @@
+import { screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { OneDataCollectionActionBar } from "../OneDataCollectionActionBar"
+
+describe("OneDataCollectionActionBar", () => {
+  it("keeps the all-items-selected label readable on the dark bar", () => {
+    render(
+      <OneDataCollectionActionBar
+        isOpen
+        selectedNumber={133}
+        allPagesSelection
+        isAllItemsSelected
+        totalItems={133}
+      />
+    )
+
+    // The label sits inside a `dark`-themed container, so it must set
+    // text-f1-foreground explicitly — otherwise it inherits the light theme's
+    // dark text and renders black-on-black.
+    const label = screen.getByText(/133/)
+    expect(label).toHaveClass("text-f1-foreground")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/components/ActionBar/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/ActionBar/index.stories.tsx
@@ -192,6 +192,15 @@ export const NoSelectedItems: Story = {
   },
 }
 
+export const AllItemsSelected: Story = {
+  args: {
+    ...Default.args,
+    allPagesSelection: true,
+    isAllItemsSelected: true,
+    totalItems: 133,
+  },
+}
+
 export const MultiplePrimaryActions: Story = {
   args: {
     ...Default.args,


### PR DESCRIPTION
## What

When a data collection's bulk-selection spans all pages ("select all N items"), the action bar's **"All N items selected"** label rendered black-on-black and was unreadable. Reported from the bulk compensation flow (screenshot showed *"133 éléments sélectionnés"* invisible on the dark bar).

## Why

The action bar's left content lives inside a `dark`-themed wrapper. The partial-selection branch sets `text-f1-foreground` explicitly (resolving to the light foreground inside `dark`), but the all-items-selected branch didn't — so the label inherited the page's default dark text.

## How

- Add `text-f1-foreground` to the all-items-selected span in `OneDataCollectionActionBar`.
- New `AllItemsSelected` story on `Data Collection/ActionBar` covering this state.
- Regression unit test (red on main, green with the fix): asserts the label carries `text-f1-foreground`.

## Verification

Reproduced the bug in Storybook (label invisible), then confirmed the fix renders "All 133 items selected" in light text on the dark bar. `oxfmt`, `oxlint` and the new vitest spec pass; `tsc` errors are pre-existing on main (39 before/after, none in these files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)