### PR TITLE
ci(release): publish to npm via trusted publishing

### DIFF
--- a/.github/actions/publish-to-npmjs/action.yaml
+++ b/.github/actions/publish-to-npmjs/action.yaml
@@ -1,11 +1,13 @@
 name: "Publish to npmjs"
 
+# Authentication is done with npm Trusted Publishers (OIDC), not with a token.
+# The calling job MUST grant `id-token: write`, and the package must have a
+# Trusted Publisher configured on npmjs.com pointing at `npm-publish.yaml`.
+# See https://docs.npmjs.com/trusted-publishers
+
 inputs:
   workspace:
     description: "Workspace"
-    required: true
-  registry_token:
-    description: "Registry token"
     required: true
 
 outputs:
@@ -19,6 +21,23 @@ runs:
     - uses: ./.github/actions/setup-node-pnpm
       name: Setup Node and pnpm
 
+    # pnpm shells out to `npm publish`, and OIDC needs npm >= 11.5.1.
+    # ubuntu-latest still ships npm 10.x with Node 22.
+    - name: Upgrade npm for trusted publishing
+      shell: bash
+      run: npm install -g npm@^11.5.1
+
+    # setup-node writes `_authToken=${NODE_AUTH_TOKEN}` into the npmrc. With no
+    # token set, npm sends that placeholder verbatim and OIDC auth fails with a
+    # confusing E404, so drop the line.
+    - name: Remove placeholder auth from npmrc
+      shell: bash
+      run: |
+        npmrc="${NPM_CONFIG_USERCONFIG:-$HOME/.npmrc}"
+        if [ -f "$npmrc" ]; then
+          sed -i '/_authToken=\${NODE_AUTH_TOKEN}/d' "$npmrc"
+        fi
+
     - name: Build
       shell: bash
       run: |
@@ -29,8 +48,9 @@ runs:
       shell: bash
       id: publish
       run: |
-        result=$(pnpm --filter ${{ inputs.workspace }} publish --no-git-checks --access=public)
-        if [[ $result == "There are no new packages that should be published" ]]
+        result=$(pnpm --filter ${{ inputs.workspace }} publish --no-git-checks --access=public --provenance)
+        echo "$result"
+        if [[ $result == *"There are no new packages that should be published"* ]]
         then
           echo "No new packages to publish"
           echo "published=false" >> $GITHUB_OUTPUT
@@ -38,5 +58,3 @@ runs:
           echo "Packages published"
           echo "published=true" >> $GITHUB_OUTPUT
         fi
-      env:
-        NODE_AUTH_TOKEN: ${{ inputs.registry_token }}

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write # npm trusted publishing (OIDC)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,7 +38,6 @@ jobs:
         id: publish
         with:
           workspace: "@factorialco/f0-react"
-          registry_token: ${{ secrets.NPMJS_TOKEN }}
       - name: Notify Slack
         if: ${{ steps.publish.outputs.published == 'true' }}
         env:
@@ -96,7 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write # npm trusted publishing (OIDC)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -106,7 +105,6 @@ jobs:
         id: publish
         with:
           workspace: "@factorialco/f0-react-native"
-          registry_token: ${{ secrets.NPMJS_TOKEN }}
       # Slack notification moved to publish-expo-production.yaml
       # which sends the notification after publishing the EAS production update
       # and creating the QR code update PR
@@ -123,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      id-token: write # npm trusted publishing (OIDC)
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -133,7 +131,6 @@ jobs:
         id: publish
         with:
           workspace: "@factorialco/f0-core"
-          registry_token: ${{ secrets.NPMJS_TOKEN }}
       - name: Notify Slack
         if: ${{ steps.publish.outputs.published == 'true' }}
         env:

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -52,10 +52,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-node-pnpm
+      # Read the version straight off the installed package rather than parsing
+      # `pnpm why --json`: that output is not a stable contract and its shape
+      # changed in pnpm 10, which silently emptied this variable. The guard is
+      # there because an empty version is worse than a hard failure — it made
+      # the install step below fetch playwright@latest, which deleted the
+      # correctly cached browsers as "unused" before the suite ever started.
       - name: Get Playwright version
         id: playwright-version
+        working-directory: packages/react
         run: |
-          PLAYWRIGHT_VERSION=$(pnpm why @playwright/test -r --json | jq -r '.[] | select(.devDependencies["@playwright/test"]) | .devDependencies["@playwright/test"].version')
+          PLAYWRIGHT_VERSION=$(node -p "require('@playwright/test/package.json').version")
+          if [ -z "$PLAYWRIGHT_VERSION" ]; then
+            echo "::error::Could not resolve the @playwright/test version"
+            exit 1
+          fi
           echo "PLAYWRIGHT_VERSION: $PLAYWRIGHT_VERSION"
           echo "version=$PLAYWRIGHT_VERSION" >> $GITHUB_OUTPUT
       - name: Cache Playwright browsers
@@ -85,10 +96,15 @@ jobs:
       # story ran — 4 of 8 shards in run 32230793617, then 7 of 8 in 32233463322.
       #
       # With the browser cache warm this step now touches no apt mirror at all.
+      #
+      # Installed through the workspace's own playwright binary, not
+      # `pnpx playwright@<version>`: the browser build has to match the
+      # playwright-core the test-runner loads, and going through the installed
+      # binary makes a mismatch impossible instead of merely unlikely.
       - name: Install Playwright
         timeout-minutes: 5
         run: |
-          pnpx playwright@${{ steps.playwright-version.outputs.version }} install chromium
+          pnpm --filter @factorialco/f0-react exec playwright install chromium
 
       # The font packages `--with-deps` used to pull (CJK/Thai/Cyrillic coverage
       # plus freefont), installed on their own so a slow or unreachable apt mirror

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": false,
   "type": "module",
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0",
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e",
   "workspaces": [
     "packages/*",
     "packages/examples/*"
@@ -34,6 +34,13 @@
     "oxlint": "^1.41.0"
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "esbuild",
+      "lefthook",
+      "msw",
+      "unrs-resolver"
+    ],
     "overrides": {
       "esm-env": "npm:esm-env-runtime@^0.1.1",
       "@types/react": "18.3.18",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@factorialco/f0-core",
   "version": "2.1.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/factorialco/f0.git",
+    "directory": "packages/core"
+  },
   "description": "Core tokens and utilities for F0 Design System",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@factorialco/f0-react-native",
   "version": "0.59.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/factorialco/f0.git",
+    "directory": "packages/react-native"
+  },
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@factorialco/f0-react",
   "version": "6.61.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/factorialco/f0.git",
+    "directory": "packages/react"
+  },
   "private": false,
   "files": [
     "assets",
@@ -283,5 +288,5 @@
   "optionalDependencies": {
     "@rollup/rollup-linux-x64-gnu": "^4.34"
   },
-  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
+  "packageManager": "pnpm@10.34.5+sha512.a4ee05f2f73658255bd6a89859c065a45c28a57daefae2c893a168ee2b73168c37b91e83e57ea67654ad03f03031746430e8bce38e362e042605fb8abc80192e"
 }


### PR DESCRIPTION
## Description

The `NPMJS_TOKEN` used to publish `@factorialco/f0-react`, `@factorialco/f0-core` and `@factorialco/f0-react-native` has to be rotated every 90 days, which is recurring manual work and a standing leak risk. This PR replaces it with [npm Trusted Publishers](https://docs.npmjs.com/trusted-publishers), which authenticates the publish job through GitHub's OIDC identity instead of a long-lived credential. The Trusted Publisher is already configured on npmjs.com for all three packages, pointing at `npm-publish.yaml`. Alpha builds are unaffected — they publish as git branches (`npm/alpha-pr-N`), never to a registry.

## Implementation details

- ci: authenticate `npm-publish.yaml` with OIDC instead of `NPMJS_TOKEN`

  <details>
  <summary>What changed in the job</summary>

  Each of the three jobs now grants `id-token: write` and drops the unused `packages: write` (nothing is published to GitHub Packages). The `registry_token` input is gone from the composite action.

  Two details are load-bearing and easy to miss:

  - `pnpm publish` shells out to `npm publish`, and OIDC needs npm >= 11.5.1. `ubuntu-latest` still ships npm 10.x with Node 22, so the action upgrades npm first.
  - `actions/setup-node` writes `_authToken=${NODE_AUTH_TOKEN}` into the npmrc. With no token set, npm sends that placeholder verbatim and OIDC fails with a misleading `E404`. The action strips the line before publishing.
  </details>

- chore: bump pnpm from 9.15.4 to 10.34.5

  <details>
  <summary>Why 10 and not 11</summary>

  OIDC support starts in the pnpm 10 line, so 9.15.4 cannot do trusted publishing at all.

  pnpm 11 is deliberately skipped: it silently stops reading the `pnpm` field from `package.json`, and this repo pins `react@18.3.1` and `@types/react` through `pnpm.overrides` there. The install would succeed with the wrong versions and no warning. It also enables `minimumReleaseAge` and `blockExoticSubdeps` by default. Moving to 11 means migrating that config to `pnpm-workspace.yaml` and is worth its own PR.

  `pnpm-lock.yaml` is unchanged — pnpm 10 reads the existing 9.0 lockfile as-is.
  </details>

- chore: allow build scripts blocked by pnpm 10's new default

  <details>
  <summary>Which ones</summary>

  pnpm 10 no longer runs dependency lifecycle scripts by default. `pnpm.onlyBuiltDependencies` re-enables the ones the builds actually need: `@swc/core`, `esbuild`, `lefthook`, `msw`, `unrs-resolver`. `canvas` is intentionally left out — it is an optional native dep of jsdom that nothing here uses.
  </details>

- chore: add `repository` to the three published packages

  Required for provenance, which npm validates against the building repo. `--provenance` is now passed on publish, so releases get the verified badge on npmjs.

### Verified locally with pnpm 10.34.5

- `pnpm install` clean, `pnpm-lock.yaml` untouched
- `f0-core` and `f0-react` build, including api-extractor and the `.d.ts` output
- `f0-react-native`: `tsc --noEmit` passes
- `pnpm pack` of `f0-react` resolves `workspace:*` to `"@factorialco/f0-core": "2.1.0"`, and `repository` reaches the published manifest
- `pnpm --filter ... publish --dry-run` still prints `There are no new packages that should be published`, so the `published` output the Slack steps depend on keeps working

### Follow-up after the first green release

Delete the `NPMJS_TOKEN` secret, revoke the token on npmjs.com, and restrict each package to trusted publishing under Settings → Publishing access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)