### PR TITLE
chore(react): exempt component-status from the i18n gate

### DIFF
--- a/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
+++ b/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
@@ -243,6 +243,8 @@ describe("excluded paths", () => {
     "mocks/people.ts",
     "lib/providers/i18n/i18n-provider-defaults.ts",
     "lib/storybook-utils/do-donts.tsx",
+    "component-status/A11yRow.tsx",
+    "component-status/component-status.ts",
   ])("excludes %s", (path) => {
     expect(isExcludedPath(path)).toBe(true)
   })

--- a/packages/react/.scripts/check-untranslated-copy.ts
+++ b/packages/react/.scripts/check-untranslated-copy.ts
@@ -88,6 +88,13 @@ const EXCLUDED_PATHS: RegExp[] = [
   // Sample data, harnesses and Storybook helpers.
   /(^|\/)(mocks|testing|examples)\//,
   /(^|\/)lib\/storybook-utils\//,
+  // The component-maturity dashboard. It ships (component-status is a build
+  // entry) but its audience is f0 contributors reading the Storybook docs, not
+  // end users of a product built on f0 — "Has unit tests", "Maturity level",
+  // "DoDont examples with realistic Factorial copy". Excluded as a module
+  // rather than line by line: the audience is a property of the whole
+  // dashboard, so a per-line marker would just get re-litigated on every edit.
+  /^component-status\//,
   // The dictionary itself: these literals ARE the translations.
   /(^|\/)lib\/providers\/i18n\//,
 ]

--- a/packages/react/.scripts/untranslated-copy-debt.json
+++ b/packages/react/.scripts/untranslated-copy-debt.json
@@ -1,36 +1,7 @@
 {
   "note": "Untranslated user-visible copy in packages/react/src — string literals that should come from the i18n layer (src/lib/providers/i18n) instead. Enforced by .scripts/check-untranslated-copy.ts. This list may only shrink: translate a string and remove it from here (or run \"--update\"), never add one.",
-  "total": 158,
+  "total": 133,
   "files": {
-    "src/component-status/A11yRow.tsx": [
-      "Accessibility",
-      "Accessibility",
-      "Accessibility",
-      "Check the rendered stories",
-      "Checked in each story’s default state — violations behind interactions (open menus, dialogs) aren’t shown here. CI enforces the full set, including play-function states.",
-      "Checking the rendered stories…",
-      "Live results are available on the Storybook docs page. See the story’s",
-      "No violations in the stories’ default state.",
-      "tab for per-element detail.",
-      "· WCAG"
-    ],
-    "src/component-status/component-status.ts": [
-      "A \"when not to use\" section",
-      "A Storybook play function (interaction test) covering the primary user flow.",
-      "Accessibility enforced",
-      "At least three named example stories",
-      "DoDont examples with realistic Factorial copy",
-      "Docs at the Good tier build on the Acceptable base and add:",
-      "Has MDX documentation",
-      "Has Storybook stories",
-      "Has a play function",
-      "Has a visual snapshot story",
-      "Has unit tests",
-      "Named with the \"F0\" prefix",
-      "No tag",
-      "Required sections (Anatomy, Guidelines, Accessibility) and a props table"
-    ],
-    "src/component-status/ComponentStability.tsx": ["Maturity level"],
     "src/components/F0Card/components/CardMetadata.tsx": [
       "Unsupported property type:"
     ],


### PR DESCRIPTION
## Description

Follow-up to #5262. The component-maturity dashboard is developer-facing: its audience is f0 contributors reading the Storybook docs, not end users of a product built on f0. Its 25 flagged strings are things like "Has unit tests", "Maturity level" and "DoDont examples with realistic Factorial copy" — translating them would be meaningless work. Exempting the module drops the tracked debt from 158 to 133, all of which is now genuinely product copy.

## Type of change

- [x] Other: tooling configuration (no product code changes)

## Notes for reviewers

Adds no translation keys, so no API-surface impact.

If you'd rather keep the dashboard in scope, revert the one regex and run `pnpm --filter @factorialco/f0-react run check:untranslated-copy --update`; the 25 strings go back to sitting in the baseline, which is where they are today.
