### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.60.1",
+  "packages/react": "6.61.0",
   "packages/react-native": "0.59.0",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.61.0](https://github.com/factorialco/f0/compare/f0-react-v6.60.1...f0-react-v6.61.0) (2026-08-26)
+
+
+### Features
+
+* **ComboChart:** fade the legend swatch of projected series ([#5264](https://github.com/factorialco/f0/issues/5264)) ([0c3d5f1](https://github.com/factorialco/f0/commit/0c3d5f1be10de672497b28482751f62c3a2531d1))
+
 ## [6.60.1](https://github.com/factorialco/f0/compare/f0-react-v6.60.0...f0-react-v6.60.1) (2026-08-26)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.60.1",
+  "version": "6.61.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.61.0</summary>

## [6.61.0](https://github.com/factorialco/f0/compare/f0-react-v6.60.1...f0-react-v6.61.0) (2026-08-26)


### Features

* **ComboChart:** fade the legend swatch of projected series ([#5264](https://github.com/factorialco/f0/issues/5264)) ([0c3d5f1](https://github.com/factorialco/f0/commit/0c3d5f1be10de672497b28482751f62c3a2531d1))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).