### PR TITLE
fix(F0DurationInput): announce status and required state, meet the stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -26,7 +26,6 @@
     "Graph/F0GraphNode",
     "Heading",
     "Image",
-    "Inputs/Duration input",
     "Inputs/Number input",
     "Inputs/Search input",
     "Inputs/Text area input",

--- a/packages/react/src/components/F0DurationInput/F0DurationInput.tsx
+++ b/packages/react/src/components/F0DurationInput/F0DurationInput.tsx
@@ -315,7 +315,7 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
     const showLabel = !hideLabel && label.length > 0
 
     // Wire the status message to the field so it is announced, not just seen.
-    // Only reference the container when it actually renders — a dangling
+    // Only reference the container when it actually renders. A dangling
     // aria-describedby is worse than none.
     const messageId = `${baseId}-message`
     const hasStatusMessage = inputStatusMessages(status).length > 0

--- a/packages/react/src/components/F0DurationInput/F0DurationInput.tsx
+++ b/packages/react/src/components/F0DurationInput/F0DurationInput.tsx
@@ -13,7 +13,10 @@ import {
 import { F0Icon } from "@/components/F0Icon"
 import { Bullet } from "@/icons/app"
 import { cn } from "@/lib/utils"
-import { InputMessages } from "@/components/F0InputField/components/InputMessages"
+import {
+  InputMessages,
+  inputStatusMessages,
+} from "@/components/F0InputField/components/InputMessages"
 import { Label } from "@/components/F0InputField/components/Label"
 
 import type {
@@ -311,6 +314,20 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
     const statusType = status?.type ?? "default"
     const showLabel = !hideLabel && label.length > 0
 
+    // Wire the status message to the field so it is announced, not just seen.
+    // Only reference the container when it actually renders — a dangling
+    // aria-describedby is worse than none.
+    const messageId = `${baseId}-message`
+    const hasStatusMessage = inputStatusMessages(status).length > 0
+    const resolvedDescribedBy =
+      [ariaDescribedBy, hasStatusMessage ? messageId : undefined]
+        .filter(Boolean)
+        .join(" ") || undefined
+    // An explicit prop always wins: F0Form drives this itself, passing
+    // `{ type: "error" }` with no message and describing the field its own way.
+    const resolvedAriaInvalid =
+      ariaInvalid ?? (statusType === "error" || undefined)
+
     return (
       <div
         ref={ref}
@@ -344,8 +361,8 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
           onClick={handleContainerClick}
           role="group"
           aria-label={resolvedAriaLabel}
-          aria-describedby={ariaDescribedBy}
-          aria-invalid={ariaInvalid}
+          aria-describedby={resolvedDescribedBy}
+          aria-invalid={resolvedAriaInvalid}
           aria-disabled={disabled || undefined}
           data-status={statusType}
           data-disabled={disabled ? "" : undefined}
@@ -392,8 +409,9 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
                   aria-label={
                     fieldConfig?.[unit]?.ariaLabel ?? UNIT_LABELS[unit]
                   }
-                  aria-describedby={ariaDescribedBy}
-                  aria-invalid={ariaInvalid}
+                  aria-describedby={resolvedDescribedBy}
+                  aria-invalid={resolvedAriaInvalid}
+                  aria-required={required || undefined}
                   value={displayValue}
                   placeholder="0"
                   onChange={handleFieldChange(unit, max)}
@@ -409,7 +427,7 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
             )
           })}
         </div>
-        <InputMessages status={status} />
+        <InputMessages status={status} id={messageId} />
       </div>
     )
   }

--- a/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.mdx
+++ b/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.mdx
@@ -182,13 +182,12 @@ A11y wiring is not visually demonstrable, so it is listed rather than shown:
 - The container is a `role="group"` with an `aria-label` derived from `label`, or from `ariaLabel` when that is set. The group is what carries the field's accessible name, which is why `hideLabel` can drop the visible `<label>` without leaving the field unnamed.
 - Every segment carries its own `aria-label` (`Days` / `Hours` / `Minutes` / `Seconds`), overridable per unit via `fields[unit].ariaLabel`, so a screen reader announces which part of the duration has focus. Those defaults are hardcoded English and are not read from `I18nProvider`, so in a localized app set `fields[unit].ariaLabel` alongside any custom `suffix`. Leaving it unset announces the segment in the wrong language, and a custom `suffix` without a matching label also breaks Label in Name (SC 2.5.3).
 - Segments are `inputMode="numeric"`, which brings up the numeric keypad on touch devices.
-- `aria-invalid` is set on the group and on every segment; `aria-disabled` on the group only (segments carry the native `disabled` attribute); `aria-readonly` on the segments only. `aria-describedby` reaches both, so an external error message is announced from any segment.
+- `aria-invalid` is set on the group and on every segment; `aria-disabled` on the group only (segments carry the native `disabled` attribute); `aria-readonly` on the segments only. `aria-describedby` reaches both, so a message is announced from any segment.
+- A `status` message is wired to the field automatically: the message container gets an id that both the group and every segment reference through `aria-describedby`, and `status={{ type: "error" }}` sets `aria-invalid` on its own. An `aria-describedby` you pass is composed with it rather than replaced, and an `aria-invalid` you pass wins outright, so a form library keeps full control.
+- `required` sets `aria-required` on every segment, so the requirement survives `hideLabel` (the asterisk beside the label is `aria-hidden`).
 - A `console.warn` fires in development when neither `label` nor `ariaLabel` is provided.
 
-Two gaps to know about, both needing a component change rather than a prop:
-
-- **The built-in `status` message is not announced.** It renders as visible text with no `id`, no `role="alert"` and no `aria-live`, and `status={{ type: "error" }}` does not set `aria-invalid` on its own. A screen-reader user gets the border colour and nothing else. Pass your own `aria-describedby` (pointing at your message element) and `aria-invalid` when the error has to be announced.
-- **`required` is visual-only.** It renders the marker beside the label but sets neither `required` nor `aria-required` on the segments, so with `hideLabel` the requirement is both invisible and unannounced.
+One gap remains: the status message is **described**, not **live**. It carries no `role="alert"` or `aria-live`, so a message that appears after the field is already focused is not announced until focus moves. Wrap it yourself if you need that.
 
 ### Keyboard interaction
 

--- a/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.mdx
+++ b/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.mdx
@@ -1,5 +1,7 @@
 import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
 
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
 import * as Stories from "./F0DurationInput.stories"
 
 <Meta of={Stories} />
@@ -10,15 +12,13 @@ import * as Stories from "./F0DurationInput.stories"
 
 It shares chrome conventions (label, status, sizes, disabled, readonly) with [F0InputField](?path=/docs/components-primitives-f0inputfield--documentation), but is not a wrapper of it — it ships its own container so the segments can share a single focus ring.
 
----
-
 ## Overview
 
 ### Anatomy
 
 <Canvas of={Stories.Default} />
 
-- **Label**: text describing the input's purpose. Always rendered into the DOM (use `hideLabel` to keep it screen-reader only).
+- **Label**: text describing the input's purpose. `hideLabel` removes it from the DOM entirely; the accessible name then comes from the container's `aria-label`, so the field stays named either way.
 - **Segments**: one `<input>` per visible unit, with an inline suffix (`d`, `h`, `min`, `s` by default).
 - **Bullet separator**: rendered between segments.
 - **Message**: optional `status` message (`error` / `warning` / `info`) below the field.
@@ -84,31 +84,49 @@ Pass `units` to control which segments are rendered. The order is always
 
 Defaults to `["hours", "minutes"]` when `units` is omitted or empty.
 
----
-
 ## Guidelines
 
 ### Design best practices
 
-#### When to use
+**When to use**
 
 - The user must enter a length of time (timer, break duration, leave balance, SLA, contract length).
 - The duration is naturally expressed in mixed units (`1h 30min`, `2d 4h`).
 - You need a tighter, segmented surface instead of a free-text input.
 
-#### When NOT to use
+**When not to use**
 
 - The value is a **point in time** (date, time of day, datetime). Use a date or time picker instead.
 - The value is a **single dimension-less number** (count, percentage). Use [F0NumberInput](?path=/docs/components-inputs-number-input--documentation).
 - You need to express ranges (`from / to`). Compose two date pickers or a range picker.
 
----
+**Do's and don'ts**
+
+<DoDonts
+  do={{
+    description:
+      "Render a segment for every unit whose precision you intend to keep, and let blur do the normalising.",
+    guidelines: [
+      'units={["hours", "minutes"]} for a working-day duration',
+      'units={["days", "hours"]} for a leave balance',
+      "Accept 75 typed into minutes; blur turns it into 1h 15min",
+      "Use fields[unit].max only when a segment must not roll over",
+    ],
+  }}
+  dont={{
+    description:
+      "Don't pass a value carrying precision finer than the segments you render. The remainder is dropped from the display, and nothing tells you.",
+    guidelines: [
+      'units={["hours", "minutes"]} with value={5430} shows 1h 30min while your state still holds 5430',
+      "Don't omit the seconds segment when seconds carry meaning",
+      "Don't reach for it to enter a point in time, or a range",
+    ],
+  }}
+/>
 
 ## Behavior
 
 What `F0DurationInput` guarantees when used as a controlled input.
-
-A11y wiring is not visually demonstrable. It includes: `role="group"` on the container with `aria-label` derived from `label` or `ariaLabel`, per-segment `aria-label` (overridable via `fields[unit].ariaLabel`), `inputMode="numeric"`, `aria-disabled`, `aria-readonly`, and `aria-invalid` propagation. A `console.warn` fires in development when neither `label` nor `ariaLabel` is provided.
 
 ### Value model
 
@@ -157,7 +175,94 @@ Pass `status={{ type, message }}` to colour the border and render a message belo
 
 <Canvas of={Stories.CustomSuffixes} />
 
----
+## Accessibility
+
+A11y wiring is not visually demonstrable, so it is listed rather than shown:
+
+- The container is a `role="group"` with an `aria-label` derived from `label`, or from `ariaLabel` when that is set. The group is what carries the field's accessible name, which is why `hideLabel` can drop the visible `<label>` without leaving the field unnamed.
+- Every segment carries its own `aria-label` (`Days` / `Hours` / `Minutes` / `Seconds`), overridable per unit via `fields[unit].ariaLabel`, so a screen reader announces which part of the duration has focus. Those defaults are hardcoded English and are not read from `I18nProvider`, so in a localized app set `fields[unit].ariaLabel` alongside any custom `suffix`. Leaving it unset announces the segment in the wrong language, and a custom `suffix` without a matching label also breaks Label in Name (SC 2.5.3).
+- Segments are `inputMode="numeric"`, which brings up the numeric keypad on touch devices.
+- `aria-invalid` is set on the group and on every segment; `aria-disabled` on the group only (segments carry the native `disabled` attribute); `aria-readonly` on the segments only. `aria-describedby` reaches both, so an external error message is announced from any segment.
+- A `console.warn` fires in development when neither `label` nor `ariaLabel` is provided.
+
+Two gaps to know about, both needing a component change rather than a prop:
+
+- **The built-in `status` message is not announced.** It renders as visible text with no `id`, no `role="alert"` and no `aria-live`, and `status={{ type: "error" }}` does not set `aria-invalid` on its own. A screen-reader user gets the border colour and nothing else. Pass your own `aria-describedby` (pointing at your message element) and `aria-invalid` when the error has to be announced.
+- **`required` is visual-only.** It renders the marker beside the label but sets neither `required` nor `aria-required` on the segments, so with `hideLabel` the requirement is both invisible and unannounced.
+
+### Keyboard interaction
+
+<Unstyled>
+  <table>
+    <thead>
+      <tr>
+        <th>Key</th>
+        <th>Result</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>
+        </td>
+        <td>
+          Moves to the next segment in{" "}
+          <code>days → hours → minutes → seconds</code> order. Leaving a segment
+          is what commits the rollover.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Shift</kbd> + <kbd>Tab</kbd>
+        </td>
+        <td>Moves to the previous segment.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>0</kbd>–<kbd>9</kbd>
+        </td>
+        <td>
+          Types into the focused segment. An over-range value stays visible
+          until blur.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>-</kbd>
+        </td>
+        <td>
+          Only with <code>allowNegative</code>, only at the start of the first
+          segment, and only once. Applies to the whole duration.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>↑</kbd> <kbd>↓</kbd>
+        </td>
+        <td>Nothing. Segments do not step; type the value.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>←</kbd> <kbd>→</kbd> <kbd>Home</kbd> <kbd>End</kbd>
+        </td>
+        <td>Native caret movement inside the focused segment.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Cmd</kbd>/<kbd>Ctrl</kbd> combos
+        </td>
+        <td>
+          Pass through, so select-all, copy and paste work. Non-digits in a
+          pasted value are stripped.
+        </td>
+      </tr>
+      <tr>
+        <td>Any other printable key</td>
+        <td>Blocked on keydown; never reaches the value.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
 
 ## Props
 
@@ -387,7 +492,11 @@ Pass `status={{ type, message }}` to colour the border and render a message belo
         <td>
           <code>boolean</code>
         </td>
-        <td>Hides the visible label; still rendered for screen readers.</td>
+        <td>
+          Removes the visible label from the DOM. The accessible name falls back
+          to the container's <code>aria-label</code>, derived from{" "}
+          <code>label</code> or <code>ariaLabel</code>.
+        </td>
       </tr>
       <tr>
         <td>

--- a/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.stories.tsx
+++ b/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { useEffect, useState } from "react"
 
+import { expect, fn, userEvent, within } from "storybook/test"
+
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0DurationInput } from ".."
@@ -13,6 +15,7 @@ const meta = {
   title: "Inputs/Duration input",
   parameters: {
     layout: "centered",
+    a11y: { test: "error" },
     docs: {
       description: {
         component:
@@ -40,6 +43,59 @@ export default meta
 type Story = StoryObj<typeof F0DurationInput>
 
 export const Default: Story = {
+  // 5400 is declared rather than left to the render fallback, because the play
+  // function asserts against it.
+  args: { value: 5400, onChange: fn() },
+  // Covers the guarantees a duration input lives or dies on: one tab stop per
+  // segment, raw values staying visible while typing and only normalising on
+  // blur, and the segments never accepting anything but digits.
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const hours = canvas.getByLabelText("Hours")
+    const minutes = canvas.getByLabelText("Minutes")
+
+    await step("Starts at 1h 30min (5400s)", async () => {
+      await expect(hours).toHaveValue("1")
+      await expect(minutes).toHaveValue("30")
+    })
+
+    await step(
+      "Gives each segment its own tab stop, in render order",
+      async () => {
+        hours.focus()
+        await userEvent.tab()
+        await expect(minutes).toHaveFocus()
+      }
+    )
+
+    await step("Keeps an over-range value raw while editing", async () => {
+      await userEvent.clear(minutes)
+      await userEvent.type(minutes, "75")
+      // 75 is deliberately not clamped to 59: rollover happens on blur, not
+      // per keystroke, so the user still sees what they typed.
+      await expect(minutes).toHaveValue("75")
+      await expect(args.onChange).toHaveBeenLastCalledWith(8100)
+      // One emit per edit (clear, "7", "5") and not one per render.
+      await expect(args.onChange).toHaveBeenCalledTimes(3)
+    })
+
+    await step("Normalises the visible units on blur", async () => {
+      await userEvent.tab()
+      await expect(hours).toHaveValue("2")
+      await expect(minutes).toHaveValue("15")
+      // Blur reshuffles the segments without emitting: 8100s either way.
+      await expect(args.onChange).toHaveBeenCalledTimes(3)
+    })
+
+    await step("Rejects non-digit keystrokes", async () => {
+      await userEvent.type(hours, "a")
+      await expect(hours).toHaveValue("2")
+      // The value alone proves nothing here — handleFieldChange strips
+      // non-digits, so an unfiltered "a" would still settle back to "2". The
+      // call count is what shows onKeyDown stopped the event at the source.
+      await expect(args.onChange).toHaveBeenCalledTimes(3)
+    })
+  },
   render: (args) => {
     const { label: labelArg, onChange: onChangeArg, ...restArgs } = args
     const [value, setValue] = useState(args.value ?? 5400)
@@ -222,6 +278,33 @@ export const AllowNegative: Story = {
       },
     },
   },
+  // The minus rule is selection-dependent (only at caret 0 of the first
+  // segment, only when no sign is present), which jsdom can only fake — the
+  // unit tests drive it with synthetic keyDown events. This drives real
+  // keystrokes and reads the emitted seconds back off the story's own readout.
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const hours = canvas.getByLabelText("Hours")
+
+    await step("Starts at minus 1h 15min (-4500s)", async () => {
+      await expect(hours).toHaveValue("-1")
+      await expect(canvas.getByText("Value: -4500 seconds")).toBeVisible()
+    })
+
+    await step("Drops the sign when the first segment is emptied", async () => {
+      await userEvent.clear(hours)
+      await expect(canvas.getByText("Value: 900 seconds")).toBeVisible()
+    })
+
+    await step(
+      "Takes a minus typed at the head of the first segment",
+      async () => {
+        await userEvent.type(hours, "-1")
+        await expect(hours).toHaveValue("-1")
+        await expect(canvas.getByText("Value: -4500 seconds")).toBeVisible()
+      }
+    )
+  },
   render: () => {
     const [value, setValue] = useState(-4500)
     return (
@@ -301,6 +384,12 @@ export const Snapshot: Story = {
           disabled
           units={["hours", "minutes", "seconds"]}
           status={{ type: "error", message: "This field has an error" }}
+        />
+        <F0DurationInput
+          label="Readonly"
+          value={5400}
+          onChange={() => {}}
+          readonly
         />
         <F0DurationInput
           label="Required"

--- a/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.stories.tsx
+++ b/packages/react/src/components/F0DurationInput/__stories__/F0DurationInput.stories.tsx
@@ -90,7 +90,7 @@ export const Default: Story = {
     await step("Rejects non-digit keystrokes", async () => {
       await userEvent.type(hours, "a")
       await expect(hours).toHaveValue("2")
-      // The value alone proves nothing here — handleFieldChange strips
+      // The value alone proves nothing here. handleFieldChange strips
       // non-digits, so an unfiltered "a" would still settle back to "2". The
       // call count is what shows onKeyDown stopped the event at the source.
       await expect(args.onChange).toHaveBeenCalledTimes(3)
@@ -279,7 +279,7 @@ export const AllowNegative: Story = {
     },
   },
   // The minus rule is selection-dependent (only at caret 0 of the first
-  // segment, only when no sign is present), which jsdom can only fake — the
+  // segment, only when no sign is present), which jsdom can only fake. The
   // unit tests drive it with synthetic keyDown events. This drives real
   // keystrokes and reads the emitted seconds back off the story's own readout.
   play: async ({ canvasElement, step }) => {

--- a/packages/react/src/components/F0DurationInput/__tests__/F0DurationInput.test.tsx
+++ b/packages/react/src/components/F0DurationInput/__tests__/F0DurationInput.test.tsx
@@ -5,6 +5,7 @@ import { fireEvent } from "@testing-library/react"
 import { useState } from "react"
 
 import { F0DurationInput } from ".."
+import type { DurationUnit } from "../types"
 import {
   fieldsToSeconds,
   secondsToFields,
@@ -862,6 +863,40 @@ describe("F0DurationInput", () => {
       )
 
       expect(screen.getByLabelText("Minutes")).toHaveValue("120")
+    })
+
+    it("re-syncs the segments when the parent pushes a new value", () => {
+      const Wrapper = ({ value }: { value: number }) => (
+        <F0DurationInput label="Duration" value={value} onChange={() => {}} />
+      )
+
+      const { rerender } = render(<Wrapper value={5400} />)
+      expect(screen.getByLabelText("Hours")).toHaveValue("1")
+      expect(screen.getByLabelText("Minutes")).toHaveValue("30")
+
+      rerender(<Wrapper value={9000} />)
+
+      expect(screen.getByLabelText("Hours")).toHaveValue("2")
+      expect(screen.getByLabelText("Minutes")).toHaveValue("30")
+    })
+
+    it("re-decomposes the same value when units change at runtime", () => {
+      const Wrapper = ({ units }: { units: DurationUnit[] }) => (
+        <F0DurationInput
+          label="Duration"
+          value={5400}
+          onChange={() => {}}
+          units={units}
+        />
+      )
+
+      const { rerender } = render(<Wrapper units={["hours", "minutes"]} />)
+      expect(screen.getByLabelText("Hours")).toHaveValue("1")
+
+      rerender(<Wrapper units={["minutes"]} />)
+
+      expect(screen.queryByLabelText("Hours")).not.toBeInTheDocument()
+      expect(screen.getByLabelText("Minutes")).toHaveValue("90")
     })
 
     it("does not preserve hidden unit remainder on change", () => {

--- a/packages/react/src/components/F0DurationInput/__tests__/F0DurationInput.test.tsx
+++ b/packages/react/src/components/F0DurationInput/__tests__/F0DurationInput.test.tsx
@@ -484,6 +484,145 @@ describe("F0DurationInput", () => {
       expect(screen.getByText("Max 8h per day")).toBeInTheDocument()
     })
 
+    it("marks the segments as required for assistive tech", () => {
+      render(
+        <F0DurationInput
+          label="Minimum hours"
+          value={0}
+          onChange={() => {}}
+          required
+        />
+      )
+
+      // The asterisk beside the label is aria-hidden, so without this the
+      // required state is visual-only (and invisible too under hideLabel).
+      expect(screen.getByLabelText("Hours")).toHaveAttribute(
+        "aria-required",
+        "true"
+      )
+      expect(screen.getByLabelText("Minutes")).toHaveAttribute(
+        "aria-required",
+        "true"
+      )
+    })
+
+    it("omits aria-required when not required", () => {
+      render(<F0DurationInput label="Duration" value={0} onChange={() => {}} />)
+
+      expect(screen.getByLabelText("Hours")).not.toHaveAttribute(
+        "aria-required"
+      )
+    })
+
+    it("announces the status message via aria-describedby", () => {
+      render(
+        <F0DurationInput
+          label="Duration"
+          value={0}
+          onChange={() => {}}
+          status={{ type: "error", message: "Duration is required" }}
+        />
+      )
+
+      const hours = screen.getByLabelText("Hours")
+      const describedBy = hours.getAttribute("aria-describedby")
+      expect(describedBy).toBeTruthy()
+
+      // The reference must resolve to the element holding the message.
+      const message = document.getElementById(describedBy as string)
+      expect(message).toHaveTextContent("Duration is required")
+      expect(screen.getByRole("group")).toHaveAttribute(
+        "aria-describedby",
+        describedBy
+      )
+    })
+
+    it("derives aria-invalid from an error status", () => {
+      render(
+        <F0DurationInput
+          label="Duration"
+          value={0}
+          onChange={() => {}}
+          status={{ type: "error", message: "Duration is required" }}
+        />
+      )
+
+      expect(screen.getByRole("group")).toHaveAttribute("aria-invalid", "true")
+      expect(screen.getByLabelText("Hours")).toHaveAttribute(
+        "aria-invalid",
+        "true"
+      )
+    })
+
+    it("does not mark a warning or info status as invalid", () => {
+      render(
+        <F0DurationInput
+          label="Duration"
+          value={3600}
+          onChange={() => {}}
+          status={{ type: "warning", message: "Over standard hours" }}
+        />
+      )
+
+      expect(screen.getByLabelText("Hours")).not.toHaveAttribute("aria-invalid")
+    })
+
+    it("lets an explicit aria-invalid win over the status", () => {
+      render(
+        <F0DurationInput
+          label="Duration"
+          value={0}
+          onChange={() => {}}
+          aria-invalid={false}
+          status={{ type: "error", message: "Duration is required" }}
+        />
+      )
+
+      expect(screen.getByLabelText("Hours")).toHaveAttribute(
+        "aria-invalid",
+        "false"
+      )
+    })
+
+    it("composes a consumer aria-describedby with the status message", () => {
+      render(
+        <F0DurationInput
+          label="Duration"
+          value={0}
+          onChange={() => {}}
+          aria-describedby="external-hint"
+          status={{ type: "error", message: "Duration is required" }}
+        />
+      )
+
+      const describedBy = screen
+        .getByLabelText("Hours")
+        .getAttribute("aria-describedby")
+      expect(describedBy).toContain("external-hint")
+      expect(describedBy?.split(" ")).toHaveLength(2)
+    })
+
+    it("does not reference a message element that never renders", () => {
+      // A status with no message renders nothing, which is how F0Form drives
+      // the error state. Pointing at the absent container would itself fail.
+      render(
+        <F0DurationInput
+          label="Duration"
+          value={0}
+          onChange={() => {}}
+          status={{ type: "error" }}
+        />
+      )
+
+      expect(screen.getByLabelText("Hours")).not.toHaveAttribute(
+        "aria-describedby"
+      )
+      expect(screen.getByLabelText("Hours")).toHaveAttribute(
+        "aria-invalid",
+        "true"
+      )
+    })
+
     it("renders required asterisk", () => {
       render(
         <F0DurationInput

--- a/packages/react/src/components/F0InputField/components/InputMessages.tsx
+++ b/packages/react/src/components/F0InputField/components/InputMessages.tsx
@@ -6,6 +6,24 @@ import { InputFieldStatus, InputFieldStatusType } from "../types"
 
 type InputMessagesProps = {
   status?: InputFieldStatus
+  /**
+   * Applied to the message container, so a field can point `aria-describedby`
+   * at it and have the message actually announced.
+   */
+  id?: string
+}
+
+/**
+ * The messages a status will really render, empty entries dropped.
+ *
+ * Exported because a field needs to know whether the container exists before
+ * referencing it: an `aria-describedby` pointing at an element that never
+ * rendered is itself an accessibility failure, not a no-op.
+ */
+export function inputStatusMessages(status?: InputFieldStatus): string[] {
+  if (!status) return []
+  const raw = Array.isArray(status.message) ? status.message : [status.message]
+  return raw.filter((message): message is string => Boolean(message))
 }
 
 const statuses: Record<
@@ -33,18 +51,16 @@ const statuses: Record<
   },
 }
 
-const InputMessages = ({ status }: InputMessagesProps) => {
+const InputMessages = ({ status, id }: InputMessagesProps) => {
   if (!status) return null
 
-  const messages = (
-    Array.isArray(status.message) ? status.message : [status.message]
-  ).filter(Boolean)
+  const messages = inputStatusMessages(status)
 
   const icon = statuses[status.type].icon
 
   return (
     messages.length > 0 && (
-      <div className="flex gap-1">
+      <div className="flex gap-1" id={id}>
         {icon && (
           <F0Icon
             icon={icon}


### PR DESCRIPTION
## Description

`Inputs/Duration input` is tagged `stable` but sat below the Definition of Done bar on three mechanical requirements. It had no play function, its docs were stuck at the `acceptable` tier, and axe was not enforced. Writing the docs that close those gaps surfaced two WCAG A failures, so this fixes them as well. The component rendered its `status` message without ever associating it with the field, and `required` never reached assistive tech at all.

Both halves are here because the docs have to describe the fixed behaviour, not the broken behaviour. The component did not need the fix to clear the bar, so the two are separable if you would rather review them apart. Commit `c4de5ef38` is the stabilization, `79a1e0589` is the a11y fix.

Worth knowing for the other 15 components still in debt. The axe gap needed no component work at all. The local remediation plan predicted `target-size` (WCAG 2.5.8) violations on the ~9x20px segments and sized the gap as L, including a visual redesign and design sign-off. Measuring instead of predicting found zero violations across all 13 stories. `target-size` is an ANY-of rule, `any: [target-size minSize 24, target-offset minOffset 24]`, so either sub-check passing is a pass. The segments fail on size and clear it on offset, because gap-1 plus the suffix span plus gap-1 plus the 12px Bullet plus gap-1 puts adjacent centres roughly 33px apart. An undersized target with enough space around it is compliant.

## Implementation details

- fix: associate the `status` message with the field so a screen reader announces it

  <details>
  <summary>What was broken</summary>

  `InputMessages` rendered the message with no `id`, and `aria-describedby` on the group and the segments only ever carried the consumer's prop. Nothing derived `aria-invalid` from `status.type` either. So `status={{ type: "error", message: "Duration is required" }}`, exactly what the `WithError` story and the Status messages docs recommend, produced a red border and text that a screen-reader user tabbing the segments never heard, with no invalid state at all. That is WCAG 3.3.1 Error Identification and 1.3.1 Info and Relationships. axe misses it because the association is absent rather than broken.

  The message container now takes an id that both the group and every segment reference. A consumer `aria-describedby` composes with it rather than replacing it, and a consumer `aria-invalid` still wins outright, so `F0Form` keeps full control of the fields it owns. A status carrying no message, which is how `DurationFieldRenderer` drives the error state, adds no reference at all. Pointing `aria-describedby` at an element that never rendered would be its own failure.
  </details>

- fix: set `aria-required` on the segments so `required` is not visual-only

  <details>
  <summary>What was broken</summary>

  The asterisk beside the label is `aria-hidden`, and neither `required` nor `aria-required` reached the segments. Assistive tech never saw the required state, and `hideLabel` removed it visually too. WCAG 3.3.2 Labels or Instructions.
  </details>

- chore: give `InputMessages` an optional `id` and export `inputStatusMessages`

  <details>
  <summary>Why this touches a shared primitive</summary>

  Both changes are additive. The other seven consumers are untouched and their suites pass unchanged. Exporting the helper rather than duplicating it keeps the field and the message from drifting on whether a container renders at all, which is the condition that decides whether referencing it is safe.

  The same gap runs across the whole input family. None of the eight `InputMessages` consumers wires the message to `aria-describedby`. Fixing them all is follow-up work, not this PR.
  </details>

- test: add a play function to `Default` covering what jsdom cannot reach, namely one tab stop per segment in render order, values staying raw while typing, and rollover committing on blur

  <details>
  <summary>Why it asserts call counts</summary>

  The obvious way to assert the digits-only filter is to type a letter and check that the value did not change. That assertion is vacuous. `handleFieldChange` strips non-digits with `raw.replace(/\D/g, "")`, so an unfiltered keystroke settles back to the same displayed value and the step passes whether or not `handleKeyDown` calls `preventDefault`. The spy call count is the only thing that separates the two. I negative-controlled both play functions, and each one goes red when its expectation is wrong.
  </details>

- test: add a play function to `AllowNegative` driving the sign rule with real keystrokes

  <details>
  <summary>Why a second one</summary>

  The minus rule depends on caret position. `handleKeyDown` accepts `-` only at `selectionStart === 0` of the first segment, and only when no sign is present yet. The existing jsdom tests drive it with synthetic `keyDown` events, where selection state is faked, so they can never prove that a real `-` keystroke lands in the value. This one asserts through the readout the story already renders, so the story itself is unchanged.
  </details>

- chore: enforce axe with `a11y: { test: "error" }` on the story meta, verified with the real test-runner over all 13 stories with the play functions included
- docs: take the MDX from the `acceptable` tier to `gold` with a Do's and don'ts block, and add a real `## Accessibility` section with a keyboard table
- fix: correct two false claims about `hideLabel`. It removes the label from the DOM entirely rather than keeping it screen-reader only, and the accessible name survives through the group's `aria-label`
- docs: note that the segment `aria-label`s are hardcoded English and bypass `I18nProvider`, which makes `fields[unit].ariaLabel` mandatory in a localized app rather than optional
- test: cover the controlled contract that had no test anywhere, a parent pushing a new `value` and `units` changing at runtime
- test: add `readonly` to the `Snapshot` story, the one state with its own compound styling and no visual-regression coverage
- chore: remove the `stable-dod-debt.json` entry, which the check requires once a component clears the bar

## Known gap left open

The status message is described, not live. It carries no `role="alert"` or `aria-live`, so a message that appears while the field already has focus waits for focus to move before anything announces it. Adding live semantics is a decision for the whole input family, and it risks double-announcing against `F0Form`'s own error handling, so the MDX documents it and this PR leaves it alone.

## Verification

- `check:stable-dod` reports `✓ Inputs/Duration input`, the check holds, and docs score `gold`
- `test-storybook` filtered to F0DurationInput passes 13 of 13, with two `play-test`s and axe in `error` mode on every story. Re-run after the a11y fix
- Unit tests number 94 for this component. Eight are new, and all eight fail if the a11y wiring is reverted. The full suite passes 6465. The 6 failures in `F0DataChart/BarChart.test.tsx` are pre-existing and reproduce identically on a clean `main` checkout
- `tsc --noEmit` is clean. `oxlint src` reports only 3 pre-existing errors in `withDataTestId.test.tsx`, baseline-verified. `oxfmt --check` is clean

Chromatic will show one diff, where the `Snapshot` story gains a `Readonly` instance. Nothing else changes visually.
