### PR TITLE
fix(F0Chat): pin composer text metrics to the textarea

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
@@ -121,7 +121,15 @@ export const TextareaField = ({
           "min-h-[20px] max-h-[240px] h-auto",
           "resize-none",
           "whitespace-pre-wrap break-words",
-          "text-[16px] sm:text-[14px] leading-[20px] font-normal",
+          // `[letter-spacing:inherit]` is load-bearing: a `<textarea>` does not
+          // inherit letter-spacing, because the UA stylesheet declares
+          // `letter-spacing: normal` on form controls and that beats the
+          // -0.005em `body` sets (packages/core/base.css) — which the sizer and
+          // overlay divs above DO inherit. Without it the transparent text and
+          // the painted overlay drift ~0.07px per character and wrap at
+          // different points. `text-base` is not usable here: the 16px mobile
+          // size is deliberate (it stops iOS zooming on focus).
+          "text-[16px] sm:text-[14px] leading-[20px] font-normal [letter-spacing:inherit]",
           "mt-3 px-3",
           "overflow-y-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
           "outline-none",

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -28,7 +28,16 @@ type ChatTextareaFieldProps = {
 
 // Shared text-box metrics — applied identically to the invisible sizer, the
 // highlight overlay and the textarea so caret and highlight align to the pixel.
-const BOX = "whitespace-pre-wrap break-words p-3 text-md leading-5"
+//
+// `text-base` is load-bearing, not decoration: it pins letter-spacing on all
+// three layers. `body` sets -0.005em (packages/core/base.css), which the two
+// divs inherit but a `<textarea>` never does — the UA stylesheet declares
+// `letter-spacing: normal` directly on form controls, and a declaration on the
+// element beats an inherited value. Leave it unpinned and the overlay runs
+// ~0.07px/char tighter than the textarea: the caret drifts away from the
+// painted glyphs and the two layers wrap at different characters. (This read
+// `text-md` before, which is not in F0's font scale and emitted no CSS at all.)
+const BOX = "whitespace-pre-wrap break-words p-3 text-base leading-5"
 const HEIGHT = "min-h-[44px] max-h-[140px]"
 
 /**

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useEmojiAutocomplete.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useEmojiAutocomplete.test.ts
@@ -144,8 +144,38 @@ describe("useEmojiAutocomplete", () => {
 
     expect(enter.preventDefault).toHaveBeenCalledOnce()
     expect(setInputValue).toHaveBeenCalledWith("Hello 😄 world")
-    expect(setCursorPosition).toHaveBeenCalledWith(9)
+    // "Hello " is 0-5, the emoji 6-7 (a surrogate pair), the pre-existing space
+    // 8. The caret belongs right after the emoji, NOT past that space — no
+    // separator was inserted here, so there is nothing extra to step over.
+    expect(setCursorPosition).toHaveBeenCalledWith(8)
     expect(textarea).toHaveFocus()
+    expect(textarea.selectionStart).toBe(8)
+  })
+
+  it("inserts a separator and steps over it when none follows the caret", () => {
+    const setInputValue = vi.fn()
+    const setCursorPosition = vi.fn()
+    const textarea = document.createElement("textarea")
+    textarea.value = "Hello :smil"
+    document.body.appendChild(textarea)
+    const { result } = renderHook(() =>
+      useEmojiAutocomplete({
+        inputValue: "Hello :smil",
+        setInputValue,
+        cursorPosition: 11,
+        setCursorPosition,
+        textareaRef: { current: textarea },
+      })
+    )
+
+    act(() =>
+      expect(result.current.handleKeyDown(keyboardEvent("Enter"))).toBe(true)
+    )
+
+    // Nothing followed the query, so a trailing space is added and the caret
+    // lands after it — ready for the next word.
+    expect(setInputValue).toHaveBeenCalledWith("Hello 😄 ")
+    expect(setCursorPosition).toHaveBeenCalledWith(9)
     expect(textarea.selectionStart).toBe(9)
   })
 

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
@@ -246,7 +246,10 @@ export function useEmojiAutocomplete({
       const hasExistingSeparator = /^\s/.test(after)
       const nextValue =
         before + candidate.native + (hasExistingSeparator ? "" : " ") + after
-      const nextCursorPosition = before.length + candidate.native.length + 1
+      // Step over the separator only when we actually inserted one; otherwise
+      // the caret jumps past the space that was already there.
+      const nextCursorPosition =
+        before.length + candidate.native.length + (hasExistingSeparator ? 0 : 1)
 
       setInputValue(nextValue)
       setCursorPosition(nextCursorPosition)


### PR DESCRIPTION
## Description

The chat composer paints its text twice — a transparent `<textarea>` supplies the caret while an overlay `div` paints the glyphs (twemoji, mention chips) — and the two laid text out differently, so the caret drifted away from the text you could see, the gap grew as you typed, and the two layers wrapped at different characters. The cause is that `body` sets `letter-spacing: -0.005em` (`packages/core/base.css`), which the overlay and sizer divs inherit but a `<textarea>` never does, because the UA stylesheet declares `letter-spacing: normal` directly on form controls and a declaration on the element beats an inherited value; the shared `BOX` constant was meant to pin identical metrics on all three layers but read `text-md`, which is not a size in F0's font scale, so Tailwind emitted no rule for it at all. Emoji only ever triggered it (they are what turns the overlay on) — this pins the metrics, applies the same fix to the `F0AiChatTextArea` twin, and corrects an unrelated off-by-one that moved the caret past a space already sitting after a picked emoji.

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [ ] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [ ] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [x] Bug fix
- [ ] Documentation only
- [ ] Refactor / internal change (no API or behavior change)
- [ ] Other:

## Screenshots (if applicable)

**Before.** The caret sits roughly a space-width to the right of where the text
visibly ends, and the gap widens the longer the message gets. Note that the
drifted line contains no emoji at all — the three earlier in the message are only
what turned the overlay on, which is why this looked like an emoji bug.


<img width="826" height="177" alt="before-caret-drift" src="https://github.com/user-attachments/assets/0d5a8f7e-d174-4fa9-8971-9414ea7b5fef" />

https://github.com/user-attachments/assets/7b554fdb-5cce-411c-a4ea-26e9b80146ce


**After.** Caret flush against the text at any length. Overlaying the (normally
transparent) textarea text in red over the overlay's black shows the two layers
sitting exactly on top of each other, where before they visibly separated after
the first line.

https://github.com/user-attachments/assets/17f5a624-d657-4fcb-ac78-005c81b4cd41


## Implementation details

- fix: pin the composer's text metrics on all three layers so the caret tracks the painted glyphs

  <details>
  <summary>Why <code>text-md</code> → <code>text-base</code> is the whole fix</summary>

  `BOX` in `ChatTextareaField.tsx` is applied identically to the invisible sizer,
  the highlight overlay and the textarea, precisely so the three agree. But `md`
  is not in F0's font scale — `packages/core/src/tokens/typography.ts` defines
  `xs sm base lg xl 2xl 3xl 4xl`, and `md` exists only under `strokeWidth`. There
  are **zero** `.text-md` rules in the 2 MB of compiled CSS, so the class was
  inert and every layer fell back to inheritance.

  The divs inherit `body`'s `-0.005em`. The textarea does not: Chrome's UA
  stylesheet sets `letter-spacing: normal` on `input, textarea, select, button`,
  and a declaration on the element beats an inherited value at any specificity.

  `.text-base` emits `font-size:.875rem; line-height:1.25rem; letter-spacing:-0.005em`
  — byte-identical to what `body` already applies, and `1.25rem` is the `leading-5`
  already in `BOX`. So nothing moves except the textarea finally receiving the
  letter-spacing it was refusing.
  </details>

- fix: pin `letter-spacing` on the `F0AiChatTextArea` textarea, which has the same three ingredients

  <details>
  <summary>Why <code>[letter-spacing:inherit]</code> and not <code>text-base</code> here</summary>

  Same transparent-textarea-plus-overlay pattern, same inherited `body` value,
  same UA opt-out. But `text-base` is unusable: the twin deliberately uses
  `text-[16px] sm:text-[14px]`, where the 16px mobile size stops iOS zooming the
  page on focus. Arbitrary values emit font-size only, so the letter-spacing has
  to be said separately.

  This one is latent rather than active — the twin's overlay only mounts when the
  host passes `searchPersons`, and no story does. Fixed so the next consumer
  doesn't rediscover it.
  </details>

- fix: keep the caret before a separator that was already there when picking an emoji from the `:` popover

  <details>
  <summary>The off-by-one</summary>

  `selectCandidate` appends a space only when nothing follows the caret, but it
  advanced the caret by 1 unconditionally. Typing `Hello :smil| world` and hitting
  Enter gave `Hello 😄 |world` — caret past the pre-existing space — instead of
  `Hello 😄| world`. Read to users as "the cursor added a space".

  The old expectation was baked into the test suite (`toHaveBeenCalledWith(9)`),
  so that assertion is corrected to `8` with the index math spelled out, and a
  new case pins the opposite branch so the fix cannot be over-applied.
  </details>

- test: add a regression case for the inserted-separator branch, and correct the assertion that encoded the bug

## Verification

- `pnpm vitest` — 498 tests / 60 files green across `F0Chat` and `F0AiChatTextArea`
- `tsc --noEmit` — 0 errors
- `oxfmt` / `oxlint` — clean; all lefthook hooks passed
- `check:bugfix-red-green` — ✔ verified: the changed tests **fail on latest main** and pass here
- Measured in a standalone F0Chat harness driving React's real event path (native value setter + `input` / `keyup` / `keydown`), before and after, side by side:

  | Check | before | after |
  |---|---|---|
  | `letter-spacing` parity across the three layers | textarea `0px` vs divs `-0.07px` | all three `-0.07px` |
  | width drift over 104 characters | **7.28px** (7.00px / 100 chars) | **0.00px** |
  | caret after picking an emoji before an existing space | `9` (wrong) | `8` |

## Related

- [💻 #4951](https://github.com/factorialco/f0/pull/4951) — complementary: the only other open PR inside `sds/chat/F0Chat`, adds forward-message support. No file overlap with this one (it touches `ChatBubble`, `ChatMessageActions`, `ChatMessageItem`, `types.ts`, `F0ChatProvider`, mocks and stories).

## Side notes for the reviewer

- **`text-md` is dead in 19 other places** across `src/` (`ui/calendar.tsx` ×4, `ui/value-display/types/file/file.tsx`, `experimental/AiPromotionChat` ×2, `sds/Home/DaytimePage`, …). All silently emit nothing today. Deliberately **not** touched here: changing them alters real type sizes and needs visual review, which does not belong in a bug fix.
- **The systemic fix would be `textarea, input, select { letter-spacing: inherit }` in `reset.css`**, which would close this hole for every F0 form control at once. Not done here — the blast radius is every input in the design system and it wants Foundations sign-off. Worth filing separately.
- **`renderTextWithEmojis`'s `inline-block` wrapper is innocent.** It was my first suspect; measured in the browser, the atomic box and the glyph it wraps are identical to three decimals (13.938px each), contributing exactly zero drift. Left alone.
- One unverified cosmetic nit in the same function, not touched: the twemoji `<img>` is `absolute inset-0 h-full w-full`, so it stretches to the 20px line box rather than the glyph's own box.
- The AI twin's fix has **no browser-level verification** here, only reasoning from the identical CSS mechanism, because nothing in the repo mounts its overlay.
