### PR TITLE
feat(F0AiChatTextArea): neutral credit warning with CTA icon

### DIFF
--- a/packages/react/src/kits/ai/F0AiChat/types.ts
+++ b/packages/react/src/kits/ai/F0AiChat/types.ts
@@ -173,6 +173,11 @@ export type AiChatCreditWarning = {
   onDismiss?: () => void
   /** Called when the user clicks the "Get Credits" button. */
   onGetCredits?: () => void
+  /**
+   * Icon rendered to the left of the "Get Credits" label. Only used when
+   * `onGetCredits` is provided. Hosts typically pass the `Upsell` icon.
+   */
+  getCreditsIcon?: IconType
 }
 
 /**

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -12,6 +12,7 @@ import {
   Marketplace,
   Pencil,
   Search,
+  Upsell,
 } from "@/icons/app"
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
 
@@ -99,6 +100,7 @@ const FILE_UPLOAD_CONFIG: AiChatFileAttachmentConfig = {
 const CREDIT_WARNING: AiChatCreditWarning = {
   level: "soft",
   onGetCredits: () => console.log("get credits clicked"),
+  getCreditsIcon: Upsell,
   onDismiss: () => console.log("dismiss clicked"),
 }
 

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -16,6 +16,7 @@ import {
   Person,
   Receipt,
   Search,
+  Settings,
   Upsell,
 } from "@/icons/app"
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/CreditWarningWrapper.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/CreditWarningWrapper.tsx
@@ -10,9 +10,9 @@ import { type AiChatCreditWarning } from "../../F0AiChat/types"
 const creditWarningConfig = {
   soft: {
     text: "" as string,
-    bg: "bg-f1-background-info",
-    fontColor: "text-f1-foreground-info",
-    formBorder: "[&_form]:border-f1-border-info",
+    bg: "bg-f1-background-secondary",
+    fontColor: "text-f1-foreground-secondary",
+    formBorder: "[&_form]:border-f1-border",
   },
 }
 
@@ -50,6 +50,7 @@ export const CreditWarningWrapper = ({
               label={translation.ai.creditWarning.getCredits ?? ""}
               size="sm"
               variant="outline"
+              icon={creditWarning.getCreditsIcon}
               tooltip={translation.ai.creditWarning.getCredits ?? ""}
               onClick={creditWarning.onGetCredits}
             />

--- a/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
+++ b/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
@@ -31,6 +31,7 @@ import {
   Pencil,
   Settings,
   SolidPlay,
+  Upsell,
 } from "@/icons/app"
 import { F0Alert } from "@/components/F0Alert"
 import { F0Button } from "@/components/F0Button"
@@ -3104,6 +3105,7 @@ function CreationWithAIFlow({
                 title: "Redirecting you to billing to top up credits…",
                 variant: "default",
               }),
+            getCreditsIcon: Upsell,
             onDismiss: () => setCreditWarningDismissed(true),
           }
         : undefined,


### PR DESCRIPTION
## Description

The soft credit warning banner that sits above the chat composer was painted with the info palette, which made a passive nudge read like a system notice. It now uses the neutral tokens, and the "Get credits" CTA takes an optional icon so hosts can mark the action as an upsell.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots (if applicable)

<img width="1773" height="994" alt="image" src="https://github.com/user-attachments/assets/d9a4680e-33ed-4d15-94ec-9e2aa3e00626" />

## Implementation details

- feat: swap the credit warning banner from the info palette to the neutral one

  <details>
  <summary>Which tokens</summary>

  `bg-f1-background-info` → `bg-f1-background-secondary` and `text-f1-foreground-info` → `text-f1-foreground-secondary`, matching the neutral status pattern already used elsewhere (e.g. `F0Tag` status `neutral`).

  The `formBorder` override drops from `border-f1-border-info` to `border-f1-border`, which is the border the composer form already carries by default, so the banner no longer tints it. The key is kept in the config so a future `hard` level can still override it.
  </details>

- feat: add an optional `getCreditsIcon` to `AiChatCreditWarning`, rendered to the left of the "Get credits" label

  <details>
  <summary>Why a prop instead of hardcoding the icon</summary>

  The banner is host-driven: the CTA can point at billing, at a plan upgrade, or at an admin asking to raise an employee cap, so the icon belongs to the host. The prop is optional, so current consumers are unaffected and the button keeps rendering label-only when it is omitted.
  </details>

- chore: use the `Upsell` icon in the `F0AiChatTextArea` and Cocreation credit warning stories