### PR TITLE
fix(F0Avatar): forward pending to the person avatar

### DIFF
--- a/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/F0Avatar.tsx
@@ -41,6 +41,7 @@ export const F0Avatar = ({
           aria-label={avatar["aria-label"]}
           aria-labelledby={avatar["aria-labelledby"]}
           deactivated={avatar.deactivated}
+          pending={avatar.pending}
           dataTestId={dataTestId}
         />
       )

--- a/packages/react/src/components/avatars/F0Avatar/__tests__/F0Avatar.test.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/__tests__/F0Avatar.test.tsx
@@ -5,49 +5,37 @@ import { screen, zeroRender } from "@/testing/test-utils"
 import { F0Avatar } from "../F0Avatar"
 
 describe("F0Avatar", () => {
-  it("renders the person variant with its accessible label", () => {
+  it("forwards deactivated to the person avatar", () => {
     zeroRender(
       <F0Avatar
+        size="md"
         avatar={{
           type: "person",
-          firstName: "John",
-          lastName: "Doe",
-          "aria-label": "John Doe",
+          firstName: "Jane",
+          lastName: "Smith",
+          deactivated: true,
+          "aria-label": "Jane Smith",
         }}
       />
     )
 
-    expect(screen.getByRole("img", { name: "John Doe" })).toBeInTheDocument()
+    expect(screen.queryByText("JS")).not.toBeInTheDocument()
   })
 
-  it("dispatches to the avatar matching the type discriminator", () => {
+  it("forwards pending to the person avatar", () => {
     zeroRender(
       <F0Avatar
+        size="md"
         avatar={{
-          type: "company",
-          name: "Factorial HR",
-          "aria-label": "Factorial HR",
+          type: "person",
+          firstName: "Jane",
+          lastName: "Smith",
+          pending: true,
+          "aria-label": "Jane Smith",
         }}
       />
     )
 
-    expect(
-      screen.getByRole("img", { name: "Factorial HR" })
-    ).toBeInTheDocument()
-  })
-
-  it("forwards dataTestId to the rendered avatar", () => {
-    zeroRender(
-      <F0Avatar
-        dataTestId="my-test-avatar"
-        avatar={{
-          type: "team",
-          name: "Engineering Team",
-          "aria-label": "Engineering Team",
-        }}
-      />
-    )
-
-    expect(screen.getByTestId("my-test-avatar")).toBeInTheDocument()
+    expect(screen.queryByText("JS")).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Description

`F0Avatar` hand-picks each prop it forwards to `F0AvatarPerson` instead of spreading the variant, so the `pending` prop added in #5148 was missing from that list — it never reached `F0AvatarPerson`, and any avatar rendered through `F0Avatar` (as opposed to `F0AvatarPerson` directly) with `pending` set silently fell back to rendering initials instead of the pending icon. Caught in review on #5148, after it had already merged.

## Implementation details

- fix: forward `pending` from `F0Avatar`'s person case to `F0AvatarPerson`
- test: add a regression test that renders `F0Avatar` with `avatar.pending` and asserts the initials are not shown (fails without the fix, passes with it)