### PR TITLE
feat(value-display): add per-segment size to the compound cell

### DIFF
--- a/packages/react/src/ui/value-display/types/compound/__stories__/compound.stories.tsx
+++ b/packages/react/src/ui/value-display/types/compound/__stories__/compound.stories.tsx
@@ -155,6 +155,30 @@ export const WithCustomSeparator: Story = {
   },
 }
 
+export const NameWithSubordinateContext: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Name / context",
+      render: () => ({
+        type: "compound",
+        value: {
+          separator: " ",
+          segments: [
+            { type: "text", value: "Junior" },
+            {
+              type: "text",
+              value: "Backend Engineer",
+              tone: "secondary",
+              size: "sm",
+            },
+          ],
+        },
+      }),
+    },
+  },
+}
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   args: {

--- a/packages/react/src/ui/value-display/types/compound/__stories__/compound.stories.tsx
+++ b/packages/react/src/ui/value-display/types/compound/__stories__/compound.stories.tsx
@@ -170,7 +170,7 @@ export const NameWithSubordinateContext: Story = {
               type: "text",
               value: "Backend Engineer",
               tone: "secondary",
-              size: "sm",
+              weight: "light",
             },
           ],
         },

--- a/packages/react/src/ui/value-display/types/compound/compound.test.tsx
+++ b/packages/react/src/ui/value-display/types/compound/compound.test.tsx
@@ -94,6 +94,30 @@ describe("CompoundCell", () => {
     expect(screen.getByText("Junior")).not.toHaveClass("text-sm")
   })
 
+  it("applies the font weight per segment, inheriting when unset", () => {
+    const args: CompoundCellValue = {
+      separator: " ",
+      segments: [
+        { type: "text", value: "Junior" },
+        {
+          type: "text",
+          value: "Backend Engineer",
+          tone: "secondary",
+          weight: "light",
+        },
+      ],
+    }
+
+    render(CompoundCell(args, tableMeta))
+
+    expect(screen.getByText("Backend Engineer")).toHaveClass("font-light")
+    const inheriting = screen.getByText("Junior")
+    expect(inheriting).not.toHaveClass("font-light")
+    expect(inheriting).not.toHaveClass("font-normal")
+    expect(inheriting).not.toHaveClass("font-medium")
+    expect(inheriting).not.toHaveClass("font-semibold")
+  })
+
   it("formats number and amount segments", () => {
     const args: CompoundCellValue = {
       segments: [

--- a/packages/react/src/ui/value-display/types/compound/compound.test.tsx
+++ b/packages/react/src/ui/value-display/types/compound/compound.test.tsx
@@ -74,6 +74,26 @@ describe("CompoundCell", () => {
     expect(screen.getByText("Neutral")).toHaveClass("text-f1-foreground")
   })
 
+  it("renders a segment one step down when size is sm, base otherwise", () => {
+    const args: CompoundCellValue = {
+      separator: " ",
+      segments: [
+        { type: "text", value: "Junior" },
+        {
+          type: "text",
+          value: "Backend Engineer",
+          tone: "secondary",
+          size: "sm",
+        },
+      ],
+    }
+
+    render(CompoundCell(args, tableMeta))
+
+    expect(screen.getByText("Backend Engineer")).toHaveClass("text-sm")
+    expect(screen.getByText("Junior")).not.toHaveClass("text-sm")
+  })
+
   it("formats number and amount segments", () => {
     const args: CompoundCellValue = {
       segments: [

--- a/packages/react/src/ui/value-display/types/compound/compound.tsx
+++ b/packages/react/src/ui/value-display/types/compound/compound.tsx
@@ -30,12 +30,22 @@ export const compoundTones = [
 
 export type CompoundTone = (typeof compoundTones)[number]
 
+export const compoundSizes = ["md", "sm"] as const
+
+/**
+ * Type scale of a single segment. Defaults to `"md"` (the cell's base size);
+ * `"sm"` renders one step down, for subordinating a segment to the ones beside
+ * it — e.g. a name in `"md"` followed by its context in `"sm"`.
+ */
+export type CompoundSize = (typeof compoundSizes)[number]
+
 type UnitsPosition = "left" | "right"
 
 export interface CompoundTextSegment extends WithPlaceholder {
   type: "text"
   value: string | number | undefined
   tone?: CompoundTone
+  size?: CompoundSize
 }
 
 export interface CompoundNumberSegment extends WithPlaceholder {
@@ -45,6 +55,7 @@ export interface CompoundNumberSegment extends WithPlaceholder {
   unitsPosition?: UnitsPosition
   decimalPlaces?: number
   tone?: CompoundTone
+  size?: CompoundSize
 }
 
 export interface CompoundPercentageSegment extends WithPlaceholder {
@@ -52,6 +63,7 @@ export interface CompoundPercentageSegment extends WithPlaceholder {
   value: number | undefined
   decimalPlaces?: number
   tone?: CompoundTone
+  size?: CompoundSize
 }
 
 export interface CompoundAmountSegment extends WithPlaceholder {
@@ -59,6 +71,7 @@ export interface CompoundAmountSegment extends WithPlaceholder {
   value: number | undefined
   currency?: CurrencyDef
   tone?: CompoundTone
+  size?: CompoundSize
 }
 
 export type CompoundSegment =
@@ -83,6 +96,12 @@ const toneClassByValue: Record<CompoundTone, string> = {
   warning: "text-f1-foreground-warning",
   info: "text-f1-foreground-info",
   selected: "text-f1-foreground-selected",
+}
+
+// "md" is the cell's base size, so it needs no class.
+const sizeClassByValue: Record<CompoundSize, string> = {
+  md: "",
+  sm: "text-sm",
 }
 
 const resolveCompoundTextValue = (
@@ -293,6 +312,7 @@ export const CompoundCell = (
             <span
               className={cn(
                 toneClassByValue[tone],
+                sizeClassByValue[segment.size ?? "md"],
                 resolvedSegment.kind === "formatted" &&
                   "inline-flex items-center gap-1"
               )}

--- a/packages/react/src/ui/value-display/types/compound/compound.tsx
+++ b/packages/react/src/ui/value-display/types/compound/compound.tsx
@@ -39,6 +39,20 @@ export const compoundSizes = ["md", "sm"] as const
  */
 export type CompoundSize = (typeof compoundSizes)[number]
 
+export const compoundWeights = [
+  "light",
+  "normal",
+  "medium",
+  "semibold",
+] as const
+
+/**
+ * Font weight of a single segment. Defaults to inheriting the cell's weight;
+ * set it to make one segment lighter or heavier than the ones beside it — e.g.
+ * a name at the inherited weight followed by lighter context.
+ */
+export type CompoundWeight = (typeof compoundWeights)[number]
+
 type UnitsPosition = "left" | "right"
 
 export interface CompoundTextSegment extends WithPlaceholder {
@@ -46,6 +60,7 @@ export interface CompoundTextSegment extends WithPlaceholder {
   value: string | number | undefined
   tone?: CompoundTone
   size?: CompoundSize
+  weight?: CompoundWeight
 }
 
 export interface CompoundNumberSegment extends WithPlaceholder {
@@ -56,6 +71,7 @@ export interface CompoundNumberSegment extends WithPlaceholder {
   decimalPlaces?: number
   tone?: CompoundTone
   size?: CompoundSize
+  weight?: CompoundWeight
 }
 
 export interface CompoundPercentageSegment extends WithPlaceholder {
@@ -64,6 +80,7 @@ export interface CompoundPercentageSegment extends WithPlaceholder {
   decimalPlaces?: number
   tone?: CompoundTone
   size?: CompoundSize
+  weight?: CompoundWeight
 }
 
 export interface CompoundAmountSegment extends WithPlaceholder {
@@ -72,6 +89,7 @@ export interface CompoundAmountSegment extends WithPlaceholder {
   currency?: CurrencyDef
   tone?: CompoundTone
   size?: CompoundSize
+  weight?: CompoundWeight
 }
 
 export type CompoundSegment =
@@ -102,6 +120,13 @@ const toneClassByValue: Record<CompoundTone, string> = {
 const sizeClassByValue: Record<CompoundSize, string> = {
   md: "",
   sm: "text-sm",
+}
+
+const weightClassByValue: Record<CompoundWeight, string> = {
+  light: "font-light",
+  normal: "font-normal",
+  medium: "font-medium",
+  semibold: "font-semibold",
 }
 
 const resolveCompoundTextValue = (
@@ -313,6 +338,7 @@ export const CompoundCell = (
               className={cn(
                 toneClassByValue[tone],
                 sizeClassByValue[segment.size ?? "md"],
+                segment.weight && weightClassByValue[segment.weight],
                 resolvedSegment.kind === "formatted" &&
                   "inline-flex items-center gap-1"
               )}


### PR DESCRIPTION
## What

Adds an optional `size` to each `compound` cell segment. `size: "sm"` renders that segment one step down (`text-sm`) from the cell's base; it defaults to `"md"`, so every existing compound cell is unchanged.

```ts
{
  type: "compound",
  value: {
    separator: " ",
    segments: [
      { type: "text", value: "Junior" },
      { type: "text", value: "Backend Engineer", tone: "secondary", size: "sm" },
    ],
  },
}
```

## Why

`compound` could vary a segment's colour (`tone`) but not its type scale, so there was no way to subordinate one segment to the ones beside it — a name followed by smaller context, for instance. Job Catalog's flattened table search needs exactly that: the matched name at base size, its disambiguating ancestor smaller and in the secondary tone.

## Testing

- New unit test: a `sm` segment gets `text-sm`, an unset one does not.
- New story `NameWithSubordinateContext` (args-only).
- `pnpm lint` (0/0), `pnpm vitest run compound.test.tsx` (11 passing), `pnpm format`. `tsc` shows only the pre-existing `f0-core`-not-built env errors, none in `compound`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)