### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.57.2",
+  "packages/react": "6.58.0",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.58.0](https://github.com/factorialco/f0/compare/f0-react-v6.57.2...f0-react-v6.58.0) (2026-08-26)
+
+
+### Features
+
+* **F0Graph:** opt-in stacked child nodes ([#5051](https://github.com/factorialco/f0/issues/5051)) ([55700d9](https://github.com/factorialco/f0/commit/55700d92e042976c01ab9eebb4b0601c102e3991))
+
 ## [6.57.2](https://github.com/factorialco/f0/compare/f0-react-v6.57.1...f0-react-v6.57.2) (2026-08-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.57.2",
+  "version": "6.58.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.58.0</summary>

## [6.58.0](https://github.com/factorialco/f0/compare/f0-react-v6.57.2...f0-react-v6.58.0) (2026-08-26)


### Features

* **F0Graph:** opt-in stacked child nodes ([#5051](https://github.com/factorialco/f0/issues/5051)) ([55700d9](https://github.com/factorialco/f0/commit/55700d92e042976c01ab9eebb4b0601c102e3991))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).