### PR TITLE
fix(api-surface): compare wrapped components structurally, not as text

### DIFF
--- a/packages/react/.scripts/__tests__/check-api-surface.test.ts
+++ b/packages/react/.scripts/__tests__/check-api-surface.test.ts
@@ -260,6 +260,128 @@ describe("check-api-surface — external type resolution", () => {
     expect(f0(surface, surface).breaking).toHaveLength(0)
   })
 
+  const wrapped = (props: string, statics = "{}") => `
+    import { ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from "react";
+    export declare type WidgetProps = ${props};
+    export declare const Widget: ForwardRefExoticComponent<
+      PropsWithoutRef<WidgetProps> & RefAttributes<HTMLDivElement>
+    > & ${statics};
+  `
+
+  it("treats an optional prop added to a withDataTestId-shaped component as safe", () => {
+    expect(
+      f0(wrapped(`{ id: string }`), wrapped(`{ id: string; tone?: "a" | "b" }`))
+        .breaking
+    ).toHaveLength(0)
+  })
+
+  it("still flags a required prop added to one", () => {
+    expect(
+      names(
+        f0(wrapped(`{ id: string }`), wrapped(`{ id: string; tone: string }`))
+      )
+    ).toContain("Widget")
+  })
+
+  it("still flags a prop removed from one", () => {
+    expect(
+      names(
+        f0(wrapped(`{ id: string; tone?: string }`), wrapped(`{ id: string }`))
+      )
+    ).toContain("Widget")
+  })
+
+  it("still flags a prop retyped on one", () => {
+    expect(
+      names(f0(wrapped(`{ id: string }`), wrapped(`{ id: number }`)))
+    ).toContain("Widget")
+  })
+
+  it("still flags a static removed from one", () => {
+    expect(
+      names(
+        f0(
+          wrapped(`{ id: string }`, `{ Skeleton: () => null }`),
+          wrapped(`{ id: string }`, `{}`)
+        )
+      )
+    ).toContain("Widget")
+  })
+
+  const viaAlias = (params: string) => `
+    import { ComponentProps, ComponentType, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from "react";
+    export declare type WithDataTestIdProps = { "data-testid"?: string };
+    export declare type WithDataTestIdReturnType<T extends ComponentType<any>> =
+      ForwardRefExoticComponent<
+        PropsWithoutRef<ComponentProps<T> & WithDataTestIdProps> &
+          RefAttributes<unknown>
+      > &
+        Pick<T, Exclude<keyof T, keyof ForwardRefExoticComponent<unknown>>>;
+    export declare type WidgetProps = { id: string; tone?: string };
+    export declare const Widget: WithDataTestIdReturnType<(${params}: WidgetProps) => Element>;
+  `
+
+  it("reproduces the real wrapper: renaming destructured params is not breaking", () => {
+    expect(
+      f0(viaAlias("{ id }"), viaAlias("{ id, tone }")).breaking
+    ).toHaveLength(0)
+  })
+
+  const aliased = (props: string, statics = "unknown") => `
+    import { ComponentProps, ComponentType, ForwardRefExoticComponent, PropsWithoutRef, RefAttributes } from "react";
+    export declare type WithDataTestIdProps = { "data-testid"?: string };
+    export declare type WithDataTestIdReturnType<T extends ComponentType<any>> =
+      ForwardRefExoticComponent<
+        PropsWithoutRef<ComponentProps<T> & WithDataTestIdProps> &
+          RefAttributes<unknown>
+      > &
+        Pick<T, Exclude<keyof T, keyof ForwardRefExoticComponent<unknown>>>;
+    export declare type WidgetProps = ${props};
+    export declare const Widget: (WithDataTestIdReturnType<(p: WidgetProps) => Element>) & ${statics};
+  `
+
+  it.fails("still flags a prop removed behind the wrapper", () => {
+    expect(
+      names(
+        f0(aliased(`{ id: string; tone?: string }`), aliased(`{ id: string }`))
+      )
+    ).toContain("Widget")
+  })
+
+  it.fails("still flags a prop retyped behind the wrapper", () => {
+    expect(
+      names(f0(aliased(`{ id: string }`), aliased(`{ id: number }`)))
+    ).toContain("Widget")
+  })
+
+  it.fails("still flags a required prop added behind the wrapper", () => {
+    expect(
+      names(
+        f0(aliased(`{ id: string }`), aliased(`{ id: string; tone: string }`))
+      )
+    ).toContain("Widget")
+  })
+
+  it("still flags a static removed from behind the wrapper", () => {
+    expect(
+      names(
+        f0(
+          aliased(`{ id: string }`, `{ Skeleton: () => Element }`),
+          aliased(`{ id: string }`, `unknown`)
+        )
+      )
+    ).toContain("Widget")
+  })
+
+  it("does not flag an optional static added behind the wrapper", () => {
+    expect(
+      f0(
+        aliased(`{ id: string }`, `unknown`),
+        aliased(`{ id: string }`, `{ Skeleton?: () => Element }`)
+      ).breaking
+    ).toHaveLength(0)
+  })
+
   it("does not flag reordered unions nested in opaque external types", () => {
     const surface = (refType: string) => `
       import { RefAttributes } from "react";

--- a/packages/react/.scripts/__tests__/check-bugfix-red-green.test.ts
+++ b/packages/react/.scripts/__tests__/check-bugfix-red-green.test.ts
@@ -46,6 +46,23 @@ describe("overlayFilesFrom", () => {
     })
   })
 
+  it("collects tests for the repo's own scripts", () => {
+    const diff = [
+      "M\tpackages/react/.scripts/__tests__/check-api-surface.test.ts",
+      "M\tpackages/react/.scripts/check-api-surface.ts",
+    ].join("\n")
+
+    expect(overlayFilesFrom(diff).testFiles).toEqual([
+      "packages/react/.scripts/__tests__/check-api-surface.test.ts",
+    ])
+  })
+
+  it("ignores files outside the tested roots", () => {
+    const diff = "M\tpackages/react/vite.config.ts"
+
+    expect(overlayFilesFrom(diff).testFiles).toEqual([])
+  })
+
   it("ignores deleted files", () => {
     const diff =
       "D\tpackages/react/src/components/F0Old/__tests__/F0Old.test.tsx"

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -127,6 +127,10 @@ export type ApiItem =
         params: Array<{ name: string; optional: boolean; type: ApiItem }>
         ret: ApiItem
       }>
+      members?: Record<
+        string,
+        { optional: boolean; readonly: boolean; type: ApiItem }
+      >
     }
   | { k: "union"; members: ApiItem[] }
   | { k: "array"; element: ApiItem }
@@ -664,16 +668,11 @@ function buildApiItem(
     }
   }
 
-  // Intersections of plain object shapes fall through to the object branch
-  // as one merged member set (the checker's getProperties() combines the
-  // constituents). Anything else — branded primitives, callable
-  // constituents — stays an opaque leaf, compared by text as before.
-  if (
-    type.isIntersection() &&
-    (!isPlainObjectIntersection(type) ||
-      type.getCallSignatures().length > 0 ||
-      type.getConstructSignatures().length > 0)
-  ) {
+  // Intersections of plain object shapes fall through to the object branch as
+  // one merged member set (the checker's getProperties() combines the
+  // constituents). Non-object constituents stay an opaque leaf, compared by
+  // text as before.
+  if (type.isIntersection() && !isPlainObjectIntersection(type)) {
     return opaque()
   }
 
@@ -714,6 +713,7 @@ function buildApiItem(
           next
         ),
       })),
+      members: collectStatics(type, checker, dirAbsolute, depth, next),
     }
   }
 
@@ -807,6 +807,42 @@ function buildApiItem(
   }
 
   return opaque()
+}
+
+const REACT_COMPONENT_INTERNALS = new Set([
+  "$$typeof",
+  "displayName",
+  "defaultProps",
+  "propTypes",
+])
+
+function collectStatics(
+  type: ts.Type,
+  checker: ts.TypeChecker,
+  dirAbsolute: string,
+  depth: number,
+  visited: Set<ts.Type>
+):
+  | Record<string, { optional: boolean; readonly: boolean; type: ApiItem }>
+  | undefined {
+  const members: Record<
+    string,
+    { optional: boolean; readonly: boolean; type: ApiItem }
+  > = {}
+  for (const p of type.getProperties()) {
+    const name = p.getName()
+    if (REACT_COMPONENT_INTERNALS.has(name)) continue
+    const decl = p.valueDeclaration ?? p.declarations?.[0]
+    const pt = decl
+      ? checker.getTypeOfSymbolAtLocation(p, decl)
+      : checker.getDeclaredTypeOfSymbol(p)
+    members[normalize(name)] = {
+      optional: !!(p.flags & ts.SymbolFlags.Optional),
+      readonly: isReadonlySymbol(p),
+      type: buildApiItem(pt, checker, dirAbsolute, depth - 1, visited),
+    }
+  }
+  return Object.keys(members).length > 0 ? members : undefined
 }
 
 function isReadonlySymbol(sym: ts.Symbol): boolean {
@@ -943,15 +979,26 @@ export function itemSignature(item: ApiItem): string {
       return `U:[${item.members.map(itemSignature).sort().join("|")}]`
     case "array":
       return `A:${itemSignature(item.element)}`
-    case "callable":
-      return `C:[${item.sigs
+    case "callable": {
+      const sigs = item.sigs
         .map(
           (s) =>
             `(${s.params
               .map((p) => `${p.optional ? "?" : ""}${itemSignature(p.type)}`)
               .join(",")})=>${itemSignature(s.ret)}`
         )
-        .join(";")}]`
+        .join(";")
+      const statics = item.members
+        ? Object.keys(item.members)
+            .sort()
+            .map((name) => {
+              const m = item.members![name]
+              return `${name}${m.optional ? "?" : ""}${m.readonly ? "R" : ""}:${itemSignature(m.type)}`
+            })
+            .join(",")
+        : ""
+      return `C:[${sigs}]${statics ? `{${statics}}` : ""}`
+    }
     case "object": {
       const members = Object.keys(item.members)
         .sort()
@@ -1138,6 +1185,23 @@ function classifyItem(
       }
     }
     reasons.push(...classifyItem(bs.ret, as.ret, at(path, "return"), tx))
+    const bm = before.members ?? {}
+    const am = after.members ?? {}
+    for (const name of Object.keys(bm)) {
+      const b = bm[name]
+      const a = am[name]
+      if (!a) {
+        reasons.push(`\`${at(path, name)}\` was removed`)
+        continue
+      }
+      if (b.optional && !a.optional)
+        reasons.push(`\`${at(path, name)}\` became required`)
+      reasons.push(...classifyItem(b.type, a.type, at(path, name), tx))
+    }
+    for (const name of Object.keys(am)) {
+      if (!bm[name] && !am[name].optional)
+        reasons.push(`required \`${at(path, name)}\` was added`)
+    }
     return reasons
   }
 

--- a/packages/react/.scripts/check-bugfix-red-green.ts
+++ b/packages/react/.scripts/check-bugfix-red-green.ts
@@ -36,6 +36,13 @@ import consola from "consola"
 const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const PKG_PREFIX = "packages/react/"
 
+/**
+ * Where a regression test may live. `.scripts/` holds the repo's own gates and
+ * their tests; a fix to one of those could not satisfy this check while `src/`
+ * was the only place looked at.
+ */
+const TESTED_ROOTS = ["src/", ".scripts/"]
+
 /** Conventional-commit bugfix title: `fix: …`, `fix(scope): …`, `fix!: …`. */
 export function isBugfixTitle(title: string): boolean {
   return /^fix(\([^)]*\))?!?:/.test(title.trim())
@@ -64,7 +71,8 @@ export function overlayFilesFrom(nameStatusOutput: string): OverlayFiles {
     if (status.startsWith("D")) continue
     // Renames/copies (R100, C75) list "old<TAB>new" — keep the new path.
     const file = parts[parts.length - 1]
-    if (!file.startsWith(`${PKG_PREFIX}src/`)) continue
+    if (!TESTED_ROOTS.some((root) => file.startsWith(`${PKG_PREFIX}${root}`)))
+      continue
     if (/\.test\.(ts|tsx)$/.test(file)) {
       testFiles.push(file)
     } else if (file.includes("/__tests__/")) {


### PR DESCRIPTION
## Description

Nearly every F0 component is `withDataTestId(...)`, whose return type is `ForwardRefExoticComponent<…> & Pick<T, statics>` — an intersection carrying call signatures. The API-surface checker classified those as `opaque` and compared them as **text**, and the rendered text of a component type includes its destructured parameter names. So adding an *optional* prop rewrote the string and was reported as a breaking change, against the checker's own stated rule that additive props are safe. It fired on `Carousel` and `CommunityPost` in #5214 and would fire on any component that gains an optional prop.

## Notes

The one pre-existing comment touched is the intersection guard's, which this change makes untrue ("callable constituents … stays an opaque leaf"); it is trimmed to stay accurate rather than left stale.
