### PR TITLE
refactor(react): read shared i18n keys instead of hardcoding 27 strings

### DIFF
--- a/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
+++ b/packages/react/.scripts/__tests__/check-untranslated-copy.test.ts
@@ -365,16 +365,34 @@ describe("suggesting an existing key", () => {
   const index = new Map([
     ["close", ["actions.close", "chat.closePreview"]],
     ["last 7 days", ["date.presets.last7Days"]],
-    ["next", ["navigation.next", "ai.clarifyingQuestion.next"]],
+    ["next", ["ai.clarifyingQuestion.next", "navigation.next"]],
+    ["back", ["chat.back", "ai.clarifyingQuestion.back"]],
   ])
 
   it("finds a key whose English matches, case-insensitively", () => {
-    expect(suggestKey("Close", index)).toBe("actions.close")
-    expect(suggestKey("last 7 DAYS", index)).toBe("date.presets.last7Days")
+    expect(suggestKey("Close", index)).toEqual({
+      key: "actions.close",
+      generic: true,
+    })
+    expect(suggestKey("last 7 DAYS", index)).toEqual({
+      key: "date.presets.last7Days",
+      generic: false,
+    })
   })
 
-  it("prefers the shallowest key when several hold the same English", () => {
-    expect(suggestKey("Next", index)).toBe("navigation.next")
+  it("prefers a shared namespace over a deeper feature key", () => {
+    // Depth alone picked wizard.previous for a date navigator.
+    expect(suggestKey("Next", index)).toEqual({
+      key: "navigation.next",
+      generic: true,
+    })
+  })
+
+  it("marks a feature-scoped key as not safe to borrow", () => {
+    expect(suggestKey("Back", index)).toEqual({
+      key: "chat.back",
+      generic: false,
+    })
   })
 
   it("returns nothing for a string the dictionary has never seen", () => {
@@ -427,34 +445,64 @@ describe("CI surfaces", () => {
     expect(annotations(wrapped)[0].split("\n")).toHaveLength(1)
   })
 
-  it("names the existing key in the annotation when there is one", () => {
+  it("names a shared key in the annotation as a straight swap", () => {
     const [line] = annotations([
-      added({ value: "Close", existingKey: "actions.close" }),
+      added({
+        value: "Close",
+        existingKey: "actions.close",
+        existingKeyIsGeneric: true,
+      }),
     ])
 
     expect(line).toContain("actions.close")
-    expect(line).toContain("A key for this already exists")
+    expect(line).toContain("A shared key already exists")
+  })
+
+  it("hedges when the only match is in another feature's namespace", () => {
+    const [line] = annotations([
+      added({
+        value: "Back",
+        existingKey: "chat.back",
+        existingKeyIsGeneric: false,
+      }),
+    ])
+
+    expect(line).toContain("chat.back")
+    expect(line).toContain("another feature's namespace")
+    // Must not read as an instruction to just use it.
+    expect(line).not.toContain("A shared key already exists")
   })
 
   it("tells you to write a key when none exists", () => {
     expect(fixHint(added({ value: "Nothing here yet" }))).toContain("Add a key")
   })
 
-  it("splits the comment into swap-a-key and write-a-key", () => {
+  it("splits the comment three ways by how reusable the key is", () => {
     const md = commentMarkdown({
       added: [
-        added({ value: "Close", existingKey: "actions.close" }),
+        added({
+          value: "Close",
+          existingKey: "actions.close",
+          existingKeyIsGeneric: true,
+        }),
+        added({
+          value: "Back",
+          existingKey: "chat.back",
+          existingKeyIsGeneric: false,
+        }),
         added({ value: "Nothing here yet", name: "emptyMessage", line: 18 }),
       ],
       fixed: {},
       staleFiles: [],
-      total: 160,
+      total: 161,
       baselineTotal: 158,
     })
 
-    expect(md).toContain("2 untranslated strings added")
-    expect(md).toContain("1 already have a key")
+    expect(md).toContain("3 untranslated strings added")
+    expect(md).toContain("1 can reuse a shared key")
     expect(md).toContain("`actions.close`")
+    expect(md).toContain("1 already translated in another feature")
+    expect(md).toContain("`chat.back`")
     expect(md).toContain("1 needs a new key")
     expect(md).toContain("`emptyMessage`")
     // The escape hatch must be discoverable from the comment alone.

--- a/packages/react/.scripts/check-untranslated-copy.ts
+++ b/packages/react/.scripts/check-untranslated-copy.ts
@@ -237,6 +237,13 @@ export interface Finding {
    * turns "go write a key" into a one-line swap.
    */
   existingKey?: string
+  /**
+   * Whether `existingKey` sits in a domain-neutral namespace (`actions.*`,
+   * `navigation.*`, `common.*`) and so is safe to read from anywhere. When
+   * false the key belongs to another feature: proof the copy is translated
+   * somewhere, but not a licence to borrow it.
+   */
+  existingKeyIsGeneric?: boolean
 }
 
 /** English value (lowercased) → dot-notation keys that already hold it. */
@@ -259,19 +266,36 @@ export function buildKeyIndex(
 }
 
 /**
- * Pick the key to suggest when several hold the same English. Prefer the
- * shallowest, then the shortest — `actions.close` reads as the reusable one,
- * `chat.closePreview` as a local coincidence.
+ * Namespaces whose copy is deliberately domain-neutral, so any component may
+ * read them. Every other namespace is scoped to a feature, and borrowing across
+ * features is a bug waiting to happen: a product translating `chat.back` does
+ * not expect the filter picker's Back button to change with it.
+ */
+const GENERIC_NAMESPACE = /^(actions|navigation|common)\./
+
+/**
+ * Pick the key to suggest when several hold the same English, and say whether it
+ * is safe to reuse anywhere.
+ *
+ * A generic key always wins. Otherwise the shallowest feature key comes back
+ * with `generic: false` — still worth surfacing, since it proves the copy is
+ * already translated somewhere, but only reusable when it is the same feature.
+ * Depth alone is not enough to decide: it happily picked `ai.today` for a date
+ * preset and `wizard.previous` for a date navigator.
  */
 export function suggestKey(
   value: string,
   index: Map<string, string[]>
-): string | undefined {
+): { key: string; generic: boolean } | undefined {
   const candidates = index.get(value.toLowerCase())
   if (!candidates?.length) return undefined
-  return [...candidates].sort(
+  const byDepth = [...candidates].sort(
     (a, b) => a.split(".").length - b.split(".").length || a.length - b.length
-  )[0]
+  )
+  const generic = byDepth.find((k) => GENERIC_NAMESPACE.test(k))
+  return generic
+    ? { key: generic, generic: true }
+    : { key: byDepth[0], generic: false }
 }
 
 /** Strip HTML entities so `&nbsp;` does not read as a word. */
@@ -464,8 +488,14 @@ export function attachExistingKeys(
   index: Map<string, string[]> = buildKeyIndex()
 ): Finding[] {
   return findings.map((finding) => {
-    const existingKey = suggestKey(finding.value, index)
-    return existingKey ? { ...finding, existingKey } : finding
+    const match = suggestKey(finding.value, index)
+    return match
+      ? {
+          ...finding,
+          existingKey: match.key,
+          existingKeyIsGeneric: match.generic,
+        }
+      : finding
   })
 }
 
@@ -607,9 +637,12 @@ const repoPath = (f: Finding) => `packages/react/${f.file}`
 
 /** The one-line "what to do about it" for a single finding. */
 export function fixHint(finding: Finding): string {
-  return finding.existingKey
-    ? `A key for this already exists — read \`${finding.existingKey}\` instead of hardcoding it.`
-    : "Add a key to `i18n-provider-defaults.ts` and read it with `useI18n()`/`t()`."
+  if (!finding.existingKey) {
+    return "Add a key to `i18n-provider-defaults.ts` and read it with `useI18n()`/`t()`."
+  }
+  return finding.existingKeyIsGeneric
+    ? `A shared key already exists — read \`${finding.existingKey}\` instead of hardcoding it.`
+    : `\`${finding.existingKey}\` already holds this text, but in another feature's namespace. Reuse it only if that is the same feature; otherwise add a key in yours.`
 }
 
 /**
@@ -644,7 +677,10 @@ export function commentMarkdown(result: CheckResult): string {
     ].join("\n")
   }
 
-  const reusable = added.filter((f) => f.existingKey)
+  const reusable = added.filter((f) => f.existingKeyIsGeneric)
+  const elsewhere = added.filter(
+    (f) => f.existingKey && !f.existingKeyIsGeneric
+  )
   const fresh = added.filter((f) => !f.existingKey)
   const lines = [
     `## ❌ ${added.length} untranslated string${added.length === 1 ? "" : "s"} added`,
@@ -655,11 +691,27 @@ export function commentMarkdown(result: CheckResult): string {
 
   if (reusable.length > 0) {
     lines.push(
-      `### ${reusable.length} already have a key — swap, don't write`,
+      `### ${reusable.length} can reuse a shared key — swap, don't write`,
       "",
       "| Where | String | Read this instead |",
       "| --- | --- | --- |",
       ...reusable.map(
+        (f) =>
+          `| \`${f.file}:${f.line}\` | \`${f.value}\` | \`${f.existingKey}\` |`
+      ),
+      ""
+    )
+  }
+
+  if (elsewhere.length > 0) {
+    lines.push(
+      `### ${elsewhere.length} already translated in another feature — check before borrowing`,
+      "",
+      "These keys hold the same English, but under another feature's namespace. Reuse one only if it is the same feature; otherwise add a key in yours, or promote the copy to `actions.*`/`navigation.*` if it is genuinely shared.",
+      "",
+      "| Where | String | Same text lives at |",
+      "| --- | --- | --- |",
+      ...elsewhere.map(
         (f) =>
           `| \`${f.file}:${f.line}\` | \`${f.value}\` | \`${f.existingKey}\` |`
       ),
@@ -783,21 +835,26 @@ export function reportResult(result: CheckResult): boolean {
       `${result.added.length} new untranslated string(s) — copy must come from ` +
         "the i18n layer, not a literal:"
     )
-    const reusable = result.added.filter((f) => f.existingKey)
+    const reusable = result.added.filter((f) => f.existingKeyIsGeneric)
     for (const finding of result.added) {
       consola.log(
         `    ${finding.file}:${finding.line} — ${finding.name} = ` +
           `${JSON.stringify(finding.value)} (${KIND_LABEL[finding.kind]})`
       )
-      if (finding.existingKey) {
-        consola.log(`      ↳ already translated as "${finding.existingKey}"`)
+      if (finding.existingKeyIsGeneric) {
+        consola.log(`      ↳ read the shared key "${finding.existingKey}"`)
+      } else if (finding.existingKey) {
+        consola.log(
+          `      ? same text at "${finding.existingKey}" — another feature's ` +
+            "namespace, borrow only if it is the same feature"
+        )
       }
     }
     consola.log("")
     if (reusable.length > 0) {
       consola.log(
-        `  ${reusable.length} of these already have a key (marked ↳ above) — ` +
-          "read that key instead of hardcoding the English."
+        `  ${reusable.length} of these can read a shared key (marked ↳ above) — ` +
+          "use it instead of hardcoding the English."
       )
     }
     consola.log(

--- a/packages/react/.scripts/untranslated-copy-debt.json
+++ b/packages/react/.scripts/untranslated-copy-debt.json
@@ -1,11 +1,10 @@
 {
   "note": "Untranslated user-visible copy in packages/react/src — string literals that should come from the i18n layer (src/lib/providers/i18n) instead. Enforced by .scripts/check-untranslated-copy.ts. This list may only shrink: translate a string and remove it from here (or run \"--update\"), never add one.",
-  "total": 133,
+  "total": 106,
   "files": {
     "src/components/F0Card/components/CardMetadata.tsx": [
       "Unsupported property type:"
     ],
-    "src/components/F0InputField/F0InputField.tsx": ["Clear"],
     "src/components/F0Link/F0Link.tsx": ["(opens in new tab)"],
     "src/components/F0NumberInput/components/Arrows.tsx": [
       "Decrease",
@@ -16,12 +15,10 @@
       "AD",
       "AD"
     ],
-    "src/components/OneChip/index.tsx": ["Close"],
     "src/components/RichText/F0NotesTextEditor/F0NotesTextEditor.tsx": [
       "Add paragraph"
     ],
     "src/components/RichText/F0RichTextEditor/components/FileList/index.tsx": [
-      "Delete",
       "Upload file"
     ],
     "src/components/RichText/F0RichTextEditor/components/Footer/index.tsx": [
@@ -63,13 +60,7 @@
       "Link popup"
     ],
     "src/deprecated/EntitySelect/Content/MainContent/index.tsx": ["Group"],
-    "src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx": ["Clear"],
     "src/experimental/Lists/OnePersonListItem/index.tsx": ["Secondary"],
-    "src/experimental/Navigation/Carousel/DynamicCarousel/index.tsx": [
-      "Next",
-      "Previous"
-    ],
-    "src/experimental/Navigation/Dropdown/index.tsx": ["Other actions"],
     "src/experimental/Navigation/F0TableOfContent/index.tsx": ["Drop here"],
     "src/experimental/Navigation/F0TableOfContent/Item/ItemDropDown.tsx": [
       "Actions"
@@ -81,11 +72,6 @@
       "Back",
       "Open main menu"
     ],
-    "src/experimental/Navigation/Header/PageNavigation/index.tsx": [
-      "Next",
-      "Previous"
-    ],
-    "src/experimental/Navigation/Header/ProductUpdates/index.tsx": ["Close"],
     "src/experimental/OneTable/TableHead/index.tsx": ["Sort"],
     "src/experimental/Widgets/Widget/index.tsx": ["Actions"],
     "src/hooks/datasource/itemNeighbors/useItemNeighbors.ts": [
@@ -96,9 +82,6 @@
       "Error fetching data",
       "Error fetching data"
     ],
-    "src/kits/ai/Banners/BaseBanner/index.tsx": ["Close"],
-    "src/kits/ai/Banners/F0AiBanner/AiBannerInternal.tsx": ["Close"],
-    "src/kits/ai/Banners/F0Callout/CalloutInternal.tsx": ["Close"],
     "src/kits/ai/F0ActionItem/components/ChatSpinner.tsx": ["Loading"],
     "src/kits/ai/F0AiChat/components/markdownRenderers/components/Image.tsx": [
       "Download"
@@ -145,14 +128,7 @@
     "src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts": [
       "Error fetching data"
     ],
-    "src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx": [
-      "Next",
-      "Previous"
-    ],
     "src/patterns/OneFilterPicker/components/FiltersControls.tsx": ["Back"],
-    "src/patterns/OneFilterPicker/filterTypes/DateFilter/DateFilter.tsx": [
-      "Clear"
-    ],
     "src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx": [
       "No options available"
     ],
@@ -168,21 +144,13 @@
       "Search widgets"
     ],
     "src/sds/Home/WidgetContainer/index.tsx": ["Actions"],
-    "src/sds/Home/WidgetUpdateDialog/index.tsx": ["Save"],
     "src/sds/Profile/TasksList/index.tsx": ["No tasks assigned"],
     "src/sds/social/Reactions/Picker/index.tsx": ["Add reaction"],
-    "src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx": [
-      "Next",
-      "Previous"
-    ],
-    "src/sds/UpsellingKit/ProductCard/index.tsx": ["Close"],
     "src/sds/UpsellingKit/ProductModal/components/CustomModal.tsx": [
       "Close modal"
     ],
-    "src/sds/UpsellingKit/ProductWidget/index.tsx": ["Close"],
     "src/ui/Action/Action.tsx": ["Loading..."],
-    "src/ui/breadcrumb.tsx": ["More"],
-    "src/ui/carousel.tsx": ["Carousel pagination", "Next", "Previous"],
+    "src/ui/carousel.tsx": ["Carousel pagination"],
     "src/ui/DatePickerPopup/components/PresetList.tsx": ["Custom"],
     "src/ui/DatePickerPopup/DatePickerPopup.tsx": ["Back"],
     "src/ui/DatePickerPopup/presets.ts": [
@@ -203,9 +171,6 @@
       "Yesterday"
     ],
     "src/ui/F0Wizard/components/WizardSteps.tsx": ["Wizard steps"],
-    "src/ui/GroupHeader/GroupHeader.tsx": ["Select all"],
-    "src/ui/Lane/components/LaneHeader.tsx": ["Add"],
-    "src/ui/Lane/Lane.tsx": ["Add"],
     "src/ui/OnePagination/index.tsx": ["Page navigation"],
     "src/ui/pagination.tsx": ["Go to next page", "Go to previous page"],
     "src/ui/Select/components/SelectItem.tsx": ["Select item"],

--- a/packages/react/src/components/F0InputField/F0InputField.tsx
+++ b/packages/react/src/components/F0InputField/F0InputField.tsx
@@ -17,6 +17,7 @@ import { AvatarVariant } from "@/components/avatars/F0Avatar/types"
 import { F0ButtonToggle } from "@/components/F0ButtonToggle/F0ButtonToggle"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { CrossedCircle } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils.ts"
 import { Spinner } from "@/ui/Spinner"
 
@@ -284,6 +285,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
     }: InputFieldProps<string>,
     ref
   ) => {
+    const i18n = useI18n()
     const generatedId = useId()
     const id = props.id ?? generatedId
 
@@ -581,7 +583,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                           "flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded-full p-0",
                           focusRing()
                         )}
-                        aria-label="Clear"
+                        aria-label={i18n.actions.clear}
                         type="button"
                         tabIndex={0}
                         data-testid="clear-button"

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -5,6 +5,7 @@ import { F0Avatar, type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { F0Icon, type IconType } from "@/components/F0Icon"
 import { CrossedCircle } from "@/icons/app"
 import { experimentalComponent } from "@/lib/experimental"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
 
 export const chipVariants = cva({
@@ -74,6 +75,7 @@ const _Chip = ({
   avatar,
   icon,
 }: ChipProps) => {
+  const i18n = useI18n()
   const closeDescriptionId = useId()
   const content = (
     <>
@@ -128,7 +130,7 @@ const _Chip = ({
             focusRing()
           )}
           tabIndex={0}
-          aria-label="Close"
+          aria-label={i18n.actions.close}
           aria-describedby={closeDescriptionId}
         >
           <F0Icon icon={CrossedCircle} size="sm" />

--- a/packages/react/src/components/RichText/F0RichTextEditor/components/FileList/index.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/components/FileList/index.tsx
@@ -1,6 +1,7 @@
 import { AnimatePresence, motion } from "motion/react"
 
 import { F0FileItem } from "@/components/F0FileItem"
+import { useI18n } from "@/lib/providers/i18n"
 
 import { UPLOAD_INPUT_ID } from "../../utils/constants"
 import {
@@ -25,6 +26,8 @@ const FileList = ({
   disabled,
   fileInputRef,
 }: FileListProps) => {
+  const i18n = useI18n()
+
   if (!filesConfig) return null
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -71,7 +74,7 @@ const FileList = ({
                   file={file}
                   actions={[
                     {
-                      label: "Delete",
+                      label: i18n.actions.delete,
                       onClick: () =>
                         handleRemoveFile(index, files, filesConfig, setFiles),
                     },

--- a/packages/react/src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx
@@ -308,7 +308,7 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
                     "flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full p-0",
                     focusRing()
                   )}
-                  aria-label="Clear"
+                  aria-label={i18n.actions.clear}
                   type="button"
                   tabIndex={0}
                   data-testid="clear-button"

--- a/packages/react/src/experimental/Navigation/Carousel/DynamicCarousel/index.tsx
+++ b/packages/react/src/experimental/Navigation/Carousel/DynamicCarousel/index.tsx
@@ -2,12 +2,14 @@ import { PropsWithChildren, useLayoutEffect, useRef, useState } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { ChevronLeft, ChevronRight } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
 export const SPACE_FOR_WIDGET_SHADOW = 28
 const GAP = 16
 
 export const DynamicCarousel = ({ children }: PropsWithChildren) => {
+  const i18n = useI18n()
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const [canScrollNext, setCanScrollNext] = useState(true)
   const [canScrollPrev, setCanScrollPrev] = useState(false)
@@ -127,7 +129,7 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
           )}
           onClick={scrollPrev}
           icon={ChevronLeft}
-          label="Previous"
+          label={i18n.navigation.previous}
           hideLabel
         ></ButtonInternal>
       )}
@@ -143,7 +145,7 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
           )}
           onClick={scrollNext}
           icon={ChevronRight}
-          label="Next"
+          label={i18n.navigation.next}
           hideLabel
         ></ButtonInternal>
       )}

--- a/packages/react/src/experimental/Navigation/Dropdown/index.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.tsx
@@ -6,6 +6,7 @@ import { EllipsisHorizontal } from "@/icons/app"
 import { DataTestIdWrapper, WithDataTestIdProps } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { Link } from "@/lib/linkHandler"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils.ts"
 import {
   Drawer,
@@ -60,6 +61,7 @@ export const Dropdown = experimentalComponent("Dropdown", _Dropdown)
 export type { DropdownItem, DropdownItemLabel, DropdownItemObject }
 
 const _MobileDropdown = ({ items, children, dataTestId }: DropdownProps) => {
+  const i18n = useI18n()
   const [open, setOpen] = useState(false)
 
   return (
@@ -68,7 +70,7 @@ const _MobileDropdown = ({ items, children, dataTestId }: DropdownProps) => {
         <DrawerTrigger asChild>
           {children || (
             <ButtonInternal
-              label="Other actions"
+              label={i18n.actions.other}
               icon={EllipsisHorizontal}
               variant="outline"
               size="lg"

--- a/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
@@ -1,6 +1,7 @@
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { IconType } from "@/components/F0Icon"
 import { ChevronLeft, ChevronRight } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 
 /**
  * One prev/next target. Carry a `url` for full-page detail navigation
@@ -69,6 +70,8 @@ function PageNavigationLink({
 }
 
 export function PageNavigation({ previous, next, counter }: NavigationProps) {
+  const i18n = useI18n()
+
   return (
     <div className="flex items-center gap-3">
       {counter && (
@@ -80,12 +83,12 @@ export function PageNavigation({ previous, next, counter }: NavigationProps) {
         <PageNavigationLink
           icon={ChevronLeft}
           target={previous}
-          fallbackLabel="Previous"
+          fallbackLabel={i18n.navigation.previous}
         />
         <PageNavigationLink
           icon={ChevronRight}
           target={next}
-          fallbackLabel="Next"
+          fallbackLabel={i18n.navigation.next}
         />
       </div>
     </div>

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/ui/dropdown-menu"
+import { useI18n } from "@/lib/providers/i18n"
 import { Skeleton } from "@/ui/skeleton"
 
 type ProductUpdate = {
@@ -442,6 +443,7 @@ const DiscoverMoreProducts = ({
   crossSelling: ProductUpdatesProp["crossSelling"]
   onDropdownClose: () => void
 }) => {
+  const i18n = useI18n()
   const [open, setOpen] = useState(isVisible)
 
   useEffect(() => {
@@ -481,7 +483,7 @@ const DiscoverMoreProducts = ({
                   size="sm"
                   hideLabel
                   onClick={handleClose}
-                  label="Close"
+                  label={i18n.actions.close}
                 />
               </div>
             )}

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
@@ -6,6 +6,7 @@ import CrossIcon from "@/icons/app/Cross"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
 import { cn } from "@/lib/utils"
+import { useI18n } from "@/lib/providers/i18n"
 import { Skeleton } from "@/ui/skeleton"
 
 export type BannerAction = {
@@ -42,6 +43,7 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
     },
     ref
   ) {
+    const i18n = useI18n()
     const isVideo = mediaUrl?.includes(".mp4")
     const [isDismissed, setIsDismissed] = useState(false)
 
@@ -129,7 +131,7 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
               size="sm"
               hideLabel
               onClick={handleClose}
-              label="Close"
+              label={i18n.actions.close}
             />
           </div>
         )}

--- a/packages/react/src/kits/ai/Banners/F0AiBanner/AiBannerInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiBanner/AiBannerInternal.tsx
@@ -5,6 +5,7 @@ import { OneEllipsis } from "@/lib/OneEllipsis"
 import { F0RichTextDisplay } from "@/components/RichText/F0RichTextDisplay"
 import { Cross } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { useI18n } from "@/lib/providers/i18n"
 import { Skeleton } from "@/ui/skeleton"
 
 import { AiBannerInternalProps, AiBannerSkeletonProps } from "./types"
@@ -16,6 +17,8 @@ export const AiBannerInternal = forwardRef<
   { title, onClose, content, primaryAction, secondaryAction },
   ref
 ) {
+  const i18n = useI18n()
+
   return (
     <div
       ref={ref}
@@ -31,7 +34,7 @@ export const AiBannerInternal = forwardRef<
             size="sm"
             hideLabel
             onClick={onClose}
-            label="Close"
+            label={i18n.actions.close}
           />
         )}
       </div>

--- a/packages/react/src/kits/ai/Banners/F0Callout/CalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/CalloutInternal.tsx
@@ -6,6 +6,7 @@ import { F0Icon, IconType } from "@/components/F0Icon"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { CheckCircle, Cross, InfoCircle, Warning } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { useI18n } from "@/lib/providers/i18n"
 import { Skeleton } from "@/ui/skeleton"
 
 import { CalloutInternalProps, CalloutSkeletonProps } from "./types"
@@ -43,6 +44,8 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
     { title, onClose, children, actions = [], variant },
     ref
   ) {
+    const i18n = useI18n()
+
     // Validate actions limit
     if (actions.length > 2) {
       throw new Error(
@@ -80,7 +83,7 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
               size="sm"
               hideLabel
               onClick={onClose}
-              label="Close"
+              label={i18n.actions.close}
             />
           )}
         </div>

--- a/packages/react/src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -177,7 +177,7 @@ const DateNavigatorTrigger = forwardRef<
               size="sm"
               variant="ghost"
               icon={ChevronLeft}
-              label="Previous"
+              label={i18n.navigation.previous}
               hideLabel
               disabled={!nextPrev?.prev}
               onClick={() => handleNavigation(nextPrev?.prev ?? false)}
@@ -197,7 +197,7 @@ const DateNavigatorTrigger = forwardRef<
             <F0Button
               variant="ghost"
               icon={ChevronRight}
-              label="Next"
+              label={i18n.navigation.next}
               hideLabel
               size="sm"
               fontSize="md"

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/DateFilter/DateFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/DateFilter/DateFilter.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/OneCalendar/types"
 
 import { FilterTypeComponentProps } from "../types"
+import { useI18n } from "@/lib/providers/i18n"
 
 export type DateFilterOptions = {
   minDate?: Date
@@ -34,6 +35,7 @@ export function DateFilter({
   schema,
   isCompactMode,
 }: DateFilterComponentProps) {
+  const i18n = useI18n()
   const options = {
     mode: "single" as const,
     view: "day" as const,
@@ -60,7 +62,7 @@ export function DateFilter({
         <div className="sticky bottom-0 left-0 right-0 z-20 flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary bg-f1-background/80 p-2 backdrop-blur-[8px]">
           <F0Button
             variant="ghost"
-            label="Clear"
+            label={i18n.actions.clear}
             onClick={() => clear()}
             disabled={!value}
             size="sm"

--- a/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetUpdateDialog/index.tsx
@@ -56,6 +56,7 @@ export interface WidgetUpdateDialogProps {
   previewWidth?: number
   /** Defaults to the provider's `t.widgets.editParamsTitle`. */
   title?: string
+  /** Defaults to the provider's `t.actions.save`. */
   saveLabel?: string
 }
 
@@ -84,7 +85,7 @@ export function WidgetUpdateDialog({
   onSave,
   previewWidth = 396,
   title,
-  saveLabel = "Save",
+  saveLabel,
 }: WidgetUpdateDialogProps) {
   const t = useI18n()
   const { position, width, bodyClassName, asideClassName } =
@@ -112,7 +113,7 @@ export function WidgetUpdateDialog({
       position={position}
       width={width}
       primaryAction={{
-        label: saveLabel,
+        label: saveLabel ?? t.actions.save,
         // Validation before saving is the FORM's, not ours: `trigger` surfaces
         // the same errors the fields would show, and a schema that says a param
         // is required is the only place "you must set this" is written down.

--- a/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
@@ -6,6 +6,7 @@ import { F0Icon } from "@/components/F0Icon"
 import CrossIcon from "@/icons/app/Cross"
 import { One } from "@/icons/special"
 import { withDataTestId } from "@/lib/data-testid"
+import { useI18n } from "@/lib/providers/i18n"
 
 export type ProductCardProps = {
   title: string
@@ -37,6 +38,7 @@ function _ProductCard({
   type,
   ...props
 }: ProductCardProps) {
+  const i18n = useI18n()
   const [open, setOpen] = useState(isVisible)
 
   useEffect(() => {
@@ -124,7 +126,7 @@ function _ProductCard({
                     size="sm"
                     hideLabel
                     onClick={handleClose}
-                    label="Close"
+                    label={i18n.actions.close}
                   />
                 </div>
               )}

--- a/packages/react/src/sds/UpsellingKit/ProductWidget/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductWidget/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react"
 
 import { ButtonVariant, F0Button } from "@/components/F0Button"
 import { withDataTestId } from "@/lib/data-testid"
+import { useI18n } from "@/lib/providers/i18n"
 import CrossIcon from "@/icons/app/Cross"
 import { Card, CardContent, CardFooter } from "@/ui/Card"
 import { Label } from "@/ui/label"
@@ -59,6 +60,7 @@ function _ProductWidget({
   actions,
   showConfirmation = true,
 }: ProductWidgetProps) {
+  const i18n = useI18n()
   const [isDismissed, setIsDismissed] = useState(false)
 
   const handleClose = () => {
@@ -89,7 +91,7 @@ function _ProductWidget({
                   size="sm"
                   hideLabel
                   onClick={handleClose}
-                  label="Close"
+                  label={i18n.actions.close}
                 />
               </div>
             )}

--- a/packages/react/src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx
+++ b/packages/react/src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx
@@ -113,7 +113,7 @@ export const F0QuestionCardMultiStep = ({
                 onClick={handlePrev}
                 disabled={currentStep <= 0}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded text-f1-foreground-secondary transition-colors hover:bg-f1-background-tertiary hover:text-f1-foreground disabled:pointer-events-none disabled:opacity-50"
-                aria-label="Previous"
+                aria-label={translations.navigation.previous}
               >
                 <F0Icon icon={ChevronLeft} size="sm" />
               </button>
@@ -125,7 +125,7 @@ export const F0QuestionCardMultiStep = ({
                 onClick={handleNext}
                 disabled={currentStep >= totalSteps - 1}
                 className="flex h-8 w-8 shrink-0 items-center justify-center rounded text-f1-foreground-secondary transition-colors hover:bg-f1-background-tertiary hover:text-f1-foreground disabled:pointer-events-none disabled:opacity-50"
-                aria-label="Next"
+                aria-label={translations.navigation.next}
               >
                 <F0Icon icon={ChevronRight} size="sm" />
               </button>

--- a/packages/react/src/ui/GroupHeader/GroupHeader.tsx
+++ b/packages/react/src/ui/GroupHeader/GroupHeader.tsx
@@ -6,6 +6,7 @@ import { Counter } from "@/ui/Counter"
 import { cn, focusRing } from "@/lib/utils"
 import { ChevronToggle } from "@/ui/ChevronToggle/ChevronToggle"
 import { Skeleton } from "@/ui/skeleton"
+import { useI18n } from "@/lib/providers/i18n"
 
 type GroupHeaderProps = {
   label: string | Promise<string>
@@ -36,6 +37,7 @@ export const GroupHeader = ({
   closedRotation,
   openRotation,
 }: GroupHeaderProps) => {
+  const i18n = useI18n()
   const [isOpen, setIsOpen] = useState(open)
 
   useEffect(() => {
@@ -94,7 +96,7 @@ export const GroupHeader = ({
         <F0Checkbox
           checked={!!select}
           indeterminate={select === "indeterminate"}
-          title="Select all"
+          title={i18n.actions.selectAll}
           hideLabel
           onCheckedChange={(checked) => onSelectChange?.(checked)}
           stopPropagation

--- a/packages/react/src/ui/Lane/Lane.tsx
+++ b/packages/react/src/ui/Lane/Lane.tsx
@@ -14,6 +14,7 @@ import { Spinner } from "@/ui/Spinner"
 import { LaneHeader } from "./components/LaneHeader"
 import { LoadingSkeleton } from "./components/LoadingSkeleton"
 import { LaneProps } from "./types"
+import { useI18n } from "@/lib/providers/i18n"
 
 export function Lane<Record extends RecordType>({
   title,
@@ -32,6 +33,8 @@ export function Lane<Record extends RecordType>({
   onFooterAction,
   dropPlaceholderIndex,
 }: LaneProps<Record>) {
+  const i18n = useI18n()
+
   // Create pagination info for infinite scroll
   const paginationInfo = {
     type: "infinite-scroll" as const,
@@ -144,7 +147,7 @@ export function Lane<Record extends RecordType>({
             size="md"
             className="w-full justify-center"
             icon={Plus}
-            label="Add"
+            label={i18n.actions.add}
             hideLabel
             onClick={onFooterAction}
           />

--- a/packages/react/src/ui/Lane/components/LaneHeader.tsx
+++ b/packages/react/src/ui/Lane/components/LaneHeader.tsx
@@ -3,6 +3,7 @@ import { F0TagDot, NewColor } from "@/components/tags/F0TagDot"
 import { F0TagStatus, Variant } from "@/components/tags/F0TagStatus"
 import { Counter } from "@/ui/Counter"
 import { Plus } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 
 type LaneHeaderProps = {
   label: string
@@ -19,6 +20,7 @@ export const LaneHeader = ({
   count,
   onPrimaryAction,
 }: LaneHeaderProps) => {
+  const i18n = useI18n()
   const showPrimary = Boolean(onPrimaryAction)
 
   return (
@@ -34,7 +36,7 @@ export const LaneHeader = ({
           <F0Button
             variant="ghost"
             size="sm"
-            label="Add"
+            label={i18n.actions.add}
             icon={Plus}
             hideLabel
             onClick={onPrimaryAction}

--- a/packages/react/src/ui/breadcrumb.tsx
+++ b/packages/react/src/ui/breadcrumb.tsx
@@ -5,6 +5,7 @@ import { ComponentProps, forwardRef, useId } from "react"
 
 import { Link } from "../lib/linkHandler"
 import { cn } from "../lib/utils"
+import { useI18n } from "@/lib/providers/i18n"
 
 const Breadcrumb = forwardRef<
   HTMLElement,
@@ -101,17 +102,21 @@ BreadcrumbSeparator.displayName = "BreadcrumbSeparator"
 const BreadcrumbEllipsis = ({
   className,
   ...props
-}: React.ComponentProps<"span">) => (
-  <span
-    role="presentation"
-    aria-hidden="true"
-    className={cn("flex h-9 w-9 items-center justify-center", className)}
-    {...props}
-  >
-    <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More</span>
-  </span>
-)
+}: React.ComponentProps<"span">) => {
+  const i18n = useI18n()
+
+  return (
+    <span
+      role="presentation"
+      aria-hidden="true"
+      className={cn("flex h-9 w-9 items-center justify-center", className)}
+      {...props}
+    >
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">{i18n.actions.more}</span>
+    </span>
+  )
+}
 BreadcrumbEllipsis.displayName = "BreadcrumbElipssis"
 
 export {

--- a/packages/react/src/ui/carousel.tsx
+++ b/packages/react/src/ui/carousel.tsx
@@ -9,6 +9,7 @@ import { ButtonInternal } from "@/components/F0Button/internal"
 import { ButtonInternalProps } from "@/components/F0Button/internal-types"
 import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight } from "@/icons/app"
 import { cn } from "@/lib/utils"
+import { useI18n } from "@/lib/providers/i18n"
 
 /**
  * THE SHADOW BLEED, as classes.
@@ -451,6 +452,7 @@ const CarouselPrevious = React.forwardRef<
   HTMLButtonElement,
   ButtonInternalProps
 >(({ className, variant = "outline", ...props }, ref) => {
+  const i18n = useI18n()
   const { orientation, scrollPrev, canScrollPrev } = useCarousel()
 
   return (
@@ -472,7 +474,7 @@ const CarouselPrevious = React.forwardRef<
         disabled={!canScrollPrev}
         onClick={scrollPrev}
         {...props}
-        label="Previous"
+        label={i18n.navigation.previous}
         icon={ArrowLeft}
         hideLabel
       />
@@ -483,6 +485,7 @@ CarouselPrevious.displayName = "CarouselPrevious"
 
 const CarouselNext = React.forwardRef<HTMLButtonElement, ButtonInternalProps>(
   ({ className, variant = "outline", ...props }, ref) => {
+    const i18n = useI18n()
     const { orientation, scrollNext, canScrollNext } = useCarousel()
 
     return (
@@ -504,7 +507,7 @@ const CarouselNext = React.forwardRef<HTMLButtonElement, ButtonInternalProps>(
           disabled={!canScrollNext}
           onClick={scrollNext}
           {...props}
-          label="Next"
+          label={i18n.navigation.next}
           icon={ArrowRight}
           hideLabel
         />


### PR DESCRIPTION
## Description

Follow-up to #5262. Twenty-seven call sites hardcoded English that `actions.*` / `navigation.*` already held — the keys were written, then later call sites spelled the text out again. A consumer translating `actions.close` saw seven buttons stay English. This wires those sites to the keys, and corrects the CI hint from #5262 that was pointing at the wrong ones.
