### PR TITLE
feat(F0ENPSButton): add experimental eNPS scale to Home

### DIFF
--- a/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.mdx
+++ b/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.mdx
@@ -69,6 +69,19 @@ on/off, visibility toggle).
 
 <Canvas of={F0ButtonToggleStories.Default} />
 
+### Colours
+
+`color` makes the toggle a member of a **coloured set**: it wears that colour
+when selected — fill, border and glyph — and stays a muted glyph when it isn't,
+so one choice out of several is readable at a glance. Without it the toggle uses
+F0's selected teal, like any other selected control.
+
+Reach for it only when the members of a set mean **different things** (a mood
+scale, a status picker). A lone toggle, or a group where every item is the same
+kind of thing, should stay on the default.
+
+<Canvas of={F0ButtonToggleStories.Colors} />
+
 ### Size Variants
 
 <Canvas of={F0ButtonToggleStories.Snapshot} />

--- a/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.mdx
+++ b/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.mdx
@@ -41,6 +41,9 @@ The F0ButtonToggle consists of:
    screen readers)
 4. **State Indicator**: Visual feedback showing current selected/unselected
    state
+5. **Tooltip** (optional): `tooltip` names the toggle on hover and on keyboard
+   focus, in place of the native browser one. A compact toggle shows no text of
+   its own, so this is where a glyph gets explained
 
 ### Interactive States
 
@@ -81,6 +84,9 @@ Available sizes:
 ### Content best practices
 
 - Labels should clearly describe the action or state
+- Reach for `tooltip` whenever the glyph alone would be a guess — it takes the
+  same string as the label, or a `{ label, description }` pair when the toggle
+  needs a line of explanation under its name
 - Use consistent icon metaphors that users understand
 - Provide immediate visual feedback when state changes
 - Ensure the purpose is clear from context

--- a/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.mdx
+++ b/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.mdx
@@ -87,6 +87,9 @@ Available sizes:
 - Reach for `tooltip` whenever the glyph alone would be a guess — it takes the
   same string as the label, or a `{ label, description }` pair when the toggle
   needs a line of explanation under its name
+- Add `instant` to that object when the tooltip is the **only** place the
+  toggle's name is written: it opens on 100ms instead of 700ms, because the
+  default wait is meant for a label that confirms text you can already read
 - Use consistent icon metaphors that users understand
 - Provide immediate visual feedback when state changes
 - Ensure the purpose is clear from context

--- a/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.stories.tsx
+++ b/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.stories.tsx
@@ -7,7 +7,11 @@ import { Microphone, MicrophoneNegative } from "@/icons/app"
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { withSkipA11y, withSnapshot } from "@/lib/storybook-utils/parameters"
 
-import { buttonToggleSizes, buttonToggleVariants } from "../"
+import {
+  buttonToggleColors,
+  buttonToggleSizes,
+  buttonToggleVariants,
+} from "../"
 import { F0ButtonToggle } from "../F0ButtonToggle"
 
 const meta = {
@@ -88,6 +92,17 @@ const meta = {
         },
       },
     },
+    color: {
+      control: "select",
+      options: [undefined, ...buttonToggleColors],
+      description:
+        "The colour the toggle wears when selected — for a set whose members mean different things. Muted glyph when unselected.",
+      table: {
+        type: {
+          summary: buttonToggleColors.join(" | "),
+        },
+      },
+    },
     ...dataTestIdArgs,
   },
 } satisfies Meta<typeof F0ButtonToggle>
@@ -116,6 +131,48 @@ export const WithDataTestId: Story = {
       canvas.getByTestId("my-test-button-toggle")
     ).toBeInTheDocument()
   },
+}
+
+export const Colors: Story = {
+  args: {
+    label: "Toggle me",
+    icon: Microphone,
+  },
+  parameters: {
+    ...withSnapshot({}),
+    docs: {
+      description: {
+        story:
+          "`color` makes the toggle a member of a coloured set: it wears the " +
+          "colour when selected and stays a muted glyph when it isn't. For a set " +
+          "whose members mean different things — a mood scale, a status picker — " +
+          "not for a lone toggle.",
+      },
+    },
+  },
+  render: () => (
+    <div className="flex flex-col gap-4">
+      {buttonToggleColors.map((color) => (
+        <div key={color} className="flex items-center gap-3">
+          <F0ButtonToggle
+            label={color}
+            icon={Microphone}
+            color={color}
+            selected
+            onSelectedChange={() => {}}
+          />
+          <F0ButtonToggle
+            label={color}
+            icon={Microphone}
+            color={color}
+            selected={false}
+            onSelectedChange={() => {}}
+          />
+          <span className="text-f1-foreground-secondary">{color}</span>
+        </div>
+      ))}
+    </div>
+  ),
 }
 
 export const WithTooltip: Story = {

--- a/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.stories.tsx
+++ b/packages/react/src/components/F0ButtonToggle/__stories__/F0ButtonToggle.stories.tsx
@@ -118,6 +118,24 @@ export const WithDataTestId: Story = {
   },
 }
 
+export const WithTooltip: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A compact toggle shows no text of its own, so `tooltip` is what says " +
+          "what it does. It replaces the native browser tooltip, and the object " +
+          "form adds a line of explanation under the name.",
+      },
+    },
+  },
+  args: {
+    label: ["Unmute", "Mute"],
+    icon: [MicrophoneNegative, Microphone],
+    tooltip: { label: "Microphone", description: "Nobody will hear you" },
+  },
+}
+
 export const SingleIcon: Story = {
   args: {
     label: "Single Icon Toggle",

--- a/packages/react/src/components/F0ButtonToggle/__tests__/F0ButtonToggle.tooltip.test.tsx
+++ b/packages/react/src/components/F0ButtonToggle/__tests__/F0ButtonToggle.tooltip.test.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
+
+import { F0ButtonToggle } from "../F0ButtonToggle"
+
+const MockIcon = React.forwardRef<SVGSVGElement>((props, ref) => (
+  <svg ref={ref} {...props} data-testid="mock-icon">
+    <title>Mock Icon</title>
+  </svg>
+))
+MockIcon.displayName = "MockIcon"
+
+describe("F0ButtonToggle tooltip", () => {
+  it("has no tooltip and keeps the native title by default", () => {
+    zeroRender(<F0ButtonToggle label="Mute" icon={MockIcon} />)
+
+    expect(screen.getByRole("button")).toHaveAttribute("title", "Mute")
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument()
+  })
+
+  it("shows the tooltip on hover and drops the native title, so only one bubble opens", async () => {
+    zeroRender(
+      <F0ButtonToggle label="Mute" icon={MockIcon} tooltip="Mute the room" />
+    )
+
+    const button = screen.getByRole("button", { name: "Mute" })
+    expect(button).not.toHaveAttribute("title")
+
+    await userEvent.hover(button)
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Mute the room")
+    })
+  })
+
+  it("takes the label/description form", async () => {
+    zeroRender(
+      <F0ButtonToggle
+        label="Mute"
+        icon={MockIcon}
+        tooltip={{ label: "Mute", description: "Nobody will hear you" }}
+      />
+    )
+
+    await userEvent.hover(screen.getByRole("button"))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent(
+        "Nobody will hear you"
+      )
+    })
+  })
+
+  it("keeps the pressed state on data-state, which the tooltip trigger would otherwise overwrite", () => {
+    zeroRender(
+      <F0ButtonToggle
+        label="Mute"
+        icon={MockIcon}
+        tooltip="Mute the room"
+        selected
+        onSelectedChange={() => {}}
+      />
+    )
+
+    const button = screen.getByRole("button")
+    expect(button).toHaveAttribute("data-state", "on")
+    expect(button).toHaveAttribute("aria-pressed", "true")
+  })
+})

--- a/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
+++ b/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from "motion/react"
 import { forwardRef, useMemo, useState } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
+import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
 import { cn, focusRing } from "@/lib/utils"
 import { actionVariants, buttonSizeVariants } from "@/ui/Action/variants"
 
@@ -73,6 +74,7 @@ export const F0ButtonToggleInternal = forwardRef<
       icon,
       size = "md",
       variant = "compact",
+      tooltip,
       withBorder = false,
       className: externalClassName,
       defaultSelected = false,
@@ -122,7 +124,15 @@ export const F0ButtonToggleInternal = forwardRef<
       return size
     }, [size, variant])
 
-    return (
+    // Same shape `Action` accepts: a bare string is the description on its own.
+    const tooltipProps =
+      typeof tooltip === "object"
+        ? tooltip
+        : tooltip
+          ? { description: tooltip }
+          : undefined
+
+    const root = (
       <TogglePrimitive.Root
         ref={ref}
         pressed={state.selected}
@@ -145,6 +155,11 @@ export const F0ButtonToggleInternal = forwardRef<
           externalClassName
         )}
         {...props}
+        // Deliberately after the spread: when a tooltip wraps this button, Radix
+        // hands the trigger's own open/closed `data-state` down through
+        // `asChild`, which would otherwise overwrite the pressed state that
+        // consumers and tests read off the button.
+        data-state={state.selected ? "on" : "off"}
       >
         <AnimatePresence initial={false}>
           <div className="main relative flex flex-col items-center justify-center">
@@ -182,6 +197,14 @@ export const F0ButtonToggleInternal = forwardRef<
         )}
       </TogglePrimitive.Root>
     )
+
+    if (!tooltipProps) {
+      return root
+    }
+
+    // `TooltipInternal` strips the native `title` off the button so the browser
+    // doesn't draw its own bubble next to this one; `aria-label` keeps the name.
+    return <TooltipInternal {...tooltipProps}>{root}</TooltipInternal>
   }
 )
 

--- a/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
+++ b/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
@@ -8,6 +8,7 @@ import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
 import { cn, focusRing } from "@/lib/utils"
 import { actionVariants, buttonSizeVariants } from "@/ui/Action/variants"
 
+import { ButtonToggleColor } from "../types"
 import { F0ButtonToggleInternalProps } from "./types.internal"
 
 const buttonToggleVariants = cva({
@@ -51,6 +52,82 @@ const buttonToggleVariants = cva({
   defaultVariants: { size: "md", variant: "compact" },
 })
 
+/**
+ * What `color` looks like once the toggle is SELECTED: the colour's own fill and
+ * glyph, over a border strong enough to hold the row when several coloured
+ * toggles sit side by side. The fill follows `f1-background-selected` (0.1, 0.2
+ * under the pointer) so a coloured answer sits at the weight F0 gives any
+ * selected control; the border goes to 0.6, where `f1-border-selected` sits at
+ * 0.4, because here it has to separate one answer from its neighbours.
+ *
+ * Written out per colour because Tailwind only generates the utilities it can
+ * see as literal strings — the classes can't be composed from the token name.
+ */
+const selectedColorClasses: Record<ButtonToggleColor, string> = {
+  accent: cn(
+    "bg-[hsl(var(--accent-50)/0.1)] hover:bg-[hsl(var(--accent-50)/0.2)]",
+    "border-[hsl(var(--accent-50)/0.6)]",
+    "text-f1-icon-accent hover:text-f1-icon-accent"
+  ),
+  critical: cn(
+    "bg-[hsl(var(--critical-50)/0.1)] hover:bg-[hsl(var(--critical-50)/0.2)]",
+    "border-[hsl(var(--critical-50)/0.6)]",
+    "text-f1-icon-critical hover:text-f1-icon-critical"
+  ),
+  warning: cn(
+    "bg-[hsl(var(--warning-50)/0.1)] hover:bg-[hsl(var(--warning-50)/0.2)]",
+    "border-[hsl(var(--warning-50)/0.6)]",
+    "text-f1-icon-warning hover:text-f1-icon-warning"
+  ),
+  promote: cn(
+    "bg-[hsl(var(--promote-50)/0.1)] hover:bg-[hsl(var(--promote-50)/0.2)]",
+    "border-[hsl(var(--promote-50)/0.6)]",
+    "text-f1-icon-promote hover:text-f1-icon-promote"
+  ),
+  info: cn(
+    "bg-[hsl(var(--info-50)/0.1)] hover:bg-[hsl(var(--info-50)/0.2)]",
+    "border-[hsl(var(--info-50)/0.6)]",
+    "text-f1-icon-info hover:text-f1-icon-info"
+  ),
+  positive: cn(
+    "bg-[hsl(var(--positive-50)/0.1)] hover:bg-[hsl(var(--positive-50)/0.2)]",
+    "border-[hsl(var(--positive-50)/0.6)]",
+    "text-f1-icon-positive hover:text-f1-icon-positive"
+  ),
+  "mood-super-negative": cn(
+    "bg-[hsl(var(--mood-super-negative)/0.1)] hover:bg-[hsl(var(--mood-super-negative)/0.2)]",
+    "border-[hsl(var(--mood-super-negative)/0.6)]",
+    "text-f1-icon-mood-super-negative hover:text-f1-icon-mood-super-negative"
+  ),
+  "mood-negative": cn(
+    "bg-[hsl(var(--mood-negative)/0.1)] hover:bg-[hsl(var(--mood-negative)/0.2)]",
+    "border-[hsl(var(--mood-negative)/0.6)]",
+    "text-f1-icon-mood-negative hover:text-f1-icon-mood-negative"
+  ),
+  "mood-neutral": cn(
+    "bg-[hsl(var(--mood-neutral)/0.1)] hover:bg-[hsl(var(--mood-neutral)/0.2)]",
+    "border-[hsl(var(--mood-neutral)/0.6)]",
+    "text-f1-icon-mood-neutral hover:text-f1-icon-mood-neutral"
+  ),
+  "mood-positive": cn(
+    "bg-[hsl(var(--mood-positive)/0.1)] hover:bg-[hsl(var(--mood-positive)/0.2)]",
+    "border-[hsl(var(--mood-positive)/0.6)]",
+    "text-f1-icon-mood-positive hover:text-f1-icon-mood-positive"
+  ),
+  "mood-super-positive": cn(
+    "bg-[hsl(var(--mood-super-positive)/0.1)] hover:bg-[hsl(var(--mood-super-positive)/0.2)]",
+    "border-[hsl(var(--mood-super-positive)/0.6)]",
+    "text-f1-icon-mood-super-positive hover:text-f1-icon-mood-super-positive"
+  ),
+}
+
+/**
+ * And what it looks like UNSELECTED: a muted glyph rather than the default
+ * near-black one. A coloured toggle only speaks up once it is chosen — five
+ * coloured glyphs at once would be decoration, not an answer.
+ */
+const unselectedColorClasses = "text-f1-icon"
+
 const labelSizeVariants = cva({
   variants: {
     size: {
@@ -75,6 +152,7 @@ export const F0ButtonToggleInternal = forwardRef<
       size = "md",
       variant = "compact",
       tooltip,
+      color,
       withBorder = false,
       className: externalClassName,
       defaultSelected = false,
@@ -152,6 +230,12 @@ export const F0ButtonToggleInternal = forwardRef<
             withBorder,
             selected: state.selected,
           }),
+          // After the variants, whose selected teal it replaces; before the
+          // consumer's own class, which still has the last word.
+          color &&
+            (state.selected
+              ? selectedColorClasses[color]
+              : unselectedColorClasses),
           externalClassName
         )}
         {...props}

--- a/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
+++ b/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
@@ -38,8 +38,13 @@ export type F0ButtonToggleInternalProps = {
    * says out loud what it does. Setting it drops the native `title` (the
    * browser would otherwise draw its own bubble beside this one) and keeps the
    * accessible name.
+   *
+   * `instant` opens it on 100ms instead of the default 700ms. Reach for it when
+   * the tooltip is the ONLY place the toggle's name is written — the default
+   * wait is for a label that merely confirms what you can already read, and on
+   * a bare glyph it withholds the whole thing.
    */
-  tooltip?: string | { label?: string; description: string }
+  tooltip?: string | { label?: string; description: string; instant?: boolean }
 
   /**
    * @private

--- a/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
+++ b/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
@@ -1,6 +1,10 @@
 import { IconType } from "@/components/F0Icon"
 
-import { ButtonToggleSize, ButtonToggleVariant } from "../types"
+import {
+  ButtonToggleColor,
+  ButtonToggleSize,
+  ButtonToggleVariant,
+} from "../types"
 
 export type F0ButtonToggleInternalProps = {
   /**
@@ -45,6 +49,18 @@ export type F0ButtonToggleInternalProps = {
    * a bare glyph it withholds the whole thing.
    */
   tooltip?: string | { label?: string; description: string; instant?: boolean }
+
+  /**
+   * Makes the toggle a member of a COLOURED SET: it wears this colour when
+   * selected — fill, border and glyph — and stays a muted glyph when it isn't,
+   * so one answer out of several is readable at a glance. Without it the toggle
+   * uses F0's selected teal, like any other selected control.
+   *
+   * Only for a set whose members mean different things (a mood scale, a status
+   * picker). A lone toggle, or a group where every item is the same kind of
+   * thing, should stay on the default.
+   */
+  color?: ButtonToggleColor
 
   /**
    * @private

--- a/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
+++ b/packages/react/src/components/F0ButtonToggle/internal/types.internal.ts
@@ -30,6 +30,18 @@ export type F0ButtonToggleInternalProps = {
   variant?: ButtonToggleVariant
 
   /**
+   * Tooltip shown on hover and on keyboard focus. A string is the description
+   * on its own; the object form adds a bold first line above it — the same
+   * shape `Action` takes.
+   *
+   * A compact toggle is a glyph with no visible text, so the tooltip is what
+   * says out loud what it does. Setting it drops the native `title` (the
+   * browser would otherwise draw its own bubble beside this one) and keeps the
+   * accessible name.
+   */
+  tooltip?: string | { label?: string; description: string }
+
+  /**
    * @private
    * Whether to show a border around the button toggle.
    */

--- a/packages/react/src/components/F0ButtonToggle/types.ts
+++ b/packages/react/src/components/F0ButtonToggle/types.ts
@@ -3,3 +3,24 @@ export type ButtonToggleSize = (typeof buttonToggleSizes)[number]
 
 export const buttonToggleVariants = ["compact", "expanded"] as const
 export type ButtonToggleVariant = (typeof buttonToggleVariants)[number]
+
+/**
+ * The colours a toggle can wear when selected, beyond F0's own selected teal.
+ * Each one is an F0 semantic colour — the six statuses, then the five points of
+ * the mood scale — so a coloured toggle carries the same meaning here as the
+ * same colour does anywhere else in the product.
+ */
+export const buttonToggleColors = [
+  "accent",
+  "critical",
+  "warning",
+  "promote",
+  "info",
+  "positive",
+  "mood-super-negative",
+  "mood-negative",
+  "mood-neutral",
+  "mood-positive",
+  "mood-super-positive",
+] as const
+export type ButtonToggleColor = (typeof buttonToggleColors)[number]

--- a/packages/react/src/components/F0ButtonToggleGroup/F0ButtonToggleGroup.tsx
+++ b/packages/react/src/components/F0ButtonToggleGroup/F0ButtonToggleGroup.tsx
@@ -88,7 +88,7 @@ export const F0ButtonToggleGroup = (props: F0ButtonToggleGroupProps) => {
             size={size}
             withBorder={withBorder}
             variant={variant}
-            className={cn(fullWidth && "w-full")}
+            className={cn(fullWidth && "w-full", item.className)}
             selected={!!selectedValues?.includes(item.value)}
             // Intentionally pass a no-op function to satisfy type requirements.
             // The group manages selection state in a controlled manner.

--- a/packages/react/src/components/F0ButtonToggleGroup/__stories__/F0ButtonToggleGroup.stories.tsx
+++ b/packages/react/src/components/F0ButtonToggleGroup/__stories__/F0ButtonToggleGroup.stories.tsx
@@ -144,6 +144,30 @@ export const Default: Story = {
   args: defaultArgs,
 }
 
+export const WithTooltips: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An item's `tooltip` names it on hover and on keyboard focus — worth " +
+          "setting on a compact group, where every item is a glyph on its own.",
+      },
+    },
+  },
+  args: {
+    ...defaultArgs,
+    items: [
+      { label: "Archive", icon: Archive, value: "archive", tooltip: "Archive" },
+      {
+        label: "Delete",
+        icon: Delete,
+        value: "delete",
+        tooltip: { label: "Delete", description: "This can't be undone" },
+      },
+    ],
+  },
+}
+
 export const Single: Story = {
   args: {
     ...defaultArgs,

--- a/packages/react/src/components/F0ButtonToggleGroup/__tests__/F0ButtonToggleGroup.items.test.tsx
+++ b/packages/react/src/components/F0ButtonToggleGroup/__tests__/F0ButtonToggleGroup.items.test.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { describe, expect, it } from "vitest"
+
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
+
+import { F0ButtonToggleGroup } from "../F0ButtonToggleGroup"
+
+const MockIcon = React.forwardRef<SVGSVGElement>((props, ref) => (
+  <svg ref={ref} {...props}>
+    <title>Mock Icon</title>
+  </svg>
+))
+MockIcon.displayName = "MockIcon"
+
+const items = [
+  {
+    value: "keep",
+    label: "Keep",
+    icon: MockIcon,
+    tooltip: "Keep this file",
+    className: "text-f1-icon-positive",
+  },
+  { value: "drop", label: "Drop", icon: MockIcon },
+]
+
+describe("F0ButtonToggleGroup per-item options", () => {
+  it("puts a per-item tooltip on its own button", async () => {
+    zeroRender(<F0ButtonToggleGroup items={items} value="keep" />)
+
+    await userEvent.hover(screen.getByRole("radio", { name: "Keep" }))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Keep this file")
+    })
+
+    // The item without a tooltip keeps the plain native title.
+    expect(screen.getByRole("radio", { name: "Drop" })).toHaveAttribute(
+      "title",
+      "Drop"
+    )
+  })
+
+  it("applies a per-item className without dropping the group's own", () => {
+    zeroRender(<F0ButtonToggleGroup items={items} value="keep" fullWidth />)
+
+    const keep = screen.getByRole("radio", { name: "Keep" })
+    expect(keep).toHaveClass("text-f1-icon-positive")
+    expect(keep).toHaveClass("w-full")
+  })
+
+  it("keeps the selected item's data-state when it also has a tooltip", () => {
+    zeroRender(<F0ButtonToggleGroup items={items} value="keep" />)
+
+    expect(screen.getByRole("radio", { name: "Keep" })).toHaveAttribute(
+      "data-state",
+      "on"
+    )
+  })
+})

--- a/packages/react/src/components/F0ButtonToggleGroup/__tests__/F0ButtonToggleGroup.items.test.tsx
+++ b/packages/react/src/components/F0ButtonToggleGroup/__tests__/F0ButtonToggleGroup.items.test.tsx
@@ -18,9 +18,10 @@ const items = [
     label: "Keep",
     icon: MockIcon,
     tooltip: "Keep this file",
-    className: "text-f1-icon-positive",
+    color: "positive" as const,
+    className: "[&_svg]:w-7",
   },
-  { value: "drop", label: "Drop", icon: MockIcon },
+  { value: "drop", label: "Drop", icon: MockIcon, color: "critical" as const },
 ]
 
 describe("F0ButtonToggleGroup per-item options", () => {
@@ -44,8 +45,23 @@ describe("F0ButtonToggleGroup per-item options", () => {
     zeroRender(<F0ButtonToggleGroup items={items} value="keep" fullWidth />)
 
     const keep = screen.getByRole("radio", { name: "Keep" })
-    expect(keep).toHaveClass("text-f1-icon-positive")
+    expect(keep).toHaveClass("[&_svg]:w-7")
     expect(keep).toHaveClass("w-full")
+  })
+
+  /**
+   * A per-item `color` is what makes a group of items that mean different things
+   * readable: the selected one wears its colour, the rest stay muted.
+   */
+  it("gives each item its own colour, and only once selected", () => {
+    zeroRender(<F0ButtonToggleGroup items={items} value="keep" />)
+
+    expect(screen.getByRole("radio", { name: "Keep" })).toHaveClass(
+      "text-f1-icon-positive"
+    )
+    const drop = screen.getByRole("radio", { name: "Drop" })
+    expect(drop).not.toHaveClass("text-f1-icon-critical")
+    expect(drop).toHaveClass("text-f1-icon")
   })
 
   it("keeps the selected item's data-state when it also has a tooltip", () => {

--- a/packages/react/src/components/F0ButtonToggleGroup/types.ts
+++ b/packages/react/src/components/F0ButtonToggleGroup/types.ts
@@ -2,7 +2,7 @@ import { ButtonToggleVariant, F0ButtonToggleProps } from "../F0ButtonToggle"
 
 export type F0ButtonToggleGroupItem = Pick<
   F0ButtonToggleProps,
-  "label" | "icon" | "disabled"
+  "label" | "icon" | "disabled" | "tooltip" | "className"
 > & {
   value: string
 }

--- a/packages/react/src/components/F0ButtonToggleGroup/types.ts
+++ b/packages/react/src/components/F0ButtonToggleGroup/types.ts
@@ -2,7 +2,7 @@ import { ButtonToggleVariant, F0ButtonToggleProps } from "../F0ButtonToggle"
 
 export type F0ButtonToggleGroupItem = Pick<
   F0ButtonToggleProps,
-  "label" | "icon" | "disabled" | "tooltip" | "className"
+  "label" | "icon" | "disabled" | "tooltip" | "color" | "className"
 > & {
   value: string
 }

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -71,6 +71,7 @@ export * from "./Overlays/exports"
 export * from "../components/RichText/exports"
 export * from "../components/F0FileItem"
 export * from "../sds/chat/F0Chat"
+export * from "../sds/Home/F0ENPSButton"
 export * from "./Utilities/exports"
 export * from "./Widgets/exports"
 /**

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -1003,6 +1003,20 @@ export const defaultTranslations = {
     /** Why a drop onto a pinned widget was refused. `{{title}}` is its name. */
     cannotMoveHere: "You can't move a widget here — {{title}} is locked.",
   },
+  enps: {
+    /**
+     * The five points of the eNPS scale, worst to best. Each one names a face
+     * that carries no text of its own: it is the button's accessible name and
+     * its tooltip, so it has to read as an answer ("Very bad"), not a number.
+     */
+    scale: {
+      superNegative: "Very bad",
+      negative: "Bad",
+      neutral: "Okay",
+      positive: "Good",
+      superPositive: "Very good",
+    },
+  },
   pdfViewer: {
     toolbar: "Document toolbar",
     previousPage: "Previous page",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -1003,20 +1003,6 @@ export const defaultTranslations = {
     /** Why a drop onto a pinned widget was refused. `{{title}}` is its name. */
     cannotMoveHere: "You can't move a widget here — {{title}} is locked.",
   },
-  enps: {
-    /**
-     * The five points of the eNPS scale, worst to best. Each one names a face
-     * that carries no text of its own: it is the button's accessible name and
-     * its tooltip, so it has to read as an answer ("Very bad"), not a number.
-     */
-    scale: {
-      superNegative: "Very bad",
-      negative: "Bad",
-      neutral: "Okay",
-      positive: "Good",
-      superPositive: "Very good",
-    },
-  },
   pdfViewer: {
     toolbar: "Document toolbar",
     previousPage: "Previous page",

--- a/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
@@ -1,59 +1,29 @@
 import { useEffect, useMemo, useState } from "react"
 
+import { type ButtonToggleColor } from "@/components/F0ButtonToggle"
 import {
   type ButtonToggleGroupSize,
   F0ButtonToggleGroup,
   type F0ButtonToggleGroupItem,
 } from "@/components/F0ButtonToggleGroup"
 import { pulseIcon, pulses, type Pulse } from "@/lib/mood"
-import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
 import type { F0ENPSButtonProps } from "./types"
 
 /**
- * The answered face takes the colour of the mood it stands for, so the scale
- * reads as a scale: the answer is recognisable from across the page, before any
- * of the copy is. Every other face stays neutral — five coloured faces at once
- * would be decoration, not an answer.
- *
- * The classes are written out per mood rather than composed from the token name
- * because Tailwind only generates the utilities it can see as literal strings.
- * The fill follows `f1-background-selected` (0.1, and 0.2 under the pointer) so a
- * mood answer sits at the same weight as any other selected control in F0. The
- * border goes heavier than `f1-border-selected`, at 0.6: five bordered faces sit
- * side by side here, and at 0.4 the answered one didn't win the row.
+ * Each face answers in the colour of the mood it stands for, so the scale reads
+ * as a scale: the answer is recognisable from across the page, before any of the
+ * copy is. `F0ButtonToggle` owns what a colour looks like — the fill, the border
+ * and the glyph, and the muted glyph on the faces not chosen.
  */
-const selectedAccent: Record<Pulse, string> = {
-  superNegative: cn(
-    "bg-[hsl(var(--mood-super-negative)/0.1)] hover:bg-[hsl(var(--mood-super-negative)/0.2)]",
-    "border-[hsl(var(--mood-super-negative)/0.6)]",
-    "text-f1-icon-mood-super-negative hover:text-f1-icon-mood-super-negative"
-  ),
-  negative: cn(
-    "bg-[hsl(var(--mood-negative)/0.1)] hover:bg-[hsl(var(--mood-negative)/0.2)]",
-    "border-[hsl(var(--mood-negative)/0.6)]",
-    "text-f1-icon-mood-negative hover:text-f1-icon-mood-negative"
-  ),
-  neutral: cn(
-    "bg-[hsl(var(--mood-neutral)/0.1)] hover:bg-[hsl(var(--mood-neutral)/0.2)]",
-    "border-[hsl(var(--mood-neutral)/0.6)]",
-    "text-f1-icon-mood-neutral hover:text-f1-icon-mood-neutral"
-  ),
-  positive: cn(
-    "bg-[hsl(var(--mood-positive)/0.1)] hover:bg-[hsl(var(--mood-positive)/0.2)]",
-    "border-[hsl(var(--mood-positive)/0.6)]",
-    "text-f1-icon-mood-positive hover:text-f1-icon-mood-positive"
-  ),
-  superPositive: cn(
-    "bg-[hsl(var(--mood-super-positive)/0.1)] hover:bg-[hsl(var(--mood-super-positive)/0.2)]",
-    "border-[hsl(var(--mood-super-positive)/0.6)]",
-    "text-f1-icon-mood-super-positive hover:text-f1-icon-mood-super-positive"
-  ),
+const moodColor: Record<Pulse, ButtonToggleColor> = {
+  superNegative: "mood-super-negative",
+  negative: "mood-negative",
+  neutral: "mood-neutral",
+  positive: "mood-positive",
+  superPositive: "mood-super-positive",
 }
-
-/** An unanswered face is a muted glyph, not a heading. */
-const unansweredFace = "text-f1-icon"
 
 /**
  * The face IS the control here — there is no label beside it to carry the
@@ -83,8 +53,6 @@ export const F0ENPSButton = ({
   disabled = false,
   required = false,
 }: F0ENPSButtonProps) => {
-  const i18n = useI18n()
-
   /**
    * Mirrors `value` so the accent follows the press even when the consumer
    * doesn't feed the answer back — the group keeps its own selection either way,
@@ -98,25 +66,20 @@ export const F0ENPSButton = ({
 
   const items = useMemo(
     () =>
-      pulses.map((pulse): F0ButtonToggleGroupItem => {
-        const label = labels?.[pulse] ?? i18n.enps.scale[pulse]
-
-        return {
+      pulses.map(
+        (pulse): F0ButtonToggleGroupItem => ({
           value: pulse,
           icon: icons?.[pulse] ?? pulseIcon[pulse],
-          label,
+          label: labels[pulse],
+          color: moodColor[pulse],
           // `instant`: the face is the whole control and this tooltip is the
           // only place its name is written, so a 700ms wait withholds the scale
           // from someone reading along it — the same call the Home rail makes.
-          tooltip: { description: label, instant: true },
-          className: cn(
-            unansweredFace,
-            faceSize[size],
-            answer === pulse && selectedAccent[pulse]
-          ),
-        }
-      }),
-    [answer, labels, icons, size, i18n]
+          tooltip: { description: labels[pulse], instant: true },
+          className: cn(faceSize[size]),
+        })
+      ),
+    [labels, icons, size]
   )
 
   const handleChange = (next: string) => {

--- a/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react"
 
 import {
+  type ButtonToggleGroupSize,
   F0ButtonToggleGroup,
   type F0ButtonToggleGroupItem,
 } from "@/components/F0ButtonToggleGroup"
@@ -54,6 +55,21 @@ const selectedAccent: Record<Pulse, string> = {
 /** An unanswered face is a muted glyph, not a heading. */
 const unansweredFace = "text-f1-icon"
 
+/**
+ * The face IS the control here — there is no label beside it to carry the
+ * meaning — so it takes as much of the button as the geometry allows: one step
+ * up from the icon size `F0ButtonToggle` derives from the button height, leaving
+ * 4px of room around it (6px at `lg`). `sm` is already at that limit and stays.
+ *
+ * Set on the svg rather than through `F0Icon`'s `size`, whose scale stops at
+ * `lg`/24px — the same way `F0AvatarModule` sizes its own glyph past the scale.
+ */
+const faceSize: Record<ButtonToggleGroupSize, string> = {
+  sm: "[&_svg]:w-4",
+  md: "[&_svg]:w-6",
+  lg: "[&_svg]:w-7",
+}
+
 const isPulse = (value: string): value is Pulse =>
   (pulses as readonly string[]).includes(value)
 
@@ -61,6 +77,7 @@ export const F0ENPSButton = ({
   value,
   onChange,
   labels,
+  icons,
   size = "lg",
   fullWidth = true,
   disabled = false,
@@ -86,7 +103,7 @@ export const F0ENPSButton = ({
 
         return {
           value: pulse,
-          icon: pulseIcon[pulse],
+          icon: icons?.[pulse] ?? pulseIcon[pulse],
           label,
           // `instant`: the face is the whole control and this tooltip is the
           // only place its name is written, so a 700ms wait withholds the scale
@@ -94,11 +111,12 @@ export const F0ENPSButton = ({
           tooltip: { description: label, instant: true },
           className: cn(
             unansweredFace,
+            faceSize[size],
             answer === pulse && selectedAccent[pulse]
           ),
         }
       }),
-    [answer, labels, i18n]
+    [answer, labels, icons, size, i18n]
   )
 
   const handleChange = (next: string) => {

--- a/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from "react"
+
+import {
+  F0ButtonToggleGroup,
+  type F0ButtonToggleGroupItem,
+} from "@/components/F0ButtonToggleGroup"
+import { pulseIcon, pulses, type Pulse } from "@/lib/mood"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+
+import type { F0ENPSButtonProps } from "./types"
+
+/**
+ * The answered face takes the colour of the mood it stands for, so the scale
+ * reads as a scale: the answer is recognisable from across the page, before any
+ * of the copy is. Every other face stays neutral — five coloured faces at once
+ * would be decoration, not an answer.
+ *
+ * The classes are written out per mood rather than composed from the token name
+ * because Tailwind only generates the utilities it can see as literal strings.
+ * The fill follows `f1-background-selected` (0.1, and 0.2 under the pointer) so a
+ * mood answer sits at the same weight as any other selected control in F0. The
+ * border goes heavier than `f1-border-selected`, at 0.6: five bordered faces sit
+ * side by side here, and at 0.4 the answered one didn't win the row.
+ */
+const selectedAccent: Record<Pulse, string> = {
+  superNegative: cn(
+    "bg-[hsl(var(--mood-super-negative)/0.1)] hover:bg-[hsl(var(--mood-super-negative)/0.2)]",
+    "border-[hsl(var(--mood-super-negative)/0.6)]",
+    "text-f1-icon-mood-super-negative hover:text-f1-icon-mood-super-negative"
+  ),
+  negative: cn(
+    "bg-[hsl(var(--mood-negative)/0.1)] hover:bg-[hsl(var(--mood-negative)/0.2)]",
+    "border-[hsl(var(--mood-negative)/0.6)]",
+    "text-f1-icon-mood-negative hover:text-f1-icon-mood-negative"
+  ),
+  neutral: cn(
+    "bg-[hsl(var(--mood-neutral)/0.1)] hover:bg-[hsl(var(--mood-neutral)/0.2)]",
+    "border-[hsl(var(--mood-neutral)/0.6)]",
+    "text-f1-icon-mood-neutral hover:text-f1-icon-mood-neutral"
+  ),
+  positive: cn(
+    "bg-[hsl(var(--mood-positive)/0.1)] hover:bg-[hsl(var(--mood-positive)/0.2)]",
+    "border-[hsl(var(--mood-positive)/0.6)]",
+    "text-f1-icon-mood-positive hover:text-f1-icon-mood-positive"
+  ),
+  superPositive: cn(
+    "bg-[hsl(var(--mood-super-positive)/0.1)] hover:bg-[hsl(var(--mood-super-positive)/0.2)]",
+    "border-[hsl(var(--mood-super-positive)/0.6)]",
+    "text-f1-icon-mood-super-positive hover:text-f1-icon-mood-super-positive"
+  ),
+}
+
+/** An unanswered face is a muted glyph, not a heading. */
+const unansweredFace = "text-f1-icon"
+
+const isPulse = (value: string): value is Pulse =>
+  (pulses as readonly string[]).includes(value)
+
+export const F0ENPSButton = ({
+  value,
+  onChange,
+  labels,
+  size = "lg",
+  fullWidth = true,
+  disabled = false,
+  required = false,
+}: F0ENPSButtonProps) => {
+  const i18n = useI18n()
+
+  /**
+   * Mirrors `value` so the accent follows the press even when the consumer
+   * doesn't feed the answer back — the group keeps its own selection either way,
+   * and a selected face without its colour would read as a rendering bug.
+   */
+  const [answer, setAnswer] = useState(value)
+
+  useEffect(() => {
+    setAnswer(value)
+  }, [value])
+
+  const items = useMemo(
+    () =>
+      pulses.map((pulse): F0ButtonToggleGroupItem => {
+        const label = labels?.[pulse] ?? i18n.enps.scale[pulse]
+
+        return {
+          value: pulse,
+          icon: pulseIcon[pulse],
+          label,
+          tooltip: label,
+          className: cn(
+            unansweredFace,
+            answer === pulse && selectedAccent[pulse]
+          ),
+        }
+      }),
+    [answer, labels, i18n]
+  )
+
+  const handleChange = (next: string) => {
+    const nextAnswer = isPulse(next) ? next : undefined
+
+    // The group replays its current selection once on mount; only a real change
+    // is an answer.
+    if (nextAnswer === answer) {
+      return
+    }
+
+    setAnswer(nextAnswer)
+    onChange?.(nextAnswer)
+  }
+
+  return (
+    <F0ButtonToggleGroup
+      items={items}
+      value={answer ?? ""}
+      onChange={handleChange}
+      size={size}
+      fullWidth={fullWidth}
+      disabled={disabled}
+      required={required}
+    />
+  )
+}
+
+F0ENPSButton.displayName = "F0ENPSButton"

--- a/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
@@ -88,7 +88,10 @@ export const F0ENPSButton = ({
           value: pulse,
           icon: pulseIcon[pulse],
           label,
-          tooltip: label,
+          // `instant`: the face is the whole control and this tooltip is the
+          // only place its name is written, so a 700ms wait withholds the scale
+          // from someone reading along it — the same call the Home rail makes.
+          tooltip: { description: label, instant: true },
           className: cn(
             unansweredFace,
             answer === pulse && selectedAccent[pulse]

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
@@ -24,22 +24,24 @@ already been given.
 <Controls of={Stories.Default} />
 
 Five faces from `pulses`, in scale order, drawn by `F0ButtonToggleGroup` as one
-single-select group. A face carries no text: its `label` is the accessible name
-**and** the tooltip, so it has to read as the answer being given ("Very bad"),
-never as a number or a position. The default copy comes from `i18n.enps.scale`;
-`labels` replaces it for one face or all five, and `icons` does the same for the
-glyphs when the question isn't about mood.
+single-select group.
+
+`labels` is required, and required in full: a face carries no text, so its label
+is the accessible name **and** the tooltip, and it has to read as the answer
+being given ("Very bad"), never as a number or a position. The component holds no
+copy of its own — the wording belongs to the question, so pass it already
+translated. `icons` is the same override for the glyphs, and defaults to the mood
+faces.
 
 The face is sized past `F0Icon`'s scale — 28px at `lg`, 24px at `md` — because
 it **is** the control: there is no label beside it to carry the meaning, so it
 takes the button, leaving 4px of room around it (6px at `lg`).
 
-Only the answered face is coloured, and it takes its own mood
-(`--mood-super-negative` through `--mood-super-positive`): a 0.1 fill, the same
-weight F0 gives any selected control, over a heavier 0.6 border — five bordered
-faces sit side by side, so the answered one needs to win the row. Five coloured
-faces at once would be decoration; one coloured face is an answer you can read
-from across the page.
+Only the answered face is coloured, through `F0ButtonToggle`'s `color`: each face
+asks for its own mood (`mood-super-negative` through `mood-super-positive`) and
+the toggle draws what that colour means — a 0.1 fill, a 0.6 border, the glyph,
+and a muted glyph on the faces not chosen. Five coloured faces at once would be
+decoration; one coloured face is an answer you can read from across the page.
 
 <Canvas of={Stories.Answered} />
 
@@ -79,7 +81,16 @@ from across the page.
     children: (
       <I18nProvider translations={defaultTranslations}>
         <div className="w-[360px]">
-          <F0ENPSButton value="positive" />
+          <F0ENPSButton
+            value="positive"
+            labels={{
+              superNegative: "Very bad",
+              negative: "Bad",
+              neutral: "Okay",
+              positive: "Good",
+              superPositive: "Very good",
+            }}
+          />
         </div>
       </I18nProvider>
     ),
@@ -115,7 +126,7 @@ from across the page.
 
 A recommendation question brings its own wording:
 
-<Canvas of={Stories.CustomLabels} />
+<Canvas of={Stories.Recommendation} />
 
 And a question that isn't about mood brings its own glyphs — a set that still
 reads worst-to-best:

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
@@ -27,7 +27,12 @@ Five faces from `pulses`, in scale order, drawn by `F0ButtonToggleGroup` as one
 single-select group. A face carries no text: its `label` is the accessible name
 **and** the tooltip, so it has to read as the answer being given ("Very bad"),
 never as a number or a position. The default copy comes from `i18n.enps.scale`;
-`labels` replaces it for one face or all five.
+`labels` replaces it for one face or all five, and `icons` does the same for the
+glyphs when the question isn't about mood.
+
+The face is sized past `F0Icon`'s scale — 28px at `lg`, 24px at `md` — because
+it **is** the control: there is no label beside it to carry the meaning, so it
+takes the button, leaving 4px of room around it (6px at `lg`).
 
 Only the answered face is coloured, and it takes its own mood
 (`--mood-super-negative` through `--mood-super-positive`): a 0.1 fill, the same
@@ -111,6 +116,11 @@ from across the page.
 A recommendation question brings its own wording:
 
 <Canvas of={Stories.CustomLabels} />
+
+And a question that isn't about mood brings its own glyphs — a set that still
+reads worst-to-best:
+
+<Canvas of={Stories.CustomFaces} />
 
 An answer that has been sent stays coloured and stops being pressable:
 

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
@@ -1,0 +1,131 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { I18nProvider, defaultTranslations } from "@/lib/providers/i18n"
+import { F0ENPSButton } from "../index"
+import * as Stories from "./F0ENPSButton.stories"
+
+<Meta of={Stories} />
+
+# ENPSButton
+
+Asks one eNPS question and takes the answer in a single press: five faces,
+worst to best, and the one that is pressed takes the colour of the mood it
+stands for.
+
+It is the answer control for Home's engagement widgets — the pulse check, the
+recommendation question — and a sibling of
+[AvatarPulse](/docs/home-avatarpulse--docs), which shows an answer that has
+already been given.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+Five faces from `pulses`, in scale order, drawn by `F0ButtonToggleGroup` as one
+single-select group. A face carries no text: its `label` is the accessible name
+**and** the tooltip, so it has to read as the answer being given ("Very bad"),
+never as a number or a position. The default copy comes from `i18n.enps.scale`;
+`labels` replaces it for one face or all five.
+
+Only the answered face is coloured, and it takes its own mood
+(`--mood-super-negative` through `--mood-super-positive`): a 0.1 fill, the same
+weight F0 gives any selected control, over a heavier 0.6 border — five bordered
+faces sit side by side, so the answered one needs to win the row. Five coloured
+faces at once would be decoration; one coloured face is an answer you can read
+from across the page.
+
+<Canvas of={Stories.Answered} />
+
+## Guidelines
+
+### When to use
+
+- A single eNPS or pulse question, answered on a five-point scale, where the
+  press **is** the answer — no separate submit.
+- The answer needs to stay visible afterwards, so the person can see what they
+  said (and change it, unless `required`).
+
+### When not to use
+
+- **A survey.** More than one question, validation, or a submit step is
+  `SurveyAnsweringForm`'s job — it owns the form, the schema and the rating
+  field.
+- **A rating that isn't a mood.** A 0–10 scale, stars, or a satisfaction number
+  are not faces; use the survey rating field so the scale stays legible.
+- **Showing an answer without taking one.** A pulse already given belongs on
+  `F0AvatarPulse` or in a chart, not on a control that invites a press.
+- **A general toggle group.** Anything that isn't the eNPS scale should use
+  `F0ButtonToggleGroup` directly — this component exists to fix the five faces,
+  their order and their colours in one place.
+
+### Do's and don'ts
+
+<DoDonts
+  do={{
+    description:
+      "Word each face as the answer the person is giving, and let the question above it carry the subject.",
+    guidelines: [
+      "Keep the five labels on one scale, worst to best",
+      "Leave the answer pressable so it can be corrected",
+      "Let the widget's heading ask the question",
+    ],
+    children: (
+      <I18nProvider translations={defaultTranslations}>
+        <div className="w-[360px]">
+          <F0ENPSButton value="positive" />
+        </div>
+      </I18nProvider>
+    ),
+  }}
+  dont={{
+    description:
+      'Don\'t label the faces with positions or scores — a tooltip that says "4 out of 5" tells the person nothing about what they are answering.',
+    guidelines: [
+      'Don\'t mix scales ("Bad" next to "Extremely likely")',
+      "Don't disable the answer the moment it is given, unless it really is final",
+      "Don't restate the question in the labels",
+    ],
+    children: (
+      <I18nProvider translations={defaultTranslations}>
+        <div className="w-[360px]">
+          <F0ENPSButton
+            value="positive"
+            labels={{
+              superNegative: "1",
+              negative: "2",
+              neutral: "3",
+              positive: "4",
+              superPositive: "5",
+            }}
+          />
+        </div>
+      </I18nProvider>
+    ),
+  }}
+/>
+
+## Examples
+
+A recommendation question brings its own wording:
+
+<Canvas of={Stories.CustomLabels} />
+
+An answer that has been sent stays coloured and stops being pressable:
+
+<Canvas of={Stories.Submitted} />
+
+## Accessibility
+
+- The scale is a single-select group, so each face is a `radio` carrying
+  `aria-checked` and named by its label — a screen reader announces "Bad, radio
+  button, not checked", not a glyph.
+- The tooltip repeats that name for sighted pointer users and opens on keyboard
+  focus too; it never carries information the label doesn't already have.
+- The faces share one roving tab stop: `Tab` reaches the scale, the arrow keys
+  move along it, `Space` answers.
+- Colour is never the only signal — the answer carries `aria-checked`, and the
+  face itself changes shape from a frown to a smile.
+- Give the group a visible question of its own (the widget's heading); this
+  component renders the scale, not the prompt.

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
@@ -14,7 +14,7 @@ stands for.
 
 It is the answer control for Home's engagement widgets — the pulse check, the
 recommendation question — and a sibling of
-[AvatarPulse](/docs/home-avatarpulse--docs), which shows an answer that has
+[AvatarPulse](/docs/domain-specific-home-avatarpulse--documentation), which shows an answer that has
 already been given.
 
 ## Anatomy

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
@@ -122,7 +122,10 @@ An answer that has been sent stays coloured and stops being pressable:
   `aria-checked` and named by its label — a screen reader announces "Bad, radio
   button, not checked", not a glyph.
 - The tooltip repeats that name for sighted pointer users and opens on keyboard
-  focus too; it never carries information the label doesn't already have.
+  focus too; it never carries information the label doesn't already have. It is
+  `instant` (100ms, not the default 700ms) — it is the only place a face's name
+  is written, and a wait per face makes the scale something you have to stop and
+  ask for.
 - The faces share one roving tab stop: `Tab` reaches the scale, the arrow keys
   move along it, `Space` answers.
 - Colour is never the only signal — the answer carries `aria-checked`, and the

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.stories.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.stories.tsx
@@ -1,0 +1,185 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
+
+import { pulses, type Pulse } from "@/lib/mood"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { F0ENPSButton } from "../index"
+import type { F0ENPSButtonProps } from "../types"
+
+const meta = {
+  component: F0ENPSButton,
+  title: "Home/ENPSButton",
+  parameters: {
+    layout: "centered",
+    a11y: { test: "error" },
+  },
+  // `!autodocs` because F0ENPSButton.mdx is the docs page.
+  tags: ["experimental", "!autodocs"],
+  argTypes: {
+    value: {
+      control: "select",
+      options: [undefined, ...pulses],
+      description: "The answered face, or `undefined` while unanswered.",
+    },
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+      table: { defaultValue: { summary: "lg" } },
+    },
+    fullWidth: {
+      control: "boolean",
+      table: { defaultValue: { summary: "true" } },
+    },
+    disabled: { control: "boolean" },
+    required: { control: "boolean" },
+    labels: { control: "object" },
+    onChange: { action: "changed" },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[420px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof F0ENPSButton>
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/** Answers its own presses, the way a widget would. */
+const Interactive = (args: F0ENPSButtonProps) => {
+  const [value, setValue] = useState<Pulse | undefined>(args.value)
+
+  return (
+    <F0ENPSButton
+      {...args}
+      value={value}
+      onChange={(next) => {
+        setValue(next)
+        args.onChange?.(next)
+      }}
+    />
+  )
+}
+
+export const Default: Story = {
+  render: (args) => <Interactive {...args} />,
+}
+
+export const Answered: Story = {
+  args: { value: "negative" },
+  render: (args) => <Interactive {...args} />,
+}
+
+export const CustomLabels: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A recommendation question answers on a likelihood scale, so the copy " +
+          "changes with it. The labels are the accessible names and the tooltips.",
+      },
+    },
+  },
+  args: {
+    labels: {
+      superNegative: "Not at all likely",
+      negative: "Unlikely",
+      neutral: "Neither",
+      positive: "Likely",
+      superPositive: "Extremely likely",
+    },
+  },
+  render: (args) => <Interactive {...args} />,
+}
+
+export const Submitted: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An answer that has been sent: the face stays coloured so the person " +
+          "can see what they said, and nothing else can be pressed.",
+      },
+    },
+  },
+  args: { value: "superPositive", disabled: true },
+}
+
+export const Sizes: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex flex-col gap-6">
+      {(["sm", "md", "lg"] as const).map((size) => (
+        <section key={size} className="flex flex-col gap-2">
+          <h4 className="font-semibold">{size}</h4>
+          <F0ENPSButton size={size} value="neutral" />
+        </section>
+      ))}
+    </div>
+  ),
+}
+
+export const Answering: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Pressing a face answers the question; hovering one names it, since a " +
+          "face carries no text of its own.",
+      },
+    },
+  },
+  render: (args) => <Interactive {...args} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const bad = canvas.getByRole("radio", { name: "Bad" })
+    await expect(bad).toHaveAttribute("aria-checked", "false")
+
+    await userEvent.click(bad)
+    await expect(bad).toHaveAttribute("aria-checked", "true")
+
+    // The tooltip is portalled out of the canvas, and it opens on a delay.
+    await userEvent.hover(bad)
+    await waitFor(
+      async () => {
+        await expect(
+          within(document.body).getByRole("tooltip")
+        ).toHaveTextContent("Bad")
+      },
+      { timeout: 3000 }
+    )
+  },
+}
+
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex flex-col gap-6">
+      <section className="flex flex-col gap-2">
+        <h4 className="font-semibold">Unanswered</h4>
+        <F0ENPSButton />
+      </section>
+      {pulses.map((pulse) => (
+        <section key={pulse} className="flex flex-col gap-2">
+          <h4 className="font-semibold">{pulse}</h4>
+          <F0ENPSButton value={pulse} />
+        </section>
+      ))}
+      <section className="flex flex-col gap-2">
+        <h4 className="font-semibold">Disabled</h4>
+        <F0ENPSButton value="positive" disabled />
+      </section>
+      <section className="flex flex-col gap-2">
+        <h4 className="font-semibold">Not full width</h4>
+        <F0ENPSButton value="neutral" fullWidth={false} />
+      </section>
+    </div>
+  ),
+}

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.stories.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.stories.tsx
@@ -3,6 +3,13 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useState } from "react"
 import { expect, userEvent, waitFor, within } from "storybook/test"
 
+import {
+  FaceNeutral,
+  ThumbsDown,
+  ThumbsDownFilled,
+  ThumbsUp,
+  ThumbsUpFilled,
+} from "@/icons/app"
 import { pulses, type Pulse } from "@/lib/mood"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
@@ -36,6 +43,7 @@ const meta = {
     disabled: { control: "boolean" },
     required: { control: "boolean" },
     labels: { control: "object" },
+    icons: { control: false },
     onChange: { action: "changed" },
   },
   decorators: [
@@ -93,6 +101,36 @@ export const CustomLabels: Story = {
       neutral: "Neither",
       positive: "Likely",
       superPositive: "Extremely likely",
+    },
+  },
+  render: (args) => <Interactive {...args} />,
+}
+
+export const CustomFaces: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`icons` swaps the glyphs for a question that isn't about mood — here a " +
+          "five-point thumbs scale, with the copy to match. Keep the replacements " +
+          "a set that reads worst-to-best on its own.",
+      },
+    },
+  },
+  args: {
+    icons: {
+      superNegative: ThumbsDownFilled,
+      negative: ThumbsDown,
+      neutral: FaceNeutral,
+      positive: ThumbsUp,
+      superPositive: ThumbsUpFilled,
+    },
+    labels: {
+      superNegative: "Definitely not",
+      negative: "Probably not",
+      neutral: "Not sure",
+      positive: "Probably",
+      superPositive: "Definitely",
     },
   },
   render: (args) => <Interactive {...args} />,

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.stories.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.stories.tsx
@@ -16,6 +16,18 @@ import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { F0ENPSButton } from "../index"
 import type { F0ENPSButtonProps } from "../types"
 
+/**
+ * A mood question's own wording. The component holds no copy — every scale
+ * brings its five labels, already translated, so these stand in for a product's.
+ */
+const MOOD_LABELS: F0ENPSButtonProps["labels"] = {
+  superNegative: "Very bad",
+  negative: "Bad",
+  neutral: "Okay",
+  positive: "Good",
+  superPositive: "Very good",
+}
+
 const meta = {
   component: F0ENPSButton,
   title: "Home/ENPSButton",
@@ -25,6 +37,7 @@ const meta = {
   },
   // `!autodocs` because F0ENPSButton.mdx is the docs page.
   tags: ["experimental", "!autodocs"],
+  args: { labels: MOOD_LABELS },
   argTypes: {
     value: {
       control: "select",
@@ -84,13 +97,14 @@ export const Answered: Story = {
   render: (args) => <Interactive {...args} />,
 }
 
-export const CustomLabels: Story = {
+export const Recommendation: Story = {
   parameters: {
     docs: {
       description: {
         story:
-          "A recommendation question answers on a likelihood scale, so the copy " +
-          "changes with it. The labels are the accessible names and the tooltips.",
+          "The same five faces answering a likelihood question instead of a mood " +
+          "one — only the copy changes. The labels are the accessible names and " +
+          "the tooltips.",
       },
     },
   },
@@ -156,7 +170,7 @@ export const Sizes: Story = {
       {(["sm", "md", "lg"] as const).map((size) => (
         <section key={size} className="flex flex-col gap-2">
           <h4 className="font-semibold">{size}</h4>
-          <F0ENPSButton size={size} value="neutral" />
+          <F0ENPSButton labels={MOOD_LABELS} size={size} value="neutral" />
         </section>
       ))}
     </div>
@@ -202,21 +216,21 @@ export const Snapshot: Story = {
     <div className="flex flex-col gap-6">
       <section className="flex flex-col gap-2">
         <h4 className="font-semibold">Unanswered</h4>
-        <F0ENPSButton />
+        <F0ENPSButton labels={MOOD_LABELS} />
       </section>
       {pulses.map((pulse) => (
         <section key={pulse} className="flex flex-col gap-2">
           <h4 className="font-semibold">{pulse}</h4>
-          <F0ENPSButton value={pulse} />
+          <F0ENPSButton labels={MOOD_LABELS} value={pulse} />
         </section>
       ))}
       <section className="flex flex-col gap-2">
         <h4 className="font-semibold">Disabled</h4>
-        <F0ENPSButton value="positive" disabled />
+        <F0ENPSButton labels={MOOD_LABELS} value="positive" disabled />
       </section>
       <section className="flex flex-col gap-2">
         <h4 className="font-semibold">Not full width</h4>
-        <F0ENPSButton value="neutral" fullWidth={false} />
+        <F0ENPSButton labels={MOOD_LABELS} value="neutral" fullWidth={false} />
       </section>
     </div>
   ),

--- a/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from "react"
 import { describe, expect, it, vi } from "vitest"
 
 import {
@@ -108,6 +109,34 @@ describe("F0ENPSButton", () => {
     expect(face("Not at all likely")).toBeInTheDocument()
     // The faces left alone keep the default scale copy.
     expect(face("Okay")).toBeInTheDocument()
+  })
+
+  it("takes the question's own glyphs through icons", () => {
+    const Thumb = forwardRef<SVGSVGElement>((props, ref) => (
+      <svg ref={ref} {...props} data-testid="thumb" />
+    ))
+    Thumb.displayName = "Thumb"
+
+    zeroRender(<F0ENPSButton icons={{ superPositive: Thumb }} />)
+
+    expect(
+      face("Very good").querySelector("[data-testid=thumb]")
+    ).not.toBeNull()
+    // The faces left alone keep the default mood glyph.
+    expect(face("Okay").querySelector("[data-testid=thumb]")).toBeNull()
+  })
+
+  /**
+   * The face is the whole control, so it is sized past F0Icon's `lg`/24px scale
+   * on the svg itself. jsdom applies no Tailwind, so the class is the assertion.
+   */
+  it("scales the face with the size of the button", () => {
+    const { unmount } = zeroRender(<F0ENPSButton />)
+    expect(face("Okay")).toHaveClass("[&_svg]:w-7")
+    unmount()
+
+    zeroRender(<F0ENPSButton size="md" />)
+    expect(face("Okay")).toHaveClass("[&_svg]:w-6")
   })
 
   it("disables every face", () => {

--- a/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
+
+import { F0ENPSButton } from "../index"
+
+const face = (name: string) => screen.getByRole("radio", { name })
+
+describe("F0ENPSButton", () => {
+  it("renders the five faces of the eNPS scale, worst to best", () => {
+    zeroRender(<F0ENPSButton />)
+
+    expect(
+      screen
+        .getAllByRole("radio")
+        .map((button) => button.getAttribute("aria-label"))
+    ).toEqual(["Very bad", "Bad", "Okay", "Good", "Very good"])
+  })
+
+  it("does not report an answer on mount", () => {
+    const onChange = vi.fn()
+    zeroRender(<F0ENPSButton value="negative" onChange={onChange} />)
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("reports the pressed face as the answer", async () => {
+    const onChange = vi.fn()
+    zeroRender(<F0ENPSButton onChange={onChange} />)
+
+    await userEvent.click(face("Very good"))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith("superPositive")
+    expect(face("Very good")).toHaveAttribute("aria-checked", "true")
+  })
+
+  it("clears the answer when the answered face is pressed again", async () => {
+    const onChange = vi.fn()
+    zeroRender(<F0ENPSButton value="neutral" onChange={onChange} />)
+
+    await userEvent.click(face("Okay"))
+
+    expect(onChange).toHaveBeenCalledWith(undefined)
+  })
+
+  it("keeps the answer when required and the answered face is pressed again", async () => {
+    const onChange = vi.fn()
+    zeroRender(<F0ENPSButton value="neutral" onChange={onChange} required />)
+
+    await userEvent.click(face("Okay"))
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(face("Okay")).toHaveAttribute("aria-checked", "true")
+  })
+
+  it("colours only the answered face with its own mood", async () => {
+    zeroRender(<F0ENPSButton value="negative" />)
+
+    expect(face("Bad")).toHaveClass("text-f1-icon-mood-negative")
+    expect(face("Very good")).not.toHaveClass(
+      "text-f1-icon-mood-super-positive"
+    )
+
+    // The colour follows the press, not just the incoming prop.
+    await userEvent.click(face("Very good"))
+
+    expect(face("Very good")).toHaveClass("text-f1-icon-mood-super-positive")
+    expect(face("Bad")).not.toHaveClass("text-f1-icon-mood-negative")
+  })
+
+  it("names the hovered face in a tooltip", async () => {
+    zeroRender(<F0ENPSButton />)
+
+    await userEvent.hover(face("Very bad"))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toHaveTextContent("Very bad")
+    })
+  })
+
+  it("takes the question's own wording through labels", () => {
+    zeroRender(
+      <F0ENPSButton
+        value="superNegative"
+        labels={{ superNegative: "Not at all likely" }}
+      />
+    )
+
+    expect(face("Not at all likely")).toBeInTheDocument()
+    // The faces left alone keep the default scale copy.
+    expect(face("Okay")).toBeInTheDocument()
+  })
+
+  it("disables every face", () => {
+    zeroRender(<F0ENPSButton disabled />)
+
+    screen
+      .getAllByRole("radio")
+      .forEach((button) => expect(button).toBeDisabled())
+  })
+})

--- a/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
@@ -11,11 +11,19 @@ import {
 
 import { F0ENPSButton } from "../index"
 
+const LABELS = {
+  superNegative: "Very bad",
+  negative: "Bad",
+  neutral: "Okay",
+  positive: "Good",
+  superPositive: "Very good",
+}
+
 const face = (name: string) => screen.getByRole("radio", { name })
 
 describe("F0ENPSButton", () => {
   it("renders the five faces of the eNPS scale, worst to best", () => {
-    zeroRender(<F0ENPSButton />)
+    zeroRender(<F0ENPSButton labels={LABELS} />)
 
     expect(
       screen
@@ -26,14 +34,16 @@ describe("F0ENPSButton", () => {
 
   it("does not report an answer on mount", () => {
     const onChange = vi.fn()
-    zeroRender(<F0ENPSButton value="negative" onChange={onChange} />)
+    zeroRender(
+      <F0ENPSButton labels={LABELS} value="negative" onChange={onChange} />
+    )
 
     expect(onChange).not.toHaveBeenCalled()
   })
 
   it("reports the pressed face as the answer", async () => {
     const onChange = vi.fn()
-    zeroRender(<F0ENPSButton onChange={onChange} />)
+    zeroRender(<F0ENPSButton labels={LABELS} onChange={onChange} />)
 
     await userEvent.click(face("Very good"))
 
@@ -44,7 +54,9 @@ describe("F0ENPSButton", () => {
 
   it("clears the answer when the answered face is pressed again", async () => {
     const onChange = vi.fn()
-    zeroRender(<F0ENPSButton value="neutral" onChange={onChange} />)
+    zeroRender(
+      <F0ENPSButton labels={LABELS} value="neutral" onChange={onChange} />
+    )
 
     await userEvent.click(face("Okay"))
 
@@ -53,7 +65,14 @@ describe("F0ENPSButton", () => {
 
   it("keeps the answer when required and the answered face is pressed again", async () => {
     const onChange = vi.fn()
-    zeroRender(<F0ENPSButton value="neutral" onChange={onChange} required />)
+    zeroRender(
+      <F0ENPSButton
+        labels={LABELS}
+        value="neutral"
+        onChange={onChange}
+        required
+      />
+    )
 
     await userEvent.click(face("Okay"))
 
@@ -62,7 +81,7 @@ describe("F0ENPSButton", () => {
   })
 
   it("colours only the answered face with its own mood", async () => {
-    zeroRender(<F0ENPSButton value="negative" />)
+    zeroRender(<F0ENPSButton labels={LABELS} value="negative" />)
 
     expect(face("Bad")).toHaveClass("text-f1-icon-mood-negative")
     expect(face("Very good")).not.toHaveClass(
@@ -84,7 +103,7 @@ describe("F0ENPSButton", () => {
   it("names the hovered face without a wait", () => {
     vi.useFakeTimers()
     try {
-      zeroRender(<F0ENPSButton />)
+      zeroRender(<F0ENPSButton labels={LABELS} />)
 
       // `fireEvent`, not `userEvent`: the tooltip is a TIMER, and userEvent's
       // own waiting deadlocks against fake ones.
@@ -98,17 +117,35 @@ describe("F0ENPSButton", () => {
     }
   })
 
-  it("takes the question's own wording through labels", () => {
+  /**
+   * The component holds no copy: the same five faces answer a mood question and
+   * a likelihood one, and only the labels say which.
+   */
+  it("names the faces from labels alone", () => {
     zeroRender(
       <F0ENPSButton
         value="superNegative"
-        labels={{ superNegative: "Not at all likely" }}
+        labels={{
+          superNegative: "Not at all likely",
+          negative: "Unlikely",
+          neutral: "Neither",
+          positive: "Likely",
+          superPositive: "Extremely likely",
+        }}
       />
     )
 
-    expect(face("Not at all likely")).toBeInTheDocument()
-    // The faces left alone keep the default scale copy.
-    expect(face("Okay")).toBeInTheDocument()
+    expect(
+      screen
+        .getAllByRole("radio")
+        .map((button) => button.getAttribute("aria-label"))
+    ).toEqual([
+      "Not at all likely",
+      "Unlikely",
+      "Neither",
+      "Likely",
+      "Extremely likely",
+    ])
   })
 
   it("takes the question's own glyphs through icons", () => {
@@ -117,7 +154,9 @@ describe("F0ENPSButton", () => {
     ))
     Thumb.displayName = "Thumb"
 
-    zeroRender(<F0ENPSButton icons={{ superPositive: Thumb }} />)
+    zeroRender(
+      <F0ENPSButton labels={LABELS} icons={{ superPositive: Thumb }} />
+    )
 
     expect(
       face("Very good").querySelector("[data-testid=thumb]")
@@ -131,16 +170,16 @@ describe("F0ENPSButton", () => {
    * on the svg itself. jsdom applies no Tailwind, so the class is the assertion.
    */
   it("scales the face with the size of the button", () => {
-    const { unmount } = zeroRender(<F0ENPSButton />)
+    const { unmount } = zeroRender(<F0ENPSButton labels={LABELS} />)
     expect(face("Okay")).toHaveClass("[&_svg]:w-7")
     unmount()
 
-    zeroRender(<F0ENPSButton size="md" />)
+    zeroRender(<F0ENPSButton labels={LABELS} size="md" />)
     expect(face("Okay")).toHaveClass("[&_svg]:w-6")
   })
 
   it("disables every face", () => {
-    zeroRender(<F0ENPSButton disabled />)
+    zeroRender(<F0ENPSButton labels={LABELS} disabled />)
 
     screen
       .getAllByRole("radio")

--- a/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
+import {
+  act,
+  fireEvent,
+  screen,
+  userEvent,
+  zeroRender,
+} from "@/testing/test-utils"
 
 import { F0ENPSButton } from "../index"
 
@@ -69,14 +75,26 @@ describe("F0ENPSButton", () => {
     expect(face("Bad")).not.toHaveClass("text-f1-icon-mood-negative")
   })
 
-  it("names the hovered face in a tooltip", async () => {
-    zeroRender(<F0ENPSButton />)
+  /**
+   * The tooltip is the only place a face's name is written, so it opens without
+   * a wait — on the default 700ms it was a name you had to stop and ask for,
+   * five times over, to read the scale.
+   */
+  it("names the hovered face without a wait", () => {
+    vi.useFakeTimers()
+    try {
+      zeroRender(<F0ENPSButton />)
 
-    await userEvent.hover(face("Very bad"))
+      // `fireEvent`, not `userEvent`: the tooltip is a TIMER, and userEvent's
+      // own waiting deadlocks against fake ones.
+      fireEvent.pointerEnter(face("Very bad"), { pointerType: "mouse" })
+      // Well past the instant 100ms, and well inside the default 700ms.
+      act(() => vi.advanceTimersByTime(200))
 
-    await waitFor(() => {
       expect(screen.getByRole("tooltip")).toHaveTextContent("Very bad")
-    })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("takes the question's own wording through labels", () => {

--- a/packages/react/src/sds/Home/F0ENPSButton/index.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/index.tsx
@@ -1,0 +1,13 @@
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0ENPSButton as F0ENPSButtonComponent } from "./F0ENPSButton"
+
+export type { F0ENPSButtonProps } from "./types"
+
+/**
+ * @experimental This is an experimental component use it at your own risk
+ */
+export const F0ENPSButton = withDataTestId(
+  experimentalComponent("F0ENPSButton", F0ENPSButtonComponent)
+)

--- a/packages/react/src/sds/Home/F0ENPSButton/types.ts
+++ b/packages/react/src/sds/Home/F0ENPSButton/types.ts
@@ -1,4 +1,5 @@
 import type { ButtonToggleGroupSize } from "@/components/F0ButtonToggleGroup"
+import type { IconType } from "@/components/F0Icon"
 import type { Pulse } from "@/lib/mood"
 
 export type F0ENPSButtonProps = {
@@ -23,6 +24,17 @@ export type F0ENPSButtonProps = {
    * "Not at all likely", a mood check answers "Terrible".
    */
   labels?: Partial<Record<Pulse, string>>
+
+  /**
+   * Override the face drawn for one or more points of the scale. Defaults to the
+   * five `Face*` icons from `lib/mood` — the same ones `F0AvatarPulse` shows, so
+   * an answer looks the same wherever it turns up.
+   *
+   * Swap them only when the question isn't about mood: a thumbs pair, a set of
+   * stars. Keep the replacements a *set* that reads worst-to-best on its own —
+   * five unrelated glyphs stop being a scale.
+   */
+  icons?: Partial<Record<Pulse, IconType>>
 
   /**
    * The size of each face.

--- a/packages/react/src/sds/Home/F0ENPSButton/types.ts
+++ b/packages/react/src/sds/Home/F0ENPSButton/types.ts
@@ -1,0 +1,52 @@
+import type { ButtonToggleGroupSize } from "@/components/F0ButtonToggleGroup"
+import type { Pulse } from "@/lib/mood"
+
+export type F0ENPSButtonProps = {
+  /**
+   * The face that is answered, or `undefined` while the question is unanswered.
+   */
+  value?: Pulse
+
+  /**
+   * Called with the answered face — or `undefined` when the answer is cleared,
+   * which only `required: false` allows. Never called on mount.
+   */
+  onChange?: (value: Pulse | undefined) => void
+
+  /**
+   * Override the copy for one or more faces. A face carries no visible text, so
+   * its label is both the accessible name and the tooltip: word it as the answer
+   * the person is giving ("Very bad"), never as a number or a position.
+   *
+   * Defaults to the built-in eNPS scale (`i18n.enps.scale`). Reach for this when
+   * the question needs its own wording — a recommendation question answers
+   * "Not at all likely", a mood check answers "Terrible".
+   */
+  labels?: Partial<Record<Pulse, string>>
+
+  /**
+   * The size of each face.
+   * @default "lg"
+   */
+  size?: ButtonToggleGroupSize
+
+  /**
+   * Whether the five faces stretch to fill the container. A widget's eNPS row
+   * usually should — an equal split reads as one scale rather than five buttons.
+   * @default true
+   */
+  fullWidth?: boolean
+
+  /**
+   * Whether every face is disabled — a submitted answer, or a question that is
+   * closed.
+   * @default false
+   */
+  disabled?: boolean
+
+  /**
+   * Whether an answer, once given, can be taken back by pressing it again.
+   * @default false
+   */
+  required?: boolean
+}

--- a/packages/react/src/sds/Home/F0ENPSButton/types.ts
+++ b/packages/react/src/sds/Home/F0ENPSButton/types.ts
@@ -15,15 +15,16 @@ export type F0ENPSButtonProps = {
   onChange?: (value: Pulse | undefined) => void
 
   /**
-   * Override the copy for one or more faces. A face carries no visible text, so
-   * its label is both the accessible name and the tooltip: word it as the answer
-   * the person is giving ("Very bad"), never as a number or a position.
+   * What each face means, worst to best. A face carries no visible text, so its
+   * label is both the accessible name and the tooltip: word it as the answer the
+   * person is giving ("Very bad"), never as a number or a position.
    *
-   * Defaults to the built-in eNPS scale (`i18n.enps.scale`). Reach for this when
-   * the question needs its own wording — a recommendation question answers
-   * "Not at all likely", a mood check answers "Terrible".
+   * Required, and required in full — the wording belongs to the question, so the
+   * component holds no copy of its own: a mood check answers "Terrible", a
+   * recommendation question answers "Not at all likely". Pass it already
+   * translated.
    */
-  labels?: Partial<Record<Pulse, string>>
+  labels: Record<Pulse, string>
 
   /**
    * Override the face drawn for one or more points of the scale. Defaults to the


### PR DESCRIPTION
## Description

Home needs a control that asks one eNPS question and takes the answer in a single press: five faces, worst to best, where the answered face takes the colour of the mood it stands for and each face names itself in a tooltip. `F0ENPSButton` lands in `sds/Home` as a domain specific component, built on `F0ButtonToggleGroup` and reusing the scale vocabulary that already existed in `lib/mood` (`pulses`, `pulseIcon`, the `--mood-*` tokens) — the same scale `F0AvatarPulse` shows once an answer has been given.

## Type of change

- [x] New component (aligned in #f0-support, lands in `experimental/`) — domain specific, so it lands in `sds/Home` tagged experimental
- [x] Component enhancement / variant (existing component, no breaking change) — `tooltip` and `color` on `F0ButtonToggle`, forwarded per item by `F0ButtonToggleGroup`

## Lifecycle phase (if applicable)

- Linked #f0-support thread: _to add — `tooltip` and `color` on `F0ButtonToggle` are public API additions to a Core component and want Foundations' sign-off; the eNPS scale itself stays domain side._
- Phase exit criteria met: full new-component Definition of Done passes (`pnpm --dir packages/react check:new-component-dod`) — stories with a play function and a snapshot story, unit tests, MDX docs, axe enforced (`a11y: { test: "error" }`, no skips added).

## Screenshots (if applicable)

Verified in Storybook against the reference: grey faces in outlined boxes, the answered one filled and outlined in its own mood colour, tooltip on hover. Chromatic covers it through `Domain specific/Home/ENPSButton` → **Snapshot** (all five moods, unanswered, disabled, not-full-width) and **Sizes**, and `Components/Button/ButtonToggle` → **Colors** (every colour, selected and not).

## Implementation details

- feat: add `F0ENPSButton` to `sds/Home` — the five `pulses` as one single-select `F0ButtonToggleGroup`, `value`/`onChange` typed as `Pulse | undefined`, the required `labels` and optional `icons` per face, `size`, `fullWidth`, `disabled` and `required`
- feat: add `color` to `F0ButtonToggle`, forwarded per item by the group — one of F0's semantic colours (the six statuses, then the five points of the mood scale), replacing the raw Tailwind class a caller previously had to hand it

  <details>
  <summary>What a colour means, and why it is written out per colour</summary>

  Selected, the toggle wears the colour: a 0.1 fill (0.2 under the pointer), a 0.6 border, the glyph. Unselected, it stays a muted glyph — a coloured toggle should only speak up once it is chosen, or five coloured glyphs at once become decoration rather than an answer.

  The fill follows `f1-background-selected`, so a coloured answer sits at the weight F0 gives any selected control; the border goes to 0.6 where `f1-border-selected` sits at 0.4, because here it has to separate one answer from its neighbours. Tailwind only generates the utilities it can see as literal strings, so the classes can't be composed from the token name — hence one entry per colour.
  </details>

- feat: add `tooltip` to `F0ButtonToggle` — the same `string | { label, description }` shape `Action` takes, plus `instant`, and it replaces the native browser title rather than opening a second bubble beside it
- feat: open the scale's tooltips instantly (100ms, not the default 700ms) — the tooltip is the only place a face's name is written, so the default wait made the scale something you had to stop and ask for, five times over; the Home action rail already makes the same call for its glyphs
- feat: size the face past `F0Icon`'s scale — 28px at `lg`, 24px at `md`, set on the svg the way `F0AvatarModule` sizes its own glyph, because the face IS the control and no label beside it carries the meaning
- feat: forward per-item `tooltip`, `color` and `className` from `F0ButtonToggleGroup` items to each toggle, merging `className` with the group's own instead of dropping it
- fix: set `data-state` explicitly on the toggle root, after the prop spread

  <details>
  <summary>Why?</summary>

  A tooltip wraps the button through Radix's `asChild`, so the trigger hands its own open/closed `data-state` down into the spread, which would otherwise overwrite the pressed state that consumers and tests read off the button. Covered by a test in `F0ButtonToggle.tooltip.test.tsx`.
  </details>

- test: unit tests for the scale (answering, clearing, `required`, the mood colour following the press, the instant tooltip, custom labels and icons, face size, disabled), for the toggle's tooltip, and for the group's per-item colour and className
- docs: MDX page for `F0ENPSButton` (anatomy, when not to use, do/don't, accessibility) and sections on `color` and `tooltip` in the `F0ButtonToggle` docs

---

Two things left alone deliberately: `F0ButtonToggleGroup` calls `onChange` once on mount with its initial value (the component drops that echo; worth fixing in the group separately, with the regression test CI asks for), and the gap between faces is the group's own `gap-1`, slightly tighter than the reference.

Note: `lefthook` didn't run in this worktree, so `tsc --noEmit`, `oxlint`, `oxfmt` and the unit suite were run by hand — all clean. In the full 6655-test run, `OneDataCollection/__tests__/urlSyncChipClear.test.tsx` failed 2 tests; it passes alone and with its whole folder, so it reads as a cross-suite ordering flake unrelated to these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
