### PR TITLE
ci(storybook): report docs index changes on PRs

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -54,6 +54,88 @@ jobs:
           build-url: ${{ steps.chromatic.outputs.buildUrl }}
           storybook-url: ${{ steps.chromatic.outputs.storybookUrl }}
 
+      # The Storybook Docs Index check (storybook-docs-index.yaml) posts its
+      # comment within about a minute, long before this Storybook exists, so its
+      # links necessarily point at the *public* Storybook — where pages the PR
+      # adds do not resolve until it merges. Now that a build for this PR is
+      # published, retarget those links at it.
+      #
+      # The comment already contains every URL, so nothing has to be carried
+      # over from that workflow's run: the base it was rendered against is
+      # recorded in the comment itself. Deliberately best-effort — if that check
+      # was skipped, is still running, or found nothing to report, there is no
+      # comment to rewrite and this is a no-op.
+      - name: Point the Storybook docs comment at this PR's build
+        if: |
+          github.event_name == 'pull_request' &&
+          steps.chromatic.outputs.storybookUrl != ''
+        uses: actions/github-script@v7
+        env:
+          STORYBOOK_URL: ${{ steps.chromatic.outputs.storybookUrl }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const identifier = "<!-- comment-type: storybook_docs_index -->";
+            const preview = process.env.STORYBOOK_URL.replace(/\/+$/, "");
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number }
+            );
+            const target = comments.find(
+              (c) => c.body && c.body.includes(identifier)
+            );
+            if (!target) {
+              core.info("No Storybook docs index comment to retarget yet.");
+              return;
+            }
+
+            // The base the comment was rendered against, recorded by
+            // check-docs-index.ts. Its absence means an older comment format.
+            const baseMatch = target.body.match(
+              /<!-- storybook-base: (\S+) -->/
+            );
+            if (!baseMatch) {
+              core.info("Comment has no storybook-base marker; leaving it be.");
+              return;
+            }
+            const currentBase = baseMatch[1];
+            if (currentBase === preview) {
+              core.info("Comment already points at this build.");
+              return;
+            }
+
+            // Swap the link base, record the new one, and replace the "these
+            // links are not live yet" note with the preview link itself.
+            let body = target.body
+              .split(`${currentBase}/?path=`)
+              .join(`${preview}/?path=`)
+              .replace(
+                /<!-- storybook-base: \S+ -->/,
+                `<!-- storybook-base: ${preview} -->`
+              )
+              .replace(
+                /<!-- link-note:start -->[\s\S]*?<!-- link-note:end -->/,
+                "<!-- link-note:start -->\n" +
+                  `_Links point at this PR's Storybook build — [browse the full Storybook](${preview})._\n` +
+                  "<!-- link-note:end -->"
+              );
+
+            if (body === target.body) {
+              core.info("Nothing to rewrite.");
+              return;
+            }
+
+            await github.rest.issues.updateComment({
+              owner,
+              repo,
+              comment_id: target.id,
+              body,
+            });
+            core.info(`Retargeted docs comment links at ${preview}`);
+
   # Single check to gate the branch on. It collapses this workflow's jobs into
   # one status, so branch protection lists one stable name and never needs
   # editing when jobs are added, removed, renamed or sharded.

--- a/.github/workflows/storybook-docs-index.yaml
+++ b/.github/workflows/storybook-docs-index.yaml
@@ -1,0 +1,215 @@
+name: Storybook Docs Index
+on:
+  pull_request:
+    branches: [main]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+jobs:
+  # Detect which packages changed (reused across quality workflows)
+  detect-changes:
+    uses: ./.github/workflows/_check-workspaces-changes.yaml
+
+  # Snapshot the Storybook index — every docs page and story, with the tags that
+  # decide whether it reaches the sidebar — for both sides of the comparison in
+  # parallel.
+  #
+  # `storybook index` only runs the indexers, not a preview build: no Vite, no
+  # bundling, no `f0-core` build needed. It costs seconds, which is why this can
+  # afford to run on every PR where `packages/react` changed.
+  snapshot:
+    needs: detect-changes
+    if: |
+      needs.detect-changes.outputs.package_react == 'true' &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    name: "[⚛️ REACT] Snapshot docs index (${{ matrix.side }})"
+    runs-on: ubuntu-22.04
+    # One side failing must not wedge the run; the diff job reports a missing
+    # artifact as "comparison unavailable" rather than as a phantom deletion.
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        side: [head, base]
+    env:
+      # Snapshot the *public* Storybook — the one at f0.factorial.dev that the
+      # links in the comment point at. This also excludes `.storybook/local-docs`
+      # exactly as the deployed build does.
+      PUBLIC_BUILD: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Both sides derive from the PR *merge commit* (github.sha for
+          # pull_request events: the PR head merged into the current tip of
+          # main), so the PR is synced with main before the index is snapshotted.
+          # Snapshotting the PR branch as-is would falsely flag every page that
+          # landed on main after the branch point as "removed".
+          #   head: the merge commit itself (PR + latest main).
+          #   base: the merge commit's first parent — the exact main tip the
+          #         head side was merged with.
+          # Depth 2 makes both parents of the merge commit available.
+          fetch-depth: 2
+      - name: Record the merge commit
+        id: refs
+        # Captured before the base leg moves off it, so the snapshot tool can be
+        # restored from it below.
+        run: echo "merge_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - name: Check out base side (first parent of the merge commit)
+        if: matrix.side == 'base'
+        run: |
+          git checkout HEAD^1
+
+          # Normalize both sides with the *same* snapshot tool. Without this the
+          # base side would use whatever version of the script exists on main —
+          # or none at all, on the PR that introduces it — and every change to
+          # the tool would masquerade as a change to the docs.
+          git checkout ${{ steps.refs.outputs.merge_sha }} -- \
+            packages/react/.scripts/check-docs-index.ts
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: "22.x"
+      - name: Build the Storybook index
+        run: |
+          mkdir -p "$GITHUB_WORKSPACE/_docs"
+          pnpm --filter @factorialco/f0-react exec \
+            storybook index -o "$GITHUB_WORKSPACE/_docs/raw-index.json" --quiet
+      - name: Normalize into a snapshot
+        # `--repo-root` is where the index's `./src/...` paths resolve from; the
+        # script hashes those files so a content edit is distinguishable from a
+        # page that moved.
+        run: |
+          pnpm --filter @factorialco/f0-react exec \
+            tsx .scripts/check-docs-index.ts \
+              --from-index "$GITHUB_WORKSPACE/_docs/raw-index.json" \
+              --out "$GITHUB_WORKSPACE/_docs/snapshot.json" \
+              --repo-root "$GITHUB_WORKSPACE/packages/react"
+      - name: Upload docs index snapshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-index-${{ matrix.side }}
+          path: _docs/snapshot.json
+          if-no-files-found: error
+          retention-days: 1
+
+  docs-diff:
+    needs: [detect-changes, snapshot]
+    if: |
+      needs.detect-changes.outputs.package_react == 'true' &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    name: "[⚛️ REACT] Storybook docs index check"
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+        with:
+          node-version: "22.x"
+      - name: Download head docs index snapshot
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: docs-index-head
+          path: _docs/head
+      - name: Download base docs index snapshot
+        uses: actions/download-artifact@v4
+        continue-on-error: true
+        with:
+          name: docs-index-base
+          path: _docs/base
+      - name: Compare the docs index against main
+        id: compare
+        env:
+          # Where the links in the comment point. Override with a repository
+          # variable if the public Storybook ever moves.
+          STORYBOOK_URL: ${{ vars.STORYBOOK_PUBLIC_URL || 'https://f0.factorial.dev' }}
+        run: |
+          cd packages/react
+
+          pnpm exec tsx .scripts/check-docs-index.ts \
+            --base "$GITHUB_WORKSPACE/_docs/base/snapshot.json" \
+            --head "$GITHUB_WORKSPACE/_docs/head/snapshot.json" \
+            --storybook-url "$STORYBOOK_URL" \
+            --json > /tmp/docs-output.txt 2>&1 || true
+
+          # Extract the last complete JSON object (the script prints pretty
+          # JSON; same extraction pattern as the API surface check).
+          LAST_JSON_LINE=$(grep -n '^{' /tmp/docs-output.txt | tail -n 1 | cut -d: -f1)
+          if [ -z "$LAST_JSON_LINE" ]; then
+            echo "ERROR: No JSON output found from the docs index check"
+            cat /tmp/docs-output.txt
+            exit 1
+          fi
+          sed -n "${LAST_JSON_LINE},\$p" /tmp/docs-output.txt > /tmp/docs-data-raw.json
+
+          if ! jq . /tmp/docs-data-raw.json > /tmp/docs-data.json 2>/tmp/jq-error.txt; then
+            echo "ERROR: Failed to parse JSON from the docs index check"
+            cat /tmp/docs-data-raw.json
+            cat /tmp/jq-error.txt
+            exit 1
+          fi
+
+          HAS_LOSSES=$(jq -r '.hasLosses // false' /tmp/docs-data.json)
+          LOSS_TOTAL=$(jq -r '.lossTotal // 0' /tmp/docs-data.json)
+          echo "has_losses=$HAS_LOSSES" >> "$GITHUB_OUTPUT"
+          echo "loss_total=$LOSS_TOTAL" >> "$GITHUB_OUTPUT"
+
+          # Log the headline counts so the run is readable without the comment.
+          jq -r '"added=\(.added|length) removed=\(.removed|length) hidden=\(.hidden|length) moved=\(.moved|length) updated=\(.updated|length) revealed=\(.revealed|length) retagged=\(.retagged|length)"' \
+            /tmp/docs-data.json
+
+          # The script renders the ready-to-post comment body.
+          jq -r '.commentMarkdown // ""' /tmp/docs-data.json > /tmp/docs-comment.md
+          {
+            echo "body<<DOCS_COMMENT_EOF"
+            cat /tmp/docs-comment.md
+            echo "DOCS_COMMENT_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          if [ "$HAS_LOSSES" = "true" ]; then
+            echo "::warning::$LOSS_TOTAL Storybook page(s) reachable on main are no longer reachable on this branch — see the PR comment."
+          fi
+      - name: Comment on PR with the docs index diff
+        uses: ./.github/actions/add-or-update-pr-comment
+        with:
+          comment-type: storybook_docs_index
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-body: ${{ steps.compare.outputs.body }}
+
+  # Single check to gate the branch on. It collapses this workflow's jobs into
+  # one status, so branch protection lists one stable name and never needs
+  # editing when jobs are added, removed, renamed or sharded.
+  #
+  # `if: always()` is load-bearing. Without it a failing dependency leaves this
+  # job *skipped* rather than *failed*, and GitHub counts a skipped required
+  # check as satisfied — the gate would go green over a red run.
+  #
+  # `skipped` is accepted on purpose: detect-changes skips the jobs when the PR
+  # does not touch the React package. Only failure/cancellation is fatal.
+  #
+  # Losing a docs page does NOT fail this gate. Deleting a page is often
+  # deliberate, and a check that blocks merges on it would be routinely
+  # overridden until it was ignored. It reports instead: a PR comment and a
+  # workflow warning annotation.
+  storybook-docs-index-passed:
+    needs: [detect-changes, snapshot, docs-diff]
+    name: "✅ Storybook Docs Index"
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm every Storybook Docs Index check passed
+        run: |
+          echo "Dependency results: ${{ join(needs.*.result, ' ') }}"
+          if ${{ contains(needs.*.result, 'failure') }}; then
+            echo "::error::A Storybook Docs Index check failed."
+            exit 1
+          fi
+          if ${{ contains(needs.*.result, 'cancelled') }}; then
+            echo "::error::A Storybook Docs Index check was cancelled."
+            exit 1
+          fi
+          echo "All Storybook Docs Index checks passed (or were skipped as not applicable)."

--- a/packages/react/.scripts/__tests__/check-docs-index.test.ts
+++ b/packages/react/.scripts/__tests__/check-docs-index.test.ts
@@ -1,0 +1,683 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import path from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  buildCommentMarkdown,
+  diffSnapshots,
+  entryUrl,
+  isMdxSource,
+  isVisible,
+  snapshotFromIndex,
+  type DiffResult,
+  type Snapshot,
+  type SnapshotEntry,
+} from "../check-docs-index"
+
+/**
+ * Snapshots are built from the real `storybook index` shape, so these tests
+ * write a minimal raw index plus the source files it points at into a temp dir
+ * and run the real normalizer — the same path CI takes.
+ */
+const createdDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of createdDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+interface RawEntryInput {
+  id: string
+  type?: "docs" | "story"
+  title?: string
+  name?: string
+  importPath: string
+  componentPath?: string
+  exportName?: string
+  tags?: string[]
+}
+
+/**
+ * Write a raw index plus its source files, then normalize it. `files` maps an
+ * `importPath` to its contents, so a test can change one file between the two
+ * sides to exercise content-hash detection.
+ */
+function snapshotOf(
+  entries: RawEntryInput[],
+  files: Record<string, string> = {}
+): Snapshot {
+  const dir = mkdtempSync(path.join(tmpdir(), "docs-index-test-"))
+  createdDirs.push(dir)
+
+  for (const [importPath, contents] of Object.entries(files)) {
+    const abs = path.resolve(dir, importPath)
+    mkdirSync(path.dirname(abs), { recursive: true })
+    writeFileSync(abs, contents)
+  }
+
+  const raw = {
+    v: 5,
+    entries: Object.fromEntries(
+      entries.map((e) => [
+        e.id,
+        {
+          type: e.type ?? "story",
+          title: e.title ?? "Components/Thing",
+          name: e.name ?? "Default",
+          tags: e.tags ?? ["dev", "test"],
+          ...e,
+        },
+      ])
+    ),
+  }
+  return snapshotFromIndex(JSON.stringify(raw), dir)
+}
+
+/** A story entry, visible by default. */
+function story(over: Partial<RawEntryInput> = {}): RawEntryInput {
+  return {
+    id: "components-thing--default",
+    type: "story",
+    title: "Components/Thing",
+    name: "Default",
+    importPath: "./thing.stories.tsx",
+    exportName: "Default",
+    tags: ["dev", "test", "stable"],
+    ...over,
+  }
+}
+
+/** The files map that makes `story()`'s importPath readable. */
+const STORY_FILES = { "./thing.stories.tsx": "export const Default = {}" }
+
+function diff(base: Snapshot, head: Snapshot): DiffResult {
+  return diffSnapshots(base, head)
+}
+
+function ids(list: SnapshotEntry[]): string[] {
+  return list.map((e) => e.id).sort()
+}
+
+describe("isVisible", () => {
+  it("requires the dev tag and the absence of no-sidebar", () => {
+    expect(isVisible(["dev", "test"])).toBe(true)
+    // `!dev` means Storybook indexes the entry but never lists it.
+    expect(isVisible(["test"])).toBe(false)
+    // This repo's own sidebar filter, applied in .storybook/manager.ts.
+    expect(isVisible(["dev", "no-sidebar"])).toBe(false)
+  })
+})
+
+describe("snapshotFromIndex", () => {
+  it("normalizes entries, sorts tags and records visibility", () => {
+    const snap = snapshotOf(
+      [story({ tags: ["test", "dev", "stable"] })],
+      STORY_FILES
+    )
+    const entry = snap.entries["components-thing--default"]!
+    expect(entry.type).toBe("story")
+    expect(entry.title).toBe("Components/Thing")
+    expect(entry.tags).toEqual(["dev", "stable", "test"])
+    expect(entry.visible).toBe(true)
+    expect(entry.hash).not.toBe("")
+  })
+
+  it("hashes the source file so content changes are detectable", () => {
+    const a = snapshotOf([story()], {
+      "./thing.stories.tsx": "export const Default = {}",
+    })
+    const b = snapshotOf([story()], {
+      "./thing.stories.tsx": "export const Default = { name: 'x' }",
+    })
+    expect(a.entries["components-thing--default"]!.hash).not.toBe(
+      b.entries["components-thing--default"]!.hash
+    )
+  })
+
+  it("leaves the hash empty when the source file is missing", () => {
+    const snap = snapshotOf([story()], {})
+    expect(snap.entries["components-thing--default"]!.hash).toBe("")
+  })
+
+  it("skips entries without an id or importPath", () => {
+    const snap = snapshotFromIndex(
+      JSON.stringify({ entries: { a: { id: "a" }, b: { importPath: "./b" } } }),
+      "/nonexistent"
+    )
+    expect(Object.keys(snap.entries)).toEqual([])
+  })
+})
+
+describe("diffSnapshots — losses", () => {
+  it("reports a visible entry that disappeared as removed", () => {
+    const result = diff(snapshotOf([story()], STORY_FILES), snapshotOf([], {}))
+    expect(ids(result.removed)).toEqual(["components-thing--default"])
+    expect(result.hasLosses).toBe(true)
+    expect(result.lossTotal).toBe(1)
+  })
+
+  it("ignores an entry that was already hidden before it disappeared", () => {
+    const result = diff(
+      snapshotOf([story({ tags: ["dev", "no-sidebar"] })], STORY_FILES),
+      snapshotOf([], {})
+    )
+    expect(result.removed).toEqual([])
+    expect(result.hasLosses).toBe(false)
+  })
+
+  it("reports a no-sidebar tag added to an existing entry as hidden", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf([story({ tags: ["dev", "test", "no-sidebar"] })], STORY_FILES)
+    )
+    expect(result.removed).toEqual([])
+    expect(result.hidden).toHaveLength(1)
+    expect(result.hasLosses).toBe(true)
+  })
+
+  it("reports a dropped dev tag as hidden", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf([story({ tags: ["test"] })], STORY_FILES)
+    )
+    expect(result.hidden).toHaveLength(1)
+    expect(result.hasLosses).toBe(true)
+  })
+
+  it("counts a move that also leaves the sidebar as a loss, not a move", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf(
+        [
+          story({
+            id: "patterns-thing--default",
+            title: "Patterns/Thing",
+            tags: ["dev", "no-sidebar"],
+          }),
+        ],
+        STORY_FILES
+      )
+    )
+    expect(result.moved).toEqual([])
+    expect(result.hidden).toHaveLength(1)
+    expect(result.hasLosses).toBe(true)
+  })
+})
+
+describe("diffSnapshots — moves", () => {
+  it("pairs a retitled entry as moved rather than removed plus added", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf(
+        [story({ id: "patterns-thing--default", title: "Patterns/Thing" })],
+        STORY_FILES
+      )
+    )
+    expect(result.removed).toEqual([])
+    expect(result.added).toEqual([])
+    expect(result.moved).toHaveLength(1)
+    expect(result.moved[0]!.base.title).toBe("Components/Thing")
+    expect(result.moved[0]!.head.title).toBe("Patterns/Thing")
+    expect(result.hasLosses).toBe(false)
+  })
+
+  it("pairs an unedited MDX page that moved file, via its content hash", () => {
+    const files = { "./old/page.mdx": "# Page" }
+    const movedFiles = { "./new/page.mdx": "# Page" }
+    const base = snapshotOf(
+      [
+        {
+          id: "guides-page--documentation",
+          type: "docs",
+          title: "Guides/Page",
+          name: "Documentation",
+          importPath: "./old/page.mdx",
+        },
+      ],
+      files
+    )
+    // Different id and different file, but byte-identical contents.
+    const head = snapshotOf(
+      [
+        {
+          id: "handbook-page--documentation",
+          type: "docs",
+          title: "Handbook/Page",
+          name: "Documentation",
+          importPath: "./new/page.mdx",
+        },
+      ],
+      movedFiles
+    )
+    // The temp dirs differ, so build the head snapshot's dir first.
+    const result = diff(base, head)
+    expect(result.removed).toEqual([])
+    expect(result.moved).toHaveLength(1)
+  })
+
+  it("does not pair two unrelated entries", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf(
+        [
+          story({
+            id: "components-other--default",
+            title: "Components/Other",
+            importPath: "./other.stories.tsx",
+            exportName: "Default",
+          }),
+        ],
+        { "./other.stories.tsx": "export const Default = { other: true }" }
+      )
+    )
+    expect(result.moved).toEqual([])
+    expect(ids(result.removed)).toEqual(["components-thing--default"])
+    expect(ids(result.added)).toEqual(["components-other--default"])
+  })
+})
+
+describe("diffSnapshots — additions and updates", () => {
+  it("separates added visible entries from added hidden ones", () => {
+    const result = diff(
+      snapshotOf([], {}),
+      snapshotOf(
+        [
+          story(),
+          story({
+            id: "components-thing--snapshot",
+            name: "Snapshot",
+            exportName: "Snapshot",
+            tags: ["dev", "no-sidebar"],
+          }),
+        ],
+        STORY_FILES
+      )
+    )
+    expect(ids(result.added)).toEqual(["components-thing--default"])
+    expect(ids(result.addedHidden)).toEqual(["components-thing--snapshot"])
+  })
+
+  it("reports a source edit as updated", () => {
+    const result = diff(
+      snapshotOf([story()], {
+        "./thing.stories.tsx": "export const Default = {}",
+      }),
+      snapshotOf([story()], {
+        "./thing.stories.tsx": "export const Default = { changed: true }",
+      })
+    )
+    expect(result.updated).toHaveLength(1)
+    expect(result.hasLosses).toBe(false)
+  })
+
+  it("does not report an unchanged source as updated", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf([story()], STORY_FILES)
+    )
+    expect(result.updated).toEqual([])
+    expect(result.retagged).toEqual([])
+  })
+
+  it("reports an entry that became visible as revealed", () => {
+    const result = diff(
+      snapshotOf([story({ tags: ["dev", "no-sidebar"] })], STORY_FILES),
+      snapshotOf([story({ tags: ["dev", "test"] })], STORY_FILES)
+    )
+    expect(result.revealed).toHaveLength(1)
+    expect(result.hasLosses).toBe(false)
+  })
+
+  it("reports a maturity change but ignores mechanical tag churn", () => {
+    const promoted = diff(
+      snapshotOf([story({ tags: ["dev", "experimental"] })], STORY_FILES),
+      snapshotOf([story({ tags: ["dev", "stable"] })], STORY_FILES)
+    )
+    expect(promoted.retagged).toHaveLength(1)
+
+    const churn = diff(
+      snapshotOf([story({ tags: ["dev", "stable"] })], STORY_FILES),
+      snapshotOf([story({ tags: ["dev", "stable", "play-fn"] })], STORY_FILES)
+    )
+    expect(churn.retagged).toEqual([])
+  })
+})
+
+/**
+ * A docs page id is one slot that two mechanisms compete for: `autodocs`
+ * generates the page, and an attached `.mdx` replaces it. These cover both the
+ * page vanishing (autodocs dropped) and the page being quietly taken over.
+ */
+describe("diffSnapshots — autodocs and overwritten docs", () => {
+  /** The docs page Storybook generates for a component from its story file. */
+  function autodocsPage(over: Partial<RawEntryInput> = {}): RawEntryInput {
+    return {
+      id: "components-thing--documentation",
+      type: "docs",
+      title: "Components/Thing",
+      name: "Documentation",
+      importPath: "./thing.stories.tsx",
+      tags: ["dev", "test", "autodocs"],
+      ...over,
+    }
+  }
+
+  it("reports a dropped autodocs tag as a removed docs page", () => {
+    // Dropping `autodocs` deletes the `--documentation` entry outright; the
+    // component's stories stay behind.
+    const result = diff(
+      snapshotOf([autodocsPage(), story()], STORY_FILES),
+      snapshotOf([story()], STORY_FILES)
+    )
+    expect(ids(result.removed)).toEqual(["components-thing--documentation"])
+    expect(result.hasLosses).toBe(true)
+  })
+
+  it("names the dropped tag as the likely cause when the stories survive", () => {
+    const result = diff(
+      snapshotOf([autodocsPage(), story()], STORY_FILES),
+      snapshotOf([story()], STORY_FILES)
+    )
+    expect(result.autodocsLikelyDropped).toEqual([
+      "components-thing--documentation",
+    ])
+    const md = buildCommentMarkdown(result, "https://sb.test")
+    expect(md).toContain("`autodocs` was probably dropped")
+  })
+
+  it("does not blame autodocs when the whole component went away", () => {
+    // No stories left either — the component was deleted, not retagged.
+    const result = diff(
+      snapshotOf([autodocsPage(), story()], STORY_FILES),
+      snapshotOf([], {})
+    )
+    expect(result.autodocsLikelyDropped).toEqual([])
+  })
+
+  it("reports an .mdx taking over an autodocs page as a source replacement", () => {
+    // Same id, same title, same URL — only the file behind it changed. This is
+    // the case an id-only diff cannot see at all.
+    const result = diff(
+      snapshotOf([autodocsPage()], STORY_FILES),
+      snapshotOf(
+        [
+          autodocsPage({
+            importPath: "./thing.mdx",
+            tags: ["dev", "test", "autodocs", "attached-mdx"],
+          }),
+        ],
+        { "./thing.mdx": "# Thing" }
+      )
+    )
+    expect(result.removed).toEqual([])
+    expect(result.added).toEqual([])
+    // Crucially NOT filed as a routine content edit.
+    expect(result.updated).toEqual([])
+    expect(result.docsSourceReplaced).toHaveLength(1)
+    expect(result.docsSourceReplaced[0]!.base.importPath).toBe(
+      "./thing.stories.tsx"
+    )
+    expect(result.docsSourceReplaced[0]!.head.importPath).toBe("./thing.mdx")
+  })
+
+  it("warns in the comment even though no page was lost", () => {
+    const result = diff(
+      snapshotOf([autodocsPage()], STORY_FILES),
+      snapshotOf([autodocsPage({ importPath: "./thing.mdx" })], {
+        "./thing.mdx": "# Thing",
+      })
+    )
+    expect(result.hasLosses).toBe(false)
+    const md = buildCommentMarkdown(result, "https://sb.test")
+    // "no pages lost" would read as all-clear while content was swapped out.
+    expect(md).not.toContain("✅ Storybook docs — no pages lost")
+    expect(md).toContain("⚠️ Storybook docs source replaced (1)")
+    expect(md).toContain("auto-generated → hand-written MDX")
+  })
+
+  it("reports the reverse direction too", () => {
+    const result = diff(
+      snapshotOf([autodocsPage({ importPath: "./thing.mdx" })], {
+        "./thing.mdx": "# Thing",
+      }),
+      snapshotOf([autodocsPage()], STORY_FILES)
+    )
+    expect(result.docsSourceReplaced).toHaveLength(1)
+    expect(buildCommentMarkdown(result, "https://sb.test")).toContain(
+      "hand-written MDX → auto-generated"
+    )
+  })
+
+  it("treats a relocated file of the same kind as a move, not a replacement", () => {
+    const result = diff(
+      snapshotOf([autodocsPage({ importPath: "./old/thing.mdx" })], {
+        "./old/thing.mdx": "# Thing",
+      }),
+      snapshotOf([autodocsPage({ importPath: "./new/thing.mdx" })], {
+        "./new/thing.mdx": "# Thing edited",
+      })
+    )
+    expect(result.docsSourceReplaced).toEqual([])
+    expect(result.sourceMoved).toHaveLength(1)
+    const md = buildCommentMarkdown(result, "https://sb.test")
+    // A plain rename must not raise the warning heading.
+    expect(md).toContain("✅ Storybook docs — no pages lost")
+    expect(md).toContain("🚚 Source file moved — 1 entry across 1 file(s)")
+  })
+})
+
+describe("isMdxSource", () => {
+  it("distinguishes hand-written pages from story-generated ones", () => {
+    expect(isMdxSource("./src/x/Thing.mdx")).toBe(true)
+    expect(isMdxSource("./src/x/Thing.stories.tsx")).toBe(false)
+  })
+})
+
+describe("entryUrl", () => {
+  it("routes docs and stories to their Storybook paths", () => {
+    const snap = snapshotOf(
+      [
+        story(),
+        {
+          id: "guides-page--documentation",
+          type: "docs",
+          title: "Guides/Page",
+          name: "Documentation",
+          importPath: "./page.mdx",
+        },
+      ],
+      { ...STORY_FILES, "./page.mdx": "# Page" }
+    )
+    expect(
+      entryUrl(snap.entries["components-thing--default"]!, "https://sb.test")
+    ).toBe("https://sb.test/?path=/story/components-thing--default")
+    expect(
+      entryUrl(snap.entries["guides-page--documentation"]!, "https://sb.test/")
+    ).toBe("https://sb.test/?path=/docs/guides-page--documentation")
+  })
+})
+
+describe("buildCommentMarkdown", () => {
+  it("leads with a warning and links every lost page", () => {
+    const result = diff(snapshotOf([story()], STORY_FILES), snapshotOf([], {}))
+    const md = buildCommentMarkdown(result, "https://sb.test")
+    expect(md).toContain("⚠️ Storybook pages lost (1)")
+    expect(md).toContain(
+      "https://sb.test/?path=/story/components-thing--default"
+    )
+    expect(md).toContain("Components/Thing › Default")
+  })
+
+  it("explains why an entry left the sidebar", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf([story({ tags: ["dev", "test", "no-sidebar"] })], STORY_FILES)
+    )
+    const md = buildCommentMarkdown(result, "https://sb.test")
+    expect(md).toContain("No longer in the sidebar (1)")
+    expect(md).toContain("gained the `no-sidebar` tag")
+  })
+
+  it("reports a clean result so a stale warning resolves", () => {
+    const result = diff(
+      snapshotOf([story()], STORY_FILES),
+      snapshotOf([story()], STORY_FILES)
+    )
+    const md = buildCommentMarkdown(result, "https://sb.test")
+    expect(md).toContain("✅ Storybook docs — no pages lost")
+    expect(md).not.toContain("⚠️")
+  })
+
+  it("links added pages and titles docs pages without a story name", () => {
+    const result = diff(
+      snapshotOf([], {}),
+      snapshotOf(
+        [
+          {
+            id: "guides-page--documentation",
+            type: "docs",
+            title: "Guides/Page",
+            name: "Documentation",
+            importPath: "./page.mdx",
+          },
+        ],
+        { "./page.mdx": "# Page" }
+      )
+    )
+    const md = buildCommentMarkdown(result, "https://sb.test")
+    expect(md).toContain("➕ Added (1)")
+    expect(md).toContain(
+      "[Guides/Page](https://sb.test/?path=/docs/guides-page--documentation)"
+    )
+    // A docs page's "Documentation" leaf is noise — the title alone is the label.
+    expect(md).not.toContain("Guides/Page › Documentation")
+  })
+
+  it("says so plainly when a side's snapshot is missing", () => {
+    const md = buildCommentMarkdown(
+      { ...diff(snapshotOf([], {}), snapshotOf([], {})), incomplete: "boom" },
+      "https://sb.test"
+    )
+    expect(md).toContain("comparison unavailable")
+    expect(md).toContain("boom")
+  })
+
+  /**
+   * `chromatic.yml` rewrites this comment in place once a Storybook for the PR
+   * exists, using only the markers in the body. These lock that contract: the
+   * rewrite has no other channel to the diff, so losing a marker silently costs
+   * the comment its working links.
+   */
+  describe("Chromatic retargeting contract", () => {
+    const rendered = (): string => {
+      const result = diff(
+        snapshotOf([], {}),
+        snapshotOf([story()], STORY_FILES)
+      )
+      return buildCommentMarkdown(result, "https://sb.test")
+    }
+
+    /** The rewrite `chromatic.yml` performs, kept in step with that script. */
+    const retarget = (body: string, preview: string): string => {
+      const base = body.match(/<!-- storybook-base: (\S+) -->/)![1]!
+      return body
+        .split(`${base}/?path=`)
+        .join(`${preview}/?path=`)
+        .replace(
+          /<!-- storybook-base: \S+ -->/,
+          `<!-- storybook-base: ${preview} -->`
+        )
+        .replace(
+          /<!-- link-note:start -->[\s\S]*?<!-- link-note:end -->/,
+          `<!-- link-note:start -->\n_[full Storybook](${preview})._\n<!-- link-note:end -->`
+        )
+    }
+
+    it("records the base it rendered against on the first line", () => {
+      expect(rendered().split("\n")[0]).toBe(
+        "<!-- storybook-base: https://sb.test -->"
+      )
+    })
+
+    it("always emits the link note, even with nothing added", () => {
+      const clean = buildCommentMarkdown(
+        diff(
+          snapshotOf([story()], STORY_FILES),
+          snapshotOf([story()], STORY_FILES)
+        ),
+        "https://sb.test"
+      )
+      expect(clean).toContain("<!-- link-note:start -->")
+      expect(clean).toContain("<!-- link-note:end -->")
+    })
+
+    it("moves every link to the preview base when retargeted", () => {
+      const out = retarget(rendered(), "https://pr-9--abc.chromatic.com")
+      expect(out).toContain(
+        "https://pr-9--abc.chromatic.com/?path=/story/components-thing--default"
+      )
+      expect(out).not.toContain("https://sb.test/?path=")
+      expect(out).toContain(
+        "<!-- storybook-base: https://pr-9--abc.chromatic.com -->"
+      )
+      expect(out).toContain("[full Storybook](https://pr-9--abc.chromatic.com)")
+    })
+
+    it("is idempotent — a second retarget changes nothing", () => {
+      const once = retarget(rendered(), "https://pr-9--abc.chromatic.com")
+      expect(retarget(once, "https://pr-9--abc.chromatic.com")).toBe(once)
+    })
+
+    it("keeps the markers even when the diff is truncated", () => {
+      const many = Array.from({ length: 400 }, (_, i) =>
+        story({
+          id: `components-thing--s${i}`,
+          name: `Story ${i}`,
+          exportName: `Story${i}`,
+          importPath: `./f${i % 40}.stories.tsx`,
+        })
+      )
+      const files = Object.fromEntries(
+        Array.from({ length: 40 }, (_, i) => [
+          `./f${i}.stories.tsx`,
+          `export const S${i} = {}`,
+        ])
+      )
+      const md = buildCommentMarkdown(
+        diff(snapshotOf([], {}), snapshotOf(many, files)),
+        "https://sb.test"
+      )
+      expect(Buffer.byteLength(md, "utf8")).toBeLessThan(65536)
+      expect(md.split("\n")[0]).toContain("storybook-base")
+      expect(md).toContain("<!-- link-note:end -->")
+    })
+  })
+
+  it("stays under GitHub's comment size limit for a huge diff", () => {
+    // 400 stories across 40 files, all removed — worse than any real PR.
+    const many = Array.from({ length: 400 }, (_, i) =>
+      story({
+        id: `components-thing--s${i}`,
+        name: `Story ${i}`,
+        exportName: `Story${i}`,
+        importPath: `./f${i % 40}.stories.tsx`,
+      })
+    )
+    const files = Object.fromEntries(
+      Array.from({ length: 40 }, (_, i) => [
+        `./f${i}.stories.tsx`,
+        `export const S${i} = {}`,
+      ])
+    )
+    const md = buildCommentMarkdown(
+      diff(snapshotOf(many, files), snapshotOf([], {})),
+      "https://sb.test"
+    )
+    expect(Buffer.byteLength(md, "utf8")).toBeLessThan(65536)
+    // The headline count stays honest even though the list is capped.
+    expect(md).toContain("⚠️ Storybook pages lost (400)")
+  })
+})

--- a/packages/react/.scripts/check-docs-index.ts
+++ b/packages/react/.scripts/check-docs-index.ts
@@ -1,0 +1,1044 @@
+/**
+ * Storybook docs & stories index snapshot / diff.
+ *
+ * Storybook's sidebar is assembled from a curated allowlist of directories in
+ * `.storybook/main.ts` plus per-entry tags. That makes it possible to *silently
+ * lose a page*: move a component to a directory that is not listed, drop an
+ * `autodocs` tag, or add `no-sidebar`, and the docs page simply stops being
+ * exposed. Nothing fails, nothing is red — the page is just gone.
+ *
+ * This script gives that class of change a voice in the PR. It works in two
+ * modes:
+ *
+ *   1. `--from-index` — normalize the raw `storybook index` output into a
+ *      stable *snapshot*: one record per docs page / story, carrying the
+ *      identity (id, title, name, source path), the sidebar-visibility verdict,
+ *      and a content hash of the source file.
+ *
+ *   2. `--base` / `--head` — compare two snapshots and classify every
+ *      difference.
+ *
+ * Both sides are normalized and compared by the *same* version of this script
+ * (CI restores it onto the base checkout), so the diff can never be an artifact
+ * of the tool changing underneath it.
+ *
+ * ## What "visible" means
+ *
+ * An entry reaches the sidebar only if it is tagged `dev` *and* is not tagged
+ * `no-sidebar`:
+ *
+ *   - `dev` is Storybook's own sidebar gate. A story or docs page carrying the
+ *     `!dev` tag is indexed (so it still runs in tests) but never listed.
+ *   - `no-sidebar` is this repo's filter, applied in `.storybook/manager.ts`.
+ *
+ * Losing either one is the exact regression this check exists to surface, so
+ * visibility is tracked per entry rather than inferred from presence.
+ *
+ * ## Classification
+ *
+ *   REGRESSION-SHAPED (surfaced first, with a ⚠️ heading)
+ *     - `removed`             — the entry is gone from the index entirely
+ *     - `hidden`              — still indexed, but no longer reaches the sidebar
+ *     - `docsSourceReplaced`  — the page survives but something else generates
+ *                               it now (see "Overwritten docs" below)
+ *   INFORMATIONAL
+ *     - `sourceMoved` — same page and mechanism, source file relocated
+ *     - `moved`       — same source + export, but a different id/title (renamed
+ *                       or relocated in the nav tree)
+ *     - `added`       — a newly exposed page or story
+ *     - `revealed`    — was indexed but hidden, now visible
+ *     - `updated`     — same entry, but its source file content changed
+ *     - `retagged`    — maturity changed (experimental → stable, deprecated, …)
+ *
+ * ## autodocs
+ *
+ * `autodocs` is what *creates* a component's docs page, so dropping it (or
+ * adding `!autodocs`) deletes the `…--documentation` entry outright — that
+ * surfaces as `removed`, with no special handling needed. What the entry cannot
+ * tell you on its own is *why* it went: a deleted component takes its stories
+ * with it, whereas a dropped tag leaves them behind. `autodocsLikelyDropped`
+ * flags that second shape so the comment can name the likely cause.
+ *
+ * ## Overwritten docs
+ *
+ * A docs page id is a single slot, and two mechanisms compete for it: Storybook
+ * generates the page from `autodocs`, and an `.mdx` attached to the same
+ * component *replaces* it. Adding an MDX file therefore silently overwrites the
+ * auto-generated page — same id, same title, same URL, entirely different
+ * content, and the props table plus story previews are gone unless the new file
+ * renders them itself. Nothing is added and nothing is removed, so an
+ * id-only diff sees no change at all. Comparing each entry's `importPath`
+ * across the two sides is what catches it.
+ *
+ * A rename is deliberately *not* reported as a removal plus an addition. Move
+ * detection pairs a disappeared id with a new one when they share a source file
+ * and export name (or a component path, or an identical file hash for an MDX
+ * page that moved untouched), so a retitled page reads as "moved" instead of
+ * falsely screaming that docs were deleted.
+ *
+ * "Updated" is derived from the hash of the entry's **source file**. That is
+ * file-level, not statement-level: editing one story in a `.stories.tsx` marks
+ * every story in that file as updated. Stories are therefore grouped by file in
+ * the rendered comment, so a one-line edit reads as one entry with its stories
+ * listed beneath it rather than as twenty separate findings.
+ *
+ * Usage:
+ *   tsx .scripts/check-docs-index.ts --from-index <raw.json> --out <snap.json>
+ *   tsx .scripts/check-docs-index.ts --base <snap.json> --head <snap.json> [--json]
+ *
+ * This check is non-blocking: losing a page is reported, never fatal. It exits
+ * 0 for every outcome (only a usage error exits 2) and reports through the
+ * `--json` payload and the PR comment it renders. It returns from `main`
+ * rather than calling `process.exit(0)` so Node can flush stdout — exiting
+ * eagerly truncates the JSON when it is piped (`… --json | jq`) instead of
+ * redirected to a file.
+ */
+
+import { createHash } from "node:crypto"
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import path from "node:path"
+
+import consola from "consola"
+
+/* -------------------------------- types ---------------------------------- */
+
+export type EntryType = "docs" | "story"
+
+/** One docs page or story, normalized out of the raw Storybook index. */
+export interface SnapshotEntry {
+  /** Storybook id — also the `?path=` URL segment. */
+  id: string
+  type: EntryType
+  /** Sidebar path, e.g. `Components/Button`. */
+  title: string
+  /** Leaf name, e.g. `Default` or `Documentation`. */
+  name: string
+  /** Source file, relative to `packages/react` (e.g. `./src/x/y.stories.tsx`). */
+  importPath: string
+  /** The documented component's source file, when Storybook resolved one. */
+  componentPath?: string
+  /** Named export backing a story. Absent for docs pages. */
+  exportName?: string
+  tags: string[]
+  /** Whether the entry actually reaches the sidebar. See module docs. */
+  visible: boolean
+  /** sha256 of `importPath`'s contents, or `""` when unreadable. */
+  hash: string
+}
+
+export interface Snapshot {
+  /** Keyed by Storybook id. */
+  entries: Record<string, SnapshotEntry>
+}
+
+/** A pair of the same logical entry on both sides. */
+export interface EntryChange {
+  base: SnapshotEntry
+  head: SnapshotEntry
+}
+
+export interface DiffResult {
+  /** Gone from the index entirely. */
+  removed: SnapshotEntry[]
+  /** Still indexed, no longer in the sidebar. */
+  hidden: EntryChange[]
+  /** Renamed or relocated in the nav tree. */
+  moved: EntryChange[]
+  /** Newly exposed. */
+  added: SnapshotEntry[]
+  /** New, but not visible (e.g. a snapshot-only story). */
+  addedHidden: SnapshotEntry[]
+  /** Was hidden, now visible. */
+  revealed: EntryChange[]
+  /**
+   * Same page, but it is now generated by a different *mechanism* — an
+   * `.mdx` file took over a page Storybook used to auto-generate, or vice
+   * versa. The page survives; the content behind it was replaced.
+   */
+  docsSourceReplaced: EntryChange[]
+  /** Same page and same mechanism, but the source file moved or was renamed. */
+  sourceMoved: EntryChange[]
+  /** Source file content changed. */
+  updated: EntryChange[]
+  /** Maturity tags changed. */
+  retagged: EntryChange[]
+  /**
+   * Ids of `removed` docs pages whose component still has indexed stories.
+   * A deleted component takes its stories with it; a page that vanished while
+   * its stories live on lost its `autodocs` tag (or gained `!autodocs`).
+   */
+  autodocsLikelyDropped: string[]
+  /** Set when a side's snapshot was missing, so counts are not trustworthy. */
+  incomplete?: string
+  /** True when anything regression-shaped (removed / hidden) was found. */
+  hasLosses: boolean
+  lossTotal: number
+}
+
+/* ------------------------------ normalizing ------------------------------- */
+
+/** Tags that describe maturity rather than mechanics — worth reporting. */
+const MATURITY_TAGS = new Set([
+  "experimental",
+  "stable",
+  "deprecated",
+  "internal",
+])
+
+/**
+ * An entry reaches the sidebar only when Storybook's own `dev` gate is present
+ * and this repo's `no-sidebar` filter does not exclude it.
+ */
+export function isVisible(tags: string[]): boolean {
+  return tags.includes("dev") && !tags.includes("no-sidebar")
+}
+
+/**
+ * Whether a page is written by hand (`.mdx`) rather than auto-generated from a
+ * story file. The two are interchangeable for the same page id — attaching an
+ * MDX file to a component silently takes over the `autodocs` page — so the
+ * extension is what tells the mechanisms apart.
+ */
+export function isMdxSource(importPath: string): boolean {
+  return /\.mdx$/.test(importPath)
+}
+
+/** sha256 of a source file's contents, newline-normalized. `""` if unreadable. */
+function hashFile(repoRoot: string, importPath: string): string {
+  // Storybook emits `./src/...`, relative to the Storybook config's root.
+  const abs = path.resolve(repoRoot, importPath)
+  if (!existsSync(abs)) return ""
+  try {
+    const text = readFileSync(abs, "utf8").replace(/\r\n/g, "\n")
+    return createHash("sha256").update(text).digest("hex").slice(0, 16)
+  } catch {
+    return ""
+  }
+}
+
+/** Raw `storybook index` entry — only the fields this check consumes. */
+interface RawEntry {
+  id?: unknown
+  type?: unknown
+  title?: unknown
+  name?: unknown
+  importPath?: unknown
+  componentPath?: unknown
+  exportName?: unknown
+  tags?: unknown
+}
+
+const str = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length > 0 ? v : undefined
+
+/**
+ * Normalize the raw `storybook index -o` output into a snapshot.
+ *
+ * `repoRoot` is the directory the `importPath`s are relative to
+ * (`packages/react`); source files are hashed from there so the diff can tell
+ * "this page's content changed" from "this page moved".
+ */
+export function snapshotFromIndex(
+  rawIndexJson: string,
+  repoRoot: string
+): Snapshot {
+  const parsed: unknown = JSON.parse(rawIndexJson)
+  const rawEntries =
+    parsed && typeof parsed === "object" && "entries" in parsed
+      ? ((parsed as { entries: Record<string, RawEntry> }).entries ?? {})
+      : {}
+
+  // One file is read once even when it backs twenty stories.
+  const hashCache = new Map<string, string>()
+  const entries: Record<string, SnapshotEntry> = {}
+
+  for (const raw of Object.values(rawEntries)) {
+    const id = str(raw.id)
+    const importPath = str(raw.importPath)
+    const type = raw.type === "docs" ? "docs" : "story"
+    if (!id || !importPath) continue
+
+    let hash = hashCache.get(importPath)
+    if (hash === undefined) {
+      hash = hashFile(repoRoot, importPath)
+      hashCache.set(importPath, hash)
+    }
+
+    const tags = Array.isArray(raw.tags)
+      ? raw.tags.filter((t): t is string => typeof t === "string").sort()
+      : []
+
+    entries[id] = {
+      id,
+      type,
+      title: str(raw.title) ?? "",
+      name: str(raw.name) ?? "",
+      importPath,
+      componentPath: str(raw.componentPath),
+      exportName: str(raw.exportName),
+      tags,
+      visible: isVisible(tags),
+      hash,
+    }
+  }
+
+  return { entries }
+}
+
+/* -------------------------------- diffing -------------------------------- */
+
+/**
+ * Identity keys used to pair a disappeared id with a new one, tried in
+ * descending confidence. Anything that matches is a move (rename / relocation),
+ * not a deletion.
+ */
+function moveKeys(e: SnapshotEntry): string[] {
+  const leaf = e.exportName ?? e.name
+  const keys = [`import:${e.importPath}::${leaf}`]
+  if (e.componentPath) keys.push(`component:${e.componentPath}::${leaf}`)
+  // An MDX page that moved without being edited keeps its content hash.
+  if (e.hash) keys.push(`hash:${e.hash}::${leaf}`)
+  return keys
+}
+
+/** Maturity tags only, so mechanical tag churn (`play-fn`, …) stays quiet. */
+function maturityOf(e: SnapshotEntry): string[] {
+  return e.tags.filter((t) => MATURITY_TAGS.has(t))
+}
+
+export function diffSnapshots(base: Snapshot, head: Snapshot): DiffResult {
+  const result: DiffResult = {
+    removed: [],
+    hidden: [],
+    moved: [],
+    added: [],
+    addedHidden: [],
+    revealed: [],
+    docsSourceReplaced: [],
+    sourceMoved: [],
+    updated: [],
+    retagged: [],
+    autodocsLikelyDropped: [],
+    hasLosses: false,
+    lossTotal: 0,
+  }
+
+  const baseIds = new Set(Object.keys(base.entries))
+  const headIds = new Set(Object.keys(head.entries))
+
+  // ── entries present on both sides ──────────────────────────────────────
+  for (const id of Array.from(baseIds)) {
+    if (!headIds.has(id)) continue
+    const b = base.entries[id]!
+    const h = head.entries[id]!
+
+    if (b.visible && !h.visible) {
+      result.hidden.push({ base: b, head: h })
+    } else if (!b.visible && h.visible) {
+      result.revealed.push({ base: b, head: h })
+    }
+
+    // A page whose source file changed identity is not an edit — something
+    // else is now generating it. Reported on its own rather than folded into
+    // `updated`, where a silent takeover would read as a routine tweak.
+    if (b.importPath !== h.importPath) {
+      if (isMdxSource(b.importPath) === isMdxSource(h.importPath)) {
+        result.sourceMoved.push({ base: b, head: h })
+      } else {
+        result.docsSourceReplaced.push({ base: b, head: h })
+      }
+    } else if (h.visible && b.hash && h.hash && b.hash !== h.hash) {
+      // Content edits are only interesting for pages someone can reach.
+      result.updated.push({ base: b, head: h })
+    }
+
+    const bm = maturityOf(b).join(",")
+    const hm = maturityOf(h).join(",")
+    if (bm !== hm) result.retagged.push({ base: b, head: h })
+  }
+
+  // ── ids that vanished vs. ids that appeared: pair up the moves ──────────
+  const gone = Array.from(baseIds)
+    .filter((id) => !headIds.has(id))
+    .map((id) => base.entries[id]!)
+  const fresh = Array.from(headIds)
+    .filter((id) => !baseIds.has(id))
+    .map((id) => head.entries[id]!)
+
+  // Index the new ids by every identity key, then consume matches so one new
+  // entry can only ever absorb a single disappeared one.
+  const freshByKey = new Map<string, SnapshotEntry[]>()
+  for (const e of fresh) {
+    for (const k of moveKeys(e)) {
+      const list = freshByKey.get(k)
+      if (list) list.push(e)
+      else freshByKey.set(k, [e])
+    }
+  }
+  const claimed = new Set<string>()
+
+  for (const b of gone) {
+    let match: SnapshotEntry | undefined
+    for (const k of moveKeys(b)) {
+      match = freshByKey.get(k)?.find((c) => !claimed.has(c.id))
+      if (match) break
+    }
+    if (match) {
+      claimed.add(match.id)
+      // A "move" that also drops out of the sidebar is still a loss.
+      if (b.visible && !match.visible) {
+        result.hidden.push({ base: b, head: match })
+      } else {
+        result.moved.push({ base: b, head: match })
+      }
+      continue
+    }
+    // Only a page that *was* reachable counts as a loss.
+    if (b.visible) result.removed.push(b)
+  }
+
+  for (const h of fresh) {
+    if (claimed.has(h.id)) continue
+    if (h.visible) result.added.push(h)
+    else result.addedHidden.push(h)
+  }
+
+  const bySortKey = (a: SnapshotEntry, b: SnapshotEntry): number =>
+    a.title.localeCompare(b.title) || a.name.localeCompare(b.name)
+  result.removed.sort(bySortKey)
+  result.added.sort(bySortKey)
+  result.addedHidden.sort(bySortKey)
+  for (const list of [
+    result.hidden,
+    result.moved,
+    result.revealed,
+    result.docsSourceReplaced,
+    result.sourceMoved,
+    result.updated,
+    result.retagged,
+  ]) {
+    list.sort((x, y) => bySortKey(x.head, y.head))
+  }
+
+  // A docs page that vanished while its component still has indexed stories
+  // points at a tag change rather than a deleted component.
+  const headTitles = new Set(Object.values(head.entries).map((e) => e.title))
+  result.autodocsLikelyDropped = result.removed
+    .filter((e) => e.type === "docs" && headTitles.has(e.title))
+    .map((e) => e.id)
+
+  result.lossTotal = result.removed.length + result.hidden.length
+  result.hasLosses = result.lossTotal > 0
+  return result
+}
+
+/* ------------------------------- rendering ------------------------------- */
+
+/** Public Storybook. Overridable so a preview deployment can be linked instead. */
+const DEFAULT_STORYBOOK_URL = "https://f0.factorial.dev"
+
+/**
+ * Markers that let the Chromatic workflow retarget this comment's links once
+ * its Storybook build exists.
+ *
+ * This check finishes in about a minute; a Chromatic build takes several. So
+ * the comment is posted immediately against the *public* Storybook, and
+ * `chromatic.yml` later rewrites every link in place to point at the PR's own
+ * build — where pages added by the PR actually resolve. Since the comment
+ * already carries every URL, the rewrite needs nothing from this run: it reads
+ * the current base out of `BASE_MARKER`, swaps it, and replaces the note
+ * between the `LINK_NOTE` markers. Re-running is a no-op, and a new commit
+ * reposts the public version and gets rewritten again.
+ */
+const BASE_MARKER = (baseUrl: string): string =>
+  `<!-- storybook-base: ${baseUrl} -->`
+const LINK_NOTE_START = "<!-- link-note:start -->"
+const LINK_NOTE_END = "<!-- link-note:end -->"
+
+/** Deep link to an entry in the deployed Storybook. */
+export function entryUrl(e: SnapshotEntry, baseUrl: string): string {
+  const kind = e.type === "docs" ? "docs" : "story"
+  return `${baseUrl.replace(/\/+$/, "")}/?path=/${kind}/${e.id}`
+}
+
+/** `Components/Button › Default` — how an entry reads in the sidebar. */
+function label(e: SnapshotEntry): string {
+  return e.type === "docs" && e.name === "Documentation"
+    ? e.title
+    : `${e.title} › ${e.name}`
+}
+
+function link(e: SnapshotEntry, baseUrl: string): string {
+  return `[${label(e)}](${entryUrl(e, baseUrl)})`
+}
+
+/** Why an entry stopped reaching the sidebar, in reviewer-facing terms. */
+function hiddenReason(c: EntryChange): string {
+  const lost = c.base.tags.filter((t) => !c.head.tags.includes(t))
+  const gained = c.head.tags.filter((t) => !c.base.tags.includes(t))
+  const reasons: string[] = []
+  if (gained.includes("no-sidebar")) {
+    reasons.push("gained the `no-sidebar` tag")
+  }
+  if (lost.includes("dev")) {
+    reasons.push("lost the `dev` tag (tagged `!dev`)")
+  }
+  if (reasons.length === 0) {
+    if (gained.length > 0) reasons.push(`gained ${fmtTags(gained)}`)
+    if (lost.length > 0) reasons.push(`lost ${fmtTags(lost)}`)
+  }
+  return reasons.join(", ") || "no longer passes the sidebar filters"
+}
+
+function fmtTags(tags: string[]): string {
+  return tags.map((t) => `\`${t}\``).join(", ")
+}
+
+/**
+ * Group entries by source file, so a single edit to a `.stories.tsx` reads as
+ * one line with its stories listed beneath it. Docs pages are one-per-file
+ * already and pass through unchanged.
+ */
+function groupByFile(entries: SnapshotEntry[]): Map<string, SnapshotEntry[]> {
+  const groups = new Map<string, SnapshotEntry[]>()
+  for (const e of entries) {
+    const list = groups.get(e.importPath)
+    if (list) list.push(e)
+    else groups.set(e.importPath, [e])
+  }
+  return groups
+}
+
+/** `./src/x/y.tsx` → `src/x/y.tsx`, for readable inline code spans. */
+function tidyPath(p: string): string {
+  return p.replace(/^\.\//, "")
+}
+
+/** Entries listed under a single source file before the rest is collapsed. */
+const PER_FILE_CAP = 8
+
+/**
+ * Render a file-grouped bullet list: one line per source file, each entry
+ * linked beneath it. Capped twice — at `fileCap` files and at `PER_FILE_CAP`
+ * entries per file — so one enormous stories file cannot crowd out the rest.
+ */
+function renderGrouped(
+  entries: SnapshotEntry[],
+  baseUrl: string,
+  fileCap: number,
+  suffix?: (e: SnapshotEntry) => string
+): string[] {
+  const { shown, rest } = capped(
+    Array.from(groupByFile(entries).entries()),
+    fileCap
+  )
+  const out: string[] = []
+  for (const [file, group] of shown) {
+    out.push(`- \`${tidyPath(file)}\``)
+    const inner = capped(group, PER_FILE_CAP)
+    for (const e of inner.shown) {
+      out.push(`  - ${link(e, baseUrl)}${suffix ? suffix(e) : ""}`)
+    }
+    if (inner.rest > 0) {
+      out.push(`  - _…and ${inner.rest} more in this file._`)
+    }
+  }
+  out.push(...restLine(rest, "file(s)"))
+  return out
+}
+
+/**
+ * Per-section item caps. A PR touching one component produces a handful of
+ * entries, but a long-lived branch can produce hundreds — and a single global
+ * truncation would cut whole sections off the bottom, which is where the
+ * *losses* would be if they were rendered last. Capping each section instead
+ * keeps every heading present, and the losses are rendered first and capped
+ * most generously because they are the reason this check exists.
+ */
+const SECTION_CAPS = {
+  removed: 60,
+  hidden: 60,
+  docsSourceReplaced: 40,
+  sourceMoved: 30,
+  moved: 40,
+  added: 40,
+  revealed: 40,
+  updated: 25,
+  retagged: 30,
+  addedHidden: 20,
+} as const
+
+/** Split a list into the part that gets rendered and the count left over. */
+function capped<T>(list: T[], cap: number): { shown: T[]; rest: number } {
+  return { shown: list.slice(0, cap), rest: Math.max(0, list.length - cap) }
+}
+
+/** `…and 12 more` footer for a capped section. */
+function restLine(rest: number, noun: string): string[] {
+  return rest > 0 ? ["", `_…and ${rest} more ${noun}._`] : []
+}
+
+/**
+ * GitHub rejects comment bodies over 65536 bytes. The per-section caps above
+ * keep us well clear of that; this is the final backstop.
+ */
+const COMMENT_BYTE_BUDGET = 55000
+
+/**
+ * `tail` is always kept, with its size reserved up front. It carries the
+ * link-base markers the Chromatic workflow rewrites, and truncating those away
+ * would silently cost the comment its retargeted links.
+ */
+function capCommentSize(lines: string[], tail: string[] = []): string[] {
+  const sizeOf = (ls: string[]): number =>
+    ls.reduce((n, l) => n + Buffer.byteLength(l, "utf8") + 1, 0)
+  const budget = COMMENT_BYTE_BUDGET - sizeOf(tail)
+  const out: string[] = []
+  let bytes = 0
+  for (const line of lines) {
+    const lineBytes = Buffer.byteLength(line, "utf8") + 1
+    if (bytes + lineBytes > budget) {
+      out.push("")
+      out.push(
+        "_…truncated to stay under GitHub's comment size limit. The counts in the summary above are complete._"
+      )
+      return out.concat(tail)
+    }
+    out.push(line)
+    bytes += lineBytes
+  }
+  return out.concat(tail)
+}
+
+/**
+ * Render the PR comment body. Posted whether or not anything changed, so a
+ * prior "⚠️ pages lost" comment resolves back to "✅" once fixed.
+ */
+export function buildCommentMarkdown(
+  diff: DiffResult,
+  baseUrl: string = DEFAULT_STORYBOOK_URL
+): string {
+  // First line, so the Chromatic rewrite can find the base it must replace.
+  const lines: string[] = [BASE_MARKER(baseUrl), ""]
+  const docs = (list: SnapshotEntry[]): number =>
+    list.filter((e) => e.type === "docs").length
+
+  if (diff.incomplete) {
+    lines.push("## 📚 Storybook docs — comparison unavailable")
+    lines.push("")
+    lines.push(
+      `Could not compare against \`main\`: ${diff.incomplete}. An index build may have failed — check this workflow's logs.`
+    )
+    return capCommentSize(lines).join("\n")
+  }
+
+  const replaced = diff.docsSourceReplaced.length
+  const droppedAutodocs = new Set(diff.autodocsLikelyDropped)
+
+  if (diff.hasLosses) {
+    lines.push(`## ⚠️ Storybook pages lost (${diff.lossTotal})`)
+    lines.push("")
+    lines.push(
+      "These pages are reachable in the sidebar on `main` but **not on this branch**. " +
+        "If that is intentional, say so in the PR description. If it is not, it is usually a " +
+        "component moved to a directory that `.storybook/main.ts` does not list, a dropped " +
+        "`autodocs` tag, or a `no-sidebar` / `!dev` tag added by accident."
+    )
+  } else if (replaced > 0) {
+    // Not "no pages lost": the pages are all still there, but the content
+    // behind one of them was swapped out, which is its own kind of loss.
+    lines.push(`## ⚠️ Storybook docs source replaced (${replaced})`)
+    lines.push("")
+    lines.push(
+      "No page disappeared, but a page is now generated by something different than it was on `main`. See below."
+    )
+  } else {
+    lines.push("## ✅ Storybook docs — no pages lost")
+    lines.push("")
+    lines.push("Every page reachable on `main` is still reachable here.")
+  }
+
+  // ── headline counts ────────────────────────────────────────────────────
+  const summary: string[] = []
+  if (diff.removed.length > 0) summary.push(`🗑️ ${diff.removed.length} removed`)
+  if (diff.hidden.length > 0) summary.push(`🙈 ${diff.hidden.length} hidden`)
+  if (replaced > 0) summary.push(`♻️ ${replaced} source replaced`)
+  if (diff.sourceMoved.length > 0) {
+    summary.push(`🚚 ${diff.sourceMoved.length} source moved`)
+  }
+  if (diff.added.length > 0) summary.push(`➕ ${diff.added.length} added`)
+  if (diff.moved.length > 0) summary.push(`📦 ${diff.moved.length} moved`)
+  if (diff.updated.length > 0) summary.push(`✏️ ${diff.updated.length} updated`)
+  if (diff.revealed.length > 0) {
+    summary.push(`👁️ ${diff.revealed.length} newly visible`)
+  }
+  if (diff.retagged.length > 0) {
+    summary.push(`🏷️ ${diff.retagged.length} maturity changed`)
+  }
+  if (summary.length > 0) {
+    lines.push("")
+    lines.push(summary.join(" · "))
+  }
+
+  /* --- losses, first and uncollapsed --- */
+
+  if (diff.removed.length > 0) {
+    lines.push("")
+    lines.push(`### 🗑️ Removed — gone from Storybook (${diff.removed.length})`)
+    lines.push("")
+    lines.push(
+      ...renderGrouped(diff.removed, baseUrl, SECTION_CAPS.removed, (e) =>
+        droppedAutodocs.has(e.id)
+          ? " — **docs page gone while its stories remain**: `autodocs` was probably dropped (or `!autodocs` added)"
+          : ` — was \`${e.type}\``
+      )
+    )
+  }
+
+  if (diff.hidden.length > 0) {
+    const { shown, rest } = capped(diff.hidden, SECTION_CAPS.hidden)
+    lines.push("")
+    lines.push(
+      `### 🙈 No longer in the sidebar (${diff.hidden.length})\n\nStill indexed — so tests keep running — but not reachable by a human.`
+    )
+    lines.push("")
+    for (const c of shown) {
+      lines.push(
+        `- ${link(c.head, baseUrl)} — ${hiddenReason(c)} · \`${tidyPath(c.head.importPath)}\``
+      )
+    }
+    lines.push(...restLine(rest, "hidden"))
+  }
+
+  if (replaced > 0) {
+    const { shown, rest } = capped(
+      diff.docsSourceReplaced,
+      SECTION_CAPS.docsSourceReplaced
+    )
+    lines.push("")
+    lines.push(`### ♻️ Docs source replaced (${replaced})`)
+    lines.push("")
+    lines.push(
+      "The page kept its URL, but something else generates it now. Attaching an `.mdx` " +
+        "file to a component **silently takes over** its auto-generated `autodocs` page: " +
+        "the props table and the story previews that page used to show are gone unless the " +
+        "new file renders them itself. Check that nothing documented on `main` was dropped."
+    )
+    lines.push("")
+    for (const c of shown) {
+      const direction = isMdxSource(c.head.importPath)
+        ? "auto-generated → hand-written MDX"
+        : "hand-written MDX → auto-generated"
+      lines.push(`- ${link(c.head, baseUrl)} — ${direction}`)
+      lines.push(`  - was \`${tidyPath(c.base.importPath)}\``)
+      lines.push(`  - now \`${tidyPath(c.head.importPath)}\``)
+    }
+    lines.push(...restLine(rest, "replaced"))
+  }
+
+  /* --- everything else --- */
+
+  if (diff.sourceMoved.length > 0) {
+    // Grouped by the file *pair*: renaming one directory moves every story in
+    // it, and that should read as one relocation, not twenty findings.
+    const pairs = new Map<string, EntryChange[]>()
+    for (const c of diff.sourceMoved) {
+      const key = `${c.base.importPath} ${c.head.importPath}`
+      const list = pairs.get(key)
+      if (list) list.push(c)
+      else pairs.set(key, [c])
+    }
+    const { shown, rest } = capped(
+      Array.from(pairs.values()),
+      SECTION_CAPS.sourceMoved
+    )
+    lines.push("")
+    lines.push(
+      `<details><summary>🚚 Source file moved — ${diff.sourceMoved.length} entr${diff.sourceMoved.length === 1 ? "y" : "ies"} across ${pairs.size} file(s)</summary>`
+    )
+    lines.push("")
+    lines.push(
+      "Same page, same mechanism — the file behind it was relocated or renamed. The Storybook URLs are unchanged."
+    )
+    lines.push("")
+    for (const group of shown) {
+      const first = group[0]!
+      lines.push(
+        `- \`${tidyPath(first.base.importPath)}\` → \`${tidyPath(first.head.importPath)}\``
+      )
+      const inner = capped(group, PER_FILE_CAP)
+      for (const c of inner.shown) {
+        lines.push(`  - ${link(c.head, baseUrl)}`)
+      }
+      if (inner.rest > 0) {
+        lines.push(`  - _…and ${inner.rest} more in this file._`)
+      }
+    }
+    lines.push(...restLine(rest, "file(s)"))
+    lines.push("</details>")
+  }
+
+  if (diff.moved.length > 0) {
+    const { shown, rest } = capped(diff.moved, SECTION_CAPS.moved)
+    lines.push("")
+    lines.push(`### 📦 Moved or renamed (${diff.moved.length})`)
+    lines.push("")
+    for (const c of shown) {
+      const from =
+        c.base.title === c.head.title
+          ? `\`${c.base.name}\` → \`${c.head.name}\``
+          : `\`${c.base.title}\` → \`${c.head.title}\``
+      lines.push(`- ${link(c.head, baseUrl)} — was ${from}`)
+    }
+    lines.push(...restLine(rest, "moved"))
+    lines.push("")
+    lines.push(
+      "_Existing links and bookmarks to the old path will 404 — the Storybook id changed._"
+    )
+  }
+
+  if (diff.added.length > 0) {
+    const docCount = docs(diff.added)
+    lines.push("")
+    lines.push(`### ➕ Added (${diff.added.length})`)
+    lines.push("")
+    if (docCount > 0) {
+      lines.push(
+        `${docCount} new docs page(s) and ${diff.added.length - docCount} new story/stories.`
+      )
+      lines.push("")
+    }
+    lines.push(...renderGrouped(diff.added, baseUrl, SECTION_CAPS.added))
+  }
+
+  if (diff.revealed.length > 0) {
+    const { shown, rest } = capped(diff.revealed, SECTION_CAPS.revealed)
+    lines.push("")
+    lines.push(`### 👁️ Newly visible (${diff.revealed.length})`)
+    lines.push("")
+    lines.push("Already indexed on `main`, now surfaced in the sidebar.")
+    lines.push("")
+    for (const c of shown) {
+      lines.push(`- ${link(c.head, baseUrl)}`)
+    }
+    lines.push(...restLine(rest, "newly visible"))
+  }
+
+  if (diff.updated.length > 0) {
+    const heads = diff.updated.map((c) => c.head)
+    const fileCount = groupByFile(heads).size
+    lines.push("")
+    lines.push(
+      `<details><summary>✏️ Updated — ${diff.updated.length} page(s)/story/stories across ${fileCount} file(s)</summary>`
+    )
+    lines.push("")
+    lines.push(
+      "The source file behind each of these changed. Detection is per *file*, so editing one story flags its siblings too."
+    )
+    lines.push("")
+    lines.push(...renderGrouped(heads, baseUrl, SECTION_CAPS.updated))
+    lines.push("</details>")
+  }
+
+  if (diff.retagged.length > 0) {
+    const { shown, rest } = capped(diff.retagged, SECTION_CAPS.retagged)
+    lines.push("")
+    lines.push(
+      `<details><summary>🏷️ Maturity changed — ${diff.retagged.length}</summary>`
+    )
+    lines.push("")
+    for (const c of shown) {
+      const before = maturityOf(c.base)
+      const after = maturityOf(c.head)
+      lines.push(
+        `- ${link(c.head, baseUrl)} — ${before.length ? fmtTags(before) : "_none_"} → ${after.length ? fmtTags(after) : "_none_"}`
+      )
+    }
+    lines.push(...restLine(rest, "retagged"))
+    lines.push("</details>")
+  }
+
+  if (diff.addedHidden.length > 0) {
+    const { shown, rest } = capped(diff.addedHidden, SECTION_CAPS.addedHidden)
+    lines.push("")
+    lines.push(
+      `<details><summary>🔇 Added but not in the sidebar — ${diff.addedHidden.length}</summary>`
+    )
+    lines.push("")
+    lines.push(
+      "Expected for snapshot-only and internal stories (`no-sidebar` / `!dev`). Listed in case one was meant to be visible."
+    )
+    lines.push("")
+    for (const e of shown) {
+      lines.push(`- \`${label(e)}\` — ${fmtTags(maturityOf(e)) || "_no tags_"}`)
+    }
+    lines.push(...restLine(rest, "added but hidden"))
+    lines.push("</details>")
+  }
+
+  // Always emitted, so the Chromatic workflow always has somewhere to put the
+  // link to this PR's Storybook — and so the reader is told, before clicking,
+  // which Storybook these links actually point at. Passed as the reserved tail
+  // so a large diff cannot truncate the markers away.
+  const tail = [
+    "",
+    LINK_NOTE_START,
+    `_Links point at the [public Storybook](${baseUrl.replace(/\/+$/, "")}), which is built from \`main\` — pages this PR adds resolve there only once it merges. Waiting on the Chromatic build to retarget them at this PR._`,
+    LINK_NOTE_END,
+    "",
+    "_Snapshot of the Storybook index (docs pages + stories) compared against `main`. Non-blocking._",
+  ]
+
+  return capCommentSize(lines, tail).join("\n")
+}
+
+/* --------------------------------- main ---------------------------------- */
+
+function parseArgs(): {
+  fromIndex?: string
+  out?: string
+  repoRoot: string
+  base?: string
+  head?: string
+  baseUrl: string
+  json: boolean
+} {
+  const args = process.argv.slice(2)
+  const valueOf = (flag: string): string | undefined => {
+    const i = args.indexOf(flag)
+    return i !== -1 && args[i + 1] ? args[i + 1] : undefined
+  }
+  return {
+    fromIndex: valueOf("--from-index"),
+    out: valueOf("--out"),
+    repoRoot: valueOf("--repo-root") ?? process.cwd(),
+    base: valueOf("--base"),
+    head: valueOf("--head"),
+    baseUrl: valueOf("--storybook-url") ?? DEFAULT_STORYBOOK_URL,
+    json: args.includes("--json"),
+  }
+}
+
+/** Read a snapshot, or return `undefined` when the file is missing/corrupt. */
+function readSnapshot(file: string): Snapshot | undefined {
+  if (!existsSync(file)) return undefined
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(file, "utf8"))
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      "entries" in parsed &&
+      (parsed as Snapshot).entries
+    ) {
+      return parsed as Snapshot
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+function emptyDiff(reason: string): DiffResult {
+  return {
+    ...diffSnapshots({ entries: {} }, { entries: {} }),
+    incomplete: reason,
+  }
+}
+
+function main(): void {
+  const { fromIndex, out, repoRoot, base, head, baseUrl, json } = parseArgs()
+
+  // ── mode 1: normalize a raw index into a snapshot ──────────────────────
+  if (fromIndex) {
+    if (!out) {
+      consola.error(
+        "Usage: tsx .scripts/check-docs-index.ts --from-index <raw.json> --out <snap.json> [--repo-root <dir>]"
+      )
+      process.exit(2)
+    }
+    const snapshot = snapshotFromIndex(
+      readFileSync(fromIndex, "utf8"),
+      repoRoot
+    )
+    mkdirSync(path.dirname(path.resolve(out)), { recursive: true })
+    writeFileSync(out, JSON.stringify(snapshot, null, 0) + "\n")
+    const all = Object.values(snapshot.entries)
+    consola.success(
+      `Snapshot written: ${all.length} entries (${all.filter((e) => e.type === "docs").length} docs, ${all.filter((e) => e.visible).length} visible) → ${out}`
+    )
+    return
+  }
+
+  // ── mode 2: diff two snapshots ─────────────────────────────────────────
+  if (!base || !head) {
+    consola.error(
+      "Usage: tsx .scripts/check-docs-index.ts --base <snap.json> --head <snap.json> [--json]"
+    )
+    process.exit(2)
+  }
+
+  const baseSnap = readSnapshot(base)
+  const headSnap = readSnapshot(head)
+
+  let diff: DiffResult
+  if (!baseSnap && !headSnap) {
+    diff = emptyDiff("neither snapshot could be read")
+  } else if (!baseSnap) {
+    diff = emptyDiff("the `main` snapshot is missing")
+  } else if (!headSnap) {
+    diff = emptyDiff("this branch's snapshot is missing")
+  } else {
+    diff = diffSnapshots(baseSnap, headSnap)
+  }
+
+  if (json) {
+    process.stdout.write(
+      JSON.stringify(
+        { ...diff, commentMarkdown: buildCommentMarkdown(diff, baseUrl) },
+        null,
+        2
+      ) + "\n"
+    )
+    return
+  }
+
+  if (diff.incomplete) {
+    consola.warn(`Comparison unavailable: ${diff.incomplete}`)
+    return
+  }
+
+  for (const e of diff.removed) consola.error(`removed: ${label(e)}`)
+  for (const c of diff.hidden) {
+    consola.error(`hidden: ${label(c.head)} — ${hiddenReason(c)}`)
+  }
+  for (const c of diff.docsSourceReplaced) {
+    consola.error(
+      `docs source replaced: ${label(c.head)} — ${tidyPath(c.base.importPath)} → ${tidyPath(c.head.importPath)}`
+    )
+  }
+  for (const c of diff.sourceMoved) {
+    consola.info(
+      `source moved: ${label(c.head)} — ${tidyPath(c.base.importPath)} → ${tidyPath(c.head.importPath)}`
+    )
+  }
+  for (const c of diff.moved) {
+    consola.info(`moved: ${label(c.base)} → ${label(c.head)}`)
+  }
+  for (const e of diff.added) consola.success(`added: ${label(e)}`)
+  for (const c of diff.revealed)
+    consola.success(`now visible: ${label(c.head)}`)
+  consola.log("")
+  consola.info(
+    `${diff.updated.length} updated · ${diff.retagged.length} maturity changed · ${diff.addedHidden.length} added but hidden`
+  )
+  if (diff.hasLosses) {
+    consola.error(`${diff.lossTotal} Storybook page(s) no longer reachable.`)
+  } else {
+    consola.success("No Storybook pages lost.")
+  }
+}
+
+// Run as a CLI only when invoked directly (not when imported by tests).
+if (process.argv[1] && /check-docs-index\.(ts|js)$/.test(process.argv[1])) {
+  main()
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,6 +48,7 @@
     "format:check": "sh -c 'oxfmt --check \"${@:-src/}\"' --",
     "tsc": "tsc --noEmit",
     "check:api-surface": "tsx .scripts/check-api-surface.ts",
+    "check:docs-index": "tsx .scripts/check-docs-index.ts",
     "check:bugfix-red-green": "tsx .scripts/check-bugfix-red-green.ts",
     "check:new-component-dod": "tsx .scripts/check-new-component-dod.ts",
     "check:stable-dod": "tsx .scripts/check-stable-dod.ts",


### PR DESCRIPTION
## Description

Storybook's sidebar is assembled from a curated directory allowlist in `.storybook/main.ts` plus per-entry tags, which means a docs page can stop being exposed without anything turning red — move a component to a directory that isn't listed, drop `autodocs`, or add `no-sidebar`, and the page is simply gone. This snapshots the Storybook index on both sides of a PR and comments the difference, so losing a page is something a reviewer sees rather than something someone notices weeks later.

## Type of change

- [x] Other: CI check (non-blocking, reports via PR comment)

## What gets flagged, and how it reads

Every example below is **real rendered output**, produced by running this check against actual commits in this repo — not mock-ups. Each is labelled with the comparison that generated it.

### 1. A docs page disappeared

From **#5095 at its pre-fix commit** (`9a6ac810`, before `fix(F0Select): restore canonical docs route`) against its merge-base. That PR added `tags: ["!autodocs"]` plus an *unattached* MDX (`<Meta title="Select/Overview" />`), which moved the canonical Select docs page to a sub-route:

```
## ⚠️ Storybook pages lost (2)

🗑️ 2 removed · ➕ 7 added · ✏️ 43 updated

### 🗑️ Removed — gone from Storybook (2)

- `src/components/F0Select/__stories__/F0Select.stories.tsx`
  - [Components/Select](…/?path=/docs/components-select--documentation) — **docs page gone while its stories remain**: `autodocs` was probably dropped (or `!autodocs` added)
  - [Components/Select › Snapshot](…/?path=/story/components-select--snapshot) — was `story`

### ➕ Added (7)

1 new docs page(s) and 6 new story/stories.

- `src/components/F0Select/__stories__/F0Select.mdx`
  - [Components/Select/Overview](…/?path=/docs/components-select-overview--documentation)
```

The diagnosis on that first bullet is the literal root cause, and the misplaced replacement sits a few lines below it under Added — which is what makes the wrong-route conclusion quick to reach.

### 2. A page is still indexed but no longer reachable

From **`main` against `main~150`**. These stories gained `no-sidebar`, so their tests kept passing while no human could find them:

```
### 🙈 No longer in the sidebar (5)

Still indexed — so tests keep running — but not reachable by a human.

- [Patterns/Navigation/Sidebar/ChatList › Cascade Loading](…) — gained the `no-sidebar` tag · `src/patterns/Navigation/Sidebar/Chats/index.stories.tsx`
- [Patterns/Navigation/Sidebar/ChatList › Empty](…) — gained the `no-sidebar` tag · `src/patterns/Navigation/Sidebar/Chats/index.stories.tsx`
- [Patterns/Navigation/Sidebar/ChatList › Live Updates](…) — gained the `no-sidebar` tag · `src/patterns/Navigation/Sidebar/Chats/index.stories.tsx`
```

### 3. A page survives but something else generates it now

From **#5095 at its current head** (`d9c11db7`, after the fix) against its merge-base. The page's URL is intact, so an id-only diff sees nothing — only the source file changed:

```
### ♻️ Docs source replaced (1)

The page kept its URL, but something else generates it now. Attaching an `.mdx` file to a
component **silently takes over** its auto-generated `autodocs` page: the props table and the
story previews that page used to show are gone unless the new file renders them itself. Check
that nothing documented on `main` was dropped.

- [Components/Select](…/?path=/docs/components-select--documentation) — auto-generated → hand-written MDX
  - was `src/components/F0Select/__stories__/F0Select.stories.tsx`
  - now `src/components/F0Select/__stories__/F0Select.mdx`
```

This one is worth reading closely, because it is a live example of real content loss: that MDX renders 3 story previews where autodocs rendered 45, and it has no `<Description />`, so the component's description no longer appears. See the known limitation below.

### 4. Informational categories, collapsed by default

A directory rename moves every story in it, so these group by file pair rather than listing 16 findings. Same mechanism on both sides, URLs unchanged, so it does **not** raise the warning heading. From **`main` against `main~150`**:

```
<details><summary>🚚 Source file moved — 16 entries across 2 file(s)</summary>

- `src/patterns/ResourceHeader/index.stories.tsx` → `src/patterns/F0ResourceHeader/index.stories.tsx`
  - [Patterns/Resource header › Company Header](…)
  - [Patterns/Resource header › Default](…)
```

`✏️ Updated`, `🏷️ Maturity changed` and `🔇 Added but not in the sidebar` are collapsed the same way.

### 5. Nothing lost

The state this PR itself is in — see the live comment below:

```
## ✅ Storybook docs — no pages lost

Every page reachable on `main` is still reachable here.
```

Reported on every run rather than staying silent, so a previous ⚠️ resolves back to ✅ once fixed instead of leaving a stale warning.

### The one-line summary

The counts line is always complete even when a section's list is capped:

```
🗑️ 10 removed · 🙈 5 hidden · ♻️ 2 source replaced · 🚚 16 source moved · ➕ 106 added · ✏️ 422 updated
```

### Known limitation

Case 3 tells a reviewer *where* to look, not *how much* was lost. The index records that a page exists and which file backs it, never which stories that file renders — so the check cannot currently say "3 previews where autodocs rendered 45". Closing that means parsing the MDX for `<Canvas of={…}>` / `<Stories />` and comparing against the stories the autodocs page covered. Deliberately left out of this PR; #5095 is a ready-made regression test for it.

The check also verifies a page is **indexed and reachable**, not that it **renders**. A page whose MDX throws at runtime would pass.

## Implementation details

- ci: add `Storybook Docs Index` workflow — snapshot the index for the PR and for `main` in parallel, diff them, comment the result

  <details>
  <summary>Why this is cheap enough to run on every PR</summary>

  `storybook index` only runs the indexers — no Vite, no bundling, and (verified) no `f0-core` build. A full snapshot of ~2,750 entries takes about 6 seconds, so the job cost is essentially `pnpm install`. This does not build Storybook. Measured in CI on this PR: 1m8s and 1m15s for the two snapshot legs in parallel, 1m16s for the diff.
  </details>

- feat: add `check-docs-index.ts` — normalizes `storybook index` output into a snapshot (identity, sidebar visibility, source-file hash) and classifies the diff

- feat: report a page that is still indexed but no longer reaches the sidebar

  <details>
  <summary>Why this needs its own category</summary>

  An entry reaches the sidebar only if it is tagged `dev` and not tagged `no-sidebar` (this repo's filter, applied in `.storybook/manager.ts`). Losing either leaves the entry in the index — so its tests keep passing and nothing looks broken — while no human can find the page. Presence alone can't detect this, so visibility is tracked per entry.
  </details>

- feat: detect a docs page whose source was replaced rather than edited

  <details>
  <summary>The case an id-only diff cannot see</summary>

  A docs page id is a single slot that two mechanisms compete for: `autodocs` generates the page, and an `.mdx` attached to the same component *replaces* it. Adding an MDX file therefore silently overwrites the auto-generated page — same id, same title, same URL, entirely different content. Nothing is added and nothing is removed, so a diff keyed on ids sees no change at all. Comparing each entry's `importPath` across both sides is what catches it.

  A same-kind relocation (`ResourceHeader` → `F0ResourceHeader`) is classified separately and does *not* raise the warning.
  </details>

- feat: name a dropped `autodocs` tag as the likely cause when a docs page vanishes

  <details>
  <summary>How the cause is inferred</summary>

  Verified against the real index by temporarily setting `!autodocs` on `F0ActionBar`: the `--documentation` entry disappears from the index outright, so it already surfaces as a removal. What the entry can't say is *why* — a deleted component takes its stories with it, whereas a dropped tag leaves them behind. That second shape is flagged explicitly, and it fired correctly on #5095, whose root cause was exactly an `autodocs` → `!autodocs` change.
  </details>

- fix: compare against the merge commit's first parent, not the branch point

  <details>
  <summary>Why</summary>

  Both sides derive from the PR merge commit, so the PR is synced with `main` before either snapshot is taken. Snapshotting the branch as-is would report every page that landed on `main` after the branch point as removed. Same approach as the Public API Surface check.
  </details>

- fix: normalize both sides with the same copy of the script

  <details>
  <summary>Why</summary>

  The base leg restores `check-docs-index.ts` from the merge commit before running. Otherwise the base side would use whatever version exists on `main` — or none at all, on this PR — and any change to the tool would masquerade as a change to the docs. Confirmed working in CI on this PR, which is the bootstrap case.
  </details>

- ci: retarget the comment's links at the PR's Storybook once Chromatic publishes one

  <details>
  <summary>How, and why not a computed permalink</summary>

  This check finishes in about a minute; a Chromatic build takes several. So the comment is posted immediately against the public Storybook, and `chromatic.yml` rewrites every link in place once a build for the PR exists. The comment records its own link base in an HTML comment, so nothing has to be carried between workflow runs — no artifacts, no `workflow_run` plumbing.

  Computing the Chromatic permalink from the branch name was rejected: branch slugs are truncated at 37 characters and collapse repeated dashes, and this repo's branch names exceed that. The published URL also turns out to be `<appId>-<buildHash>.chromatic.com`, a different shape from the documented branch permalink — so a computed URL would have pointed somewhere else entirely. The URL comes from the Chromatic action's own output instead.

  Best-effort by design. If Chromatic wins the race, the comment keeps its public links and self-corrects on the next push.
  </details>

- chore: add `check:docs-index` script for running the comparison locally

### Non-blocking on purpose

Losing a page does not fail the gate. Deleting a page is often deliberate, and a check that blocked merges on it would be routinely overridden until it was ignored. It reports through a PR comment and a workflow warning annotation.

### Verification

- 38 unit tests covering each classification, the comment rendering, and the retargeting contract
- Validated against real indexes rather than fixtures: `HEAD` vs `main` correctly reports no changes; `main` vs `main~150` surfaces real losses, hidden pages and overwrites; and #5095's pre-fix commit reproduces the exact regression it was opened to fix
- The Chromatic rewrite script was extracted from the YAML and run against real rendered output: all links retargeted, no public links left, and idempotent on re-run, missing comment, and older comment formats. Confirmed in CI — `Retargeted docs comment links at https://66a7a8d7d124220c363457cc-dzcelszubf.chromatic.com`
- Because this PR touches `packages/react`, its own check runs on it — the comment below is this tooling reporting on itself

🤖 Generated with [Claude Code](https://claude.com/claude-code)
