### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.60.0",
+  "packages/react": "6.60.1",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.60.1](https://github.com/factorialco/f0/compare/f0-react-v6.60.0...f0-react-v6.60.1) (2026-08-26)
+
+
+### Bug Fixes
+
+* **one-data-collection:** keep defaultExpanded across revisits and tree resets ([#5231](https://github.com/factorialco/f0/issues/5231)) ([9d093e7](https://github.com/factorialco/f0/commit/9d093e7171e11a52805f8438bbd4fc78ff948def))
+
 ## [6.60.0](https://github.com/factorialco/f0/compare/f0-react-v6.59.0...f0-react-v6.60.0) (2026-08-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.60.0",
+  "version": "6.60.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.60.1</summary>

## [6.60.1](https://github.com/factorialco/f0/compare/f0-react-v6.60.0...f0-react-v6.60.1) (2026-08-26)


### Bug Fixes

* **one-data-collection:** keep defaultExpanded across revisits and tree resets ([#5231](https://github.com/factorialco/f0/issues/5231)) ([9d093e7](https://github.com/factorialco/f0/commit/9d093e7171e11a52805f8438bbd4fc78ff948def))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).