### PR TITLE
feat(Home): a widget's header controls, as data

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -13,7 +13,6 @@ import { F0Card } from "@/components/F0Card"
 import { F0Heading } from "@/components/F0Heading"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
-import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { One } from "@/icons/ai"
 import {
   MockAiChatRuntimeProvider,
@@ -27,7 +26,6 @@ import {
   Calendar,
   ChartVerticalBars,
   Check,
-  ChevronDown,
   ChevronRight,
   Clock,
   Comment,
@@ -889,9 +887,14 @@ const SLOT_RENDERERS: SlotRenderers = {
     skeleton: () => <ClockInTile loading />,
   },
   "community-posts": {
-    render: (params) => (
+    render: (params, ctx) => (
       <F0CommunityPostsCarousel
-        posts={(params as CommunityPostsParams).posts}
+        posts={postsForScope((ctx.selection ?? "all") as CommunityScope).map(
+          (post) => ({
+            ...post,
+            onClick: () => (params as CommunityPostsParams).onOpenPost(post.id),
+          })
+        )}
         labels={COMMUNITY_CAROUSEL_LABELS}
       />
     ),
@@ -1082,12 +1085,17 @@ const CommunityPostDetail = ({ post }: { post: CommunityPostSummary }) => (
 /**
  * The Communities widget as DATA, built for the scope it is currently showing.
  *
- * Its two controls sit in the header (`headerControls`): the SCOPE SWITCHER —
- * a GHOST `F0Button` naming what is selected, wrapped in `Dropdown` so pressing
- * it opens the scopes — and "New post", the one thing you can do from the card
- * without leaving the page. Both are ghosts: this row sits beside the widget's
- * own title, and two filled buttons there read as the card's subject rather than
- * as its controls. The way OUT of the widget is still the title ("Go to
+ * Its two controls sit in the header AS DATA — `headerActions` for "New post",
+ * the one thing you can do from the card without leaving the page, and
+ * `headerSelect` for the SCOPE SWITCHER. Neither is a React node: the card draws
+ * them both as ghosts (this row sits beside the widget's own title, and a filled
+ * button there reads as the card's subject rather than as something you press),
+ * and it KEEPS the scope, handing it to the slots as `ctx.selection`.
+ *
+ * Which is why this widget is built from no scope of its own. The story still
+ * hears about it — `onChange` mirrors it into state — but only because its
+ * carousel DIALOG walks the same set of posts; the card itself needs nobody to
+ * hold the value. The way OUT of the widget is still the title ("Go to
  * Communities"), and the three-dots menu is still the column's.
  */
 const communitiesWidget = ({
@@ -1111,36 +1119,13 @@ const communitiesWidget = ({
       info: "The latest posts from the spaces you follow.",
       link: { title: "Go to Communities", url: "/communities" },
     },
-    headerControls: (
-      <>
-        <F0Button
-          variant="ghost"
-          size="sm"
-          icon={Plus}
-          label="New Post"
-          onClick={onNewPost}
-        />
-        <Dropdown
-          items={COMMUNITY_SCOPES.map((option) => ({
-            label: option.label,
-            // The menu says which one you are on: a trigger that names the scope
-            // still leaves the list itself unmarked.
-            ...(option.value === scope ? { icon: Check } : {}),
-            onClick: () => onChangeScope(option.value),
-          }))}
-        >
-          <F0Button
-            variant="ghost"
-            size="sm"
-            icon={ChevronDown}
-            label={
-              COMMUNITY_SCOPES.find((option) => option.value === scope)
-                ?.label ?? "Show"
-            }
-          />
-        </Dropdown>
-      </>
-    ),
+    headerActions: [{ icon: Plus, label: "New Post", onClick: onNewPost }],
+    headerSelect: {
+      tooltip: "Show",
+      value: scope,
+      options: COMMUNITY_SCOPES.map((option) => ({ ...option })),
+      onChange: (value) => onChangeScope(value as CommunityScope),
+    },
     actions: [
       { label: "Mark all as read", icon: Check, onClick: () => {} },
       { label: "Notification settings", icon: Settings, onClick: () => {} },
@@ -1151,22 +1136,22 @@ const communitiesWidget = ({
     slots: [
       {
         visualization: "community-posts",
+        // NO POSTS HERE. Which ones to draw is the scope the card is showing,
+        // and the card hands that to the renderer (`ctx.selection`) — so the
+        // slot carries only what the renderer cannot work out for itself.
         params: {
-          posts: postsForScope(scope).map((post) => ({
-            ...post,
-            // No `href`: the post opens OVER the Home rather than navigating away
-            // from it, so the feed you were reading is still behind the dialog and
-            // still where you left it.
-            onClick: () => onOpenPost(post.id),
-          })),
+          // No `href`: a post opens OVER the Home rather than navigating away
+          // from it, so the feed you were reading is still behind the dialog and
+          // still where you left it.
+          onOpenPost,
         },
       },
     ],
   })
 
-/** What the bespoke `community-posts` slot carries. */
+/** What the bespoke `community-posts` slot carries — which posts is `ctx`'s. */
 interface CommunityPostsParams {
-  posts: CommunityPostSummary[]
+  onOpenPost: (id: string) => void
 }
 
 /* ============================ add-widget catalog ============================ */

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -8,6 +8,8 @@ import {
   LIST_COMPACT_AFTER,
   listSlot,
   SLOT_SKELETON_ITEM_TESTID,
+  type SlotRenderers,
+  widgetChrome,
 } from "../slotRenderers"
 import { SlotWidget } from "./index"
 
@@ -1002,5 +1004,156 @@ describe("SlotWidget chrome", () => {
     )
 
     expect(screen.getByRole("button", { name: "New Post" })).toBeInTheDocument()
+  })
+})
+
+/* --------------------- the card's own header controls --------------------- */
+
+/**
+ * A widget declared as DATA still needs the two things a Home card offers in
+ * its header: what you can DO from it, and what it is SHOWING. Neither used to
+ * be expressible without handing f0 a React node — which a host that builds its
+ * widgets as data has nowhere to build.
+ */
+describe("headerActions", () => {
+  test("draws the card's own buttons in the header", () => {
+    zeroRender(
+      <SlotWidget
+        header={{ title: "Community posts" }}
+        headerActions={[{ label: "Write post", href: "/dashboard/post/new" }]}
+        slots={[]}
+      />
+    )
+
+    // A route, so it is a real link — right-clickable, openable in a new tab.
+    expect(screen.getByRole("link", { name: "Write post" })).toHaveAttribute(
+      "href",
+      "/dashboard/post/new"
+    )
+  })
+
+  test("draws the header row for them even when there is no title", () => {
+    zeroRender(
+      <SlotWidget
+        headerActions={[{ label: "Write post", onClick: () => {} }]}
+        slots={[]}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Write post" })
+    ).toBeInTheDocument()
+  })
+})
+
+describe("headerSelect", () => {
+  /** A slot that reports what the card told it it is showing. */
+  const showsSelection: SlotRenderers = {
+    scope: (_params, ctx) => <span>showing {ctx.selection ?? "nothing"}</span>,
+  }
+
+  const withSelect = (props = {}) =>
+    zeroRender(
+      <SlotWidget
+        header={{ title: "Community posts" }}
+        headerSelect={{
+          tooltip: "Show",
+          options: [
+            { value: "all", label: "All communities" },
+            { value: "design", label: "Design" },
+          ],
+          ...props,
+        }}
+        slotRenderers={showsSelection}
+        slots={[{ visualization: "scope", params: {} }]}
+      />
+    )
+
+  test("starts on the first option, and tells the slots which", () => {
+    withSelect()
+
+    expect(
+      screen.getByRole("button", { name: /All communities/ })
+    ).toBeInTheDocument()
+    expect(screen.getByText("showing all")).toBeInTheDocument()
+  })
+
+  test("starts on the option it was given", () => {
+    withSelect({ value: "design" })
+
+    expect(screen.getByText("showing design")).toBeInTheDocument()
+  })
+
+  /**
+   * THE POINT OF IT. The choice lives in the card, so a widget the host built as
+   * data can be switched without the host holding the value — and the slot that
+   * owns the data hears about it.
+   */
+  test("switching redraws the slots for the new option", async () => {
+    const onChange = vi.fn()
+    withSelect({ onChange })
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /All communities/ })
+    )
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Design" })
+    )
+
+    await waitFor(() => {
+      expect(screen.getByText("showing design")).toBeInTheDocument()
+    })
+    expect(screen.getByRole("button", { name: /Design/ })).toBeInTheDocument()
+    expect(onChange).toHaveBeenCalledWith("design")
+  })
+
+  test("leaves the slots alone when the header has no select", () => {
+    zeroRender(
+      <SlotWidget
+        header={{ title: "Community posts" }}
+        slotRenderers={showsSelection}
+        slots={[{ visualization: "scope", params: {} }]}
+      />
+    )
+
+    expect(screen.getByText("showing nothing")).toBeInTheDocument()
+  })
+})
+
+/**
+ * The chrome a widget declares has to SURVIVE the trip from the item to the
+ * card. `widgetChrome` hand-copies those fields, so one left out of it is a
+ * prop that type-checks, reads well, and draws nothing — which is exactly what
+ * happened to these two the first time.
+ */
+describe("widgetChrome", () => {
+  test("carries every chrome field the item declares", () => {
+    const select = { options: [{ value: "all", label: "All communities" }] }
+    const chrome = widgetChrome({
+      id: "communities",
+      slots: [],
+      action: { label: "Go to Communities" },
+      headerControls: <span>host's own</span>,
+      headerActions: [{ label: "Write post" }],
+      headerSelect: select,
+      status: undefined,
+    })
+
+    expect(chrome.headerActions).toEqual([{ label: "Write post" }])
+    expect(chrome.headerSelect).toBe(select)
+    expect(chrome.action).toEqual({ label: "Go to Communities" })
+    expect(chrome.headerControls).toBeDefined()
+  })
+
+  test("carries them on an alerting widget too", () => {
+    const chrome = widgetChrome({
+      id: "communities",
+      slots: [],
+      alert: "Something to know",
+      headerActions: [{ label: "Write post" }],
+    })
+
+    expect(chrome.headerActions).toEqual([{ label: "Write post" }])
+    expect("alert" in chrome && chrome.alert).toBeTruthy()
   })
 })

--- a/packages/react/src/sds/Home/SlotWidget/index.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.tsx
@@ -1,6 +1,8 @@
 import { Fragment, useEffect, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
+import { Dropdown } from "@/experimental/Navigation/Dropdown"
+import { Check, ChevronDown } from "@/icons/app"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -189,6 +191,8 @@ export function SlotWidget({
   action,
   summaries,
   headerControls,
+  headerActions,
+  headerSelect,
   alert,
   status,
   slots,
@@ -223,6 +227,67 @@ export function SlotWidget({
   // frame draws it as the title itself.
   // `info` comes OUT: it is not a tooltip beside the title, it is what the card
   // shows when it is turned over.
+  /**
+   * WHAT THE CARD IS SHOWING, when its header carries a select. It lives HERE
+   * rather than in the host: a widget declared as data has nowhere to keep a
+   * live choice — params would persist it into a setting, and page state means
+   * the page knowing about one particular card — so the card keeps it and hands
+   * it to its slots (`ctx.selection`).
+   *
+   * A SESSION choice, deliberately: the card starts at `headerSelect.value`
+   * every time it mounts. Something that should outlive the visit is a param.
+   */
+  const [picked, setPicked] = useState<string | undefined>(undefined)
+  const selection = headerSelect
+    ? (picked ?? headerSelect.value ?? headerSelect.options[0]?.value)
+    : undefined
+  const selected = headerSelect?.options.find(
+    (option) => option.value === selection
+  )
+
+  const pick = (value: string) => {
+    setPicked(value)
+    headerSelect?.onChange?.(value)
+  }
+
+  // The card's own controls, in the order the header reads: what you can DO,
+  // then what it is SHOWING, then whatever the host drew itself.
+  const controls =
+    headerActions?.length || headerSelect ? (
+      <>
+        {headerActions?.map((button, index) => (
+          <F0Button key={index} variant="ghost" size="sm" {...button} />
+        ))}
+        {headerSelect ? (
+          <Dropdown
+            items={headerSelect.options.map((option) => ({
+              label: option.label,
+              // The menu says which one you are on; the trigger only names it.
+              ...(option.value === selection
+                ? { icon: Check }
+                : option.icon
+                  ? { icon: option.icon }
+                  : {}),
+              onClick: () => pick(option.value),
+            }))}
+          >
+            <F0Button
+              variant="ghost"
+              size="sm"
+              icon={ChevronDown}
+              label={selected?.label ?? headerSelect.tooltip ?? ""}
+              {...(headerSelect.tooltip
+                ? { tooltip: headerSelect.tooltip }
+                : {})}
+            />
+          </Dropdown>
+        ) : null}
+        {headerControls}
+      </>
+    ) : (
+      headerControls
+    )
+
   const { info, ...headerRest } = resolveWidgetHeader(header, params) ?? {}
   // Dropping `info` can leave the header with nothing in it — then there is no
   // header row to draw, unless the overflow menu needs one to sit in.
@@ -232,7 +297,7 @@ export function SlotWidget({
   const headerProps =
     Object.values(headerRest).some((value) => value !== undefined) ||
     (actions && actions.length > 0) ||
-    headerControls
+    controls
       ? headerRest
       : undefined
 
@@ -243,13 +308,15 @@ export function SlotWidget({
       action={action}
       footerClassName={FOOTER_CLASS}
       actions={actions}
-      headerControls={headerControls}
+      headerControls={controls}
       summaries={summaries}
       {...(alert ? { alert } : { status })}
       isDragging={isDragging}
     >
       <SlotWidgetContent
-        ctx={ctx}
+        // The selection goes DOWN, so a slot that owns its data fetches for
+        // whatever the header is showing.
+        ctx={selection === undefined ? ctx : { ...ctx, selection }}
         loading={loading}
         slotRenderers={slotRenderers}
         slots={slots}

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/avatars/F0AvatarModule"
 import type { AvatarSize } from "@/components/avatars/internal/BaseAvatar"
 import { F0Button } from "@/components/F0Button"
+import { type F0ButtonProps } from "@/components/F0Button"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { cn } from "@/lib/utils"
 import { Counter } from "@/ui/Counter"
@@ -61,6 +62,13 @@ export interface HomeRenderCtx {
    * { slotRowBleed}).
    */
   isLastSlot?: boolean
+  /**
+   * WHAT THE CARD IS SHOWING, when its header carries a `headerSelect`: the
+   * option the reader is on. A slot renderer that owns its own data reads this
+   * to fetch for it — the switcher is in the header, the fetching is here, and
+   * neither needs the host to hold the value.
+   */
+  selection?: string
 }
 
 /** Draws ONE slot from its params. Keyed by `visualization` in a renderer map. */
@@ -496,11 +504,56 @@ export const listSlot = <const S extends ListSchema>(
 export type HomeWidgetChrome = Pick<
   WidgetProps,
   "action" | "summaries" | "headerControls"
-> &
-  (
+> & {
+  /**
+   * THE CARD'S OWN BUTTONS, in the header's top-right — as DATA, so a host that
+   * builds its widgets as data ("Write post", pointing at a route) can put one
+   * there without handing over a React node.
+   *
+   * `F0ButtonProps`, the same shape `action` takes, so a button can carry an
+   * `href` and be a real link. Drawn `ghost`/`sm` unless they say otherwise:
+   * this row is the TITLE's, and a filled button beside a title reads as the
+   * card's subject rather than as something you press.
+   *
+   * Keep it to one or two. What the card can do that needs no button belongs in
+   * `actions`, the overflow menu.
+   */
+  headerActions?: F0ButtonProps[]
+  /**
+   * WHAT THE CARD IS SHOWING, as a select in the same row — a scope switcher, as
+   * data. See {@link WidgetHeaderSelect}: `SlotWidget` keeps the choice and
+   * hands it to the slots as `ctx.selection`, so a widget declared as data can
+   * still be switched without its host holding the value.
+   */
+  headerSelect?: WidgetHeaderSelect
+} & (
     | { alert?: WidgetProps["alert"]; status?: never }
     | { status?: WidgetProps["status"]; alert?: never }
   )
+
+/**
+ * A SELECT IN THE WIDGET'S HEADER: which of several things the card is showing.
+ *
+ * The value lives in `SlotWidget`, not in the host — that is the point of it.
+ * A host that builds its widgets as plain data has nowhere to keep a live
+ * choice: params persist (and turn a switcher into a saved setting), and page
+ * state means the page knowing about one particular widget. So the card keeps
+ * it, hands it down to its slots (`ctx.selection`), and tells the host through
+ * `onChange` if it wants to know.
+ *
+ * It is therefore a SESSION choice: the card starts at `value` every time it
+ * mounts. A choice that should outlive the visit is a param, not this.
+ */
+export interface WidgetHeaderSelect {
+  /** What the reader can switch between. The first one is the default. */
+  options: Array<{ value: string; label: string; icon?: IconType }>
+  /** Which one the card starts on. Defaults to the first option. */
+  value?: string
+  /** The trigger names the selection, so this is what says what KIND it is. */
+  tooltip?: string
+  /** Told when the reader picks another one. The card switches either way. */
+  onChange?: (value: string) => void
+}
 
 /* ---------------------------- configurable widgets ---------------------------- */
 
@@ -781,20 +834,26 @@ export type HomeWidgetItem = HomeWidgetChrome & {
  * Public because drawing a `HomeWidgetItem` yourself is public (`SlotWidget`),
  * and this is the one part of that spread with a rule in it.
  */
-export const widgetChrome = (widget: HomeWidgetItem): HomeWidgetChrome =>
-  ("alert" in widget && widget.alert !== undefined
-    ? {
-        action: widget.action,
-        summaries: widget.summaries,
-        headerControls: widget.headerControls,
-        alert: widget.alert,
-      }
-    : {
-        action: widget.action,
-        summaries: widget.summaries,
-        headerControls: widget.headerControls,
-        status: "status" in widget ? widget.status : undefined,
-      }) as HomeWidgetChrome
+export const widgetChrome = (widget: HomeWidgetItem): HomeWidgetChrome => {
+  // EVERY chrome field, or the ones left out are dropped on the way to the card
+  // — which is how a widget can declare a header control and see nothing drawn.
+  const chrome = {
+    action: widget.action,
+    summaries: widget.summaries,
+    headerControls: widget.headerControls,
+    headerActions: widget.headerActions,
+    headerSelect: widget.headerSelect,
+  }
+
+  return (
+    "alert" in widget && widget.alert !== undefined
+      ? { ...chrome, alert: widget.alert }
+      : {
+          ...chrome,
+          status: "status" in widget ? widget.status : undefined,
+        }
+  ) as HomeWidgetChrome
+}
 
 /**
  * Row-based slots cancel their rows' own padding so the rows sit flush with the


### PR DESCRIPTION
## Description

Two things a Home widget could not offer as **data**, and one a post could not offer at all.

`actions` covers a widget's overflow menu, but "Write post" belongs beside the title and a scope switcher belongs there too — and the only way in was `headerControls`, a `ReactNode`. A host that builds its widgets as plain data has nowhere to build one: it ends up reaching into the page that draws the column, which then knows about one particular widget. (That is what we hit building the Communities card on the Home: its button and its community switcher lived in `NewHomePage`, along with a query run for them there.)

## Public API

**New props** on the widget item (`HomeWidgetChrome`, so `HomeWidgetItem` and `SlotWidget` both take them):

| Prop | What |
| --- | --- |
| `headerActions?: F0ButtonProps[]` | The card's own buttons in the header's top-right, drawn `ghost`/`sm`. The same shape `action` already takes, so one can carry an `href` and be a real link rather than a handler. |
| `headerSelect?: WidgetHeaderSelect` | What the card is SHOWING, as a select in the same row: `{ options, value?, tooltip?, onChange? }`. |

**`HomeRenderCtx.selection`** — the option the reader is on. `SlotWidget` keeps the choice and hands it down, so a slot that owns its own data fetches for whatever the header says **without the host holding the value**. That is the point: params would persist a live switcher into a saved setting, and page state means the page knowing about one particular card. It is a **session** choice by design — the card starts at `value` every mount; anything that should outlive the visit is a param, and `paramsSchema` is still where that belongs.

**`CommunityPost.viewComments?: { label, onClick }`** — a way INTO the comments, for a post shown where its thread isn't. `comment` adds one; nothing read them. In a feed that is fine (the thread is under the post), but opened on its own in the carousel dialog the count said "23 comments" and there was nothing to press. It sits on the counters' own line, so the number and the way to read it are together. Optional, so every feed card is unchanged.

All additive: a widget passing none of these is untouched, and `headerControls` still works (it renders after the new controls).

## Also fixed on the way

`widgetChrome` hand-copied the fields it forwards from an item to its card, so the two new props were dropped en route — they type-checked, read well and drew nothing until the story showed it. It builds from one object now, so a field is forwarded by being named once instead of twice, with tests that every declared chrome field survives the trip (alerting widgets included).

## Tests

310 pass across `src/sds/Home/`:

- `SlotWidget/index.spec.tsx` — a header action with an `href` renders as a link; header actions alone earn the header row; the select starts on the first option and on a given `value`; **switching redraws the slots for the new option** and calls `onChange`; a card with no select leaves `ctx.selection` undefined; and `widgetChrome` carries every field.
- `CommunityPost/index.test.tsx` — the comments button appears beside the count and calls back; it stays away when not asked for.

## The story

The Home story's Communities widget is built this way now — no React node for its chrome, its tiles chosen by `ctx.selection`, and its dialog offering "View comments". Checked in the browser as well as in jsdom, which is how the `widgetChrome` gap turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)