### PR TITLE
feat(F0DataChart): show how far a bar passed its target

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -181,6 +181,36 @@ export const WithTargets: Story = {
   },
 }
 
+/**
+ * `highlightOverachievement` splits a bar that ran past its target at the target
+ * itself, drawing the stretch beyond it in a darker shade — without it, Q2 and
+ * Q4 would read the same as a quarter that landed exactly on its number.
+ * `showTargetProgress` adds what that comes to (`value / target`) to the
+ * tooltip, under the target row.
+ */
+export const WithOverachievement: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Q1", "Q2", "Q3", "Q4"],
+    series: [
+      {
+        name: "Attainment",
+        data: [
+          { value: 125_000, target: 185_000 },
+          { value: 200_000, target: 185_000 },
+          { value: 92_000, target: 185_000 },
+          { value: 268_000, target: 185_000 },
+        ],
+      },
+    ],
+    highlightOverachievement: true,
+    showTargetProgress: true,
+    showLegend: false,
+    valueFormatter: (v) => `${v / 1000}k €`,
+  },
+}
+
 /** Multiple series stacked into a single bar per category. */
 export const Stacked: Story = {
   render: (args) => <F0DataChart {...args} />,

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -92,6 +92,12 @@ Renders a gradient fade from the bar top up to the target value.
 
 <Canvas of={BarStories.WithTargets} />
 
+### Overachievement
+
+`highlightOverachievement` draws the stretch of a bar that passed its target in a darker shade of its own color, split at the target — otherwise a bar that beat its target looks like one that landed exactly on it. `showTargetProgress` adds `value / target` to the tooltip, under the target row.
+
+<Canvas of={BarStories.WithOverachievement} />
+
 ### Horizontal
 
 <Canvas of={BarStories.Horizontal} />

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1,3 +1,4 @@
+import * as echarts from "echarts"
 import {
   afterAll,
   afterEach,
@@ -2174,5 +2175,147 @@ describe("BarChart — the window takes data order, not rank", () => {
     // (Barcelona, 90) being inside it is a coincidence of position.
     expect(shown).toBeLessThan(categories.length)
     expect(onHidden).toHaveBeenLastCalledWith(categories.length - shown)
+  })
+})
+
+describe("BarChart — overachievement", () => {
+  const base = {
+    type: "bar" as const,
+    categories: ["Q1", "Q2"],
+    series: [
+      {
+        name: "Attainment",
+        data: [
+          { value: 80, target: 100 },
+          { value: 150, target: 100 },
+        ],
+      },
+    ],
+  }
+
+  /**
+   * The gradient built for the overachieving bar: the one with four stops. The
+   * two-stop gradients are the target ghosts.
+   */
+  function overachievementGradient() {
+    return vi
+      .mocked(echarts.graphic.LinearGradient)
+      .mock.calls.find((args) => (args[4] as { offset: number }[]).length === 4)
+  }
+
+  beforeEach(() => {
+    vi.mocked(echarts.graphic.LinearGradient).mockClear()
+  })
+
+  it("leaves the bars alone until the flag is on", () => {
+    render(<F0DataChart {...base} />)
+
+    // Both points stay plain numbers: no per-point fill to describe.
+    expect(getLatestOption().series[0]?.data).toEqual([80, 150])
+  })
+
+  it("fills the stretch past the target with a darker shade of the bar", () => {
+    render(<F0DataChart {...base} highlightOverachievement />)
+
+    const data = getLatestOption().series[0]?.data
+    // The bar that fell short is untouched; only the one that passed its
+    // target carries a fill of its own.
+    expect(data?.[0]).toBe(80)
+    expect(typeof data?.[1]).toBe("object")
+
+    // 150 against a target of 100: the darker third sits at the top, and the
+    // two stops meet exactly at the target.
+    const stops = overachievementGradient()?.[4] as
+      | { offset: number; color: string }[]
+      | undefined
+    expect(stops?.map((s) => s.offset)).toEqual([0, 1 / 3, 1 / 3, 1])
+    expect(stops?.[0]?.color).toBe(stops?.[1]?.color)
+    expect(stops?.[2]?.color).toBe(stops?.[3]?.color)
+    expect(stops?.[0]?.color).not.toBe(stops?.[3]?.color)
+  })
+
+  it("runs the darker stretch in from the far end of a horizontal bar", () => {
+    render(
+      <F0DataChart
+        {...base}
+        orientation="horizontal"
+        highlightOverachievement
+      />
+    )
+
+    // Right-to-left, so the dark end is the one the bar grew towards.
+    expect(overachievementGradient()?.slice(0, 4)).toEqual([1, 0, 0, 0])
+  })
+
+  it("ignores points that have no target of their own", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A"]}
+        series={[{ name: "S", data: [42] }]}
+        highlightOverachievement
+      />
+    )
+
+    expect(getLatestOption().series[0]?.data).toEqual([42])
+  })
+})
+
+describe("BarChart — target progress row", () => {
+  function getTooltipFormatter() {
+    const call = setOptionMock.mock.calls.at(-1)
+    if (!call) throw new Error("setOption was never called")
+    return (call[0] as { tooltip?: { formatter?: (p: unknown) => string } })
+      .tooltip?.formatter
+  }
+
+  const base = {
+    type: "bar" as const,
+    categories: ["Q2"],
+    series: [
+      { name: "Attainment", data: [{ value: 200_000, target: 185_000 }] },
+    ],
+  }
+  const hover = {
+    seriesName: "Attainment",
+    name: "Q2",
+    value: 200_000,
+    dataIndex: 0,
+  }
+
+  it("stays out of the tooltip until asked for", () => {
+    render(<F0DataChart {...base} />)
+
+    const html = getTooltipFormatter()?.(hover)
+    expect(html).toContain("185,000")
+    expect(html).not.toContain("of target")
+  })
+
+  it("reports what the bar came to against its target", () => {
+    render(<F0DataChart {...base} showTargetProgress />)
+
+    const html = getTooltipFormatter()?.(hover)
+    expect(html).toContain("108.1%")
+    expect(html).toContain("of target")
+  })
+
+  it("says nothing about a target of zero", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A"]}
+        series={[{ name: "S", data: [{ value: 5, target: 0 }] }]}
+        showTargetProgress
+      />
+    )
+
+    const html = getTooltipFormatter()?.({
+      seriesName: "S",
+      name: "A",
+      value: 5,
+      dataIndex: 0,
+    })
+    expect(html).not.toContain("of target")
+    expect(html).not.toContain("Infinity")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1,4 +1,3 @@
-import * as echarts from "echarts"
 import {
   afterAll,
   afterEach,
@@ -22,6 +21,21 @@ import { resolveChartTheme } from "../utils/theme"
 // ---------------------------------------------------------------------------
 
 const setOptionMock = vi.fn()
+
+/**
+ * Stands in for the gradient constructor, so the tests that assert on a fill can
+ * read the stops it was built with. Hoisted because the `echarts` mock factory
+ * reads it as it is built, before module-level bindings exist.
+ */
+const { linearGradientMock } = vi.hoisted(() => ({
+  linearGradientMock: vi.fn(function LinearGradient(
+    this: object,
+    ..._args: unknown[]
+  ) {
+    // eslint-disable-next-line react/no-this-in-sfc -- echarts constructor mock, not a component
+    return this
+  }),
+}))
 
 /** Handlers the chart registered, so tests can fire ECharts events at it. */
 const chartHandlers: Record<string, ((params: unknown) => void)[]> = {}
@@ -50,10 +64,7 @@ vi.mock("echarts", () => ({
   use: vi.fn(),
   getInstanceByDom: vi.fn(),
   graphic: {
-    LinearGradient: vi.fn(function LinearGradient(this: object) {
-      // eslint-disable-next-line react/no-this-in-sfc -- echarts constructor mock, not a component
-      return this
-    }),
+    LinearGradient: linearGradientMock,
   },
 }))
 
@@ -2198,13 +2209,13 @@ describe("BarChart — overachievement", () => {
    * two-stop gradients are the target ghosts.
    */
   function overachievementGradient() {
-    return vi
-      .mocked(echarts.graphic.LinearGradient)
-      .mock.calls.find((args) => (args[4] as { offset: number }[]).length === 4)
+    return linearGradientMock.mock.calls.find(
+      (args) => (args[4] as { offset: number }[]).length === 4
+    )
   }
 
   beforeEach(() => {
-    vi.mocked(echarts.graphic.LinearGradient).mockClear()
+    linearGradientMock.mockClear()
   })
 
   it("leaves the bars alone until the flag is on", () => {

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -10,7 +10,11 @@ import type {
   F0DataChartBarSeries,
 } from "../../types"
 
-import { paletteColor, resolveChartColorToken } from "../../utils/colors"
+import {
+  darkenChartColor,
+  paletteColor,
+  resolveChartColorToken,
+} from "../../utils/colors"
 import {
   buildBaseChartOptions,
   buildItemTooltip,
@@ -201,6 +205,51 @@ function resolveColor(series: F0DataChartBarSeries, index: number): string {
   return series.color
     ? resolveChartColorToken(series.color)
     : paletteColor(index)
+}
+
+/**
+ * Fill for a bar that ran past its target: the stretch beyond the target in a
+ * darker shade of the bar's own colour, split at the exact target.
+ *
+ * One gradient with a hard stop rather than a second stacked series, so the bar
+ * stays a single mark — its label, its tooltip, its rounded end and its share
+ * of a stack all keep counting the whole value.
+ */
+function overachievementFill(
+  color: string,
+  value: number,
+  target: number,
+  isVertical: boolean
+): echarts.graphic.LinearGradient {
+  // Offset 0 is the far end from the axis (top of a column, right of a row),
+  // so the darker stretch runs from there down to the target.
+  const split = (value - target) / value
+  const darker = darkenChartColor(color)
+  return new echarts.graphic.LinearGradient(
+    ...(isVertical
+      ? ([0, 0, 0, 1] as [number, number, number, number])
+      : ([1, 0, 0, 0] as [number, number, number, number])),
+    [
+      { offset: 0, color: darker },
+      { offset: split, color: darker },
+      { offset: split, color },
+      { offset: 1, color },
+    ]
+  )
+}
+
+/**
+ * The part of a point that passed its target, or `undefined` when it didn't.
+ * Negative bars are left alone: they grow away from zero, so "past the target"
+ * has no single reading.
+ */
+function overachievesTarget(
+  point: F0DataChartBarDataPoint
+): number | undefined {
+  const value = getValue(point)
+  const target = getTarget(point)
+  if (target === undefined || value <= 0 || value <= target) return undefined
+  return target
 }
 
 /** Check whether a series contains any target values */
@@ -464,6 +513,7 @@ function buildSeriesEntries(
   isVertical: boolean,
   showLabels: boolean,
   stacked: boolean,
+  highlightOverachievement: boolean,
   labelColor: string,
   stackGapColor: string,
   labelFontSize: number,
@@ -489,13 +539,25 @@ function buildSeriesEntries(
     const value = getValue(point)
     const pointColor = getPointColor(point)
     const pointBorderRadius = resolveBorderRadius?.(index, dataIndex, value)
-    if (pointColor === undefined && pointBorderRadius === undefined) {
+    const passedTarget = highlightOverachievement
+      ? overachievesTarget(point)
+      : undefined
+    const fill =
+      passedTarget === undefined
+        ? pointColor
+        : overachievementFill(
+            pointColor ?? color,
+            value,
+            passedTarget,
+            isVertical
+          )
+    if (fill === undefined && pointBorderRadius === undefined) {
       return value
     }
     return {
       value,
       itemStyle: {
-        ...(pointColor !== undefined && { color: pointColor }),
+        ...(fill !== undefined && { color: fill }),
         ...(pointBorderRadius !== undefined && {
           borderRadius: pointBorderRadius,
         }),
@@ -848,6 +910,8 @@ export function useBarChartOptions(
     series,
     orientation = "vertical",
     stacked = false,
+    highlightOverachievement = false,
+    showTargetProgress = false,
     showLegend = true,
     showGrid = true,
     showLabels = false,
@@ -1019,6 +1083,7 @@ export function useBarChartOptions(
         isVertical,
         showLabels,
         stacked,
+        highlightOverachievement,
         theme.colors.foregroundSecondary,
         theme.colors.containerBackground ?? theme.colors.background,
         resolvedLabelFontSize,
@@ -1273,6 +1338,12 @@ export function useBarChartOptions(
                   value: formatTooltipValue(target),
                   label: i18n.dataChart.tooltip.target,
                 },
+                showTargetProgress &&
+                  target !== undefined &&
+                  target !== 0 && {
+                    value: `${((value / target) * 100).toFixed(1)}%`,
+                    label: i18n.dataChart.tooltip.ofTarget,
+                  },
               ],
             },
             theme
@@ -1361,6 +1432,8 @@ export function useBarChartOptions(
     series,
     orientation,
     stacked,
+    highlightOverachievement,
+    showTargetProgress,
     showLegend,
     showGrid,
     showLabels,

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -234,6 +234,33 @@ export interface F0DataChartBarProps extends F0DataChartBaseProps {
   /** Stack all series into a single bar per category. @default false */
   stacked?: boolean
   /**
+   * Draw the stretch of a bar that ran past its `target` in a darker shade of
+   * the bar's own colour, split at the target.
+   *
+   * Left off, a target only shows as the faded ghost the bar has yet to reach,
+   * so a bar that beat its target looks the same as one that landed exactly on
+   * it — the reader has to eye its height against the ghosts beside it. Turn it
+   * on wherever passing the target is itself the news: attainment against a
+   * quota, a goal, a budget.
+   *
+   * Ignored by points with no target, and by negative values — "past the
+   * target" has no single reading when the bar grows downwards.
+   * @default false
+   */
+  highlightOverachievement?: boolean
+  /**
+   * Add the share of the target the bar reached to its tooltip, under the
+   * target row (e.g. "108.1% of target").
+   *
+   * Opt-in: the percentage answers "how did this do against its target", which
+   * is the question on a quota or a goal, and noise on a chart where the target
+   * is a reference line the reader is not scoring against.
+   *
+   * The percentage is `value / target`, the same two numbers the bar draws.
+   * @default false
+   */
+  showTargetProgress?: boolean
+  /**
    * When {@link F0DataChartBaseProps.showLabels} is on, hide a category's value
    * labels if the widest value in that category doesn't fit the bar. The whole
    * category drops together (all-or-nothing), so a tight chart never shows a

--- a/packages/react/src/kits/F0DataChart/utils/colors.ts
+++ b/packages/react/src/kits/F0DataChart/utils/colors.ts
@@ -120,6 +120,18 @@ export function paletteColor(index: number): string {
   return echartsColorPalette[index % echartsColorPalette.length] ?? "#999"
 }
 
+/**
+ * Amount a fill is darkened to read as "beyond the reference" — enough to
+ * separate the two stretches of one bar at a glance, little enough that they
+ * still read as the same series.
+ */
+const DARKEN_AMOUNT = 0.12
+
+/** Darker variant of a hex color, for the part of a mark that passed its target */
+export function darkenChartColor(color: string): string {
+  return colord(color).darken(DARKEN_AMOUNT).toHex()
+}
+
 /** Linearly interpolate between two hex colors */
 export function lerpColor(from: string, to: string, t: number): string {
   const f = colord(from).toRgb()

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -706,6 +706,7 @@ export const defaultTranslations = {
       ofTotal: "of total",
       total: "total",
       target: "target",
+      ofTarget: "of target",
       ofRange: "of range",
       fromPrevious: "from previous",
       fromStage: "from {{stage}}",


### PR DESCRIPTION
## Before & After
<img width="3952" height="1444" alt="image" src="https://github.com/user-attachments/assets/a6733e68-3525-4d46-abc4-0429fd3cb1a2" />


## Description

A bar chart with targets draws the gap a bar has yet to close as a faded ghost, and nothing at all once the bar is past its target — so a bar that beat its number looks exactly like one that landed on it, and the reader is left eyeing its height against the ghosts beside it.

This adds two opt-in props for the charts where clearing the target is itself the news (a quota, a goal, a budget): one that marks what a bar did beyond its target, and one that puts the number on the tooltip.

Both default to `false`, so no existing chart changes — `F0AnalyticsDashboard` included.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots (if applicable)

New story: **F0DataChart/Bar → With Overachievement** (`kits-f0datachart-bar--with-overachievement`). Q2 and Q4 pass their 185k target and split at it; Q1 and Q3 keep the ghost they didn't close. The tooltip on Q2 reads `200k €` / `185k € target` / `108.1% of target`.

## Implementation details

**`highlightOverachievement`** — the stretch of a bar beyond its `target`, in a darker shade (−12% lightness) of the bar's own colour, split at the target.

It is one gradient with a hard stop on the point's `itemStyle`, not a second stacked series: the bar stays a single mark, so its value label, its tooltip, its rounded end and its share of a stack all keep counting the whole value, and nothing had to learn about an extra internal series. Points with no target are untouched; so are negative bars, where "past the target" has no single reading.

**`showTargetProgress`** — adds `value / target` to the tooltip under the target row, behind a new `dataChart.tooltip.ofTarget` translation (sibling of the existing `ofTotal`). A target of `0` renders no row rather than `Infinity%`.

The percentage is deliberately the two numbers the bar draws, so the tooltip can never contradict the mark. A domain that measures attainment from a baseline (progress from a start value, say) keeps that in its own tooltip.

### Checks

`pnpm tsc`, `pnpm format:check`, `pnpm lint` clean. `BarChart.test.tsx` 126 passing, including 7 new: the fill only appears with the flag on, its stops meet exactly at the target, horizontal bars darken from the far end, points without a target are left alone, and the progress row shows up only when asked for (and never for a zero target).
