### PR TITLE
fix(DateNavigator): keep periods out of the shared granularity key

### DIFF
--- a/packages/react/src/components/F0DatePicker/F0DatePicker.tsx
+++ b/packages/react/src/components/F0DatePicker/F0DatePicker.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import {
-  GranularityDefinitionKey,
-  granularityDefinitions,
+  NavigationGranularityKey,
+  resolveGranularityDefinition,
 } from "@/components/OneCalendar"
 import { useI18n } from "@/lib/providers/i18n"
 import { DatePickerPopup, isSameDatePickerValue } from "@/ui/DatePickerPopup"
@@ -37,13 +37,10 @@ export function F0DatePicker({
   }, [granularities])
 
   const getGranularity = useCallback(
-    (granularityKey: GranularityDefinitionKey | undefined) => {
+    (granularityKey: NavigationGranularityKey | undefined) => {
       const key = granularityKey || defaultGranularity
-      if (!granularityDefinitions[key]) {
-        throw new Error(`Invalid granularity ${key}`)
-      }
       return {
-        ...granularityDefinitions[key],
+        ...resolveGranularityDefinition(key),
         key,
       }
     },

--- a/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
+++ b/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
@@ -11,7 +11,8 @@ import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { withSkipA11y, withSnapshot } from "@/lib/storybook-utils/parameters"
 import { getInputFieldArgs } from "@/components/F0InputField/__stories__/F0InputField.args"
 
-import { CalendarView, DateRange } from "@/components/OneCalendar/types"
+import { DateRange } from "@/components/OneCalendar/types"
+import { GranularityDefinitionKey } from "@/components/OneCalendar/granularities"
 import { F0DatePicker } from "../index"
 import { predefinedPresets } from "../presets"
 import { datepickerSizes, DatePickerValue } from "../types"
@@ -142,7 +143,7 @@ const presets = [
   predefinedPresets.lastYear,
   {
     label: "Last 7 days",
-    granularity: "day" as CalendarView,
+    granularity: "day" as GranularityDefinitionKey,
     value: {
       from: subDays(today, 7),
       to: today,

--- a/packages/react/src/components/F0DatePicker/components/DateInput.tsx
+++ b/packages/react/src/components/F0DatePicker/components/DateInput.tsx
@@ -2,7 +2,7 @@ import { forwardRef, useEffect, useState } from "react"
 
 import type {
   GranularityDefinition,
-  GranularityDefinitionKey,
+  NavigationGranularityKey,
 } from "@/components/OneCalendar"
 
 import { DateStringFormat } from "@/components/OneCalendar/granularities/types"
@@ -20,7 +20,7 @@ type DateInputProps = {
   className?: string
   onDateChange?: (date: DatePickerValue | undefined) => void
   onClick?: () => void
-  granularity: GranularityDefinition & { key: GranularityDefinitionKey }
+  granularity: GranularityDefinition & { key: NavigationGranularityKey }
   onOpenChange?: (open: boolean) => void
   onClear?: () => void
   minDate?: Date
@@ -64,7 +64,7 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
 
     const handleNewValue = (
       inputValue: string,
-      granularity: GranularityDefinition & { key: GranularityDefinitionKey }
+      granularity: GranularityDefinition & { key: NavigationGranularityKey }
     ) => {
       if (inputValue === "") {
         onDateChange?.({

--- a/packages/react/src/components/F0DatePicker/types.ts
+++ b/packages/react/src/components/F0DatePicker/types.ts
@@ -1,3 +1,4 @@
+import { GranularityDefinitionKey } from "@/components/OneCalendar/granularities"
 import { DateStringFormat } from "@/components/OneCalendar/granularities/types"
 import {
   DatePickerPopupProps,
@@ -13,7 +14,6 @@ export type DatePickerValue = DatePickerPopupValue
 
 export type F0DatePickerProps = Pick<
   DatePickerPopupProps,
-  | "granularities"
   | "minDate"
   | "maxDate"
   | "presets"
@@ -21,6 +21,8 @@ export type F0DatePickerProps = Pick<
   | "onOpenChange"
   | "selectOnCellOnly"
 > & {
+  /** The picker has no `periods` prop, so it can only offer the calendar granularities. */
+  granularities?: GranularityDefinitionKey[]
   showIcon?: boolean
   /** Controls how the selected date is displayed in the input. Defaults to "long" (e.g. "01 Aug 2025"). Use "default" for dd/MM/yyyy. */
   displayFormat?: DateStringFormat

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -11,10 +11,10 @@ import { Input } from "@/ui/input"
 import {
   DatePeriodsDefinition,
   GranularityDefinition,
-  GranularityDefinitionKey,
+  NavigationGranularityKey,
+  resolveGranularityDefinition,
   GranularityDefinitionSimple,
   getGranularityDefinitions,
-  granularityDefinitions,
 } from "./granularities/index"
 import {
   CalendarMode,
@@ -56,14 +56,9 @@ export type OneCalendarProps = Omit<
 >
 
 export const getGranularitySimpleDefinition = (
-  granularityKey: GranularityDefinitionKey
+  granularityKey: NavigationGranularityKey
 ): GranularityDefinitionSimple => {
-  const granularity = granularityDefinitions[granularityKey]
-  if (!granularity) {
-    throw new Error(
-      `Granularity simple definition for view ${granularityKey} not found`
-    )
-  }
+  const granularity = resolveGranularityDefinition(granularityKey)
   return {
     toRangeString: granularity.toRangeString,
     toString: granularity.toString,
@@ -71,14 +66,8 @@ export const getGranularitySimpleDefinition = (
 }
 
 export const getGranularityDefinition = (
-  granularityKey: GranularityDefinitionKey
-): GranularityDefinition => {
-  const granularity = granularityDefinitions[granularityKey]
-  if (!granularity) {
-    throw new Error(`Granularity definition ${granularityKey} not found`)
-  }
-  return granularity
-}
+  granularityKey: NavigationGranularityKey
+): GranularityDefinition => resolveGranularityDefinition(granularityKey)
 
 const OneCalendarInternal = ({
   mode = "single",

--- a/packages/react/src/components/OneCalendar/__tests__/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/__tests__/OneCalendar.test.tsx
@@ -1,0 +1,14 @@
+import { screen } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { OneCalendar } from "../OneCalendar"
+
+describe("OneCalendar", () => {
+  it("renders the empty periods state when the view is periods and none are supplied", () => {
+    render(<OneCalendar mode="single" view="periods" />)
+
+    expect(screen.getByText("No periods available")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/components/OneCalendar/granularities/__tests__/index.test.ts
+++ b/packages/react/src/components/OneCalendar/granularities/__tests__/index.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+
+import { granularityDefinitions, resolveGranularityDefinition } from "../index"
+
+describe("granularityDefinitions", () => {
+  // `periods` has no definition until a consumer supplies its ranges. Keeping it out of
+  // the record is what keeps it out of `GranularityDefinitionKey`, and so out of every
+  // exhaustive map a consumer writes over that key — form-field presets and compare-to
+  // included, where it could do nothing anyway.
+  it("holds only the calendar granularities", () => {
+    expect(Object.keys(granularityDefinitions)).toEqual([
+      "day",
+      "week",
+      "month",
+      "quarter",
+      "halfyear",
+      "year",
+      "range",
+    ])
+  })
+})
+
+describe("resolveGranularityDefinition", () => {
+  it("resolves a calendar key to its static definition", () => {
+    expect(resolveGranularityDefinition("month")).toBe(
+      granularityDefinitions.month
+    )
+  })
+
+  // The one key with no entry in the record still has to resolve to something: the empty
+  // periods definition renders the "no periods" state instead of throwing.
+  it("resolves periods to the empty definition", () => {
+    expect(resolveGranularityDefinition("periods").calendarView).toBe("periods")
+  })
+})

--- a/packages/react/src/components/OneCalendar/granularities/__tests__/index.test.ts
+++ b/packages/react/src/components/OneCalendar/granularities/__tests__/index.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from "vitest"
 
-import { granularityDefinitions, resolveGranularityDefinition } from "../index"
+import {
+  getGranularityDefinitions,
+  granularityDefinitions,
+  resolveGranularityDefinition,
+} from "../index"
 
 describe("granularityDefinitions", () => {
   // `periods` has no definition until a consumer supplies its ranges. Keeping it out of
@@ -31,5 +35,15 @@ describe("resolveGranularityDefinition", () => {
   // periods definition renders the "no periods" state instead of throwing.
   it("resolves periods to the empty definition", () => {
     expect(resolveGranularityDefinition("periods").calendarView).toBe("periods")
+  })
+})
+
+describe("getGranularityDefinitions", () => {
+  // The picker, the calendar and the navigator index this record with whatever
+  // key their value carries, and a value can carry `periods` while the consumer
+  // supplies none. The entry has to be there for that render not to throw.
+  it("carries the empty periods definition when no periods are supplied", () => {
+    expect(getGranularityDefinitions().periods.calendarView).toBe("periods")
+    expect(getGranularityDefinitions().month).toBe(granularityDefinitions.month)
   })
 })

--- a/packages/react/src/components/OneCalendar/granularities/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/index.tsx
@@ -121,12 +121,8 @@ export function getGranularityDefinitions(
           week: createWeekGranularity(effectiveWeekStartsOn),
         }
 
-  if (!periods) {
-    return definitions
-  }
-
   return {
     ...definitions,
-    periods: getPeriodsGranularity(periods),
+    periods: periods ? getPeriodsGranularity(periods) : periodsGranularity,
   }
 }

--- a/packages/react/src/components/OneCalendar/granularities/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/index.tsx
@@ -24,10 +24,29 @@ export const granularityDefinitions = {
   halfyear: halfyearGranularity,
   year: yearGranularity,
   range: rangeGranularity,
-  periods: periodsGranularity,
 } as const satisfies Record<string, GranularityDefinition>
 
 export type GranularityDefinitionKey = keyof typeof granularityDefinitions
+
+/**
+ * The keys a date navigation can be set to. `periods` is not a member of the
+ * static record — it has no definition until a consumer supplies its ranges —
+ * so it widens only the types that can actually render it. Keeping it out of
+ * `GranularityDefinitionKey` is what stops it leaking into every exhaustive map
+ * over that key, in places (form-field presets, compare-to) where it can do
+ * nothing.
+ */
+export type NavigationGranularityKey = GranularityDefinitionKey | "periods"
+
+/**
+ * The definition behind a key with no consumer data to build it from. Only
+ * `periods` has one: its empty definition renders the "no periods" state, which
+ * is what a periods value without periods means.
+ */
+export const resolveGranularityDefinition = (
+  key: NavigationGranularityKey
+): GranularityDefinition =>
+  key === "periods" ? periodsGranularity : granularityDefinitions[key]
 
 export type GranularityDefinitionsOptions = {
   weekStartsOn?: WeekStartsOn

--- a/packages/react/src/patterns/OneDataCollection/navigationFilters/filterTypes/DateNavigation/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/navigationFilters/filterTypes/DateNavigation/types.ts
@@ -1,7 +1,7 @@
 import { DateRange, DateRangeComplete } from "@/components/OneCalendar"
 import {
   DatePeriodsDefinition,
-  GranularityDefinitionKey,
+  NavigationGranularityKey,
 } from "@/components/OneCalendar/granularities/index"
 import { DatePreset } from "@/ui/DatePickerPopup"
 
@@ -10,8 +10,8 @@ import {
   NavigationFilterDefinitionBase,
 } from "../../types"
 export type DateNavigationOptions = {
-  granularity?: GranularityDefinitionKey[] | GranularityDefinitionKey
-  defaultGranularity?: GranularityDefinitionKey
+  granularity?: NavigationGranularityKey[] | NavigationGranularityKey
+  defaultGranularity?: NavigationGranularityKey
   min?: Date
   max?: Date
   presets?: DatePreset[]
@@ -34,7 +34,7 @@ export type DateValue = {
   value: DateRangeComplete
   // Represents the selected value in a date-time range, e.g  for a day "2021-01-01"
   valueString: string
-  granularity: GranularityDefinitionKey
+  granularity: NavigationGranularityKey
 }
 
 export type DateNavigationProps = NavigationFilterComponentProps<DateValue>

--- a/packages/react/src/patterns/OneDateNavigator/__stories__/OneDateNavigator.stories.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/__stories__/OneDateNavigator.stories.tsx
@@ -5,12 +5,9 @@ import { useState } from "react"
 import { expect, within } from "storybook/test"
 
 import { granularityDefinitions } from "@/components/OneCalendar"
+import { GranularityDefinitionKey } from "@/components/OneCalendar/granularities"
 
-import {
-  CalendarView,
-  DateRange,
-  WeekStartDay,
-} from "@/components/OneCalendar/types"
+import { DateRange, WeekStartDay } from "@/components/OneCalendar/types"
 import { OneDateNavigator } from "../OneDateNavigator"
 import { predefinedPresets } from "../presets"
 import { DatePickerValue } from "../types"
@@ -238,7 +235,7 @@ const presets = [
   predefinedPresets.lastYear,
   {
     label: "Last 7 days",
-    granularity: "day" as CalendarView,
+    granularity: "day" as GranularityDefinitionKey,
     value: {
       from: subDays(today, 7),
       to: today,

--- a/packages/react/src/patterns/OneDateNavigator/__tests__/OneDateNavigator.test.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/__tests__/OneDateNavigator.test.tsx
@@ -43,6 +43,22 @@ describe("OneDateNavigator", () => {
     expect(trigger).toBeDefined()
   })
 
+  it("renders a periods value when no periods are supplied", () => {
+    render(
+      <OneDateNavigator
+        onSelect={vi.fn()}
+        granularities={["periods"]}
+        value={{
+          granularity: "periods",
+          value: { from: new Date(2026, 0, 25), to: new Date(2026, 1, 24) },
+        }}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Previous" })).toBeInTheDocument()
+  })
+
   it("handles disabled state", () => {
     const onSelect = vi.fn()
 

--- a/packages/react/src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -8,14 +8,16 @@ import type {
 
 import { F0Button } from "@/components/F0Button"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { granularityDefinitions } from "@/components/OneCalendar/granularities"
 import { isAfterOrEqual, isBeforeOrEqual } from "@/components/OneCalendar/utils"
 import { ChevronLeft, ChevronRight } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { useL10n } from "@/lib/providers/l10n"
 import { cn, focusRing } from "@/lib/utils"
 
-import { GranularityDefinitionKey } from "@/components/OneCalendar/granularities"
+import {
+  NavigationGranularityKey,
+  resolveGranularityDefinition,
+} from "@/components/OneCalendar/granularities"
 import { DatePickerValue } from "../types"
 
 type DateNavigatorTriggerProps = {
@@ -65,7 +67,7 @@ const DateNavigatorTrigger = forwardRef<
 
       // Use the granularity prop if provided, otherwise fall back to static definitions
       const granularityToUse =
-        granularity || granularityDefinitions[value.granularity]
+        granularity || resolveGranularityDefinition(value.granularity)
 
       const values = [
         value.value,
@@ -145,7 +147,7 @@ const DateNavigatorTrigger = forwardRef<
     }
 
     type GranularityTranslations = {
-      [key in GranularityDefinitionKey]: {
+      [key in NavigationGranularityKey]: {
         currentDate: string
       }
     }

--- a/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
+++ b/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
@@ -2,10 +2,12 @@ import { useContext, useEffect, useMemo, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Select } from "@/components/F0Select"
-import { GranularityDefinitionKey, OneCalendar } from "@/components/OneCalendar"
+import { OneCalendar } from "@/components/OneCalendar"
 import {
   DatePeriodsDefinition,
   getGranularityDefinitions,
+  GranularityDefinitionKey,
+  NavigationGranularityKey,
 } from "@/components/OneCalendar/granularities"
 import {
   DateRange,
@@ -35,7 +37,7 @@ export type CompareToDef = {
 }
 
 export type DatePickerCompareTo = Partial<
-  Record<GranularityDefinitionKey, CompareToDef[]>
+  Record<NavigationGranularityKey, CompareToDef[]>
 >
 
 export interface DatePickerPopupProps {
@@ -43,7 +45,7 @@ export interface DatePickerPopupProps {
   value?: DatePickerValue
   defaultValue?: DatePickerValue
   presets?: DatePreset[]
-  granularities?: GranularityDefinitionKey[]
+  granularities?: NavigationGranularityKey[]
   minDate?: Date
   maxDate?: Date
   disabled?: boolean
@@ -194,7 +196,7 @@ export function DatePickerPopup({
 
   const [customRangeMode, setCustomRangeMode] = useState(false)
 
-  const handleSelectGranularity = (granularity: GranularityDefinitionKey) => {
+  const handleSelectGranularity = (granularity: NavigationGranularityKey) => {
     // View-only: switch granularity without emitting or closing.
     if (selectOnCellOnly) {
       setLocalValue((prev) =>

--- a/packages/react/src/ui/DatePickerPopup/__stories__/DatePickerPopup.stories.tsx
+++ b/packages/react/src/ui/DatePickerPopup/__stories__/DatePickerPopup.stories.tsx
@@ -3,7 +3,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { subDays } from "date-fns"
 import { useState } from "react"
 
-import { CalendarView, DateRange } from "@/components/OneCalendar/types"
+import { DateRange } from "@/components/OneCalendar/types"
+import { GranularityDefinitionKey } from "@/components/OneCalendar/granularities"
 
 import { DatePickerPopup, DatePickerPopupProps } from "../DatePickerPopup"
 import { predefinedPresets } from "../presets"
@@ -59,7 +60,7 @@ const presets = [
   predefinedPresets.lastYear,
   {
     label: "Last 7 days",
-    granularity: "day" as CalendarView,
+    granularity: "day" as GranularityDefinitionKey,
     value: {
       from: subDays(today, 7),
       to: today,

--- a/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupPeriods.test.tsx
+++ b/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupPeriods.test.tsx
@@ -115,3 +115,25 @@ describe("DatePickerPopup with periods", () => {
     expect(screen.queryByText("January 2026")).toBeNull()
   })
 })
+
+describe("DatePickerPopup with a periods value and no periods", () => {
+  it("renders the empty periods state instead of throwing", async () => {
+    const user = userEvent.setup()
+    render(
+      <DatePickerPopup
+        onSelect={vi.fn()}
+        value={{
+          granularity: "periods",
+          value: { from: new Date(2026, 0, 25), to: new Date(2026, 1, 24) },
+        }}
+        asChild
+      >
+        <button>Trigger</button>
+      </DatePickerPopup>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }))
+
+    expect(await screen.findByText("No periods available")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/ui/DatePickerPopup/components/GranularitySelector.tsx
+++ b/packages/react/src/ui/DatePickerPopup/components/GranularitySelector.tsx
@@ -1,14 +1,14 @@
 import {
   GranularityDefinition,
-  GranularityDefinitionKey,
+  NavigationGranularityKey,
 } from "@/components/OneCalendar"
 import { useI18n } from "@/lib/providers/i18n"
 import { Select, SelectContent, SelectItem } from "@/ui/Select"
 
 interface GranularitySelectorProps {
-  granularities: GranularityDefinitionKey[]
-  value?: GranularityDefinitionKey
-  onChange: (granularity: GranularityDefinitionKey) => void
+  granularities: NavigationGranularityKey[]
+  value?: NavigationGranularityKey
+  onChange: (granularity: NavigationGranularityKey) => void
   /** Definitions in play, so a data-driven granularity can name itself. */
   definitions?: Record<string, GranularityDefinition>
 }
@@ -21,15 +21,15 @@ export function GranularitySelector({
 }: GranularitySelectorProps) {
   const i18n = useI18n()
 
-  const handleChange = (granularity: GranularityDefinitionKey) => {
+  const handleChange = (granularity: NavigationGranularityKey) => {
     onChange(granularity)
   }
 
-  const labelOf = (granularity: GranularityDefinitionKey) =>
+  const labelOf = (granularity: NavigationGranularityKey) =>
     definitions?.[granularity]?.selectorLabel ||
     (
       i18n.date.granularities as Record<
-        GranularityDefinitionKey,
+        NavigationGranularityKey,
         { label: string }
       >
     )[granularity]?.label ||

--- a/packages/react/src/ui/DatePickerPopup/types.ts
+++ b/packages/react/src/ui/DatePickerPopup/types.ts
@@ -1,4 +1,7 @@
-import { GranularityDefinitionKey } from "@/components/OneCalendar/granularities"
+import {
+  GranularityDefinitionKey,
+  NavigationGranularityKey,
+} from "@/components/OneCalendar/granularities"
 import { DateRange, DateRangeComplete } from "@/components/OneCalendar/types"
 
 export interface DatePreset {
@@ -8,5 +11,5 @@ export interface DatePreset {
 }
 export type DatePickerValue = {
   value: DateRangeComplete | undefined
-  granularity: GranularityDefinitionKey
+  granularity: NavigationGranularityKey
 }


### PR DESCRIPTION
## Description

#5161 registered the empty `periods` definition in `granularityDefinitions`, which made `"periods"` a member of `GranularityDefinitionKey`. Every consumer of that key inherited it — including code that can never render periods. The API-diff bot flagged this and the PR argued it was a safe union widening. It isn't:

```ts
// A consumer's exhaustive map, compiling on 6.52.0, broken by 6.53.0
const PERIOD_RULE_BY_GRANULARITY: Record<GranularityDefinitionKey, Rule> = {
  year: ..., halfyear: ..., quarter: ..., month: ..., week: ..., day: ..., range: ...,
}   // ✗ Property 'periods' is missing
```

That consumer's navigator offers no consumer-defined periods; the entry it has to add is unreachable. Form-field presets and compare-to gained an option they cannot act on for the same reason.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Implementation details

- `GranularityDefinitionKey` is the seven calendar granularities again — exactly its 6.52.0 shape.
- `NavigationGranularityKey` adds `"periods"` and is used only where periods can appear: the picker popup's `granularities`, `DatePickerValue`, the calendar view helpers, the navigator trigger, and the DataCollection `date-navigator` filter.
- `DatePreset` and the compare-to `units` stay narrow, so `F0FormField`'s preset surface is unchanged — two of the flags on #5161 retire with this.
- `DatePickerCompareTo` widens, but it is `Partial<Record<…>>`, so no consumer gains a required key.

<details>
<summary>Why a lookup helper instead of leaving the record alone</summary>

Nothing holds a definition for `"periods"` in the static record any more, so the places that resolve a key they were handed (`getGranularityDefinition`, the navigator trigger's fallback, `F0DatePicker`) go through `resolveGranularityDefinition`. For `"periods"` it returns the same empty definition the record used to hold.

The three render paths that index the *dynamic* record instead — `DatePickerPopup`, `OneCalendar`, `OneDateNavigator` — are covered by `getGranularityDefinitions()`, which now always carries a `periods` entry and falls back to the empty definition when the consumer supplies none. The first cut of this PR let it return without one, which crashed all three on a `"periods"` value with no periods (caught in review). Either way a periods value with no periods renders the empty state rather than throwing.
</details>

`F0DatePicker` used to pick `granularities` straight from `DatePickerPopupProps`; it now declares its own `GranularityDefinitionKey[]`, since a form field has no `periods` prop to populate the entry with.

The three preset stories annotated their granularity `as CalendarView`, which type-checked only while both unions carried `periods`. They now say `GranularityDefinitionKey`, which is what a preset actually takes.

## Testing

`granularities/__tests__/index.test.ts` — 4 examples. Verified red against `main` (`expected [ 'day', 'week', … 8 keys ] to deeply equal [ … 7 keys ]`, and the resolver does not exist there) and green here.

The dynamic-record regression has a render assertion at each of the three sites (`OneCalendar.test.tsx`, `DatePickerPopupPeriods.test.tsx`, `OneDateNavigator.test.tsx`), each verified red without the `getGranularityDefinitions` fallback — `TypeError: Cannot read properties of undefined (reading 'calendarView' | 'calendarMode')` — and green with it. 393 examples pass across OneCalendar, DatePickerPopup, OneDateNavigator, F0DatePicker and the navigation filters; `tsc` clean on the touched files.

## API surface

The bot will flag `granularityDefinitions` losing a required `periods` key and `GranularityDefinitionKey` narrowing. Both restore the 6.52.0 shape: this reverts a widening that only existed in 6.53.0, released today. Anything written against 6.53.0's wider key keeps compiling unless it stored `"periods"` in a `GranularityDefinitionKey` variable, which only the navigator types would do — and those widened instead.
