### PR TITLE
feat(OneDataCollection): freeze table columns from settings

### DIFF
--- a/.factorial/skill-tracker/learnings-used.jsonl
+++ b/.factorial/skill-tracker/learnings-used.jsonl
@@ -1,0 +1,1 @@
+{"event":"captured","ts":"2026-08-20T09:52:30Z","path":"docs/engineering/solutions/logic-error/ts/2026-08-20-motion-reorder-preserve-fixed-items.md","signal":"repeated"}

--- a/docs/engineering/solutions/logic-error/ts/2026-08-20-motion-reorder-preserve-fixed-items.md
+++ b/docs/engineering/solutions/logic-error/ts/2026-08-20-motion-reorder-preserve-fixed-items.md
@@ -1,0 +1,88 @@
+---
+schema_version: 1
+title: Motion reorder callbacks must preserve non-reorderable items
+problem_type: logic-error
+language: ts
+runtime: node
+stack_tags: [react, motion, reorder, f0]
+severity: high
+module: one-data-collection
+component: SortAndHideList
+date: 2026-08-20
+tags: [controlled-state, drag-and-drop, ordering, regression-testing]
+related_components: [packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx]
+symptoms: [Dragging a movable row removes fixed row IDs from the persisted order, A locked middle row moves to the end after the next settings render]
+root_cause: wrong-api
+resolution_type: code-fix
+applied_count: 0
+validated: true
+last_validated: 2026-08-20
+status: active
+graduated: false
+confidence: 8
+---
+
+## Problem
+
+A Motion `Reorder.Group` can contain ordinary list elements alongside
+`Reorder.Item` children. Its reorder callback represents the registered
+reorderable children, not necessarily every value in the controlled source
+array. Persisting that callback payload as the complete order can silently drop
+fixed rows.
+
+## Symptoms
+
+- Dragging any movable row causes non-reorderable IDs to disappear from saved
+  settings.
+- On the next render, IDs absent from the saved order fall to the end, so a
+  supposedly locked row moves indirectly.
+
+## What didn't work
+
+- Rendering fixed rows as plain `li` elements prevented direct dragging, but it
+  also excluded them from Motion's registered reorder values.
+- Persisting the callback payload unchanged assumed it was a full snapshot of
+  the controlled array.
+
+## Solution
+
+Treat the callback as an ordering of movable rows only. Validate that it
+contains the expected movable count, then merge those rows back into the
+original array while preserving every fixed index.
+
+```ts
+const reorderedMovable = next.filter(isMovable)
+
+if (reorderedMovable.length !== current.filter(isMovable).length) {
+  return current
+}
+
+let movableIndex = 0
+return current.map((item) =>
+  isMovable(item) ? reorderedMovable[movableIndex++]! : item
+)
+```
+
+Cover a fixed middle row, not only a fixed first row: leading slices can hide
+the truncation by keeping the fixed item outside the sortable settings array.
+
+## Why this works
+
+The movable subset supplies the user's intended relative order, while the
+current controlled array remains authoritative for membership and fixed
+positions. A partial callback can therefore never erase or indirectly move a
+non-reorderable item.
+
+## Prevention
+
+- When a drag library mixes registered and unregistered children, verify
+  whether callback values are a full collection or a movable subset.
+- Never persist a reorder callback as complete state unless membership and
+  identity have been validated.
+- Add a regression with a fixed item between two movable items and assert both
+  the resulting order and complete membership.
+
+## History
+
+- 2026-08-20: Captured while adding controlled column locks to F0
+  OneDataCollection tables.

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -247,6 +247,8 @@ export const defaultTranslations = {
         hideAllColumns: "Hide all",
         addColumn: "Add column",
         removeColumn: "Remove column",
+        lockColumn: "Lock column: {{label}}",
+        unlockColumn: "Unlock column: {{label}}",
       },
     },
     editableTable: {

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import type { SortAndHideListItem } from "../visualizations/collection/Table/components/SortAndHideList/types"
+import { mergeUnlockedOrderIntoBaseline } from "./SortAndHideSettings"
+
+const item = (id: string, locked = false): SortAndHideListItem => ({
+  id,
+  label: id,
+  locked,
+})
+
+describe("mergeUnlockedOrderIntoBaseline", () => {
+  it("keeps locked columns in their saved slots while unlocked rows reorder", () => {
+    expect(
+      mergeUnlockedOrderIntoBaseline(
+        ["name", "email", "role", "location"],
+        [item("role", true), item("location"), item("name"), item("email")]
+      )
+    ).toEqual(["location", "name", "role", "email"])
+  })
+
+  it("keeps multiple locked columns anchored and appends new columns", () => {
+    expect(
+      mergeUnlockedOrderIntoBaseline(
+        ["name", "email", "role"],
+        [
+          item("name", true),
+          item("role", true),
+          item("location"),
+          item("email"),
+        ]
+      )
+    ).toEqual(["name", "location", "role", "email"])
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest"
 
 import type { SortAndHideListItem } from "../visualizations/collection/Table/components/SortAndHideList/types"
-import { mergeUnlockedOrderIntoBaseline } from "./SortAndHideSettings"
+import {
+  mergeUnlockedOrderIntoBaseline,
+  setAllItemsVisibility,
+} from "./SortAndHideSettings"
 
 const item = (id: string, locked = false): SortAndHideListItem => ({
   id,
@@ -31,5 +34,32 @@ describe("mergeUnlockedOrderIntoBaseline", () => {
         ]
       )
     ).toEqual(["name", "location", "role", "email"])
+  })
+})
+
+describe("setAllItemsVisibility", () => {
+  const visibleItem = (id: string, locked = false): SortAndHideListItem => ({
+    ...item(id, locked),
+    canHide: !locked,
+    visible: true,
+  })
+
+  it("keeps the existing hide-all behavior by default", () => {
+    const result = setAllItemsVisibility(
+      [visibleItem("name"), visibleItem("email")],
+      false
+    )
+
+    expect(result.map(({ visible }) => visible)).toEqual([false, false])
+  })
+
+  it("retains the final unlocked item when requested by table settings", () => {
+    const result = setAllItemsVisibility(
+      [visibleItem("name", true), visibleItem("email"), visibleItem("role")],
+      false,
+      true
+    )
+
+    expect(result.map(({ visible }) => visible)).toEqual([true, false, true])
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -30,8 +30,38 @@ export type SortAndHideSettingsProps = {
    * calls this with the entry id. Removing is distinct from hiding.
    */
   onRemoveColumn?: (id: string) => void
-  /** Called when the user transfers or clears the required-column lock. */
-  onLockedColumnChange?: (id: string | null) => void
+  /** Called when the user locks or unlocks a column. */
+  onLockedColumnChange?: (id: string, locked: boolean) => void
+  /**
+   * Logical column order before locked rows are moved into their visual group.
+   * When present, reordering unlocked rows keeps locked ids in these slots.
+   */
+  orderBaseline?: readonly string[]
+}
+
+export const mergeUnlockedOrderIntoBaseline = (
+  baseline: readonly string[],
+  nextItems: SortAndHideListItem[]
+) => {
+  const nextIds = new Set(nextItems.map((item) => item.id))
+  const lockedIds = new Set(
+    nextItems.filter((item) => item.locked).map((item) => item.id)
+  )
+  const reorderedUnlockedIds = nextItems
+    .filter((item) => !item.locked)
+    .map((item) => item.id)
+  let unlockedIndex = 0
+  const merged = baseline
+    .filter((id) => nextIds.has(id))
+    .map((id) =>
+      lockedIds.has(id) ? id : reorderedUnlockedIds[unlockedIndex++]!
+    )
+  const mergedIds = new Set(merged)
+
+  return [
+    ...merged,
+    ...nextItems.map((item) => item.id).filter((id) => !mergedIds.has(id)),
+  ]
 }
 
 /**
@@ -51,6 +81,7 @@ export const SortAndHideSettings = ({
   onAddColumn,
   onRemoveColumn,
   onLockedColumnChange,
+  orderBaseline,
 }: SortAndHideSettingsProps) => {
   const i18n = useI18n()
   const { setVisualizationSettings } = useDataCollectionSettings()
@@ -58,7 +89,9 @@ export const SortAndHideSettings = ({
   const onChange = (next: SortAndHideListItem[]) => {
     setVisualizationSettings(visualizationKey, (prev) => ({
       ...prev,
-      order: next.map((item) => item.id),
+      order: orderBaseline
+        ? mergeUnlockedOrderIntoBaseline(orderBaseline, next)
+        : next.map((item) => item.id),
       hidden: next.filter((item) => !item.visible).map((item) => item.id),
     }))
   }
@@ -105,7 +138,7 @@ export const SortAndHideSettings = ({
           }
           onLockedChange={
             onLockedColumnChange
-              ? (item, locked) => onLockedColumnChange(locked ? item.id : null)
+              ? (item, locked) => onLockedColumnChange(item.id, locked)
               : undefined
           }
           allowSorting={allowSorting}

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -30,6 +30,8 @@ export type SortAndHideSettingsProps = {
    * calls this with the entry id. Removing is distinct from hiding.
    */
   onRemoveColumn?: (id: string) => void
+  /** Called when the user transfers or clears the required-column lock. */
+  onLockedColumnChange?: (id: string | null) => void
 }
 
 /**
@@ -48,6 +50,7 @@ export const SortAndHideSettings = ({
   allowHiding,
   onAddColumn,
   onRemoveColumn,
+  onLockedColumnChange,
 }: SortAndHideSettingsProps) => {
   const i18n = useI18n()
   const { setVisualizationSettings } = useDataCollectionSettings()
@@ -99,6 +102,11 @@ export const SortAndHideSettings = ({
           onChange={onChange}
           onRemove={
             onRemoveColumn ? (item) => onRemoveColumn(item.id) : undefined
+          }
+          onLockedChange={
+            onLockedColumnChange
+              ? (item, locked) => onLockedColumnChange(locked ? item.id : null)
+              : undefined
           }
           allowSorting={allowSorting}
           allowHiding={allowHiding}

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -37,6 +37,8 @@ export type SortAndHideSettingsProps = {
    * When present, reordering unlocked rows keeps locked ids in these slots.
    */
   orderBaseline?: readonly string[]
+  /** Prevents bulk hiding from removing the final scrollable table column. */
+  keepOneUnlockedVisible?: boolean
 }
 
 export const mergeUnlockedOrderIntoBaseline = (
@@ -64,6 +66,29 @@ export const mergeUnlockedOrderIntoBaseline = (
   ]
 }
 
+export const setAllItemsVisibility = (
+  items: SortAndHideListItem[],
+  visible: boolean,
+  keepOneUnlockedVisible = false
+) => {
+  const itemToKeepVisible =
+    !visible && keepOneUnlockedVisible
+      ? [...items]
+          .reverse()
+          .find((item) => !item.locked && item.visible && item.canHide)
+      : undefined
+
+  return items.map((item) => ({
+    ...item,
+    visible:
+      item.id === itemToKeepVisible?.id
+        ? true
+        : item.canHide
+          ? visible
+          : item.visible,
+  }))
+}
+
 /**
  * Shared settings UI for reordering and hiding a list of entries (table
  * columns, graph metadata, …). Persists `{ order, hidden }` to the given
@@ -82,6 +107,7 @@ export const SortAndHideSettings = ({
   onRemoveColumn,
   onLockedColumnChange,
   orderBaseline,
+  keepOneUnlockedVisible = false,
 }: SortAndHideSettingsProps) => {
   const i18n = useI18n()
   const { setVisualizationSettings } = useDataCollectionSettings()
@@ -97,12 +123,7 @@ export const SortAndHideSettings = ({
   }
 
   const toggleAll = (visible: boolean) => {
-    onChange(
-      items.map((item) => ({
-        ...item,
-        visible: item.canHide ? visible : item.visible,
-      }))
-    )
+    onChange(setAllItemsVisibility(items, visible, keepOneUnlockedVisible))
   }
 
   const showToggleAll =

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -425,13 +425,18 @@ Allow users to show/hide columns using column settings:
 ### User-managed Frozen Columns
 
 Use `lockedColumnIds` with `onLockedColumnIdsChange` when users need to choose
-which columns remain visible while scrolling horizontally. Every locked column
-moves into a sticky group on the left and cannot be hidden, reordered, or
-removed. The order of `lockedColumnIds` is the order of that group, so newly
-locked columns append beside the existing locks. Unlocking removes only that
-column and returns it to its saved table position. Its closed-lock button
-removes the lock; hovering or keyboard-focusing an unlocked settings row
-reveals a closed-lock action that adds it without changing the other locks.
+which columns remain visible while scrolling horizontally. Locked columns move
+into a sticky group on the left and cannot be hidden, reordered, or removed.
+When at least one column exists outside the permanent `frozenColumns` group,
+the table keeps one of those columns visible and unlocked as its scrollable
+region. The final such column cannot be hidden or locked, and an externally
+controlled set that requests every managed column is normalized to the same
+invariant.
+The order of `lockedColumnIds` is the order of the frozen group, so newly locked
+columns append beside the existing locks. Unlocking removes only that column
+and returns it to its saved table position. Its closed-lock button removes the
+lock; hovering or keyboard-focusing an unlocked settings row reveals a
+closed-lock action that adds it without changing the other locks.
 
 Columns covered by `frozenColumns` remain permanently locked before the
 user-managed group. Omit `onLockedColumnIdsChange` when the locked set is fixed
@@ -444,6 +449,19 @@ reviewable.
 
 <Canvas
   of={TableStories.WithLockableColumns}
+  meta={TableStories}
+  story={{ autoplay: true }}
+/>
+
+Locked columns also survive a collapse of their header group, even when they
+are not listed in the group's `collapsedColumns`. Collapse can remove unlocked
+detail columns, but it does not alter the frozen count or sticky offsets. The
+story below starts with Email and Role locked inside a collapsed Employment
+details group; Department is hidden while both locks and the scrollable Name
+column remain visible.
+
+<Canvas
+  of={TableStories.WithLockableColumnsAndCollapsedGroup}
   meta={TableStories}
   story={{ autoplay: true }}
 />
@@ -607,6 +625,10 @@ Notes:
   ordering and hiding.
 - A collapsed group always keeps at least one column visible. Passing `[]`, or
   only ids that don't belong to the group, leaves the group's first column.
+- Frozen and user-locked columns stay visible regardless of
+  `collapsedColumns`. When a column exists outside the permanent
+  `frozenColumns` group, collapsing also retains one such unlocked column if it
+  would otherwise leave only sticky columns.
 - `defaultCollapsed` is read once on mount. Afterwards the collapsed state
   belongs to the table; use `onHeaderGroupCollapsedChange` to observe it.
 - The group label takes the alignment of the columns under it, and the toggle

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -437,6 +437,11 @@ Columns covered by `frozenColumns` remain permanently locked before the
 user-managed group. Omit `onLockedColumnIdsChange` when the locked set is fixed
 and should not expose controls.
 
+The review story renders 15 columns in a 720 px container and scrolls to the
+right after locking Name and Role. This keeps the sticky pair visible beside
+the far-right columns and makes horizontal freeze behavior directly
+reviewable.
+
 <Canvas
   of={TableStories.WithLockableColumns}
   meta={TableStories}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -116,16 +116,16 @@ type TableVisualizationOptions<T> = {
   onRemoveColumn?: (columnId: string) => void
 
   /**
-   * The current user-managed required column. This is independent from
-   * frozenColumns and does not make the column sticky while scrolling.
+   * The user-managed frozen columns. They move into a sticky group on the left
+   * in the order listed here.
    */
-  lockedColumnId?: string | null
+  lockedColumnIds?: readonly string[]
 
   /**
-   * Enables lock/unlock actions in the settings popover. Receives the next
-   * locked column id, or null when the current lock is cleared.
+   * Enables lock/unlock actions in the settings popover. Receives the complete
+   * set of locked column ids after each change.
    */
-  onLockedColumnChange?: (columnId: string | null) => void
+  onLockedColumnIdsChange?: (columnIds: string[]) => void
 
   /** Wraps the table in a rounded border container. */
   bordered?: boolean
@@ -422,18 +422,20 @@ Allow users to show/hide columns using column settings:
 
 <Canvas of={TableStories.TableColumnOrderingAndHidden} meta={TableStories} />
 
-### User-managed Required Column
+### User-managed Frozen Columns
 
-Use `lockedColumnId` with `onLockedColumnChange` when users need to choose which
-column must remain in the table. The locked column stays visible and cannot be
-reordered or removed. Its lock button clears the requirement; hovering or
-keyboard-focusing an unlocked row reveals an action that transfers the lock.
-Omit the callback when the locked column is fixed and should not expose lock
-controls.
+Use `lockedColumnIds` with `onLockedColumnIdsChange` when users need to choose
+which columns remain visible while scrolling horizontally. Every locked column
+moves into a sticky group on the left and cannot be hidden, reordered, or
+removed. The order of `lockedColumnIds` is the order of that group, so newly
+locked columns append beside the existing locks. Unlocking removes only that
+column and returns it to its saved table position. Its closed-lock button
+removes the lock; hovering or keyboard-focusing an unlocked settings row
+reveals a closed-lock action that adds it without changing the other locks.
 
-This lock controls table configuration only. It does not freeze a column while
-scrolling. Set `frozenColumns: 0` for one transferable lock; any column covered
-by `frozenColumns` remains permanently locked.
+Columns covered by `frozenColumns` remain permanently locked before the
+user-managed group. Omit `onLockedColumnIdsChange` when the locked set is fixed
+and should not expose controls.
 
 <Canvas
   of={TableStories.WithLockableColumns}
@@ -442,7 +444,7 @@ by `frozenColumns` remains permanently locked.
 />
 
 ```tsx
-const [lockedColumnId, setLockedColumnId] = useState<string | null>("name")
+const [lockedColumnIds, setLockedColumnIds] = useState<string[]>(["name"])
 
 <OneDataCollection
   source={source}
@@ -454,8 +456,8 @@ const [lockedColumnId, setLockedColumnId] = useState<string | null>("name")
         frozenColumns: 0,
         allowColumnHiding: true,
         allowColumnReordering: true,
-        lockedColumnId,
-        onLockedColumnChange: setLockedColumnId,
+        lockedColumnIds,
+        onLockedColumnIdsChange: setLockedColumnIds,
         onRemoveColumn: removeColumn,
       },
     },
@@ -466,7 +468,8 @@ const [lockedColumnId, setLockedColumnId] = useState<string | null>("name")
 Keyboard users can tab to the visible lock button or the focus-revealed row
 actions and activate them with <kbd>Enter</kbd> or <kbd>Space</kbd>. The icon
 buttons include the target label in their accessible name, for example “Lock
-column: Email.”
+column: Email.” Pointer activation does not leave the row actions visually
+stuck; keyboard activation keeps focus on the corresponding control.
 
 ### Reference Rows
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -115,6 +115,18 @@ type TableVisualizationOptions<T> = {
    */
   onRemoveColumn?: (columnId: string) => void
 
+  /**
+   * The current user-managed required column. This is independent from
+   * frozenColumns and does not make the column sticky while scrolling.
+   */
+  lockedColumnId?: string | null
+
+  /**
+   * Enables lock/unlock actions in the settings popover. Receives the next
+   * locked column id, or null when the current lock is cleared.
+   */
+  onLockedColumnChange?: (columnId: string | null) => void
+
   /** Wraps the table in a rounded border container. */
   bordered?: boolean
 
@@ -409,6 +421,52 @@ Allow users to show/hide columns using column settings:
 ```
 
 <Canvas of={TableStories.TableColumnOrderingAndHidden} meta={TableStories} />
+
+### User-managed Required Column
+
+Use `lockedColumnId` with `onLockedColumnChange` when users need to choose which
+column must remain in the table. The locked column stays visible and cannot be
+reordered or removed. Its lock button clears the requirement; hovering or
+keyboard-focusing an unlocked row reveals an action that transfers the lock.
+Omit the callback when the locked column is fixed and should not expose lock
+controls.
+
+This lock controls table configuration only. It does not freeze a column while
+scrolling. Set `frozenColumns: 0` for one transferable lock; any column covered
+by `frozenColumns` remains permanently locked.
+
+<Canvas
+  of={TableStories.WithLockableColumns}
+  meta={TableStories}
+  story={{ autoplay: true }}
+/>
+
+```tsx
+const [lockedColumnId, setLockedColumnId] = useState<string | null>("name")
+
+<OneDataCollection
+  source={source}
+  visualizations={[
+    {
+      type: "table",
+      options: {
+        columns,
+        frozenColumns: 0,
+        allowColumnHiding: true,
+        allowColumnReordering: true,
+        lockedColumnId,
+        onLockedColumnChange: setLockedColumnId,
+        onRemoveColumn: removeColumn,
+      },
+    },
+  ]}
+/>
+```
+
+Keyboard users can tab to the visible lock button or the focus-revealed row
+actions and activate them with <kbd>Enter</kbd> or <kbd>Space</kbd>. The icon
+buttons include the target label in their accessible name, for example “Lock
+column: Email.”
 
 ### Reference Rows
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1542,6 +1542,125 @@ const addRemoveColumns: {
   { id: "manager", label: "Manager", render: (item) => item.manager },
 ]
 
+type LockableColumnRow = {
+  id: number
+  name: string
+  email: string
+  role: string
+  department: string
+  team: string
+  location: string
+  manager: string
+  employmentType: string
+  startDate: string
+  office: string
+  country: string
+  timeZone: string
+  costCenter: string
+  legalEntity: string
+  status: string
+}
+
+const lockableColumnRecords: LockableColumnRow[] = Array.from(
+  { length: 6 },
+  (_, i) => ({
+    id: i + 1,
+    name: `Person ${i + 1}`,
+    email: `person${i + 1}@example.com`,
+    role: "Engineer",
+    department: "Product",
+    team: "Platform",
+    location: "Madrid",
+    manager: "Alice",
+    employmentType: "Full time",
+    startDate: "2024-01-15",
+    office: "Madrid HQ",
+    country: "Spain",
+    timeZone: "Europe/Madrid",
+    costCenter: "CC-100",
+    legalEntity: "Factorial HR",
+    status: "Active",
+  })
+)
+
+const lockableColumns: {
+  id: string
+  label: string
+  minWidth: number
+  render: (item: LockableColumnRow) => string
+}[] = [
+  { id: "name", label: "Name", minWidth: 180, render: (item) => item.name },
+  { id: "email", label: "Email", minWidth: 240, render: (item) => item.email },
+  { id: "role", label: "Role", minWidth: 180, render: (item) => item.role },
+  {
+    id: "department",
+    label: "Department",
+    minWidth: 180,
+    render: (item) => item.department,
+  },
+  { id: "team", label: "Team", minWidth: 160, render: (item) => item.team },
+  {
+    id: "manager",
+    label: "Manager",
+    minWidth: 180,
+    render: (item) => item.manager,
+  },
+  {
+    id: "employment-type",
+    label: "Employment type",
+    minWidth: 180,
+    render: (item) => item.employmentType,
+  },
+  {
+    id: "start-date",
+    label: "Start date",
+    minWidth: 160,
+    render: (item) => item.startDate,
+  },
+  {
+    id: "office",
+    label: "Office",
+    minWidth: 160,
+    render: (item) => item.office,
+  },
+  {
+    id: "location",
+    label: "Location",
+    minWidth: 160,
+    render: (item) => item.location,
+  },
+  {
+    id: "country",
+    label: "Country",
+    minWidth: 160,
+    render: (item) => item.country,
+  },
+  {
+    id: "time-zone",
+    label: "Time zone",
+    minWidth: 180,
+    render: (item) => item.timeZone,
+  },
+  {
+    id: "cost-center",
+    label: "Cost center",
+    minWidth: 160,
+    render: (item) => item.costCenter,
+  },
+  {
+    id: "legal-entity",
+    label: "Legal entity",
+    minWidth: 180,
+    render: (item) => item.legalEntity,
+  },
+  {
+    id: "status",
+    label: "Status",
+    minWidth: 140,
+    render: (item) => item.status,
+  },
+]
+
 /**
  * Demonstrates the column add/remove affordances. Open the settings popover
  * (sliders icon): an "Add column" entry sits on top, and hovering any
@@ -1605,21 +1724,21 @@ export const WithColumnAddRemove: Story = {
  */
 export const WithLockableColumns: Story = {
   render: () => {
-    const [visibleIds, setVisibleIds] = useState<string[]>([
-      "name",
-      "email",
-      "role",
-    ])
+    const [visibleIds, setVisibleIds] = useState<string[]>(() =>
+      lockableColumns.map(({ id }) => id)
+    )
     const [lockedColumnIds, setLockedColumnIds] = useState<string[]>(["name"])
 
     const columns = visibleIds
-      .map((id) => addRemoveColumns.find((column) => column.id === id))
-      .filter((column): column is (typeof addRemoveColumns)[number] =>
+      .map((id) => lockableColumns.find((column) => column.id === id))
+      .filter((column): column is (typeof lockableColumns)[number] =>
         Boolean(column)
       )
 
     const source = useDataCollectionSource({
-      dataAdapter: { fetchData: async () => ({ records: addRemoveRecords }) },
+      dataAdapter: {
+        fetchData: async () => ({ records: lockableColumnRecords }),
+      },
     })
 
     return (
@@ -1637,7 +1756,7 @@ export const WithLockableColumns: Story = {
                 lockedColumnIds,
                 onLockedColumnIdsChange: setLockedColumnIds,
                 onAddColumn: () => {
-                  const next = addRemoveColumns.find(
+                  const next = lockableColumns.find(
                     (column) => !visibleIds.includes(column.id)
                   )
                   if (next) {
@@ -1686,7 +1805,7 @@ export const WithLockableColumns: Story = {
       ).toHaveFocus()
     })
 
-    const expectColumnOrder = async (labels: string[]) => {
+    const expectLeadingColumnOrder = async (labels: string[]) => {
       await waitFor(() => {
         expect(
           canvas
@@ -1694,6 +1813,8 @@ export const WithLockableColumns: Story = {
             .map((header) =>
               labels.find((label) => header.textContent?.startsWith(label))
             )
+            .filter(Boolean)
+            .slice(0, labels.length)
         ).toEqual(labels)
       })
     }
@@ -1719,13 +1840,82 @@ export const WithLockableColumns: Story = {
           })
         ).toBeInTheDocument()
       })
-      await expectColumnOrder(["Name", "Role", "Email"])
+      await expectLeadingColumnOrder(["Name", "Role", "Email"])
       const [nameHeader, roleHeader, emailHeader] =
         canvas.getAllByRole("columnheader")
       expect(getComputedStyle(nameHeader!).position).toBe("sticky")
       expect(getComputedStyle(roleHeader!).position).toBe("sticky")
       expect(getComputedStyle(emailHeader!).position).not.toBe("sticky")
     })
+
+    await step(
+      "Keep frozen columns visible while scrolling sideways",
+      async () => {
+        const table = canvas.getByRole("table")
+        const scrollContainer = table.closest(".overflow-auto")
+        if (!(scrollContainer instanceof HTMLElement)) {
+          throw new Error("Table scroll container not found")
+        }
+        const [nameHeader, roleHeader, emailHeader] =
+          canvas.getAllByRole("columnheader")
+        const statusHeader = canvas.getByRole("columnheader", {
+          name: "Status",
+        })
+        const firstRow = canvas.getByText("Person 1").closest("tr")!
+        const [nameCell, roleCell, emailCell] =
+          within(firstRow).getAllByRole("cell")
+
+        expect(scrollContainer.scrollWidth).toBeGreaterThan(
+          scrollContainer.clientWidth
+        )
+        expect(scrollContainer).toHaveClass("overflow-auto")
+        expect(canvas.getAllByRole("columnheader")).toHaveLength(15)
+
+        const stickyPositions = [
+          nameHeader!.getBoundingClientRect().left,
+          roleHeader!.getBoundingClientRect().left,
+          nameCell!.getBoundingClientRect().left,
+          roleCell!.getBoundingClientRect().left,
+        ]
+
+        const maxScrollLeft =
+          scrollContainer.scrollWidth - scrollContainer.clientWidth
+        scrollContainer.scrollLeft = maxScrollLeft
+        scrollContainer.dispatchEvent(new Event("scroll"))
+
+        await waitFor(() => {
+          expect(scrollContainer.scrollLeft).toBe(maxScrollLeft)
+          expect(nameHeader!.getBoundingClientRect().left).toBeCloseTo(
+            stickyPositions[0]!,
+            0
+          )
+          expect(roleHeader!.getBoundingClientRect().left).toBeCloseTo(
+            stickyPositions[1]!,
+            0
+          )
+          expect(nameCell!.getBoundingClientRect().left).toBeCloseTo(
+            stickyPositions[2]!,
+            0
+          )
+          expect(roleCell!.getBoundingClientRect().left).toBeCloseTo(
+            stickyPositions[3]!,
+            0
+          )
+          expect(
+            emailHeader!.getBoundingClientRect().right
+          ).toBeLessThanOrEqual(roleHeader!.getBoundingClientRect().right)
+          expect(emailCell!.getBoundingClientRect().right).toBeLessThanOrEqual(
+            roleCell!.getBoundingClientRect().right
+          )
+          expect(
+            statusHeader.getBoundingClientRect().right
+          ).toBeLessThanOrEqual(scrollContainer.getBoundingClientRect().right)
+          expect(
+            statusHeader.getBoundingClientRect().left
+          ).toBeGreaterThanOrEqual(roleHeader!.getBoundingClientRect().right)
+        })
+      }
+    )
 
     await step("Return an unlocked column to its saved position", async () => {
       const lockedRoleRow = settingsDialog.getByText("Role").closest("li")!
@@ -1734,7 +1924,7 @@ export const WithLockableColumns: Story = {
           name: "Unlock column: Role",
         })
       )
-      await expectColumnOrder(["Name", "Email", "Role"])
+      await expectLeadingColumnOrder(["Name", "Email", "Role"])
       const unlockedRoleRow = settingsDialog.getByText("Role").closest("li")!
       const roleActions = unlockedRoleRow.querySelector(
         "[data-column-actions]"
@@ -1747,7 +1937,7 @@ export const WithLockableColumns: Story = {
 
       lockRole.focus()
       await userEvent.keyboard("{Enter}")
-      await expectColumnOrder(["Name", "Role", "Email"])
+      await expectLeadingColumnOrder(["Name", "Role", "Email"])
       await expect(
         settingsDialog.getByRole("button", { name: "Unlock column: Role" })
       ).toHaveFocus()
@@ -1765,6 +1955,30 @@ export const WithLockableColumns: Story = {
         expect(emailActions).toHaveFocus()
         expect(getComputedStyle(emailActions).opacity).toBe("1")
         expect(page.queryByRole("tooltip")).toBeNull()
+      })
+
+      const table = canvas.getByRole("table")
+      const scrollContainer = table.closest(".overflow-auto")
+      if (!(scrollContainer instanceof HTMLElement)) {
+        throw new Error("Table scroll container not found")
+      }
+      const maxScrollLeft =
+        scrollContainer.scrollWidth - scrollContainer.clientWidth
+      scrollContainer.scrollLeft = maxScrollLeft
+      scrollContainer.dispatchEvent(new Event("scroll"))
+
+      await waitFor(() => {
+        expect(scrollContainer.scrollLeft).toBe(maxScrollLeft)
+        const statusHeader = canvas.getByRole("columnheader", {
+          name: "Status",
+        })
+        expect(statusHeader.getBoundingClientRect().right).toBeLessThanOrEqual(
+          scrollContainer.getBoundingClientRect().right
+        )
+        const roleHeader = canvas.getByRole("columnheader", { name: "Role" })
+        expect(
+          statusHeader.getBoundingClientRect().left
+        ).toBeGreaterThanOrEqual(roleHeader.getBoundingClientRect().right)
       })
     })
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1599,9 +1599,9 @@ export const WithColumnAddRemove: Story = {
 }
 
 /**
- * Demonstrates a consumer-controlled required column. The current lock can be
- * cleared, then transferred to any non-frozen column. Locked columns stay
- * visible and cannot be reordered or removed.
+ * Demonstrates consumer-controlled frozen columns. Each lock can be toggled
+ * independently; locked columns move left, stay sticky, and return to their
+ * saved positions when unlocked.
  */
 export const WithLockableColumns: Story = {
   render: () => {
@@ -1610,7 +1610,7 @@ export const WithLockableColumns: Story = {
       "email",
       "role",
     ])
-    const [lockedColumnId, setLockedColumnId] = useState<string | null>("name")
+    const [lockedColumnIds, setLockedColumnIds] = useState<string[]>(["name"])
 
     const columns = visibleIds
       .map((id) => addRemoveColumns.find((column) => column.id === id))
@@ -1634,8 +1634,8 @@ export const WithLockableColumns: Story = {
                 allowColumnReordering: true,
                 allowColumnHiding: true,
                 columns,
-                lockedColumnId,
-                onLockedColumnChange: setLockedColumnId,
+                lockedColumnIds,
+                onLockedColumnIdsChange: setLockedColumnIds,
                 onAddColumn: () => {
                   const next = addRemoveColumns.find(
                     (column) => !visibleIds.includes(column.id)
@@ -1665,11 +1665,13 @@ export const WithLockableColumns: Story = {
       await settingsDialog.findByText("Table settings")
     })
 
-    await step("Unlock the current required column", async () => {
+    await step("Unlock and relock the first frozen column", async () => {
       const nameRow = settingsDialog.getByText("Name").closest("li")!
-      await userEvent.click(
-        within(nameRow).getByRole("button", { name: "Unlock column: Name" })
-      )
+      const unlockName = within(nameRow).getByRole("button", {
+        name: "Unlock column: Name",
+      })
+      unlockName.focus()
+      await userEvent.keyboard("{Enter}")
       await waitFor(() => {
         const updatedNameRow = settingsDialog.getByText("Name").closest("li")!
         const updatedName = within(updatedNameRow)
@@ -1678,36 +1680,90 @@ export const WithLockableColumns: Story = {
           updatedName.getByRole("button", { name: "Lock column: Name" })
         ).toHaveFocus()
       })
+      await userEvent.keyboard("{Enter}")
+      await expect(
+        settingsDialog.getByRole("button", { name: "Unlock column: Name" })
+      ).toHaveFocus()
     })
 
-    await step("Lock another column", async () => {
-      const emailRow = settingsDialog.getByText("Email").closest("li")!
-      await userEvent.click(
-        within(emailRow).getByRole("button", { name: "Lock column: Email" })
-      )
+    const expectColumnOrder = async (labels: string[]) => {
       await waitFor(() => {
-        const updatedEmailRow = settingsDialog.getByText("Email").closest("li")!
         expect(
-          within(updatedEmailRow).getByRole("button", {
-            name: "Unlock column: Email",
+          canvas
+            .getAllByRole("columnheader")
+            .map((header) =>
+              labels.find((label) => header.textContent?.startsWith(label))
+            )
+        ).toEqual(labels)
+      })
+    }
+
+    await step("Freeze a later column beside the existing lock", async () => {
+      const roleRow = settingsDialog.getByText("Role").closest("li")!
+      const lockRole = within(roleRow).getByRole("button", {
+        name: "Lock column: Role",
+      })
+      lockRole.focus()
+      await userEvent.keyboard("{Enter}")
+      await waitFor(() => {
+        const updatedRoleRow = settingsDialog.getByText("Role").closest("li")!
+        expect(
+          within(updatedRoleRow).getByRole("button", {
+            name: "Unlock column: Role",
           })
         ).toHaveFocus()
-        expect(within(updatedEmailRow).getByRole("switch")).toBeDisabled()
+        expect(within(updatedRoleRow).getByRole("switch")).toBeDisabled()
+        expect(
+          settingsDialog.getByRole("button", {
+            name: "Unlock column: Name",
+          })
+        ).toBeInTheDocument()
       })
-      settingsDialog
-        .getByRole("button", { name: "Unlock column: Email" })
-        .blur()
-      const nameRow = settingsDialog
-        .getByText("Name")
-        .closest("li") as HTMLElement
-      const nameActions = nameRow.querySelector(
+      await expectColumnOrder(["Name", "Role", "Email"])
+      const [nameHeader, roleHeader, emailHeader] =
+        canvas.getAllByRole("columnheader")
+      expect(getComputedStyle(nameHeader!).position).toBe("sticky")
+      expect(getComputedStyle(roleHeader!).position).toBe("sticky")
+      expect(getComputedStyle(emailHeader!).position).not.toBe("sticky")
+    })
+
+    await step("Return an unlocked column to its saved position", async () => {
+      const lockedRoleRow = settingsDialog.getByText("Role").closest("li")!
+      await userEvent.click(
+        within(lockedRoleRow).getByRole("button", {
+          name: "Unlock column: Role",
+        })
+      )
+      await expectColumnOrder(["Name", "Email", "Role"])
+      const unlockedRoleRow = settingsDialog.getByText("Role").closest("li")!
+      const roleActions = unlockedRoleRow.querySelector(
         "[data-column-actions]"
       ) as HTMLElement
-      nameActions.tabIndex = -1
-      nameActions.focus()
+      const lockRole = within(unlockedRoleRow).getByRole("button", {
+        name: "Lock column: Role",
+      })
+      expect(lockRole).not.toHaveFocus()
+      expect(roleActions.contains(document.activeElement)).toBe(false)
+
+      lockRole.focus()
+      await userEvent.keyboard("{Enter}")
+      await expectColumnOrder(["Name", "Role", "Email"])
+      await expect(
+        settingsDialog.getByRole("button", { name: "Unlock column: Role" })
+      ).toHaveFocus()
+
+      settingsDialog.getByRole("button", { name: "Unlock column: Role" }).blur()
+      const emailRow = settingsDialog
+        .getByText("Email")
+        .closest("li") as HTMLElement
+      const emailActions = emailRow.querySelector(
+        "[data-column-actions]"
+      ) as HTMLElement
+      emailActions.tabIndex = -1
+      emailActions.focus()
       await waitFor(() => {
-        expect(nameActions).toHaveFocus()
-        expect(getComputedStyle(nameActions).opacity).toBe("1")
+        expect(emailActions).toHaveFocus()
+        expect(getComputedStyle(emailActions).opacity).toBe("1")
         expect(page.queryByRole("tooltip")).toBeNull()
       })
     })

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1985,6 +1985,138 @@ export const WithLockableColumns: Story = {
 }
 
 /**
+ * Locks two columns inside a collapsible group. Collapsing removes the group's
+ * unlocked detail while both locks retain their sticky positions and the Name
+ * column remains the scrollable boundary.
+ */
+export const WithLockableColumnsAndCollapsedGroup: Story = {
+  render: () => {
+    const [lockedColumnIds, setLockedColumnIds] = useState<string[]>([
+      "email",
+      "role",
+    ])
+    const source = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: async () => ({ records: lockableColumnRecords }),
+      },
+    })
+    const columns = [
+      { ...lockableColumns[1]!, headerGroupId: "employment" },
+      { ...lockableColumns[2]!, headerGroupId: "employment" },
+      { ...lockableColumns[3]!, headerGroupId: "employment" },
+      lockableColumns[0]!,
+      lockableColumns[14]!,
+    ]
+
+    return (
+      <div style={{ maxWidth: 720 }}>
+        <OneDataCollection
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                columns,
+                frozenColumns: 0,
+                allowColumnHiding: true,
+                allowColumnReordering: true,
+                lockedColumnIds,
+                onLockedColumnIdsChange: setLockedColumnIds,
+                headerGroups: {
+                  employment: {
+                    label: "Employment details",
+                    collapsedColumns: ["email"],
+                    defaultCollapsed: true,
+                  },
+                },
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const visibleColumnOrder = () =>
+      canvas
+        .getAllByRole("columnheader")
+        .map((header) => header.textContent)
+        .filter((label) =>
+          ["Email", "Role", "Department", "Name", "Status"].includes(
+            label ?? ""
+          )
+        )
+    const stickyOffsets = () => ({
+      email: getComputedStyle(
+        canvas.getByRole("columnheader", { name: "Email" })
+      ).left,
+      role: getComputedStyle(canvas.getByRole("columnheader", { name: "Role" }))
+        .left,
+    })
+    let collapsedOffsets!: ReturnType<typeof stickyOffsets>
+    let collapsedOrder!: ReturnType<typeof visibleColumnOrder>
+
+    await step(
+      "Keep both locked columns when the group starts collapsed",
+      async () => {
+        await canvas.findByText("Person 1")
+
+        expect(
+          canvas.getByRole("button", { name: "Employment details" })
+        ).toHaveAttribute("aria-expanded", "false")
+        expect(
+          canvas.queryByRole("columnheader", { name: "Department" })
+        ).not.toBeInTheDocument()
+
+        const emailHeader = canvas.getByRole("columnheader", { name: "Email" })
+        const roleHeader = canvas.getByRole("columnheader", { name: "Role" })
+        const nameHeader = canvas.getByRole("columnheader", { name: "Name" })
+        expect(getComputedStyle(emailHeader).position).toBe("sticky")
+        expect(getComputedStyle(roleHeader).position).toBe("sticky")
+        expect(getComputedStyle(nameHeader).position).not.toBe("sticky")
+        collapsedOffsets = stickyOffsets()
+        collapsedOrder = visibleColumnOrder()
+        expect(Number.parseFloat(collapsedOffsets.role)).toBeGreaterThan(
+          Number.parseFloat(collapsedOffsets.email)
+        )
+      }
+    )
+
+    await step(
+      "Expand and collapse without changing the frozen group",
+      async () => {
+        const toggle = canvas.getByRole("button", {
+          name: "Employment details",
+        })
+        toggle.focus()
+        await userEvent.keyboard("{Enter}")
+        expect(toggle).toHaveFocus()
+        expect(toggle).toHaveAttribute("aria-expanded", "true")
+        await canvas.findByRole("columnheader", { name: "Department" })
+        await waitFor(() => {
+          expect(
+            canvasElement.querySelector('[class*="f0-collapsing-group-"]')
+          ).not.toBeInTheDocument()
+        })
+        expect(stickyOffsets()).toEqual(collapsedOffsets)
+
+        await userEvent.keyboard("{Enter}")
+        expect(toggle).toHaveFocus()
+        expect(toggle).toHaveAttribute("aria-expanded", "false")
+        await waitFor(() => {
+          expect(
+            canvas.queryByRole("columnheader", { name: "Department" })
+          ).not.toBeInTheDocument()
+        })
+        expect(stickyOffsets()).toEqual(collapsedOffsets)
+        expect(visibleColumnOrder()).toEqual(collapsedOrder)
+      }
+    )
+  },
+}
+
+/**
  * The hover "⋮" row-actions overlay must not swallow the last column's content.
  * Here the trailing column is a `tagList` whose "+N" pill sits under the overlay's
  * fade area. The overlay is transparent to pointer events (only the buttons are

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1599,6 +1599,122 @@ export const WithColumnAddRemove: Story = {
 }
 
 /**
+ * Demonstrates a consumer-controlled required column. The current lock can be
+ * cleared, then transferred to any non-frozen column. Locked columns stay
+ * visible and cannot be reordered or removed.
+ */
+export const WithLockableColumns: Story = {
+  render: () => {
+    const [visibleIds, setVisibleIds] = useState<string[]>([
+      "name",
+      "email",
+      "role",
+    ])
+    const [lockedColumnId, setLockedColumnId] = useState<string | null>("name")
+
+    const columns = visibleIds
+      .map((id) => addRemoveColumns.find((column) => column.id === id))
+      .filter((column): column is (typeof addRemoveColumns)[number] =>
+        Boolean(column)
+      )
+
+    const source = useDataCollectionSource({
+      dataAdapter: { fetchData: async () => ({ records: addRemoveRecords }) },
+    })
+
+    return (
+      <div style={{ maxWidth: 720 }}>
+        <OneDataCollection
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                frozenColumns: 0,
+                allowColumnReordering: true,
+                allowColumnHiding: true,
+                columns,
+                lockedColumnId,
+                onLockedColumnChange: setLockedColumnId,
+                onAddColumn: () => {
+                  const next = addRemoveColumns.find(
+                    (column) => !visibleIds.includes(column.id)
+                  )
+                  if (next) {
+                    setVisibleIds((prev) => [...prev, next.id])
+                  }
+                },
+                onRemoveColumn: (columnId) =>
+                  setVisibleIds((prev) => prev.filter((id) => id !== columnId)),
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const page = within(canvasElement.closest("body")!)
+    let settingsDialog!: ReturnType<typeof within>
+
+    await step("Open the table settings", async () => {
+      await canvas.findByText("Person 1")
+      await userEvent.click(canvas.getByRole("button", { name: "Settings" }))
+      settingsDialog = within(await page.findByRole("dialog"))
+      await settingsDialog.findByText("Table settings")
+    })
+
+    await step("Unlock the current required column", async () => {
+      const nameRow = settingsDialog.getByText("Name").closest("li")!
+      await userEvent.click(
+        within(nameRow).getByRole("button", { name: "Unlock column: Name" })
+      )
+      await waitFor(() => {
+        const updatedNameRow = settingsDialog.getByText("Name").closest("li")!
+        const updatedName = within(updatedNameRow)
+        expect(updatedName.getByRole("switch")).not.toBeDisabled()
+        expect(
+          updatedName.getByRole("button", { name: "Lock column: Name" })
+        ).toHaveFocus()
+      })
+    })
+
+    await step("Lock another column", async () => {
+      const emailRow = settingsDialog.getByText("Email").closest("li")!
+      await userEvent.click(
+        within(emailRow).getByRole("button", { name: "Lock column: Email" })
+      )
+      await waitFor(() => {
+        const updatedEmailRow = settingsDialog.getByText("Email").closest("li")!
+        expect(
+          within(updatedEmailRow).getByRole("button", {
+            name: "Unlock column: Email",
+          })
+        ).toHaveFocus()
+        expect(within(updatedEmailRow).getByRole("switch")).toBeDisabled()
+      })
+      settingsDialog
+        .getByRole("button", { name: "Unlock column: Email" })
+        .blur()
+      const nameRow = settingsDialog
+        .getByText("Name")
+        .closest("li") as HTMLElement
+      const nameActions = nameRow.querySelector(
+        "[data-column-actions]"
+      ) as HTMLElement
+      nameActions.tabIndex = -1
+      nameActions.focus()
+      await waitFor(() => {
+        expect(nameActions).toHaveFocus()
+        expect(getComputedStyle(nameActions).opacity).toBe("1")
+        expect(page.queryByRole("tooltip")).toBeNull()
+      })
+    })
+  },
+}
+
+/**
  * The hover "⋮" row-actions overlay must not swallow the last column's content.
  * Here the trailing column is a `tagList` whose "+N" pill sits under the overlay's
  * fade area. The overlay is transparent to pointer events (only the buttons are

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -157,7 +157,7 @@ export const TableCollection = <
     lockedColumnIds !== undefined || !!onLockedColumnIdsChange
 
   // Sorted and hidden columns
-  const { columns: orderedColumns } = useColumns(
+  const { columns: orderedColumns, stickyColumnIds } = useColumns(
     originalColumns,
     frozenColumns,
     visualizationSettings ?? settings.visualization?.table,
@@ -165,6 +165,10 @@ export const TableCollection = <
     allowColumnHiding,
     lockedColumnIds,
     usesExplicitColumnLocking
+  )
+  const stickyColumnIdSet = useMemo(
+    () => new Set(stickyColumnIds),
+    [stickyColumnIds]
   )
 
   // Header groups own the collapsed state and drop the columns hidden by a
@@ -179,6 +183,7 @@ export const TableCollection = <
   } = useHeaderGroups(orderedColumns, {
     headerGroups: headerGroupsOption,
     onCollapsedChange: onHeaderGroupCollapsedChange,
+    preservedColumnIds: stickyColumnIdSet,
   })
 
   const tableContainerRef = useRef<HTMLDivElement>(null)
@@ -250,22 +255,7 @@ export const TableCollection = <
     // eslint-disable-next-line react-hooks/exhaustive-deps --  we don't want to re-run this effect when the filters change, just when the data changes
   }, [paginationInfo?.total, data.records])
 
-  const frozenColumnIds = useMemo(
-    () =>
-      new Set([
-        ...originalColumns.slice(0, frozenColumns).map(getColumnId),
-        ...(lockedColumnIds ?? []),
-      ]),
-    [originalColumns, frozenColumns, lockedColumnIds]
-  )
-  const frozenColumnsLeft = useMemo(() => {
-    const firstUnlockedColumnIndex = columns.findIndex(
-      (column) => !frozenColumnIds.has(getColumnId(column))
-    )
-    return firstUnlockedColumnIndex === -1
-      ? columns.length
-      : firstUnlockedColumnIndex
-  }, [columns, frozenColumnIds])
+  const frozenColumnsLeft = stickyColumnIds.length
   const getRowKey = (item: R, index: number) => {
     if ("id" in item && item.id !== undefined && item.id !== null) {
       return `id:${String(item.id)}`

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -111,8 +111,8 @@ export const TableCollection = <
   onLoadError,
   allowColumnHiding,
   allowColumnReordering,
-  lockedColumnId,
-  onLockedColumnChange,
+  lockedColumnIds,
+  onLockedColumnIdsChange,
   referenceRowType,
   boldRootRows,
   headerGroups: headerGroupsOption,
@@ -153,6 +153,8 @@ export const TableCollection = <
   )
 
   const { settings } = useDataCollectionSettings()
+  const usesExplicitColumnLocking =
+    lockedColumnIds !== undefined || !!onLockedColumnIdsChange
 
   // Sorted and hidden columns
   const { columns: orderedColumns } = useColumns(
@@ -161,8 +163,8 @@ export const TableCollection = <
     visualizationSettings ?? settings.visualization?.table,
     allowColumnReordering,
     allowColumnHiding,
-    lockedColumnId,
-    lockedColumnId !== undefined || !!onLockedColumnChange
+    lockedColumnIds,
+    usesExplicitColumnLocking
   )
 
   // Header groups own the collapsed state and drop the columns hidden by a
@@ -248,7 +250,22 @@ export const TableCollection = <
     // eslint-disable-next-line react-hooks/exhaustive-deps --  we don't want to re-run this effect when the filters change, just when the data changes
   }, [paginationInfo?.total, data.records])
 
-  const frozenColumnsLeft = useMemo(() => frozenColumns, [frozenColumns])
+  const frozenColumnIds = useMemo(
+    () =>
+      new Set([
+        ...originalColumns.slice(0, frozenColumns).map(getColumnId),
+        ...(lockedColumnIds ?? []),
+      ]),
+    [originalColumns, frozenColumns, lockedColumnIds]
+  )
+  const frozenColumnsLeft = useMemo(() => {
+    const firstUnlockedColumnIndex = columns.findIndex(
+      (column) => !frozenColumnIds.has(getColumnId(column))
+    )
+    return firstUnlockedColumnIndex === -1
+      ? columns.length
+      : firstUnlockedColumnIndex
+  }, [columns, frozenColumnIds])
   const getRowKey = (item: R, index: number) => {
     if ("id" in item && item.id !== undefined && item.id !== null) {
       return `id:${String(item.id)}`

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -111,6 +111,8 @@ export const TableCollection = <
   onLoadError,
   allowColumnHiding,
   allowColumnReordering,
+  lockedColumnId,
+  onLockedColumnChange,
   referenceRowType,
   boldRootRows,
   headerGroups: headerGroupsOption,
@@ -158,7 +160,9 @@ export const TableCollection = <
     frozenColumns,
     visualizationSettings ?? settings.visualization?.table,
     allowColumnReordering,
-    allowColumnHiding
+    allowColumnHiding,
+    lockedColumnId,
+    lockedColumnId !== undefined || !!onLockedColumnChange
   )
 
   // Header groups own the collapsed state and drop the columns hidden by a

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -1534,6 +1534,27 @@ describe("TableCollection", () => {
         />
       )
 
+    it("uses the normalized sticky count when every managed column is requested", async () => {
+      renderTable({
+        lockedColumnIds: ["name", "email", "display"],
+        onLockedColumnIdsChange: vi.fn(),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      expect(screen.getByRole("columnheader", { name: "Name" })).toHaveClass(
+        "sticky"
+      )
+      expect(screen.getByRole("columnheader", { name: "Email" })).toHaveClass(
+        "sticky"
+      )
+      expect(
+        screen.getByRole("columnheader", { name: "Display" })
+      ).not.toHaveClass("sticky")
+    })
+
     it("renders no toggle for groups without collapsedColumns", async () => {
       renderTable({ headerGroups: { contact: "Contact" } })
 
@@ -1652,6 +1673,83 @@ describe("TableCollection", () => {
       expect(
         screen.queryByText(testData[0].displayName)
       ).not.toBeInTheDocument()
+    })
+
+    it("keeps locked group columns sticky and retains a scrollable column when collapsed", async () => {
+      renderTable({
+        columns: [
+          {
+            label: "Email",
+            id: "email",
+            headerGroupId: "contact",
+            render: (item: Person) => item.email,
+          },
+          {
+            label: "Display",
+            id: "display",
+            headerGroupId: "contact",
+            render: (item: Person) => item.displayName,
+          },
+          {
+            label: "Detail",
+            id: "detail",
+            headerGroupId: "contact",
+            render: () => "Contact detail",
+          },
+          {
+            label: "Name",
+            id: "name",
+            headerGroupId: "contact",
+            render: (item: Person) => item.name,
+          },
+        ],
+        lockedColumnIds: ["email", "display"],
+        onLockedColumnIdsChange: vi.fn(),
+        headerGroups: {
+          contact: {
+            label: "Contact",
+            collapsedColumns: ["email"],
+            defaultCollapsed: true,
+          },
+        },
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText(testData[0].name)).toBeInTheDocument()
+      })
+
+      expect(screen.getByText(testData[0].email)).toBeInTheDocument()
+      expect(screen.getByText(testData[0].displayName)).toBeInTheDocument()
+      expect(screen.queryByText("Contact detail")).not.toBeInTheDocument()
+
+      const emailHeader = screen.getByRole("columnheader", { name: "Email" })
+      const displayHeader = screen.getByRole("columnheader", {
+        name: "Display",
+      })
+      const nameHeader = screen.getByRole("columnheader", { name: "Name" })
+      expect(emailHeader).toHaveClass("sticky")
+      expect(displayHeader).toHaveClass("sticky")
+      expect(nameHeader).not.toHaveClass("sticky")
+
+      await userEvent.click(screen.getByRole("button", { name: "Contact" }))
+      await waitFor(() => {
+        expect(screen.getAllByText("Contact detail")).toHaveLength(
+          testData.length
+        )
+      })
+      await userEvent.click(screen.getByRole("button", { name: "Contact" }))
+      await waitFor(() => {
+        expect(screen.queryAllByText("Contact detail")).toHaveLength(0)
+      })
+      expect(screen.getByRole("columnheader", { name: "Email" })).toHaveClass(
+        "sticky"
+      )
+      expect(screen.getByRole("columnheader", { name: "Display" })).toHaveClass(
+        "sticky"
+      )
+      expect(
+        screen.getByRole("columnheader", { name: "Name" })
+      ).not.toHaveClass("sticky")
     })
 
     it("renders no group header row when headerGroups is omitted", async () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.test.tsx
@@ -1,10 +1,15 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
+import {
+  screen,
+  userEvent,
+  within,
+  zeroRender as render,
+} from "@/testing/test-utils"
 
 import type { SortAndHideListItem } from "./types"
 
-import { SortAndHideList } from "./SortAndHideList"
+import { mergeReorderedItems, SortAndHideList } from "./SortAndHideList"
 
 const items: SortAndHideListItem[] = [
   { id: "name", label: "Name", sortable: false, canHide: false, visible: true },
@@ -108,6 +113,109 @@ describe("SortAndHideList remove affordance", () => {
     expect(
       screen.queryByRole("button", { name: "Remove column" })
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("SortAndHideList lock affordance", () => {
+  const lockableItems: SortAndHideListItem[] = [
+    {
+      id: "name",
+      label: "Name",
+      sortable: false,
+      canHide: false,
+      visible: true,
+      removable: false,
+      locked: true,
+      lockable: true,
+    },
+    {
+      id: "email",
+      label: "Email",
+      sortable: true,
+      canHide: true,
+      visible: true,
+      removable: true,
+      locked: false,
+      lockable: true,
+    },
+  ]
+
+  it("unlocks the current required column", async () => {
+    const onLockedChange = vi.fn()
+    render(
+      <SortAndHideList
+        items={lockableItems}
+        onLockedChange={onLockedChange}
+        allowSorting
+        allowHiding
+      />
+    )
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Unlock column: Name" })
+    )
+
+    expect(onLockedChange).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "name" }),
+      false
+    )
+  })
+
+  it("locks another column from its row actions", async () => {
+    const onLockedChange = vi.fn()
+    render(
+      <SortAndHideList
+        items={lockableItems}
+        onLockedChange={onLockedChange}
+        allowSorting
+        allowHiding
+      />
+    )
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Lock column: Email" })
+    )
+
+    expect(onLockedChange).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "email" }),
+      true
+    )
+  })
+
+  it("keeps remove and visibility unavailable for the locked column", () => {
+    const onRemove = vi.fn()
+    render(
+      <SortAndHideList
+        items={lockableItems}
+        onRemove={onRemove}
+        onLockedChange={vi.fn()}
+        allowSorting
+        allowHiding
+      />
+    )
+
+    const nameRow = screen.getByText("Name").closest("li") as HTMLElement
+    expect(
+      within(nameRow).queryByRole("button", { name: "Remove column" })
+    ).not.toBeInTheDocument()
+    expect(screen.getAllByRole("switch")[0]).toBeDisabled()
+  })
+
+  it("keeps a locked middle item at its current index when other rows reorder", () => {
+    const role = {
+      id: "role",
+      label: "Role",
+      sortable: true,
+      canHide: true,
+      visible: true,
+    }
+
+    expect(
+      mergeReorderedItems(
+        [lockableItems[1]!, lockableItems[0]!, role],
+        [role, lockableItems[1]!]
+      )
+    ).toEqual([role, lockableItems[0], lockableItems[1]])
   })
 })
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.test.tsx
@@ -140,7 +140,7 @@ describe("SortAndHideList lock affordance", () => {
     },
   ]
 
-  it("unlocks the current required column", async () => {
+  it("shows a closed lock on a locked column and unlocks it", async () => {
     const onLockedChange = vi.fn()
     render(
       <SortAndHideList
@@ -151,9 +151,18 @@ describe("SortAndHideList lock affordance", () => {
       />
     )
 
-    await userEvent.click(
-      screen.getByRole("button", { name: "Unlock column: Name" })
-    )
+    const unlockButton = screen.getByRole("button", {
+      name: "Unlock column: Name",
+    })
+    expect(
+      Array.from(unlockButton.querySelectorAll("path")).some(
+        (path) =>
+          path.getAttribute("d") ===
+          "M8 10V8C8 5.79086 9.79086 4 12 4V4C14.2091 4 16 5.79086 16 8V10"
+      )
+    ).toBe(true)
+
+    await userEvent.click(unlockButton)
 
     expect(onLockedChange).toHaveBeenCalledWith(
       expect.objectContaining({ id: "name" }),
@@ -180,6 +189,24 @@ describe("SortAndHideList lock affordance", () => {
       expect.objectContaining({ id: "email" }),
       true
     )
+  })
+
+  it("renders independent unlock actions for every locked column", () => {
+    render(
+      <SortAndHideList
+        items={lockableItems.map((item) => ({ ...item, locked: true }))}
+        onLockedChange={vi.fn()}
+        allowSorting
+        allowHiding
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Unlock column: Name" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Unlock column: Email" })
+    ).toBeInTheDocument()
   })
 
   it("keeps remove and visibility unavailable for the locked column", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
@@ -5,7 +5,7 @@ import { Reorder, useDragControls } from "motion/react"
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
 import { Switch } from "@/experimental/Forms/Fields/Switch"
-import { Delete, Handle, LockLocked, LockUnlocked } from "@/icons/app"
+import { Delete, Handle, LockLocked } from "@/icons/app"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { TooltipWrapper } from "@/lib/tooltip-wrapper"
@@ -77,6 +77,19 @@ const Item = ({
   const lockButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null)
   const unlockButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null)
   const pendingLockFocusRef = useRef<"lock" | "unlock" | null>(null)
+  const keyboardActivationRef = useRef(false)
+
+  const shouldRestoreFocus = (event: React.MouseEvent<HTMLElement>) => {
+    const shouldRestore = keyboardActivationRef.current || event.detail === 0
+    keyboardActivationRef.current = false
+    return shouldRestore
+  }
+
+  const trackKeyboardActivation = (event: React.KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      keyboardActivationRef.current = true
+    }
+  }
 
   useEffect(() => {
     const pendingFocus = pendingLockFocusRef.current
@@ -95,7 +108,7 @@ const Item = ({
 
   const content = (
     <div className={classes}>
-      {(allowSorting || locked) && (
+      {(allowSorting || item.showLockState) && (
         <div
           className={cn(
             "flex shrink-0 items-center justify-center text-f1-icon",
@@ -111,21 +124,30 @@ const Item = ({
           {sortable ? (
             <F0Icon icon={Handle} size="xs" />
           ) : showUnlock ? (
-            <ButtonInternal
-              variant="ghost"
-              size="sm"
-              compact
-              hideLabel
-              icon={LockUnlocked}
-              label={i18n.t("collections.table.settings.unlockColumn", {
-                label: item.label,
-              })}
-              ref={unlockButtonRef}
-              onClick={() => {
-                pendingLockFocusRef.current = "lock"
-                onLockedChange?.(item, false)
+            <span
+              onKeyDown={trackKeyboardActivation}
+              onPointerDown={() => {
+                keyboardActivationRef.current = false
               }}
-            />
+            >
+              <ButtonInternal
+                variant="ghost"
+                size="sm"
+                compact
+                hideLabel
+                icon={LockLocked}
+                label={i18n.t("collections.table.settings.unlockColumn", {
+                  label: item.label,
+                })}
+                ref={unlockButtonRef}
+                onClick={(event) => {
+                  pendingLockFocusRef.current = shouldRestoreFocus(event)
+                    ? "lock"
+                    : null
+                  onLockedChange?.(item, false)
+                }}
+              />
+            </span>
           ) : item.disabledReason ? null : (
             <F0Icon icon={LockLocked} size="sm" />
           )}
@@ -146,21 +168,30 @@ const Item = ({
         >
           <div className="flex items-center">
             {showLock && (
-              <ButtonInternal
-                variant="ghost"
-                size="sm"
-                compact
-                hideLabel
-                icon={LockLocked}
-                label={i18n.t("collections.table.settings.lockColumn", {
-                  label: item.label,
-                })}
-                ref={lockButtonRef}
-                onClick={() => {
-                  pendingLockFocusRef.current = "unlock"
-                  onLockedChange?.(item, true)
+              <span
+                onKeyDown={trackKeyboardActivation}
+                onPointerDown={() => {
+                  keyboardActivationRef.current = false
                 }}
-              />
+              >
+                <ButtonInternal
+                  variant="ghost"
+                  size="sm"
+                  compact
+                  hideLabel
+                  icon={LockLocked}
+                  label={i18n.t("collections.table.settings.lockColumn", {
+                    label: item.label,
+                  })}
+                  ref={lockButtonRef}
+                  onClick={(event) => {
+                    pendingLockFocusRef.current = shouldRestoreFocus(event)
+                      ? "unlock"
+                      : null
+                    onLockedChange?.(item, true)
+                  }}
+                />
+              </span>
             )}
             {showRemove && (
               <ButtonInternal

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
@@ -1,9 +1,11 @@
+import { useEffect, useRef } from "react"
+
 import { Reorder, useDragControls } from "motion/react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
 import { Switch } from "@/experimental/Forms/Fields/Switch"
-import { Delete, Handle, LockLocked } from "@/icons/app"
+import { Delete, Handle, LockLocked, LockUnlocked } from "@/icons/app"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { TooltipWrapper } from "@/lib/tooltip-wrapper"
@@ -11,10 +13,36 @@ import { cn } from "@/lib/utils"
 
 import { SortAndHideListItem } from "./types"
 
+const isLocked = (item: SortAndHideListItem) =>
+  item.locked ?? (!item.sortable && !item.canHide && !item.disabledReason)
+
+const isSortable = (item: SortAndHideListItem) =>
+  !!item.sortable && !isLocked(item)
+
+export const mergeReorderedItems = (
+  currentItems: SortAndHideListItem[],
+  reorderedItems: SortAndHideListItem[]
+) => {
+  const reorderedSortableItems = reorderedItems.filter(isSortable)
+  const sortableCount = currentItems.filter(isSortable).length
+
+  // Motion only reports its registered Reorder.Item values. Abort rather than
+  // persist a partial order if a drag frame ever omits a sortable row.
+  if (reorderedSortableItems.length !== sortableCount) {
+    return currentItems
+  }
+
+  let sortableIndex = 0
+  return currentItems.map((item) =>
+    isSortable(item) ? reorderedSortableItems[sortableIndex++]! : item
+  )
+}
+
 type ItemProps = {
   item: SortAndHideListItem
   onChangeVisibility: (item: SortAndHideListItem) => void
   onRemove?: (item: SortAndHideListItem) => void
+  onLockedChange?: (item: SortAndHideListItem, locked: boolean) => void
   allowSorting: boolean
   allowHiding: boolean
   isFirst: boolean
@@ -25,6 +53,7 @@ const Item = ({
   item,
   onChangeVisibility,
   onRemove,
+  onLockedChange,
   allowSorting,
   allowHiding,
   isFirst,
@@ -40,25 +69,63 @@ const Item = ({
     isLast && "pb-1"
   )
   const controls = useDragControls()
-  const showRemove = !!item.removable && !!onRemove
+  const locked = isLocked(item)
+  const sortable = isSortable(item)
+  const showRemove = !!item.removable && !locked && !!onRemove
+  const showLock = !!item.lockable && !locked && !!onLockedChange
+  const showUnlock = !!item.lockable && locked && !!onLockedChange
+  const lockButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null)
+  const unlockButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null)
+  const pendingLockFocusRef = useRef<"lock" | "unlock" | null>(null)
+
+  useEffect(() => {
+    const pendingFocus = pendingLockFocusRef.current
+    const target =
+      pendingFocus === "lock" && showLock
+        ? lockButtonRef.current
+        : pendingFocus === "unlock" && showUnlock
+          ? unlockButtonRef.current
+          : null
+
+    if (target) {
+      pendingLockFocusRef.current = null
+      target.focus()
+    }
+  }, [showLock, showUnlock])
 
   const content = (
     <div className={classes}>
-      {allowSorting && (
+      {(allowSorting || locked) && (
         <div
           className={cn(
             "flex shrink-0 items-center justify-center text-f1-icon",
-            item.sortable && "cursor-grab"
+            sortable && "cursor-grab"
           )}
-          style={{ width: "20px" }}
+          style={{ width: showUnlock ? "28px" : "20px" }}
           onPointerDown={(e) => {
-            if (item.sortable) {
+            if (sortable) {
               controls.start(e)
             }
           }}
         >
-          {item.sortable ? (
+          {sortable ? (
             <F0Icon icon={Handle} size="xs" />
+          ) : showUnlock ? (
+            <ButtonInternal
+              variant="ghost"
+              size="sm"
+              compact
+              hideLabel
+              icon={LockUnlocked}
+              label={i18n.t("collections.table.settings.unlockColumn", {
+                label: item.label,
+              })}
+              ref={unlockButtonRef}
+              onClick={() => {
+                pendingLockFocusRef.current = "lock"
+                onLockedChange?.(item, false)
+              }}
+            />
           ) : item.disabledReason ? null : (
             <F0Icon icon={LockLocked} size="sm" />
           )}
@@ -67,22 +134,46 @@ const Item = ({
       <span
         className={cn(
           "flex-1 min-w-0",
-          item.sortable ? "text-f1-foreground" : "text-f1-foreground-secondary"
+          sortable ? "text-f1-foreground" : "text-f1-foreground-secondary"
         )}
       >
         <OneEllipsis>{item.label}</OneEllipsis>
       </span>
-      {showRemove && (
-        <div className="shrink-0 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100">
-          <ButtonInternal
-            variant="ghost"
-            size="sm"
-            compact
-            hideLabel
-            icon={Delete}
-            label={i18n.collections.table.settings.removeColumn}
-            onClick={() => onRemove?.(item)}
-          />
+      {(showLock || showRemove) && (
+        <div
+          data-column-actions
+          className="shrink-0 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
+        >
+          <div className="flex items-center">
+            {showLock && (
+              <ButtonInternal
+                variant="ghost"
+                size="sm"
+                compact
+                hideLabel
+                icon={LockLocked}
+                label={i18n.t("collections.table.settings.lockColumn", {
+                  label: item.label,
+                })}
+                ref={lockButtonRef}
+                onClick={() => {
+                  pendingLockFocusRef.current = "unlock"
+                  onLockedChange?.(item, true)
+                }}
+              />
+            )}
+            {showRemove && (
+              <ButtonInternal
+                variant="ghost"
+                size="sm"
+                compact
+                hideLabel
+                icon={Delete}
+                label={i18n.collections.table.settings.removeColumn}
+                onClick={() => onRemove?.(item)}
+              />
+            )}
+          </div>
         </div>
       )}
       {allowHiding &&
@@ -107,13 +198,13 @@ const Item = ({
             }}
             title={item.label}
             hideLabel
-            disabled={!item.canHide}
+            disabled={!item.canHide || locked}
           />
         ))}
     </div>
   )
 
-  return item.sortable ? (
+  return sortable ? (
     <Reorder.Item
       value={item}
       drag="y"
@@ -140,6 +231,8 @@ export type SortAndHideListProps = {
    * hiding: the caller is expected to drop the entry from its source.
    */
   onRemove?: (item: SortAndHideListItem) => void
+  /** Called when the user locks or unlocks an item. */
+  onLockedChange?: (item: SortAndHideListItem, locked: boolean) => void
   allowSorting: boolean
   allowHiding: boolean
 }
@@ -148,6 +241,7 @@ export const SortAndHideList = ({
   items,
   onChange,
   onRemove,
+  onLockedChange,
   allowSorting,
   allowHiding,
 }: SortAndHideListProps) => {
@@ -155,8 +249,8 @@ export const SortAndHideList = ({
     onChange?.(items.map((i) => (i.id === item.id ? item : i)))
   }
 
-  const handleOnChange = (items: SortAndHideListItem[]) => {
-    onChange?.(items)
+  const handleOnChange = (reorderedItems: SortAndHideListItem[]) => {
+    onChange?.(mergeReorderedItems(items, reorderedItems))
   }
 
   return (
@@ -173,6 +267,7 @@ export const SortAndHideList = ({
           key={item.id}
           onChangeVisibility={onChangeVisibility}
           onRemove={onRemove}
+          onLockedChange={onLockedChange}
           allowSorting={allowSorting}
           allowHiding={allowHiding}
           isFirst={index === 0}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.mdx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.mdx
@@ -32,8 +32,8 @@ functionality.
 - **Toggle Visibility**: Switches control whether columns are shown or hidden
 - **Frozen Columns**: Some columns can be marked as non-hideable (disabled
   switches)
-- **User-managed Locks**: Any number of columns can be independently locked or
-  unlocked
+- **User-managed Locks**: Caller-controlled rows can be independently marked as
+  lockable, locked, or unlocked
 - **Accessible Controls**: Visibility, lock, and remove actions support keyboard
   and screen reader use
 
@@ -121,9 +121,11 @@ Each item has the following structure:
 
 - `onChange` controls order and visibility.
 - `onRemove` mutates the caller-owned item set rather than hiding an item.
-- `onLockedChange` reports each item and its next lock state; the table caller
-  keeps any number of locks, moves them into its frozen group, and persists
-  their order.
+- `onLockedChange` reports each item and its next lock state. The list renders
+  the caller-provided `locked`, `lockable`, and `canHide` values; `TableSettings`
+  uses them to keep one visible scrollable column whenever one exists outside
+  the permanent frozen group, while moving the other locks into their frozen
+  group.
 
 ## Accessibility
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.mdx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.mdx
@@ -17,6 +17,7 @@ order and visibility of table columns. It allows users to:
 - Reorder items by dragging (visual indication with sort icons)
 - Toggle column visibility using switches
 - Manage required vs optional columns (some columns cannot be hidden)
+- Transfer a controlled lock between columns when lock callbacks are provided
 
 ## Introduction
 
@@ -31,8 +32,10 @@ functionality.
 - **Toggle Visibility**: Switches control whether columns are shown or hidden
 - **Required Columns**: Some columns can be marked as non-hideable (disabled
   switches)
-- **Accessible**: Full keyboard and screen reader support through proper ARIA
-  attributes
+- **User-managed Lock**: A current required column can be unlocked, then a
+  lock action on another row can make that column required
+- **Accessible Controls**: Visibility, lock, and remove actions support keyboard
+  and screen reader use
 
 ## Default Usage
 
@@ -61,6 +64,18 @@ hidden), visible optional columns, and hidden optional columns.
 
 <Canvas of={SortAndHideListStories.WithMixedStates} />
 
+### Lockable Items
+
+The lock state is controlled by the caller. Clicking the current lock unlocks
+that row. Hovering or keyboard-focusing another row reveals “Lock column” next
+to the remove action. The story transfers the lock from Name to Email and
+leaves the unlocked Name actions visible for visual review.
+
+<Canvas
+  of={SortAndHideListStories.WithLockableItems}
+  story={{ autoplay: true }}
+/>
+
 ### Edge Cases
 
 #### Empty List
@@ -80,8 +95,11 @@ truncation.
 
 ## Props
 
-The component accepts a single `items` prop which is an array of objects with
-the following structure:
+`allowSorting` and `allowHiding` are required feature flags. `items` contains
+the controlled row state, while `onChange`, `onRemove`, and `onLockedChange`
+report reordering/visibility, removal, and lock changes respectively.
+
+Each item has the following structure:
 
 ```typescript
 {
@@ -89,26 +107,28 @@ the following structure:
   label: string       // Display name for the column
   sortable?: boolean  // Whether the column supports sorting (affects drag handle display)
   canHide?: boolean   // Whether the column can be hidden (affects switch disabled state)
-  hidden?: boolean    // Current visibility state of the column
+  visible?: boolean   // Current visibility state of the column
   order?: number      // Sort order (used for initial ordering)
+  locked?: boolean    // Whether this is the current required item
+  lockable?: boolean  // Whether lock/unlock actions are available
 }
 ```
 
 ## Implementation Notes
 
-- The component currently logs switch changes to the console
-- Integration with actual state management would require passing appropriate
-  callbacks
-- The drag and drop functionality for reordering is indicated visually but not
-  implemented
-- Switch states are controlled by the `hidden` and `canHide` properties
+- `onChange` controls order and visibility.
+- `onRemove` mutates the caller-owned item set rather than hiding an item.
+- `onLockedChange` controls the single required item; the caller decides how to
+  persist that choice.
+- Locking is distinct from freezing a table column while scrolling.
 
 ## Accessibility
 
-- Uses semantic HTML with proper `<ol>` and `<li>` elements
-- Switch components include appropriate `title` attributes for screen readers
-- Maintains proper focus management for keyboard navigation
-- Visual sort icons provide context for drag-and-drop capability
+- Uses semantic list items and native button/switch semantics.
+- Icon-only lock actions include the column label in their accessible name, for
+  example “Lock column: Email.”
+- Hover-revealed actions also appear with keyboard focus.
+- The locked row's visibility switch is disabled and remains on.
 
 ## Related Components
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.mdx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.mdx
@@ -17,7 +17,7 @@ order and visibility of table columns. It allows users to:
 - Reorder items by dragging (visual indication with sort icons)
 - Toggle column visibility using switches
 - Manage required vs optional columns (some columns cannot be hidden)
-- Transfer a controlled lock between columns when lock callbacks are provided
+- Independently lock or unlock several columns when callbacks are provided
 
 ## Introduction
 
@@ -30,10 +30,10 @@ functionality.
 
 - **Drag to Reorder**: Visual sort icons indicate that items can be reordered
 - **Toggle Visibility**: Switches control whether columns are shown or hidden
-- **Required Columns**: Some columns can be marked as non-hideable (disabled
+- **Frozen Columns**: Some columns can be marked as non-hideable (disabled
   switches)
-- **User-managed Lock**: A current required column can be unlocked, then a
-  lock action on another row can make that column required
+- **User-managed Locks**: Any number of columns can be independently locked or
+  unlocked
 - **Accessible Controls**: Visibility, lock, and remove actions support keyboard
   and screen reader use
 
@@ -59,17 +59,20 @@ columns would still be visible in the actual table.
 
 ### Mixed States
 
-A realistic example showing a combination of required columns (that cannot be
+A realistic example showing a combination of frozen columns (that cannot be
 hidden), visible optional columns, and hidden optional columns.
 
 <Canvas of={SortAndHideListStories.WithMixedStates} />
 
 ### Lockable Items
 
-The lock state is controlled by the caller. Clicking the current lock unlocks
-that row. Hovering or keyboard-focusing another row reveals “Lock column” next
-to the remove action. The story transfers the lock from Name to Email and
-leaves the unlocked Name actions visible for visual review.
+The lock state is controlled by the caller. Clicking a closed lock unlocks that
+row. Hovering or keyboard-focusing another row reveals “Lock column” next to
+the remove action. Pointer activation releases focus when the row changes, so
+those actions do not remain visually stuck; keyboard activation transfers
+focus to the corresponding control. The story finishes with Name and Email
+locked at the same time and leaves Role's unlocked actions visible for visual
+review.
 
 <Canvas
   of={SortAndHideListStories.WithLockableItems}
@@ -109,7 +112,7 @@ Each item has the following structure:
   canHide?: boolean   // Whether the column can be hidden (affects switch disabled state)
   visible?: boolean   // Current visibility state of the column
   order?: number      // Sort order (used for initial ordering)
-  locked?: boolean    // Whether this is the current required item
+  locked?: boolean    // Whether this is one of the frozen items
   lockable?: boolean  // Whether lock/unlock actions are available
 }
 ```
@@ -118,15 +121,17 @@ Each item has the following structure:
 
 - `onChange` controls order and visibility.
 - `onRemove` mutates the caller-owned item set rather than hiding an item.
-- `onLockedChange` controls the single required item; the caller decides how to
-  persist that choice.
-- Locking is distinct from freezing a table column while scrolling.
+- `onLockedChange` reports each item and its next lock state; the table caller
+  keeps any number of locks, moves them into its frozen group, and persists
+  their order.
 
 ## Accessibility
 
 - Uses semantic list items and native button/switch semantics.
 - Icon-only lock actions include the column label in their accessible name, for
   example “Lock column: Email.”
+- Locked rows display a closed-lock icon even though activating the button
+  performs the inverse “Unlock column” action.
 - Hover-revealed actions also appear with keyboard focus.
 - The locked row's visibility switch is disabled and remains on.
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.stories.tsx
@@ -1,4 +1,9 @@
+import { useState } from "react"
+
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, fn, userEvent, waitFor, within } from "storybook/test"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { SortAndHideList } from "../SortAndHideList"
 
@@ -14,7 +19,7 @@ const meta = {
       },
     },
   },
-  tags: ["autodocs", "internal"],
+  tags: ["internal", "!autodocs"],
   argTypes: {
     items: {
       description: "Array of items that can be sorted and hidden",
@@ -295,4 +300,127 @@ export const WithRemovableItems: Story = {
       },
     ],
   },
+}
+
+const lockableItems = [
+  {
+    id: "name",
+    label: "Name",
+    visible: true,
+    removable: true,
+    order: 1,
+  },
+  {
+    id: "email",
+    label: "Email",
+    visible: true,
+    removable: true,
+    order: 2,
+  },
+  {
+    id: "role",
+    label: "Role",
+    visible: true,
+    removable: true,
+    order: 3,
+  },
+]
+
+const LockableList = () => {
+  const [lockedId, setLockedId] = useState<string | null>("name")
+
+  return (
+    <div className="w-72">
+      <SortAndHideList
+        allowSorting
+        allowHiding
+        items={lockableItems.map((item) => ({
+          ...item,
+          locked: item.id === lockedId,
+          lockable: true,
+          sortable: item.id !== lockedId,
+          canHide: item.id !== lockedId,
+        }))}
+        onLockedChange={(item, locked) => setLockedId(locked ? item.id : null)}
+        onRemove={fn()}
+      />
+    </div>
+  )
+}
+
+/**
+ * Unlock the required column, then lock another one. Hover or keyboard focus
+ * reveals lock and remove actions for every unlocked row.
+ */
+const playLockTransfer: NonNullable<Story["play"]> = async ({
+  canvasElement,
+  step,
+}) => {
+  const canvas = within(canvasElement)
+  const page = within(canvasElement.ownerDocument.body)
+
+  await step("Unlock the current required column", async () => {
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Unlock column: Name" })
+    )
+    await expect(
+      canvas.queryByRole("button", { name: "Unlock column: Name" })
+    ).not.toBeInTheDocument()
+    await expect(
+      canvas.getByRole("button", { name: "Lock column: Name" })
+    ).toHaveFocus()
+  })
+
+  await step("Lock a different column", async () => {
+    const emailRow = canvas.getByText("Email").closest("li")!
+    await userEvent.click(
+      within(emailRow).getByRole("button", { name: "Lock column: Email" })
+    )
+    await waitFor(() => {
+      const updatedEmailRow = canvas.getByText("Email").closest("li")!
+      expect(
+        within(updatedEmailRow).getByRole("button", {
+          name: "Unlock column: Email",
+        })
+      ).toHaveFocus()
+      expect(within(updatedEmailRow).getByRole("switch")).toBeDisabled()
+    })
+  })
+
+  const focusedUnlock = canvas.getByRole("button", {
+    name: "Unlock column: Email",
+  })
+  focusedUnlock.blur()
+  const nameRow = canvas.getByText("Name").closest("li") as HTMLElement
+  const nameActions = nameRow.querySelector(
+    "[data-column-actions]"
+  ) as HTMLElement
+  nameActions.tabIndex = -1
+  nameActions.focus()
+  await waitFor(() => {
+    expect(nameActions).toHaveFocus()
+    expect(getComputedStyle(nameActions).opacity).toBe("1")
+    expect(page.queryByRole("tooltip")).toBeNull()
+  })
+}
+
+export const WithLockableItems: Story = {
+  args: {
+    allowSorting: true,
+    allowHiding: true,
+    items: lockableItems,
+  },
+  render: () => <LockableList />,
+  play: playLockTransfer,
+}
+
+export const Snapshot: Story = {
+  args: {
+    allowSorting: true,
+    allowHiding: true,
+    items: lockableItems,
+  },
+  parameters: withSnapshot({}),
+  render: () => <LockableList />,
+  play: playLockTransfer,
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/__stories__/SortAndHideList.stories.tsx
@@ -327,7 +327,7 @@ const lockableItems = [
 ]
 
 const LockableList = () => {
-  const [lockedId, setLockedId] = useState<string | null>("name")
+  const [lockedIds, setLockedIds] = useState<string[]>(["name"])
 
   return (
     <div className="w-72">
@@ -336,12 +336,18 @@ const LockableList = () => {
         allowHiding
         items={lockableItems.map((item) => ({
           ...item,
-          locked: item.id === lockedId,
+          locked: lockedIds.includes(item.id),
           lockable: true,
-          sortable: item.id !== lockedId,
-          canHide: item.id !== lockedId,
+          sortable: !lockedIds.includes(item.id),
+          canHide: !lockedIds.includes(item.id),
         }))}
-        onLockedChange={(item, locked) => setLockedId(locked ? item.id : null)}
+        onLockedChange={(item, locked) =>
+          setLockedIds((current) =>
+            locked
+              ? [...new Set([...current, item.id])]
+              : current.filter((id) => id !== item.id)
+          )
+        }
         onRemove={fn()}
       />
     </div>
@@ -349,7 +355,7 @@ const LockableList = () => {
 }
 
 /**
- * Unlock the required column, then lock another one. Hover or keyboard focus
+ * Independently unlock and lock frozen columns. Hover or keyboard focus
  * reveals lock and remove actions for every unlocked row.
  */
 const playLockTransfer: NonNullable<Story["play"]> = async ({
@@ -359,23 +365,25 @@ const playLockTransfer: NonNullable<Story["play"]> = async ({
   const canvas = within(canvasElement)
   const page = within(canvasElement.ownerDocument.body)
 
-  await step("Unlock the current required column", async () => {
-    await userEvent.click(
-      canvas.getByRole("button", { name: "Unlock column: Name" })
-    )
+  await step("Unlock and relock the first frozen column", async () => {
+    canvas.getByRole("button", { name: "Unlock column: Name" }).focus()
+    await userEvent.keyboard("{Enter}")
     await expect(
       canvas.queryByRole("button", { name: "Unlock column: Name" })
     ).not.toBeInTheDocument()
     await expect(
       canvas.getByRole("button", { name: "Lock column: Name" })
     ).toHaveFocus()
+    await userEvent.keyboard("{Enter}")
+    await expect(
+      canvas.getByRole("button", { name: "Unlock column: Name" })
+    ).toHaveFocus()
   })
 
-  await step("Lock a different column", async () => {
+  await step("Lock a second column without unlocking the first", async () => {
     const emailRow = canvas.getByText("Email").closest("li")!
-    await userEvent.click(
-      within(emailRow).getByRole("button", { name: "Lock column: Email" })
-    )
+    within(emailRow).getByRole("button", { name: "Lock column: Email" }).focus()
+    await userEvent.keyboard("{Enter}")
     await waitFor(() => {
       const updatedEmailRow = canvas.getByText("Email").closest("li")!
       expect(
@@ -384,22 +392,42 @@ const playLockTransfer: NonNullable<Story["play"]> = async ({
         })
       ).toHaveFocus()
       expect(within(updatedEmailRow).getByRole("switch")).toBeDisabled()
+      expect(
+        canvas.getByRole("button", { name: "Unlock column: Name" })
+      ).toBeInTheDocument()
     })
+  })
+
+  await step("Pointer activation does not pin row actions", async () => {
+    await userEvent.click(
+      canvas.getByRole("button", { name: "Unlock column: Email" })
+    )
+    const emailRow = canvas.getByText("Email").closest("li")!
+    const lockEmail = within(emailRow).getByRole("button", {
+      name: "Lock column: Email",
+    })
+    expect(lockEmail).not.toHaveFocus()
+
+    lockEmail.focus()
+    await userEvent.keyboard("{Enter}")
+    await expect(
+      canvas.getByRole("button", { name: "Unlock column: Email" })
+    ).toHaveFocus()
   })
 
   const focusedUnlock = canvas.getByRole("button", {
     name: "Unlock column: Email",
   })
   focusedUnlock.blur()
-  const nameRow = canvas.getByText("Name").closest("li") as HTMLElement
-  const nameActions = nameRow.querySelector(
+  const roleRow = canvas.getByText("Role").closest("li") as HTMLElement
+  const roleActions = roleRow.querySelector(
     "[data-column-actions]"
   ) as HTMLElement
-  nameActions.tabIndex = -1
-  nameActions.focus()
+  roleActions.tabIndex = -1
+  roleActions.focus()
   await waitFor(() => {
-    expect(nameActions).toHaveFocus()
-    expect(getComputedStyle(nameActions).opacity).toBe("1")
+    expect(roleActions).toHaveFocus()
+    expect(getComputedStyle(roleActions).opacity).toBe("1")
     expect(page.queryByRole("tooltip")).toBeNull()
   })
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/types.ts
@@ -7,9 +7,14 @@ export type SortAndHideListItem = {
   order?: number
   /**
    * Whether the user can remove (not just hide) this entry. When `true` and the
-   * list has an `onRemove` handler, a trash affordance is revealed on hover.
+   * list has an `onRemove` handler, a trash affordance is revealed on hover or
+   * keyboard focus.
    */
   removable?: boolean
+  /** Whether this entry is the current user-managed required column. */
+  locked?: boolean
+  /** Whether this entry exposes the lock/unlock controls. */
+  lockable?: boolean
   /**
    * When set, the entry is locked: its switch renders forced OFF and disabled,
    * wrapped in a tooltip showing this text (e.g. a missing-permission reason).

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/types.ts
@@ -11,10 +11,12 @@ export type SortAndHideListItem = {
    * keyboard focus.
    */
   removable?: boolean
-  /** Whether this entry is the current user-managed required column. */
+  /** Whether this entry is one of the user-managed frozen columns. */
   locked?: boolean
   /** Whether this entry exposes the lock/unlock controls. */
   lockable?: boolean
+  /** Whether to show a locked state when sorting controls are otherwise off. */
+  showLockState?: boolean
   /**
    * When set, the entry is locked: its switch renders forced OFF and disabled,
    * wrapped in a tooltip showing this text (e.g. a missing-permission reason).

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
@@ -46,7 +46,7 @@ export const TableSettings = ({
 
   const usesExplicitColumnLocking =
     lockedColumnIds !== undefined || !!onLockedColumnIdsChange
-  const { columnsWithStatus, savedOrder } = useColumns(
+  const { columnsWithStatus, savedOrder, managedLockedColumnIds } = useColumns(
     originalColumns,
     frozenColumns,
     visualizationSettings,
@@ -57,6 +57,12 @@ export const TableSettings = ({
   )
 
   const items = useMemo(() => {
+    const visibleUnlockedIds = new Set(
+      columnsWithStatus
+        .filter((column) => column.visible && !column.locked)
+        .map((column) => column.column.id)
+    )
+
     return (
       columnsWithStatus
         // If allowHiding is false, we show only the columns that are visible
@@ -68,7 +74,13 @@ export const TableSettings = ({
           canHide: column.canHide,
           visible: column.visible,
           locked: column.locked,
-          lockable: !!onLockedColumnIdsChange && !column.frozen,
+          lockable:
+            !!onLockedColumnIdsChange &&
+            !column.frozen &&
+            (column.locked ||
+              [...visibleUnlockedIds].some(
+                (columnId) => columnId !== column.column.id
+              )),
           showLockState: usesExplicitColumnLocking && column.locked,
           removable:
             !!onRemoveColumn && !column.locked && !column.column.noRemoving,
@@ -94,12 +106,13 @@ export const TableSettings = ({
         onLockedColumnIdsChange
           ? (columnId, locked) => {
               onLockedColumnIdsChange(
-                getNextLockedColumnIds(lockedColumnIds, columnId, locked)
+                getNextLockedColumnIds(managedLockedColumnIds, columnId, locked)
               )
             }
           : undefined
       }
       orderBaseline={usesExplicitColumnLocking ? savedOrder : undefined}
+      keepOneUnlockedVisible={usesExplicitColumnLocking}
     />
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
@@ -23,6 +23,10 @@ type TableSettingsProps = {
    * sets `noRemoving`). Called with the column id to drop it from the table.
    */
   onRemoveColumn?: (columnId: string) => void
+  /** The currently user-managed required column. */
+  lockedColumnId?: string | null
+  /** Enables transferring or clearing the required-column lock. */
+  onLockedColumnChange?: (columnId: string | null) => void
 }
 
 export const TableSettings = ({
@@ -33,27 +37,26 @@ export const TableSettings = ({
   visualizationKey = "table",
   onAddColumn,
   onRemoveColumn,
+  lockedColumnId,
+  onLockedColumnChange,
 }: TableSettingsProps) => {
   const { settings } = useDataCollectionSettings()
 
   const visualizationSettings = settings.visualization[visualizationKey]
 
+  const usesExplicitColumnLocking =
+    lockedColumnId !== undefined || !!onLockedColumnChange
   const { columnsWithStatus } = useColumns(
     originalColumns,
     frozenColumns,
     visualizationSettings,
     allowSorting,
-    allowHiding
+    allowHiding,
+    lockedColumnId,
+    usesExplicitColumnLocking
   )
 
   const items = useMemo(() => {
-    // The leading `frozenColumns || 1` columns are non-editable (always-visible,
-    // not reorderable). They can never be removed — mirror that for the trash.
-    const lockedCount = frozenColumns || 1
-    const lockedIds = new Set(
-      columnsWithStatus.slice(0, lockedCount).map((column) => column.column.id)
-    )
-
     return (
       columnsWithStatus
         // If allowHiding is false, we show only the columns that are visible
@@ -64,13 +67,13 @@ export const TableSettings = ({
           sortable: column.sortable,
           canHide: column.canHide,
           visible: column.visible,
+          locked: column.locked,
+          lockable: !!onLockedColumnChange && !column.frozen,
           removable:
-            !!onRemoveColumn &&
-            !lockedIds.has(column.column.id) &&
-            !column.column.noRemoving,
+            !!onRemoveColumn && !column.locked && !column.column.noRemoving,
         }))
     )
-  }, [columnsWithStatus, allowHiding, frozenColumns, onRemoveColumn])
+  }, [columnsWithStatus, allowHiding, onLockedColumnChange, onRemoveColumn])
 
   return (
     <SortAndHideSettings
@@ -80,6 +83,7 @@ export const TableSettings = ({
       allowHiding={allowHiding}
       onAddColumn={onAddColumn}
       onRemoveColumn={onRemoveColumn}
+      onLockedColumnChange={onLockedColumnChange}
     />
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
@@ -3,7 +3,7 @@ import { useMemo } from "react"
 import { useDataCollectionSettings } from "@/patterns/OneDataCollection/Settings/SettingsProvider"
 import { SortAndHideSettings } from "@/patterns/OneDataCollection/Settings/SortAndHideSettings"
 
-import { useColumns } from "../hooks/useColums"
+import { getNextLockedColumnIds, useColumns } from "../hooks/useColums"
 import { TableColumnDefinition } from "../types"
 
 export type TableVisualizationSettingsKey = "table" | "editableTable"
@@ -23,10 +23,10 @@ type TableSettingsProps = {
    * sets `noRemoving`). Called with the column id to drop it from the table.
    */
   onRemoveColumn?: (columnId: string) => void
-  /** The currently user-managed required column. */
-  lockedColumnId?: string | null
-  /** Enables transferring or clearing the required-column lock. */
-  onLockedColumnChange?: (columnId: string | null) => void
+  /** The currently user-managed frozen columns. */
+  lockedColumnIds?: readonly string[]
+  /** Enables independently locking or unlocking columns. */
+  onLockedColumnIdsChange?: (columnIds: string[]) => void
 }
 
 export const TableSettings = ({
@@ -37,22 +37,22 @@ export const TableSettings = ({
   visualizationKey = "table",
   onAddColumn,
   onRemoveColumn,
-  lockedColumnId,
-  onLockedColumnChange,
+  lockedColumnIds,
+  onLockedColumnIdsChange,
 }: TableSettingsProps) => {
   const { settings } = useDataCollectionSettings()
 
   const visualizationSettings = settings.visualization[visualizationKey]
 
   const usesExplicitColumnLocking =
-    lockedColumnId !== undefined || !!onLockedColumnChange
-  const { columnsWithStatus } = useColumns(
+    lockedColumnIds !== undefined || !!onLockedColumnIdsChange
+  const { columnsWithStatus, savedOrder } = useColumns(
     originalColumns,
     frozenColumns,
     visualizationSettings,
     allowSorting,
     allowHiding,
-    lockedColumnId,
+    lockedColumnIds,
     usesExplicitColumnLocking
   )
 
@@ -68,12 +68,19 @@ export const TableSettings = ({
           canHide: column.canHide,
           visible: column.visible,
           locked: column.locked,
-          lockable: !!onLockedColumnChange && !column.frozen,
+          lockable: !!onLockedColumnIdsChange && !column.frozen,
+          showLockState: usesExplicitColumnLocking && column.locked,
           removable:
             !!onRemoveColumn && !column.locked && !column.column.noRemoving,
         }))
     )
-  }, [columnsWithStatus, allowHiding, onLockedColumnChange, onRemoveColumn])
+  }, [
+    columnsWithStatus,
+    allowHiding,
+    onLockedColumnIdsChange,
+    onRemoveColumn,
+    usesExplicitColumnLocking,
+  ])
 
   return (
     <SortAndHideSettings
@@ -83,7 +90,16 @@ export const TableSettings = ({
       allowHiding={allowHiding}
       onAddColumn={onAddColumn}
       onRemoveColumn={onRemoveColumn}
-      onLockedColumnChange={onLockedColumnChange}
+      onLockedColumnChange={
+        onLockedColumnIdsChange
+          ? (columnId, locked) => {
+              onLockedColumnIdsChange(
+                getNextLockedColumnIds(lockedColumnIds, columnId, locked)
+              )
+            }
+          : undefined
+      }
+      orderBaseline={usesExplicitColumnLocking ? savedOrder : undefined}
     />
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
@@ -1,5 +1,6 @@
-import { renderHook } from "@testing-library/react"
 import { describe, expect, it } from "vitest"
+
+import { zeroRenderHook as renderHook } from "@/testing/test-utils"
 
 import { TableColumnDefinition, TableVisualizationSettings } from "../../types"
 import { useColumns } from "../useColums"
@@ -456,5 +457,81 @@ describe("useColumns with settings", () => {
         locked: true,
       }),
     ])
+    expect(result.current.stickyColumnIds).toEqual([
+      "column1",
+      "column2",
+      "column3",
+    ])
+  })
+
+  it("leaves the final ordered column visible and unlocked when every managed column is requested", () => {
+    const { result } = renderHook(() =>
+      useColumns(
+        mockColumns,
+        0,
+        { hidden: ["column4"] },
+        true,
+        true,
+        ["column1", "column2", "column3", "column4"],
+        true
+      )
+    )
+
+    expect(result.current.managedLockedColumnIds).toEqual([
+      "column1",
+      "column2",
+      "column3",
+    ])
+    expect(result.current.stickyColumnIds).toEqual([
+      "column1",
+      "column2",
+      "column3",
+    ])
+    expect(
+      result.current.columnsWithStatus.find(
+        ({ column }) => column.id === "column4"
+      )
+    ).toMatchObject({
+      canHide: false,
+      locked: false,
+      visible: true,
+    })
+  })
+
+  it("restores a hidden unlocked column when every scrollable column is hidden", () => {
+    const { result } = renderHook(() =>
+      useColumns(
+        mockColumns,
+        0,
+        { hidden: ["column3", "column4"] },
+        true,
+        true,
+        ["column1", "column2"],
+        true
+      )
+    )
+
+    expect(result.current.columns.map((column) => column.id)).toEqual([
+      "column1",
+      "column2",
+      "column4",
+    ])
+    expect(
+      result.current.columnsWithStatus.find(
+        ({ column }) => column.id === "column4"
+      )
+    ).toMatchObject({
+      canHide: false,
+      locked: false,
+      visible: true,
+    })
+  })
+
+  it("does not turn the legacy non-editable first column into a sticky column", () => {
+    const { result } = renderHook(() =>
+      useColumns(mockColumns, 0, {}, true, true)
+    )
+
+    expect(result.current.stickyColumnIds).toEqual([])
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
@@ -337,4 +337,78 @@ describe("useColumns with settings", () => {
     // Should restore developer-defined order
     expect(result.current.colsOrder).toEqual(["column2", "column3", "column1"])
   })
+
+  it("uses the controlled lock instead of implicitly locking the first column", () => {
+    const { result } = renderHook(() =>
+      useColumns(
+        mockColumns,
+        0,
+        { hidden: ["column2"] },
+        true,
+        true,
+        "column2",
+        true
+      )
+    )
+
+    const first = result.current.columnsWithStatus.find(
+      ({ column }) => column.id === "column1"
+    )
+    const locked = result.current.columnsWithStatus.find(
+      ({ column }) => column.id === "column2"
+    )
+
+    expect(first).toMatchObject({
+      canHide: true,
+      frozen: false,
+      locked: false,
+      sortable: true,
+    })
+    expect(locked).toMatchObject({
+      canHide: false,
+      frozen: false,
+      locked: true,
+      sortable: false,
+      visible: true,
+    })
+    expect(result.current.columns.map((column) => column.id)).toContain(
+      "column2"
+    )
+  })
+
+  it("allows every non-frozen column to be editable when the controlled lock is cleared", () => {
+    const { result } = renderHook(() =>
+      useColumns(mockColumns, 0, {}, true, true, null, true)
+    )
+
+    expect(result.current.columnsWithStatus).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          column: expect.objectContaining({ id: "column1" }),
+          canHide: true,
+          locked: false,
+          sortable: true,
+        }),
+      ])
+    )
+  })
+
+  it("keeps frozen columns permanently locked alongside the controlled lock", () => {
+    const { result } = renderHook(() =>
+      useColumns(mockColumns, 1, {}, true, true, "column2", true)
+    )
+
+    expect(result.current.columnsWithStatus.slice(0, 2)).toEqual([
+      expect.objectContaining({
+        column: expect.objectContaining({ id: "column1" }),
+        frozen: true,
+        locked: true,
+      }),
+      expect.objectContaining({
+        column: expect.objectContaining({ id: "column2" }),
+        frozen: false,
+        locked: true,
+      }),
+    ])
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
@@ -338,7 +338,7 @@ describe("useColumns with settings", () => {
     expect(result.current.colsOrder).toEqual(["column2", "column3", "column1"])
   })
 
-  it("uses the controlled lock instead of implicitly locking the first column", () => {
+  it("uses controlled locks instead of implicitly locking the first column", () => {
     const { result } = renderHook(() =>
       useColumns(
         mockColumns,
@@ -346,7 +346,7 @@ describe("useColumns with settings", () => {
         { hidden: ["column2"] },
         true,
         true,
-        "column2",
+        ["column2", "column3"],
         true
       )
     )
@@ -354,8 +354,11 @@ describe("useColumns with settings", () => {
     const first = result.current.columnsWithStatus.find(
       ({ column }) => column.id === "column1"
     )
-    const locked = result.current.columnsWithStatus.find(
+    const firstLocked = result.current.columnsWithStatus.find(
       ({ column }) => column.id === "column2"
+    )
+    const secondLocked = result.current.columnsWithStatus.find(
+      ({ column }) => column.id === "column3"
     )
 
     expect(first).toMatchObject({
@@ -364,21 +367,59 @@ describe("useColumns with settings", () => {
       locked: false,
       sortable: true,
     })
-    expect(locked).toMatchObject({
+    expect(firstLocked).toMatchObject({
       canHide: false,
       frozen: false,
       locked: true,
       sortable: false,
       visible: true,
     })
-    expect(result.current.columns.map((column) => column.id)).toContain(
-      "column2"
-    )
+    expect(secondLocked).toMatchObject({
+      canHide: false,
+      frozen: false,
+      locked: true,
+      sortable: false,
+      visible: true,
+    })
+    expect(result.current.columns.map((column) => column.id)).toEqual([
+      "column2",
+      "column3",
+      "column1",
+      "column4",
+    ])
   })
 
-  it("allows every non-frozen column to be editable when the controlled lock is cleared", () => {
+  it("returns an unlocked column to its saved position", () => {
+    const settings: TableVisualizationSettings = {
+      hidden: [],
+      order: ["column2", "column1", "column3", "column4"],
+    }
+    const { result, rerender } = renderHook(
+      ({ lockedColumnIds }) =>
+        useColumns(mockColumns, 0, settings, true, true, lockedColumnIds, true),
+      { initialProps: { lockedColumnIds: ["column3"] } }
+    )
+
+    expect(result.current.columns.map((column) => column.id)).toEqual([
+      "column3",
+      "column2",
+      "column1",
+      "column4",
+    ])
+
+    rerender({ lockedColumnIds: [] })
+
+    expect(result.current.columns.map((column) => column.id)).toEqual([
+      "column2",
+      "column1",
+      "column3",
+      "column4",
+    ])
+  })
+
+  it("allows every non-frozen column to be editable when controlled locks are empty", () => {
     const { result } = renderHook(() =>
-      useColumns(mockColumns, 0, {}, true, true, null, true)
+      useColumns(mockColumns, 0, {}, true, true, [], true)
     )
 
     expect(result.current.columnsWithStatus).toEqual(
@@ -393,12 +434,12 @@ describe("useColumns with settings", () => {
     )
   })
 
-  it("keeps frozen columns permanently locked alongside the controlled lock", () => {
+  it("keeps frozen columns permanently locked alongside controlled locks", () => {
     const { result } = renderHook(() =>
-      useColumns(mockColumns, 1, {}, true, true, "column2", true)
+      useColumns(mockColumns, 1, {}, true, true, ["column2", "column3"], true)
     )
 
-    expect(result.current.columnsWithStatus.slice(0, 2)).toEqual([
+    expect(result.current.columnsWithStatus.slice(0, 3)).toEqual([
       expect.objectContaining({
         column: expect.objectContaining({ id: "column1" }),
         frozen: true,
@@ -406,6 +447,11 @@ describe("useColumns with settings", () => {
       }),
       expect.objectContaining({
         column: expect.objectContaining({ id: "column2" }),
+        frozen: false,
+        locked: true,
+      }),
+      expect.objectContaining({
+        column: expect.objectContaining({ id: "column3" }),
         frozen: false,
         locked: true,
       }),

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
@@ -20,6 +20,15 @@ export const getColumnId = <
 ) => {
   return column.id ?? column.label ?? "column"
 }
+
+export const getNextLockedColumnIds = (
+  currentIds: readonly ColId[] | undefined,
+  columnId: ColId,
+  locked: boolean
+) =>
+  locked
+    ? [...new Set([...(currentIds ?? []), columnId])]
+    : (currentIds ?? []).filter((id) => id !== columnId)
 /**
  * Get the order of the columns from the definition and sort them by the order putting the ones with no order at the end
  * @param columns - The columns to get the order from
@@ -59,6 +68,7 @@ type UseColumnsReturn<
   setColsHidden: (colsHidden: ColId[]) => void
   colsOrder: ColId[]
   setColsOrder: (colsOrder: ColId[]) => void
+  savedOrder: ColId[]
   columnsWithStatus: {
     column: TableColumnDefinition<R, Sortings, Summaries> & { id: ColId }
     canHide: boolean
@@ -86,7 +96,7 @@ export const useColumns = <
   settings?: TableVisualizationSettings,
   allowSorting?: boolean,
   allowHiding?: boolean,
-  lockedColumnId?: ColId | null,
+  lockedColumnIds?: readonly ColId[],
   usesExplicitColumnLocking?: boolean
 ): UseColumnsReturn<R, Sortings, Summaries> => {
   // Merge user preferences with developer defaults for NEW columns
@@ -137,11 +147,44 @@ export const useColumns = <
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we don't want to re-run this effect when the settings change
   }, [JSON.stringify(settings?.order), allowSorting])
 
+  const nonEditableColumns = usesExplicitColumnLocking
+    ? frozenColumns
+    : frozenColumns || 1
+  const columnsInSavedOrder = useMemo(() => {
+    const leadingColumns = originalColumns.slice(0, nonEditableColumns)
+    const orderedColumns = [...originalColumns.slice(nonEditableColumns)].sort(
+      (a, b) => {
+        const aIndex = colsOrder.indexOf(getColumnId(a))
+        const bIndex = colsOrder.indexOf(getColumnId(b))
+        const aPos = aIndex === -1 ? colsOrder.length : aIndex
+        const bPos = bIndex === -1 ? colsOrder.length : bIndex
+        return aPos - bPos
+      }
+    )
+
+    return [...leadingColumns, ...orderedColumns]
+  }, [originalColumns, nonEditableColumns, colsOrder])
+  const savedOrder = useMemo(
+    () => columnsInSavedOrder.map(getColumnId),
+    [columnsInSavedOrder]
+  )
+
   const columnsWithStatus = useMemo(() => {
-    const cols = [...originalColumns]
-    const nonEditableColumns = usesExplicitColumnLocking
-      ? frozenColumns
-      : frozenColumns || 1
+    const leadingColumns = columnsInSavedOrder.slice(0, nonEditableColumns)
+    const orderedColumns = columnsInSavedOrder.slice(nonEditableColumns)
+    const orderedColumnsById = new Map(
+      orderedColumns.map((column) => [getColumnId(column), column])
+    )
+    const managedLockedColumns = [...new Set(lockedColumnIds ?? [])]
+      .map((id) => orderedColumnsById.get(id))
+      .filter(
+        (column): column is TableColumnDefinition<R, Sortings, Summaries> =>
+          !!column
+      )
+    const managedLockedIds = new Set(managedLockedColumns.map(getColumnId))
+    const unlockedColumns = orderedColumns.filter(
+      (column) => !managedLockedIds.has(getColumnId(column))
+    )
 
     const withStatus = (
       column: TableColumnDefinition<R, Sortings, Summaries>,
@@ -150,7 +193,8 @@ export const useColumns = <
     ) => {
       const id = getColumnId(column)
       const locked =
-        frozen || (!!usesExplicitColumnLocking && id === lockedColumnId)
+        frozen ||
+        (!!usesExplicitColumnLocking && !!lockedColumnIds?.includes(id))
 
       return {
         column: {
@@ -174,32 +218,30 @@ export const useColumns = <
       // Frozen columns can not be hidden even if the id is in status
       // The first column remains non-editable by default for backwards
       // compatibility. A lock value or callback opts into explicit semantics.
-      ...cols
-        .slice(0, nonEditableColumns)
-        .map((column, index) => withStatus(column, index, true)),
-      // The rest of the columns are sorted and hidden using the status in colsOrder and colsHidden
-      ...cols
-        .slice(nonEditableColumns)
-        .sort((a, b) => {
-          const aIndex = colsOrder.indexOf(getColumnId(a))
-          const bIndex = colsOrder.indexOf(getColumnId(b))
-          // Columns not in saved order (indexOf === -1) should appear at the end
-          const aPos = aIndex === -1 ? colsOrder.length : aIndex
-          const bPos = bIndex === -1 ? colsOrder.length : bIndex
-          return aPos - bPos
-        })
-        .map((column, index) =>
-          withStatus(column, index + nonEditableColumns, false)
-        ),
+      ...leadingColumns.map((column, index) => withStatus(column, index, true)),
+      // User-managed locks form a frozen group after permanent frozen columns.
+      // Their array order records the order in which users locked them.
+      ...managedLockedColumns.map((column, index) =>
+        withStatus(column, index + leadingColumns.length, false)
+      ),
+      // Unlocked columns retain their saved order, so unlocking returns a
+      // column to the position it had before it joined the frozen group.
+      ...unlockedColumns.map((column, index) =>
+        withStatus(
+          column,
+          index + leadingColumns.length + managedLockedColumns.length,
+          false
+        )
+      ),
     ]
   }, [
     frozenColumns,
-    colsOrder,
     colsHidden,
-    originalColumns,
+    columnsInSavedOrder,
+    nonEditableColumns,
     allowSorting,
     allowHiding,
-    lockedColumnId,
+    lockedColumnIds,
     usesExplicitColumnLocking,
   ])
 
@@ -216,5 +258,6 @@ export const useColumns = <
     setColsHidden,
     colsOrder,
     setColsOrder,
+    savedOrder,
   }
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
@@ -64,6 +64,8 @@ type UseColumnsReturn<
     canHide: boolean
     visible: boolean
     sortable: boolean
+    frozen: boolean
+    locked: boolean
     order: number
   }[]
 }
@@ -83,7 +85,9 @@ export const useColumns = <
   frozenColumns: number,
   settings?: TableVisualizationSettings,
   allowSorting?: boolean,
-  allowHiding?: boolean
+  allowHiding?: boolean,
+  lockedColumnId?: ColId | null,
+  usesExplicitColumnLocking?: boolean
 ): UseColumnsReturn<R, Sortings, Summaries> => {
   // Merge user preferences with developer defaults for NEW columns
   // New columns (not in saved order) should respect their hidden: true default
@@ -135,21 +139,44 @@ export const useColumns = <
 
   const columnsWithStatus = useMemo(() => {
     const cols = [...originalColumns]
-    const nonEditableColumns = frozenColumns || 1
+    const nonEditableColumns = usesExplicitColumnLocking
+      ? frozenColumns
+      : frozenColumns || 1
+
+    const withStatus = (
+      column: TableColumnDefinition<R, Sortings, Summaries>,
+      index: number,
+      frozen: boolean
+    ) => {
+      const id = getColumnId(column)
+      const locked =
+        frozen || (!!usesExplicitColumnLocking && id === lockedColumnId)
+
+      return {
+        column: {
+          ...column,
+          id,
+        },
+        canHide: locked
+          ? false
+          : allowHiding
+            ? !(column.noHiding ?? false)
+            : false,
+        visible: locked || !colsHidden.includes(id),
+        sortable: !locked && !!allowSorting,
+        frozen,
+        locked,
+        order: index,
+      }
+    }
 
     return [
       // Frozen columns can not be hidden even if the id is in status
-      // The frist column is always visible and not sortable even if frozenColumns is 0
-      ...cols.slice(0, nonEditableColumns).map((column, index) => ({
-        column: {
-          ...column,
-          id: getColumnId(column),
-        },
-        canHide: false,
-        visible: true,
-        sortable: false,
-        order: index,
-      })),
+      // The first column remains non-editable by default for backwards
+      // compatibility. A lock value or callback opts into explicit semantics.
+      ...cols
+        .slice(0, nonEditableColumns)
+        .map((column, index) => withStatus(column, index, true)),
       // The rest of the columns are sorted and hidden using the status in colsOrder and colsHidden
       ...cols
         .slice(nonEditableColumns)
@@ -161,16 +188,9 @@ export const useColumns = <
           const bPos = bIndex === -1 ? colsOrder.length : bIndex
           return aPos - bPos
         })
-        .map((column, index) => ({
-          column: {
-            ...column,
-            id: getColumnId(column),
-          },
-          canHide: allowHiding ? !(column.noHiding ?? false) : false,
-          visible: !colsHidden.includes(getColumnId(column)),
-          sortable: !!allowSorting,
-          order: index + frozenColumns,
-        })),
+        .map((column, index) =>
+          withStatus(column, index + nonEditableColumns, false)
+        ),
     ]
   }, [
     frozenColumns,
@@ -179,6 +199,8 @@ export const useColumns = <
     originalColumns,
     allowSorting,
     allowHiding,
+    lockedColumnId,
+    usesExplicitColumnLocking,
   ])
 
   const columns = useMemo(() => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
@@ -69,6 +69,10 @@ type UseColumnsReturn<
   colsOrder: ColId[]
   setColsOrder: (colsOrder: ColId[]) => void
   savedOrder: ColId[]
+  /** User-managed lock ids after enforcing a remaining scrollable column. */
+  managedLockedColumnIds: ColId[]
+  /** Permanent and user-managed columns that participate in sticky layout. */
+  stickyColumnIds: ColId[]
   columnsWithStatus: {
     column: TableColumnDefinition<R, Sortings, Summaries> & { id: ColId }
     canHide: boolean
@@ -169,22 +173,88 @@ export const useColumns = <
     [columnsInSavedOrder]
   )
 
-  const columnsWithStatus = useMemo(() => {
+  const columnGroups = useMemo(() => {
     const leadingColumns = columnsInSavedOrder.slice(0, nonEditableColumns)
     const orderedColumns = columnsInSavedOrder.slice(nonEditableColumns)
     const orderedColumnsById = new Map(
       orderedColumns.map((column) => [getColumnId(column), column])
     )
-    const managedLockedColumns = [...new Set(lockedColumnIds ?? [])]
+    const requestedManagedLockedColumns = [...new Set(lockedColumnIds ?? [])]
       .map((id) => orderedColumnsById.get(id))
       .filter(
         (column): column is TableColumnDefinition<R, Sortings, Summaries> =>
           !!column
       )
+    const requestedManagedLockedIds = new Set(
+      requestedManagedLockedColumns.map(getColumnId)
+    )
+    const requestedUnlockedColumns = orderedColumns.filter(
+      (column) => !requestedManagedLockedIds.has(getColumnId(column))
+    )
+
+    // A user-managed frozen group must never consume the whole scrollable
+    // table. Prefer an already-visible unlocked column; invalid controlled
+    // input that locks every column falls back to the final ordered column.
+    const fallbackUnlockedColumn = usesExplicitColumnLocking
+      ? (requestedUnlockedColumns.find(
+          (column) => !colsHidden.includes(getColumnId(column))
+        ) ??
+        requestedUnlockedColumns.at(-1) ??
+        orderedColumns.at(-1))
+      : undefined
+    const fallbackUnlockedId = fallbackUnlockedColumn
+      ? getColumnId(fallbackUnlockedColumn)
+      : undefined
+    const managedLockedColumns = requestedManagedLockedColumns.filter(
+      (column) => getColumnId(column) !== fallbackUnlockedId
+    )
     const managedLockedIds = new Set(managedLockedColumns.map(getColumnId))
     const unlockedColumns = orderedColumns.filter(
       (column) => !managedLockedIds.has(getColumnId(column))
     )
+    const visibleUnlockedColumns = unlockedColumns.filter(
+      (column) => !colsHidden.includes(getColumnId(column))
+    )
+    const forcedVisibleUnlockedId =
+      usesExplicitColumnLocking && visibleUnlockedColumns.length === 0
+        ? fallbackUnlockedId
+        : undefined
+    const effectiveVisibleUnlockedIds = unlockedColumns
+      .filter(
+        (column) =>
+          getColumnId(column) === forcedVisibleUnlockedId ||
+          !colsHidden.includes(getColumnId(column))
+      )
+      .map(getColumnId)
+
+    return {
+      leadingColumns,
+      managedLockedColumns,
+      managedLockedIds,
+      unlockedColumns,
+      forcedVisibleUnlockedId,
+      soleVisibleUnlockedId:
+        usesExplicitColumnLocking && effectiveVisibleUnlockedIds.length === 1
+          ? effectiveVisibleUnlockedIds[0]
+          : undefined,
+    }
+  }, [
+    columnsInSavedOrder,
+    nonEditableColumns,
+    lockedColumnIds,
+    usesExplicitColumnLocking,
+    colsHidden,
+  ])
+
+  const columnsWithStatus = useMemo(() => {
+    const {
+      leadingColumns,
+      managedLockedColumns,
+      managedLockedIds,
+      unlockedColumns,
+      forcedVisibleUnlockedId,
+      soleVisibleUnlockedId,
+    } = columnGroups
 
     const withStatus = (
       column: TableColumnDefinition<R, Sortings, Summaries>,
@@ -192,21 +262,21 @@ export const useColumns = <
       frozen: boolean
     ) => {
       const id = getColumnId(column)
-      const locked =
-        frozen ||
-        (!!usesExplicitColumnLocking && !!lockedColumnIds?.includes(id))
+      const locked = frozen || managedLockedIds.has(id)
 
       return {
         column: {
           ...column,
           id,
         },
-        canHide: locked
-          ? false
-          : allowHiding
-            ? !(column.noHiding ?? false)
-            : false,
-        visible: locked || !colsHidden.includes(id),
+        canHide:
+          locked || id === soleVisibleUnlockedId
+            ? false
+            : allowHiding
+              ? !(column.noHiding ?? false)
+              : false,
+        visible:
+          locked || id === forcedVisibleUnlockedId || !colsHidden.includes(id),
         sortable: !locked && !!allowSorting,
         frozen,
         locked,
@@ -234,16 +304,19 @@ export const useColumns = <
         )
       ),
     ]
-  }, [
-    frozenColumns,
-    colsHidden,
-    columnsInSavedOrder,
-    nonEditableColumns,
-    allowSorting,
-    allowHiding,
-    lockedColumnIds,
-    usesExplicitColumnLocking,
-  ])
+  }, [colsHidden, allowSorting, allowHiding, columnGroups])
+
+  const managedLockedColumnIds = useMemo(
+    () => columnGroups.managedLockedColumns.map(getColumnId),
+    [columnGroups.managedLockedColumns]
+  )
+  const stickyColumnIds = useMemo(
+    () => [
+      ...columnsInSavedOrder.slice(0, frozenColumns).map(getColumnId),
+      ...managedLockedColumnIds,
+    ],
+    [columnsInSavedOrder, frozenColumns, managedLockedColumnIds]
+  )
 
   const columns = useMemo(() => {
     return columnsWithStatus
@@ -259,5 +332,7 @@ export const useColumns = <
     colsOrder,
     setColsOrder,
     savedOrder,
+    managedLockedColumnIds,
+    stickyColumnIds,
   }
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useHeaderGroups.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useHeaderGroups.ts
@@ -55,6 +55,8 @@ type HeaderGroupRun = {
   columnIndices: number[]
 }
 
+const emptyPreservedColumnIds: ReadonlySet<ColId> = new Set()
+
 /**
  * Resolves the shorthand string form and the per-group defaults into a single
  * definition map. Returns `null` when no groups are configured.
@@ -124,7 +126,8 @@ const getCollapsedColumnIndices = <
 >(
   columns: ReadonlyArray<Col>,
   definitions: NormalizedHeaderGroups,
-  collapsedGroups: ReadonlySet<string>
+  collapsedGroups: ReadonlySet<string>,
+  preservedColumnIds: ReadonlySet<ColId> = emptyPreservedColumnIds
 ): ReadonlySet<number> => {
   const hidden = new Set<number>()
 
@@ -132,15 +135,33 @@ const getCollapsedColumnIndices = <
     if (!collapsedGroups.has(run.groupId)) return
 
     const collapsedColumns = definitions[run.groupId]?.collapsedColumns
-    const kept = run.columnIndices.filter((index) =>
-      collapsedColumns?.includes(getColumnId(columns[index]))
-    )
+    const kept = run.columnIndices.filter((index) => {
+      const columnId = getColumnId(columns[index])
+      return (
+        preservedColumnIds.has(columnId) || collapsedColumns?.includes(columnId)
+      )
+    })
     const keptIndices = new Set(kept.length > 0 ? kept : [run.columnIndices[0]])
 
     run.columnIndices.forEach((index) => {
       if (!keptIndices.has(index)) hidden.add(index)
     })
   })
+
+  // Collapsing must not leave a table made entirely of sticky columns. If the
+  // configured groups would hide every scrollable column, retain the final one
+  // in table order as the stable horizontal-scroll boundary.
+  const scrollableIndices = columns
+    .map((column, index) =>
+      preservedColumnIds.has(getColumnId(column)) ? -1 : index
+    )
+    .filter((index) => index !== -1)
+  if (
+    scrollableIndices.length > 0 &&
+    scrollableIndices.every((index) => hidden.has(index))
+  ) {
+    hidden.delete(scrollableIndices.at(-1)!)
+  }
 
   return hidden
 }
@@ -192,6 +213,8 @@ export const computeHeaderGroups = (
 export type UseHeaderGroupsOptions = {
   headerGroups?: Record<string, string | HeaderGroupDefinition>
   onCollapsedChange?: (groupId: string, collapsed: boolean) => void
+  /** Columns that stay rendered even when their header group collapses. */
+  preservedColumnIds?: ReadonlySet<ColId>
 }
 
 export type UseHeaderGroupsReturn<
@@ -234,7 +257,11 @@ export const useHeaderGroups = <
   Summaries extends SummariesDefinition,
 >(
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>,
-  { headerGroups, onCollapsedChange }: UseHeaderGroupsOptions = {}
+  {
+    headerGroups,
+    onCollapsedChange,
+    preservedColumnIds = emptyPreservedColumnIds,
+  }: UseHeaderGroupsOptions = {}
 ): UseHeaderGroupsReturn<R, Sortings, Summaries> => {
   const definitions = useMemo(
     () => normalizeHeaderGroups(headerGroups),
@@ -311,7 +338,8 @@ export const useHeaderGroups = <
             const hidden = getCollapsedColumnIndices(
               columns,
               definitions,
-              settledCollapsedGroups
+              settledCollapsedGroups,
+              preservedColumnIds
             )
             return hidden.size === 0
               ? columns
@@ -327,7 +355,7 @@ export const useHeaderGroups = <
         ? { ...column, highlighted: true }
         : column
     )
-  }, [columns, definitions, settledCollapsedGroups])
+  }, [columns, definitions, settledCollapsedGroups, preservedColumnIds])
 
   // Stable order, so a group's marker class does not change between renders.
   const collapsibleGroupIds = useMemo(
@@ -351,7 +379,8 @@ export const useHeaderGroups = <
       const indices = getCollapsedColumnIndices(
         visibleColumns,
         definitions,
-        new Set([groupId])
+        new Set([groupId]),
+        preservedColumnIds
       )
 
       indices.forEach((index) => {
@@ -363,7 +392,13 @@ export const useHeaderGroups = <
     })
 
     return classes
-  }, [visibleColumns, definitions, animatingGroups, collapsibleGroupIds])
+  }, [
+    visibleColumns,
+    definitions,
+    animatingGroups,
+    collapsibleGroupIds,
+    preservedColumnIds,
+  ])
 
   // One entry per group in flight, for the animation to pick up.
   const collapseTransitions = useMemo(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/SettingsRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/SettingsRenderer.tsx
@@ -23,7 +23,8 @@ export const SettingsRenderer = <
     !props.allowColumnHiding &&
     !props.allowColumnReordering &&
     !props.onAddColumn &&
-    !props.onRemoveColumn
+    !props.onRemoveColumn &&
+    !props.onLockedColumnChange
   ) {
     return null
   }
@@ -37,6 +38,8 @@ export const SettingsRenderer = <
       visualizationKey={props.visualizationKey}
       onAddColumn={props.onAddColumn}
       onRemoveColumn={props.onRemoveColumn}
+      lockedColumnId={props.lockedColumnId}
+      onLockedColumnChange={props.onLockedColumnChange}
     />
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/SettingsRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/SettingsRenderer.tsx
@@ -24,7 +24,7 @@ export const SettingsRenderer = <
     !props.allowColumnReordering &&
     !props.onAddColumn &&
     !props.onRemoveColumn &&
-    !props.onLockedColumnChange
+    !props.onLockedColumnIdsChange
   ) {
     return null
   }
@@ -38,8 +38,8 @@ export const SettingsRenderer = <
       visualizationKey={props.visualizationKey}
       onAddColumn={props.onAddColumn}
       onRemoveColumn={props.onRemoveColumn}
-      lockedColumnId={props.lockedColumnId}
-      onLockedColumnChange={props.onLockedColumnChange}
+      lockedColumnIds={props.lockedColumnIds}
+      onLockedColumnIdsChange={props.onLockedColumnIdsChange}
     />
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/__tests__/SettingsRenderer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/__tests__/SettingsRenderer.test.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react"
+
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  screen,
+  userEvent,
+  within,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { DataCollectionSettingsProvider } from "../../../../../Settings/SettingsProvider"
+import { SettingsRenderer } from "../SettingsRenderer"
+
+const columns = [
+  { id: "name", label: "Name", render: () => "Ada Lovelace" },
+  { id: "email", label: "Email", render: () => "ada@example.com" },
+]
+
+describe("Table SettingsRenderer column locking", () => {
+  it("enforces a read-only lockedColumnId without exposing lock controls", () => {
+    render(
+      <DataCollectionSettingsProvider>
+        <SettingsRenderer
+          columns={columns}
+          frozenColumns={0}
+          allowColumnReordering
+          allowColumnHiding
+          lockedColumnId="email"
+          onRemoveColumn={vi.fn()}
+        />
+      </DataCollectionSettingsProvider>
+    )
+
+    const nameRow = screen.getByText("Name").closest("li") as HTMLElement
+    const emailRow = screen.getByText("Email").closest("li") as HTMLElement
+    expect(within(nameRow).getByRole("switch")).not.toBeDisabled()
+    expect(within(emailRow).getByRole("switch")).toBeDisabled()
+    expect(
+      within(emailRow).queryByRole("button", { name: /column: Email/ })
+    ).not.toBeInTheDocument()
+    expect(
+      within(emailRow).queryByRole("button", { name: "Remove column" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("transfers the controlled lock and updates the available row actions", async () => {
+    const onLockedColumnChange = vi.fn()
+
+    const Harness = () => {
+      const [lockedColumnId, setLockedColumnId] = useState<string | null>(
+        "name"
+      )
+
+      return (
+        <DataCollectionSettingsProvider>
+          <SettingsRenderer
+            columns={columns}
+            frozenColumns={0}
+            allowColumnReordering
+            allowColumnHiding
+            lockedColumnId={lockedColumnId}
+            onLockedColumnChange={(columnId) => {
+              onLockedColumnChange(columnId)
+              setLockedColumnId(columnId)
+            }}
+            onRemoveColumn={vi.fn()}
+          />
+        </DataCollectionSettingsProvider>
+      )
+    }
+
+    render(<Harness />)
+
+    const nameRow = screen.getByText("Name").closest("li") as HTMLElement
+    const emailRow = screen.getByText("Email").closest("li") as HTMLElement
+
+    expect(within(nameRow).getByRole("switch")).toBeDisabled()
+    expect(within(emailRow).getByRole("switch")).not.toBeDisabled()
+
+    await userEvent.click(
+      within(nameRow).getByRole("button", { name: "Unlock column: Name" })
+    )
+    expect(
+      screen.getByRole("button", { name: "Lock column: Name" })
+    ).toHaveFocus()
+    const unlockedEmailRow = screen
+      .getByText("Email")
+      .closest("li") as HTMLElement
+    await userEvent.click(
+      within(unlockedEmailRow).getByRole("button", {
+        name: "Lock column: Email",
+      })
+    )
+    expect(
+      screen.getByRole("button", { name: "Unlock column: Email" })
+    ).toHaveFocus()
+
+    expect(onLockedColumnChange).toHaveBeenNthCalledWith(1, null)
+    expect(onLockedColumnChange).toHaveBeenNthCalledWith(2, "email")
+    const updatedNameRow = screen.getByText("Name").closest("li") as HTMLElement
+    const updatedEmailRow = screen
+      .getByText("Email")
+      .closest("li") as HTMLElement
+    expect(within(updatedNameRow).getByRole("switch")).not.toBeDisabled()
+    expect(within(updatedEmailRow).getByRole("switch")).toBeDisabled()
+    expect(
+      within(updatedEmailRow).queryByRole("button", { name: "Remove column" })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/__tests__/SettingsRenderer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/__tests__/SettingsRenderer.test.tsx
@@ -5,6 +5,7 @@ import { describe, expect, it, vi } from "vitest"
 import {
   screen,
   userEvent,
+  waitFor,
   within,
   zeroRender as render,
 } from "@/testing/test-utils"
@@ -38,7 +39,9 @@ describe("Table SettingsRenderer column locking", () => {
     const roleRow = screen.getByText("Role").closest("li") as HTMLElement
     expect(within(nameRow).getByRole("switch")).toBeDisabled()
     expect(within(emailRow).getByRole("switch")).toBeDisabled()
-    expect(within(roleRow).getByRole("switch")).not.toBeDisabled()
+    // The remaining scrollable column cannot be hidden even when the locked
+    // set is read-only.
+    expect(within(roleRow).getByRole("switch")).toBeDisabled()
     expect(
       within(nameRow).queryByRole("button", { name: /column: Name/ })
     ).not.toBeInTheDocument()
@@ -117,6 +120,15 @@ describe("Table SettingsRenderer column locking", () => {
     expect(
       screen.getByRole("button", { name: "Unlock column: Name" })
     ).toBeInTheDocument()
+    const onlyScrollableEmailRow = screen
+      .getByText("Email")
+      .closest("li") as HTMLElement
+    expect(within(onlyScrollableEmailRow).getByRole("switch")).toBeDisabled()
+    expect(
+      within(onlyScrollableEmailRow).queryByRole("button", {
+        name: "Lock column: Email",
+      })
+    ).not.toBeInTheDocument()
 
     expect(
       screen
@@ -165,5 +177,62 @@ describe("Table SettingsRenderer column locking", () => {
     expect(
       within(updatedNameRow).queryByRole("button", { name: "Remove column" })
     ).not.toBeInTheDocument()
+  })
+
+  it("normalizes an externally controlled all-locked set before emitting changes", async () => {
+    const onLockedColumnIdsChange = vi.fn()
+
+    render(
+      <DataCollectionSettingsProvider>
+        <SettingsRenderer
+          columns={columns}
+          frozenColumns={0}
+          allowColumnReordering
+          allowColumnHiding
+          lockedColumnIds={["name", "email", "role"]}
+          onLockedColumnIdsChange={onLockedColumnIdsChange}
+        />
+      </DataCollectionSettingsProvider>
+    )
+
+    const roleRow = screen.getByText("Role").closest("li") as HTMLElement
+    expect(within(roleRow).getByRole("switch")).toBeDisabled()
+    expect(
+      within(roleRow).queryByRole("button", { name: "Lock column: Role" })
+    ).not.toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Unlock column: Email" })
+    )
+
+    expect(onLockedColumnIdsChange).toHaveBeenCalledWith(["name"])
+  })
+
+  it("keeps one visible unlocked column when bulk hiding", async () => {
+    render(
+      <DataCollectionSettingsProvider>
+        <SettingsRenderer
+          columns={columns}
+          frozenColumns={0}
+          allowColumnReordering
+          allowColumnHiding
+          lockedColumnIds={["name"]}
+          onLockedColumnIdsChange={vi.fn()}
+        />
+      </DataCollectionSettingsProvider>
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Hide all" }))
+
+    await waitFor(() => {
+      const emailRow = screen.getByText("Email").closest("li") as HTMLElement
+      const roleRow = screen.getByText("Role").closest("li") as HTMLElement
+      expect(within(emailRow).getByRole("switch")).not.toBeChecked()
+      expect(within(roleRow).getByRole("switch")).toBeChecked()
+      expect(within(roleRow).getByRole("switch")).toBeDisabled()
+      expect(
+        within(roleRow).queryByRole("button", { name: "Lock column: Role" })
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/__tests__/SettingsRenderer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/settings/__tests__/SettingsRenderer.test.tsx
@@ -15,10 +15,11 @@ import { SettingsRenderer } from "../SettingsRenderer"
 const columns = [
   { id: "name", label: "Name", render: () => "Ada Lovelace" },
   { id: "email", label: "Email", render: () => "ada@example.com" },
+  { id: "role", label: "Role", render: () => "Engineer" },
 ]
 
 describe("Table SettingsRenderer column locking", () => {
-  it("enforces a read-only lockedColumnId without exposing lock controls", () => {
+  it("enforces read-only lockedColumnIds without exposing lock controls", () => {
     render(
       <DataCollectionSettingsProvider>
         <SettingsRenderer
@@ -26,7 +27,7 @@ describe("Table SettingsRenderer column locking", () => {
           frozenColumns={0}
           allowColumnReordering
           allowColumnHiding
-          lockedColumnId="email"
+          lockedColumnIds={["name", "email"]}
           onRemoveColumn={vi.fn()}
         />
       </DataCollectionSettingsProvider>
@@ -34,23 +35,48 @@ describe("Table SettingsRenderer column locking", () => {
 
     const nameRow = screen.getByText("Name").closest("li") as HTMLElement
     const emailRow = screen.getByText("Email").closest("li") as HTMLElement
-    expect(within(nameRow).getByRole("switch")).not.toBeDisabled()
+    const roleRow = screen.getByText("Role").closest("li") as HTMLElement
+    expect(within(nameRow).getByRole("switch")).toBeDisabled()
     expect(within(emailRow).getByRole("switch")).toBeDisabled()
+    expect(within(roleRow).getByRole("switch")).not.toBeDisabled()
+    expect(
+      within(nameRow).queryByRole("button", { name: /column: Name/ })
+    ).not.toBeInTheDocument()
     expect(
       within(emailRow).queryByRole("button", { name: /column: Email/ })
     ).not.toBeInTheDocument()
     expect(
       within(emailRow).queryByRole("button", { name: "Remove column" })
     ).not.toBeInTheDocument()
+    expect(nameRow.querySelector("svg")).toBeInTheDocument()
+    expect(emailRow.querySelector("svg")).toBeInTheDocument()
   })
 
-  it("transfers the controlled lock and updates the available row actions", async () => {
-    const onLockedColumnChange = vi.fn()
+  it("preserves the legacy UI when column locking is not enabled", () => {
+    render(
+      <DataCollectionSettingsProvider>
+        <SettingsRenderer
+          columns={columns}
+          frozenColumns={0}
+          allowColumnReordering={false}
+          allowColumnHiding
+        />
+      </DataCollectionSettingsProvider>
+    )
+
+    const nameRow = screen.getByText("Name").closest("li") as HTMLElement
+    expect(within(nameRow).getByRole("switch")).toBeDisabled()
+    expect(nameRow.querySelector("svg")).not.toBeInTheDocument()
+    expect(
+      within(nameRow).queryByRole("button", { name: /column: Name/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("independently locks and unlocks columns", async () => {
+    const onLockedColumnIdsChange = vi.fn()
 
     const Harness = () => {
-      const [lockedColumnId, setLockedColumnId] = useState<string | null>(
-        "name"
-      )
+      const [lockedColumnIds, setLockedColumnIds] = useState<string[]>(["name"])
 
       return (
         <DataCollectionSettingsProvider>
@@ -59,10 +85,10 @@ describe("Table SettingsRenderer column locking", () => {
             frozenColumns={0}
             allowColumnReordering
             allowColumnHiding
-            lockedColumnId={lockedColumnId}
-            onLockedColumnChange={(columnId) => {
-              onLockedColumnChange(columnId)
-              setLockedColumnId(columnId)
+            lockedColumnIds={lockedColumnIds}
+            onLockedColumnIdsChange={(columnIds) => {
+              onLockedColumnIdsChange(columnIds)
+              setLockedColumnIds(columnIds)
             }}
             onRemoveColumn={vi.fn()}
           />
@@ -74,38 +100,70 @@ describe("Table SettingsRenderer column locking", () => {
 
     const nameRow = screen.getByText("Name").closest("li") as HTMLElement
     const emailRow = screen.getByText("Email").closest("li") as HTMLElement
+    const roleRow = screen.getByText("Role").closest("li") as HTMLElement
 
     expect(within(nameRow).getByRole("switch")).toBeDisabled()
     expect(within(emailRow).getByRole("switch")).not.toBeDisabled()
+    expect(within(roleRow).getByRole("switch")).not.toBeDisabled()
 
+    const roleLock = within(roleRow).getByRole("button", {
+      name: "Lock column: Role",
+    })
+    roleLock.focus()
+    await userEvent.keyboard("{Enter}")
+    expect(
+      screen.getByRole("button", { name: "Unlock column: Role" })
+    ).toHaveFocus()
+    expect(
+      screen.getByRole("button", { name: "Unlock column: Name" })
+    ).toBeInTheDocument()
+
+    expect(
+      screen
+        .getAllByRole("listitem")
+        .map((row) => row.textContent?.match(/Name|Email|Role/)?.[0])
+    ).toEqual(["Name", "Role", "Email"])
+
+    const lockedRoleRow = screen.getByText("Role").closest("li") as HTMLElement
     await userEvent.click(
-      within(nameRow).getByRole("button", { name: "Unlock column: Name" })
+      within(lockedRoleRow).getByRole("button", { name: "Unlock column: Role" })
     )
     expect(
-      screen.getByRole("button", { name: "Lock column: Name" })
-    ).toHaveFocus()
-    const unlockedEmailRow = screen
-      .getByText("Email")
-      .closest("li") as HTMLElement
+      screen.getByRole("button", { name: "Lock column: Role" })
+    ).not.toHaveFocus()
+
+    expect(onLockedColumnIdsChange).toHaveBeenNthCalledWith(1, ["name", "role"])
+    expect(onLockedColumnIdsChange).toHaveBeenNthCalledWith(2, ["name"])
+
     await userEvent.click(
-      within(unlockedEmailRow).getByRole("button", {
-        name: "Lock column: Email",
-      })
+      screen.getByRole("button", { name: "Lock column: Role" })
     )
     expect(
-      screen.getByRole("button", { name: "Unlock column: Email" })
+      screen.getByRole("button", { name: "Unlock column: Role" })
+    ).not.toHaveFocus()
+
+    const pointerLockedRole = screen.getByRole("button", {
+      name: "Unlock column: Role",
+    })
+    pointerLockedRole.focus()
+    await userEvent.keyboard("{Enter}")
+    expect(
+      screen.getByRole("button", { name: "Lock column: Role" })
     ).toHaveFocus()
 
-    expect(onLockedColumnChange).toHaveBeenNthCalledWith(1, null)
-    expect(onLockedColumnChange).toHaveBeenNthCalledWith(2, "email")
+    expect(onLockedColumnIdsChange).toHaveBeenNthCalledWith(3, ["name", "role"])
+    expect(onLockedColumnIdsChange).toHaveBeenNthCalledWith(4, ["name"])
+    expect(
+      screen
+        .getAllByRole("listitem")
+        .map((row) => row.textContent?.match(/Name|Email|Role/)?.[0])
+    ).toEqual(["Name", "Email", "Role"])
     const updatedNameRow = screen.getByText("Name").closest("li") as HTMLElement
-    const updatedEmailRow = screen
-      .getByText("Email")
-      .closest("li") as HTMLElement
-    expect(within(updatedNameRow).getByRole("switch")).not.toBeDisabled()
-    expect(within(updatedEmailRow).getByRole("switch")).toBeDisabled()
+    const updatedRoleRow = screen.getByText("Role").closest("li") as HTMLElement
+    expect(within(updatedNameRow).getByRole("switch")).toBeDisabled()
+    expect(within(updatedRoleRow).getByRole("switch")).not.toBeDisabled()
     expect(
-      within(updatedEmailRow).queryByRole("button", { name: "Remove column" })
+      within(updatedNameRow).queryByRole("button", { name: "Remove column" })
     ).not.toBeInTheDocument()
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -224,21 +224,21 @@ export type TableVisualizationOptions<
   onRemoveColumn?: (columnId: ColId) => void
 
   /**
-   * The user-managed required column in the column-settings popover. A locked
-   * column stays visible and cannot be reordered or removed. This does not pin
-   * the column while scrolling; use `frozenColumns` for that behavior.
+   * The user-managed frozen columns in the column-settings popover. Locked
+   * columns move into a sticky group on the left, stay visible, and cannot be
+   * reordered or removed. Their array order controls their order in that group.
    *
-   * Set `frozenColumns` to `0` when the user should be able to transfer the
-   * only lock between columns. Frozen columns remain permanently locked.
+   * Unlocking a column returns it to its saved position. Columns covered by
+   * `frozenColumns` remain permanently locked before this managed group.
    */
-  lockedColumnId?: ColId | null
+  lockedColumnIds?: readonly ColId[]
 
   /**
-   * Called when the user locks a column or unlocks the current one. Passing
-   * this callback enables the lock controls in the column-settings popover.
-   * The new value is a column id, or `null` when no column is locked.
+   * Called with the complete set of user-managed locked column ids whenever a
+   * user locks or unlocks a column. Passing this callback enables the lock
+   * controls in the column-settings popover.
    */
-  onLockedColumnChange?: (columnId: ColId | null) => void
+  onLockedColumnIdsChange?: (columnIds: ColId[]) => void
 
   /** Maps a row to a visual variant: `"striped"`, `"striked"`, or `"none"`. */
   referenceRowType?: (item: R) => ReferenceType

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -227,6 +227,8 @@ export type TableVisualizationOptions<
    * The user-managed frozen columns in the column-settings popover. Locked
    * columns move into a sticky group on the left, stay visible, and cannot be
    * reordered or removed. Their array order controls their order in that group.
+   * One visible managed column always remains unlocked as the table's
+   * scrollable region; an all-locked input is normalized accordingly.
    *
    * Unlocking a column returns it to its saved position. Columns covered by
    * `frozenColumns` remain permanently locked before this managed group.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -223,6 +223,23 @@ export type TableVisualizationOptions<
    */
   onRemoveColumn?: (columnId: ColId) => void
 
+  /**
+   * The user-managed required column in the column-settings popover. A locked
+   * column stays visible and cannot be reordered or removed. This does not pin
+   * the column while scrolling; use `frozenColumns` for that behavior.
+   *
+   * Set `frozenColumns` to `0` when the user should be able to transfer the
+   * only lock between columns. Frozen columns remain permanently locked.
+   */
+  lockedColumnId?: ColId | null
+
+  /**
+   * Called when the user locks a column or unlocks the current one. Passing
+   * this callback enables the lock controls in the column-settings popover.
+   * The new value is a column id, or `null` when no column is locked.
+   */
+  onLockedColumnChange?: (columnId: ColId | null) => void
+
   /** Maps a row to a visual variant: `"striped"`, `"striked"`, or `"none"`. */
   referenceRowType?: (item: R) => ReferenceType
 


### PR DESCRIPTION
## Description

Semantic-layer tables need an Excel-like way to keep whichever columns matter visible while scrolling, rather than relying only on the legacy implicit first column. This change adds an opt-in, settings-popover-only API for freezing and unfreezing multiple columns.

The scope is deliberately limited to Table settings: there are no new controls in column headers, so existing header information and sorting affordances are unchanged.

## Type of change

- [x] Variant or improvement of existing pattern

## Behavior

- Users can freeze multiple columns independently from the Table settings popover while one visible managed column remains unlocked as the scrollable region.
- If a controlled `lockedColumnIds` value requests every managed column, the table normalizes the final ordered column back to visible and unlocked.
- The final visible unlocked column cannot be hidden or locked. Bulk Hide all preserves it.
- Freezing a column moves it into the sticky group on the left, after any permanent `frozenColumns`, in `lockedColumnIds` order.
- Unfreezing restores the column to its saved logical position.
- Frozen columns stay visible and cannot be hidden, reordered, or removed.
- Locked columns remain visible and keep stable sticky offsets when their header group collapses; collapse also retains a scrollable column.
- Locked rows use the closed-lock icon. Unlocked rows reveal a named closed-lock action on hover or keyboard focus.
- Pointer activation does not leave the replacement row action focused or visually stuck. Keyboard activation keeps focus on the corresponding replacement control.

## Compatibility and ownership

- Adds `lockedColumnIds?: readonly ColId[]` and `onLockedColumnIdsChange?: (columnIds: ColId[]) => void`.
- The feature is opt-in. Omitting both props preserves the existing first-column behavior and UI.
- Passing only `lockedColumnIds` creates read-only managed locks without exposing controls.
- Passing the callback enables the lock/unlock controls and leaves state ownership with the host.
- Existing `frozenColumns` remain permanently frozen before the managed group and cannot be unlocked.
- Reordering unlocked rows preserves locked rows in the saved order, so later unfreezing restores the correct position.

## Storybook and visual review

https://github.com/user-attachments/assets/7b67cb2f-7470-40e1-b168-67218fb08270

With horizontal scroll

https://github.com/user-attachments/assets/500a3e45-4b1a-4a4a-8b23-cee8469f0698

The behavior is documented and executable in Storybook:

- `Patterns / Data Collection / Visualizations / Table` → `With Lockable Columns`
  - Renders 15 columns in a 720 px viewport, producing a 2,600 px-wide table.
  - Opens Table settings and unlocks/relocks the first column by keyboard.
  - Freezes Role beside Name and verifies both sticky headers and body cells.
  - Scrolls to the exact 1,880 px maximum offset and proves the far-right Status column is visible without being covered by the frozen group.
  - Verifies the restored saved position after unfreezing.
  - Covers pointer focus cleanup and keyboard focus handoff.
  - Leaves the final multi-lock, far-right scroll state and an unlocked row's actions visible for visual review.
- `Patterns / Data Collection / Visualizations / Table` → `With Lockable Columns And Collapsed Group`
  - Starts with Email and Role locked inside a collapsed Employment details group.
  - Verifies that locked headers stay sticky at stable, non-overlapping offsets while Department collapses.
  - Expands and collapses by keyboard, retaining focus, `aria-expanded`, sticky offsets, and visible column order.
  - Leaves the group collapsed with Name as the scrollable boundary for visual review.
- `Patterns / Data Collection / Internal / SortAndHideList` → `With Lockable Items`
- `Patterns / Data Collection / Internal / SortAndHideList` → `Snapshot`

The public and internal MDX pages explain the API, opt-in boundary, remaining-scrollable-column invariant, saved-position behavior, collapse interaction, pointer behavior, keyboard path, and horizontal freeze behavior. Chromatic will attach the hosted preview to this PR.

Suggested PR evidence:

1. Settings open after locking all but one managed column, showing that the final visible unlocked row has no Lock action and its visibility switch is disabled.
2. The 15-column table scrolled fully right, with Name and Role still sticky on the left and Status visible.
3. The collapsed Employment details story showing Email and Role sticky, Department hidden, and Name still scrollable.
4. Optional short recording: freeze Role, scroll sideways, unfreeze it, and show it returning to its original position without the row actions staying focused.

## Verification

- Focused Vitest after the feedback fix: 4 files, 99 tests passed.
- Repository pre-push changed-test gate: 5 files, 112 tests passed.
- React TypeScript: passed.
- Full React format and focused lint: passed with 0 warnings/errors.
- Pre-commit cycle-dependency, format, lint, and file-size checks: passed.
- Production Storybook build: passed.
- Original public lock/scroll story interaction run in Chrome: PASS, 50 assertions.
- New collapse/lock story in Chrome: PASS; Email and Role remained sticky at `0px` and `240px`, Department collapsed, Name remained scrollable, keyboard focus stayed on the toggle, and the console was clean.
- Settings interaction in Chrome: PASS; after locking every other managed column, the final Lock action was unavailable and the remaining visibility switch was disabled.
- Horizontal-scroll geometry: 2,600 px table / 720 px viewport / 1,880 px exact maximum offset.
- Storybook accessibility panel: 0 violations, 20 passes, 2 inconclusive.
- Independent correctness, compatibility, accessibility, documentation, Storybook, and coverage reviews: no blocking findings.

Design review: pending for the new stable Table-settings affordance.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0
> - factorial-f0-component-documentation
> - factorial-pr
