### PR TITLE
fix(F0Graph): repair the accessible tree and meet stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -19,7 +19,6 @@
     "DatePicker",
     "EmptyState",
     "Filters/FilterPicker",
-    "Graph/F0Graph",
     "Graph/F0GraphControls",
     "Graph/F0GraphEdge",
     "Graph/F0GraphNode",

--- a/packages/react/src/patterns/F0Graph/F0Graph.tsx
+++ b/packages/react/src/patterns/F0Graph/F0Graph.tsx
@@ -363,6 +363,15 @@ export interface F0GraphNodeRenderContext {
   setSize: number
   posInSet: number
   nodeId: string
+  /**
+   * @deprecated Always `undefined`. F0Graph used to nest the accessible tree by
+   * having each expanded node `aria-owns` its children, but React Flow culls
+   * painted nodes independently, so a node whose parent was culled ended up with
+   * no owner at all (axe `aria-required-parent`, critical). The `role="tree"`
+   * element now owns every painted treeitem directly and `aria-level` carries
+   * the depth. Drop it from custom `renderNode` implementations; the field will
+   * be removed in the next major.
+   */
   ariaOwns?: string
   /**
    * `true` when this node is one row of its parent's stacked column (the parent

--- a/packages/react/src/patterns/F0Graph/__stories__/F0Graph.mdx
+++ b/packages/react/src/patterns/F0Graph/__stories__/F0Graph.mdx
@@ -202,6 +202,12 @@ decoupled from focus. Search and node detail are owned by the consumer
 (e.g. OneDataCollection's search and an `F0Dialog` opened from the node
 click), not by F0Graph.
 
+Pass `expandedNodes` and `selectedNodes` alongside `onExpandedNodesChange`
+and `onSelectedNodesChange` to drive both from your own state, for example to
+restore a view from the URL or sync it with a side panel.
+
+<Canvas of={F0GraphStories.Controlled} />
+
 ---
 
 ## Guidelines
@@ -228,6 +234,19 @@ click), not by F0Graph.
     ],
   }}
 />
+
+### When not to use
+
+Reach for something else when the structure is not the point:
+
+- **A flat or two-level hierarchy.** A grouped list or `OneDataCollection`
+  with a group-by carries the same information without the pan-and-zoom cost.
+- **Comparing attributes across many items.** A graph shows one node at a
+  time in detail; a table shows fifty side by side. Use `OneDataCollection`.
+- **Relationships that are not a tree.** Cycles and many-to-many edges have
+  no layout here. F0Graph assumes every node has at most one parent.
+- **A tree the user only ever reads once.** If nobody expands, collapses or
+  selects, render the hierarchy as static text or a nested list.
 
 ### Content best practices
 
@@ -263,6 +282,20 @@ color = team).
 
 - The canvas is keyboard-navigable: arrow keys move focus between nodes,
   `Enter` selects the focused node, `Space` toggles expansion
+- Arrow keys reach nodes that are currently off-screen. The camera flies to
+  the target first and focus lands on it once it mounts, so a windowed-out
+  node is still reachable from the keyboard
+- One node at a time is in the tab order (roving `tabindex`), so the graph
+  costs a single Tab stop no matter how large the tree is
+- The tree structure is exposed through `aria-owns` rather than DOM nesting.
+  React Flow renders every node as a flat, absolutely positioned sibling behind
+  its own `role="application"` wrapper, so nesting carries no tree relationship.
+  A `role="tree"` element beside the canvas owns every painted node, and depth
+  comes from `aria-level` / `aria-setsize` / `aria-posinset`
+- `<F0GraphNode>` wires `role="treeitem"`, `aria-level`, `aria-setsize`,
+  `aria-posinset`, `aria-expanded` and `aria-selected` from the render context.
+  If you write your own `renderNode`, spread the whole context onto your root
+  element, and give it the `ctx.nodeId`-derived `id` so the tree can own it
 - Override the default English control labels via `controlLabels` for
   localized experiences
 

--- a/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { useCallback, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 import "@xyflow/react/dist/style.css"
 import { F0Button } from "@/components/F0Button"
 import { Laptop, Money, People, Star } from "@/icons/app"
@@ -15,10 +16,85 @@ import {
 } from "../F0Graph"
 import { F0GraphNode, type F0GraphNodeTag } from "../components/F0GraphNode"
 
+/**
+ * Waits for a story to stop moving before axe scans it.
+ *
+ * F0Graph fades cards in and cross-fades between zoom variants, and the
+ * test-runner scans after two animation frames, around 33ms. axe then composites
+ * part-faded text against whatever is behind it and reports contrast failures
+ * that do not exist in the settled story: a `StackedNodesWithTags` tag label
+ * measures 2.3:1 mid-fade and about 16:1 when it lands, and four `InitialFocus`
+ * node titles fail the same way.
+ *
+ * This has to be a convergence check rather than a single sample. Traced on
+ * `InitialFocus`, the story moves in two waves: nodes mount at ~320ms and go
+ * quiet, then the mount-time camera fly lands at ~900ms and cross-fades a second
+ * time, ending at ~1115ms. A gate that exits on the first quiet frame passes
+ * during the lull and axe scans the second wave. So quiet has to hold.
+ *
+ * The three signals are what actually moves. The rendered node count changes as
+ * windowing follows the camera; `getAnimations` covers CSS transitions; and a
+ * fractional opacity catches a cross-fade driven from React state rather than by
+ * a transition, which is what the zoom layers do. No element in any of these
+ * stories sits at a fractional opacity once settled, so the check converges
+ * rather than waiting out the cap.
+ */
+async function settleGraph(canvasElement: HTMLElement): Promise<void> {
+  const QUIET_MS = 400
+  const CAP_MS = 8000
+  const STEP_MS = 50
+
+  const reading = () => {
+    const nodes = canvasElement.querySelectorAll(".react-flow__node")
+    const fading = Array.from(canvasElement.querySelectorAll("*")).some(
+      (el) => {
+        const opacity = Number(getComputedStyle(el).opacity)
+        return opacity > 0 && opacity < 1
+      }
+    )
+    return {
+      count: nodes.length,
+      moving: nodes.length === 0 || fading,
+      animations: canvasElement.getAnimations({ subtree: true }).length,
+    }
+  }
+
+  const deadline = Date.now() + CAP_MS
+  let quietSince: number | null = null
+  let previousCount = -1
+
+  while (Date.now() < deadline) {
+    const now = reading()
+    const quiet =
+      !now.moving && now.animations === 0 && now.count === previousCount
+    previousCount = now.count
+
+    if (!quiet) {
+      quietSince = null
+    } else {
+      quietSince ??= Date.now()
+      if (Date.now() - quietSince >= QUIET_MS) return
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, STEP_MS))
+  }
+
+  throw new Error(
+    `settleGraph: story still moving after ${CAP_MS}ms (${JSON.stringify(reading())})`
+  )
+}
+
 const meta = {
   title: "Graph/F0Graph",
   component: F0Graph<Employee>,
   tags: ["stable", "!autodocs"],
+  parameters: {
+    a11y: { test: "error" },
+  },
+  // Every story fades its nodes in, and axe has to scan the settled result.
+  play: async ({ canvasElement }) => {
+    await settleGraph(canvasElement)
+  },
   decorators: [
     (Story) => (
       <div className="h-[600px] w-full bg-f1-background">
@@ -228,6 +304,71 @@ export const Tree: Story = {
     nodes: BASIC_NODES,
     renderNode: renderEmployee,
     defaultExpandDepth: 2,
+  },
+  // The primary flow: read the hierarchy, close a branch and reopen it from the
+  // keyboard, then select a person. The first block doubles as the regression
+  // guard for the accessible tree, which is the part of this component most
+  // easily broken without anyone noticing.
+  play: async ({ canvasElement }) => {
+    await settleGraph(canvasElement)
+
+    const canvas = within(canvasElement)
+    const tree = canvas.getByRole("tree", { name: "Graph view" })
+    const ownedIds = (el: Element): string[] =>
+      (el.getAttribute("aria-owns") ?? "").split(" ").filter(Boolean)
+
+    // React Flow mounts its nodes after the first commit, so the ownership map
+    // settles a frame or two later than the tree container itself.
+    await waitFor(() =>
+      expect(canvas.getAllByRole("treeitem")).toHaveLength(BASIC_NODES.length)
+    )
+
+    // Every painted treeitem is owned by the tree, exactly once, and carries its
+    // depth. React Flow lays every node out as a flat, absolutely positioned
+    // sibling behind its hardcoded `role="application"` wrapper, so DOM nesting
+    // carries no tree relationship and `aria-owns` is the only thing holding the
+    // structure together. A treeitem the tree does not own has no tree parent at
+    // all, which axe reports as `aria-required-parent`.
+    const items = canvas.getAllByRole("treeitem")
+    const owned = ownedIds(tree)
+    for (const item of items) {
+      await expect(owned.filter((id) => id === item.id)).toHaveLength(1)
+      await expect(item).toHaveAttribute("aria-level")
+    }
+    // And nothing is owned that is not in the DOM — a dangling reference is
+    // `aria-valid-attr-value`.
+    for (const id of owned) {
+      await expect(
+        canvasElement.ownerDocument.getElementById(id)
+      ).not.toBeNull()
+    }
+
+    // Collapse the focused branch and reopen it. Asserts `aria-expanded` on the
+    // node rather than whether a given child is on screen: the camera culls
+    // off-screen nodes, and which ones survive is not stable enough to assert.
+    const focused = canvasElement.querySelector<HTMLElement>(
+      '[role="treeitem"][tabindex="0"]'
+    )
+    if (!focused) throw new Error("no treeitem holds the roving tabindex")
+    focused.focus()
+    await expect(focused).toHaveAttribute("aria-expanded", "true")
+
+    await userEvent.keyboard("{ArrowLeft}")
+    await waitFor(() =>
+      expect(focused).toHaveAttribute("aria-expanded", "false")
+    )
+    await userEvent.keyboard("{ArrowRight}")
+    await waitFor(() =>
+      expect(focused).toHaveAttribute("aria-expanded", "true")
+    )
+
+    // Selecting a person, last, because the click flies the camera.
+    await userEvent.click(canvas.getByRole("treeitem", { name: /Sofia Reyes/ }))
+    await waitFor(() =>
+      expect(
+        canvas.getByRole("treeitem", { name: /Sofia Reyes/ })
+      ).toHaveAttribute("aria-selected", "true")
+    )
   },
 }
 
@@ -1276,6 +1417,36 @@ function makeDeferredPayload(count: number): DeferredNodesPayload<Employee> {
 }
 
 /** Demonstrates progressive payload loading with deferred batch merge. */
+/**
+ * Builds the deferred payload on mount instead of at module load.
+ *
+ * `deferredNodes: new Promise(...)` inside `args` runs when this CSF module is
+ * imported, so its timer fires while some other story is on screen. Two things
+ * went wrong because of that: the `StagedLoadingError` rejection arrived as an
+ * unhandled rejection attributed to whichever story happened to be running (it
+ * failed `LargeTree` in the Storybook test run), and by the time a reader opened
+ * either story the promise had usually already settled, so there was nothing to
+ * watch.
+ */
+function StagedLoadingDemo({
+  fail = false,
+  ...props
+}: { fail?: boolean } & Omit<F0GraphProps<Employee>, "deferredNodes">) {
+  const deferredNodes = useMemo(
+    () =>
+      new Promise<DeferredNodesPayload<Employee>>((resolve, reject) => {
+        if (fail) {
+          setTimeout(() => reject(new Error("Simulated network failure")), 1000)
+          return
+        }
+        setTimeout(() => resolve(makeDeferredPayload(500)), 2500)
+      }),
+    [fail]
+  )
+
+  return <F0Graph<Employee> {...props} deferredNodes={deferredNodes} />
+}
+
 export const StagedLoading: Story = {
   parameters: {
     docs: {
@@ -1287,9 +1458,6 @@ export const StagedLoading: Story = {
   },
   args: {
     nodes: INITIAL_STAGED_NODES,
-    deferredNodes: new Promise<DeferredNodesPayload<Employee>>((resolve) => {
-      setTimeout(() => resolve(makeDeferredPayload(500)), 2500)
-    }),
     renderNode: renderEmployee,
     showControls: true,
     defaultExpandDepth: 2,
@@ -1298,6 +1466,7 @@ export const StagedLoading: Story = {
       console.log("[StagedLoading] Deferred nodes merged")
     },
   },
+  render: (args) => <StagedLoadingDemo {...args} />,
 }
 
 /** Demonstrates error handling when the deferred payload rejects. */
@@ -1312,9 +1481,6 @@ export const StagedLoadingError: Story = {
   },
   args: {
     nodes: INITIAL_STAGED_NODES,
-    deferredNodes: new Promise<DeferredNodesPayload<Employee>>((_, reject) => {
-      setTimeout(() => reject(new Error("Simulated network failure")), 1000)
-    }),
     renderNode: renderEmployee,
     showControls: true,
     defaultExpandDepth: 2,
@@ -1323,6 +1489,7 @@ export const StagedLoadingError: Story = {
       console.error("[StagedLoadingError] Deferred load failed:", error.message)
     },
   },
+  render: (args) => <StagedLoadingDemo fail {...args} />,
 }
 
 // ─── Stacked nodes ──────────────────────────────────────────

--- a/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
@@ -362,6 +362,20 @@ export const Tree: Story = {
       expect(focused).toHaveAttribute("aria-expanded", "true")
     )
 
+    // The graph is one Tab stop, not one per node. React Flow marks its own node
+    // wrappers and edges focusable, which doubles every node and adds a stop per
+    // edge announced as "Edge from 1 to 2"; `nodesFocusable` / `edgesFocusable`
+    // turn that off so the roving tabindex is the only thing in the tab order.
+    // axe has no rule for this, so only an assertion catches a regression.
+    const tabbable = canvasElement.querySelectorAll(
+      '[tabindex="0"], button:not([tabindex]), a[href]'
+    )
+    await expect(tabbable).toHaveLength(2)
+    await expect(canvas.getByLabelText("Graph canvas")).toHaveAttribute(
+      "tabindex",
+      "0"
+    )
+
     // Selecting a person, last, because the click flies the camera.
     await userEvent.click(canvas.getByRole("treeitem", { name: /Sofia Reyes/ }))
     await waitFor(() =>

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.a11y.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.a11y.test.tsx
@@ -6,6 +6,8 @@ import type { GraphNode } from "../../types"
 
 import { F0Graph, type F0GraphNodeRenderContext } from "../F0Graph"
 
+import { graphContainer } from "./helpers"
+
 // ─── Helpers ───────────────────────────────────────────────────
 
 function makeNodes(): GraphNode<string>[] {
@@ -150,7 +152,7 @@ describe("F0Graph a11y — arrow-key navigation", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     expect(tree).toBeTruthy()
   })
 
@@ -187,7 +189,14 @@ describe("F0Graph a11y — arrow-key navigation", () => {
 // ─── Task 3 — aria-owns ───────────────────────────────────────
 
 describe("F0Graph a11y — aria-owns", () => {
-  it("passes ariaOwns for expanded nodes with visible children", () => {
+  it("no longer hands renderNode an ariaOwns to nest the tree with", () => {
+    // The graph used to nest ownership: each expanded node `aria-owns`-ed its
+    // own visible children. React Flow culls painted nodes on a schedule F0 does
+    // not see, so a node whose parent got culled ended up with no owner at all
+    // (axe `aria-required-parent`, critical, measured on InitialFocus and
+    // StagedLoading). Ownership is flat now — the `role="tree"` element owns
+    // every painted treeitem and `aria-level` carries the depth — so the field
+    // is deprecated and always undefined.
     const capturedOwns = new Map<string, string | undefined>()
 
     const spyRenderNode = (
@@ -208,47 +217,30 @@ describe("F0Graph a11y — aria-owns", () => {
       </div>
     )
 
-    if (capturedOwns.size > 0) {
-      // Node 1 (CEO) is expanded with children 2 and 3 visible
-      const ceoOwns = capturedOwns.get("1")
-      expect(ceoOwns).toContain("f0-graph-node-2")
-      expect(ceoOwns).toContain("f0-graph-node-3")
-
-      // Node 2 (CTO) is expanded with children 4 and 5 visible
-      const ctoOwns = capturedOwns.get("2")
-      expect(ctoOwns).toContain("f0-graph-node-4")
-      expect(ctoOwns).toContain("f0-graph-node-5")
-
-      // Node 3 (CFO) has no children — no ariaOwns
-      expect(capturedOwns.get("3")).toBeUndefined()
+    for (const owns of capturedOwns.values()) {
+      expect(owns).toBeUndefined()
     }
   })
 
-  it("does not pass ariaOwns for collapsed nodes", () => {
-    const capturedOwns = new Map<string, string | undefined>()
-
-    const spyRenderNode = (
-      node: GraphNode<string>,
-      ctx: F0GraphNodeRenderContext
-    ) => {
-      capturedOwns.set(node.id, ctx.ariaOwns)
-      return <span>{node.data}</span>
-    }
-
+  it("owns the treeitems from the tree element, not from their parents", () => {
+    // React Flow renders no nodes under jsdom, so the end-to-end invariant is
+    // asserted in the browser by the `Tree` story's play function. What is
+    // checkable here is that the tree element is the one carrying `aria-owns`,
+    // and that it is not an ancestor of React Flow's `role="application"`
+    // wrapper — the placement axe rejects.
     zeroRender(
       <div style={{ width: 800, height: 600 }}>
         <F0Graph
           nodes={makeNodes()}
-          renderNode={spyRenderNode}
+          renderNode={renderNodeFn}
           defaultExpandedNodes={new Set(["1"])}
         />
       </div>
     )
 
-    if (capturedOwns.size > 0) {
-      // Node 2 (CTO) is collapsed — no ariaOwns even though it has children
-      expect(capturedOwns.get("2")).toBeUndefined()
-    }
+    const tree = screen.getByRole("tree", { name: "Graph view" })
+    expect(tree.querySelector(".react-flow")).toBeNull()
+    expect(tree.contains(graphContainer())).toBe(false)
   })
 })
 

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.clickCenter.test.tsx
@@ -9,11 +9,13 @@ import {
   vi,
 } from "vitest"
 
-import { screen, zeroRender } from "@/testing/test-utils"
+import { zeroRender } from "@/testing/test-utils"
 
 import type { GraphNode } from "../types"
 import { FOCUS_SETTLE_DELAY_MS } from "../constants"
 import { F0Graph } from "../F0Graph"
+
+import { graphContainer } from "./helpers"
 
 // Spy React Flow instance so we can observe the fly-to on click. Only the public
 // `useReactFlow` is mocked; the ReactFlow component itself renders normally.
@@ -61,7 +63,7 @@ afterEach(() => vi.restoreAllMocks())
 // exactly as it does with a real node). This exercises the click → select + fly
 // wiring without depending on React Flow's DOM output.
 function pressNode(id: string) {
-  const tree = screen.getByRole("tree", { name: "Graph view" })
+  const tree = graphContainer()
   const nodeEl = document.createElement("div")
   nodeEl.className = "react-flow__node"
   nodeEl.setAttribute("data-id", id)

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.imperative.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.imperative.test.tsx
@@ -12,6 +12,8 @@ import {
   type F0GraphNodeRenderContext,
 } from "../F0Graph"
 
+import { graphContainer } from "./helpers"
+
 // ─── Helpers ───────────────────────────────────────────────────
 
 function makeNodes(): GraphNode<string>[] {
@@ -86,7 +88,7 @@ describe("F0Graph — imperative handle", () => {
     )
 
     // Select the first focused node via keyboard.
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     dispatchKey(tree, "Enter")
     expect(onSelectedNodesChange.mock.calls.at(-1)?.[0]).toEqual(new Set(["1"]))
 

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.integration.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.integration.test.tsx
@@ -14,6 +14,8 @@ import type {
 
 import { F0Graph, type F0GraphNodeRenderContext } from "../F0Graph"
 
+import { graphContainer } from "./helpers"
+
 // ─── Helpers ───────────────────────────────────────────────────
 
 function makeNodes(): GraphNode<string>[] {
@@ -84,7 +86,7 @@ describe("F0Graph integration — expand/collapse uncontrolled", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Focus starts on node "1" (root, collapsed, has children)
     dispatchKey(tree, "ArrowRight")
 
@@ -106,7 +108,7 @@ describe("F0Graph integration — expand/collapse uncontrolled", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     dispatchKey(tree, "ArrowLeft")
     expect(onExpandToggle).toHaveBeenCalledWith("1", false)
   })
@@ -129,7 +131,7 @@ describe("F0Graph integration — expand/collapse controlled", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Focus on "1" (expanded), ArrowRight moves to first child "2"
     dispatchKey(tree, "ArrowRight")
     // Focus on "2" (collapsed), ArrowRight expands it
@@ -174,7 +176,7 @@ describe("F0Graph integration — selection single mode", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Press Enter to select the focused node (node "1")
     dispatchKey(tree, "Enter")
 
@@ -208,7 +210,7 @@ describe("F0Graph integration — selection single mode", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Select node "1"
     dispatchKey(tree, "Enter")
     // Move to next node
@@ -243,7 +245,7 @@ describe("F0Graph integration — selection multi mode", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Select node "1"
     dispatchKey(tree, "Enter")
     // Move down

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.keyboardCulledFocus.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.keyboardCulledFocus.test.tsx
@@ -1,0 +1,107 @@
+import { act } from "react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import type { GraphNode } from "../types"
+import { F0Graph } from "../F0Graph"
+
+import { graphKeyTarget } from "./helpers"
+
+// Only `useReactFlow` is mocked, so we can observe the camera. The ReactFlow
+// component itself renders normally.
+const mockReactFlow = {
+  fitView: vi.fn(),
+  setCenter: vi.fn(),
+  getZoom: () => 1,
+  getNode: vi.fn(),
+  fitBounds: vi.fn(),
+  zoomIn: vi.fn(),
+  zoomOut: vi.fn(),
+  setViewport: vi.fn(),
+  getViewport: () => ({ x: 0, y: 0, zoom: 1 }),
+}
+vi.mock("@xyflow/react", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@xyflow/react")>()
+  return { ...actual, useReactFlow: () => mockReactFlow }
+})
+
+const NODES: GraphNode<string>[] = [
+  { id: "1", parentId: null, data: "Root", childrenCount: 2 },
+  { id: "2", parentId: "1", data: "Child A", childrenCount: 0 },
+  { id: "3", parentId: "1", data: "Child B", childrenCount: 0 },
+]
+
+// Deliberately does NOT attach `ctx.nodeRef`, so no node ever registers itself.
+// That reproduces the culled case: every keyboard target is absent from the ref
+// map, exactly as it is when React Flow has dropped an off-screen node.
+const renderUnregistered = (node: GraphNode<string>) => (
+  <span data-testid={`node-${node.id}`}>{node.data}</span>
+)
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+
+beforeEach(() => {
+  mockReactFlow.fitView.mockClear()
+})
+
+function dispatchKey(element: HTMLElement, key: string) {
+  act(() => {
+    element.dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true })
+    )
+  })
+}
+
+describe("F0Graph — keyboard focus on a node culling removed", () => {
+  it("still flies to the target when the node is not mounted", () => {
+    // Regression: the fly used to sit inside an `if (mounted)` guard, so a target
+    // that culling had removed was never flown to, and therefore never mounted,
+    // and therefore never focusable. Focus stranded and the roving tabindex
+    // pointed at an element that did not exist.
+    zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderUnregistered}
+          defaultExpandedNodes={new Set(["1"])}
+        />
+      </div>
+    )
+
+    // Ignore the mount-time framing so only the keypress is counted.
+    mockReactFlow.fitView.mockClear()
+    dispatchKey(graphKeyTarget(), "ArrowDown")
+
+    expect(mockReactFlow.fitView).toHaveBeenCalledTimes(1)
+    expect(mockReactFlow.fitView).toHaveBeenLastCalledWith(
+      expect.objectContaining({ nodes: [{ id: "2" }] })
+    )
+  })
+
+  it("strips the pseudo-node prefix before flying to an expander", () => {
+    zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          nodes={NODES}
+          renderNode={renderUnregistered}
+          defaultExpandedNodes={new Set()}
+        />
+      </div>
+    )
+
+    // Root is collapsed, so the DFS order after it is `expander-1`.
+    mockReactFlow.fitView.mockClear()
+    dispatchKey(graphKeyTarget(), "ArrowDown")
+
+    expect(mockReactFlow.fitView).toHaveBeenLastCalledWith(
+      expect.objectContaining({ nodes: [{ id: "1" }] })
+    )
+  })
+})

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.lazyTree.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.lazyTree.test.tsx
@@ -7,6 +7,8 @@ import type { GraphNode } from "../types"
 
 import { F0Graph, type F0GraphNodeRenderContext } from "../F0Graph"
 
+import { graphContainer } from "./helpers"
+
 // ─── Helpers ───────────────────────────────────────────────────
 
 function renderNodeFn(node: GraphNode<string>, ctx: F0GraphNodeRenderContext) {
@@ -77,7 +79,7 @@ describe("F0Graph lazy tree — loadChildren", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Expand root-1 via ArrowRight
     dispatchKey(tree, "ArrowRight")
 
@@ -105,7 +107,7 @@ describe("F0Graph lazy tree — loadChildren", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
 
     // Expand
     dispatchKey(tree, "ArrowRight")
@@ -149,7 +151,7 @@ describe("F0Graph lazy tree — loadChildren", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     dispatchKey(tree, "ArrowRight")
 
     // Resolve the load
@@ -176,7 +178,7 @@ describe("F0Graph lazy tree — loadChildren", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     dispatchKey(tree, "ArrowRight")
 
     // Wait for the rejected promise to settle

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.stackedHoverReveal.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.stackedHoverReveal.test.tsx
@@ -1,10 +1,12 @@
 import { beforeAll, describe, expect, it, vi } from "vitest"
 
-import { fireEvent, screen, zeroRender } from "@/testing/test-utils"
+import { fireEvent, zeroRender } from "@/testing/test-utils"
 
 import type { GraphNode } from "../types"
 
 import { F0Graph, type F0GraphNodeRenderContext } from "../F0Graph"
+
+import { graphContainer } from "./helpers"
 
 /**
  * A stacked column's collapse affordance is revealed by its own narrow CSS hover
@@ -61,7 +63,7 @@ const revealFlags = (): string[] =>
     (el) => el.getAttribute("data-revealed") ?? ""
   )
 
-const tree = (): HTMLElement => screen.getByRole("tree")
+const tree = (): HTMLElement => graphContainer()
 
 describe("revealing a stacked parent's collapse button from inside its column", () => {
   beforeAll(() => {

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.test.tsx
@@ -7,6 +7,8 @@ import type { GraphNode, ZoomLevel } from "../../types"
 
 import { F0Graph, type F0GraphNodeRenderContext } from "../F0Graph"
 
+import { graphContainer } from "./helpers"
+
 // React Flow requires DOM dimensions to render nodes.
 // For unit tests we verify mount, callbacks, and structure.
 
@@ -174,7 +176,7 @@ describe("F0Graph", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     expect(tree).toBeTruthy()
   })
 
@@ -367,7 +369,7 @@ describe("F0Graph keyboard navigation", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Focus starts on node "1" (only visible root, collapsed, has children)
     dispatchKey(tree, "ArrowRight")
     expect(onExpandToggle).toHaveBeenCalledWith("1", true)
@@ -387,7 +389,7 @@ describe("F0Graph keyboard navigation", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Focus starts on node "1" (expanded root)
     dispatchKey(tree, "ArrowLeft")
     expect(onExpandToggle).toHaveBeenCalledWith("1", false)
@@ -407,7 +409,7 @@ describe("F0Graph keyboard navigation", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Focus on node "1" (expanded). ArrowRight moves focus to first child "2".
     dispatchKey(tree, "ArrowRight")
     // Now focused on node "2" (collapsed, has children). ArrowRight expands it.
@@ -429,7 +431,7 @@ describe("F0Graph keyboard navigation", () => {
       </div>
     )
 
-    const tree = screen.getByRole("tree", { name: "Graph view" })
+    const tree = graphContainer()
     // Focus on node "1" (expanded). ArrowRight → first child "2".
     dispatchKey(tree, "ArrowRight")
     // Focus on "2" (collapsed). ArrowLeft → move to parent "1".

--- a/packages/react/src/patterns/F0Graph/__tests__/helpers.ts
+++ b/packages/react/src/patterns/F0Graph/__tests__/helpers.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared helpers for the F0Graph test suite.
+ */
+
+/**
+ * The element carrying F0Graph's own pointer and key handlers: the direct parent
+ * of React Flow's wrapper.
+ *
+ * `role="tree"` no longer sits on this element. React Flow hardcodes
+ * `role="application"` on its wrapper, which axe rejects as a child of a tree
+ * (`aria-required-children`), so the tree is now an empty element beside the
+ * canvas that owns the rendered items through `aria-owns` (see
+ * `useAccessibleTreeOwns`). Events dispatched on that element would never reach
+ * the handlers, because it is a sibling of the canvas rather than its parent.
+ *
+ * In a real browser a keystroke lands on the treeitem holding the roving
+ * tabindex and bubbles up to this container, so dispatching here is the faithful
+ * stand-in. Use `graphKeyTarget()` when the focused treeitem itself matters.
+ */
+export function graphContainer(): HTMLElement {
+  const container = document.querySelector(".react-flow")?.parentElement
+  if (container instanceof HTMLElement) return container
+
+  throw new Error("graphContainer: no graph container in the document")
+}
+
+/**
+ * The element a graph keystroke actually originates from in a browser: the
+ * treeitem holding the roving tabindex when one is rendered, otherwise the
+ * container itself. Either way the event bubbles to the key handler.
+ */
+export function graphKeyTarget(): HTMLElement {
+  const focused = document.querySelector<HTMLElement>(
+    '[role="treeitem"][tabindex="0"]'
+  )
+  if (focused) return focused
+  return graphContainer()
+}

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -928,6 +928,16 @@ export function F0GraphView<T = unknown>(
                         // imperatively (see `didInitialFitRef` above), so a later
                         // layout change can never re-fire React Flow's queued fit.
                         nodesDraggable={false}
+                        // React Flow puts `tabindex="0"` on every node wrapper
+                        // and every edge of its own accord. That doubles each
+                        // node's tab stop and adds one per edge, announced as
+                        // "Edge from 1 to 2", which defeats the roving tabindex
+                        // the graph implements: the Tree story had 9 tab stops
+                        // where the design calls for 2, the canvas and the one
+                        // focused treeitem. axe cannot see this, so enforcing it
+                        // did not surface it.
+                        nodesFocusable={false}
+                        edgesFocusable={false}
                         nodesConnectable={false}
                         elementsSelectable={false}
                         nodeClickDistance={4}

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -57,6 +57,7 @@ import {
   F0GraphZoomContext,
   useF0GraphRenderConfigInternal,
 } from "../../contexts"
+import { useAccessibleTreeOwns } from "../../hooks/useAccessibleTreeOwns"
 import { useDeferredMerge } from "../../hooks/useDeferredMerge"
 import { useExpandState } from "../../hooks/useExpandState"
 import { useGraphKeyboard } from "../../hooks/useGraphKeyboard"
@@ -304,6 +305,7 @@ export function F0GraphView<T = unknown>(
   // ── Refs for the canvas / pointer tracking ──
   const canvasRef = useRef<HTMLDivElement>(null)
   const containerRef = useRef<HTMLDivElement>(null)
+  const treeRef = useRef<HTMLDivElement>(null)
   // Distinguishes a click on a node from a pan drag ending over one.
   const pointerDownRef = useRef<{ x: number; y: number; id: number } | null>(
     null
@@ -392,7 +394,7 @@ export function F0GraphView<T = unknown>(
     setFocusedNodeId,
     focusedNodeIdRef,
     registerNodeRef,
-    nodeRefsMapRef,
+    requestNodeFocus,
     flatVisibleOrderRef,
     selectNode,
     clearSelection,
@@ -433,7 +435,6 @@ export function F0GraphView<T = unknown>(
     reservedTagHeight,
     renderedNodeCount,
     renderedNodeIds,
-    treeRootNodeIds,
     contentBounds,
     getNodePosition,
     stackHoverZones,
@@ -557,7 +558,7 @@ export function F0GraphView<T = unknown>(
     setFocusedNodeId,
     flatVisibleOrderRef,
     expandedNodesRef,
-    nodeRefsMapRef,
+    requestNodeFocus,
   })
 
   // Notify parent of visible node count changes
@@ -813,23 +814,12 @@ export function F0GraphView<T = unknown>(
     [focusedNodeId, setFocusedNodeId, registerNodeRef]
   )
 
-  // React Flow wraps its content in a hardcoded `role="application"` div, which
-  // sits between this `role="tree"` container and the `role="treeitem"` nodes
-  // and severs the ARIA tree relationship. Reconnect it with `aria-owns`: the
-  // tree owns the rendered forest-root treeitems (`treeRootNodeIds`), and each
-  // in-window parent node re-owns its own children (see `visibleChildIds`), so
-  // every rendered treeitem has exactly one owner. While the tree renders no
-  // treeitems (deferred / staged / viewport data loading, or an empty graph),
-  // `aria-busy` keeps the empty tree valid instead of failing
-  // `aria-required-children`.
-  const treeIsEmpty = treeRootNodeIds.length === 0
-  const treeAriaOwns = useMemo(
-    () =>
-      treeRootNodeIds.length > 0
-        ? treeRootNodeIds.map((id) => `f0-graph-node-${id}`).join(" ")
-        : undefined,
-    [treeRootNodeIds]
-  )
+  // The `role="tree"` element is a sibling of the canvas, not an ancestor, and
+  // claims the treeitems by reference. `aria-owns` and `aria-busy` are written
+  // imperatively from the DOM because React Flow culls painted nodes on its own
+  // schedule; see `useAccessibleTreeOwns` for the measured reason why neither
+  // the placement nor the DOM read is optional.
+  useAccessibleTreeOwns(treeRef, containerRef)
 
   return (
     <F0GraphActionsContext.Provider value={actionsContextValue}>
@@ -850,11 +840,13 @@ export function F0GraphView<T = unknown>(
                     className="f0-graph relative h-full w-full outline-none"
                   >
                     <div
-                      ref={containerRef}
+                      ref={treeRef}
                       role="tree"
                       aria-label={controlLabels?.graphView ?? i18n.graph.view}
-                      aria-owns={treeAriaOwns}
-                      aria-busy={treeIsEmpty || undefined}
+                      className="pointer-events-none absolute h-0 w-0 overflow-hidden"
+                    />
+                    <div
+                      ref={containerRef}
                       onKeyDown={handleTreeKeyDown}
                       onPointerMove={handleCanvasPointerMove}
                       onPointerLeave={handleCanvasPointerLeave}

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useAccessibleTreeOwns.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useAccessibleTreeOwns.test.ts
@@ -1,0 +1,139 @@
+import { renderHook } from "@testing-library/react"
+import { act } from "react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { useAccessibleTreeOwns } from "../useAccessibleTreeOwns"
+
+let tree: HTMLDivElement
+let container: HTMLDivElement
+
+/** Lets the MutationObserver callback run. */
+async function settle(): Promise<void> {
+  // MutationObserver callbacks are delivered as microtasks, and the hook writes
+  // straight out of the callback rather than deferring to a frame, so a single
+  // microtask turn is enough.
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
+function addTreeitem(id: string): HTMLElement {
+  const el = document.createElement("div")
+  el.id = id
+  el.setAttribute("role", "treeitem")
+  container.appendChild(el)
+  return el
+}
+
+function render() {
+  return renderHook(() =>
+    useAccessibleTreeOwns({ current: tree }, { current: container })
+  )
+}
+
+const owned = (): string[] =>
+  (tree.getAttribute("aria-owns") ?? "").split(" ").filter(Boolean)
+
+beforeEach(() => {
+  tree = document.createElement("div")
+  tree.setAttribute("role", "tree")
+  container = document.createElement("div")
+  document.body.append(tree, container)
+})
+
+afterEach(() => {
+  tree.remove()
+  container.remove()
+})
+
+describe("useAccessibleTreeOwns", () => {
+  it("owns every treeitem present on mount, in document order", () => {
+    addTreeitem("f0-graph-node-1")
+    addTreeitem("f0-graph-node-2")
+    render()
+
+    expect(owned()).toEqual(["f0-graph-node-1", "f0-graph-node-2"])
+    expect(tree.getAttribute("aria-busy")).toBeNull()
+  })
+
+  it("marks an empty tree aria-busy instead of leaving it childless", () => {
+    // A `role="tree"` owning nothing fails axe `aria-required-children`. The
+    // graph is genuinely still loading here (deferred, staged, or fetching
+    // viewport data), which is what aria-busy says.
+    render()
+
+    expect(tree.getAttribute("aria-owns")).toBeNull()
+    expect(tree.getAttribute("aria-busy")).toBe("true")
+  })
+
+  it("picks up a treeitem that mounts after the first render", async () => {
+    render()
+    expect(tree.getAttribute("aria-busy")).toBe("true")
+
+    addTreeitem("f0-graph-node-late")
+    await settle()
+
+    expect(owned()).toEqual(["f0-graph-node-late"])
+    expect(tree.getAttribute("aria-busy")).toBeNull()
+  })
+
+  it("drops a culled treeitem so no reference dangles", async () => {
+    // The bug this exists for: React Flow culls painted nodes on its own
+    // schedule, so ids taken from React state outlive the elements. A dangling
+    // `aria-owns` target is axe `aria-valid-attr-value`, critical.
+    const first = addTreeitem("f0-graph-node-1")
+    addTreeitem("f0-graph-node-2")
+    render()
+
+    first.remove()
+    await settle()
+
+    expect(owned()).toEqual(["f0-graph-node-2"])
+    for (const id of owned()) {
+      expect(document.getElementById(id)).not.toBeNull()
+    }
+  })
+
+  it("goes back to aria-busy when the last treeitem is culled", async () => {
+    const only = addTreeitem("f0-graph-node-1")
+    render()
+
+    only.remove()
+    await settle()
+
+    expect(tree.getAttribute("aria-owns")).toBeNull()
+    expect(tree.getAttribute("aria-busy")).toBe("true")
+  })
+
+  it("ignores an element that has no id to reference", () => {
+    const anonymous = document.createElement("div")
+    anonymous.setAttribute("role", "treeitem")
+    container.appendChild(anonymous)
+    addTreeitem("f0-graph-node-1")
+    render()
+
+    expect(owned()).toEqual(["f0-graph-node-1"])
+  })
+
+  it("stops observing on unmount", async () => {
+    const { unmount } = render()
+    addTreeitem("f0-graph-node-1")
+    await settle()
+    expect(owned()).toEqual(["f0-graph-node-1"])
+
+    unmount()
+    addTreeitem("f0-graph-node-2")
+    await settle()
+
+    expect(owned()).toEqual(["f0-graph-node-1"])
+  })
+
+  it("does nothing when either element is missing", () => {
+    renderHook(() =>
+      useAccessibleTreeOwns({ current: null }, { current: container })
+    )
+
+    expect(tree.getAttribute("aria-owns")).toBeNull()
+    expect(tree.getAttribute("aria-busy")).toBeNull()
+  })
+})

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
@@ -131,11 +131,6 @@ const fixedLayout = (
   },
 })
 
-const graphNodeData = (
-  rfNodes: ReturnType<typeof useGraphRenderModel>["rfNodes"],
-  id: string
-) => rfNodes.find((n) => n.id === id)?.data as GraphNodeData | undefined
-
 describe("useGraphRenderModel — node windowing", () => {
   beforeEach(() => {
     mockViewportRect = null
@@ -211,42 +206,6 @@ describe("useGraphRenderModel — node windowing", () => {
     expect(result.current.rfNodes.map((n) => n.id)).not.toContain("far")
   })
 
-  it("keeps aria-owns to an off-window child once its edge pulls it in", () => {
-    const child = treeNode("child", "root", 0, [], 1)
-    const root = treeNode("root", null, 1, [child])
-    mockViewportRect = { minX: -10, minY: -10, maxX: 200, maxY: 200 }
-    const { result } = renderModel({
-      ...baseOptions([root], ["root"]),
-      enableNodeWindowing: true,
-      layoutEngineProp: fixedLayout({
-        root: { x: 0, y: 0 },
-        child: { x: 0, y: 5000 },
-      }),
-    })
-    // The off-window child is materialized to keep the parent's edge, so it is a
-    // valid aria-owns target (not a dangling ref).
-    expect(
-      graphNodeData(result.current.rfNodes, "root")?.visibleChildIds
-    ).toEqual(["child"])
-  })
-
-  it("keeps aria-owns children that remain in the window", () => {
-    const child = treeNode("child", "root", 0, [], 1)
-    const root = treeNode("root", null, 1, [child])
-    mockViewportRect = { minX: -100, minY: -100, maxX: 5200, maxY: 5200 }
-    const { result } = renderModel({
-      ...baseOptions([root], ["root"]),
-      enableNodeWindowing: true,
-      layoutEngineProp: fixedLayout({
-        root: { x: 0, y: 0 },
-        child: { x: 0, y: 100 },
-      }),
-    })
-    expect(
-      graphNodeData(result.current.rfNodes, "root")?.visibleChildIds
-    ).toEqual(["child"])
-  })
-
   it("materializes a windowed node's ancestors so the reporting line stays connected", () => {
     // Deep chain root → mid → leaf. Only `leaf` sits inside the viewport; its
     // ancestors are far above it. Regression: a windowed node whose parent
@@ -277,62 +236,6 @@ describe("useGraphRenderModel — node windowing", () => {
       )
     expect(hasEdge("root", "mid")).toBe(true)
     expect(hasEdge("mid", "leaf")).toBe(true)
-  })
-})
-
-describe("useGraphRenderModel — tree forest roots (aria-owns)", () => {
-  beforeEach(() => {
-    mockViewportRect = null
-  })
-
-  it("returns only the parentless root; nested children are owned by their parent", () => {
-    // root → child → grandchild, all expanded and on-window. The `role="tree"`
-    // container owns just the forest root; child/grandchild are re-owned by their
-    // in-window parent node's own aria-owns (visibleChildIds).
-    const grandchild = treeNode("grandchild", "child", 0, [], 2)
-    const child = treeNode("child", "root", 1, [grandchild], 1)
-    const root = treeNode("root", null, 1, [child])
-    const { result } = renderModel(baseOptions([root], ["root", "child"]))
-
-    expect(result.current.treeRootNodeIds).toEqual(["root"])
-  })
-
-  it("returns every top-level root of a multi-root forest", () => {
-    const a = treeNode("a", null, 0)
-    const b = treeNode("b", null, 0)
-    const c = treeNode("c", null, 0)
-    const { result } = renderModel(baseOptions([a, b, c], []))
-
-    expect([...result.current.treeRootNodeIds].sort()).toEqual(["a", "b", "c"])
-  })
-
-  it("gives every rendered treeitem exactly one owner under windowing", () => {
-    // Only `leaf` is inside the viewport; its ancestors are materialized to keep
-    // the reporting line connected. Each rendered node is a forest root iff its
-    // parent is not itself rendered — so no treeitem is left orphaned and none is
-    // double-owned.
-    const leaf = treeNode("leaf", "mid", 0, [], 2)
-    const mid = treeNode("mid", "root", 1, [leaf], 1)
-    const root = treeNode("root", null, 1, [mid])
-    mockViewportRect = { minX: -10, minY: 4900, maxX: 200, maxY: 5200 }
-    const { result } = renderModel({
-      ...baseOptions([root], ["root", "mid"]),
-      enableNodeWindowing: true,
-      layoutEngineProp: fixedLayout({
-        root: { x: 0, y: 0 },
-        mid: { x: 0, y: 2500 },
-        leaf: { x: 0, y: 5000 },
-      }),
-    })
-
-    const rendered = new Set(result.current.renderedNodeIds)
-    for (const id of result.current.renderedNodeIds) {
-      const parentId = graphNodeData(result.current.rfNodes, id)?.graphNode
-        .parentId
-      const ownedByTree = result.current.treeRootNodeIds.includes(id)
-      expect(ownedByTree).toBe(parentId == null || !rendered.has(parentId))
-    }
-    expect(result.current.treeRootNodeIds).toContain("root")
   })
 })
 

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useSelectionFocus.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useSelectionFocus.test.ts
@@ -1,0 +1,152 @@
+import { renderHook } from "@testing-library/react"
+import { createRef } from "react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import type { TreeNode } from "../../types"
+import { useSelectionFocus } from "../useSelectionFocus"
+
+function treeNode(
+  id: string,
+  parentId: string | null,
+  children: TreeNode<string>[] = []
+): TreeNode<string> {
+  return {
+    id,
+    parentId,
+    data: id,
+    children,
+    depth: parentId === null ? 0 : 1,
+    childrenCount: children.length,
+    childrenLoaded: true,
+  }
+}
+
+const child = treeNode("child", "root")
+const roots = [treeNode("root", null, [child])]
+
+/** A focusable stand-in for a mounted graph node. */
+function nodeEl(id: string, parent: HTMLElement): HTMLElement {
+  const el = document.createElement("div")
+  el.id = id
+  el.setAttribute("role", "treeitem")
+  el.tabIndex = 0
+  parent.appendChild(el)
+  return el
+}
+
+let canvas: HTMLDivElement
+
+function render() {
+  const canvasRef = createRef<HTMLDivElement>() as {
+    current: HTMLDivElement | null
+  }
+  canvasRef.current = canvas
+  return renderHook(() =>
+    useSelectionFocus<string>({
+      roots,
+      expandedNodes: new Set(["root"]),
+      selectionMode: "single",
+      canvasRef,
+    })
+  )
+}
+
+beforeEach(() => {
+  canvas = document.createElement("div")
+  document.body.appendChild(canvas)
+})
+
+afterEach(() => {
+  canvas.remove()
+})
+
+describe("useSelectionFocus — requestNodeFocus", () => {
+  it("focuses a mounted node straight away", () => {
+    const { result } = render()
+    const el = nodeEl("root", canvas)
+    result.current.registerNodeRef("root", el)
+
+    result.current.requestNodeFocus("root")
+
+    expect(document.activeElement).toBe(el)
+  })
+
+  it("focuses a node that is not mounted yet once it registers", () => {
+    // The case that used to strand keyboard focus: React Flow culls off-screen
+    // nodes, so an arrow key can target a node that only exists after the camera
+    // has flown to it.
+    const { result } = render()
+
+    // Mirrors useGraphKeyboard: the focused id is set before the request, so the
+    // staleness guard knows this is still the node the graph wants focused.
+    result.current.focusedNodeIdRef.current = "child"
+    result.current.requestNodeFocus("child")
+
+    const el = nodeEl("child", canvas)
+    result.current.registerNodeRef("child", el)
+
+    expect(document.activeElement).toBe(el)
+  })
+
+  it("honours only the most recent request", () => {
+    const { result } = render()
+
+    result.current.focusedNodeIdRef.current = "root"
+    result.current.requestNodeFocus("root")
+    result.current.focusedNodeIdRef.current = "child"
+    result.current.requestNodeFocus("child")
+
+    const rootEl = nodeEl("root", canvas)
+    result.current.registerNodeRef("root", rootEl)
+    expect(document.activeElement).not.toBe(rootEl)
+
+    const childEl = nodeEl("child", canvas)
+    result.current.registerNodeRef("child", childEl)
+    expect(document.activeElement).toBe(childEl)
+  })
+
+  it("drops a pending request once the focused node has moved on", () => {
+    const { result } = render()
+
+    result.current.focusedNodeIdRef.current = "child"
+    result.current.requestNodeFocus("child")
+    // Something else takes focus before the node arrives.
+    result.current.selectNode("root")
+
+    const el = nodeEl("child", canvas)
+    result.current.registerNodeRef("child", el)
+
+    expect(document.activeElement).not.toBe(el)
+  })
+
+  it("drops a pending request when focus has left the graph", () => {
+    const { result } = render()
+    const outside = document.createElement("button")
+    document.body.appendChild(outside)
+
+    result.current.focusedNodeIdRef.current = "child"
+    result.current.requestNodeFocus("child")
+    outside.focus()
+    expect(document.activeElement).toBe(outside)
+
+    const el = nodeEl("child", canvas)
+    result.current.registerNodeRef("child", el)
+
+    // A node mounting must not yank focus out of a side panel or dialog.
+    expect(document.activeElement).toBe(outside)
+    outside.remove()
+  })
+
+  it("clearSelection discards a pending request", () => {
+    const { result } = render()
+
+    result.current.focusedNodeIdRef.current = "child"
+    result.current.requestNodeFocus("child")
+    result.current.clearSelection()
+
+    const el = nodeEl("child", canvas)
+    result.current.registerNodeRef("child", el)
+
+    expect(document.activeElement).not.toBe(el)
+  })
+})

--- a/packages/react/src/patterns/F0Graph/hooks/useAccessibleTreeOwns.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useAccessibleTreeOwns.ts
@@ -1,0 +1,84 @@
+import { type RefObject, useEffect } from "react"
+
+/**
+ * Keeps the graph's `role="tree"` element owning exactly the treeitems that are
+ * in the DOM right now, and marks it `aria-busy` while there are none.
+ *
+ * Two constraints force this shape.
+ *
+ * **The tree cannot be an ancestor of the canvas.** React Flow hardcodes
+ * `role="application"` on its own wrapper, after the props spread, so it cannot
+ * be overridden. axe reports `aria-required-children` on any `role="tree"`
+ * above it: "Element has children which are not allowed: [role=application]".
+ * Wrapping React Flow in a `role="group"` does not help, axe descends through
+ * it. So the tree is an empty element beside the canvas that claims the items by
+ * reference.
+ *
+ * **The item list has to be read from the DOM, not from React state.** F0 hands
+ * React Flow an array of nodes, then React Flow culls the off-screen ones
+ * (`onlyRenderVisibleElements`) on its own schedule. The two sets differ: on the
+ * `InitialFocus` story the render model counts the root as rendered and owns
+ * `f0-graph-node-root`, while React Flow has painted three nodes deep in the
+ * tree and no root at all. That leaves a dangling `aria-owns` reference
+ * (`aria-valid-attr-value`) and three treeitems with no owner
+ * (`aria-required-parent`), both critical. Mirroring the DOM cannot drift.
+ *
+ * Ownership is flat: the tree owns every painted treeitem and `aria-level` /
+ * `aria-setsize` / `aria-posinset` carry the hierarchy. Nesting the ownership
+ * instead (each parent owning its own children) cannot survive culling, because
+ * a node whose parent was culled has no owner to attach to.
+ *
+ * Document order is React's render order, which is the depth-first order the
+ * render model produces, so the tree reads top to bottom.
+ *
+ * The sync runs straight out of the observer callback rather than being deferred
+ * to the next frame. A frame of lag is a frame in which a node exists and is
+ * unowned, which axe reports as `aria-required-parent` — measured on the
+ * `InitialFocus` story, where the mount-time camera fly mounts and unmounts nodes
+ * in bursts. The browser already batches the callback per mutation record group,
+ * and the observer ignores style and transform changes, so the write frequency is
+ * bounded by node mounts rather than by pan and zoom.
+ */
+export function useAccessibleTreeOwns(
+  treeRef: RefObject<HTMLElement | null>,
+  containerRef: RefObject<HTMLElement | null>
+): void {
+  useEffect(() => {
+    const tree = treeRef.current
+    const container = containerRef.current
+    if (!tree || !container) return
+
+    const sync = (): void => {
+      const ids = Array.from(
+        container.querySelectorAll<HTMLElement>('[role="treeitem"]')
+      )
+        .map((el) => el.id)
+        .filter(Boolean)
+
+      if (ids.length > 0) {
+        tree.setAttribute("aria-owns", ids.join(" "))
+        tree.removeAttribute("aria-busy")
+      } else {
+        // A tree with no treeitems fails `aria-required-children` on its own.
+        // `aria-busy` says the content is still arriving, which is the truth
+        // while the graph is deferred, staged, or loading viewport data.
+        tree.removeAttribute("aria-owns")
+        tree.setAttribute("aria-busy", "true")
+      }
+    }
+
+    sync()
+
+    const observer = new MutationObserver(sync)
+    observer.observe(container, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ["id", "role"],
+    })
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [treeRef, containerRef])
+}

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphKeyboard.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphKeyboard.ts
@@ -19,7 +19,8 @@ interface UseGraphKeyboardOptions<T> {
   setFocusedNodeId: (id: string | null) => void
   flatVisibleOrderRef: MutableRefObject<string[]>
   expandedNodesRef: MutableRefObject<Set<string>>
-  nodeRefsMapRef: MutableRefObject<Map<string, HTMLElement>>
+  /** Focuses a node, deferring until it mounts when culling removed it. */
+  requestNodeFocus: (nodeId: string) => void
 }
 
 export interface UseGraphKeyboardResult {
@@ -41,7 +42,7 @@ export function useGraphKeyboard<T>({
   setFocusedNodeId,
   flatVisibleOrderRef,
   expandedNodesRef,
-  nodeRefsMapRef,
+  requestNodeFocus,
 }: UseGraphKeyboardOptions<T>): UseGraphKeyboardResult {
   const reactFlow = useReactFlow()
 
@@ -170,19 +171,23 @@ export function useGraphKeyboard<T>({
       if (targetId) {
         focusedNodeIdRef.current = targetId
         setFocusedNodeId(targetId)
-        const targetEl = nodeRefsMapRef.current.get(targetId)
-        if (targetEl) {
-          targetEl.focus()
-          // Fly-to focused node respecting reduced motion
-          const rm = window.matchMedia(
-            "(prefers-reduced-motion: reduce)"
-          ).matches
-          reactFlow.fitView({
-            nodes: [{ id: targetId.replace(/^(expander|collapser)-/, "") }],
-            duration: rm ? 0 : 300,
-            padding: FIT_VIEW_PADDING_LOOSE,
-          })
-        }
+
+        // Fly unconditionally. The target may have been culled or windowed out,
+        // and flying is what puts it back in the DOM. This used to sit inside an
+        // `if (mounted)` guard, which stranded focus outright: the node could not
+        // be focused because it was off-screen, and the camera never moved
+        // because the node could not be focused. Nothing brought it back, so the
+        // roving tabindex pointed at an element that did not exist and the graph
+        // dropped out of the tab order.
+        const rm = window.matchMedia("(prefers-reduced-motion: reduce)").matches
+        reactFlow.fitView({
+          nodes: [{ id: targetId.replace(/^(expander|collapser)-/, "") }],
+          duration: rm ? 0 : 300,
+          padding: FIT_VIEW_PADDING_LOOSE,
+        })
+
+        // Focus now when it is mounted, otherwise as soon as the fly mounts it.
+        requestNodeFocus(targetId)
       }
     },
     [
@@ -193,7 +198,7 @@ export function useGraphKeyboard<T>({
       focusedNodeIdRef,
       flatVisibleOrderRef,
       expandedNodesRef,
-      nodeRefsMapRef,
+      requestNodeFocus,
       setFocusedNodeId,
     ]
   )

--- a/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useGraphRenderModel.ts
@@ -118,13 +118,6 @@ export interface UseGraphRenderModelResult<T> {
   renderedNodeCount: number
   /** Ids of those `graphNode`s — for viewport-driven data loading. */
   renderedNodeIds: string[]
-  /**
-   * Ids of the rendered `graphNode`s with no rendered parent (roots, plus nodes
-   * whose parent is windowed out). The `role="tree"` container `aria-owns` these
-   * so every rendered `role="treeitem"` has exactly one owner across React
-   * Flow's `role="application"` wrapper.
-   */
-  treeRootNodeIds: string[]
   /** Bounding box of the full layout (`null` when empty), for fit-view. */
   contentBounds: { x: number; y: number; width: number; height: number } | null
   /** Layout position of a node id, regardless of whether it is windowed out. */
@@ -751,16 +744,6 @@ export function useGraphRenderModel<T>({
       }
       const aria = ariaTreeInfo.get(treeNode.id)
 
-      // aria-owns: only for expanded nodes, and only the children still in the
-      // window (an entry pointing at a windowed-out node would be a dangling ref).
-      let visibleChildIds: string[] | undefined
-      if (expandedNodes.has(treeNode.id) && treeNode.children.length > 0) {
-        const kept = treeNode.children
-          .map((c) => c.id)
-          .filter((id) => inWindow(id))
-        visibleChildIds = kept.length > 0 ? kept : undefined
-      }
-
       // A stacked row carries its own (shorter) box from the layout; every
       // other node uses the shared card size. As a sub-flow child its box is
       // the group-relative one, already narrowed to the width it paints.
@@ -820,7 +803,6 @@ export function useGraphRenderModel<T>({
           ariaLevel: aria?.level ?? 1,
           ariaSetSize: aria?.setSize ?? 1,
           ariaPosInSet: aria?.posInSet ?? 1,
-          visibleChildIds,
           stacked: isStacked || undefined,
         } as GraphNodeData,
       })
@@ -936,25 +918,6 @@ export function useGraphRenderModel<T>({
     [rfNodes]
   )
 
-  // Forest roots among the rendered treeitems: a rendered node whose parent is
-  // not itself rendered — either it has no parent, or the parent is windowed
-  // out. React Flow wraps its nodes in a `role="application"` div, so the
-  // `role="tree"` container can't reach any `role="treeitem"` through the DOM;
-  // it re-owns these ids via `aria-owns` instead. In-window parents already
-  // re-own their in-window children (`visibleChildIds` above), so owning the
-  // forest roots here gives every rendered treeitem exactly one owner and leaves
-  // none orphaned under windowing.
-  const treeRootNodeIds = useMemo(() => {
-    const rendered = new Set(renderedNodeIds)
-    return rfNodes
-      .filter((n) => n.type === "graphNode")
-      .filter((n) => {
-        const { parentId } = (n.data as GraphNodeData).graphNode
-        return parentId == null || !rendered.has(parentId)
-      })
-      .map((n) => n.id)
-  }, [rfNodes, renderedNodeIds])
-
   // ── Build React Flow edges ──
   const rfEdges = useMemo((): RFEdge[] => {
     // Parents that have a collapser button sitting on their outgoing edges
@@ -1027,7 +990,6 @@ export function useGraphRenderModel<T>({
     tagsAffectLayout,
     renderedNodeCount: renderedNodeIds.length,
     renderedNodeIds,
-    treeRootNodeIds,
     contentBounds,
     getNodePosition,
     stackHoverZones,

--- a/packages/react/src/patterns/F0Graph/hooks/useSelectionFocus.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useSelectionFocus.ts
@@ -27,11 +27,16 @@ export interface UseSelectionFocusResult {
   setFocusedNodeId: (id: string | null) => void
   focusedNodeIdRef: MutableRefObject<string | null>
   registerNodeRef: (nodeId: string, el: HTMLElement | null) => void
-  nodeRefsMapRef: MutableRefObject<Map<string, HTMLElement>>
   /** DFS order of visible node + expander/collapser ids, for keyboard nav. */
   flatVisibleOrderRef: MutableRefObject<string[]>
   selectNode: (nodeId: string) => void
   clearSelection: () => void
+  /**
+   * Focus a node now if it is mounted, otherwise as soon as it mounts. Culling
+   * and windowing drop off-screen nodes, so keyboard navigation regularly
+   * targets a node that has to be flown into view before it exists.
+   */
+  requestNodeFocus: (nodeId: string) => void
 }
 
 /**
@@ -77,16 +82,50 @@ export function useSelectionFocus<T>({
 
   // Node ref map for imperative .focus() calls
   const nodeRefsMapRef = useRef(new Map<string, HTMLElement>())
+
+  // A focus request for a node that is not in the DOM yet. React Flow culls
+  // off-screen nodes (and F0 windowing removes them too), so a keyboard move can
+  // target a node that only exists once the camera has flown to it.
+  const pendingFocusIdRef = useRef<string | null>(null)
+
   const registerNodeRef = useCallback(
     (nodeId: string, el: HTMLElement | null) => {
-      if (el) {
-        nodeRefsMapRef.current.set(nodeId, el)
-      } else {
+      if (!el) {
         nodeRefsMapRef.current.delete(nodeId)
+        return
       }
+      nodeRefsMapRef.current.set(nodeId, el)
+
+      if (pendingFocusIdRef.current !== nodeId) return
+      pendingFocusIdRef.current = null
+
+      // Drop the request if it went stale. Either the focused node moved on
+      // while the camera was flying, or focus left the graph altogether: a click
+      // into a side panel must not be yanked back because a node just mounted.
+      if (focusedNodeIdRef.current !== nodeId) return
+      const active = document.activeElement
+      if (
+        active &&
+        active !== document.body &&
+        !canvasRef.current?.contains(active)
+      ) {
+        return
+      }
+
+      el.focus()
     },
-    []
+    [canvasRef]
   )
+
+  const requestNodeFocus = useCallback((nodeId: string) => {
+    const el = nodeRefsMapRef.current.get(nodeId)
+    if (el) {
+      pendingFocusIdRef.current = null
+      el.focus()
+      return
+    }
+    pendingFocusIdRef.current = nodeId
+  }, [])
 
   // ── Flat visible order (DFS) for keyboard navigation ──
   // Includes expander/collapser pseudo-node IDs for roving tabindex
@@ -160,6 +199,7 @@ export function useSelectionFocus<T>({
   )
 
   const clearSelection = useCallback(() => {
+    pendingFocusIdRef.current = null
     const current = selectedNodesRef.current
     if (!isSelectionControlled) {
       setInternalSelected(new Set())
@@ -177,9 +217,9 @@ export function useSelectionFocus<T>({
     setFocusedNodeId,
     focusedNodeIdRef,
     registerNodeRef,
-    nodeRefsMapRef,
     flatVisibleOrderRef,
     selectNode,
     clearSelection,
+    requestNodeFocus,
   }
 }

--- a/packages/react/src/patterns/F0Graph/internal/ReactFlowAdapters.tsx
+++ b/packages/react/src/patterns/F0Graph/internal/ReactFlowAdapters.tsx
@@ -101,7 +101,6 @@ export interface GraphNodeData extends Record<string, unknown> {
   ariaLevel: number
   ariaSetSize: number
   ariaPosInSet: number
-  visibleChildIds?: string[]
   /** Set when this node is one row of its parent's stacked column. */
   stacked?: boolean
 }
@@ -219,7 +218,6 @@ function F0GraphNodeWrapperInner({ data, id }: NodeProps<GraphRFNode>) {
     ariaLevel,
     ariaSetSize,
     ariaPosInSet,
-    visibleChildIds,
     stacked,
   } = data as GraphNodeData
   const { source: sourcePos, target: targetPos } = handlePositions(
@@ -246,11 +244,6 @@ function F0GraphNodeWrapperInner({ data, id }: NodeProps<GraphRFNode>) {
     ? (el: HTMLDivElement | null) => focusCtx.registerNodeRef(id, el)
     : () => {}
 
-  const ariaOwns =
-    isExpanded && visibleChildIds && visibleChildIds.length > 0
-      ? visibleChildIds.map((cid) => `f0-graph-node-${cid}`).join(" ")
-      : undefined
-
   const ctx: F0GraphNodeRenderContext = {
     zoomLevel,
     variant,
@@ -263,7 +256,6 @@ function F0GraphNodeWrapperInner({ data, id }: NodeProps<GraphRFNode>) {
     setSize: ariaSetSize,
     posInSet: ariaPosInSet,
     nodeId: id,
-    ariaOwns,
     stacked: stacked ?? false,
     stackedHeight: renderCfg?.stackedNodeHeight,
     onExpandToggle: () => toggleExpand(id),
@@ -327,11 +319,6 @@ export const F0GraphNodeWrapper = memo(
     if (prevData.ariaSetSize !== nextData.ariaSetSize) return false
     if (prevData.ariaPosInSet !== nextData.ariaPosInSet) return false
     if (prevData.stacked !== nextData.stacked) return false
-    if (
-      (prevData.visibleChildIds?.join(",") ?? "") !==
-      (nextData.visibleChildIds?.join(",") ?? "")
-    )
-      return false
     if (prev.positionAbsoluteX !== next.positionAbsoluteX) return false
     if (prev.positionAbsoluteY !== next.positionAbsoluteY) return false
     return true


### PR DESCRIPTION
## Description

Enforcing axe on the F0Graph stories turned up three critical violations in the accessible tree. All 16 stories failed, and everything below was measured with the Storybook test-runner in Chromium, not inferred.

Fixing them also fixed two problems axe has no rule for: arrow-key navigation froze the first time it targeted an off-screen node, and the graph offered 9 tab stops where its roving tabindex calls for 2. With all of it fixed and axe enforced, `Graph/F0Graph` leaves the stable DoD debt list.

> **Rebased, not merged.** #5228 landed an accessible-tree fix on main while this branch sat open, so the branch was rebuilt from `c2b7f0580` rather than merged. #5228's mechanism turned out to fail axe (see below) and is replaced here. The keyboard fix is the only thing carried over from the original branch.

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [ ] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [x] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [x] Bug fix
- [ ] Documentation only
- [ ] Refactor / internal change (no API or behavior change)
- [x] Other: clears `Graph/F0Graph` from the stable DoD debt list

## Lifecycle phase (if applicable)

Not a promotion. F0Graph is already tagged `stable`; it sat on the `stable-dod-debt.json` ratchet because it did not meet the mechanical Definition of Done. This closes the three remaining gaps so the entry can be deleted, in the same shape as #5023 and #5039.

- Linked #f0-support thread: n/a (bug fixes plus DoD debt paydown)
- Phase exit criteria met: axe enforced across all 16 stories, a play function covering the primary flow, MDX at gold, unit tests and a snapshot story already present. `pnpm check:stable-dod` passes with the entry removed.

## Implementation details

### The tree cannot be an ancestor of the canvas

React Flow hardcodes `role="application"` on its wrapper, after the props spread, so it cannot be overridden. axe rejects it as a child of a tree on every story:

```
aria-required-children (critical)
  Element has children which are not allowed: [role=application]
  <div role="tree" aria-label="Graph view" aria-owns="f0-graph-node-1">
```

Wrapping React Flow in a `role="group"` does not help — group is a legal tree child, but axe descends through it and still finds the `application`. Measured, not assumed.

So `role="tree"` moves to an empty element beside the canvas, which claims the treeitems by reference. The container keeps its pointer and key handlers, so event flow is unchanged: in a browser a keystroke lands on the focused treeitem and bubbles to that same element as before.

### Ownership has to be read from the DOM

F0 hands React Flow an array of nodes, and React Flow then culls the off-screen ones (`onlyRenderVisibleElements`) on its own schedule. The two sets disagree, and #5228 computed ownership from the array. On `InitialFocus`:

```
tree aria-owns : ["f0-graph-node-root"]   <- root was never painted
painted nodes  : dept-4-member-99, -100, -101
```

That is a dangling reference (`aria-valid-attr-value`, critical) plus three treeitems with no owner (`aria-required-parent`, critical, 22 nodes on `StagedLoading`).

`useAccessibleTreeOwns` reads the list from the DOM through a `MutationObserver` and writes straight out of the callback rather than deferring to a frame — a frame of lag is a frame in which a node exists unowned, which is exactly what `InitialFocus` produced under its mount-time camera fly.

Ownership is flat now: the tree owns every painted treeitem and `aria-level` / `aria-setsize` / `aria-posinset` carry the depth. Nesting it cannot survive culling, because a node whose parent was culled has no owner to attach to. That is also the shape a virtualized tree uses — the rendered slice is present and setsize reports the real total.

`F0GraphNodeRenderContext.ariaOwns` is `@deprecated` and no longer populated as a result. It stays in the type so nothing breaks; a custom `renderNode` should drop it. `F0GraphNodeProps.ariaOwns` is untouched, since F0GraphNode is still used standalone.

### Keyboard focus stranded on a culled node

`useGraphKeyboard` moved the focused id unconditionally but put both the `.focus()` and the `fitView` behind `if (node is mounted)`. A culled node has no ref entry, so nothing flew the camera toward it, so it never mounted. The roving tabindex then pointed at an element that did not exist and the graph dropped out of the tab order.

The fly runs unconditionally now and focusing is deferred until the node mounts, via `requestNodeFocus`. Two guards stop a deferred request misfiring: it is dropped if the focused node moved on while the camera was flying, and dropped if focus has left the graph, so a node mounting cannot yank focus out of a side panel.

### 9 tab stops instead of 2

React Flow marks its own node wrappers and every edge focusable, so Tab walked three "Edge from 1 to 2" stops and hit each node twice. `nodesFocusable` and `edgesFocusable` turn that off. axe has no rule for this, so enforcing axe did not surface it — the play function asserts the count.

### Two test-infrastructure fixes it depended on

- **`settleGraph` in the play function.** The test-runner scans two animation frames in, around 33ms, while the cards are still fading. axe composited the part-faded text and reported contrast failures that do not exist: a `StackedNodesWithTags` tag label read 2.3:1 mid-fade and about 16:1 once it landed. It has to be a convergence check rather than one sample — `InitialFocus` moves in two waves, nodes at ~320ms and the camera fly landing at ~900ms, so a gate that exits on the first quiet frame scans the second wave.
- **The staged-loading promises now build on mount.** Created in `args`, they ran at module import and their timers fired while another story was on screen, so `StagedLoadingError`'s rejection failed whichever story was running. It also meant that by the time you opened either story the promise had usually already settled, with nothing left to watch.

## Verification

Measured in Chromium against a built Storybook:

| | before (`c2b7f0580`) | after |
|---|---|---|
| F0Graph stories violating axe | 16 of 16 | 0 |
| `aria-required-children` | every story | 0 |
| dangling `aria-owns` refs | `InitialFocus`, `StagedLoading`, `ViewportDataLoading` | 0 |
| painted treeitems with no tree parent | 3 on `InitialFocus`, 22 on `StagedLoading` | 0 |
| tab stops (Tree story) | 9 | 2 |

All 16 stories pass with `a11y: { test: "error" }` across `wcag2a/2aa/21a/21aa/22a/22aa`, twice in a row. 368 F0Graph unit tests pass, 7484 across the package. The keyboard regression test was confirmed red on `c2b7f0580` before the fix and green after.

Accessible names still come from the rendered node content, so no new API and no behavior change for existing consumers.

Truly stable goes from 11 components to 12.

## Notes for reviewers

**#5228's mechanism is replaced, deliberately.** It was only ever exercised under `a11y: { test: "todo" }`, where axe logs and moves on, so nothing contradicted it. Turning axe on is what surfaced the three failures. Its two unit tests asserting per-node `ariaOwns` are replaced by tests for the flat model, and `treeRootNodeIds` / `visibleChildIds` are gone from the render model. Worth a look from whoever reviewed #5228.

**Test churn is mechanical.** 28 call-sites queried `getByRole("tree")` to dispatch events at the container. Since the tree is no longer that element, they use `graphContainer()` from the new `__tests__/helpers.ts`. Assertions about the tree's own attributes still query the tree.

**Directly useful for #5043.** Its `F0GraphNode / With Toolbar` story still fails `aria-required-children` in `todo` mode, and it is the same root cause fixed here: a `role="tree"` wrapper containing React Flow's `role="application"`. The remaining 7 F0GraphNode stories fail `aria-required-parent` (28 nodes total), which is that PR's scope. Note that #5043's MDX says F0GraphNode "must remain inside a `role=tree` ancestor" — that is no longer how F0Graph itself does it.

**The aggressive keyboard zoom is left alone.** `FIT_VIEW_PADDING_LOOSE` on a single node is what culls the neighbours and set up the stranding. How far the camera should zoom on keyboard navigation is a design call, and with the stranding fixed an aggressive zoom is merely aggressive rather than a trap.
