### PR TITLE
docs(skills): component file structure rules for f0-component-patterns

### DIFF
--- a/vendor/skills/f0-component-patterns/SKILL.md
+++ b/vendor/skills/f0-component-patterns/SKILL.md
@@ -13,6 +13,7 @@ Load this skill when you need to:
 
 - Build a new F0 component from scratch
 - Modify an existing component's architecture
+- Add a component, split one out of a file, or write a `useEffect`
 - Implement context/state management patterns
 - Add styling with CVA, Tailwind, or Framer Motion
 - Add i18n support to a component
@@ -26,6 +27,7 @@ Load this skill when you need to:
 | CVA, cn(), focusRing(), container queries, Framer Motion, design tokens                                       | `references/styling-and-animation.md`  |
 | Unit tests (zeroRender, vi.hoisted(), fake timers, deferred promises)                                         | Load the `f0-unit-testing` skill       |
 | useI18n, defaultTranslations, TranslationsType, plurals, interpolation                                        | `references/i18n-patterns.md`          |
+| One component per declaration site, no statement blocks inside JSX, named effect callbacks                    | `references/component-files.md`        |
 
 ## Key Rules
 

--- a/vendor/skills/f0-component-patterns/references/component-files.md
+++ b/vendor/skills/f0-component-patterns/references/component-files.md
@@ -1,0 +1,80 @@
+# Component File Structure
+
+Applies to `packages/react` and `packages/react-native`.
+
+## Never declare a component inside another component
+
+```tsx
+// Wrong — StatusIndicator is a new function on every render of F0StatusCard
+export const F0StatusCard = forwardRef<HTMLDivElement, F0StatusCardProps>(
+  ({ status, title }, ref) => {
+    const StatusIndicator = () =>
+      status === "error" ? (
+        <F0Icon icon={AlertCircle} className="text-f1-icon-critical" />
+      ) : (
+        <F0Icon icon={CheckCircle} className="text-f1-icon-positive" />
+      )
+
+    return (
+      <div ref={ref}>
+        <StatusIndicator />
+      </div>
+    )
+  }
+)
+```
+
+React compares element types by identity, so a new function each render makes it unmount and remount the subtree: state is discarded, effects re-run, a focused input loses focus. Hoist it to module scope and give it props.
+
+This matters more in a design system than in product code: a component that remounts its own subtree does so for every consumer at once.
+
+**A file that already contains one is not a precedent.** Do not add a second to match the existing style — write plain JSX, or hoist.
+
+## Move a component to its own file once it needs a test or a second consumer
+
+Until then, a non-exported helper used once in that file is fine. When it does need its own file, it goes in the component folder's `components/` directory and stays out of `index.tsx`'s exports:
+
+```text
+F0StatusCard/
+  index.tsx                  <- exports only
+  F0StatusCard.tsx
+  components/MetricRow.tsx   <- internal, not exported
+```
+
+Do not add `export` to an existing in-file component so another module can import it — move it in the same change.
+
+## No statement blocks inside JSX
+
+A JSX expression container holds an expression — a value, a call, a ternary, or `&&`. A `const`, an `if`, or an early `return` means you are writing a component: move the derivation into the child.
+
+```tsx
+// Wrong — an anonymous component with no name, props type, test, or memoization boundary
+{items.map((item, index) => {
+  const label = item.text || t("dropdown.untitled")
+  const isDestructive = item.variant === "critical" && !item.disabled
+  return <DropdownItem key={item.id} item={item} label={label} isDestructive={isDestructive} />
+})}
+
+// Right
+{items.map((item, index) => (
+  <DropdownListItem key={item.id} item={item} isLast={index === items.length - 1} />
+))}
+```
+
+Extracting the derivation into a helper that returns a bag of values is not enough — the `if`/`const` must leave the JSX callback, and the thing that replaces it needs a props contract.
+
+## Name the function you pass to `useEffect`
+
+```tsx
+useEffect(function scrollActiveTabIntoView() {
+  containerRef.current
+    ?.querySelector<HTMLElement>(`[data-tab-id="${activeTabId}"]`)
+    ?.scrollIntoView({ block: "nearest", inline: "nearest" })
+}, [activeTabId, containerRef])
+```
+
+Applies to `useEffect` and `useLayoutEffect`. If the name needs an "and", split the effect. If you cannot name the side effect, it is not one: `deriveTotalFromItems` is a computed value, `handleSelectPress` is an event handler. Name the side effect, not the trigger.
+
+`react-hooks/exhaustive-deps` treats a named function expression exactly like an arrow function.
+
+Related: `packages/react/AGENTS.md` already forbids syncing controlled/uncontrolled state through `useEffect` — use `useControllable`.


### PR DESCRIPTION
## What

Adds `vendor/skills/f0-component-patterns/references/component-files.md` (80 lines) with three rules, and links it from that skill's Quick Reference table.

Companion PRs applying the same rules to the product frontend and mobile app: factorialco/factorial#111042, factorialco/factorial-skills#233.

## Why

Three patterns exist in `packages/react` today, nothing in the skills covers them, and no lint rule catches them.

| Pattern | `packages/react` | `packages/react-native` |
| --- | --- | --- |
| `.tsx` files | 2,424 | 448 |
| Component declared **inside** another component | 26 files | 0 |
| `.map` with a statement block inside a JSX container | 75 | 4 |
| …the same behind `&&`, a ternary, or a tag boundary | ~14 | 0 |
| Anonymous `useEffect` | 508 | 4 |
| **Named effect callbacks** | **0** | **0** |
| Inline `renderItem` with a block body | — | 0 |

`packages/react-native` is clean on all three. It is in scope because the rules are the same React rules, not because it has a problem to fix.

The `.map` figures come from a parser that classifies each block-body callback by what syntactically precedes it. Plain data transforms (`const x = items.map(…)` — 25 in `packages/react`) and `return items.map(…)` (7) are excluded: the rule is about callbacks sitting inside a JSX expression container, and only those are counted.

## The rules

### 1. Never declare a component inside another component

React compares element types by identity, and for a function component the type *is* the function object. A component defined in a render body is a new function every render, so React unmounts the old subtree — running every cleanup — and mounts a new one, resetting `useState` and re-running effects. The user sees an input lose focus mid-typing, or a panel collapse on every keystroke elsewhere.

This costs more in a design system than in product code: a component that remounts its own subtree does it for every consumer at once.

The clause that testing showed matters most is not the rule, it is the sentence after it: **a file that already contains one is not a precedent.** See the test results below.

### 2. Move a component to its own file once it needs a test or a second consumer

Deliberately *not* "one component per file". 915 of 1,545 `packages/react` files declare more than one top-level component, and that is the folder architecture working as designed — `components/` holds internal subcomponents, and wrapper HOCs produce several declarations per file.

The rule is trigger-based instead: it needs its own test, or a second file needs it. Until then a non-exported helper used once in the file is fine, which is what most of those 915 files are. When it does move, it goes in the component folder's `components/` directory.

### 3. No statement blocks inside JSX

A `.map` callback with a block body is a component in everything but name: it takes props, derives values, branches, and returns JSX with no name, no props type, no test, and no boundary React can memoize. Every derivation re-runs on every parent render and the profiler attributes it to the parent.

One f0-specific note in the rule, which came directly out of a test run: extracting the derivation into a *helper that returns a bag of values* is not enough. The `if`/`const` still has to leave the JSX callback, and what replaces it needs a props contract.

### 4. Name the function you pass to `useEffect`

`useEffect(function scrollActiveTabIntoView() { … }, [deps])`.

If the name needs an "and", the effect does two things and should be split. If you cannot name the side effect, it is not one. `packages/react` has 508 effects and zero named callbacks.

`packages/react/AGENTS.md` already forbids syncing controlled/uncontrolled state through `useEffect` in favour of `useControllable`; the reference points at that rather than restating it.

## How this was tested

Every rule was run as a pressure scenario against a fresh agent, once with no reference loaded and once with it. A rule was kept only where the agent actually failed without it. Scenarios were built from real code in this repo — `experimental/Navigation/Dropdown`, `F0StatusCard`, `SidebarTabs` — with F0's conventions stated in the prompt (`forwardRef`, `withSkeleton`, `withDataTestId`, CVA, `f1-*` tokens, `useI18n`).

| Scenario | Without reference | With reference |
| --- | --- | --- |
| Nested component, file already has **one** | **no failure** — wrote plain inline JSX | — |
| Nested component, file already has **two** | **failed** — added a third, "so the new code reads like it was always part of the file" | **passed** — created `components/MetricRow.tsx` |
| `.map` statement block, 4 per-item derivations | **failed** | **passed** — hoisted to module scope |
| Two effects, one with a `ResizeObserver` cleanup | **failed** — both anonymous | **passed** — both named |

Two findings worth keeping:

- **One nested component is not enough precedent; two is.** The first attempt stayed clean and the second failed, with a rationalization almost identical to the one captured in the product frontend ("reads like it was always part of the file"). That is why the rule carries the "not a precedent" sentence.
- **F0's wrapper conventions did not prevent the failure.** I expected `forwardRef` plus the HOC stack to make extracting a component feel expensive enough to change the outcome. It did not.

The GREEN runs above used the wording already reviewed in factorialco/factorial#111042; the version in this PR, with F0 examples, was then re-tested against three fresh scenarios (`F0StatusCard`, `CalendarEvent` tags, `F0Carousel`).

## What this PR does not do

**No lint rule.** A nested component declaration and an anonymous `useEffect` are both cheaply detectable, but any rule would fire on the 508 existing effects. If we want enforcement, the nested-component case is the one worth a rule, since it is a defect rather than a preference.

**No change to `f0-code-review`.** I have not tested whether an F0 review agent misses these without help. In the product-frontend PR that exact test deleted one of my two review-prompt edits, so I am not adding an untested one here.

**Pre-existing nested components are not swept.** In testing, an agent that correctly avoided adding one still left the existing two alone, calling them out but treating the ticket as a scoped addition. That matches how changes are normally scoped here.

## Files

- `vendor/skills/f0-component-patterns/references/component-files.md` (new)
- `vendor/skills/f0-component-patterns/SKILL.md` (Quick Reference row, one "When to Use" bullet)

`.claude/skills/` and `.opencode/skills/` are generated from `vendor/skills/` by `scripts/install-skills.ts` and are gitignored, so only the canonical source is committed. Run `pnpm skills:sync` after pulling.
