### PR TITLE
fix(OneFilterPicker): track nested filter keys when options load async

### DIFF
--- a/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
@@ -162,7 +162,7 @@ const FiltersRoot = <Definition extends FiltersDefinition>({
     // Also clear nested child filter keys to avoid orphaned values
     const filterDef = filters?.[key]
     if (filterDef?.type === "in" && filterDef.options) {
-      const nestedKeys = collectNestedFilterKeys(filterDef.options)
+      const nestedKeys = collectNestedFilterKeys(filterDef)
       nestedKeys.forEach((nestedKey) => {
         delete newFilters[nestedKey as keyof Definition]
       })

--- a/packages/react/src/patterns/OneFilterPicker/__test__/nestedAsyncOptions.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/__test__/nestedAsyncOptions.test.tsx
@@ -1,0 +1,147 @@
+import userEvent from "@testing-library/user-event"
+import "@testing-library/jest-dom/vitest"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import type { FiltersDefinition } from "../types"
+
+import { OneFilterPicker } from "../index"
+
+/**
+ * A nested ("in" filter with children) filter whose options arrive from an async
+ * loader can't have its nested child keys read off the definition. Without them
+ * the picker treats the parent as empty: no active dot, no count, nothing to
+ * clear or to drop along with the chip — even though the child key holds values.
+ *
+ * `nestedFilterKeys` declares those keys up front so every one of those branches
+ * works before (and without) the options ever being loaded.
+ */
+const officeOptions = [
+  {
+    value: "101",
+    label: "Barcelona HQ",
+    children: {
+      filterKey: "space",
+      options: [
+        { value: "1", label: "Floor 1" },
+        { value: "2", label: "Floor 2" },
+      ],
+    },
+  },
+]
+
+const asyncDefinition = {
+  office: {
+    type: "in",
+    label: "Office",
+    options: {
+      nestedFilterKeys: ["space"],
+      options: async () => officeOptions,
+    },
+  },
+  space: {
+    type: "in",
+    label: "Space",
+    hideSelector: true,
+    options: {
+      options: [
+        { value: "1", label: "Floor 1" },
+        { value: "2", label: "Floor 2" },
+      ],
+    },
+  },
+} as const satisfies FiltersDefinition
+
+const openPicker = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("button", { name: /filters/i }))
+  await waitFor(() =>
+    expect(screen.getByRole("button", { name: "Office" })).toBeInTheDocument()
+  )
+}
+
+describe("OneFilterPicker - nested filters with async options", () => {
+  it("marks the parent filter as active when only a nested child is selected", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+
+    render(
+      <OneFilterPicker
+        filters={asyncDefinition}
+        value={{ space: ["1"] }}
+        onChange={vi.fn()}
+      />
+    )
+
+    await openPicker(user)
+
+    expect(
+      screen.getByRole("button", {
+        name: "Office",
+        description: "Active filters: Office",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("counts nested child selections in the parent's selected label", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+
+    render(
+      <OneFilterPicker
+        filters={asyncDefinition}
+        value={{ space: ["1", "2"] }}
+        onChange={vi.fn()}
+      />
+    )
+
+    await openPicker(user)
+    await user.click(screen.getByRole("button", { name: "Office" }))
+
+    expect(await screen.findByText("2 selected")).toBeInTheDocument()
+  })
+
+  it("clears nested child selections from the parent's select-all toggle", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const onChange = vi.fn()
+
+    render(
+      <OneFilterPicker
+        filters={asyncDefinition}
+        value={{ space: ["1"] }}
+        onChange={onChange}
+      />
+    )
+
+    await openPicker(user)
+    await user.click(screen.getByRole("button", { name: "Office" }))
+
+    // With a nested selection the toggle is indeterminate, so it clears.
+    await user.click(
+      await screen.findByRole("checkbox", { name: /select all/i })
+    )
+    await user.click(screen.getByRole("button", { name: /apply filters/i }))
+
+    // Empty values are dropped on apply: an orphaned `space: ["1"]` would survive.
+    expect(onChange).toHaveBeenCalledWith({})
+  })
+
+  it("drops nested child selections together with the parent chip", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const onChange = vi.fn()
+
+    render(
+      <OneFilterPicker
+        filters={asyncDefinition}
+        value={{ office: ["101"], space: ["1"] }}
+        onChange={onChange}
+      />
+    )
+
+    const removeChip = await screen.findByRole("button", {
+      name: "Close",
+      description: /^Office:/,
+    })
+    await user.click(removeChip)
+
+    expect(onChange).toHaveBeenCalledWith({})
+  })
+})

--- a/packages/react/src/patterns/OneFilterPicker/__test__/nestedAsyncOptions.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/__test__/nestedAsyncOptions.test.tsx
@@ -9,13 +9,9 @@ import type { FiltersDefinition } from "../types"
 import { OneFilterPicker } from "../index"
 
 /**
- * A nested ("in" filter with children) filter whose options arrive from an async
- * loader can't have its nested child keys read off the definition. Without them
- * the picker treats the parent as empty: no active dot, no count, nothing to
- * clear or to drop along with the chip — even though the child key holds values.
- *
- * `nestedFilterKeys` declares those keys up front so every one of those branches
- * works before (and without) the options ever being loaded.
+ * With async options the picker can't walk the tree to find the nested child
+ * keys, so it used to treat the parent as empty: no active dot, no count,
+ * nothing to clear or to drop with the chip. `nestedFilterKeys` declares them.
  */
 const officeOptions = [
   {
@@ -114,7 +110,6 @@ describe("OneFilterPicker - nested filters with async options", () => {
     await openPicker(user)
     await user.click(screen.getByRole("button", { name: "Office" }))
 
-    // With a nested selection the toggle is indeterminate, so it clears.
     await user.click(
       await screen.findByRole("checkbox", { name: /select all/i })
     )

--- a/packages/react/src/patterns/OneFilterPicker/components/FilterList.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FilterList.tsx
@@ -69,7 +69,7 @@ export function FilterList<Definition extends FiltersDefinition>({
     for (const [key, filter] of Object.entries(definition)) {
       if (filter.type === "in" && "options" in filter) {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any -- accessing nested options generically
-        const nested = collectNestedFilterKeys((filter as any).options)
+        const nested = collectNestedFilterKeys(filter as any)
         if (nested.length > 0) map.set(key, nested)
       }
     }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
@@ -16,6 +16,7 @@ import { InFilterFlatOption } from "./components/InFilterFlatOption"
 import { InFilterOptionRow } from "./components/InFilterOptionRow"
 import {
   collectNestedFilterKeys,
+  collectNestedFilterKeysFromOptions,
   optionMatchesSearch,
 } from "./components/option-utils"
 import { InFilterOptionItem, InFilterOptions } from "./types"
@@ -167,9 +168,16 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
     [hasSource, options, searchTermLower]
   )
 
+  // The schema alone only knows the nested keys it declares or lists literally;
+  // the loaded options add the ones that were still unresolved at that point.
   const nestedFilterKeys = useMemo(
-    () => collectNestedFilterKeys(schema.options),
-    [schema.options]
+    () => [
+      ...new Set([
+        ...collectNestedFilterKeys(schema),
+        ...collectNestedFilterKeysFromOptions(options),
+      ]),
+    ],
+    [schema, options]
   )
 
   const nestedSelectionsCount = useMemo(

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
@@ -168,8 +168,6 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
     [hasSource, options, searchTermLower]
   )
 
-  // The schema alone only knows the nested keys it declares or lists literally;
-  // the loaded options add the ones that were still unresolved at that point.
   const nestedFilterKeys = useMemo(
     () => [
       ...new Set([

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/__tests__/option-utils.test.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/__tests__/option-utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest"
+
+import type { FilterTypeSchema } from "../../../types"
+import type { InFilterOptionItem, InFilterOptions } from "../../types"
+
+import { getCacheKey, loadOptions } from "../../useLoadOptions"
+import { collectNestedFilterKeys } from "../option-utils"
+
+type Schema = FilterTypeSchema<InFilterOptions<string>>
+
+const workplaceOptions: InFilterOptionItem<string>[] = [
+  {
+    value: "barcelona",
+    label: "Barcelona Office",
+    children: {
+      filterKey: "workArea",
+      options: [
+        {
+          value: "floor-1",
+          label: "Floor 1",
+          children: {
+            filterKey: "desk",
+            options: [{ value: "desk-1", label: "Desk 1" }],
+          },
+        },
+      ],
+    },
+  },
+  { value: "remote", label: "Remote" },
+]
+
+describe("collectNestedFilterKeys", () => {
+  it("walks literal option arrays at every depth", () => {
+    const schema: Schema = {
+      label: "Workplace",
+      options: { options: workplaceOptions },
+    }
+
+    expect(collectNestedFilterKeys(schema)).toEqual(["workArea", "desk"])
+  })
+
+  it("returns no keys for a flat filter", () => {
+    const schema: Schema = {
+      label: "Department",
+      options: { options: [{ value: "eng", label: "Engineering" }] },
+    }
+
+    expect(collectNestedFilterKeys(schema)).toEqual([])
+  })
+
+  it("reads the keys declared in the schema when options are async", () => {
+    const schema: Schema = {
+      label: "Workplace",
+      options: {
+        nestedFilterKeys: ["workArea"],
+        options: async () => workplaceOptions,
+      },
+    }
+
+    expect(collectNestedFilterKeys(schema)).toEqual(["workArea"])
+  })
+
+  it("reads the keys declared in the schema when options come from a source", () => {
+    const schema: Schema = {
+      label: "Workplace",
+      options: {
+        nestedFilterKeys: ["workArea"],
+        source: { dataAdapter: { fetchData: async () => ({ records: [] }) } },
+        mapOptions: (item: InFilterOptionItem<string>) => item,
+      },
+    }
+
+    expect(collectNestedFilterKeys(schema)).toEqual(["workArea"])
+  })
+
+  it("falls back to the options resolved by a previous load", async () => {
+    const schema: Schema = {
+      label: "Workplace (cached)",
+      options: { cache: true, options: async () => workplaceOptions },
+    }
+
+    expect(collectNestedFilterKeys(schema)).toEqual([])
+
+    await loadOptions(getCacheKey(schema), () => workplaceOptions, true)
+
+    expect(collectNestedFilterKeys(schema)).toEqual(["workArea", "desk"])
+  })
+
+  it("merges the declared keys with the ones found in the options", async () => {
+    const schema: Schema = {
+      label: "Workplace (merged)",
+      options: {
+        cache: true,
+        nestedFilterKeys: ["workArea"],
+        options: async () => workplaceOptions,
+      },
+    }
+
+    await loadOptions(getCacheKey(schema), () => workplaceOptions, true)
+
+    expect(collectNestedFilterKeys(schema)).toEqual(["workArea", "desk"])
+  })
+})

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/option-utils.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/option-utils.ts
@@ -1,4 +1,6 @@
+import { FilterTypeSchema } from "../../types"
 import { InFilterOptionItem, InFilterOptions } from "../types"
+import { getCacheKey, getCachedOptions } from "../useLoadOptions"
 
 /**
  * Recursively checks whether an option or any of its nested children
@@ -36,12 +38,10 @@ export function hasSelectedDescendant<T>(
 }
 
 /**
- * Collects all nested child filter keys from an InFilter's options.
- * Used to determine if a parent filter should show an active indicator
- * when any of its nested children have selections.
+ * Collects the nested child filter keys reachable from an option tree.
  */
-export function collectNestedFilterKeys<T>(
-  filterOptions: InFilterOptions<T>
+export function collectNestedFilterKeysFromOptions<T>(
+  options: InFilterOptionItem<T>[] | undefined
 ): string[] {
   const keys = new Set<string>()
 
@@ -54,8 +54,34 @@ export function collectNestedFilterKeys<T>(
     }
   }
 
-  if ("options" in filterOptions && Array.isArray(filterOptions.options)) {
-    collect(filterOptions.options)
+  collect(options ?? [])
+
+  return [...keys]
+}
+
+/**
+ * All nested child filter keys of an InFilter, used to decide whether a parent
+ * filter holds selections through its children (active indicator, selected
+ * count, clearing).
+ *
+ * The keys must be knowable without the options at hand, because the filter
+ * list and the chips render before the filter is ever opened. Three sources,
+ * in decreasing reliability: the `nestedFilterKeys` declared in the schema,
+ * literal option arrays, and the options resolved by a previous load.
+ */
+export function collectNestedFilterKeys<T>(
+  schema: FilterTypeSchema<InFilterOptions<T>>
+): string[] {
+  const filterOptions = schema.options
+  const keys = new Set<string>(filterOptions.nestedFilterKeys ?? [])
+
+  const resolvedOptions =
+    "options" in filterOptions && Array.isArray(filterOptions.options)
+      ? filterOptions.options
+      : getCachedOptions<T>(getCacheKey(schema))
+
+  for (const key of collectNestedFilterKeysFromOptions(resolvedOptions)) {
+    keys.add(key)
   }
 
   return [...keys]

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/option-utils.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/option-utils.ts
@@ -37,9 +37,7 @@ export function hasSelectedDescendant<T>(
   return false
 }
 
-/**
- * Collects the nested child filter keys reachable from an option tree.
- */
+/** Nested child filter keys reachable from an option tree. */
 export function collectNestedFilterKeysFromOptions<T>(
   options: InFilterOptionItem<T>[] | undefined
 ): string[] {
@@ -60,14 +58,10 @@ export function collectNestedFilterKeysFromOptions<T>(
 }
 
 /**
- * All nested child filter keys of an InFilter, used to decide whether a parent
- * filter holds selections through its children (active indicator, selected
- * count, clearing).
- *
- * The keys must be knowable without the options at hand, because the filter
- * list and the chips render before the filter is ever opened. Three sources,
- * in decreasing reliability: the `nestedFilterKeys` declared in the schema,
- * literal option arrays, and the options resolved by a previous load.
+ * Nested child filter keys of an InFilter. The filter list and the chips render
+ * before the filter is ever opened, so the keys have to be resolvable without
+ * the options: declared in the schema, listed literally, or left over in the
+ * cache from a previous load.
  */
 export function collectNestedFilterKeys<T>(
   schema: FilterTypeSchema<InFilterOptions<T>>

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/types.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/types.ts
@@ -37,10 +37,8 @@ export type InFilterOptionItem<T = unknown> = {
 export type InFilterOptions<T, _R extends RecordType = RecordType> = {
   cache?: boolean
   /**
-   * Filter keys where nested child selections are stored, declared up front.
-   * Only needed when `options` is async or comes from a `source`: the picker
-   * has to know the nested keys to track child selections (active dot, counts,
-   * clearing) before — or without ever — loading the options.
+   * Filter keys holding nested child selections. Only needed for async or
+   * `source` options, which the picker can't walk to discover them.
    */
   nestedFilterKeys?: string[]
   /**

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/types.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/types.ts
@@ -37,6 +37,13 @@ export type InFilterOptionItem<T = unknown> = {
 export type InFilterOptions<T, _R extends RecordType = RecordType> = {
   cache?: boolean
   /**
+   * Filter keys where nested child selections are stored, declared up front.
+   * Only needed when `options` is async or comes from a `source`: the picker
+   * has to know the nested keys to track child selections (active dot, counts,
+   * clearing) before — or without ever — loading the options.
+   */
+  nestedFilterKeys?: string[]
+  /**
    * Optional function to resolve labels for specific values without fetching all options.
    * This is useful when you have a dynamic source and want to avoid fetching all options
    * just to display labels for selected values.

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions.ts
@@ -22,11 +22,7 @@ export function getCacheKey<T, R extends RecordType = RecordType>(
   return JSON.stringify(schema)
 }
 
-/**
- * Resolved options for a schema, if they have been loaded at least once.
- * Lets callers outside the filter body (filter list, chip removal) inspect the
- * option tree without triggering a load.
- */
+/** Options a previous load resolved for a schema, without triggering one. */
 export function getCachedOptions<T>(
   cacheKey: string
 ): InFilterOptionItem<T>[] | undefined {

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from "react"
 
 import { RecordType, useData, useDataSource } from "@/hooks/datasource"
 
-import { InFilterDefinition } from "."
+import type { InFilterDefinition } from "."
 import { FilterTypeSchema } from "../types"
 import { InFilterOptionItem, InFilterOptions } from "./types"
 
@@ -20,6 +20,17 @@ export function getCacheKey<T, R extends RecordType = RecordType>(
   schema: FilterTypeSchema<InFilterOptions<T, R>>
 ): string {
   return JSON.stringify(schema)
+}
+
+/**
+ * Resolved options for a schema, if they have been loaded at least once.
+ * Lets callers outside the filter body (filter list, chip removal) inspect the
+ * option tree without triggering a load.
+ */
+export function getCachedOptions<T>(
+  cacheKey: string
+): InFilterOptionItem<T>[] | undefined {
+  return optionsCache.get(cacheKey) as InFilterOptionItem<T>[] | undefined
 }
 
 /**

--- a/packages/react/src/patterns/OneFilterPicker/internal/getClearedFiltersValue.ts
+++ b/packages/react/src/patterns/OneFilterPicker/internal/getClearedFiltersValue.ts
@@ -18,7 +18,7 @@ export function getClearedFiltersValue<Filters extends FiltersDefinition>(
       continue
     }
 
-    for (const nestedKey of collectNestedFilterKeys(filter.options)) {
+    for (const nestedKey of collectNestedFilterKeys(filter)) {
       clearedFilters[nestedKey as keyof Filters] =
         [] as unknown as FiltersState<Filters>[keyof Filters]
     }


### PR DESCRIPTION
## Problem

A nested `in` filter exposed its child filter keys only when its `options` were a literal array. Any filter that loads its options from a function (or a `source`) resolved to **no** nested keys, so the picker treated the parent as empty everywhere it is summarised outside the option list:

| Where | Symptom |
| --- | --- |
| `FilterList` | Parent gets no active dot when only a child is selected — the reported bug |
| `InFilter` | Child selections missing from the "N selected" count and the select-all indeterminate state |
| `InFilter` | Parent's clear / select-all toggle leaves the child values behind |
| `OneFilterPicker.removeFilterValue` | Removing the parent chip orphans the child values: chip gone, list still filtered |
| `getClearedFiltersValue` | Same call — masked today only when the child key is also declared as its own filter |

Repro in the product: **People → Filters → Workplace**, select only a work area under an office. The office row gets its dot (that path reads the already-loaded options), the *Workplace* entry in the filter list does not.

<img width="617" height="411" alt="Screenshot 2026-08-26 at 16 57 44" src="https://github.com/user-attachments/assets/ce5a9167-8573-4b63-b16f-2b7ce7bcfc24" />


## Fix

The nested keys have to be knowable **without** the options at hand, because the filter list and the chips render before the filter is ever opened — and still render that way after a reload with filters in the URL.

- New optional `nestedFilterKeys` on the in-filter options, declaring the child keys up front. Authoritative and always available, including for `source`-backed options.
- `collectNestedFilterKeys` now takes the whole schema, so when `options` is not a literal array it can also fall back to the options a previous load already resolved.
- Inside `InFilter` the keys additionally union with the currently loaded options, so they pick up children that were still unresolved when the schema was read.

Consumers with literal arrays keep working untouched; `nestedFilterKeys` is only needed for async/`source` options.

```ts
options: {
  cache: true,
  nestedFilterKeys: ["workArea"],
  options: loadWorkplaces,
}
```

<img width="618" height="188" alt="Screenshot 2026-08-26 at 17 04 27" src="https://github.com/user-attachments/assets/f20162e4-fd21-41eb-b624-4b69ceaaab27" />


<img width="615" height="308" alt="Screenshot 2026-08-26 at 17 03 09" src="https://github.com/user-attachments/assets/c4a8948c-9d49-4135-a441-1949cb29e80c" />


## Testing

`packages/react/src/patterns/OneFilterPicker/__test__/nestedAsyncOptions.test.tsx` — nested filter with async options, covering the four behaviours above end to end. All four fail on `main`.

`.../InFilter/components/__tests__/option-utils.test.ts` — unit coverage for the three key sources (declared, literal, resolved-from-cache) and their merge.

The existing nested tests all use literal arrays, which is why this slipped through.

Ref: https://factorialmakers.atlassian.net/browse/FCT-61539