### PR TITLE
fix(EditableTable): hide select chevron on disabled cells

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
@@ -93,6 +93,33 @@ describe("DisabledCell", () => {
     expect(screen.queryByRole("button")).not.toBeInTheDocument()
   })
 
+  it("shows the select chevron when the column has a selectConfig", () => {
+    const { container } = render(
+      <DisabledCell
+        {...defaultProps}
+        editableColumn={makeEditableColumn({
+          selectConfig: { options: [] },
+        })}
+      />
+    )
+
+    expect(container.querySelector("svg")).toBeInTheDocument()
+  })
+
+  it("hides the select chevron when disabledConfig.hideSelectChevron is set", () => {
+    const { container } = render(
+      <DisabledCell
+        {...defaultProps}
+        editableColumn={makeEditableColumn({
+          selectConfig: { options: [] },
+          disabledConfig: { hideSelectChevron: true },
+        })}
+      />
+    )
+
+    expect(container.querySelector("svg")).not.toBeInTheDocument()
+  })
+
   it("shows the hint tooltip on hover", async () => {
     const user = userEvent.setup()
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
@@ -57,7 +57,10 @@ export function ReadOnlyCellContent<R extends RecordType>({
       ? getFieldInputIcon("date")
       : resolveTextCellIcon(editableColumn.textConfig)
     : undefined
-  const isSelect = showFieldAffordances && !!editableColumn.selectConfig
+  const isSelect =
+    showFieldAffordances &&
+    !editableColumn.disabledConfig?.hideSelectChevron &&
+    !!editableColumn.selectConfig
   const alignRight = editableColumn.align === "right"
 
   // Date cells store an ISO string; format it here so a read-only date cell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -195,6 +195,19 @@ export type EditableTableColumnDefinition<
   dateConfig?: DateCellConfig | ((item: R) => DateCellConfig)
 
   /**
+   * Configuration for `"disabled"` cells.
+   *
+   * By default a disabled cell keeps the same affordances as its editable
+   * counterpart (leading icon, units, select chevron) so the column still
+   * reads as its field type. Set `hideSelectChevron` when the column also
+   * uses `editType: "select"` for other rows but the chevron shouldn't
+   * appear here since the cell isn't interactive.
+   */
+  disabledConfig?: {
+    hideSelectChevron?: boolean
+  }
+
+  /**
    * Called after this cell's value changes. Use to compute derived values
    * and update other cells in the same row.
    *


### PR DESCRIPTION
## Description

Disabled `EditableTable` cells with a `selectConfig` showed the select dropdown chevron even though the cell isn't clickable, which reads as broken affordance. Adds an opt-in `disabledConfig.hideSelectChevron` column option so a consumer can hide it where it applies, without changing the default behavior for existing disabled cells.

Jira: https://factorialmakers.atlassian.net/browse/FCT-60852

## Screenshots

**Before** (chevron 
<img width="970" height="764" alt="Screenshot 2026-08-19 at 18 34 23" src="https://github.com/user-attachments/assets/4979637e-6d63-4760-9612-f4613cb78c11" />


**After** (`disabledConfig: { hideSelectChevron: true }`):
<img width="1499" height="814" alt="Screenshot 2026-08-20 at 11 02 37" src="https://github.com/user-attachments/assets/68a94d04-e5c7-4fed-8976-e014b458e49b" />


## Implementation details

- feat: add `disabledConfig.hideSelectChevron` to `EditableTableColumnDefinition`
- fix: skip rendering the select chevron in `ReadOnlyCellContent` when `disabledConfig.hideSelectChevron` is set
- test: cover both the default (chevron shown) and opt-in (chevron hidden) cases in `DisabledCell.test.tsx`