### PR TITLE
feat(F0AnalyticsDashboard): expose widget, point, and drag Ask One targets

### DIFF
--- a/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { expect, fireEvent, waitFor, within } from "storybook/test"
 
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 
 import { F0AnalyticsDashboard } from "@/patterns/F0AnalyticsDashboard"
 import {
@@ -26,6 +26,7 @@ import {
  */
 const WidgetDropLayout = () => {
   const { setOpen } = useAiChat()
+  const [observedTarget, setObservedTarget] = useState("No target observed")
 
   useEffect(() => {
     setOpen(true)
@@ -37,12 +38,18 @@ const WidgetDropLayout = () => {
     // `min-height: auto`, so the tall dashboard would otherwise stretch the row
     // (and with it the chat card) far past the viewport.
     <div className="flex h-full w-full gap-2 overflow-hidden">
-      <div className="min-h-0 min-w-0 flex-1 overflow-auto">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-auto">
+        <output className="text-sm" data-widget-drop-target>
+          {observedTarget}
+        </output>
         <F0AnalyticsDashboard
           filters={dashboardFilters}
           presets={dashboardPresets}
           items={mixedItems}
           editMode
+          onAskAiTarget={({ id, quote }) => {
+            setObservedTarget(`${id}: quote=${quote.text}`)
+          }}
         />
       </div>
       <div className="flex min-h-0 w-[420px] shrink-0">
@@ -145,6 +152,9 @@ export const DragWidgetToQuote: Story = {
       })
       await expect(removeQuote.parentElement).toHaveTextContent(
         "Total Headcount"
+      )
+      await expect(canvas.getByText(/headcount: quote=/)).toHaveTextContent(
+        "headcount: quote=Total Headcount"
       )
       await waitFor(() => expect(canvas.getByRole("textbox")).toHaveFocus())
       await expect(

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -18,7 +18,11 @@ import {
   useAiChat,
 } from "../providers/AiChatStateProvider"
 
-const Probe = () => {
+const Probe = ({
+  onCaptureQuote,
+}: {
+  onCaptureQuote?: (quote: ReturnType<typeof useAiChat>["pendingQuote"]) => void
+}) => {
   const {
     setOpen,
     pendingQuote,
@@ -54,6 +58,11 @@ const Probe = () => {
         Start Pong
       </button>
       <span data-testid="quote">{pendingQuote?.text ?? ""}</span>
+      {onCaptureQuote && (
+        <button type="button" onClick={() => onCaptureQuote(pendingQuote)}>
+          Capture pending quote
+        </button>
+      )}
     </>
   )
 }
@@ -74,7 +83,13 @@ const TestChatInput = () => {
  * No `fileAttachments`, so the file-drop path is off throughout — these tests
  * also cover that the widget overlay isn't gated behind an upload handler.
  */
-const renderChat = ({ overlay }: { overlay?: ReactNode } = {}) =>
+const renderChat = ({
+  overlay,
+  onCaptureQuote,
+}: {
+  overlay?: ReactNode
+  onCaptureQuote?: (quote: ReturnType<typeof useAiChat>["pendingQuote"]) => void
+} = {}) =>
   render(
     <AiChatStateProvider
       enabled
@@ -83,17 +98,23 @@ const renderChat = ({ overlay }: { overlay?: ReactNode } = {}) =>
       chatInput={<TestChatInput />}
       VoiceMode={() => <div>Voice content</div>}
     >
-      <Probe />
+      <Probe onCaptureQuote={onCaptureQuote} />
       <F0AiChat overlay={overlay} />
     </AiChatStateProvider>
   )
 
 /** Stands in for the dashboard grid announcing a drag. */
-const startWidgetDrag = (title: string) =>
+const startWidgetDrag = (
+  title: string,
+  callbacks: Pick<
+    import("@/lib/dnd/widgetDragEvents").WidgetDragStartDetail,
+    "onAskAi" | "onAskAiTarget"
+  > = {}
+) =>
   act(() => {
     window.dispatchEvent(
       new CustomEvent(WIDGET_DRAG_START, {
-        detail: { id: "headcount", title },
+        detail: { id: "headcount", title, ...callbacks },
       })
     )
   })
@@ -148,11 +169,35 @@ describe("F0AiChat widget drop", () => {
     ).not.toBeInTheDocument()
   })
 
+  it("observes the dropped widget with the exact built-in quote", async () => {
+    const onAskAiTarget = vi.fn()
+    const capturePendingQuote = vi.fn()
+    renderChat({ onCaptureQuote: capturePendingQuote })
+    await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
+
+    startWidgetDrag("Headcount by department", { onAskAiTarget })
+    fireEvent.pointerUp(dropZone())
+
+    expect(onAskAiTarget).toHaveBeenCalledWith({
+      id: "headcount",
+      title: "Headcount by department",
+      quote: { text: "Headcount by department" },
+    })
+    expect(screen.getByRole("textbox", { name: "Ask One" })).toHaveFocus()
+    await userEvent.click(
+      screen.getByRole("button", { name: "Capture pending quote" })
+    )
+    expect(capturePendingQuote.mock.calls[0][0]).toBe(
+      onAskAiTarget.mock.calls[0][0].quote
+    )
+  })
+
   it("withdraws the invitation when the drag ends away from the chat", async () => {
+    const onAskAiTarget = vi.fn()
     renderChat()
     await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
 
-    startWidgetDrag("Headcount by department")
+    startWidgetDrag("Headcount by department", { onAskAiTarget })
     endWidgetDrag()
 
     expect(
@@ -162,6 +207,7 @@ describe("F0AiChat widget drop", () => {
     // A later stray release must not retroactively quote the widget.
     fireEvent.pointerUp(dropZone())
     expect(screen.getByTestId("quote")).toHaveTextContent("")
+    expect(onAskAiTarget).not.toHaveBeenCalled()
   })
 
   it("stops accepting widget drops as soon as the chat starts closing", async () => {
@@ -312,6 +358,7 @@ describe("F0AiChat widget drop", () => {
 
   it("hands a dropped widget to the host without mutating the built-in quote", async () => {
     const onAskAi = vi.fn()
+    const onAskAiTarget = vi.fn()
     renderChat()
     await userEvent.click(screen.getByRole("button", { name: "Open chat" }))
 
@@ -322,6 +369,7 @@ describe("F0AiChat widget drop", () => {
             id: "headcount",
             title: "Headcount by department",
             onAskAi,
+            onAskAiTarget,
           },
         })
       )
@@ -332,6 +380,7 @@ describe("F0AiChat widget drop", () => {
       id: "headcount",
       title: "Headcount by department",
     })
+    expect(onAskAiTarget).not.toHaveBeenCalled()
     expect(screen.getByTestId("quote")).toHaveTextContent("")
   })
 })

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -199,7 +199,9 @@ export const SidebarWindow = ({
     if (detail.onAskAi) {
       detail.onAskAi({ id: detail.id, title: detail.title })
     } else {
-      setPendingQuote({ text: detail.title })
+      const quote = { text: detail.title }
+      detail.onAskAiTarget?.({ id: detail.id, title: detail.title, quote })
+      setPendingQuote(quote)
       focusChatInput()
     }
   }, [canAcceptWidgetDrop, focusChatInput, setDragQuoteBoth, setPendingQuote])

--- a/packages/react/src/lib/dnd/widgetDragEvents.ts
+++ b/packages/react/src/lib/dnd/widgetDragEvents.ts
@@ -18,4 +18,10 @@ export type WidgetDragStartDetail = {
   title: string
   /** Host override for Ask One. When present, chat must not mutate its quote. */
   onAskAi?: (item: { id: string; title: string }) => void
+  /** Observes the built-in quote without replacing the chat behavior. */
+  onAskAiTarget?: (item: {
+    id: string
+    title: string
+    quote: { text: string }
+  }) => void
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
@@ -50,6 +50,7 @@ export const F0AnalyticsDashboard = <
   resetKey,
   onTransformChart,
   onAskAi,
+  onAskAiTarget,
   navigationFilters,
   filtersLoading,
 }: F0AnalyticsDashboardProps<Filters>) => {
@@ -174,6 +175,7 @@ export const F0AnalyticsDashboard = <
           onLayoutChange={onLayoutChange}
           onTransformChart={onTransformChart}
           onAskAi={onAskAi}
+          onAskAiTarget={onAskAiTarget}
           resetKey={resetKey}
           onFullscreenChange={setIsItemFullscreen}
         />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { useState } from "react"
+
 import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import { F0AiChat, F0AiChatProvider } from "@/kits/ai/F0AiChat"
@@ -38,6 +40,39 @@ const AskOneLayout = ({ items = widget }: { items?: DashboardItem[] }) => {
     <div className="flex h-full w-full gap-2 overflow-hidden">
       <div className="min-h-0 min-w-0 flex-1 overflow-auto">
         <F0AnalyticsDashboard items={items} />
+      </div>
+      <div className="flex min-h-0 w-[420px] shrink-0">
+        <F0AiChat
+          header={<MockConnectedChatHeader />}
+          messages={<MockConnectedMessagesContainer />}
+          input={<MockConnectedChatInput />}
+        />
+      </div>
+    </div>
+  )
+}
+
+const TargetObserverLayout = ({
+  items = widget,
+}: {
+  items?: DashboardItem[]
+}) => {
+  const [observedTarget, setObservedTarget] = useState("No target observed")
+
+  return (
+    <div className="flex h-full w-full gap-2 overflow-hidden">
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-2 overflow-auto">
+        <output className="text-sm" data-ask-one-target>
+          {observedTarget}
+        </output>
+        <F0AnalyticsDashboard
+          items={items}
+          onAskAiTarget={({ id, point, quote }) => {
+            setObservedTarget(
+              `${id}: ${point ? `point=${point.category}/${point.value}` : "widget"}; quote=${quote.text}`
+            )
+          }}
+        />
       </div>
       <div className="flex min-h-0 w-[420px] shrink-0">
         <F0AiChat
@@ -150,6 +185,85 @@ export const WidgetQuotedInChat: Story = {
       )
       const textbox = await canvas.findByRole("textbox")
       await waitFor(() => expect(textbox).toHaveFocus())
+    })
+  },
+}
+
+/**
+ * A host can observe the exact built-in Ask One target and quote without
+ * replacing F0's chat behavior.
+ */
+export const TargetObserver: Story = {
+  tags: ["ask-one-target-observer"],
+  render: () => <TargetObserverLayout />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    let menu: ReturnType<typeof within> | undefined
+
+    await step("Open the widget actions menu", async () => {
+      menu = (await openAskOneMenu(canvasElement)).menu
+    })
+
+    if (!menu) throw new Error("The widget actions menu did not open")
+
+    await step("Ask One about the widget", async () => {
+      await userEvent.click(
+        await menu.findByRole("menuitem", { name: "Ask One" })
+      )
+    })
+
+    await step("Verify the observer and built-in quote", async () => {
+      await expect(
+        canvas.getByText(/headcount: widget; quote=/)
+      ).toHaveTextContent("headcount: widget; quote=Headcount by Department")
+      const removeQuote = await canvas.findByRole("button", {
+        name: "Remove quote",
+      })
+      await expect(removeQuote.parentElement).toHaveTextContent(
+        "Headcount by Department"
+      )
+    })
+  },
+}
+
+/** The point observer receives raw identity while the composer keeps its quote. */
+export const PointTargetObserver: Story = {
+  tags: ["ask-one-target-observer"],
+  render: () => <TargetObserverLayout items={pointWidget} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step("Choose a chart point with the keyboard action", async () => {
+      const trigger = await canvas.findByRole("button", {
+        name: "Ask One: Headcount by Department",
+      })
+      trigger.focus()
+      await userEvent.keyboard("{Enter}")
+      const menuId = trigger.getAttribute("aria-controls")
+      if (!menuId)
+        throw new Error("The point menu trigger has no aria-controls")
+      const menu = await waitFor(() => {
+        const element = canvasElement.ownerDocument.getElementById(menuId)
+        expect(element).toBeInTheDocument()
+        return within(element!)
+      })
+      await userEvent.click(
+        await menu.findByRole("menuitem", {
+          name: "Headcount by Department — Engineering, Headcount: 145 people",
+        })
+      )
+    })
+
+    await step("Verify raw target and formatted built-in quote", async () => {
+      await expect(
+        canvas.getByText(/point-headcount: point=Engineering\/145/)
+      ).toHaveTextContent("point-headcount: point=Engineering/145")
+      const removeQuote = await canvas.findByRole("button", {
+        name: "Remove quote",
+      })
+      await expect(removeQuote.parentElement).toHaveTextContent(
+        "Headcount by Department — Engineering Headcount: 145 people"
+      )
     })
   },
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
@@ -255,9 +255,11 @@ export const PointTargetObserver: Story = {
     })
 
     await step("Verify raw target and formatted built-in quote", async () => {
-      await expect(
-        canvas.getByText(/point-headcount: point=Engineering\/145/)
-      ).toHaveTextContent("point-headcount: point=Engineering/145")
+      await waitFor(() =>
+        expect(
+          canvas.getByText(/point-headcount: point=Engineering\/145/)
+        ).toHaveTextContent("point-headcount: point=Engineering/145")
+      )
       const removeQuote = await canvas.findByRole("button", {
         name: "Remove quote",
       })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -161,14 +161,34 @@ the mounted chat:
 />
 ```
 
+Pass `onAskAiTarget` when the mounted chat should keep the built-in quote,
+open, and focus behavior while the host attaches structured analytical
+context. The observer receives the widget identity plus the exact `quote`
+object staged in the composer. Point asks also include the raw `point`.
+
+```tsx
+<F0AnalyticsDashboard
+  items={items}
+  onAskAiTarget={({ id, point, quote }) => {
+    attachAnalyticalContext({ widgetId: id, point, quote })
+  }}
+/>
+```
+
+<Canvas of={AskOneStories.TargetObserver} />
+
+If both callbacks are supplied, `onAskAi` owns the interaction:
+`onAskAiTarget` is not invoked and F0 does not stage a built-in quote.
+
 - WHEN an enabled AI chat is mounted and a widget has a title → THEN its actions menu includes **Ask One**.
 - WHEN a widget is in an error state but still has a title → THEN **Ask One** remains available from its error header.
 - WHEN no chat is available and `onAskAi` is omitted → THEN the action is hidden instead of offering a dead command.
 - WHEN **Ask One** uses the built-in behavior → THEN the dashboard exits widget fullscreen, quotes the title, and opens the chat.
 - WHEN `onAskAi` is provided → THEN the action calls the host with the widget `id` and `title` without changing chat or fullscreen state.
+- WHEN `onAskAiTarget` observes the built-in behavior → THEN it receives the widget `id`, `title`, and exact pending `quote` before F0 stages that quote, without replacing any chat behavior.
 - WHEN a directly rendered widget has `onAskAi` but no `itemId` → THEN the action is hidden rather than sending an empty ID.
-- WHEN a widget is dropped on chat → THEN it follows the same built-in or
-  host-owned behavior as the menu action.
+- WHEN a widget is dropped on chat → THEN it follows the same built-in,
+  observed, or host-owned behavior as the menu action.
 - WHEN the reorder grip is only clicked → THEN no drag invitation appears and
   no widget action runs.
 - WHEN the pointer drag is cancelled or ends outside chat → THEN no quote or
@@ -188,6 +208,13 @@ In this story, click the Engineering bar to reveal the anchored action. Choose
 chat composer.
 
 <Canvas of={AskOneStories.ChartPointFlow} />
+
+**Observed point target**
+
+This story keeps the built-in formatted quote while exposing the raw point to
+the non-overriding observer.
+
+<Canvas of={AskOneStories.PointTargetObserver} />
 
 The host-owned callback receives the raw point as `point`, in addition to the
 widget `id` and `title`. `point.values` preserves every measure carried by one
@@ -212,6 +239,7 @@ no pointer position to anchor to.
 - WHEN a scatter point is quoted → THEN both the X and Y measures are included with their axis names and formatters.
 - WHEN a line category is quoted → THEN every visible series at that category is included, matching the axis tooltip.
 - WHEN `onAskAi` owns the action → THEN it receives the raw point and the built-in chat state remains unchanged.
+- WHEN `onAskAiTarget` observes the built-in action → THEN it receives that exact pending quote together with the raw point.
 - WHEN the chart has no title → THEN pointer and keyboard point actions are hidden because there is no widget context to quote.
 - WHEN the chart moves because of scrolling or resizing, or the reader presses <kbd>Escape</kbd> or clicks elsewhere → THEN the anchored action closes.
 - WHEN a screen reader reaches the point action → THEN its trigger is named **Ask One: _chart title_** and each menu item exposes the complete formatted point context.

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   screen,
@@ -17,7 +17,7 @@ import {
   useAiChat,
 } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 
-import type { DashboardChartItem } from "../types"
+import type { DashboardChartConfig, DashboardChartItem } from "../types"
 import type { F0AnalyticsDashboardPointClick } from "../types"
 
 import {
@@ -87,7 +87,11 @@ const pickAMark = async () => {
   await userEvent.click(screen.getByRole("button", { name: "Ask One" }))
 }
 
-const ChatProbe = () => {
+const ChatProbe = ({
+  onCapture,
+}: {
+  onCapture?: (quote: ReturnType<typeof useAiChat>["pendingQuote"]) => void
+} = {}) => {
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const { pendingQuote, open, setFocusChatInputFunction } = useAiChat()
 
@@ -104,15 +108,58 @@ const ChatProbe = () => {
         data-open={String(open)}
       />
       <textarea ref={inputRef} aria-label="Chat question" />
+      {onCapture && (
+        <button type="button" onClick={() => onCapture(pendingQuote)}>
+          Capture pending quote
+        </button>
+      )}
     </>
   )
 }
 
 describe("ChartItem — asking about a mark", () => {
+  beforeEach(() => localStorage.clear())
+
+  it.each([
+    { type: "bar" },
+    { type: "line" },
+    { type: "funnel" },
+    { type: "pie" },
+    { type: "radar" },
+    { type: "gauge" },
+    { type: "heatmap" },
+    { type: "scatter" },
+  ] satisfies DashboardChartConfig[])(
+    "observes built-in point asks for $type charts",
+    async (chart) => {
+      const onAskAiTarget = vi.fn()
+      render(
+        <AiChatStateProvider enabled>
+          <ChatProbe />
+          <ChartItem
+            item={{ ...item, chart }}
+            filters={{}}
+            onAskAiTarget={onAskAiTarget}
+          />
+        </AiChatStateProvider>
+      )
+
+      await pickAMark()
+
+      expect(onAskAiTarget).toHaveBeenCalledWith({
+        id: "headcount",
+        title: "Headcount by workplace",
+        point: POINT,
+        quote: { text: expect.any(String) },
+      })
+    }
+  )
+
   it("hands the host the mark, not a sentence built from it", async () => {
     const onAskAi = vi.fn(() =>
       screen.getByRole("button", { name: "Host chat" }).focus()
     )
+    const onAskAiTarget = vi.fn()
     const onFullscreenChange = vi.fn()
     render(
       <AiChatStateProvider enabled>
@@ -122,6 +169,7 @@ describe("ChartItem — asking about a mark", () => {
           item={item}
           filters={{}}
           onAskAi={onAskAi}
+          onAskAiTarget={onAskAiTarget}
           isFullscreen
           onFullscreenChange={onFullscreenChange}
         />
@@ -137,6 +185,7 @@ describe("ChartItem — asking about a mark", () => {
       title: "Headcount by workplace",
       point: POINT,
     })
+    expect(onAskAiTarget).not.toHaveBeenCalled()
     expect(screen.getByTestId("probe")).toHaveAttribute("data-quote", "")
     expect(screen.getByTestId("probe")).toHaveAttribute("data-open", "false")
     expect(
@@ -304,15 +353,18 @@ describe("ChartItem — asking about a mark", () => {
   })
 
   it("puts the visible mark in the built-in chat", async () => {
+    const onAskAiTarget = vi.fn()
+    const capturePendingQuote = vi.fn()
     const onFullscreenChange = vi.fn()
 
     render(
       <AiChatStateProvider enabled>
-        <ChatProbe />
+        <ChatProbe onCapture={capturePendingQuote} />
         <ChartItem
           item={item}
           filters={{}}
           isFullscreen
+          onAskAiTarget={onAskAiTarget}
           onFullscreenChange={onFullscreenChange}
         />
       </AiChatStateProvider>
@@ -325,7 +377,21 @@ describe("ChartItem — asking about a mark", () => {
       "Headcount by workplace — Barcelona office\nMale: 18"
     )
     expect(screen.getByTestId("probe")).toHaveAttribute("data-open", "true")
+    expect(onAskAiTarget).toHaveBeenCalledWith({
+      id: "headcount",
+      title: "Headcount by workplace",
+      point: POINT,
+      quote: {
+        text: "Headcount by workplace — Barcelona office\nMale: 18",
+      },
+    })
     expect(screen.getByRole("textbox", { name: "Chat question" })).toHaveFocus()
+    await userEvent.click(
+      screen.getByRole("button", { name: "Capture pending quote" })
+    )
+    expect(capturePendingQuote.mock.calls[0][0]).toBe(
+      onAskAiTarget.mock.calls[0][0].quote
+    )
     expect(onFullscreenChange).toHaveBeenCalledWith(false)
   })
 
@@ -746,6 +812,26 @@ describe("buildAccessibleChartPoints", () => {
     expected: F0AnalyticsDashboardPointClick[]
   }> = [
     {
+      name: "finite bar marks",
+      chart: {
+        type: "bar",
+        categories: ["Engineering"],
+        series: [{ name: "Headcount", data: [145] }],
+      },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "Headcount",
+          category: "Engineering",
+          value: 145,
+          values: [145],
+          series: [{ name: "Headcount", seriesIndex: 0, value: 145 }],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+      ],
+    },
+    {
       name: "line categories with their complete finite series column",
       chart: {
         type: "line",
@@ -842,6 +928,26 @@ describe("buildAccessibleChartPoints", () => {
           value: 72,
           values: [72],
           series: [{ name: "", seriesIndex: 0, value: 72 }],
+          dataIndex: 0,
+          seriesIndex: 0,
+        },
+      ],
+    },
+    {
+      name: "complete finite radar series",
+      chart: {
+        type: "radar",
+        indicators: [{ name: "Performance" }, { name: "Engagement" }],
+        series: [{ name: "Team A", data: [8, 7] }],
+      },
+      expected: [
+        {
+          ...keyboardPosition,
+          seriesName: "",
+          category: "Team A",
+          value: 7,
+          values: [8, 7],
+          series: [{ name: "", seriesIndex: 0, value: 7 }],
           dataIndex: 0,
           seriesIndex: 0,
         },

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -1,6 +1,19 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { fireEvent, zeroRender as render, waitFor } from "@/testing/test-utils"
+import {
+  fireEvent,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { AiChatStateProvider } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
+import {
+  WIDGET_DRAG_START,
+  type WidgetDragStartDetail,
+} from "@/lib/dnd/widgetDragEvents"
 
 import type { DashboardItem } from "../types"
 
@@ -151,6 +164,36 @@ describe("DashboardGrid", () => {
 
     await waitFor(() => {
       expect(collectionRow.style.height).toBe("960px")
+    })
+  })
+
+  it("forwards a collection widget's built-in Ask One target", async () => {
+    const onAskAiTarget = vi.fn()
+    const { container } = render(
+      <AiChatStateProvider enabled>
+        <DashboardGrid
+          items={makeCollectionItems(480)}
+          filters={{}}
+          onAskAiTarget={onAskAiTarget}
+        />
+      </AiChatStateProvider>
+    )
+    const card = container.querySelector('[data-card-id="expenses"]')
+    if (!(card instanceof HTMLElement)) {
+      throw new Error("Expected collection item to be rendered")
+    }
+
+    await userEvent.click(
+      within(card).getByRole("button", { name: "Other actions" })
+    )
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Ask One" })
+    )
+
+    expect(onAskAiTarget).toHaveBeenCalledWith({
+      id: "expenses",
+      title: "Expenses",
+      quote: { text: "Expenses" },
     })
   })
 
@@ -331,6 +374,58 @@ describe("DashboardGrid", () => {
       // `draggable`. The grip drives a pointer gesture instead.
       expect(card.getAttribute("draggable")).toBeNull()
       expect(grip.getAttribute("draggable")).toBeNull()
+    })
+
+    it("announces the exact target observer to the chat drop path", () => {
+      const onAskAiTarget = vi.fn()
+      const onStart = vi.fn<(event: Event) => void>()
+      window.addEventListener(WIDGET_DRAG_START, onStart)
+
+      try {
+        const { container } = render(
+          <DashboardGrid
+            items={makeCollectionItems(480)}
+            filters={{}}
+            editMode
+            onAskAiTarget={onAskAiTarget}
+          />
+        )
+        const grip = container.querySelector('[aria-label="Drag to reorder"]')
+        if (!(grip instanceof HTMLElement)) {
+          throw new Error("Expected a grip to be rendered")
+        }
+
+        fireEvent.pointerDown(grip, { button: 0 })
+        fireEvent(
+          document,
+          new MouseEvent("pointermove", {
+            clientX: 10,
+            clientY: 10,
+            bubbles: true,
+          })
+        )
+
+        expect(onStart).toHaveBeenCalledTimes(1)
+        const event = onStart.mock
+          .calls[0][0] as CustomEvent<WidgetDragStartDetail>
+        expect(event.detail).toEqual({
+          id: "expenses",
+          title: "Expenses",
+          onAskAi: undefined,
+          onAskAiTarget,
+        })
+
+        fireEvent(
+          document,
+          new MouseEvent("pointerup", {
+            clientX: 10,
+            clientY: 10,
+            bubbles: true,
+          })
+        )
+      } finally {
+        window.removeEventListener(WIDGET_DRAG_START, onStart)
+      }
     })
 
     it("reorders a widget via a pointerdown-on-grip → move → up gesture (no native drag)", () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
@@ -10,6 +10,7 @@ import {
   AiChatStateProvider,
   useAiChat,
 } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
+import type { PendingQuote } from "@/kits/ai/F0AiChat/types"
 
 import { DashboardItem } from "../components/DashboardItem/DashboardItem"
 
@@ -184,14 +185,25 @@ describe("DashboardItem — description action", () => {
     // stops meaning anything.
     beforeEach(() => localStorage.clear())
 
-    const QuoteProbe = () => {
+    const QuoteProbe = ({
+      onCapture,
+    }: {
+      onCapture?: (quote: PendingQuote | null) => void
+    } = {}) => {
       const { pendingQuote, open } = useAiChat()
       return (
-        <span
-          data-testid="probe"
-          data-quote={pendingQuote?.text ?? ""}
-          data-open={String(open)}
-        />
+        <>
+          <span
+            data-testid="probe"
+            data-quote={pendingQuote?.text ?? ""}
+            data-open={String(open)}
+          />
+          {onCapture && (
+            <button type="button" onClick={() => onCapture(pendingQuote)}>
+              Capture pending quote
+            </button>
+          )}
+        </>
       )
     }
 
@@ -202,14 +214,18 @@ describe("DashboardItem — description action", () => {
     }
 
     it("offers the action and hands the widget to the chat", async () => {
+      const onAskAiTarget = vi.fn()
+      const capturePendingQuote = vi.fn()
       const onFullscreenChange = vi.fn()
       render(
         <AiChatStateProvider enabled>
-          <QuoteProbe />
+          <QuoteProbe onCapture={capturePendingQuote} />
           <DashboardItem
             title="Headcount by workplace"
+            itemId="headcount"
             isLoading={false}
             isFullscreen
+            onAskAiTarget={onAskAiTarget}
             onFullscreenChange={onFullscreenChange}
           >
             <div>Content</div>
@@ -224,11 +240,22 @@ describe("DashboardItem — description action", () => {
       expect(probe).toHaveAttribute("data-quote", "Headcount by workplace")
       // Opens the chat too — otherwise the quote lands somewhere unseen.
       expect(probe).toHaveAttribute("data-open", "true")
-      expect(onFullscreenChange).toHaveBeenCalledWith(false)
+      expect(onAskAiTarget).toHaveBeenCalledWith({
+        id: "headcount",
+        title: "Headcount by workplace",
+        quote: { text: "Headcount by workplace" },
+      })
       // The composer is not mounted in this harness. Radix must keep its
       // normal restoration instead of dropping focus on document.body while
       // the provider buffers the request.
       await waitFor(() => expect(trigger).toHaveFocus())
+      await userEvent.click(
+        screen.getByRole("button", { name: "Capture pending quote" })
+      )
+      expect(capturePendingQuote.mock.calls[0][0]).toBe(
+        onAskAiTarget.mock.calls[0][0].quote
+      )
+      expect(onFullscreenChange).toHaveBeenCalledWith(false)
     })
 
     it("is absent without a chat provider, where the setters are inert", async () => {
@@ -251,6 +278,7 @@ describe("DashboardItem — description action", () => {
 
     it("hands the widget to the host instead, when it takes the action", async () => {
       const onAskAi = vi.fn()
+      const onAskAiTarget = vi.fn()
       const onFullscreenChange = vi.fn()
       render(
         <AiChatStateProvider enabled>
@@ -261,6 +289,7 @@ describe("DashboardItem — description action", () => {
             isLoading={false}
             isFullscreen
             onAskAi={onAskAi}
+            onAskAiTarget={onAskAiTarget}
             onFullscreenChange={onFullscreenChange}
           >
             <div>Content</div>
@@ -275,6 +304,7 @@ describe("DashboardItem — description action", () => {
         id: "headcount",
         title: "Headcount by workplace",
       })
+      expect(onAskAiTarget).not.toHaveBeenCalled()
       // The chat is left alone entirely — the host may not even be sending the
       // widget there, so quoting into it would be a second, unasked-for action.
       const probe = screen.getByTestId("probe")

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.test.tsx
@@ -11,6 +11,10 @@ import type {
   FiltersDefinition,
   FiltersState,
 } from "@/patterns/OneFilterPicker/types"
+import {
+  AiChatStateProvider,
+  useAiChat,
+} from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 
 import { F0AnalyticsDashboard } from "../F0AnalyticsDashboard"
 import type { DashboardMetricItem } from "../types"
@@ -57,6 +61,11 @@ function metricItem(
     type: "metric",
     fetchData,
   }
+}
+
+function QuoteProbe() {
+  const { pendingQuote } = useAiChat()
+  return <span data-testid="pending-quote">{pendingQuote?.text ?? ""}</span>
 }
 
 describe("F0AnalyticsDashboard report filters", () => {
@@ -243,6 +252,87 @@ describe("F0AnalyticsDashboard Ask One", () => {
       id: "headcount",
       title: "Headcount",
     })
+  })
+
+  it("passes the public target observer without replacing built-in chat behavior", async () => {
+    const user = userEvent.setup()
+    const onAskAiTarget = vi.fn()
+
+    render(
+      <AiChatStateProvider enabled>
+        <QuoteProbe />
+        <F0AnalyticsDashboard
+          items={[metricItem(vi.fn().mockResolvedValue({ value: 42 }))]}
+          onAskAiTarget={onAskAiTarget}
+        />
+      </AiChatStateProvider>
+    )
+
+    await user.click(
+      await screen.findByRole("button", { name: "Other actions" })
+    )
+    await user.click(screen.getByRole("menuitem", { name: "Ask One" }))
+
+    expect(onAskAiTarget).toHaveBeenCalledWith({
+      id: "headcount",
+      title: "Headcount",
+      quote: { text: "Headcount" },
+    })
+    expect(screen.getByTestId("pending-quote")).toHaveTextContent("Headcount")
+  })
+
+  it("passes a chart point through the public target observer and built-in chat", async () => {
+    const user = userEvent.setup()
+    const onAskAiTarget = vi.fn()
+
+    render(
+      <AiChatStateProvider enabled>
+        <QuoteProbe />
+        <F0AnalyticsDashboard
+          items={[
+            {
+              id: "headcount-chart",
+              title: "Headcount by department",
+              type: "chart",
+              chart: { type: "bar" },
+              fetchData: () =>
+                Promise.resolve({
+                  categories: ["Engineering"],
+                  series: [{ name: "Headcount", data: [145] }],
+                }),
+            },
+          ]}
+          onAskAiTarget={onAskAiTarget}
+        />
+      </AiChatStateProvider>
+    )
+
+    const trigger = await screen.findByRole("button", {
+      name: "Ask One: Headcount by department",
+    })
+    trigger.focus()
+    await user.keyboard("{Enter}")
+    await user.click(
+      await screen.findByRole("menuitem", {
+        name: "Headcount by department — Engineering, Headcount: 145",
+      })
+    )
+
+    expect(onAskAiTarget).toHaveBeenCalledWith({
+      id: "headcount-chart",
+      title: "Headcount by department",
+      point: expect.objectContaining({
+        source: "keyboard",
+        category: "Engineering",
+        value: 145,
+      }),
+      quote: {
+        text: "Headcount by department — Engineering\nHeadcount: 145",
+      },
+    })
+    expect(screen.getByTestId("pending-quote")).toHaveTextContent(
+      "Headcount by department — Engineering Headcount: 145"
+    )
   })
 
   it("passes a keyboard-selected chart point through the public handler", async () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -39,6 +39,7 @@ import type {
   DashboardChartData,
   DashboardChartItem,
   F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardAskAiTargetWithQuote,
   F0AnalyticsDashboardPointClick,
 } from "../../types"
 
@@ -802,6 +803,7 @@ interface ChartItemProps<Filters extends FiltersDefinition> {
   editMode?: boolean
   handleDelete?: (itemId: string) => void
   onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
+  onAskAiTarget?: (item: F0AnalyticsDashboardAskAiTargetWithQuote) => void
   onTransformChart?: (
     itemId: string,
     newType: string,
@@ -818,6 +820,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
   editMode,
   handleDelete,
   onAskAi,
+  onAskAiTarget,
   onTransformChart,
   isFullscreen,
   onFullscreenChange,
@@ -913,9 +916,11 @@ export function ChartItem<Filters extends FiltersDefinition>({
 
       if (!chartProps) return
 
-      setPendingQuote({
+      const quote = {
         text: buildPointQuoteText(item.title, chartProps, point),
-      })
+      }
+      onAskAiTarget?.({ id: item.id, title: item.title, point, quote })
+      setPendingQuote(quote)
       // Fullscreen covers the chat, matching the widget-level Ask One action.
       if (isFullscreen) onFullscreenChange?.(false)
       // Without this the quote would land in a panel the user cannot see.
@@ -927,6 +932,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       item,
       chartProps,
       onAskAi,
+      onAskAiTarget,
       isFullscreen,
       onFullscreenChange,
       setPendingQuote,
@@ -1144,6 +1150,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       editMode={editMode}
       handleDelete={handleDelete}
       onAskAi={onAskAi}
+      onAskAiTarget={onAskAiTarget}
       itemId={item.id}
       chartTypeOptions={chartTypeOptions}
       isFullscreen={isFullscreen}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -13,6 +13,7 @@ import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useD
 import type {
   DashboardCollectionItem,
   F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardAskAiTargetWithQuote,
 } from "../../types"
 
 import { useCollectionDownloadActions } from "../../hooks/useCollectionDownloadActions"
@@ -25,6 +26,7 @@ interface CollectionItemProps<Filters extends FiltersDefinition> {
   editMode?: boolean
   handleDelete?: (itemId: string) => void
   onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
+  onAskAiTarget?: (item: F0AnalyticsDashboardAskAiTargetWithQuote) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }
@@ -44,6 +46,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
   editMode,
   handleDelete,
   onAskAi,
+  onAskAiTarget,
   isFullscreen,
   onFullscreenChange,
 }: CollectionItemProps<Filters>) {
@@ -131,6 +134,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
       editMode={editMode}
       handleDelete={handleDelete}
       onAskAi={onAskAi}
+      onAskAiTarget={onAskAiTarget}
       itemId={item.id}
       isFullscreen={isFullscreen}
       onFullscreenChange={onFullscreenChange}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -15,6 +15,7 @@ import type {
   DashboardItem as DashboardItemType,
   DashboardItemLayout,
   F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardAskAiTargetWithQuote,
 } from "../../types"
 
 import { ChartItem, chartItemFitsContent } from "../ChartItem/ChartItem"
@@ -65,6 +66,8 @@ interface DashboardGridProps<Filters extends FiltersDefinition> {
   ) => void
   /** Overrides the built-in "Ask One" action on a widget. See `F0AnalyticsDashboardProps.onAskAi`. */
   onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
+  /** Observes built-in Ask One actions without replacing chat behavior. */
+  onAskAiTarget?: (item: F0AnalyticsDashboardAskAiTargetWithQuote) => void
   /**
    * Notifies the parent when the grid enters/exits a "fill height" mode —
    * triggered by click-to-fullscreen on a multi-item dashboard. The parent
@@ -92,6 +95,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   resetKey,
   onTransformChart,
   onAskAi,
+  onAskAiTarget,
   onFullscreenChange,
 }: DashboardGridProps<Filters>) {
   const containerRef = useRef<HTMLDivElement>(null)
@@ -399,7 +403,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           if (title) {
             window.dispatchEvent(
               new CustomEvent(WIDGET_DRAG_START, {
-                detail: { id, title, onAskAi },
+                detail: { id, title, onAskAi, onAskAiTarget },
               })
             )
           }
@@ -464,7 +468,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
       document.addEventListener("pointerup", up)
       document.addEventListener("pointercancel", cancel)
     },
-    [commitDrop, onAskAi, resolveDropTarget]
+    [commitDrop, onAskAi, onAskAiTarget, resolveDropTarget]
   )
 
   // A drag in flight when this unmounts (navigating away, switching
@@ -543,6 +547,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           onDelete={handleDelete}
           onTransformChart={onTransformChart}
           onAskAi={onAskAi}
+          onAskAiTarget={onAskAiTarget}
           isFullscreen
         />
       </div>
@@ -582,6 +587,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
             onDelete={handleDelete}
             onTransformChart={onTransformChart}
             onAskAi={onAskAi}
+            onAskAiTarget={onAskAiTarget}
             isFullscreen
             onFullscreenChange={(fs) =>
               setFullscreenItemId(fs ? fullscreenItemId : null)
@@ -669,6 +675,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                       onDelete={handleDelete}
                       onTransformChart={onTransformChart}
                       onAskAi={onAskAi}
+                      onAskAiTarget={onAskAiTarget}
                       onFullscreenChange={(fs) =>
                         setFullscreenItemId(fs ? id : null)
                       }
@@ -1079,6 +1086,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
   onDelete,
   onTransformChart,
   onAskAi,
+  onAskAiTarget,
   isFullscreen,
   onFullscreenChange,
 }: {
@@ -1093,6 +1101,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
     orientation?: "vertical" | "horizontal"
   ) => void
   onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
+  onAskAiTarget?: (item: F0AnalyticsDashboardAskAiTargetWithQuote) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }) {
@@ -1106,6 +1115,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           editMode={editMode}
           handleDelete={onDelete}
           onAskAi={onAskAi}
+          onAskAiTarget={onAskAiTarget}
           onTransformChart={onTransformChart}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
@@ -1120,6 +1130,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           editMode={editMode}
           handleDelete={onDelete}
           onAskAi={onAskAi}
+          onAskAiTarget={onAskAiTarget}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
         />
@@ -1133,6 +1144,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
           editMode={editMode}
           handleDelete={onDelete}
           onAskAi={onAskAi}
+          onAskAiTarget={onAskAiTarget}
           isFullscreen={isFullscreen}
           onFullscreenChange={onFullscreenChange}
         />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -1,6 +1,9 @@
 import { useRef, useState, type ReactNode } from "react"
 
-import type { F0AnalyticsDashboardAskAiTarget } from "../../types"
+import type {
+  F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardAskAiTargetWithQuote,
+} from "../../types"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0ButtonToggleGroup } from "@/components/F0ButtonToggleGroup"
@@ -64,6 +67,8 @@ interface DashboardItemProps {
    * needs a chat to be mounted at all.
    */
   onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
+  /** Observes the built-in chat action without replacing it. */
+  onAskAiTarget?: (item: F0AnalyticsDashboardAskAiTargetWithQuote) => void
   /** Item ID — required when editMode is true for the delete callback */
   itemId?: string
   /** Chart type transform options — rendered as a toggle group in the dropdown */
@@ -122,6 +127,7 @@ export function DashboardItem({
   editMode,
   handleDelete,
   onAskAi,
+  onAskAiTarget,
   itemId,
   chartTypeOptions,
   explanation,
@@ -186,7 +192,9 @@ export function DashboardItem({
     // over — same reason the delete action does.
     if (isFullscreen) onFullscreenChange?.(false)
     shouldFocusChatAfterMenuRef.current = true
-    setPendingQuote({ text: title })
+    const quote = { text: title }
+    if (itemId) onAskAiTarget?.({ id: itemId, title, quote })
+    setPendingQuote(quote)
     setAiChatOpen(true)
   }
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -14,6 +14,7 @@ import type {
   DashboardMetricData,
   DashboardMetricItem,
   F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardAskAiTargetWithQuote,
   MetricFormat,
 } from "../../types"
 
@@ -28,6 +29,7 @@ interface MetricItemProps<Filters extends FiltersDefinition> {
   editMode?: boolean
   handleDelete?: (itemId: string) => void
   onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
+  onAskAiTarget?: (item: F0AnalyticsDashboardAskAiTargetWithQuote) => void
   isFullscreen?: boolean
   onFullscreenChange?: (fullscreen: boolean) => void
 }
@@ -190,6 +192,7 @@ export function MetricItem<Filters extends FiltersDefinition>({
   editMode,
   handleDelete,
   onAskAi,
+  onAskAiTarget,
 }: MetricItemProps<Filters>) {
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -213,6 +216,7 @@ export function MetricItem<Filters extends FiltersDefinition>({
       editMode={editMode}
       handleDelete={handleDelete}
       onAskAi={onAskAi}
+      onAskAiTarget={onAskAiTarget}
       itemId={item.id}
     >
       {data && (

--- a/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
@@ -13,6 +13,7 @@ export type {
   DashboardMetricData,
   DashboardMetricItem,
   F0AnalyticsDashboardAskAiTarget,
+  F0AnalyticsDashboardAskAiTargetWithQuote,
   F0AnalyticsDashboardPointClick,
   F0AnalyticsDashboardProps,
   FunnelChartConfig,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -9,6 +9,7 @@ import type {
   F0DataChartRadarSeries,
   F0DataChartScatterSeries,
 } from "@/kits/F0DataChart"
+import type { PendingQuote } from "@/kits/ai/F0AiChat/types"
 import type { InfoHintContent } from "@/lib/InfoHint"
 import type { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import type {
@@ -465,6 +466,18 @@ export interface F0AnalyticsDashboardAskAiTarget {
 }
 
 /**
+ * A built-in Ask One interaction together with the exact quote F0 staged.
+ *
+ * The quote object is kept by the chat composer until it is submitted or
+ * dismissed. Hosts can therefore associate hidden analytical context with
+ * this exact interaction without replacing F0's quote/open/focus behavior.
+ */
+export type F0AnalyticsDashboardAskAiTargetWithQuote =
+  F0AnalyticsDashboardAskAiTarget & {
+    quote: PendingQuote
+  }
+
+/**
  * Props for the F0AnalyticsDashboard component.
  *
  * The entire dashboard is defined declaratively via `filters` (optional shared
@@ -567,6 +580,19 @@ export interface F0AnalyticsDashboardProps<
    * them apart by anything other than its presence.
    */
   onAskAi?: (item: F0AnalyticsDashboardAskAiTarget) => void
+  /**
+   * Observes built-in Ask One interactions without replacing them.
+   *
+   * Called immediately before F0 stages the quoted widget or point in the
+   * mounted chat. `quote` is the same object the composer later submits or
+   * dismisses, so a host can bind structured analytical context to the exact
+   * pending interaction and clean it up by quote identity.
+   *
+   * This observer does not make Ask One available by itself. A mounted,
+   * enabled AI chat still owns the built-in behavior; use `onAskAi` instead
+   * when the host must replace that behavior entirely.
+   */
+  onAskAiTarget?: (item: F0AnalyticsDashboardAskAiTargetWithQuote) => void
   /**
    * Navigation filter definitions (e.g. date-navigator).
    * Rendered above the grid alongside the regular filter bar.


### PR DESCRIPTION
## Why

People ask relative questions from analytical dashboards: “What happened here?”, “Why is this value high?”, or “How is this calculated?”. A visible quote tells the person what they attached, but Factorial also needs an exact machine-readable target so One can resolve “this”, “here”, and “that point” without asking the user to identify the chart again.

F0 owns the dashboard interactions and the built-in composer behavior, so it is the correct layer to expose that target without making hosts reimplement quoting, opening One, focus, or drag behavior.

## Supported use cases

1. **Widget menu → Ask One**: identify the exact dashboard widget.
2. **Chart point → Ask One**: identify the widget plus the selected series, category, and value. Covered for bar, line, funnel, pie, radar, gauge, heatmap, and scatter charts.
3. **Drag widget into One**: emit the same widget target as the menu action while preserving dashboard order.

## What changes

- Add a public, non-overriding `onAskAiTarget` observer for built-in Ask One actions.
- Emit `{ id, title, quote }` for widget targets and include the normalized raw `point` for chart-point targets.
- Preserve the exact `PendingQuote` object identity so a host can bind hidden context to that quote and clear it only when the quote is submitted or removed.
- Forward the same target through the widget drag-to-chat path.
- Preserve the existing `onAskAi` replacement contract: if `onAskAi` is provided, it owns the interaction and `onAskAiTarget` is not called.
- Document and demonstrate widget, point, and drag observer flows in Storybook/MDX.

## Out of scope

Painted chart-area selection is intentionally separate and remains in #5218. This PR is only the generic target foundation needed by existing widget, point, and drag interactions.

## Validation

- 117 focused Vitest tests across dashboard Ask One and chat-drop suites.
- Point-target battery across all eight supported chart types.
- TypeScript, lint, formatting, Storybook build/tests, Chromatic, public API surface, accessibility, ownership, and package quality checks are green.
- React PR artifact published by CI at GitHub package commit `5685921a69ac626aedacd855ed2c12d0e27d8625` (manifest version `6.54.3`); install it by the exact GitHub commit, not from the npm registry.

## Reviewer map

- [Public API and lifecycle docs](https://github.com/factorialco/f0/blob/a43c4ea69ca5924495b5eda7cd07735e7e85f7f7/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx): observer versus override semantics, widget/point/drag payloads, and exact quote identity.
- [Dashboard interaction stories](https://github.com/factorialco/f0/blob/a43c4ea69ca5924495b5eda7cd07735e7e85f7f7/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx): real widget-menu and chart-point flows with visible observer output and composer assertions.
- [Drag-to-chat story](https://github.com/factorialco/f0/blob/a43c4ea69ca5924495b5eda7cd07735e7e85f7f7/packages/react/src/kits/ai/F0AiChat/__stories__/F0AiChatWidgetDrop.stories.tsx): observer emission while built-in quote, focus, and dashboard order remain intact.
- [Current Chromatic build](https://www.chromatic.com/build?appId=66a7a8d7d124220c363457cc&number=14411).

## Integration

- [Factorial host attachment](https://github.com/factorialco/factorial/pull/111326)
- [factorial-agent target resolution](https://github.com/factorialco/factorial-agent/pull/2845)
