### PR TITLE
ci(react): block newly added untranslated copy

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -140,6 +140,26 @@ jobs:
         run: pnpm --filter @factorialco/f0-react run check:new-component-dod
         env:
           BASE_REF: origin/${{ github.base_ref }}
+  # User-visible copy must come from the i18n layer, not a string literal — a
+  # literal is untranslatable by construction. Existing debt is baselined in
+  # .scripts/untranslated-copy-debt.json, so this only blocks copy the PR ADDS.
+  # Escape hatch is the inline `i18n-exempt` comment rather than a label: it
+  # lands in the diff, so a reviewer sees the claim and can judge it.
+  untranslated-copy:
+    needs: detect-changes
+    # Prevents running on the release-please branch
+    if: |
+      needs.detect-changes.outputs.package_react == 'true' &&
+      github.head_ref != 'release-please--branches--master' &&
+      !contains(github.event.pull_request.labels.*.name, 'autorelease')
+    name: "[⚛️ REACT] Untranslated copy"
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node-pnpm
+      # Pure AST scan of src/ — no build or Storybook needed.
+      - name: Check the PR adds no untranslated copy
+        run: pnpm --filter @factorialco/f0-react run check:untranslated-copy
   cycle-dependencies:
     needs: detect-changes
     # Prevents running on the release-please branch
@@ -305,7 +325,7 @@ jobs:
   # `skipped` is accepted on purpose: detect-changes skips the jobs for a
   # package that this PR did not touch. Only failure/cancellation is fatal.
   quality-passed:
-    needs: [detect-changes, format, format-react-native, lint, lint-react-native, stable-dod, new-component-dod, cycle-dependencies]
+    needs: [detect-changes, format, format-react-native, lint, lint-react-native, stable-dod, new-component-dod, untranslated-copy, cycle-dependencies]
     name: "✅ Quality"
     if: always()
     runs-on: ubuntu-latest

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -154,12 +154,41 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'autorelease')
     name: "[⚛️ REACT] Untranslated copy"
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-pnpm
       # Pure AST scan of src/ — no build or Storybook needed.
+      #
+      # The script emits `::error file=,line=` annotations, which is what puts
+      # each offending string inline on the Files tab. `continue-on-error` lets
+      # the comment step run on failure; the gate step below restores the
+      # failure, so the job still blocks.
       - name: Check the PR adds no untranslated copy
+        id: check
+        continue-on-error: true
         run: pnpm --filter @factorialco/f0-react run check:untranslated-copy
+      - name: Build the PR comment
+        id: comment
+        run: |
+          {
+            echo "body<<COMMENT_BODY_EOF"
+            pnpm --filter @factorialco/f0-react --silent run check:untranslated-copy --comment
+            echo "COMMENT_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Comment on the PR
+        uses: ./.github/actions/add-or-update-pr-comment
+        with:
+          comment-type: untranslated_copy
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-body: ${{ steps.comment.outputs.body }}
+      - name: Fail if untranslated copy was added
+        if: steps.check.outcome == 'failure'
+        run: |
+          echo "::error::This PR adds untranslated copy — see the annotations on the Files tab and the PR comment."
+          exit 1
   cycle-dependencies:
     needs: detect-changes
     # Prevents running on the release-please branch

--- a/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
+++ b/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
@@ -1,0 +1,354 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildDebtFile,
+  check,
+  type DebtFile,
+  type Finding,
+  findInSource,
+  isExcludedPath,
+  isTextBearingName,
+  readsAsCopy,
+  readsAsProse,
+} from "../check-untranslated-copy"
+
+/** Shorthand: scan a .tsx snippet and return `name = "value"` strings. */
+const scanTsx = (source: string): string[] =>
+  findInSource("src/probe.tsx", source).map(
+    (f) => `${f.name} = ${JSON.stringify(f.value)}`
+  )
+
+const finding = (overrides: Partial<Finding> = {}): Finding => ({
+  file: "src/ui/Thing.tsx",
+  line: 1,
+  name: "label",
+  value: "Save",
+  kind: "jsx-attribute",
+  ...overrides,
+})
+
+describe("text-bearing names", () => {
+  it.each([
+    "label",
+    "title",
+    "placeholder",
+    "emptyMessage",
+    "confirmLabel",
+    "aria-label",
+    "searchPlaceholder",
+    "alt",
+  ])("treats %s as copy-bearing", (name) => {
+    expect(isTextBearingName(name)).toBe(true)
+  })
+
+  it.each(["onClick", "variant", "size", "href", "count"])(
+    "leaves %s alone",
+    (name) => {
+      expect(isTextBearingName(name)).toBe(false)
+    }
+  )
+
+  it("does not mistake a boolean flag for copy just because it ends in a text word", () => {
+    expect(isTextBearingName("showTooltip")).toBe(false)
+    expect(isTextBearingName("hasTitle")).toBe(false)
+    expect(isTextBearingName("noLabel")).toBe(false)
+  })
+})
+
+describe("readsAsCopy", () => {
+  it.each(["Save", "Close the dialog", "Are you sure?", "AD"])(
+    "accepts %s",
+    (value) => {
+      expect(readsAsCopy(value)).toBe(true)
+    }
+  )
+
+  it.each([
+    "w-6",
+    "text-f1-foreground-warning",
+    "cursor-text",
+    "font-medium",
+    "md:flex-1",
+  ])("rejects the Tailwind class %s", (value) => {
+    expect(readsAsCopy(value)).toBe(false)
+  })
+
+  it.each(["send", "onHover", "txt", "hide/show"])(
+    "rejects the identifier %s",
+    (value) => {
+      expect(readsAsCopy(value)).toBe(false)
+    }
+  )
+
+  it.each(["/settings", "https://example.com", "", "—", "…"])(
+    "rejects %s as a non-copy value",
+    (value) => {
+      expect(readsAsCopy(value)).toBe(false)
+    }
+  )
+})
+
+describe("readsAsProse", () => {
+  // The brief's own example: an arbitrary name holding obvious copy.
+  it("catches lowercase prose under a meaningless name", () => {
+    expect(readsAsProse("hey hey")).toBe(true)
+  })
+
+  it.each(["Good morning", "opens in new tab", "{{count}} items left"])(
+    "accepts %s",
+    (value) => {
+      expect(readsAsProse(value)).toBe(true)
+    }
+  )
+
+  it("needs more than one word, so enum members stay quiet", () => {
+    expect(readsAsProse("Pending")).toBe(false)
+  })
+
+  it.each([
+    "flex items-center",
+    "text-sm font-medium",
+    "Inter, sans-serif",
+    "w-6 h-6",
+    "md:flex lg:grid",
+  ])("rejects %s, which is styling rather than copy", (value) => {
+    expect(readsAsProse(value)).toBe(false)
+  })
+})
+
+describe("findInSource", () => {
+  it("flags JSX text", () => {
+    expect(scanTsx("const A = () => <p>Hello there</p>")).toEqual([
+      '<jsx-text> = "Hello there"',
+    ])
+  })
+
+  it("flags a literal on a text-bearing JSX attribute", () => {
+    expect(
+      scanTsx('const A = () => <X label="Close" aria-label="Close it" />')
+    ).toEqual(['label = "Close"', 'aria-label = "Close it"'])
+  })
+
+  it("flags a literal in a JSX expression container", () => {
+    expect(scanTsx('const A = () => <X title={"Select all"} />')).toEqual([
+      'title = "Select all"',
+    ])
+  })
+
+  it("flags copy in a flat default parameter", () => {
+    expect(
+      scanTsx('const A = ({ label = "Actions" }) => <p>{label}</p>')
+    ).toEqual(['label = "Actions"'])
+  })
+
+  it("flags prose in a default parameter whose name says nothing", () => {
+    expect(
+      scanTsx('const A = ({ hola = "hey hey" }) => <p>{hola}</p>')
+    ).toEqual(['hola = "hey hey"'])
+  })
+
+  it("flags copy nested in objects inside arrays inside a default", () => {
+    expect(
+      scanTsx(
+        'const A = ({ presets = [{ label: "Today", meta: { title: "Deep" } }] }) => <p />'
+      )
+    ).toEqual(['label = "Today"', 'title = "Deep"'])
+  })
+
+  it("flags copy in a module-level lookup table", () => {
+    expect(
+      scanTsx(
+        'export const PRESETS = [{ id: "today", label: "Today" }, { id: "week", label: "This week" }]'
+      )
+    ).toEqual(['label = "Today"', 'label = "This week"'])
+  })
+
+  it("ignores interpolated templates — those cannot be a raw literal", () => {
+    expect(scanTsx("const A = ({ n }) => <X label={`Page ${n}`} />")).toEqual(
+      []
+    )
+  })
+
+  it("ignores copy that already comes from the i18n layer", () => {
+    expect(
+      scanTsx(
+        "const A = () => { const i18n = useI18n(); return <X label={i18n.actions.save} /> }"
+      )
+    ).toEqual([])
+  })
+
+  it("ignores Tailwind classes even under a text-bearing key", () => {
+    expect(scanTsx('const S = { label: "w-6", text: "font-medium" }')).toEqual(
+      []
+    )
+  })
+
+  it("ignores CSS values inside a style declaration", () => {
+    expect(
+      scanTsx(
+        'const A = () => <div style={{ transformOrigin: "top left", overflow: "hidden auto" }} />'
+      )
+    ).toEqual([])
+  })
+
+  it("ignores HTML plumbing attributes", () => {
+    expect(
+      scanTsx('const A = () => <a rel="noopener noreferrer" target="_blank" />')
+    ).toEqual([])
+  })
+
+  it("does not look for JSX text in a .ts file", () => {
+    // A .ts file parsed as TSX turns `<T>` casts and comparisons into elements,
+    // and their contents into "JSX text".
+    expect(
+      findInSource(
+        "src/util.ts",
+        "const f = (a: number, b: number) => a < b && b > a"
+      )
+    ).toEqual([])
+  })
+
+  it("honours an i18n-exempt marker on the same line", () => {
+    expect(
+      scanTsx('const A = () => <X label="Factorial One" /> // i18n-exempt')
+    ).toEqual([])
+  })
+
+  it("honours an i18n-exempt marker on the line above", () => {
+    expect(
+      scanTsx(
+        'const A = () =>\n  // i18n-exempt\n  <X label="Factorial One" />'
+      )
+    ).toEqual([])
+  })
+})
+
+describe("excluded paths", () => {
+  it.each([
+    "components/F0Thing/F0Thing.stories.tsx",
+    "components/F0Thing/F0Thing.spec.tsx",
+    "components/F0Thing/F0Thing.test.tsx",
+    "components/F0Thing/__tests__/helpers.ts",
+    "components/F0Thing/__storybook__/mockData.ts",
+    "components/F0Thing/thing.factory.tsx",
+    "sds/Home/slotRenderers.test-d.ts",
+    "docs/Guide.mdx",
+    "icons/app/Add.tsx",
+    "mocks/people.ts",
+    "lib/providers/i18n/i18n-provider-defaults.ts",
+    "lib/storybook-utils/do-donts.tsx",
+  ])("excludes %s", (path) => {
+    expect(isExcludedPath(path)).toBe(true)
+  })
+
+  it.each([
+    "components/F0Thing/F0Thing.tsx",
+    "ui/DatePickerPopup/presets.ts",
+    "patterns/OneDataCollection/visualizations.tsx",
+  ])("scans %s", (path) => {
+    expect(isExcludedPath(path)).toBe(false)
+  })
+})
+
+describe("the ratchet", () => {
+  const baseline = (files: Record<string, string[]>): DebtFile => ({
+    note: "",
+    total: Object.values(files).flat().length,
+    files,
+  })
+
+  it("passes when the findings match the baseline exactly", () => {
+    const result = check(
+      [finding({ value: "Save" })],
+      baseline({ "src/ui/Thing.tsx": ["Save"] })
+    )
+
+    expect(result.added).toEqual([])
+    expect(result.fixed).toEqual({})
+    expect(result.staleFiles).toEqual([])
+  })
+
+  it("blocks a string the baseline does not excuse", () => {
+    const result = check(
+      [finding({ value: "Save" }), finding({ value: "Discard", line: 9 })],
+      baseline({ "src/ui/Thing.tsx": ["Save"] })
+    )
+
+    expect(result.added.map((f) => f.value)).toEqual(["Discard"])
+  })
+
+  it("blocks the same string appearing one extra time", () => {
+    const result = check(
+      [finding(), finding({ line: 2 })],
+      baseline({ "src/ui/Thing.tsx": ["Save"] })
+    )
+
+    expect(result.added).toHaveLength(1)
+  })
+
+  it("blocks a baselined string copied into a different file", () => {
+    const result = check(
+      [finding({ file: "src/ui/Other.tsx" })],
+      baseline({ "src/ui/Thing.tsx": ["Save"] })
+    )
+
+    expect(result.added.map((f) => f.file)).toEqual(["src/ui/Other.tsx"])
+    expect(result.staleFiles).toEqual(["src/ui/Thing.tsx"])
+  })
+
+  it("tolerates a baselined string moving to another line", () => {
+    const result = check(
+      [finding({ line: 412 })],
+      baseline({ "src/ui/Thing.tsx": ["Save"] })
+    )
+
+    expect(result.added).toEqual([])
+    expect(result.fixed).toEqual({})
+  })
+
+  it("flags a translated string still sitting in the baseline, to lock the win in", () => {
+    const result = check(
+      [finding({ value: "Save" })],
+      baseline({ "src/ui/Thing.tsx": ["Save", "Discard"] })
+    )
+
+    expect(result.added).toEqual([])
+    expect(result.fixed).toEqual({ "src/ui/Thing.tsx": ["Discard"] })
+  })
+
+  it("flags a baseline entry for a file that is now clean", () => {
+    const result = check([], baseline({ "src/ui/Gone.tsx": ["Save"] }))
+
+    expect(result.staleFiles).toEqual(["src/ui/Gone.tsx"])
+  })
+
+  it("reports current and baseline totals", () => {
+    const result = check(
+      [finding(), finding({ value: "Discard", line: 2 })],
+      baseline({ "src/ui/Thing.tsx": ["Save"] })
+    )
+
+    expect(result.total).toBe(2)
+    expect(result.baselineTotal).toBe(1)
+  })
+})
+
+describe("buildDebtFile", () => {
+  it("groups by file, sorts values, and totals the findings", () => {
+    const debt = buildDebtFile([
+      finding({ file: "src/b.tsx", value: "Zebra" }),
+      finding({ file: "src/a.tsx", value: "Beta" }),
+      finding({ file: "src/a.tsx", value: "Alpha" }),
+    ])
+
+    expect(Object.keys(debt.files)).toEqual(["src/a.tsx", "src/b.tsx"])
+    expect(debt.files["src/a.tsx"]).toEqual(["Alpha", "Beta"])
+    expect(debt.total).toBe(3)
+  })
+
+  it("round-trips: a freshly built baseline accepts its own findings", () => {
+    const findings = [finding(), finding({ value: "Discard", line: 2 })]
+
+    expect(check(findings, buildDebtFile(findings)).added).toEqual([])
+  })
+})

--- a/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
+++ b/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest"
 
 import {
   annotations,
+  attachExistingKeys,
+  buildKeyIndex,
   buildDebtFile,
   check,
   commentMarkdown,
@@ -13,7 +15,6 @@ import {
   isTextBearingName,
   readsAsCopy,
   readsAsProse,
-  scan,
   suggestKey,
 } from "../check-untranslated-copy"
 
@@ -378,12 +379,25 @@ describe("suggesting an existing key", () => {
     expect(suggestKey("Nothing here yet", index)).toBeUndefined()
   })
 
-  it("attaches real keys from the shipped dictionary during a scan", () => {
-    // Guards the wiring, not any specific key.
-    const withKeys = scan().filter((f) => f.existingKey)
+  // Reads the real dictionary but not the source tree: buildKeyIndex only walks
+  // a plain object, so this stays in the millisecond range. Scanning src/ here
+  // instead cost ~1.6s locally and timed out under CI's coverage run.
+  it("attaches keys from the shipped dictionary", () => {
+    const [close, novel] = attachExistingKeys([
+      finding({ value: "Close" }),
+      finding({ value: "Nothing here yet" }),
+    ])
 
-    expect(withKeys.length).toBeGreaterThan(0)
-    for (const f of withKeys) expect(f.existingKey).toMatch(/^[a-zA-Z]+\./)
+    expect(close.existingKey).toBe("actions.close")
+    expect(novel.existingKey).toBeUndefined()
+  })
+
+  it("indexes the shipped dictionary by English value", () => {
+    const real = buildKeyIndex()
+
+    expect(real.get("save")).toContain("actions.save")
+    // Nested and pluralised keys must be reachable too.
+    expect(real.get("last 7 days")).toContain("date.presets.last7Days")
   })
 })
 

--- a/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
+++ b/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  annotations,
   buildDebtFile,
   check,
+  commentMarkdown,
   type DebtFile,
   type Finding,
   findInSource,
+  fixHint,
   isExcludedPath,
   isTextBearingName,
   readsAsCopy,
   readsAsProse,
+  scan,
+  suggestKey,
 } from "../check-untranslated-copy"
 
 /** Shorthand: scan a .tsx snippet and return `name = "value"` strings. */
@@ -350,5 +355,106 @@ describe("buildDebtFile", () => {
     const findings = [finding(), finding({ value: "Discard", line: 2 })]
 
     expect(check(findings, buildDebtFile(findings)).added).toEqual([])
+  })
+})
+
+describe("suggesting an existing key", () => {
+  const index = new Map([
+    ["close", ["actions.close", "chat.closePreview"]],
+    ["last 7 days", ["date.presets.last7Days"]],
+    ["next", ["navigation.next", "ai.clarifyingQuestion.next"]],
+  ])
+
+  it("finds a key whose English matches, case-insensitively", () => {
+    expect(suggestKey("Close", index)).toBe("actions.close")
+    expect(suggestKey("last 7 DAYS", index)).toBe("date.presets.last7Days")
+  })
+
+  it("prefers the shallowest key when several hold the same English", () => {
+    expect(suggestKey("Next", index)).toBe("navigation.next")
+  })
+
+  it("returns nothing for a string the dictionary has never seen", () => {
+    expect(suggestKey("Nothing here yet", index)).toBeUndefined()
+  })
+
+  it("attaches real keys from the shipped dictionary during a scan", () => {
+    // Guards the wiring, not any specific key.
+    const withKeys = scan().filter((f) => f.existingKey)
+
+    expect(withKeys.length).toBeGreaterThan(0)
+    for (const f of withKeys) expect(f.existingKey).toMatch(/^[a-zA-Z]+\./)
+  })
+})
+
+describe("CI surfaces", () => {
+  const added = (over: Partial<Finding> = {}): Finding =>
+    finding({ file: "src/ui/Lane/Lane.tsx", line: 19, ...over })
+
+  it("anchors the annotation to the repo-relative path and line", () => {
+    const [line] = annotations([added()])
+
+    expect(line).toContain("::error file=packages/react/src/ui/Lane/Lane.tsx,")
+    expect(line).toContain("line=19,")
+    expect(line).toContain("title=Untranslated copy::")
+  })
+
+  // A newline mid-annotation would truncate it and GitHub would drop the rest,
+  // so wrapped JSX text has to survive capture as a single line.
+  it("stays on one line even when the source string spans several", () => {
+    const wrapped = findInSource(
+      "src/probe.tsx",
+      "const A = () => <p>\n  A sentence that the formatter\n  wrapped over lines.\n</p>"
+    )
+
+    expect(wrapped).toHaveLength(1)
+    expect(annotations(wrapped)[0].split("\n")).toHaveLength(1)
+  })
+
+  it("names the existing key in the annotation when there is one", () => {
+    const [line] = annotations([
+      added({ value: "Close", existingKey: "actions.close" }),
+    ])
+
+    expect(line).toContain("actions.close")
+    expect(line).toContain("A key for this already exists")
+  })
+
+  it("tells you to write a key when none exists", () => {
+    expect(fixHint(added({ value: "Nothing here yet" }))).toContain("Add a key")
+  })
+
+  it("splits the comment into swap-a-key and write-a-key", () => {
+    const md = commentMarkdown({
+      added: [
+        added({ value: "Close", existingKey: "actions.close" }),
+        added({ value: "Nothing here yet", name: "emptyMessage", line: 18 }),
+      ],
+      fixed: {},
+      staleFiles: [],
+      total: 160,
+      baselineTotal: 158,
+    })
+
+    expect(md).toContain("2 untranslated strings added")
+    expect(md).toContain("1 already have a key")
+    expect(md).toContain("`actions.close`")
+    expect(md).toContain("1 needs a new key")
+    expect(md).toContain("`emptyMessage`")
+    // The escape hatch must be discoverable from the comment alone.
+    expect(md).toContain("i18n-exempt")
+  })
+
+  it("posts a passing comment when the PR adds nothing", () => {
+    const md = commentMarkdown({
+      added: [],
+      fixed: {},
+      staleFiles: [],
+      total: 158,
+      baselineTotal: 158,
+    })
+
+    expect(md).toContain("No untranslated copy added")
+    expect(md).not.toContain("|")
   })
 })

--- a/packages/react/.scripts/check-untranslated-copy.ts
+++ b/packages/react/.scripts/check-untranslated-copy.ts
@@ -44,6 +44,10 @@
  *   tsx .scripts/check-untranslated-copy.ts --report     # full inventory, exit 0
  *   tsx .scripts/check-untranslated-copy.ts --json       # machine-readable
  *   tsx .scripts/check-untranslated-copy.ts --update     # rewrite the baseline
+ *   tsx .scripts/check-untranslated-copy.ts --comment   # PR-comment markdown
+ *
+ * Under GitHub Actions it also emits `::error file=,line=` annotations, which
+ * is what puts each offending string inline on the PR's Files tab.
  */
 import { spawnSync } from "node:child_process"
 import { readdirSync, readFileSync, writeFileSync } from "node:fs"
@@ -52,6 +56,8 @@ import { fileURLToPath } from "node:url"
 
 import consola from "consola"
 import ts from "typescript"
+
+import { defaultTranslations } from "../src/lib/providers/i18n/i18n-provider-defaults"
 
 const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const SRC_DIR = resolve(PKG_DIR, "src")
@@ -217,6 +223,48 @@ export interface Finding {
   name: string
   value: string
   kind: FindingKind
+  /**
+   * A dictionary key whose English value is exactly this string, when one
+   * already exists. Roughly 40% of findings have one: the key was written, then
+   * a later call site hardcoded the English instead of reading it. Naming it
+   * turns "go write a key" into a one-line swap.
+   */
+  existingKey?: string
+}
+
+/** English value (lowercased) → dot-notation keys that already hold it. */
+function buildKeyIndex(
+  dictionary: Record<string, unknown> = defaultTranslations
+): Map<string, string[]> {
+  const index = new Map<string, string[]>()
+  const walk = (node: Record<string, unknown>, path: string[]): void => {
+    for (const [key, value] of Object.entries(node)) {
+      if (typeof value === "string") {
+        const k = value.toLowerCase()
+        index.set(k, [...(index.get(k) ?? []), [...path, key].join(".")])
+      } else if (value && typeof value === "object" && !Array.isArray(value)) {
+        walk(value as Record<string, unknown>, [...path, key])
+      }
+    }
+  }
+  walk(dictionary, [])
+  return index
+}
+
+/**
+ * Pick the key to suggest when several hold the same English. Prefer the
+ * shallowest, then the shortest — `actions.close` reads as the reusable one,
+ * `chat.closePreview` as a local coincidence.
+ */
+export function suggestKey(
+  value: string,
+  index: Map<string, string[]>
+): string | undefined {
+  const candidates = index.get(value.toLowerCase())
+  if (!candidates?.length) return undefined
+  return [...candidates].sort(
+    (a, b) => a.split(".").length - b.split(".").length || a.length - b.length
+  )[0]
 }
 
 /** Strip HTML entities so `&nbsp;` does not read as a word. */
@@ -403,9 +451,15 @@ export function scan(srcDir = SRC_DIR): Finding[] {
   const files = walk(srcDir).filter(
     (file) => !isExcludedPath(relative(srcDir, file))
   )
-  return files.flatMap((file) =>
-    findInSource(relative(PKG_DIR, file), readFileSync(file, "utf-8"))
-  )
+  const keyIndex = buildKeyIndex()
+  return files
+    .flatMap((file) =>
+      findInSource(relative(PKG_DIR, file), readFileSync(file, "utf-8"))
+    )
+    .map((finding) => {
+      const existingKey = suggestKey(finding.value, keyIndex)
+      return existingKey ? { ...finding, existingKey } : finding
+    })
 }
 
 export interface DebtFile {
@@ -530,6 +584,97 @@ function printInventory(findings: Finding[]): void {
   }
 }
 
+/** Repo-root-relative path, which is what GitHub annotations need. */
+const repoPath = (f: Finding) => `packages/react/${f.file}`
+
+/** The one-line "what to do about it" for a single finding. */
+export function fixHint(finding: Finding): string {
+  return finding.existingKey
+    ? `A key for this already exists — read \`${finding.existingKey}\` instead of hardcoding it.`
+    : "Add a key to `i18n-provider-defaults.ts` and read it with `useI18n()`/`t()`."
+}
+
+/**
+ * Workflow-command annotations, so each offending line is flagged inline on the
+ * PR's Files tab instead of only inside the job log. Newlines must be encoded
+ * as `%0A`, and the file path must be relative to the repo root.
+ */
+export function annotations(added: Finding[]): string[] {
+  return added.map((f) => {
+    const message =
+      `Untranslated copy: ${f.name} = ${JSON.stringify(f.value)}. ` +
+      `${fixHint(f)} ` +
+      `If it must stay a literal, add an "${EXEMPT_MARKER}" comment on this line.`
+    return (
+      `::error file=${repoPath(f)},line=${f.line},` +
+      `title=Untranslated copy::${message.replace(/\r?\n/g, "%0A")}`
+    )
+  })
+}
+
+/**
+ * Markdown for the PR comment. Leads with the reusable-key cases, because those
+ * are a one-line swap rather than a copywriting decision.
+ */
+export function commentMarkdown(result: CheckResult): string {
+  const { added } = result
+  if (added.length === 0) {
+    return [
+      "## ✅ No untranslated copy added",
+      "",
+      `Every user-visible string in this PR comes from the i18n layer. Codebase total unchanged at **${result.total}**.`,
+    ].join("\n")
+  }
+
+  const reusable = added.filter((f) => f.existingKey)
+  const fresh = added.filter((f) => !f.existingKey)
+  const lines = [
+    `## ❌ ${added.length} untranslated string${added.length === 1 ? "" : "s"} added`,
+    "",
+    "A string literal cannot be translated: no consumer dictionary can reach it, so every locale renders English.",
+    "",
+  ]
+
+  if (reusable.length > 0) {
+    lines.push(
+      `### ${reusable.length} already have a key — swap, don't write`,
+      "",
+      "| Where | String | Read this instead |",
+      "| --- | --- | --- |",
+      ...reusable.map(
+        (f) =>
+          `| \`${f.file}:${f.line}\` | \`${f.value}\` | \`${f.existingKey}\` |`
+      ),
+      ""
+    )
+  }
+
+  if (fresh.length > 0) {
+    lines.push(
+      `### ${fresh.length} need${fresh.length === 1 ? "s" : ""} a new key`,
+      "",
+      "| Where | Bound to | String |",
+      "| --- | --- | --- |",
+      ...fresh.map(
+        (f) => `| \`${f.file}:${f.line}\` | \`${f.name}\` | \`${f.value}\` |`
+      ),
+      "",
+      "Add each to `src/lib/providers/i18n/i18n-provider-defaults.ts` (camelCase, domain-namespaced — `actions.save`) and read it with `useI18n()`/`t()`.",
+      ""
+    )
+  }
+
+  lines.push(
+    "<details><summary>If a string genuinely must not be translated</summary>",
+    "",
+    `Brand names, keyboard keys and the like are fine as literals. Put \`${EXEMPT_MARKER}\` in a comment on that line — it lands in the diff, so a reviewer can judge the claim.`,
+    "</details>",
+    "",
+    `<sub>Each line is also annotated inline on the Files tab. Full inventory: \`pnpm --filter @factorialco/f0-react run check:untranslated-copy --report\`</sub>`
+  )
+  return lines.join("\n")
+}
+
 function main(): void {
   const args = process.argv.slice(2)
   const wants = (flag: string) => args.includes(flag)
@@ -574,6 +719,13 @@ function main(): void {
     process.exit(result.added.length > 0 ? 1 : 0)
   }
 
+  // Plain stdout, not consola: the workflow captures this verbatim as the
+  // comment body.
+  if (wants("--comment")) {
+    process.stdout.write(`${commentMarkdown(result)}\n`)
+    process.exit(0)
+  }
+
   if (wants("--verbose")) {
     consola.log(
       `Untranslated copy: ${result.total} (baseline ${result.baselineTotal})\n`
@@ -597,21 +749,42 @@ export function reportResult(result: CheckResult): boolean {
 
   if (result.added.length > 0) {
     failed = true
+
+    // Inline annotations first, so GitHub attaches them to the diff even if
+    // nobody reads the rest of the log.
+    // Raw stdout, not consola: a workflow command must start the line exactly,
+    // with no prefix or colour codes, or GitHub ignores it.
+    if (process.env.GITHUB_ACTIONS === "true") {
+      for (const line of annotations(result.added)) {
+        process.stdout.write(`${line}\n`)
+      }
+    }
+
     consola.log("")
     consola.error(
       `${result.added.length} new untranslated string(s) — copy must come from ` +
         "the i18n layer, not a literal:"
     )
+    const reusable = result.added.filter((f) => f.existingKey)
     for (const finding of result.added) {
       consola.log(
         `    ${finding.file}:${finding.line} — ${finding.name} = ` +
           `${JSON.stringify(finding.value)} (${KIND_LABEL[finding.kind]})`
       )
+      if (finding.existingKey) {
+        consola.log(`      ↳ already translated as "${finding.existingKey}"`)
+      }
     }
     consola.log("")
+    if (reusable.length > 0) {
+      consola.log(
+        `  ${reusable.length} of these already have a key (marked ↳ above) — ` +
+          "read that key instead of hardcoding the English."
+      )
+    }
     consola.log(
-      "  Add the key to src/lib/providers/i18n/i18n-provider-defaults.ts and read " +
-        "it with useI18n()/t()."
+      "  For the rest: add a key to src/lib/providers/i18n/i18n-provider-defaults.ts " +
+        "and read it with useI18n()/t()."
     )
     consola.log(
       `  If the string genuinely must not be translated, put "${EXEMPT_MARKER}" ` +

--- a/packages/react/.scripts/check-untranslated-copy.ts
+++ b/packages/react/.scripts/check-untranslated-copy.ts
@@ -233,7 +233,7 @@ export interface Finding {
 }
 
 /** English value (lowercased) → dot-notation keys that already hold it. */
-function buildKeyIndex(
+export function buildKeyIndex(
   dictionary: Record<string, unknown> = defaultTranslations
 ): Map<string, string[]> {
   const index = new Map<string, string[]>()
@@ -447,19 +447,30 @@ export function findInSource(filePath: string, source: string): Finding[] {
   return findings
 }
 
+/**
+ * Tag each finding with the dictionary key that already holds its English, if
+ * there is one. Split out from `scan` so it can be exercised without walking
+ * the source tree.
+ */
+export function attachExistingKeys(
+  findings: Finding[],
+  index: Map<string, string[]> = buildKeyIndex()
+): Finding[] {
+  return findings.map((finding) => {
+    const existingKey = suggestKey(finding.value, index)
+    return existingKey ? { ...finding, existingKey } : finding
+  })
+}
+
 export function scan(srcDir = SRC_DIR): Finding[] {
   const files = walk(srcDir).filter(
     (file) => !isExcludedPath(relative(srcDir, file))
   )
-  const keyIndex = buildKeyIndex()
-  return files
-    .flatMap((file) =>
+  return attachExistingKeys(
+    files.flatMap((file) =>
       findInSource(relative(PKG_DIR, file), readFileSync(file, "utf-8"))
     )
-    .map((finding) => {
-      const existingKey = suggestKey(finding.value, keyIndex)
-      return existingKey ? { ...finding, existingKey } : finding
-    })
+  )
 }
 
 export interface DebtFile {

--- a/packages/react/.scripts/check-untranslated-copy.ts
+++ b/packages/react/.scripts/check-untranslated-copy.ts
@@ -1,0 +1,664 @@
+#!/usr/bin/env tsx
+/**
+ * check-untranslated-copy.ts
+ *
+ * Gate: user-visible copy in `packages/react` must come from the i18n layer
+ * (`useI18n()` / `t()` — see src/lib/providers/i18n), not from a string literal
+ * baked into the component. A literal is untranslatable by construction: a
+ * consumer's dictionary can never reach it, so every locale renders English.
+ *
+ * The scan is AST-based (no regex over source) and looks at four positions:
+ *
+ *   1. JSX text          — `<span>Save</span>`
+ *   2. JSX attributes    — `label="Close"`, `aria-label="Clear"`
+ *   3. Object properties — `{ label: "Today" }`, at any depth, including
+ *                          inside arrays and const maps
+ *   4. Default values    — `function f({ label = "Actions" })`, `x = "Add"`
+ *
+ * Positions 3 and 4 are what catch copy hiding in default params and lookup
+ * tables, which is where most of this debt actually lives.
+ *
+ * A literal is reported when EITHER
+ *   - the name it is bound to is text-bearing (`label`, `title`, `placeholder`,
+ *     `aria-label`, `emptyMessage`, …) and the value reads as copy, OR
+ *   - the name is arbitrary but the value reads as prose ("hey hey"), which is
+ *     how `hola = 'hey hey'` gets caught despite `hola` meaning nothing.
+ *
+ * Because the whole codebase predates the check, this is a **ratchet** rather
+ * than a hard wall — the same idiom as `.scripts/stable-dod-debt.json`:
+ *
+ *   - `untranslated-copy-debt.json` records the known-untranslated strings per
+ *     file. The list may only ever shrink.
+ *   - A string not in the baseline for its file fails the check. That is the
+ *     blocking half: a PR cannot add untranslated copy.
+ *   - A baseline entry that no longer exists also fails, with the fix being to
+ *     run `--update`. That is what locks each translation win in.
+ *
+ * Escape hatch for a literal that genuinely must not be translated (a brand
+ * name, a keyboard key, a developer-facing dev tool): put `i18n-exempt` in a
+ * comment on the same line or the line above.
+ *
+ * Usage:
+ *   tsx .scripts/check-untranslated-copy.ts             # gate (exit 1 on drift)
+ *   tsx .scripts/check-untranslated-copy.ts --verbose    # + every finding
+ *   tsx .scripts/check-untranslated-copy.ts --report     # full inventory, exit 0
+ *   tsx .scripts/check-untranslated-copy.ts --json       # machine-readable
+ *   tsx .scripts/check-untranslated-copy.ts --update     # rewrite the baseline
+ */
+import { spawnSync } from "node:child_process"
+import { readdirSync, readFileSync, writeFileSync } from "node:fs"
+import { dirname, relative, resolve, sep } from "node:path"
+import { fileURLToPath } from "node:url"
+
+import consola from "consola"
+import ts from "typescript"
+
+const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const SRC_DIR = resolve(PKG_DIR, "src")
+const DEBT_FILE = resolve(PKG_DIR, ".scripts/untranslated-copy-debt.json")
+
+/** Marker that opts a single line out of the check. */
+const EXEMPT_MARKER = "i18n-exempt"
+
+/**
+ * Paths whose strings are not shipped copy. Tests, stories and fixtures are
+ * excluded per the brief; the rest are either generated (icons, flags),
+ * Storybook-only scaffolding, or the dictionary itself.
+ *
+ * Matched against the src-relative path with "/" separators.
+ */
+const EXCLUDED_PATHS: RegExp[] = [
+  // Tests, stories, docs and type-level tests.
+  /\.(spec|test|bench)\.(ts|tsx)$/,
+  /\.test-d\.ts$/,
+  /\.stories\.tsx?$/,
+  /\.mdx$/,
+  /\.d\.ts$/,
+  /(^|\/)(__tests__|__test__|__stories__|__storybook__|__mocks__|__snapshots__)\//,
+  // Fixture/sample data: `*.factory.tsx` exists only to feed stories.
+  /\.(factory|fixture|mock|mocks)\.(ts|tsx)$/,
+  // Generated from @factorialco/f0-core assets — never hand-edited.
+  /(^|\/)(icons|flags)\//,
+  // Sample data, harnesses and Storybook helpers.
+  /(^|\/)(mocks|testing|examples)\//,
+  /(^|\/)lib\/storybook-utils\//,
+  // The dictionary itself: these literals ARE the translations.
+  /(^|\/)lib\/providers\/i18n\//,
+]
+
+/**
+ * Names that carry copy. Matched as a whole name or as a camelCase suffix, so
+ * `emptyStateTitle`, `searchPlaceholder` and `confirmLabel` all qualify.
+ */
+const TEXT_WORDS = [
+  "label",
+  "title",
+  "subtitle",
+  "description",
+  "placeholder",
+  "text",
+  "message",
+  "tooltip",
+  "caption",
+  "heading",
+  "hint",
+  "cta",
+  "alt",
+  "copy",
+  "prompt",
+  "legend",
+]
+const TEXT_SUFFIX = new RegExp(`(^|[a-z])(${TEXT_WORDS.join("|")})s?$`, "i")
+
+/** Text-bearing names the suffix rule cannot express (they contain a dash). */
+const TEXT_EXACT = new Set([
+  "aria-label",
+  "aria-description",
+  "aria-roledescription",
+  "aria-valuetext",
+  "aria-placeholder",
+  "content",
+])
+
+/**
+ * `showTooltip`, `hasTitle`, `noLabel` … end in a text word but hold a flag or
+ * an enum, not copy.
+ */
+const BOOLEAN_PREFIX =
+  /^(is|has|show|hide|should|can|with|without|enable|disable|use|no|allow|omit)[A-Z]/
+
+/**
+ * Names that never hold copy, however prose-like the value looks. Only consulted
+ * by the prose pass — a text-bearing name always wins. `name` is the big one:
+ * person and entity names dominate sample data and are not translatable copy.
+ */
+const NON_COPY_NAMES = new Set([
+  // Identifiers and routing.
+  "name",
+  "id",
+  "key",
+  "type",
+  "role",
+  "variant",
+  "value",
+  "href",
+  "src",
+  "url",
+  "path",
+  "testId",
+  "data-testid",
+  "event",
+  "icon",
+  "color",
+  "format",
+  // Presentation.
+  "className",
+  "class",
+  "style",
+  "fontFamily",
+  "font",
+  // HTML plumbing whose values are keywords, not copy — `rel="noopener
+  // noreferrer"` is the common one.
+  "rel",
+  "target",
+  "download",
+  "charSet",
+  "crossOrigin",
+  "referrerPolicy",
+  "autoComplete",
+  "inputMode",
+  "enterKeyHint",
+  "sandbox",
+  "srcSet",
+  "sizes",
+  "media",
+  "accept",
+  "encType",
+  "method",
+  "action",
+  "dir",
+  "lang",
+  "slot",
+])
+
+/**
+ * Props/keys whose object value is a style or animation declaration. CSS values
+ * (`overflow: "hidden auto"`, `transformOrigin: "top left"`) read as prose but
+ * are never copy, so the whole subtree is skipped.
+ */
+const STYLE_CONTAINERS = new Set([
+  "style",
+  "css",
+  "sx",
+  // framer-motion.
+  "animate",
+  "initial",
+  "exit",
+  "transition",
+  "variants",
+  "whileHover",
+  "whileTap",
+  "whileFocus",
+  "whileDrag",
+  "whileInView",
+])
+
+export type FindingKind =
+  | "jsx-text"
+  | "jsx-attribute"
+  | "object-property"
+  | "default-value"
+
+export interface Finding {
+  /** Path relative to `packages/react`, e.g. `src/ui/carousel.tsx`. */
+  file: string
+  line: number
+  /** Prop/attribute/binding name, or `<jsx-text>` for element children. */
+  name: string
+  value: string
+  kind: FindingKind
+}
+
+/** Strip HTML entities so `&nbsp;` does not read as a word. */
+const decodeEntities = (s: string): string =>
+  s.replace(/&[a-z]+;|&#\d+;/gi, " ")
+
+/** `w-6`, `text-f1-foreground-warning`, `md:flex-1` — CSS classes, not copy. */
+const CLASS_TOKEN = /^-?[a-z][a-z0-9]*([-:/.][a-z0-9[\]%.]+)+$/
+const looksLikeClassNames = (value: string): boolean =>
+  value.split(/\s+/).every((token) => CLASS_TOKEN.test(token))
+
+/**
+ * One word of prose: letters, an optional internal apostrophe, and trailing
+ * sentence punctuation. Interpolations (`{{count}}`) and bare numbers count as
+ * words too. Deliberately no dash, colon or slash — that omission is what
+ * rejects Tailwind ("flex items-center"), font stacks ("Inter, sans-serif")
+ * and code snippets, which are the only things in these positions that
+ * otherwise read as prose.
+ */
+const PROSE_WORD =
+  /^[("“]?([A-Za-z]+(['’][A-Za-z]+)?|\{\{\w+\}\}|\d+([.,]\d+)?)[.,!?:;)"”]*$/
+
+export const isTextBearingName = (name: string): boolean =>
+  TEXT_EXACT.has(name) || (!BOOLEAN_PREFIX.test(name) && TEXT_SUFFIX.test(name))
+
+/**
+ * Does this literal read as something a user sees? Applied when the name
+ * already tells us the position holds copy, so a bare "Save" qualifies.
+ */
+export function readsAsCopy(raw: string): boolean {
+  const value = decodeEntities(raw).trim()
+  if (value.length < 2) return false
+  if (!/[A-Za-z]/.test(value)) return false
+  // URLs and paths.
+  if (/^(https?:)?\/\//.test(value) || value.startsWith("/")) return false
+  if (looksLikeClassNames(value)) return false
+  // A single uncapitalised token is an identifier, enum member or CSS value
+  // (`send`, `onHover`, `txt`) — copy starts with a capital or has more words.
+  if (!/\s/.test(value) && !/^[A-Z]/.test(value)) return false
+  return true
+}
+
+/**
+ * Does this literal read as prose? Applied when the name tells us nothing, so
+ * the bar is higher: two or more plain words. Case is not required — this is
+ * what catches `hola = "hey hey"`, an arbitrary name holding obvious copy.
+ */
+export function readsAsProse(raw: string): boolean {
+  const value = decodeEntities(raw).trim()
+  if (!readsAsCopy(value)) return false
+  const words = value.split(/\s+/)
+  // One word is never enough: alone it is far likelier an enum member or a CSS
+  // value than copy.
+  if (words.length < 2) return false
+  return words.every((word) => PROSE_WORD.test(word))
+}
+
+export function isExcludedPath(srcRelativePath: string): boolean {
+  const normalized = srcRelativePath.split(sep).join("/")
+  return EXCLUDED_PATHS.some((pattern) => pattern.test(normalized))
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = resolve(dir, entry.name)
+    if (entry.isDirectory()) walk(full, out)
+    else if (/\.(ts|tsx)$/.test(entry.name)) out.push(full)
+  }
+  return out
+}
+
+/**
+ * Scan one file's source. Exported so tests can drive it with a string instead
+ * of a fixture tree.
+ */
+export function findInSource(filePath: string, source: string): Finding[] {
+  const findings: Finding[] = []
+  const isTsx = filePath.endsWith(".tsx")
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    isTsx ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  )
+  const lines = source.split("\n")
+  const exemptLine = (line: number) =>
+    (lines[line - 1] ?? "").includes(EXEMPT_MARKER) ||
+    (lines[line - 2] ?? "").includes(EXEMPT_MARKER)
+
+  const lineOf = (node: ts.Node) =>
+    sourceFile.getLineAndCharacterOfPosition(node.getStart(sourceFile)).line + 1
+
+  /** Literal text, or undefined for anything with interpolation or non-strings. */
+  const literalOf = (node: ts.Node): string | undefined =>
+    ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)
+      ? node.text
+      : undefined
+
+  const record = (
+    node: ts.Node,
+    name: string,
+    value: string,
+    kind: FindingKind
+  ) => {
+    const line = lineOf(node)
+    if (exemptLine(line)) return
+    findings.push({
+      file: filePath,
+      line,
+      name,
+      value: decodeEntities(value).trim().replace(/\s+/g, " "),
+      kind,
+    })
+  }
+
+  /** Apply the name-driven rule, falling back to the prose rule. */
+  const consider = (
+    node: ts.Node,
+    name: string,
+    value: string,
+    kind: FindingKind
+  ) => {
+    if (isTextBearingName(name)) {
+      if (readsAsCopy(value)) record(node, name, value, kind)
+      return
+    }
+    if (!NON_COPY_NAMES.has(name) && readsAsProse(value)) {
+      record(node, name, value, kind)
+    }
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxAttribute(node) && node.initializer) {
+      const attrName = node.name.getText(sourceFile)
+      if (STYLE_CONTAINERS.has(attrName)) return
+      const { initializer } = node
+      const value = ts.isStringLiteral(initializer)
+        ? initializer.text
+        : ts.isJsxExpression(initializer) && initializer.expression
+          ? literalOf(initializer.expression)
+          : undefined
+      if (value !== undefined) {
+        consider(node, attrName, value, "jsx-attribute")
+      }
+    }
+
+    if (ts.isPropertyAssignment(node)) {
+      const name =
+        ts.isIdentifier(node.name) || ts.isStringLiteral(node.name)
+          ? node.name.text
+          : undefined
+      if (name !== undefined && STYLE_CONTAINERS.has(name)) return
+      const value = literalOf(node.initializer)
+      if (name !== undefined && value !== undefined) {
+        consider(node, name, value, "object-property")
+      }
+    }
+
+    // `function f(label = "x")` and `const { label = "x" } = props`.
+    if (
+      (ts.isParameter(node) || ts.isBindingElement(node)) &&
+      node.initializer
+    ) {
+      const name = ts.isIdentifier(node.name) ? node.name.text : undefined
+      const value = literalOf(node.initializer)
+      if (name !== undefined && value !== undefined) {
+        consider(node, name, value, "default-value")
+      }
+    }
+
+    if (isTsx && ts.isJsxText(node) && readsAsCopy(node.text)) {
+      record(node, "<jsx-text>", node.text, "jsx-text")
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return findings
+}
+
+export function scan(srcDir = SRC_DIR): Finding[] {
+  const files = walk(srcDir).filter(
+    (file) => !isExcludedPath(relative(srcDir, file))
+  )
+  return files.flatMap((file) =>
+    findInSource(relative(PKG_DIR, file), readFileSync(file, "utf-8"))
+  )
+}
+
+export interface DebtFile {
+  /** Why this file exists and the rule that governs it. */
+  note: string
+  /** Total across every file — the headline number. */
+  total: number
+  /**
+   * File → the untranslated strings it is known to contain. Values, not line
+   * numbers, so moving code inside a file does not churn the baseline.
+   */
+  files: Record<string, string[]>
+}
+
+/** file → sorted list of findings' values. */
+function groupValues(findings: Finding[]): Map<string, string[]> {
+  const grouped = new Map<string, string[]>()
+  for (const finding of findings) {
+    const bucket = grouped.get(finding.file) ?? []
+    bucket.push(finding.value)
+    grouped.set(finding.file, bucket)
+  }
+  for (const bucket of grouped.values()) bucket.sort()
+  return grouped
+}
+
+export function buildDebtFile(findings: Finding[]): DebtFile {
+  const files: Record<string, string[]> = {}
+  for (const [file, values] of [...groupValues(findings)].sort(([a], [b]) =>
+    a.localeCompare(b)
+  )) {
+    files[file] = values
+  }
+  return {
+    note:
+      "Untranslated user-visible copy in packages/react/src — string literals that should " +
+      "come from the i18n layer (src/lib/providers/i18n) instead. Enforced by " +
+      ".scripts/check-untranslated-copy.ts. This list may only shrink: translate a string " +
+      'and remove it from here (or run "--update"), never add one.',
+    total: findings.length,
+    files,
+  }
+}
+
+export interface CheckResult {
+  /** Untranslated strings this branch introduces — the blocking set. */
+  added: Finding[]
+  /** file → strings in the baseline that no longer exist. Delete these. */
+  fixed: Record<string, string[]>
+  /** Baseline entries for files that no longer exist (or have no findings). */
+  staleFiles: string[]
+  /** Total findings across the codebase right now. */
+  total: number
+  /** Total recorded in the baseline. */
+  baselineTotal: number
+}
+
+export function check(findings: Finding[], baseline: DebtFile): CheckResult {
+  const current = groupValues(findings)
+  const added: Finding[] = []
+
+  // Consume the baseline as a multiset per file: a finding is new only if the
+  // baseline has no unclaimed copy of that exact string in that exact file.
+  const remaining = new Map<string, Map<string, number>>()
+  for (const [file, values] of Object.entries(baseline.files)) {
+    const counts = new Map<string, number>()
+    for (const value of values) counts.set(value, (counts.get(value) ?? 0) + 1)
+    remaining.set(file, counts)
+  }
+
+  for (const finding of findings) {
+    const counts = remaining.get(finding.file)
+    const left = counts?.get(finding.value) ?? 0
+    if (left > 0) counts!.set(finding.value, left - 1)
+    else added.push(finding)
+  }
+
+  const fixed: Record<string, string[]> = {}
+  const staleFiles: string[] = []
+  for (const [file, counts] of remaining) {
+    const leftover = [...counts.entries()].flatMap(([value, count]) =>
+      Array.from({ length: count }, () => value)
+    )
+    if (leftover.length === 0) continue
+    if (!current.has(file)) staleFiles.push(file)
+    else fixed[file] = leftover.sort()
+  }
+
+  return {
+    added,
+    fixed,
+    staleFiles: staleFiles.sort(),
+    total: findings.length,
+    baselineTotal: baseline.total,
+  }
+}
+
+const KIND_LABEL: Record<FindingKind, string> = {
+  "jsx-text": "JSX text",
+  "jsx-attribute": "JSX attribute",
+  "object-property": "object property",
+  "default-value": "default value",
+}
+
+function readBaseline(): DebtFile {
+  return JSON.parse(readFileSync(DEBT_FILE, "utf-8")) as DebtFile
+}
+
+function printInventory(findings: Finding[]): void {
+  const byFile = new Map<string, Finding[]>()
+  for (const finding of findings) {
+    byFile.set(finding.file, [...(byFile.get(finding.file) ?? []), finding])
+  }
+  for (const file of [...byFile.keys()].sort()) {
+    consola.log(`  ${file}`)
+    for (const finding of byFile.get(file)!) {
+      consola.log(
+        `    ${finding.line}: ${finding.name} = ${JSON.stringify(finding.value)}` +
+          ` (${KIND_LABEL[finding.kind]})`
+      )
+    }
+  }
+}
+
+function main(): void {
+  const args = process.argv.slice(2)
+  const wants = (flag: string) => args.includes(flag)
+
+  const findings = scan()
+
+  if (wants("--update")) {
+    const payload = buildDebtFile(findings)
+    writeFileSync(DEBT_FILE, `${JSON.stringify(payload, null, 2)}\n`)
+    // oxfmt collapses short arrays onto one line, which JSON.stringify cannot
+    // reproduce. Normalise here so a later `oxfmt .scripts/` does not reflow a
+    // freshly generated baseline into a confusing no-op diff.
+    spawnSync("pnpm", ["exec", "oxfmt", DEBT_FILE], {
+      cwd: PKG_DIR,
+      stdio: "ignore",
+    })
+    consola.success(
+      `Wrote ${payload.total} untranslated string(s) across ` +
+        `${Object.keys(payload.files).length} file(s) to ` +
+        ".scripts/untranslated-copy-debt.json"
+    )
+    process.exit(0)
+  }
+
+  if (wants("--report")) {
+    if (wants("--json")) {
+      consola.log(JSON.stringify({ total: findings.length, findings }, null, 2))
+      process.exit(0)
+    }
+    const files = new Set(findings.map((f) => f.file)).size
+    consola.log(
+      `${findings.length} untranslated string(s) across ${files} file(s):\n`
+    )
+    printInventory(findings)
+    process.exit(0)
+  }
+
+  const result = check(findings, readBaseline())
+
+  if (wants("--json")) {
+    consola.log(JSON.stringify(result, null, 2))
+    process.exit(result.added.length > 0 ? 1 : 0)
+  }
+
+  if (wants("--verbose")) {
+    consola.log(
+      `Untranslated copy: ${result.total} (baseline ${result.baselineTotal})\n`
+    )
+    printInventory(findings)
+  }
+
+  process.exit(reportResult(result) ? 0 : 1)
+}
+
+/**
+ * Print the verdict and return whether it passed. Shared with
+ * pre-push-preflight.ts so the local and CI messages cannot drift.
+ */
+export function reportResult(result: CheckResult): boolean {
+  consola.log(
+    `Untranslated copy: ${result.total} (baseline ${result.baselineTotal})`
+  )
+
+  let failed = false
+
+  if (result.added.length > 0) {
+    failed = true
+    consola.log("")
+    consola.error(
+      `${result.added.length} new untranslated string(s) — copy must come from ` +
+        "the i18n layer, not a literal:"
+    )
+    for (const finding of result.added) {
+      consola.log(
+        `    ${finding.file}:${finding.line} — ${finding.name} = ` +
+          `${JSON.stringify(finding.value)} (${KIND_LABEL[finding.kind]})`
+      )
+    }
+    consola.log("")
+    consola.log(
+      "  Add the key to src/lib/providers/i18n/i18n-provider-defaults.ts and read " +
+        "it with useI18n()/t()."
+    )
+    consola.log(
+      `  If the string genuinely must not be translated, put "${EXEMPT_MARKER}" ` +
+        "in a comment on that line."
+    )
+  }
+
+  const fixedFiles = Object.keys(result.fixed)
+  if (fixedFiles.length > 0 || result.staleFiles.length > 0) {
+    failed = true
+    const fixedCount = Object.values(result.fixed).reduce(
+      (sum, values) => sum + values.length,
+      0
+    )
+    consola.log("")
+    consola.error(
+      `${fixedCount + result.staleFiles.length} baseline entr(y/ies) no longer ` +
+        "exist — the debt list must shrink to lock the win in:"
+    )
+    for (const file of fixedFiles) {
+      consola.log(`    ${file}: ${result.fixed[file].join(", ")}`)
+    }
+    for (const file of result.staleFiles) {
+      consola.log(`    ${file}: file gone or fully translated`)
+    }
+    consola.log("")
+    consola.log(
+      '  Run "pnpm --filter @factorialco/f0-react run check:untranslated-copy --update".'
+    )
+  }
+
+  if (failed) return false
+
+  consola.log("")
+  consola.success("No new untranslated copy.")
+  return true
+}
+
+/** Run the gate end to end. Used by pre-push-preflight.ts. */
+export function runGate(): boolean {
+  return reportResult(check(scan(), readBaseline()))
+}
+
+// Run as a CLI only when invoked directly (not when imported by tests).
+if (
+  process.argv[1] &&
+  /check-untranslated-copy\.(ts|js)$/.test(process.argv[1])
+) {
+  main()
+}

--- a/packages/react/.scripts/pre-push-preflight.ts
+++ b/packages/react/.scripts/pre-push-preflight.ts
@@ -2,8 +2,8 @@
 /**
  * pre-push-preflight.ts
  *
- * Local (pre-push) version of the two CI merge gates, so agents and humans
- * find out BEFORE pushing — wired into lefthook's `pre-push` hook:
+ * Local (pre-push) version of the CI merge gates, so agents and humans find out
+ * BEFORE pushing — wired into lefthook's `pre-push` hook:
  *
  *   1. Bugfix pushes — if any outgoing commit is a `fix:` conventional commit,
  *      the branch must add or modify a unit test (the regression test), and
@@ -12,11 +12,15 @@
  *   2. New components — every component whose story file is added by the
  *      branch must meet the full mechanical Definition of Done
  *      (check-new-component-dod.ts runs the same policy in CI).
+ *   3. Untranslated copy — the branch must not add user-visible string literals
+ *      that bypass the i18n layer (check-untranslated-copy.ts, same policy in
+ *      CI). Its own escape hatch is the inline `i18n-exempt` comment.
  *
  * Escape hatches (e.g. pushing WIP to a personal branch):
- *   F0_SKIP_PREFLIGHT=1 git push          # skip both checks once
+ *   F0_SKIP_PREFLIGHT=1 git push          # skip every check once
  *   SKIP_RED_GREEN=1 git push             # skip only the bugfix gate
  *   SKIP_NEW_COMPONENT_DOD=1 git push     # skip only the new-component gate
+ *   SKIP_UNTRANSLATED_COPY=1 git push     # skip only the i18n gate
  *
  * The CI gates still run on the PR (with the `skip-red-green` /
  * `skip-new-component-dod` labels as their escape hatches), so skipping here
@@ -39,6 +43,7 @@ import {
   gatherSignals,
   reportResult,
 } from "./check-new-component-dod"
+import { runGate as untranslatedCopyGate } from "./check-untranslated-copy"
 import { type StatusEntry } from "./check-stable-dod"
 
 const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -108,6 +113,16 @@ function checkNewComponentsDod(): boolean {
   return ok
 }
 
+function checkUntranslatedCopy(): boolean {
+  const ok = untranslatedCopyGate()
+  if (!ok) {
+    consola.log(
+      "  To push anyway (e.g. WIP): SKIP_UNTRANSLATED_COPY=1 git push"
+    )
+  }
+  return ok
+}
+
 function main(): void {
   if (process.env.F0_SKIP_PREFLIGHT === "1") {
     consola.warn("F0_SKIP_PREFLIGHT=1 — skipping pre-push preflight.")
@@ -144,6 +159,12 @@ function main(): void {
     )
   } else {
     ok = checkNewComponentsDod() && ok
+  }
+
+  if (process.env.SKIP_UNTRANSLATED_COPY === "1") {
+    consola.warn("SKIP_UNTRANSLATED_COPY=1 — skipping the i18n copy gate.")
+  } else {
+    ok = checkUntranslatedCopy() && ok
   }
 
   process.exit(ok ? 0 : 1)

--- a/packages/react/.scripts/untranslated-copy-debt.json
+++ b/packages/react/.scripts/untranslated-copy-debt.json
@@ -1,0 +1,246 @@
+{
+  "note": "Untranslated user-visible copy in packages/react/src — string literals that should come from the i18n layer (src/lib/providers/i18n) instead. Enforced by .scripts/check-untranslated-copy.ts. This list may only shrink: translate a string and remove it from here (or run \"--update\"), never add one.",
+  "total": 158,
+  "files": {
+    "src/component-status/A11yRow.tsx": [
+      "Accessibility",
+      "Accessibility",
+      "Accessibility",
+      "Check the rendered stories",
+      "Checked in each story’s default state — violations behind interactions (open menus, dialogs) aren’t shown here. CI enforces the full set, including play-function states.",
+      "Checking the rendered stories…",
+      "Live results are available on the Storybook docs page. See the story’s",
+      "No violations in the stories’ default state.",
+      "tab for per-element detail.",
+      "· WCAG"
+    ],
+    "src/component-status/component-status.ts": [
+      "A \"when not to use\" section",
+      "A Storybook play function (interaction test) covering the primary user flow.",
+      "Accessibility enforced",
+      "At least three named example stories",
+      "DoDont examples with realistic Factorial copy",
+      "Docs at the Good tier build on the Acceptable base and add:",
+      "Has MDX documentation",
+      "Has Storybook stories",
+      "Has a play function",
+      "Has a visual snapshot story",
+      "Has unit tests",
+      "Named with the \"F0\" prefix",
+      "No tag",
+      "Required sections (Anatomy, Guidelines, Accessibility) and a props table"
+    ],
+    "src/component-status/ComponentStability.tsx": ["Maturity level"],
+    "src/components/F0Card/components/CardMetadata.tsx": [
+      "Unsupported property type:"
+    ],
+    "src/components/F0InputField/F0InputField.tsx": ["Clear"],
+    "src/components/F0Link/F0Link.tsx": ["(opens in new tab)"],
+    "src/components/F0NumberInput/components/Arrows.tsx": [
+      "Decrease",
+      "Increase"
+    ],
+    "src/components/F0Slider/F0SliderSkeleton.tsx": ["Loading slider"],
+    "src/components/F0VideoPlayer/components/AudioDescriptionToggleIcons.tsx": [
+      "AD",
+      "AD"
+    ],
+    "src/components/OneChip/index.tsx": ["Close"],
+    "src/components/RichText/F0NotesTextEditor/F0NotesTextEditor.tsx": [
+      "Add paragraph"
+    ],
+    "src/components/RichText/F0RichTextEditor/components/FileList/index.tsx": [
+      "Delete",
+      "Upload file"
+    ],
+    "src/components/RichText/F0RichTextEditor/components/Footer/index.tsx": [
+      "Add Attachment",
+      "Rich text editor toolbar",
+      "Toolbar"
+    ],
+    "src/components/RichText/F0RichTextEditor/components/Head/index.tsx": [
+      "Fullscreen",
+      "Toggle fullscreen mode"
+    ],
+    "src/components/RichText/internal/Enhance/EnhanceMenu.tsx": [
+      "Accept",
+      "Discard",
+      "Stop",
+      "Thinking...",
+      "Try again"
+    ],
+    "src/components/RichText/internal/Extensions/Accessibility/index.tsx": [
+      "Rich text editor"
+    ],
+    "src/components/RichText/internal/Extensions/Image/index.tsx": [
+      "Resize image"
+    ],
+    "src/components/RichText/internal/Extensions/Mention/MentionList/index.tsx": [
+      "No results found"
+    ],
+    "src/components/RichText/internal/Extensions/SlashCommand/AvailableCommands.tsx": [
+      "Image"
+    ],
+    "src/components/RichText/internal/Toolbar/index.tsx": [
+      "Center",
+      "Justify",
+      "Left",
+      "Right"
+    ],
+    "src/components/RichText/internal/Toolbar/LinkPopup/index.tsx": [
+      "Close link popup",
+      "Link popup"
+    ],
+    "src/deprecated/EntitySelect/Content/MainContent/index.tsx": ["Group"],
+    "src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx": ["Clear"],
+    "src/experimental/Lists/OnePersonListItem/index.tsx": ["Secondary"],
+    "src/experimental/Navigation/Carousel/DynamicCarousel/index.tsx": [
+      "Next",
+      "Previous"
+    ],
+    "src/experimental/Navigation/Dropdown/index.tsx": ["Other actions"],
+    "src/experimental/Navigation/F0TableOfContent/index.tsx": ["Drop here"],
+    "src/experimental/Navigation/F0TableOfContent/Item/ItemDropDown.tsx": [
+      "Actions"
+    ],
+    "src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx": [
+      "Drag to reorder"
+    ],
+    "src/experimental/Navigation/Header/PageHeader/index.tsx": [
+      "Back",
+      "Open main menu"
+    ],
+    "src/experimental/Navigation/Header/PageNavigation/index.tsx": [
+      "Next",
+      "Previous"
+    ],
+    "src/experimental/Navigation/Header/ProductUpdates/index.tsx": ["Close"],
+    "src/experimental/OneTable/TableHead/index.tsx": ["Sort"],
+    "src/experimental/Widgets/Widget/index.tsx": ["Actions"],
+    "src/hooks/datasource/itemNeighbors/useItemNeighbors.ts": [
+      "Error fetching item neighbors"
+    ],
+    "src/hooks/datasource/useData.ts": [
+      "All",
+      "Error fetching data",
+      "Error fetching data"
+    ],
+    "src/kits/ai/Banners/BaseBanner/index.tsx": ["Close"],
+    "src/kits/ai/Banners/F0AiBanner/AiBannerInternal.tsx": ["Close"],
+    "src/kits/ai/Banners/F0Callout/CalloutInternal.tsx": ["Close"],
+    "src/kits/ai/F0ActionItem/components/ChatSpinner.tsx": ["Loading"],
+    "src/kits/ai/F0AiChat/components/markdownRenderers/components/Image.tsx": [
+      "Download"
+    ],
+    "src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx": ["Enter", "Esc"],
+    "src/kits/Charts/CategoryBarChart/index.tsx": ["Category bar chart"],
+    "src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx": ["Value"],
+    "src/kits/surveys/SurveyFormBuilder/lib.ts": ["New option 1"],
+    "src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/ActionsMenu/useQuestionActions.ts": [
+      "Emojis"
+    ],
+    "src/lib/F0GridStack/components/grid-stack-provider.tsx": ["No content"],
+    "src/lib/xray.tsx": ["XRay"],
+    "src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx": [
+      "Drag to reorder"
+    ],
+    "src/patterns/F0AnalyticsDashboard/components/FilterBar/FilterBarSkeleton.tsx": [
+      "Loading filters"
+    ],
+    "src/patterns/F0Form/components/ActionBar.tsx": [
+      "Go to next error",
+      "Go to previous error"
+    ],
+    "src/patterns/F0Form/fields/date/DateTimeFieldRenderer.tsx": ["Time"],
+    "src/patterns/F0Form/fields/file/FileFieldRenderer.tsx": ["Text files"],
+    "src/patterns/Navigation/Sidebar/Icon/index.tsx": [
+      "Close Sidebar",
+      "Close Sidebar"
+    ],
+    "src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx": [
+      "Actions"
+    ],
+    "src/patterns/OneDataCollection/components/itemActions/ItemActionsDropdown/ItemActionsDropdown.tsx": [
+      "Actions"
+    ],
+    "src/patterns/OneDataCollection/components/itemActions/ItemActionsMobile/ItemActionsMobile.tsx": [
+      "Mobile Actions"
+    ],
+    "src/patterns/OneDataCollection/Settings/Settings.tsx": ["Settings"],
+    "src/patterns/OneDataCollection/visualizations.tsx": ["Filters"],
+    "src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx": [
+      "Loading card"
+    ],
+    "src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts": [
+      "Error fetching data"
+    ],
+    "src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx": [
+      "Next",
+      "Previous"
+    ],
+    "src/patterns/OneFilterPicker/components/FiltersControls.tsx": ["Back"],
+    "src/patterns/OneFilterPicker/filterTypes/DateFilter/DateFilter.tsx": [
+      "Clear"
+    ],
+    "src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx": [
+      "No options available"
+    ],
+    "src/sds/Home/ClockIn/ClockInControls/index.tsx": [
+      "Select break type",
+      "Select location"
+    ],
+    "src/sds/Home/DaytimePage/index.tsx": ["Open main menu"],
+    "src/sds/Home/NewHomeLayout/index.tsx": ["Open main menu"],
+    "src/sds/Home/WidgetCatalog/index.tsx": [
+      "Add widget",
+      "Add widget",
+      "Search widgets"
+    ],
+    "src/sds/Home/WidgetContainer/index.tsx": ["Actions"],
+    "src/sds/Home/WidgetUpdateDialog/index.tsx": ["Save"],
+    "src/sds/Profile/TasksList/index.tsx": ["No tasks assigned"],
+    "src/sds/social/Reactions/Picker/index.tsx": ["Add reaction"],
+    "src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx": [
+      "Next",
+      "Previous"
+    ],
+    "src/sds/UpsellingKit/ProductCard/index.tsx": ["Close"],
+    "src/sds/UpsellingKit/ProductModal/components/CustomModal.tsx": [
+      "Close modal"
+    ],
+    "src/sds/UpsellingKit/ProductWidget/index.tsx": ["Close"],
+    "src/ui/Action/Action.tsx": ["Loading..."],
+    "src/ui/breadcrumb.tsx": ["More"],
+    "src/ui/carousel.tsx": ["Carousel pagination", "Next", "Previous"],
+    "src/ui/DatePickerPopup/components/PresetList.tsx": ["Custom"],
+    "src/ui/DatePickerPopup/DatePickerPopup.tsx": ["Back"],
+    "src/ui/DatePickerPopup/presets.ts": [
+      "Last 3 months",
+      "Last 3 years",
+      "Last 6 months",
+      "Last 7 days",
+      "Last half year",
+      "Last month",
+      "Last quarter",
+      "Last week",
+      "Last year",
+      "This half year",
+      "This month",
+      "This quarter",
+      "This week",
+      "Today",
+      "Yesterday"
+    ],
+    "src/ui/F0Wizard/components/WizardSteps.tsx": ["Wizard steps"],
+    "src/ui/GroupHeader/GroupHeader.tsx": ["Select all"],
+    "src/ui/Lane/components/LaneHeader.tsx": ["Add"],
+    "src/ui/Lane/Lane.tsx": ["Add"],
+    "src/ui/OnePagination/index.tsx": ["Page navigation"],
+    "src/ui/pagination.tsx": ["Go to next page", "Go to previous page"],
+    "src/ui/Select/components/SelectItem.tsx": ["Select item"],
+    "src/ui/value-display/types/barSeries/barSeries.tsx": ["Bar series"],
+    "src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx": [
+      "Category bar chart"
+    ]
+  }
+}

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -227,10 +227,13 @@ renderers) imports the same constant.
 - Translation keys: camelCase, domain-namespaced (`actions.save`), `one`/`other` sub-keys for plurals
 - Missing keys: log `console.warn` and return the key string
 - **Never hardcode user-visible copy.** A string literal is untranslatable by construction — no consumer dictionary can reach it, so every locale renders English. This includes defaults: `label = "Actions"` and `{ label: "Today" }` in a lookup table are the same bug as `<span>Save</span>`.
+- **Check for an existing key before writing one.** Around 40% of the current debt is a string whose key already exists — someone hardcoded the English next to a key that already held it (`date.presets.last7Days` exists; `ui/DatePickerPopup/presets.ts` hardcodes `"Last 7 days"` and nothing reads the key). The check names the existing key when it finds one.
 - `pnpm check:untranslated-copy` enforces this, and blocks CI on copy a PR **adds**. Existing debt is baselined in `.scripts/untranslated-copy-debt.json`; the list may only shrink.
   - `--report` — the full inventory across `src/`
   - `--update` — rewrite the baseline (after translating something, to lock the win in)
+  - `--comment` — the PR-comment markdown CI posts
   - Genuinely untranslatable literal (brand name, keyboard key)? Put `i18n-exempt` in a comment on that line.
+- On a failing PR the offending lines are annotated **inline on the Files tab** (`::error file=,line=`) and summarised in a PR comment that separates "already has a key, swap it" from "needs a new key" — no digging through CI logs.
 
 See `f0-component-patterns` skill for `TranslationsType`, `defaultTranslations`, and pluralization examples.
 

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -226,6 +226,11 @@ renderers) imports the same constant.
 - `useI18n()` from `@/lib/providers/i18n` — returns direct property access and `t()` for dot-notation keys with `{{placeholder}}` interpolation
 - Translation keys: camelCase, domain-namespaced (`actions.save`), `one`/`other` sub-keys for plurals
 - Missing keys: log `console.warn` and return the key string
+- **Never hardcode user-visible copy.** A string literal is untranslatable by construction — no consumer dictionary can reach it, so every locale renders English. This includes defaults: `label = "Actions"` and `{ label: "Today" }` in a lookup table are the same bug as `<span>Save</span>`.
+- `pnpm check:untranslated-copy` enforces this, and blocks CI on copy a PR **adds**. Existing debt is baselined in `.scripts/untranslated-copy-debt.json`; the list may only shrink.
+  - `--report` — the full inventory across `src/`
+  - `--update` — rewrite the baseline (after translating something, to lock the win in)
+  - Genuinely untranslatable literal (brand name, keyboard key)? Put `i18n-exempt` in a comment on that line.
 
 See `f0-component-patterns` skill for `TranslationsType`, `defaultTranslations`, and pluralization examples.
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -52,6 +52,7 @@
     "check:bugfix-red-green": "tsx .scripts/check-bugfix-red-green.ts",
     "check:new-component-dod": "tsx .scripts/check-new-component-dod.ts",
     "check:stable-dod": "tsx .scripts/check-stable-dod.ts",
+    "check:untranslated-copy": "tsx .scripts/check-untranslated-copy.ts",
     "preflight": "tsx .scripts/pre-push-preflight.ts",
     "vitest": "vitest --project=unit",
     "vitest:ui": "vitest --project=unit --ui",


### PR DESCRIPTION
## Description

User-visible copy must come from the i18n layer (`useI18n()` / `t()`), but nothing stopped a string literal from being baked into a component — and a literal is untranslatable by construction, since no consumer dictionary can reach it and every locale renders English. This adds an AST-based scan over `packages/react/src` and wires it into CI as a blocking check, so a PR can no longer introduce untranslated copy. The codebase already contains 158 such strings, so the check is a ratchet against a recorded baseline rather than a hard wall: only copy a PR *adds* fails.

## Type of change

- [x] Other: CI check + tooling (no product code changes)

## What a failing PR looks like

The point of the check is that the author never has to open CI to understand it. On failure they get three things:

**1. Inline on the Files tab.** Each offending line is annotated via `::error file=,line=`, so the error sits on the exact line in the diff:

```
::error file=packages/react/src/ui/Lane/Lane.tsx,line=19,title=Untranslated copy::Untranslated copy: label = "Close". A key for this already exists — read actions.close instead of hardcoding it. If it must stay a literal, add an "i18n-exempt" comment on this line.
```

**2. A PR comment**, posted through the existing `add-or-update-pr-comment` action, split by what the author actually has to do:

> ### 2 already have a key — swap, don't write
>
> | Where | String | Read this instead |
> | --- | --- | --- |
> | `src/ui/Lane/Lane.tsx:19` | `Close` | `actions.close` |
> | `src/ui/Lane/Lane.tsx:19` | `Last 7 days` | `date.presets.last7Days` |
>
> ### 2 need a new key
>
> | Where | Bound to | String |
> | --- | --- | --- |
> | `src/ui/Lane/Lane.tsx:18` | `emptyMessage` | `Nothing here yet` |
> | `src/ui/Lane/Lane.tsx:18` | `hola` | `hey hey` |

**3. The job log**, with the same content plus the `↳ already translated as "actions.close"` hint per line.

That "already have a key" split is the useful part, and it came out of auditing the debt: **68 of the 158 existing sites (43%) hardcode a string whose key already exists.** `date.presets.last7Days` is in the dictionary, nothing reads it, and `ui/DatePickerPopup/presets.ts` hardcodes `"Last 7 days"` — so a consumer who translates `date.presets.*` sees no effect and no warning. Those are one-line swaps, not copywriting, so the check names the key rather than saying "go write one".

## Notes for reviewers

Escape hatch is an inline `i18n-exempt` comment rather than a PR label, so the claim lands in the diff where a reviewer can judge it.

Two scope calls worth a look:

- **`packages/react-native` is excluded.** It has 448 `.tsx` files but no i18n provider at all, so there is nothing for a literal to be "not translated into" yet. Extending the scan is a one-constant change once it gains a translation layer.
- **`src/component-status` is included**, and is the largest single slice (25 findings). It is a real build entry, but its copy is the developer-facing maturity dashboard in Storybook docs, not product UI. Left in rather than carving out an exemption; say the word and it drops the total to 133.

The current debt is 158 strings across 92 files, concentrated in `component-status` (25), `components/RichText` (23) and `ui/DatePickerPopup` (17). Full inventory:

```bash
pnpm --filter @factorialco/f0-react run check:untranslated-copy --report
```


