### PR TITLE
feat(ComboChart): fade the legend swatch of projected series

### DIFF
--- a/packages/react/src/kits/Charts/utils/ProjectedBar.tsx
+++ b/packages/react/src/kits/Charts/utils/ProjectedBar.tsx
@@ -1,6 +1,8 @@
 import { useId } from "react"
 import { Bar, BarProps, Rectangle, RectangleProps } from "recharts"
 
+import { projectedFade } from "@/ui/chart"
+
 type GradientSign = "positive" | "negative"
 
 type BarShapeProps = RectangleProps & {
@@ -67,12 +69,16 @@ const ProjectedBarComponent = ({
             <stop
               offset="0%"
               stopColor={barProps.fill}
-              stopOpacity={sign === "positive" ? 0.4 : 0.05}
+              stopOpacity={
+                sign === "positive" ? projectedFade.strong : projectedFade.faint
+              }
             />
             <stop
               offset="100%"
               stopColor={barProps.fill}
-              stopOpacity={sign === "positive" ? 0.05 : 0.4}
+              stopOpacity={
+                sign === "positive" ? projectedFade.faint : projectedFade.strong
+              }
             />
           </linearGradient>
         ))}

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -335,6 +335,13 @@ const ChartTooltipContent = React.forwardRef<
 
 ChartTooltipContent.displayName = "ChartTooltip"
 
+/**
+ * Opacity ramp shared by everything that renders a projected series: bars
+ * fade from `strong` at the tip to `faint` at the zero line, and the legend
+ * swatch mirrors the same gradient.
+ */
+const projectedFade = { strong: 0.4, faint: 0.05 } as const
+
 const ChartLegend = RechartsPrimitive.Legend
 
 const ChartLegendContent = React.forwardRef<
@@ -397,9 +404,13 @@ const ChartLegendContent = React.forwardRef<
                 itemConfig && (
                   <div
                     className="h-2 w-2 shrink-0 rounded-full"
-                    style={{
-                      backgroundColor: item.color,
-                    }}
+                    style={
+                      itemConfig.projected
+                        ? {
+                            background: `linear-gradient(to bottom, color-mix(in srgb, ${item.color} ${projectedFade.strong * 100}%, transparent), color-mix(in srgb, ${item.color} ${projectedFade.faint * 100}%, transparent))`,
+                          }
+                        : { backgroundColor: item.color }
+                    }
                   />
                 )
               )}
@@ -464,4 +475,5 @@ export {
   ChartStyle,
   ChartTooltip,
   ChartTooltipContent,
+  projectedFade,
 }


### PR DESCRIPTION
## Description

Legend swatches for series flagged as `projected` rendered in the solid series color, which made provisional series indistinguishable from actual ones in the legend. The swatch now renders the same fading gradient as the projected bars.

## Screenshots (if applicable)

See the `Kits/Charts/ComboChart → ProjectedBars` story in Storybook: the "Forecast growth" and "Forecast attrition" legend dots render faded while solid series keep their color.

## Implementation details

- feat: render the legend dot of projected series with a `linear-gradient` + `color-mix` version of the series color, matching the bar fade
- refactor: extract the gradient opacity ramp into a shared `projectedFade` constant used by both `ProjectedBar` and the legend, so they cannot drift apart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<img width="473" height="250" alt="Captura de pantalla 2026-08-26 a las 14 19 01" src="https://github.com/user-attachments/assets/4a7c968f-d358-4c72-afe0-c5b46bdc510b" />
