### PR TITLE
chore(F0NumberInput): meet the stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -27,7 +27,6 @@
     "Heading",
     "Image",
     "Inputs/Duration input",
-    "Inputs/Number input",
     "Inputs/Search input",
     "Inputs/Text area input",
     "Inputs/Text input",

--- a/packages/react/src/components/F0NumberInput/__stories__/F0NumberInput.mdx
+++ b/packages/react/src/components/F0NumberInput/__stories__/F0NumberInput.mdx
@@ -1,5 +1,7 @@
 import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
 
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
 import * as Stories from "./F0NumberInput.stories"
 
 <Meta of={Stories} />
@@ -41,6 +43,29 @@ import * as Stories from "./F0NumberInput.stories"
 - The value is a duration in hours/minutes. Use [F0DurationInput](?path=/docs/components-inputs-duration-input--documentation).
 - The value is one of a small, discrete set of numbers (e.g. a 1–5 rating). Use a selector with the available options instead.
 - The value is an identifier that happens to look numeric (phone, postal code, credit card). These are formatted strings, not quantities — leading zeros, spaces and country variants matter, and locale-aware formatting would corrupt them. Use [F0TextInput](?path=/docs/components-inputs-text-input--documentation) with the right `autocomplete` and `inputMode`.
+
+**Do's and don'ts**
+
+<DoDonts
+  do={{
+    description:
+      "Describe the number you expect, and let the field enforce it.",
+    guidelines: [
+      "Set `min`/`max`. The value is clamped as the user types, and the range hint is written for you",
+      "Set `maxDecimals` to the precision the value actually has (`0` for counts, `2` for money)",
+      "Pass `locale` so the decimal and thousands separators match the user",
+      "Add `units` for the unit of measure (`EUR`, `%`, `kg`) instead of asking the user to type it",
+    ],
+  }}
+  dont={{
+    description: "Don't make the stepper the only way to reach a value.",
+    guidelines: [
+      "The stepper arrows only appear on hover or keyboard focus, so a value that takes many steps is hard work. Keep `step` for small nudges and let typing carry the rest",
+      "Don't use it for identifiers that merely look numeric (phone, postal code). Locale formatting corrupts them",
+      "Don't leave `maxDecimals` unset for a count. Decimals are accepted until you set it to `0`",
+    ],
+  }}
+/>
 
 ---
 

--- a/packages/react/src/components/F0NumberInput/__stories__/F0NumberInput.stories.tsx
+++ b/packages/react/src/components/F0NumberInput/__stories__/F0NumberInput.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { useState } from "react"
-import { fn } from "storybook/test"
+import { expect, fn, userEvent, within } from "storybook/test"
 
 import { Placeholder } from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
@@ -65,6 +65,7 @@ const meta = {
     },
   },
   parameters: {
+    a11y: { test: "error" },
     jsx: {
       filterProps: (_: unknown, propName: string) => propName !== "key",
     },
@@ -81,6 +82,18 @@ export const Primary: Story = {
   render: (props) => {
     const [value, setValue] = useState<number | null>(props.value ?? 1)
     return <F0NumberInput {...props} value={value} onChange={setValue} />
+  },
+  // The render above holds the value in its own state and overrides onChange,
+  // so the meta-level fn() never fires. Assert the DOM value instead.
+  play: async ({ canvasElement }) => {
+    const input = within(canvasElement).getByRole("textbox", {
+      name: "Label text here",
+    })
+
+    // Seeded at 1, so clear before typing or the field reads "142".
+    await userEvent.clear(input)
+    await userEvent.type(input, "42")
+    await expect(input).toHaveValue("42")
   },
 }
 


### PR DESCRIPTION
## Description

`Inputs/Number input` is tagged `stable` but sat on the stable-DoD debt list, three
requirements short. This closes all three and removes it from the list, so the
ratchet locks the win in. No component source changes, only stories and docs.

Truly stable count goes 10 to 11.

## Type of change

- [x] Documentation only
- [x] Other: story-level a11y enforcement + play function (DoD compliance)

## Lifecycle phase (if applicable)

Not a promotion. The component is already tagged `stable`; this is the mechanical
DoD backfill tracked by `.scripts/check-stable-dod.ts`.

## Implementation details

Three gaps, from `check-stable-dod --verbose`:

**play function.** Added to `Primary`: clear the field, type `42`, assert the
formatted value. It asserts the DOM value rather than `args.onChange` because
Primary's own `render` overrides `onChange` with its local `setValue`, so the
meta-level `fn()` never fires. `Primary` is the deliberate host rather than
`WithStep`: Primary passes no `step`, so `Arrows` returns `null` and there are no
stepper arrows to be revealed by the focus the play function leaves behind for the
axe run that follows it.

**docs "good" tier.** The MDX already had 3 canvases, `<Controls>`, the prop
tables and both when-to-use sections. `DoDonts` was the single missing signal, so
one block under Guidelines moves the tier from `acceptable` to `good`. The guidance
is drawn from real behaviour: min/max clamping runs on every keystroke via
`handleChange`, the range hint is auto-generated from min/max, and `maxDecimals`
is unset by default so decimals are accepted until you set it to `0`.

**axe enforced.** `a11y: { test: "error" }` on the story meta, replacing the
repo-wide `todo` default from `.storybook/preview.tsx`.

### The axe gap was measured, not predicted

Our remediation plan for this component predicted `target-size` (WCAG 2.5.8)
failures on the 16x12px stepper arrows, budgeted a hit-area redesign, and expected
`Snapshot` to need a `skipCi` grandfather. None of that was real. An axe run over
all 16 stories, at CI's rule scope and scan root, found **zero violations** before
the flag was flipped.

Two reasons the arrows never match the rule, both worth knowing for the sibling
inputs still on the list:

1. They are `display:none` at rest (`Arrows.tsx:17`), and axe skips hidden nodes.
2. They carry no `tabIndex`, so `widget-not-inline-matches` fails its
   `_isFocusable` precondition and `target-size` never evaluates them at all.

Point 2 has a consequence for future work: making the arrows keyboard-reachable by
adding `tabIndex` would newly expose them to `target-size`, and at 16x12px with
~12px between centres they would fail both sub-checks. The stepper is in fact
mouse-only today (`role="button"` divs with `onClick`, no key handler, and no
ArrowUp/ArrowDown on the input), which is a genuine WCAG 2.1.1 failure that axe
cannot see. That is deliberately **not** in this PR. It needs a behaviour change,
unit tests and i18n for the hardcoded "Increase"/"Decrease" labels, and it is
better reviewed on its own now that this file enforces axe.

## Verification

Run from `packages/react`:

- `pnpm tsc` clean
- `npx oxlint src/components/F0NumberInput` 0 warnings, 0 errors
- `pnpm vitest --project=unit run src/components/F0NumberInput` 56 tests pass
- `oxfmt --check` clean
- `pnpm test-storybook --url … F0NumberInput` 15/15 pass, with `Primary` reported
  as `play-test` rather than `smoke-test`, confirming the play function actually
  ran under enforced axe
- `check-stable-dod` reports `✓ Inputs/Number input`, ratchet holds

The play assertion was mutation-checked, not just observed green: changing the
expected value to `43` in the built bundle turns it red with
`expect(element).toHaveValue(43)`, so it fails when the component misbehaves.