### PR TITLE
feat(NewHomeLayout): add F0OneSwitch to the top-right controls

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -192,6 +192,24 @@ describe("NewHomeLayout", () => {
       expect(screen.queryByLabelText("Edit Home")).not.toBeInTheDocument()
     })
 
+    test("names the collapse toggle with f0's tooltip, not a native title", async () => {
+      renderLayout(1400)
+
+      const toggle = screen.getByLabelText("Collapse widgets panel")
+      // The browser's own late, unstyled tooltip is gone — f0's is the name.
+      expect(toggle).not.toHaveAttribute("title")
+
+      await userEvent.hover(toggle)
+
+      expect(
+        await screen.findByRole(
+          "tooltip",
+          { name: /Collapse widgets panel/ },
+          { timeout: 3000 }
+        )
+      ).toBeInTheDocument()
+    })
+
     /**
      * Arranging is always available, so the chrome for it is on the widgets
      * themselves: the unlocked one carries a menu, the pinned one carries none.

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -16,6 +16,13 @@ import { F0Icon, type IconType } from "@/components/F0Icon"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
 import { One } from "@/icons/ai"
 import {
+  MockAiChatRuntimeProvider,
+  MockConnectedChatHeader,
+  MockConnectedChatInput,
+  MockConnectedMessagesContainer,
+} from "@/kits/ai/F0AiChat/__stories__/_mock"
+import ApplicationFrameStories from "@/patterns/ApplicationFrame/index.stories"
+import {
   Building,
   Calendar,
   ChartVerticalBars,
@@ -1567,20 +1574,38 @@ const meta = {
   parameters: { layout: "fullscreen", docsFullWidth: true },
   decorators: [
     (Story, { parameters }) => (
-      <ApplicationFrame
-        // The frame's top row, outside the layout entirely: it takes real height
-        // off the content area, which is what the height probe is testing.
-        banner={parameters.frameBanner ? <FrameBanner /> : undefined}
-        sidebar={
-          <Sidebar
-            header={<SidebarHeader {...SidebarHeaderStories.Default.args} />}
-            body={<SidebarMenu {...SidebarMenuStories.Default.args} />}
-            footer={<SidebarFooter {...SidebarFooterStories.Default.args} />}
-          />
-        }
-      >
-        <Story />
-      </ApplicationFrame>
+      // The AI chat's own mock runtime, exactly as `ApplicationFrame`'s stories
+      // wire it: the panel the One switch opens has to hold A CHAT, and its
+      // header, transcript and composer are slots the app fills.
+      <MockAiChatRuntimeProvider>
+        <ApplicationFrame
+          // The frame's top row, outside the layout entirely: it takes real height
+          // off the content area, which is what the height probe is testing.
+          banner={parameters.frameBanner ? <FrameBanner /> : undefined}
+          // The One switch in the layout's top-right draws NOTHING unless the
+          // frame's AI chat is enabled — same as `DaytimePage`'s story. THE ONE
+          // THING IT OPENS is this chat: no panel content is ever pushed here,
+          // so the switch has nothing else to swap with.
+          ai={{
+            // THE SAME CHAT the frame's own story gives `HomeLayout` — its
+            // args, not a second configuration that can drift from them — with
+            // the mock header/transcript/composer filling the panel's slots.
+            ...ApplicationFrameStories.args.ai,
+            chatHeader: <MockConnectedChatHeader />,
+            chatMessages: <MockConnectedMessagesContainer />,
+            chatInput: <MockConnectedChatInput />,
+          }}
+          sidebar={
+            <Sidebar
+              header={<SidebarHeader {...SidebarHeaderStories.Default.args} />}
+              body={<SidebarMenu {...SidebarMenuStories.Default.args} />}
+              footer={<SidebarFooter {...SidebarFooterStories.Default.args} />}
+            />
+          }
+        >
+          <Story />
+        </ApplicationFrame>
+      </MockAiChatRuntimeProvider>
     ),
   ],
 } satisfies Meta<typeof NewHomeLayout>

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -19,6 +19,7 @@ import { Tooltip } from "@/experimental/Overlays/Tooltip"
 // No `Pencil`/`Check`: there is no edit mode to toggle any more.
 import { Plus } from "@/icons/app"
 import Menu from "@/icons/app/Menu"
+import { F0OneSwitch } from "@/kits/ai/F0OneSwitch"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -607,6 +608,15 @@ export interface NewHomeLayoutProps {
   stackedPinsAfter?: number
   ctx?: HomeRenderCtx
   className?: string
+  /** Tooltip copy for the One switch, forwarded to `F0OneSwitch`. */
+  oneSwitchTooltip?: { whenDisabled?: string; whenEnabled?: string }
+  /** Opens the One switch's tooltip for 3s on mount. */
+  oneSwitchAutoOpen?: boolean
+  /**
+   * Hides the One AI toggle in the controls row. Use when One is reached
+   * elsewhere (e.g. a sidebar tab) so Home doesn't show a redundant switch.
+   */
+  hideOneSwitch?: boolean
 }
 
 /**
@@ -650,6 +660,9 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       stackedPinsAfter = 2,
       ctx = {},
       className,
+      oneSwitchTooltip,
+      oneSwitchAutoOpen,
+      hideOneSwitch = false,
     },
     ref
   ) {
@@ -752,6 +765,11 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       rightWidgets.length > 0 &&
       (autoCollapsed || (manualCollapsed ?? false))
     const railWidth = collapsed ? COLLAPSED_RAIL_WIDTH : asideWidth
+    // ONE string for the rail toggle: its accessible name AND what the tooltip
+    // says. A control whose tooltip and label can drift is two controls.
+    const railToggleLabel = collapsed
+      ? "Expand widgets panel"
+      : "Collapse widgets panel"
     // NOTHING ON THE RIGHT UNTIL THE BOX HAS BEEN MEASURED. Which presentation the
     // rail is in — column, strip, or nothing at all — is decided entirely by the
     // width, so drawn before there is one its first state is a guess the next
@@ -1022,23 +1040,33 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 is collapsed regardless, so a toggle there would be a control
                 that does nothing. */}
             {hasSide && rightWidgets.length > 0 && !autoCollapsed ? (
-              <Action
-                variant="ghost"
-                size="md"
-                compact
-                onClick={() => setManualCollapsed(!collapsed)}
-                title={
-                  collapsed ? "Expand widgets panel" : "Collapse widgets panel"
-                }
-                aria-label={
-                  collapsed ? "Expand widgets panel" : "Collapse widgets panel"
-                }
-              >
-                {/* The sidebar's own collapse glyph, so collapsing the rail and
-                    collapsing the sidebar read as the same gesture. */}
-                <SidebarIconSvg isExpanded={!collapsed} />
-              </Action>
+              // f0's own tooltip rather than the browser's `title`: an
+              // icon-only control needs its name on hover, and the native one
+              // arrives late, unstyled, and never for a keyboard.
+              <Tooltip label={railToggleLabel}>
+                <Action
+                  variant="ghost"
+                  size="md"
+                  compact
+                  onClick={() => setManualCollapsed(!collapsed)}
+                  aria-label={railToggleLabel}
+                >
+                  {/* The sidebar's own collapse glyph, so collapsing the rail and
+                      collapsing the sidebar read as the same gesture. */}
+                  <SidebarIconSvg isExpanded={!collapsed} />
+                </Action>
+              </Tooltip>
             ) : null}
+            {/* The One toggle sits where it sits on every other layout — last in
+                the top-right controls, after the rail's own collapse button. It
+                draws NOTHING unless the AI chat context is enabled, so a Home
+                without One keeps the row it had. */}
+            {!hideOneSwitch && (
+              <F0OneSwitch
+                tooltip={oneSwitchTooltip}
+                autoOpen={oneSwitchAutoOpen}
+              />
+            )}
           </div>
         </HomeEntrance>
         {/* Main column: its own scroll region, no mask — a reading column should

--- a/packages/react/src/sds/Home/NewHomeLayout/oneSwitch.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/oneSwitch.spec.tsx
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+import { Calendar } from "@/icons/app"
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { type HomeWidgetItem } from "../slotRenderers"
+import { NewHomeLayout } from "./index"
+
+// The real switch draws NOTHING unless the AI chat context is enabled, so it is
+// stubbed to a marker here and only this layout's own show/hide decision — and
+// where it puts it — is under test.
+vi.mock("@/kits/ai/F0OneSwitch", () => ({
+  F0OneSwitch: () => <div data-testid="one-switch" />,
+}))
+
+/** The width the layout reports for itself — wide enough for both columns. */
+const LAYOUT_WIDTH = 1400
+
+const RAIL: HomeWidgetItem[] = [
+  {
+    id: "events",
+    icon: Calendar,
+    header: { title: "events" },
+    slots: [
+      {
+        visualization: "indicators",
+        params: { items: [{ label: "requests", content: "1" }] },
+      },
+    ],
+  },
+]
+
+const renderLayout = (props = {}) =>
+  zeroRender(
+    <NewHomeLayout rightWidgets={RAIL} {...props}>
+      <p>greeting</p>
+    </NewHomeLayout>
+  )
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => LAYOUT_WIDTH,
+  })
+  // jsdom has no ResizeObserver, and the layout measures itself with one.
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: () => void) {
+        callback()
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+})
+
+describe("NewHomeLayout one switch", () => {
+  test("renders the One switch by default", () => {
+    renderLayout()
+
+    expect(screen.getByTestId("one-switch")).toBeInTheDocument()
+  })
+
+  test("puts it after the rail's collapse button, in the same row", () => {
+    renderLayout()
+
+    const collapse = screen.getByLabelText("Collapse widgets panel")
+    const oneSwitch = screen.getByTestId("one-switch")
+
+    expect(collapse.parentElement).toBe(oneSwitch.parentElement)
+    expect(
+      collapse.compareDocumentPosition(oneSwitch) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  test("hides it when hideOneSwitch is set", () => {
+    renderLayout({ hideOneSwitch: true })
+
+    expect(screen.queryByTestId("one-switch")).toBeNull()
+    // The collapse toggle is independent and stays.
+    expect(screen.getByLabelText("Collapse widgets panel")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description

`NewHomeLayout` was the only layout without the One AI toggle: `PageHeader` and `DaytimePage` both render `F0OneSwitch` at the top right, so Home lost that entry point. This adds it as the last control in the layout's own top-right row, immediately after the rail's collapse button, and gives that collapse button its label through f0's `Tooltip` instead of the browser's native `title`.