### PR TITLE
fix(ci): handle stateless GitHub App token format in secret redaction

### DIFF
--- a/.github/scripts/agentic-check.sh
+++ b/.github/scripts/agentic-check.sh
@@ -29,10 +29,13 @@ GITHUB_API="https://api.github.com"
 # GitHub masks secrets in logs but not in API-posted comments.
 redact_secrets() {
 	local text="$1"
-	# Redact GitHub tokens
-	text=$(printf '%s' "${text}" | sed -E 's/ghp_[A-Za-z0-9]{36}/[REDACTED]/g')
-	text=$(printf '%s' "${text}" | sed -E 's/gho_[A-Za-z0-9]{36}/[REDACTED]/g')
-	text=$(printf '%s' "${text}" | sed -E 's/ghs_[A-Za-z0-9]{36}/[REDACTED]/g')
+	# Redact GitHub tokens. Patterns must be open-ended: an exact-length
+	# quantifier redacts only the head of a longer token and leaks the tail.
+	# Stateless ghs_ installation tokens are JWT-like (dots, dashes,
+	# underscores, hundreds of chars), so ghs_ needs the wider charset.
+	text=$(printf '%s' "${text}" | sed -E 's/ghp_[A-Za-z0-9]{36,}/[REDACTED]/g')
+	text=$(printf '%s' "${text}" | sed -E 's/gho_[A-Za-z0-9]{36,}/[REDACTED]/g')
+	text=$(printf '%s' "${text}" | sed -E 's/ghs_[A-Za-z0-9._-]{36,}/[REDACTED]/g')
 	text=$(printf '%s' "${text}" | sed -E 's/github_pat_[A-Za-z0-9_]{80,}/[REDACTED]/g')
 	# Redact generic API key patterns (long hex/base64 strings after common key labels)
 	text=$(printf '%s' "${text}" | sed -E 's/(api[_-]?key|token|secret|password|credential)["\x27]?\s*[:=]\s*["\x27]?[A-Za-z0-9+\/\-_]{20,}/\1=[REDACTED]/gi')


### PR DESCRIPTION
## Why

GitHub App installation tokens move to a new stateless format ([changelog](https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/)). The tokens keep the `ghs_` prefix, but become JWT-like values of ~520 characters that contain `.`, `-`, and `_`. The Actions-issued `GITHUB_TOKEN` is one of these tokens, and its staged rollout has already started.

`redact_secrets()` in `.github/scripts/agentic-check.sh` uses exact-length regexes (`ghs_[A-Za-z0-9]{36}`). Against a long token, `sed` replaces only the first 40 characters. The remaining ~480 characters of a live token get posted verbatim to the PR comment. GitHub masks secrets in logs, but not in API-posted comments, so this redaction is the only protection on that path. This repo is public, which makes the exposure worse.

## What

Make the token patterns open-ended (`{36,}`) and widen the `ghs_` charset to `[A-Za-z0-9._-]`. This follows GitHub's recommended pattern `ghs_[A-Za-z0-9\.\-_]{36,}`.

Same fix as factorialco/factorial#111292.

## Verification

Piped synthetic tokens (legacy 40-char and stateless 522-char, generated locally) through the updated `redact_secrets()`: fully redacted, no tail left. With the old regex, the tail of the long token survives redaction.