### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.57.1",
+  "packages/react": "6.57.2",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.57.2](https://github.com/factorialco/f0/compare/f0-react-v6.57.1...f0-react-v6.57.2) (2026-08-26)
+
+
+### Bug Fixes
+
+* **OneTable:** keep the hover background on sticky rows ([#5150](https://github.com/factorialco/f0/issues/5150)) ([bfe0e98](https://github.com/factorialco/f0/commit/bfe0e98d5ea581a2cd6ac7e22e0fc54b0e25dff7))
+
 ## [6.57.1](https://github.com/factorialco/f0/compare/f0-react-v6.57.0...f0-react-v6.57.1) (2026-08-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.57.1",
+  "version": "6.57.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.57.2</summary>

## [6.57.2](https://github.com/factorialco/f0/compare/f0-react-v6.57.1...f0-react-v6.57.2) (2026-08-26)


### Bug Fixes

* **OneTable:** keep the hover background on sticky rows ([#5150](https://github.com/factorialco/f0/issues/5150)) ([bfe0e98](https://github.com/factorialco/f0/commit/bfe0e98d5ea581a2cd6ac7e22e0fc54b0e25dff7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).