### PR TITLE
fix(react): stop team and company names overflowing their column

### DIFF
--- a/packages/react/src/ui/value-display/types/company/__stories__/company.mdx
+++ b/packages/react/src/ui/value-display/types/company/__stories__/company.mdx
@@ -5,8 +5,7 @@ import * as CompanyStories from "./company.stories"
 
 ### company
 
-Renders a company avatar. It supports the same badge as the person type (check
-it for more details).
+Renders a company avatar.
 
 #### Value type
 
@@ -14,9 +13,7 @@ it for more details).
 type value = {
     name: string
     src?: string // the avatar image
-    badge?: AvatarBadge
 }
-// Check PersonType for the AvatarBadge type
 ```
 
 <Canvas
@@ -33,3 +30,10 @@ render: (item) => ({
 `,
   }}
 />
+
+**Long name inside a fixed-width column**
+
+A name wider than its cell truncates with an ellipsis and shows the full name
+in a tooltip on hover, the same as the person type.
+
+<Canvas of={CompanyStories.CompanyTypeWithLongName} />

--- a/packages/react/src/ui/value-display/types/company/__stories__/company.stories.tsx
+++ b/packages/react/src/ui/value-display/types/company/__stories__/company.stories.tsx
@@ -8,8 +8,7 @@ const meta = {
     layout: "padded",
     docs: {
       description: {
-        component:
-          "Renders a company avatar with name. Supports the same badge system as the person type.",
+        component: "Renders a company avatar with name.",
       },
       source: {
         code: null,
@@ -33,6 +32,38 @@ export const CompanyType: Story = {
           src: item.companyLogo,
         },
       }),
+    },
+  },
+}
+
+export const CompanyTypeWithLongName: Story = {
+  args: {
+    item: {
+      ...mockItem,
+      companyName: "Factorial AI handles the paperwork, you handle the people.",
+    },
+    property: {
+      label: "Company",
+      render: (item) => ({
+        type: "company",
+        value: {
+          name: item.companyName,
+          src: item.companyLogo,
+        },
+      }),
+    },
+  },
+  render: (args) => (
+    <div style={{ width: 200 }}>
+      <Cell {...args} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Inside a fixed-width column, a name wider than the cell truncates with an ellipsis and shows the full name in a tooltip on hover, instead of clipping mid-character.",
+      },
     },
   },
 }

--- a/packages/react/src/ui/value-display/types/company/company.test.tsx
+++ b/packages/react/src/ui/value-display/types/company/company.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ValueDisplayRendererContext } from "../../renderers"
+import { CompanyCell, CompanyCellValue } from "./company"
+
+const defaultMeta: ValueDisplayRendererContext = {
+  visualization: "table",
+}
+
+describe("CompanyCell", () => {
+  beforeEach(() => {
+    class MockResizeObserver {
+      observe = vi.fn()
+      unobserve = vi.fn()
+      disconnect = vi.fn()
+    }
+    window.ResizeObserver = MockResizeObserver as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth
+    delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+  })
+
+  it("renders the company name", () => {
+    const args: CompanyCellValue = { name: "Factorial" }
+
+    render(CompanyCell(args, defaultMeta))
+
+    expect(screen.getByText("Factorial")).toBeInTheDocument()
+  })
+
+  it("truncates a name wider than the cell instead of clipping it mid-character", () => {
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 100,
+    })
+
+    const args: CompanyCellValue = {
+      name: "Factorial AI handles the paperwork, you handle the people.",
+    }
+
+    render(CompanyCell(args, defaultMeta))
+
+    expect(screen.getByTestId("one-ellipsis")).toBeInTheDocument()
+  })
+
+  it("shows a tooltip with the full name when it overflows", async () => {
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 100,
+    })
+
+    const args: CompanyCellValue = {
+      name: "Factorial AI handles the paperwork, you handle the people.",
+    }
+
+    render(CompanyCell(args, defaultMeta))
+
+    await userEvent.hover(screen.getByTestId("one-ellipsis"))
+
+    expect(
+      await screen.findByRole("tooltip", {
+        name: "Factorial AI handles the paperwork, you handle the people.",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("lets the name shrink instead of overflowing its fixed-width container", () => {
+    const args: CompanyCellValue = { name: "Factorial" }
+
+    render(CompanyCell(args, defaultMeta))
+
+    expect(screen.getByText("Factorial").closest("div")).toHaveClass(
+      "min-w-0",
+      "flex-1"
+    )
+  })
+})

--- a/packages/react/src/ui/value-display/types/company/company.tsx
+++ b/packages/react/src/ui/value-display/types/company/company.tsx
@@ -3,6 +3,7 @@
  * Shows company name alongside a company avatar with optional badge.
  */
 import { F0Avatar } from "@/components/avatars/F0Avatar"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { cn } from "@/lib/utils"
 import { tableDisplayClassNames } from "../../const"
 import { ValueDisplayRendererContext } from "../../renderers"
@@ -20,7 +21,7 @@ export const CompanyCell = (
 ) => (
   <div
     className={cn(
-      "flex items-center gap-2",
+      "flex min-w-0 flex-1 items-center gap-2",
       meta.visualization === "table" && tableDisplayClassNames.avatar
     )}
   >
@@ -32,6 +33,8 @@ export const CompanyCell = (
       }}
       size="xs"
     />
-    <span className="text-f1-foreground">{args.name.toString()}</span>
+    <OneEllipsis className="min-w-0 flex-1 text-f1-foreground" tag="span">
+      {args.name.toString()}
+    </OneEllipsis>
   </div>
 )

--- a/packages/react/src/ui/value-display/types/team/__stories__/team.mdx
+++ b/packages/react/src/ui/value-display/types/team/__stories__/team.mdx
@@ -5,8 +5,7 @@ import * as TeamStories from "./team.stories"
 
 ### team
 
-Renders a team avatar. It supports the same badge as the person type (check it
-for more details).
+Renders a team avatar.
 
 #### Value type
 
@@ -14,9 +13,7 @@ for more details).
 type value = {
     name: string
     src?: string // the avatar image
-    badge?: AvatarBadge
 }
-// Check PersonType for the AvatarBadge type
 ```
 
 Example:
@@ -35,3 +32,10 @@ render: (item) => ({
 `,
   }}
 />
+
+**Long name inside a fixed-width column**
+
+A name wider than its cell truncates with an ellipsis and shows the full name
+in a tooltip on hover, the same as the person type.
+
+<Canvas of={TeamStories.TeamTypeWithLongName} />

--- a/packages/react/src/ui/value-display/types/team/__stories__/team.stories.tsx
+++ b/packages/react/src/ui/value-display/types/team/__stories__/team.stories.tsx
@@ -8,8 +8,7 @@ const meta = {
     layout: "padded",
     docs: {
       description: {
-        component:
-          "Renders a team avatar with name. Supports the same badge system as the person type.",
+        component: "Renders a team avatar with name.",
       },
       source: {
         code: null,
@@ -33,6 +32,38 @@ export const TeamType: Story = {
           src: item.teamLogo,
         },
       }),
+    },
+  },
+}
+
+export const TeamTypeWithLongName: Story = {
+  args: {
+    item: {
+      ...mockItem,
+      teamName: "Engineering Department for International Product Operations",
+    },
+    property: {
+      label: "Team",
+      render: (item) => ({
+        type: "team",
+        value: {
+          name: item.teamName,
+          src: item.teamLogo,
+        },
+      }),
+    },
+  },
+  render: (args) => (
+    <div style={{ width: 200 }}>
+      <Cell {...args} />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Inside a fixed-width column, a name wider than the cell truncates with an ellipsis and shows the full name in a tooltip on hover, instead of clipping mid-character.",
+      },
     },
   },
 }

--- a/packages/react/src/ui/value-display/types/team/team.test.tsx
+++ b/packages/react/src/ui/value-display/types/team/team.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { ValueDisplayRendererContext } from "../../renderers"
+import { TeamCell, TeamCellValue } from "./team"
+
+const defaultMeta: ValueDisplayRendererContext = {
+  visualization: "table",
+}
+
+describe("TeamCell", () => {
+  beforeEach(() => {
+    class MockResizeObserver {
+      observe = vi.fn()
+      unobserve = vi.fn()
+      disconnect = vi.fn()
+    }
+    window.ResizeObserver = MockResizeObserver as typeof ResizeObserver
+  })
+
+  afterEach(() => {
+    delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth
+    delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+  })
+
+  it("renders the team name", () => {
+    const args: TeamCellValue = { name: "Engineering" }
+
+    render(TeamCell(args, defaultMeta))
+
+    expect(screen.getByText("Engineering")).toBeInTheDocument()
+  })
+
+  it("truncates a name wider than the cell instead of clipping it mid-character", () => {
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 100,
+    })
+
+    const args: TeamCellValue = {
+      name: "Engineering Department for International Product Operations",
+    }
+
+    render(TeamCell(args, defaultMeta))
+
+    expect(screen.getByTestId("one-ellipsis")).toBeInTheDocument()
+  })
+
+  it("shows a tooltip with the full name when it overflows", async () => {
+    Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+      configurable: true,
+      value: 200,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      value: 100,
+    })
+
+    const args: TeamCellValue = {
+      name: "Engineering Department for International Product Operations",
+    }
+
+    render(TeamCell(args, defaultMeta))
+
+    await userEvent.hover(screen.getByTestId("one-ellipsis"))
+
+    expect(
+      await screen.findByRole("tooltip", {
+        name: "Engineering Department for International Product Operations",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("lets the name shrink instead of overflowing its fixed-width container", () => {
+    const args: TeamCellValue = { name: "Engineering" }
+
+    render(TeamCell(args, defaultMeta))
+
+    expect(screen.getByText("Engineering").closest("div")).toHaveClass(
+      "min-w-0",
+      "flex-1"
+    )
+  })
+})

--- a/packages/react/src/ui/value-display/types/team/team.tsx
+++ b/packages/react/src/ui/value-display/types/team/team.tsx
@@ -3,6 +3,7 @@
  * Shows team name alongside a team avatar with optional badge.
  */
 import { F0Avatar } from "@/components/avatars/F0Avatar"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { cn } from "@/lib/utils"
 import { tableDisplayClassNames } from "../../const"
 import { ValueDisplayRendererContext } from "../../renderers"
@@ -20,7 +21,7 @@ export const TeamCell = (
 ) => (
   <div
     className={cn(
-      "flex items-center gap-2",
+      "flex min-w-0 flex-1 items-center gap-2",
       meta.visualization === "table" && tableDisplayClassNames.avatar
     )}
   >
@@ -32,6 +33,8 @@ export const TeamCell = (
       }}
       size="xs"
     />
-    <span className="text-f1-foreground">{args.name.toString()}</span>
+    <OneEllipsis className="min-w-0 flex-1 text-f1-foreground" tag="span">
+      {args.name.toString()}
+    </OneEllipsis>
   </div>
 )


### PR DESCRIPTION
## Description

`TeamCell` and `CompanyCell` rendered the name as a plain `span` with no `min-w-0` inside a flex row that never shrank. In a fixed-width column (e.g. the goals Assignees column, `ASSIGNEE_COLUMN_WIDTH = 200`) the name spilled out of the column and got clipped mid-character.

Measuring `main`'s markup at a range of widths shows the failure is width-dependent: a flex item can shrink down to its longest word, so a 200px column already **wraps** to three lines and clips nothing — clipping only starts once the column is narrower than the name's longest word (around 80px, where it spills ~30px past the column).

So the fix keeps wrapping as the default and makes the name breakable, rather than capping it at one line:

- `min-w-0 flex-1` so the name shrinks to the column instead of overflowing it
- `break-words` so a name too long to fit even one line of its own breaks mid-word and stays inside the column, instead of spilling out and clipping
- a new optional `lines` in the value opts into a cap where a caller wants one

Capping by default was the first approach here, and it was wrong: it would have turned every currently-wrapping name into a single truncated line, in consumers we can't audit from this repo. See the commits for the flip.

## Value type

```ts
value: { name, src }            // default — wraps as far as the name needs, hiding nothing
value: { name, src, lines: 2 }  // two lines, then an ellipsis + tooltip
value: { name, src, lines: 1 }  // one line, ellipsis + tooltip (PersonCell's behavior)
```

## Screenshots

**Before** — the name overflows the 200px column with no ellipsis:

![team cell before fix, overflowing column](https://github.com/user-attachments/assets/49228afd-0649-43c1-8a3e-4eab7153f187)
![company cell before fix, overflowing column](https://github.com/user-attachments/assets/d2d8ea6f-4bdc-486d-bde5-b38d3f3864f2)

**After** — see the `Team Type With Long Name` / `Company Type With Long Name` stories in Chromatic for the default, plus `… With Lines` (`lines: 2`) and `… Truncated To One Line` (`lines: 1`).
<img width="888" height="799" alt="CleanShot 2026-09-18 at 10 48 32" src="https://github.com/user-attachments/assets/3b83b9f5-b6ac-4e29-b37b-cf4aacc502b6" />
<img width="883" height="615" alt="CleanShot 2026-09-18 at 10 48 53" src="https://github.com/user-attachments/assets/37409b29-8266-4437-b027-c09020fe89b8" />


## Verification

Measured in a browser against `main`'s own markup at the same widths:

| column width | `main` | this branch (default) |
|---|---|---|
| 200px | wraps to 3 lines, nothing clipped | wraps to 3 lines — identical |
| 80px | spills 30px past the column, clips mid-letter | stays inside the column, wraps |

## Implementation details

- fix: add `min-w-0 flex-1` and `break-words` so the name shrinks and breaks inside its column instead of overflowing it
- feat: optional `lines` in the `team`/`company` value caps the name at N lines, truncating with `OneEllipsis` (ellipsis + F0 tooltip) past them
- fix: a name that can wrap top-aligns its row and uses `tableDisplayClassNames.multiline`, so the avatar sits on the first line and that line shares a baseline with the single-line cells beside it
- test: unit tests for both cells covering the uncapped default, `lines: 1`/`lines: 2`, tooltip presence and absence, and avatar alignment
- test: Storybook stories per mode, in a fixed-width column, with source snippets
- docs: document `lines` in `team.mdx`/`company.mdx`; drop the "supports the same badge as the person type" claim, since `TeamCell`/`CompanyCell` never forward `badge` to `F0Avatar` today (pre-existing, separate from this fix)

Fixes FCT-61911
