### PR TITLE
fix(OneTable): contain skeleton table within its own scroll area

### DIFF
--- a/packages/react/src/experimental/OneTable/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/experimental/OneTable/Table/__tests__/Table.test.tsx
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import { OneTable } from "../../index"
+
+describe("OneTable.Skeleton", () => {
+  it("wraps the placeholder table in the same scroll container as the loaded table", () => {
+    // Regression test: with many columns the skeleton's intrinsic table
+    // width can exceed its card, and without this wrapper it overflowed
+    // the card uncontained instead of scrolling within it like TableBase.
+    const { container } = zeroRender(<OneTable.Skeleton columns={12} />)
+
+    const table = container.querySelector("table")
+    expect(table).not.toBeNull()
+    // `table` sits inside the Table primitive's own "relative w-full" div
+    // (see `@/ui/table`), so the scroll container is its grandparent — the
+    // same nesting depth TableBase uses for the loaded table.
+    expect(table?.parentElement?.parentElement?.className).toContain(
+      "overflow-auto"
+    )
+  })
+})

--- a/packages/react/src/experimental/OneTable/Table/index.tsx
+++ b/packages/react/src/experimental/OneTable/Table/index.tsx
@@ -93,32 +93,38 @@ function TableSkeleton({ columns = 5 }: TableSkeletonProps) {
         setIsScrolledRight: () => {},
       }}
     >
-      <TableRoot
-        className="cursor-progress"
-        role="presentation"
-        aria-hidden="true"
-      >
-        <TableHeader>
-          <TableRow>
-            {Array.from({ length: columns }).map((_, i) => (
-              <TableHead key={`skeleton-header-${i}`}>
-                <Skeleton className="h-4 w-[80px]" />
-              </TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {Array.from({ length: 5 }).map((_, rowIndex) => (
-            <TableRow key={`skeleton-row-${rowIndex}`}>
-              {Array.from({ length: columns }).map((_, colIndex) => (
-                <TableCell key={`skeleton-cell-${rowIndex}-${colIndex}`}>
+      {/* Mirrors TableBase's scroll container so a wide skeleton (many
+          columns) scrolls within its own bounds instead of overflowing
+          past the parent card, which has no clipping wrapper while this
+          initial-loading state is shown. */}
+      <div className="relative h-full w-full overflow-auto">
+        <TableRoot
+          className="cursor-progress"
+          role="presentation"
+          aria-hidden="true"
+        >
+          <TableHeader>
+            <TableRow>
+              {Array.from({ length: columns }).map((_, i) => (
+                <TableHead key={`skeleton-header-${i}`}>
                   <Skeleton className="h-4 w-[80px]" />
-                </TableCell>
+                </TableHead>
               ))}
             </TableRow>
-          ))}
-        </TableBody>
-      </TableRoot>
+          </TableHeader>
+          <TableBody>
+            {Array.from({ length: 5 }).map((_, rowIndex) => (
+              <TableRow key={`skeleton-row-${rowIndex}`}>
+                {Array.from({ length: columns }).map((_, colIndex) => (
+                  <TableCell key={`skeleton-cell-${rowIndex}-${colIndex}`}>
+                    <Skeleton className="h-4 w-[80px]" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </TableRoot>
+      </div>
     </TableContext.Provider>
   )
 }


### PR DESCRIPTION
## Summary
- `TableSkeleton` (the initial loading state of `OneTable`) rendered the placeholder `<table>` with no wrapping scroll container, unlike `TableBase` (the loaded table), which wraps it in `overflow-auto`.
- With many columns, the skeleton's intrinsic table width could exceed its card and overflow uncontained to the right instead of scrolling within it.
- Fix wraps `TableSkeleton` in the same `overflow-auto` container `TableBase` already uses, at the same nesting depth (verified with a unit test).

## Test plan
- [x] New unit test: `OneTable.Skeleton` wraps the table in an `overflow-auto` ancestor (`Table/__tests__/Table.test.tsx`)
- [x] `oxlint` clean on changed files
- [x] `tsc --noEmit` — no new errors (pre-existing unrelated `libphonenumber-js` module-resolution errors only)
- [x] Manual check in local Storybook with 14 columns inside a 640px card — before/after screenshots below

## Screenshots

`OneTable.Skeleton columns={14}` inside a 640px card (local Storybook, temporary story — not committed).

**Before** — the placeholder rows spill past the card's right edge:

<img src="https://raw.githubusercontent.com/factorialco/f0/1cfc68a211a086b47f3e70828c7c6ab324ab97c7/.github/assets/table-skeleton-overflow/before.png" width="900" alt="Before: skeleton table overflowing its card to the right" />

**After** — the skeleton scrolls inside its own container, the same as the loaded table:

<img src="https://raw.githubusercontent.com/factorialco/f0/1cfc68a211a086b47f3e70828c7c6ab324ab97c7/.github/assets/table-skeleton-overflow/after.png" width="900" alt="After: skeleton table clipped inside its card" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
