### PR TITLE
feat(CardSelectable): add an opt-in compact density

### DIFF
--- a/packages/react/src/components/CardSelectable/CardSelectable.tsx
+++ b/packages/react/src/components/CardSelectable/CardSelectable.tsx
@@ -94,6 +94,8 @@ interface CardSelectableProps<T extends CardSelectableValue> {
   isToggle?: boolean
   /** When true, renders without individual card borders (for grouped layout) */
   grouped?: boolean
+  /** When true, uses 12px padding instead of 16px (standalone cards only) */
+  compact?: boolean
 }
 
 function _CardSelectable<T extends CardSelectableValue>({
@@ -104,6 +106,7 @@ function _CardSelectable<T extends CardSelectableValue>({
   onSelect,
   isToggle,
   grouped,
+  compact,
 }: CardSelectableProps<T>) {
   const { forms } = useI18n()
   const shouldReduceMotion = useReducedMotion()
@@ -166,7 +169,7 @@ function _CardSelectable<T extends CardSelectableValue>({
         className={cn(
           "flex cursor-pointer items-center gap-3",
           "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-f1-special-ring",
-          grouped ? "px-4 py-3" : "p-4",
+          grouped ? "px-4 py-3" : compact ? "p-3" : "p-4",
           // The link row below supplies the bottom padding so the gap between
           // description and link matches the old in-column `gap-2`.
           moreInfoLink && "pb-0"
@@ -201,7 +204,7 @@ function _CardSelectable<T extends CardSelectableValue>({
         <div
           className={cn(
             "flex flex-row items-start gap-3 pt-2",
-            grouped ? "px-4 pb-3" : "px-4 pb-4"
+            grouped ? "px-4 pb-3" : compact ? "px-3 pb-3" : "px-4 pb-4"
           )}
         >
           {item.avatar && (

--- a/packages/react/src/components/CardSelectable/__tests__/CardSelectable.test.tsx
+++ b/packages/react/src/components/CardSelectable/__tests__/CardSelectable.test.tsx
@@ -216,3 +216,81 @@ describe("CardSelectable moreInfoLink", () => {
     expect(onChange).not.toHaveBeenCalled()
   })
 })
+
+describe("CardSelectable compact", () => {
+  const items: CardSelectableItem<string>[] = [
+    { value: "a", title: "Option A" },
+  ]
+
+  const linkItems: CardSelectableItem<string>[] = [
+    {
+      value: "a",
+      title: "Option A",
+      moreInfoLink: { href: "https://example.test", label: "More" },
+    },
+  ]
+
+  it("keeps the default padding when compact is not set", () => {
+    render(
+      <CardSelectableContainer
+        items={items}
+        value="a"
+        onChange={vi.fn()}
+        label="test"
+      />
+    )
+
+    expect(screen.getByRole("radio")).toHaveClass("p-4")
+  })
+
+  it("tightens the padding when compact is set", () => {
+    render(
+      <CardSelectableContainer
+        items={items}
+        value="a"
+        onChange={vi.fn()}
+        compact
+        label="test"
+      />
+    )
+
+    const card = screen.getByRole("radio")
+    expect(card).toHaveClass("p-3")
+    expect(card).not.toHaveClass("p-4")
+  })
+
+  it("is a no-op in grouped layout, whose rows are already 12px tall", () => {
+    render(
+      <CardSelectableContainer
+        items={items}
+        value="a"
+        onChange={vi.fn()}
+        grouped
+        compact
+        label="test"
+      />
+    )
+
+    const card = screen.getByRole("radio")
+    expect(card).toHaveClass("px-4")
+    expect(card).toHaveClass("py-3")
+    expect(card).not.toHaveClass("p-3")
+  })
+
+  it("keeps the moreInfoLink row aligned with the tightened card", () => {
+    render(
+      <CardSelectableContainer
+        items={linkItems}
+        value="a"
+        onChange={vi.fn()}
+        compact
+        label="test"
+      />
+    )
+
+    const linkRow = screen.getByRole("link").parentElement
+    expect(linkRow).toHaveClass("px-3")
+    expect(linkRow).toHaveClass("pb-3")
+    expect(linkRow).not.toHaveClass("px-4")
+  })
+})

--- a/packages/react/src/components/CardSelectable/index.stories.tsx
+++ b/packages/react/src/components/CardSelectable/index.stories.tsx
@@ -178,6 +178,49 @@ export const Horizontal: Story = {
   },
 }
 
+const compactLinkItems: CardSelectableItem<string>[] = [
+  {
+    value: "workflows",
+    title: "Link this course with Workflows",
+    description:
+      "Automate actions such as generating certificates or sending questionnaires.",
+    moreInfoLink: {
+      href: "https://help.factorial.co/workflows",
+    },
+  },
+]
+
+/**
+ * `compact` drops standalone card padding from 16px to 12px. The horizontal row
+ * is the density the form designs specify; the card below it checks that the
+ * `moreInfoLink` row stays aligned with the tightened card.
+ */
+export const Compact: Story = {
+  render: function Render() {
+    const [value, setValue] = useState<string | undefined>("new")
+    const [linked, setLinked] = useState<string | undefined>("workflows")
+    return (
+      <div className="flex flex-col gap-4">
+        <CardSelectableContainer
+          layout="horizontal"
+          items={defaultItems}
+          value={value}
+          onChange={setValue}
+          compact
+          label="Payment type selection"
+        />
+        <CardSelectableContainer
+          items={compactLinkItems}
+          value={linked}
+          onChange={setLinked}
+          compact
+          label="Course settings"
+        />
+      </div>
+    )
+  },
+}
+
 const titleOnlyItems: CardSelectableItem<string>[] = [
   { value: "yes", title: "Yes" },
   { value: "no", title: "No" },

--- a/packages/react/src/components/CardSelectable/index.tsx
+++ b/packages/react/src/components/CardSelectable/index.tsx
@@ -23,6 +23,7 @@ function _CardSelectableContainer<T extends CardSelectableValue>(
     multiple,
     isToggle,
     grouped,
+    compact,
   } = props
 
   const isMultiple = multiple === true
@@ -68,7 +69,7 @@ function _CardSelectableContainer<T extends CardSelectableValue>(
       <div
         role={groupRole}
         aria-label={label}
-        className="rounded-xl border border-solid border-f1-border overflow-hidden"
+        className="overflow-hidden rounded-xl border border-solid border-f1-border"
       >
         {items.map((item, index) => (
           <div
@@ -86,6 +87,7 @@ function _CardSelectableContainer<T extends CardSelectableValue>(
               onSelect={() => handleSelect(item.value)}
               isToggle={isToggle}
               grouped
+              compact={compact}
             />
           </div>
         ))}
@@ -112,6 +114,7 @@ function _CardSelectableContainer<T extends CardSelectableValue>(
           multiple={isMultiple}
           onSelect={() => handleSelect(item.value)}
           isToggle={isToggle}
+          compact={compact}
         />
       ))}
     </div>

--- a/packages/react/src/components/CardSelectable/types.ts
+++ b/packages/react/src/components/CardSelectable/types.ts
@@ -49,6 +49,9 @@ export interface CardSelectableSingleProps<T extends CardSelectableValue> {
   isToggle?: boolean
   /** When true, items are grouped in a single bordered container with dividers */
   grouped?: boolean
+  /** Standalone cards only: 12px padding instead of 16px. Grouped rows already
+   * use 12px vertical padding, so they are unaffected. */
+  compact?: boolean
 }
 
 export interface CardSelectableMultipleProps<T extends CardSelectableValue> {
@@ -70,6 +73,9 @@ export interface CardSelectableMultipleProps<T extends CardSelectableValue> {
   isToggle?: boolean
   /** When true, items are grouped in a single bordered container with dividers */
   grouped?: boolean
+  /** Standalone cards only: 12px padding instead of 16px. Grouped rows already
+   * use 12px vertical padding, so they are unaffected. */
+  compact?: boolean
 }
 
 export type CardSelectableContainerProps<T extends CardSelectableValue> =


### PR DESCRIPTION
## What

Adds an opt-in `compact` prop to `CardSelectableContainer`: standalone card padding `p-4` → `p-3` (16px → 12px).

Opt-in, so all current call sites keep today's density. In `grouped` layout the rows already use `px-4 py-3`, so `compact` is a no-op there.

## This follows the existing F0Card pattern

Not a new concept: `F0Card` already exposes exactly this knob, and this PR mirrors it rather than inventing an API.

```tsx
// F0Card — CardInternalProps
/** Whether the card has a compact layout */
compact?: boolean
...
compact && "p-3",   // CardInternal.tsx:267 and :500, over a default p-4
```

Same prop name, same boolean shape, same `p-4` → `p-3` flip. Across `packages/react/src/components`, 16px is the card family's default (`F0Card`, `CardSelectable`, `F0Select`'s `SelectionPreview`) and 12px is the compact density (`F0Card` compact, dialog wrapper, `F0NumberInput`, audio/video player cards). `CardSelectable` was simply the one card primitive missing the density knob its sibling has.

## Why opt-in rather than changing the default

`CardSelectableContainer` is not only used directly — inside f0 it also backs `F0Form`'s `cardSelect` field renderer and `SwitchGroupRenderer`. In the Factorial monorepo alone there are 27 direct call sites plus two `fieldType: 'cardSelect'` forms, spanning trainings, expenses, banking, procurement, benefits, employees, IT, compensations and job catalog. Changing the default would silently restyle all of them.

## Why it is needed

The form designs now landing across modules — ATS "Schedule an interview" ([FCT-61677](https://factorialmakers.atlassian.net/browse/FCT-61677)) and the trainings session form among them — specify 12px padding on these cards. The value was hardcoded in `CardSelectable.tsx` with no prop reaching it, so a consumer's only alternative was overriding f0 internals with CSS, which the boundary policy rules out.

**Question for Design:** if 12px is meant to be the density for *every* selectable card rather than a per-screen choice, that is a design-system decision of its own and would want the same treatment on `F0Card`. Happy to turn this into a default flip plus a Chromatic sweep instead — say the word, and this PR can be dropped.

A secondary effect worth noting: with three horizontal cards the label box is `min-w-0 flex-1`, and f0's global `div[role=dialog] { overflow-wrap: anywhere }` lets a single long word break mid-word once that box is narrower than the word. `compact` gives each card 8px more room for text, which clears the threshold in the ATS wizard's layout. It does not remove the underlying behaviour, so a follow-up on the title's break behaviour (`break-keep`, or nowrap + truncate with a tooltip) may still be worth doing.

## Tests

- Four unit tests in `CardSelectable.test.tsx`: the default keeps `p-4`; `compact` yields `p-3`; `grouped` + `compact` is a no-op; and `compact` keeps the `moreInfoLink` row aligned with the tightened card. That last one needed a fix — the link row is a sibling of the interactive header (to avoid `nested-interactive`) and hardcoded `px-4 pb-4`, so under `compact` the link sat 4px past the title with 16px of bottom padding against 12px sides.
- 14 tests in the file pass; `oxlint` and `oxfmt` clean; `tsc --project tsconfig-build.json` clean.
- `Compact` story next to `Horizontal`, covering both the horizontal row and the `moreInfoLink` case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FCT-61677]: https://factorialmakers.atlassian.net/browse/FCT-61677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ