### PR TITLE
fix(SidebarTabs): re-measure when labels outgrow the row

### DIFF
--- a/packages/react/src/patterns/Navigation/Sidebar/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Tabs/__tests__/Tabs.test.tsx
@@ -1,3 +1,4 @@
+import { act } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
@@ -5,6 +6,48 @@ import { Menu, Messages } from "@/icons/app"
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
 import { SidebarTab, SidebarTabs } from "../index"
+
+// jsdom has no layout and the suite-wide ResizeObserver mock never fires, so
+// the measure effect has to be driven by hand. This fake delivers a resize the
+// way a browser does — to the observers watching the element that changed, and
+// to no one else — which is what lets a test resize a *label* rather than the
+// row and see whether the component notices.
+type FakeObserver = { callback: ResizeObserverCallback; targets: Set<Element> }
+const observers: FakeObserver[] = []
+globalThis.ResizeObserver = class FakeResizeObserver {
+  callback: ResizeObserverCallback
+  targets = new Set<Element>()
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback
+    observers.push(this)
+  }
+  observe = (element: Element) => {
+    this.targets.add(element)
+  }
+  unobserve = (element: Element) => {
+    this.targets.delete(element)
+  }
+  disconnect = () => {
+    this.targets.clear()
+  }
+} as unknown as typeof ResizeObserver
+
+/** Report that `element` changed size, to whoever is actually watching it. */
+const resize = (element: Element) => {
+  act(() => {
+    for (const observer of observers) {
+      if (!observer.targets.has(element)) continue
+      observer.callback(
+        [{ target: element } as ResizeObserverEntry],
+        {} as ResizeObserver
+      )
+    }
+  })
+}
+
+const setWidth = (element: Element, property: string, value: number) => {
+  Object.defineProperty(element, property, { value, configurable: true })
+}
 
 const tabs: SidebarTab[] = [
   { id: "main", label: "Main", icon: Menu },
@@ -109,6 +152,40 @@ describe("SidebarTabs", () => {
     // The active tab keeps its label; the inactive one falls back to the icon.
     expect(labelState("Main")).toBe("revealed")
     expect(labelState("Messages!")).toBe("collapsed")
+  })
+
+  it("clips the measurement probe so it cannot leak scrollable overflow into the row", () => {
+    const { container } = renderTabs({ activeTab: "main" })
+    const probe = container.querySelector(".invisible") as HTMLElement
+
+    // The probe lays every tab out at full width, so it is wider than the row
+    // whenever the labels do not fit. It is `visibility: hidden` rather than
+    // `display: none`, and a hidden box still contributes scrollable overflow
+    // to its ancestors, so unclipped it pushes that overflow into the sidebar.
+    expect(probe.className).toContain("overflow-hidden")
+  })
+
+  it("collapses the labels when they outgrow a row that never resized", () => {
+    observers.length = 0
+    const { container } = renderTabs({ activeTab: "main" })
+    const probe = container.querySelector(".invisible") as HTMLElement
+    const group = screen.getByRole("group", { name: "Sidebar sections" })
+
+    // Everything fits to begin with, so every label is revealed.
+    setWidth(probe, "scrollWidth", 200)
+    setWidth(group, "clientWidth", 216)
+    resize(group)
+    expect(labelState("Messages")).toBe("revealed")
+
+    // Now the labels reach their final width: the probe outgrows the row while
+    // the row's own box is untouched, so a label is the only thing that
+    // resized. The verdict has to be recomputed off that alone — the row will
+    // never report a resize, being a fixed width.
+    setWidth(probe, "scrollWidth", 219)
+    resize(probe.children[0])
+
+    expect(labelState("Main")).toBe("revealed")
+    expect(labelState("Messages")).toBe("collapsed")
   })
 })
 

--- a/packages/react/src/patterns/Navigation/Sidebar/Tabs/index.stories.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Tabs/index.stories.tsx
@@ -12,13 +12,22 @@ const tabs: SidebarTab[] = [
   { id: "messages", label: "Messages", icon: Messages },
 ]
 
+/** The product's French strings: a little wider than the 216px row. */
+const borderlineTabs: SidebarTab[] = [
+  { id: "main", label: "Menu", icon: Menu },
+  { id: "messages", label: "Discussions", icon: Messages },
+]
+
 const meta = {
   title: "Navigation/Sidebar/Tabs",
   component: SidebarTabs,
   parameters: { layout: "centered" },
   decorators: [
     (Story) => (
-      <div className="w-fit bg-f1-background-tertiary py-3">
+      // The real sidebar width. A `w-fit` wrapper hugs the *collapsed* row, so
+      // the probe can never fit and every story is pinned to the icon-only
+      // state — the one thing the product does not render.
+      <div className="w-[var(--ds-sidebar-width)] bg-f1-background-tertiary py-3">
         <Story />
       </div>
     ),
@@ -29,9 +38,15 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const Interactive = ({ initial = "main" }: { initial?: string }) => {
+const Interactive = ({
+  initial = "main",
+  items = tabs,
+}: {
+  initial?: string
+  items?: SidebarTab[]
+}) => {
   const [active, setActive] = useState(initial)
-  return <SidebarTabs tabs={tabs} activeTab={active} onTabChange={setActive} />
+  return <SidebarTabs tabs={items} activeTab={active} onTabChange={setActive} />
 }
 
 export const Default: Story = {
@@ -63,4 +78,15 @@ export const WithBadges: Story = {
       />
     )
   },
+}
+
+/**
+ * The product's French pair at the real sidebar width: the labels need a few
+ * pixels more than the row has, so they must collapse to icons. A fixture for
+ * that margin rather than a reproduction — the bug needs a measure taken before
+ * the labels reach their final width, which a page load does not produce.
+ */
+export const LabelsJustOverTheRow: Story = {
+  ...Default,
+  render: () => <Interactive items={borderlineTabs} />,
 }

--- a/packages/react/src/patterns/Navigation/Sidebar/Tabs/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Tabs/index.tsx
@@ -253,8 +253,14 @@ export const SidebarTabs = ({
       setLabelsFit(probe.scrollWidth <= group.clientWidth)
     }
     measure()
+    // The row's width is not the only input. The row is a fixed width that
+    // never resizes, while the labels inside the probe can still reach their
+    // final width after this first measure — styles landing late, a font or a
+    // translation swapping in. Observing only the row leaves that stale verdict
+    // standing, and the labels revealed in a row too narrow to hold them.
     const observer = new ResizeObserver(measure)
     observer.observe(group)
+    for (const child of Array.from(probe.children)) observer.observe(child)
     return () => observer.disconnect()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [tabsKey])
@@ -269,12 +275,13 @@ export const SidebarTabs = ({
       >
         {/* Measurement probe: the real TabButton rendered inert at its
             expanded (icon + label) width, so the measure always matches the
-            actual paddings/typography. Invisible and absolute, it never
-            affects layout. */}
+            actual paddings/typography. Absolute, so it never affects layout,
+            and clipped, because a `visibility: hidden` box still contributes
+            scrollable overflow to its ancestors. */}
         <div
           ref={probeRef}
           aria-hidden="true"
-          className="pointer-events-none invisible absolute left-0 top-0 flex flex-row"
+          className="pointer-events-none invisible absolute left-0 top-0 flex flex-row overflow-hidden"
         >
           {tabs.map((tab) => (
             <TabButton


### PR DESCRIPTION
## Description

Inactive tab labels collapse to icons only when every label fits, a verdict computed as `probe.scrollWidth <= group.clientWidth`. Only the row was watched for resizes, and the row is a fixed sidebar width that never resizes — while the labels inside the probe can still reach their final width after that first measure. The stale verdict then stood, leaving every label revealed in a row too narrow to hold them, and the second label clipped at the sidebar edge. Reported in French, where "Menu" + "Discussions" need a few pixels more than the 216px the sidebar leaves; English fits comfortably, which is why it read as locale-specific.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)
Before:
<img width="478" height="232" alt="image (2)" src="https://github.com/user-attachments/assets/c0606910-c923-4e89-ac0d-0d4e2fd0b28f" />


## Implementation details

- fix: observe the probe's children, not just the row, so the verdict is recomputed when the labels reach their final width

- fix: clip the measurement probe

  <details>
  <summary>Why?</summary>

  The probe lays every tab out at full width, so it is wider than the row whenever the labels do not fit. It is `visibility: hidden` rather than `display: none`, and a hidden box still contributes scrollable overflow to its ancestors — so it was pushing real overflow into the sidebar. Measured in Chrome at 261px (German) and 354px (long labels) against a 216px row; now equal to the row.
  </details>

- test: cover both, one behavioural and one CSS-contract

  <details>
  <summary>Why the fake ResizeObserver?</summary>

  jsdom has no layout and the suite-wide `ResizeObserver` mock never fires, so the measure effect has to be driven by hand. The fake delivers a resize the way a browser does — only to observers watching the element that changed — which is what lets the test resize a *label* rather than the row and assert the rendered outcome, instead of asserting which elements got observed. It fails on unfixed code with `expected 'revealed' to be 'collapsed'`.

  The clipping test asserts the `overflow-hidden` class rather than real overflow, since that needs layout; this follows the `F0TagList` precedent. Verified by hand in Chrome.
  </details>

- chore: point the story fixture at the real sidebar width

  <details>
  <summary>Visual change to existing stories</summary>

  The meta decorator was `w-fit`, which hugs the *collapsed* row — so the probe could never fit and every story was pinned to the icon-only state, the one thing the product does not render. Now `w-[var(--ds-sidebar-width)]`. `Default`, `MessagesActive` and `WithBadges` consequently show both labels, which is what the product actually renders in English.
  </details>

- chore: add `LabelsJustOverTheRow`, the French pair at the real sidebar width — a fixture for that margin rather than a reproduction, since the bug needs a measure taken before the labels reach their final width
