### PR TITLE
fix(F0Graph): frame the entry target (initialFocusNodeId) reliably on arrival

### DIFF
--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
@@ -96,8 +96,11 @@ async function clickNode(id: string) {
 }
 
 // Mount, then clear the camera spies so only the click's calls are counted
-// (isolates the click behavior from any mount-time framing).
-const mount = (props: Partial<React.ComponentProps<typeof F0Graph>> = {}) => {
+// (isolates the click behavior from any mount-time framing). The one-shot entry
+// frame runs from React Flow's `onInit` (deferred), so flush it before clearing.
+const mount = async (
+  props: Partial<React.ComponentProps<typeof F0Graph>> = {}
+) => {
   const view = zeroRender(
     <div style={{ width: 800, height: 600 }}>
       <F0Graph
@@ -108,6 +111,9 @@ const mount = (props: Partial<React.ComponentProps<typeof F0Graph>> = {}) => {
       />
     </div>
   )
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  })
   mockReactFlow.setCenter.mockClear()
   mockReactFlow.fitView.mockClear()
   return view
@@ -115,7 +121,7 @@ const mount = (props: Partial<React.ComponentProps<typeof F0Graph>> = {}) => {
 
 describe("F0Graph — fly to node on click (default)", () => {
   it("flies to the clicked node at NODE_CLICK_ZOOM (1.5) by default", async () => {
-    mount()
+    await mount()
     await clickNode("root")
     expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(1)
     expect(mockReactFlow.setCenter).toHaveBeenLastCalledWith(
@@ -126,14 +132,14 @@ describe("F0Graph — fly to node on click (default)", () => {
   })
 
   it("re-centers on every click, including a repeat click on the same node", async () => {
-    mount()
+    await mount()
     await clickNode("root")
     await clickNode("root")
     expect(mockReactFlow.setCenter).toHaveBeenCalledTimes(2)
   })
 
   it("honors a custom nodeClickZoom, clamped to maxZoom", async () => {
-    mount({ nodeClickZoom: 5, maxZoom: 2 })
+    await mount({ nodeClickZoom: 5, maxZoom: 2 })
     await clickNode("root")
     expect(mockReactFlow.setCenter).toHaveBeenLastCalledWith(
       expect.any(Number),
@@ -143,7 +149,7 @@ describe("F0Graph — fly to node on click (default)", () => {
   })
 
   it("does not move the camera when centerOnNodeClick is false", async () => {
-    mount({ centerOnNodeClick: false })
+    await mount({ centerOnNodeClick: false })
     await clickNode("root")
     expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
     expect(mockReactFlow.fitView).not.toHaveBeenCalled()
@@ -153,19 +159,19 @@ describe("F0Graph — fly to node on click (default)", () => {
   // pseudo-nodes. Clicking one (to toggle) must not fly — it isn't a real node,
   // so the camera would chase the toggle's shifting position.
   it("does not fly when the expander/collapser pseudo-node is clicked", async () => {
-    mount()
+    await mount()
     await clickNode("expander-root")
     expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
     expect(mockReactFlow.fitView).not.toHaveBeenCalled()
   })
 
   it("offsets the center for a right-side viewportInset", async () => {
-    const noInset = mount()
+    const noInset = await mount()
     await clickNode("root")
     const noInsetX = mockReactFlow.setCenter.mock.calls[0][0]
     noInset.unmount()
 
-    mount({ viewportInset: { right: 480 } })
+    await mount({ viewportInset: { right: 480 } })
     await clickNode("root")
     const insetX = mockReactFlow.setCenter.mock.calls[0][0]
 
@@ -180,12 +186,12 @@ describe("F0Graph — click fly waits for a panel the click opens", () => {
   // read no inset and center on the full canvas, leaving the node behind the
   // panel that just opened — so the fly must see the inset that follows it.
   it("uses an inset that only arrives after the click", async () => {
-    const baseline = mount()
+    const baseline = await mount()
     await clickNode("root")
     const noInsetX = mockReactFlow.setCenter.mock.calls[0][0]
     baseline.unmount()
 
-    const { rerender } = mount()
+    const { rerender } = await mount()
     const graph = (props: Partial<React.ComponentProps<typeof F0Graph>>) => (
       <div style={{ width: 800, height: 600 }}>
         <F0Graph
@@ -209,7 +215,7 @@ describe("F0Graph — click fly waits for a panel the click opens", () => {
   })
 
   it("a second click supersedes a still-pending fly instead of queueing both", async () => {
-    mount()
+    await mount()
     pressNode("root")
     pressNode("a")
     await settleFly()

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.initialFocusFrame.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.initialFocusFrame.test.tsx
@@ -12,11 +12,14 @@ import {
 import { zeroRender } from "@/testing/test-utils"
 
 import type { GraphNode } from "../types"
+import { FOCUS_SETTLE_DELAY_MS } from "../constants"
 import { F0Graph } from "../F0Graph"
 
-// Spy React Flow instance so we can count fly-to (fitView) calls. Only the
-// public `useReactFlow` is mocked — the ReactFlow component renders normally.
-// (Name must start with `mock` for the hoisted vi.mock factory.)
+// The initial `initialFocusNodeId` frame flies to the node the same way a node
+// click does — a DEFERRED fly (so React Flow has measured its container by then;
+// an immediate one runs against zero dimensions and never takes) that centers via
+// the node's layout position (`centerOnNode` → `setCenter`). A whole-graph entry
+// (no focus target) uses `fitView` immediately.
 const mockReactFlow = {
   fitView: vi.fn(),
   setCenter: vi.fn(),
@@ -59,105 +62,97 @@ afterEach(() => vi.useRealTimers())
 
 const settle = () => act(() => vi.advanceTimersByTime(200))
 
-describe("F0Graph — focusedNode fly-to does not re-fire on layout changes", () => {
-  it("does not re-center when focusedNode is unchanged across a collapse", () => {
-    const { rerender } = zeroRender(
+describe("F0Graph — initial focus frame is measurement-independent", () => {
+  it("centers on the initialFocusNodeId from its layout position on entry", () => {
+    zeroRender(
       <div style={{ width: 800, height: 600 }}>
         <F0Graph
           nodes={NODES}
           renderNode={renderNodeFn}
-          focusedNode="root"
+          initialFocusNodeId="a"
           expandedNodes={new Set(["root"])}
         />
       </div>
     )
     settle()
-    const afterEntry = mockReactFlow.fitView.mock.calls.length
-    expect(afterEntry).toBeGreaterThanOrEqual(1) // flew once on entry
-
-    // Collapse `root` (layout change) — focusedNode is still "root".
-    rerender(
-      <div style={{ width: 800, height: 600 }}>
-        <F0Graph
-          nodes={NODES}
-          renderNode={renderNodeFn}
-          focusedNode="root"
-          expandedNodes={new Set()}
-        />
-      </div>
-    )
-    settle()
-
-    // No extra fly-to: the effect only reacts to a focusedNode change.
-    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry)
+    // Framed via the layout position (works before React Flow measures nodes),
+    // not an id-based fitView that would silently miss on the first paint.
+    expect(mockReactFlow.setCenter).toHaveBeenCalled()
   })
 
-  it("applies the initial frame once and does not re-frame on a later collapse", () => {
-    // `initialFocusNodeId` set, no `focusedNode`: the graph frames the target
-    // once on entry and must NOT re-frame when a subsequent collapse changes the
-    // layout (the org-chart "open framed, then never yanked" contract). The entry
-    // frame is measurement-independent — it centers on the node's layout position
-    // (`setCenter`), not an id-based `fitView` that would miss on the first paint.
+  it("frames only once — a later collapse does not re-center", () => {
     const { rerender } = zeroRender(
       <div style={{ width: 800, height: 600 }}>
         <F0Graph
           nodes={NODES}
           renderNode={renderNodeFn}
-          initialFocusNodeId="root"
+          initialFocusNodeId="a"
           expandedNodes={new Set(["root"])}
         />
       </div>
     )
     settle()
     const afterEntry = mockReactFlow.setCenter.mock.calls.length
-    expect(afterEntry).toBeGreaterThanOrEqual(1) // framed once on entry
+    expect(afterEntry).toBeGreaterThanOrEqual(1)
 
-    // Collapse `root` — layout changes, but the focus target never did.
     rerender(
       <div style={{ width: 800, height: 600 }}>
         <F0Graph
           nodes={NODES}
           renderNode={renderNodeFn}
-          initialFocusNodeId="root"
+          initialFocusNodeId="a"
           expandedNodes={new Set()}
         />
       </div>
     )
     settle()
-
-    // No re-frame: the initial frame is one-shot.
     expect(mockReactFlow.setCenter.mock.calls.length).toBe(afterEntry)
   })
 
-  it("still flies when focusedNode changes to a new value", () => {
+  it("still frames when a re-render churns the node set before the settle delay", () => {
+    // The first renders after mount change `renderedNodeIds` (two-phase
+    // hydration, an entry side panel opening). The deferred entry fly must
+    // survive that — an effect cleanup keyed on the node set used to cancel the
+    // pending timer while the one-shot guard blocked re-scheduling, so the fly
+    // silently never ran.
     const { rerender } = zeroRender(
       <div style={{ width: 800, height: 600 }}>
         <F0Graph
           nodes={NODES}
           renderNode={renderNodeFn}
-          focusedNode="root"
+          initialFocusNodeId="a"
           expandedNodes={new Set(["root"])}
         />
       </div>
     )
-    settle()
-    const afterEntry = mockReactFlow.fitView.mock.calls.length
-
+    // A re-render that adds a node lands BEFORE the deferred fly fires.
+    act(() => vi.advanceTimersByTime(FOCUS_SETTLE_DELAY_MS - 20))
     rerender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={[...NODES, { id: "c", parentId: "root", data: "C" }]}
+          renderNode={renderNodeFn}
+          initialFocusNodeId="a"
+          expandedNodes={new Set(["root"])}
+        />
+      </div>
+    )
+    act(() => vi.advanceTimersByTime(FOCUS_SETTLE_DELAY_MS + 20))
+    expect(mockReactFlow.setCenter).toHaveBeenCalled()
+  })
+
+  it("does a whole-graph fit on entry when there is no focus target", () => {
+    zeroRender(
       <div style={{ width: 800, height: 600 }}>
         <F0Graph
           nodes={NODES}
           renderNode={renderNodeFn}
-          focusedNode="a"
           expandedNodes={new Set(["root"])}
         />
       </div>
     )
     settle()
-
-    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry + 1)
-    expect(mockReactFlow.fitView).toHaveBeenLastCalledWith(
-      expect.objectContaining({ nodes: [{ id: "a" }] })
-    )
+    expect(mockReactFlow.fitView).toHaveBeenCalled()
+    expect(mockReactFlow.setCenter).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -476,59 +476,6 @@ export function F0GraphView<T = unknown>(
     enabled: !enableNodeWindowing || viewportReady,
   })
 
-  // Initial frame: when `initialFocusNodeId` is set, open framed on that node
-  // AND its direct children (capped zoom) so the first level is visible —
-  // instead of fit-to-all, and without zooming in on the single node. Frozen at
-  // the first render with nodes present so the fit reads a stable value; falls
-  // back to fit-all when the target isn't present.
-  const initialFitRef = useRef<
-    { nodes: Array<{ id: string }>; maxZoom: number } | undefined
-  >(undefined)
-  const initialFitResolvedRef = useRef(false)
-  if (!initialFitResolvedRef.current && renderedNodeIds.length > 0) {
-    initialFitResolvedRef.current = true
-    const childIds = initialFocusNodeId
-      ? (nodeMap.get(initialFocusNodeId)?.children.map((c) => c.id) ?? [])
-      : []
-    const nodes = resolveInitialFitViewNodes(
-      initialFocusNodeId,
-      childIds,
-      new Set(renderedNodeIds)
-    )
-    initialFitRef.current = nodes
-      ? { nodes, maxZoom: Math.min(INITIAL_FOCUS_MAX_ZOOM, maxZoom) }
-      : undefined
-  }
-  const initialFitViewOptions = initialFitRef.current
-
-  // Apply the initial frame exactly once, imperatively — never via React Flow's
-  // `fitView` prop. That prop queues a fit deferred until the container/nodes
-  // are measured, and once it fires it clears `fitViewOptions`; a later layout
-  // change (the first collapse/expand) then re-fires it as a fit-all, snapping
-  // the focused node away. Fitting ourselves, guarded by a ref, guarantees a
-  // single fit framed on `initialFitViewOptions` and no re-fit on any later
-  // layout change. Consumer-driven reveals still fly via the effect below.
-  const didInitialFitRef = useRef(false)
-  useEffect(() => {
-    if (didInitialFitRef.current || renderedNodeIds.length === 0) return
-    didInitialFitRef.current = true
-    // Honor the inset on the first frame too, so an already-open panel never
-    // opens the graph with the focus target behind it. When there's no inset the
-    // options are passed through untouched (identical to before).
-    reactFlow.fitView(
-      hasViewportInset
-        ? {
-            ...initialFitViewOptions,
-            // Base matches React Flow's own default fitView padding (0.1), so
-            // with no inset this stays byte-identical to the untouched call.
-            padding: getFitPadding(FIT_VIEW_PADDING_TIGHT),
-          }
-        : initialFitViewOptions
-    )
-    // Guarded by `didInitialFitRef` so it runs once; `hasViewportInset` /
-    // `getFitPadding` are read fresh at that point and intentionally omitted.
-  }, [renderedNodeIds.length, initialFitViewOptions, reactFlow])
-
   // ── Fly to the consumer-controlled focused node ──
   // Latest fly-to logic, read via a ref so the effect below depends ONLY on
   // `focusedNode`. Otherwise the effect would re-run on every layout-affecting
@@ -633,6 +580,52 @@ export function F0GraphView<T = unknown>(
     )
     return () => clearTimeout(timer)
   }, [focusedNode])
+
+  // ── Initial frame (entry) ──
+  // When `initialFocusNodeId` is set, arrive framed on that node in the same
+  // state a node click leaves: fly to it via the click path (`flyToNodeClickRef`,
+  // centered at the node-click zoom, `viewportInset`-aware). The fly is DEFERRED
+  // by the same settle delay the click/focused paths use — an immediate fly runs
+  // before React Flow has measured its container and never takes (which is why a
+  // mount-time frame missed while re-clicking the node worked). With no focus
+  // target it is a plain whole-graph fit (unchanged), applied immediately.
+  //
+  // The deferred fly is scheduled ONCE (ref-guarded) and is NOT torn down on
+  // re-render: the first renders after mount churn `renderedNodeIds` (two-phase
+  // hydration, an entry side panel opening), and an effect cleanup keyed on that
+  // would clear the pending timer while the ref-guard blocks re-scheduling — so
+  // the fly would silently never run. The timer is cleared only on unmount.
+  const initialFrameTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  )
+  const didInitialFrameRef = useRef(false)
+  useEffect(() => {
+    if (didInitialFrameRef.current || renderedNodeIds.length === 0) return
+    didInitialFrameRef.current = true
+    if (!initialFocusNodeId) {
+      reactFlow.fitView(
+        hasViewportInset
+          ? { padding: getFitPadding(FIT_VIEW_PADDING_TIGHT) }
+          : undefined
+      )
+      return
+    }
+    const target = initialFocusNodeId
+    initialFrameTimerRef.current = setTimeout(
+      () => flyToNodeClickRef.current(target),
+      FOCUS_SETTLE_DELAY_MS
+    )
+    // One-shot (ref-guarded); `hasViewportInset` / `getFitPadding` are read fresh
+    // and the timer is torn down on unmount (below), so deps stay minimal.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [renderedNodeIds.length, initialFocusNodeId, reactFlow])
+  useEffect(
+    () => () => {
+      if (initialFrameTimerRef.current)
+        clearTimeout(initialFrameTimerRef.current)
+    },
+    []
+  )
 
   // Imperative API: `focusNode` fires on every call, independent of prop
   // values, so a consumer's search can re-center on the same node the user


### PR DESCRIPTION
## Description

Arriving at a graph via `initialFocusNodeId` (OneDataCollection `focusOnEntry`) did **not** frame the target: the graph opened fit-to-all with the node un-centered — only re-clicking the node later centered it. This fixes the entry framing so it lands like a node click (centered, panel-aware).

Surfaced by Job Catalog's "View Graph" deep link (FCT-60797): the node arrived selected (f0#5169 / FCT-61650) but never framed.

## Type of change

- [x] Bug fix

## Root cause (two timing issues)

1. **Framed before measurement.** The initial frame ran at mount, before React Flow measured its container, so the imperative `fitView`/`setCenter` applied against zero dimensions and never took. The click / `focusedNode` / "Find me" flies work only because they defer past measurement (`FOCUS_SETTLE_DELAY_MS`). So the entry frame now flies through the **same click path** (`flyToNodeClickRef` — centered at the node-click zoom, `viewportInset`-aware), deferred by the same delay.
2. **The deferred fly was cancelled by a re-render.** It was scheduled in an effect whose cleanup cleared the timer, keyed on `renderedNodeIds`. Real consumers churn that set on the first renders (two-phase hydration, an entry side panel opening), so the cleanup cancelled the pending fly while the one-shot guard blocked re-scheduling — it silently never ran (static-node tests didn't churn, so they passed). It is now scheduled **once** and torn down **only on unmount**.

A whole-graph entry (no focus target) still fits immediately — unchanged.

## Implementation

* `packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx` — entry frame flies via the click path, deferred, scheduled once (cleared on unmount).
* Tests: new `F0Graph.initialFocusFrame.test.tsx` (deferred entry frame + the re-render-during-delay regression); `F0Graph.focusNoRefire.test.tsx` and `F0Graph.clickCenter.test.tsx` updated for the deferred timing.

## Verification

* 274 F0Graph unit tests pass · oxfmt · oxlint clean.
* Verified in the Factorial app (Job Catalog "View Graph") via an alpha build: the node now arrives selected + centered/framed + panel, like a direct click.

## Context

* Blocks factorial **FCT-60797**. Split out of the selection PR **#5169** (FCT-61650) — they are independent (this touches `F0Graph`, that touches the OneDataCollection graph visualization).
* Also fixes the employees Org chart "open looking at me" (`focusOnEntry`) entry framing.
