### PR TITLE
feat(NewHomeLayout): withdraw the add offer per column

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -231,6 +231,65 @@ describe("NewHomeLayout", () => {
     })
   })
 
+  /**
+   * A column's catalog can RUN OUT — a main column that only takes one kind of
+   * widget has nothing left to offer once that widget is on it — and a "+" that
+   * opens an empty picker is an offer the app cannot keep. Naming the sides that
+   * still take widgets withdraws the offer without withdrawing the arranging.
+   */
+  describe("addableWidgetContainers", () => {
+    /** Both columns' add affordances, by the name the provider gives them. */
+    const addOffers = () => screen.queryAllByLabelText("Add widget")
+
+    test("offers both columns when it is not given", () => {
+      renderLayout(1400, { leftWidgets: [widget("communities")] })
+
+      expect(addOffers()).toHaveLength(2)
+    })
+
+    test("withdraws the offer from a column it leaves out", () => {
+      renderLayout(1400, {
+        leftWidgets: [widget("communities")],
+        addableWidgetContainers: ["right"],
+      })
+
+      expect(addOffers()).toHaveLength(1)
+    })
+
+    test("leaves that column arrangeable — only the offer goes", () => {
+      renderLayout(1400, {
+        leftWidgets: [widget("communities")],
+        addableWidgetContainers: ["right"],
+        onRemoveWidget: () => {},
+      })
+
+      // The main widget keeps its own menu (where "Remove widget" lives), as
+      // does the rail's unlocked one: two menus, one add offer.
+      expect(screen.getAllByRole("button", { name: "Actions" })).toHaveLength(2)
+    })
+
+    test("withdraws it from the collapsed strip too", async () => {
+      renderLayout(1400, { addableWidgetContainers: ["main"] })
+
+      await userEvent.click(screen.getByLabelText("Collapse widgets panel"))
+
+      // The strip carries the rail's only add affordance while collapsed, and
+      // the rail is not addable — so the one left is the main column's.
+      expect(addOffers()).toHaveLength(1)
+    })
+
+    test("is a NARROWING of editableWidgetContainers, never a widening", () => {
+      renderLayout(1400, {
+        leftWidgets: [widget("communities")],
+        editableWidgetContainers: ["right"],
+        addableWidgetContainers: ["main", "right"],
+      })
+
+      // Main is not arrangeable, so naming it addable cannot conjure the offer.
+      expect(addOffers()).toHaveLength(1)
+    })
+  })
+
   describe("too narrow for both columns, but wide enough for the strip", () => {
     test("collapses the rail on its own", () => {
       renderLayout(1000)

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -9,11 +9,11 @@ import { f0FormField } from "@/patterns/F0Form"
 import { F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
-import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
 import { F0Card } from "@/components/F0Card"
 import { F0Heading } from "@/components/F0Heading"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
+import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { One } from "@/icons/ai"
 import {
   MockAiChatRuntimeProvider,
@@ -27,6 +27,7 @@ import {
   Calendar,
   ChartVerticalBars,
   Check,
+  ChevronDown,
   ChevronRight,
   Clock,
   Comment,
@@ -1082,10 +1083,12 @@ const CommunityPostDetail = ({ post }: { post: CommunityPostSummary }) => (
  * The Communities widget as DATA, built for the scope it is currently showing.
  *
  * Its two controls sit in the header (`headerControls`): the SCOPE SWITCHER —
- * `F0ButtonDropdown` in `dropdown` mode, so the trigger names what is selected
- * and the whole button opens the menu — and "New post", the one thing you can do
- * from the card without leaving the page. The way OUT of the widget is still the
- * title ("Go to Communities"), and the three-dots menu is still the column's.
+ * a GHOST `F0Button` naming what is selected, wrapped in `Dropdown` so pressing
+ * it opens the scopes — and "New post", the one thing you can do from the card
+ * without leaving the page. Both are ghosts: this row sits beside the widget's
+ * own title, and two filled buttons there read as the card's subject rather than
+ * as its controls. The way OUT of the widget is still the title ("Go to
+ * Communities"), and the three-dots menu is still the column's.
  */
 const communitiesWidget = ({
   scope,
@@ -1117,15 +1120,25 @@ const communitiesWidget = ({
           label="New Post"
           onClick={onNewPost}
         />
-        <F0ButtonDropdown
-          mode="dropdown"
-          variant="neutral"
-          size="sm"
-          tooltip="Show"
-          value={scope}
-          items={COMMUNITY_SCOPES.map((option) => ({ ...option }))}
-          onClick={(value) => onChangeScope(value as CommunityScope)}
-        />
+        <Dropdown
+          items={COMMUNITY_SCOPES.map((option) => ({
+            label: option.label,
+            // The menu says which one you are on: a trigger that names the scope
+            // still leaves the list itself unmarked.
+            ...(option.value === scope ? { icon: Check } : {}),
+            onClick: () => onChangeScope(option.value),
+          }))}
+        >
+          <F0Button
+            variant="ghost"
+            size="sm"
+            icon={ChevronDown}
+            label={
+              COMMUNITY_SCOPES.find((option) => option.value === scope)
+                ?.label ?? "Show"
+            }
+          />
+        </Dropdown>
       </>
     ),
     actions: [

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -521,6 +521,18 @@ export interface NewHomeLayoutProps {
    */
   editableWidgetContainers?: WidgetContainerSide[]
   /**
+   * Which containers may still be ADDED TO. Narrower than
+   * `editableWidgetContainers`, which it is a subset of: a column not named here
+   * keeps its dragging and its "Remove widget" and only loses the offer to add.
+   *
+   * Defaults to every editable container — the common case, where the catalog
+   * always has something for every column. Name the sides once a column's
+   * catalog can run out: a main column that only ever holds one kind of widget
+   * has nothing to offer the moment that widget is on it, and a "+" that opens
+   * an empty picker is an offer the app cannot keep.
+   */
+  addableWidgetContainers?: WidgetContainerSide[]
+  /**
    * Which containers keep ONLY THE WIDGETS YOU CAN SEE in the DOM. None by
    * default: for a Home of a dozen widgets, mounting them all is what keeps a
    * card's data, clock and animation alive across everything this layout does to
@@ -579,7 +591,10 @@ export interface NewHomeLayoutProps {
     widget: HomeWidgetItem,
     params: WidgetParams
   ) => ReactNode
-  /** When set, renders a "+ Add widget" affordance at the bottom of each column. */
+  /**
+   * When set, renders a "+ Add widget" affordance at the bottom of each column
+   * that takes widgets — see `addableWidgetContainers`.
+   */
   onClickAddNewWidget?: (side: WidgetContainerSide) => void
   /** Called with a side and its widget ids in their new order after a drag. */
   onReorderWidgets?: (side: WidgetContainerSide, ids: string[]) => void
@@ -645,6 +660,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       slotRenderers,
       renderWidget,
       editableWidgetContainers = ["main", "right"],
+      addableWidgetContainers,
       virtualizedWidgetContainers = [],
       virtualization,
       onRemoveWidget,
@@ -705,6 +721,11 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     const [manualCollapsed, setManualCollapsed] = useState<boolean | null>(null)
     const canEditSide = (side: WidgetContainerSide) =>
       editableWidgetContainers.includes(side)
+    // ADDING is a narrowing of arranging: a column you cannot arrange is not one
+    // you can add to, and an omitted `addableWidgetContainers` means every
+    // arrangeable column takes new widgets.
+    const canAddToSide = (side: WidgetContainerSide) =>
+      canEditSide(side) && (addableWidgetContainers?.includes(side) ?? true)
 
     const render = (widget: HomeWidgetItem) => {
       const node = renderWidget ? (
@@ -753,7 +774,9 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
         : false
 
     const hasSide =
-      aside != null || rightWidgets.length > 0 || onClickAddNewWidget != null
+      aside != null ||
+      rightWidgets.length > 0 ||
+      (onClickAddNewWidget != null && canAddToSide("right"))
     // Two reasons the rail collapses, and they don't compete: there ISN'T ROOM
     // for both columns, or you ASKED for the space. Narrowness always wins —
     // expanding by hand can't conjure room the layout doesn't have — so the
@@ -1131,7 +1154,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             renderWidgetPreview={renderWidgetPreview}
             paramsPreviewWidth={mainWidth}
             onClickAddNewWidget={
-              onClickAddNewWidget
+              onClickAddNewWidget && canAddToSide("main")
                 ? () => onClickAddNewWidget("main")
                 : undefined
             }
@@ -1224,7 +1247,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               {/* Always offered, not only in edit mode: collapsed, the strip has
                     no edit affordance of its own, and adding a widget is the one
                     thing you would still want from it. */}
-              {canEditSide("right") && onClickAddNewWidget ? (
+              {canAddToSide("right") && onClickAddNewWidget ? (
                 // The same control the column's placeholder is — a dashed box
                 // around one glyph, named only on hover — at the strip's size.
                 <Tooltip label={t.widgets.addWidget}>
@@ -1352,7 +1375,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               // affordance, and a placeholder under a single floating widget
               // would be an offer in the wrong place.
               onClickAddNewWidget={
-                onClickAddNewWidget && !collapsed
+                onClickAddNewWidget && canAddToSide("right") && !collapsed
                   ? () => onClickAddNewWidget("right")
                   : undefined
               }


### PR DESCRIPTION
## Description

Two things for the Home, both from building the Communities widget on top of it.

**1. A column's catalog can run out.** On the Home we are building, the main column takes one kind of widget — a Communities carousel needs the 712px a rail row does not — so the moment that widget is on it there is nothing left to offer, and the `+` at the column's foot opens an empty picker. `editableWidgetContainers` could not express that: it gates arranging and adding *together*, so hiding the offer also took dragging and "Remove widget" away from the column — and removing the widget is exactly what you'd want to do next.

**2. The widget's two header controls were not the same kind of thing to look at.** "New post" a ghost, the scope switcher an `F0ButtonDropdown` in `neutral`. That row is the widget TITLE's own, and a filled control beside a title reads as the card's subject rather than as something you press.

## Public API

**Added prop**

| Component | Prop | Why |
| --- | --- | --- |
| `NewHomeLayout` | `addableWidgetContainers?: WidgetContainerSide[]` | Which columns may still be added to. A **narrowing** of `editableWidgetContainers` — defaults to all of it, so nothing changes for anyone who doesn't pass it. |

Applied at all three places the offer appears: the main column's placeholder, the expanded rail's, and the collapsed strip's own button (where the rail's offer lives while collapsed). `hasSide` follows too — the rail no longer exists *just* to carry an add offer that has been withdrawn.

Naming a side that isn't editable cannot conjure the offer: the predicate is `canEditSide(side) && (addableWidgetContainers?.includes(side) ?? true)`.

**No API change** for the second part — it is the Home story's own Communities widget. `F0ButtonDropdown`'s variants stop at `neutral`, so the switcher becomes what it always was underneath: a button that opens a menu, as a ghost `F0Button` naming the current scope wrapped in `Dropdown`. The menu now marks the scope you are on with a check, which trigger-only selection never showed.

## Tests

5 cases in `NewHomeLayout/index.spec.tsx`: both columns offered by default, the offer withdrawn from a named-out column, that column still arrangeable (its widgets keep their menus), the collapsed strip's button withdrawn too, and the narrowing-not-widening rule. 49 pass in `src/sds/Home/NewHomeLayout/`, plus tsc / oxlint / oxfmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)