### PR TITLE
fix(Home): the drag ghost is a copy of the card, not a second render

### DIFF
--- a/packages/react/src/sds/Home/WidgetContainer/dragGhost.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/dragGhost.test.tsx
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, test } from "vitest"
+
+import { useState } from "react"
+
+import { Calendar } from "@/icons/app"
+import { zeroRender } from "@/testing/test-utils"
+
+import { type HomeWidgetItem, type SlotRenderers } from "../slotRenderers"
+import { takeCardGhost } from "./dragGhost"
+import { WidgetContainer } from "./index"
+
+/**
+ * The ghost is a COPY of the card's DOM rather than a second render of the
+ * widget, which is the whole point: a second render is a second mount, and
+ * everything the card had built up — which page of its carousel you were on,
+ * what its clock said — started over for the length of the drag.
+ */
+const card = (html: string): HTMLElement => {
+  const node = document.createElement("div")
+  node.className = "cursor-grab invisible"
+  node.dataset.widgetId = "communities"
+  node.style.transform = "translate3d(0, 40px, 0)"
+  node.style.transition = "transform 200ms"
+  node.innerHTML = html
+
+  return node
+}
+
+/** How many times the counting tile has been built from scratch. */
+let tileMounts = 0
+
+/**
+ * A tile with STATE OF ITS OWN, the way the real ones have: a carousel on its
+ * third page, a clock mid-tick, a list scrolled down. It counts its mounts and
+ * shows what it counted to, so a second mount is visible rather than silent.
+ */
+const CountingTile = () => {
+  const [mounted] = useState(() => (tileMounts += 1))
+
+  return <span>page {mounted}</span>
+}
+
+const RENDERERS: SlotRenderers = { counting: () => <CountingTile /> }
+
+const statefulWidget = (id: string): HomeWidgetItem => ({
+  id,
+  icon: Calendar,
+  header: { title: id },
+  slots: [{ visualization: "counting", params: {} }],
+})
+
+/**
+ * THE REGRESSION. The ghost used to be `render(active, { isDragging: true })` —
+ * the widget a second time — so the card the pointer carried had mounted afresh:
+ * a carousel on its third page showed its first for the length of the drag and
+ * snapped back on release. Copying the card cannot do that, and this is the
+ * assertion that says so: the copy shows what the card showed, and building it
+ * mounted nothing.
+ */
+describe("the ghost of a card with state in it", () => {
+  beforeEach(() => {
+    tileMounts = 0
+  })
+
+  test("shows what the card showed, and mounts nothing to do it", () => {
+    const { container } = zeroRender(
+      <WidgetContainer
+        widgets={[statefulWidget("communities"), statefulWidget("events")]}
+        slotRenderers={RENDERERS}
+        onReorder={() => {}}
+      />
+    )
+
+    expect(tileMounts).toBe(2)
+    const card = container.querySelector('[data-widget-id="communities"]')
+    // The card is on its first page here; a real one would be on its third.
+    expect(card?.textContent).toContain("page 1")
+
+    const ghost = takeCardGhost(card)
+
+    // The SAME page, not a fresh tile — and no third mount anywhere.
+    expect(ghost?.textContent).toContain("page 1")
+    expect(tileMounts).toBe(2)
+  })
+})
+
+describe("takeCardGhost", () => {
+  test("copies the card as it looks, subtree and all", () => {
+    const ghost = takeCardGhost(
+      card("<h3>Community posts</h3><p>page three</p>")
+    )
+
+    expect(ghost?.textContent).toBe("Community postspage three")
+    expect(ghost?.dataset.widgetId).toBe("communities")
+  })
+
+  test("is VISIBLE and STILL, whatever the card it copied was doing", () => {
+    // The original goes invisible for the drag and carries the sortable's
+    // transform; the copy is the one you see, and it does not move on its own.
+    const ghost = takeCardGhost(card("<span>x</span>"))
+
+    expect(ghost?.classList.contains("invisible")).toBe(false)
+    expect(ghost?.style.transform).toBe("none")
+    expect(ghost?.style.transition).toBe("none")
+  })
+
+  test("takes no ids with it", () => {
+    // Two nodes with one id breaks every `aria-*` and label pointing at it,
+    // and `document.getElementById` would start answering with the ghost.
+    const source = card('<button id="menu">…</button><div id="panel"></div>')
+    source.id = "widget-card"
+
+    const ghost = takeCardGhost(source)
+
+    expect(ghost?.hasAttribute("id")).toBe(false)
+    expect(ghost?.querySelectorAll("[id]")).toHaveLength(0)
+    // The original is untouched: it is still the card in the column.
+    expect(source.id).toBe("widget-card")
+    expect(source.querySelectorAll("[id]")).toHaveLength(2)
+  })
+
+  test("is a picture, not a control", () => {
+    const ghost = takeCardGhost(card("<button>Actions</button>"))
+
+    expect(ghost?.getAttribute("aria-hidden")).toBe("true")
+    expect(ghost?.hasAttribute("inert")).toBe(true)
+  })
+
+  test("has nothing to copy when the card is gone", () => {
+    // A column that scrolled the card out from under the pointer, or an id no
+    // longer in the DOM: no ghost rather than a crash.
+    expect(takeCardGhost(null)).toBeNull()
+    expect(takeCardGhost(undefined)).toBeNull()
+  })
+})

--- a/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
@@ -1,0 +1,37 @@
+/**
+ * THE CARD THE POINTER CARRIES while a widget is dragged: a static COPY of the
+ * real card's DOM, taken as the drag starts.
+ *
+ * It used to be a second RENDER of the widget in the DragOverlay, and a second
+ * render is a second mount: the copy's slot content started over while the
+ * original — hidden, holding its slot — kept the state you had built up. A
+ * carousel showed its first page for the length of the drag and snapped back on
+ * release; a clock restarted; a scrolled list went to the top.
+ *
+ * A copy of the DOM cannot do that. It has no state to start over and runs no
+ * effects: it is the card exactly as it looked when you picked it up. What it
+ * cannot carry is anything that isn't IN the DOM — a canvas's pixels, a playing
+ * video — which goes blank in the ghost and is whole again on release.
+ */
+export const takeCardGhost = (
+  card: Element | null | undefined
+): HTMLElement | null => {
+  const copy = card?.cloneNode(true)
+
+  if (!(copy instanceof HTMLElement)) return null
+
+  // The original goes invisible while dragged and may carry the sortable's own
+  // transform; the copy is the one you see, and it stands still.
+  copy.classList.remove("invisible")
+  copy.style.transform = "none"
+  copy.style.transition = "none"
+  // NOT a second copy of the app's ids, and not somewhere to tab into: a
+  // duplicated id breaks every `aria-*` and label that points at one, and a
+  // ghost is a picture rather than a control.
+  copy.removeAttribute("id")
+  copy.querySelectorAll("[id]").forEach((node) => node.removeAttribute("id"))
+  copy.setAttribute("aria-hidden", "true")
+  copy.setAttribute("inert", "")
+
+  return copy
+}

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -45,6 +45,7 @@ import {
 } from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
 import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
+import { takeCardGhost } from "./dragGhost"
 import { SortableWidget } from "./SortableWidget"
 import {
   useWidgetVirtualizer,
@@ -387,8 +388,8 @@ export function WidgetContainer({
   const isHidden = (widget: HomeWidgetItem) =>
     visibleWidgetId !== undefined && widget.id !== visibleWidgetId
   const canDrag = canEdit && onReorder != null && widgets.length > 1
-  // The widget being dragged: its in-list card hides while a clone rides the
-  // pointer in the DragOverlay (see below).
+  // The widget being dragged: its in-list card hides while a copy of it rides
+  // the pointer in the DragOverlay (see below).
   const [activeId, setActiveId] = useState<string | null>(null)
   // A small activation distance so a press on a widget still reads as a press
   // rather than the start of a drag — the sensor itself already refuses to
@@ -404,6 +405,19 @@ export function WidgetContainer({
   // same column is a fairground, not an explanation.
   const [flippedId, setFlippedId] = useState<string | null>(null)
   const columnRef = useRef<HTMLDivElement>(null)
+  /** The static copy of the dragged card that rides the pointer — {@link takeCardGhost}. */
+  const ghostRef = useRef<HTMLElement | null>(null)
+
+  const takeGhost = (id: string) => {
+    ghostRef.current = takeCardGhost(
+      columnRef.current?.querySelector(`[data-widget-id="${id}"]`)
+    )
+  }
+
+  /** Puts the copy in the overlay dnd-kit positions for us. */
+  const mountGhost = (host: HTMLDivElement | null) => {
+    if (host && ghostRef.current) host.replaceChildren(ghostRef.current)
+  }
   /**
    * WHICH WIDGETS ARE WORTH HAVING IN THE DOM — every one of them unless this
    * column is virtualized. See `useWidgetVirtualizer`.
@@ -762,10 +776,19 @@ export function WidgetContainer({
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
-          onDragStart={({ active }) => setActiveId(String(active.id))}
-          onDragCancel={() => setActiveId(null)}
+          onDragStart={({ active }) => {
+            // BEFORE the card is told it is being dragged: what the ghost
+            // should look like is what is on screen right now.
+            takeGhost(String(active.id))
+            setActiveId(String(active.id))
+          }}
+          onDragCancel={() => {
+            setActiveId(null)
+            ghostRef.current = null
+          }}
           onDragEnd={(event) => {
             setActiveId(null)
+            ghostRef.current = null
             handleDragEnd(event)
           }}
         >
@@ -780,23 +803,21 @@ export function WidgetContainer({
           >
             {list}
           </SortableContext>
-          {/* The card that follows the pointer is a CLONE in an overlay — the
-              in-list card hides meanwhile (SortableWidget). On release the
-              clone GLIDES from where it was dropped into its final slot
-              (dropAnimation), which is what makes the drop soft: without the
-              overlay, committing the reorder snaps the real card's DOM slot
-              and transform in one frame. */}
+          {/* The card that follows the pointer is a COPY of the real one's DOM
+              (`takeGhost`) in an overlay — the in-list card hides meanwhile
+              (SortableWidget). On release the copy GLIDES from where it was
+              dropped into its final slot (dropAnimation), which is what makes
+              the drop soft: without the overlay, committing the reorder snaps
+              the real card's DOM slot and transform in one frame. */}
           <DragOverlay dropAnimation={DROP_ANIMATION}>
-            {(() => {
-              const active = widgets.find((widget) => widget.id === activeId)
-              return active ? (
-                // Solid backdrop: Card's own background is translucent, and the
-                // clone rides over whatever the column shows beneath it.
-                <div className="cursor-grabbing rounded-xl bg-f1-background [&_*]:shadow-none">
-                  {render(active, { isDragging: true })}
-                </div>
-              ) : null
-            })()}
+            {activeId ? (
+              // Solid backdrop: Card's own background is translucent, and the
+              // copy rides over whatever the column shows beneath it.
+              <div
+                ref={mountGhost}
+                className="h-full w-full cursor-grabbing rounded-xl bg-f1-background [&_*]:shadow-none"
+              />
+            ) : null}
           </DragOverlay>
         </DndContext>
       ) : (


### PR DESCRIPTION
## Description

Dragging a widget showed you a card that had **started over**.

`WidgetContainer` rendered the dragged widget twice: the in-list card (hidden by `SortableWidget`) and a second, independent render in the `DragOverlay` — `render(active, { isDragging: true })`. A second render is a second mount, so the ghost's slot content began from scratch while the original, still mounted underneath, kept the state you had built up.

Reported on the Home's Community posts carousel: **while dragging, it jumps to the first page; on release it is back where it was.** The same trap catches anything with state of its own — a clock mid-tick, a list scrolled down.

## The fix

The ghost is now a static **copy of the real card's DOM**, taken as the drag starts — `takeCardGhost` in `WidgetContainer/dragGhost.ts`:

- visible where the original is hidden, and still where the original carried the sortable's transform;
- stripped of its `id`s, so two copies of one card can share a document without breaking every `aria-*` and label that points at one;
- `aria-hidden` + `inert`: a ghost is a picture, not something to tab into.

It has no state to lose and runs no effects. The overlay still owns the drop glide, so nothing about the settle changes.

**The trade**: a copy carries only what is *in* the DOM. A canvas's pixels or a playing video go blank in the ghost and are whole again on release — the price of never resetting what the card was showing.

## Tests

`dragGhost.test.tsx`:

- **the regression** — a column whose tiles count their own mounts: the ghost of a card shows the page that card was showing, and building it mounts nothing. That is exactly what the old second render could not do.
- five cases on the copy itself: it keeps the card's subtree, comes out visible and still, takes no ids with it (leaving the original's intact), is `aria-hidden` + `inert`, and yields nothing when the card is gone (a column that scrolled it out from under the pointer).

**What is not covered, and why**: an end-to-end drag. dnd-kit's sensor does not activate under jsdom — I wrote the pointer-driven version first and took it back out, because it passed without a drag ever starting, which is green for the wrong reason (f0's only other "drag" test drives a custom mouse implementation, not dnd-kit). If you want the gesture itself covered, a Storybook interaction test is the place that can drive real pointer events; happy to add one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)