### PR TITLE
fix(F0NumberInput): make the stepper keyboard operable

### DIFF
--- a/packages/react/src/components/F0NumberInput/__tests__/F0NumberInput.test.tsx
+++ b/packages/react/src/components/F0NumberInput/__tests__/F0NumberInput.test.tsx
@@ -143,6 +143,55 @@ describe("F0NumberInput", () => {
 
       expect(input).toHaveValue("1")
     })
+
+    // The arrow buttons are mouse-only on purpose, so the keyboard route to
+    // the stepper is ArrowUp/ArrowDown on the input (WCAG 2.1.1).
+    describe("from the keyboard", () => {
+      test("ArrowUp increases and ArrowDown decreases the value", async () => {
+        render(<WithStepStory />)
+
+        const input = screen.getByRole("textbox")
+        await userEvent.click(input)
+
+        await userEvent.keyboard("{ArrowUp}")
+        await waitFor(() => expect(input).toHaveValue("2"))
+
+        await userEvent.keyboard("{ArrowDown}")
+        await waitFor(() => expect(input).toHaveValue("1"))
+      })
+
+      test("ArrowUp does not increase the value above the max", async () => {
+        render(<WithStepStory value={5} />)
+
+        const input = screen.getByRole("textbox")
+        await userEvent.click(input)
+        await userEvent.keyboard("{ArrowUp}")
+
+        expect(input).toHaveValue("5")
+      })
+
+      test("ArrowDown does not decrease the value below the min", async () => {
+        render(<WithStepStory value={1} />)
+
+        const input = screen.getByRole("textbox")
+        await userEvent.click(input)
+        await userEvent.keyboard("{ArrowDown}")
+
+        expect(input).toHaveValue("1")
+      })
+
+      test("leaves the value alone when no step is set", async () => {
+        render(
+          <F0NumberInput locale="en-US" value={5} label="No stepper here" />
+        )
+
+        const input = screen.getByRole("textbox")
+        await userEvent.click(input)
+        await userEvent.keyboard("{ArrowUp}")
+
+        expect(input).toHaveValue("5")
+      })
+    })
   })
 
   describe("inline extraContent mode", () => {

--- a/packages/react/src/components/F0NumberInput/components/Arrows.tsx
+++ b/packages/react/src/components/F0NumberInput/components/Arrows.tsx
@@ -2,6 +2,7 @@ import { ChevronDown } from "lucide-react"
 
 import { F0Icon } from "@/components/F0Icon/F0Icon"
 import { ChevronUp } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 
 type ArrowsProps = {
   step?: number
@@ -9,7 +10,20 @@ type ArrowsProps = {
   onClickArrow: (type: "increase" | "decrease") => () => void
 }
 
+/**
+ * Mouse affordance for the stepper. Deliberately kept out of the tab order:
+ * the keyboard route to the same behaviour is ArrowUp/ArrowDown on the input
+ * itself (see the `onKeyDown` in ../internal.tsx), which is what a native
+ * number input does and what a keyboard user reaches for first.
+ *
+ * Do not add `tabIndex` here without resizing the targets. These are 16x12 CSS
+ * px stacked ~12px apart, so making them focusable brings them into the scope
+ * of axe's `target-size` rule (WCAG 2.5.8), which they fail on both the size
+ * and the offset sub-check.
+ */
 export const Arrows = ({ onClickArrow, step, disabled }: ArrowsProps) => {
+  const i18n = useI18n()
+
   if (!step || disabled) return null
 
   return (
@@ -21,7 +35,7 @@ export const Arrows = ({ onClickArrow, step, disabled }: ArrowsProps) => {
         onClick={onClickArrow("increase")}
         className="h-3 cursor-pointer"
         role="button"
-        aria-label="Increase"
+        aria-label={i18n.t("numberInput.increase")}
       >
         <F0Icon size="sm" icon={ChevronUp} />
       </div>
@@ -29,7 +43,7 @@ export const Arrows = ({ onClickArrow, step, disabled }: ArrowsProps) => {
         onClick={onClickArrow("decrease")}
         className="h-3 cursor-pointer"
         role="button"
-        aria-label="Decrease"
+        aria-label={i18n.t("numberInput.decrease")}
       >
         <F0Icon size="sm" icon={ChevronDown} />
       </div>

--- a/packages/react/src/components/F0NumberInput/internal.tsx
+++ b/packages/react/src/components/F0NumberInput/internal.tsx
@@ -2,6 +2,7 @@ import { useControllableState } from "@radix-ui/react-use-controllable-state"
 import {
   CSSProperties,
   ComponentProps,
+  type KeyboardEvent,
   type ReactNode,
   forwardRef,
   useCallback,
@@ -350,6 +351,23 @@ export const NumberInputInternal = forwardRef<
     handleChange(formatValue(newValue, locale, maxDecimals))
   }
 
+  /**
+   * Keyboard route to the stepper. The arrow buttons are mouse-only by design
+   * (see components/Arrows.tsx), so without this the stepper is unreachable
+   * for a keyboard user: WCAG 2.1.1. Mirrors a native number input, which
+   * steps on ArrowUp/ArrowDown while the field has focus.
+   *
+   * Gated on `step` by handleStep, so fields with no stepper are unaffected.
+   */
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (!step || disabled || readonly) return
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") return
+
+    // Stop the caret jumping to the start/end of the field as it steps.
+    event.preventDefault()
+    handleStep(event.key === "ArrowUp" ? "increase" : "decrease")()
+  }
+
   useEffect(() => {
     // With grouping, the resting (blurred) display shows thousands separators
     // and the focused display drops them for editing. This branch also drives
@@ -401,6 +419,7 @@ export const NumberInputInternal = forwardRef<
           onBlur?.()
         }}
         onBeforeInput={handleBeforeInput}
+        onKeyDown={handleKeyDown}
         appendTag={units}
         append={
           step ? (

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -711,6 +711,8 @@ export const defaultTranslations = {
     between: "It should be between {{min}} and {{max}}",
     greaterThan: "It should be greater than {{min}}",
     lessThan: "It should be less than {{max}}",
+    increase: "Increase",
+    decrease: "Decrease",
   },
   phoneInput: {
     country: "Country",


### PR DESCRIPTION
## Description

The `F0NumberInput` stepper is mouse-only, which is a WCAG 2.1.1 Keyboard failure
(level A) in a component tagged `stable`. This adds ArrowUp/ArrowDown on the input.

> **Stacked on #5192.** Base is `chore/number-input-stable-dod`, not `main`, so this
> PR's CI inherits the `a11y: { test: "error" }` that #5192 adds. Based on `main` it
> would run with axe unenforced and would not guard this change. Merge #5192 first;
> this will need a rebase if that one is squashed.

## Type of change

- [x] Bug fix

## Implementation details

### The defect

`components/Arrows.tsx` renders the increase/decrease controls as `role="button"`
**divs** carrying an `onClick` and nothing else: no `tabIndex`, no key handler.
`internal.tsx` had no `onKeyDown`, so the input did not step on arrow keys either.

The shape of the failure is worse than plain "no keyboard support". The arrows are
revealed by `group-focus-within`, so tabbing into the field makes them appear, and
then they cannot be reached or activated. Tab moves straight past to the next
field. The affordance shows up precisely for the user who cannot operate it, and
anyone who cannot use a mouse has no way to reach the stepper.

**axe cannot catch this class of defect.** The rule that flags a `role="button"`
with no focusability is `focus-order-semantics`, which is `best-practice` and
outside the enforced WCAG tag set. #5192 turned on axe enforcement for this file
and went green on all 16 stories with the defect sitting there untouched.

### The fix

`onKeyDown` on the input routes ArrowUp/ArrowDown into the existing `handleStep`,
which already clamps to `min`/`max` and seeds from `step` when the value is null.
This mirrors a native number input and is what a keyboard user reaches for first.

Details worth reviewing:

- `preventDefault()` on the two handled keys, otherwise the caret jumps to the
  start/end of the field while stepping.
- Guarded on `step`, `disabled` and `readonly`. Fields with no stepper are
  unaffected, so this changes behaviour only where a stepper was opted into.
- No handler composition needed: `NumberInputInternalProps` is a `Pick` that does
  not include `onKeyDown`, so consumers cannot pass one today.
- Attaches for real: `src/ui/input.tsx` destructures `onKeyDown` and forwards it to
  the native `<input>`, so it is not swallowed by the wrapper.

### Why the arrows keep no tabIndex

Adding `tabIndex` to the arrow divs is the obvious-looking fix and it is the wrong
one. Un-focusable controls are outside the scope of axe's `target-size` rule
(WCAG 2.5.8), because `widget-not-inline-matches` requires `_isFocusable`. Making
them focusable brings two 16x12 CSS px targets, stacked roughly 12px apart, into
scope, where they fail the size sub-check and the 24px offset sub-check alike. That
would break the axe enforcement this file gains from #5192. Keying the input avoids
the problem entirely.

The reasoning is recorded as a comment above `Arrows` so the next person does not
undo it.

### Also in here

The hardcoded English `"Increase"` / `"Decrease"` labels now read through
`useI18n()`, joining the existing `numberInput` namespace in
`i18n-provider-defaults.ts` alongside `between` / `greaterThan` / `lessThan`. The
component already used `useI18n()` for its range hints, so these two were the
outliers.

## Verification

Run from `packages/react`:

- `pnpm tsc` clean
- `oxlint` on the touched trees, 0 warnings / 0 errors
- `pnpm vitest --project=unit run src/components/F0NumberInput` 60 pass (was 56)
- `pnpm vitest --project=unit run src/lib/providers/i18n` 4 pass, 1 skipped
- `oxfmt --check` clean
- axe probe over all 16 stories at CI's rule scope and scan root: still 16/16
  clean, so the fix exposed no new targets
- `pnpm test-storybook --url … F0NumberInput` 15/15 pass, with axe enforced via the
  base branch

### Red-green

`check-bugfix-red-green` against the stacked base passes:

```
✔ Red-green verified: the changed unit tests fail on latest main
  and pass with this PR's changes.
```

One honest note on the four new tests: only
`ArrowUp increases and ArrowDown decreases the value` is red on the base. The other
three assert that the value does **not** move (above `max`, below `min`, and with no
`step` set), and those pass trivially on a branch where arrow keys do nothing. They
are regression guards for the clamping and the `step` gate rather than reproductions
of this bug.

## Follow-up, deliberately not here

The arrow divs stay `role="button"` divs. Converting them to real `<button>`
elements is the tidier long-term shape, but it needs the 24px hit-area work first
for the `target-size` reason above, which is a visual density change that wants
design sign-off and moves the Chromatic baseline.
