### PR TITLE
feat(F0AiChatTextArea): move welcome suggestions into the action row

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -14,6 +14,7 @@ import { F0OneIcon } from "../F0OneIcon"
 import { ActionBar } from "./components/ActionBar"
 import { AttachedFilesList } from "./components/AttachedFilesList"
 import { CreditWarningWrapper } from "./components/CreditWarningWrapper"
+import { DictationButton } from "./components/DictationButton"
 import { MentionPopover } from "./components/MentionPopover"
 import { PendingQuoteChip } from "./components/PendingQuoteChip"
 import { SubmitButton } from "./components/SubmitButton"
@@ -86,6 +87,7 @@ export const F0AiChatTextArea = ({
   welcomeScreenSuggestions,
   onSuggestionClick,
   welcomeScreenSuggestionsPlacement = "above",
+  welcomeScreenSuggestionsCollapsedByDefault = false,
   welcomeScreenCards,
   padding = "default",
   ref,
@@ -101,9 +103,20 @@ export const F0AiChatTextArea = ({
   const [pendingSubmit, setPendingSubmit] = useState(false)
   const [hoveredSuggestion, setHoveredSuggestion] =
     useState<WelcomeScreenSuggestionItem | null>(null)
+  // Whether focus is anywhere in the composer — what opens a collapsed bar, and
+  // what closes it again. See `welcomeScreenSuggestionsCollapsedByDefault`.
+  const [focusWithin, setFocusWithin] = useState(false)
   const formRef = useRef<HTMLFormElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const highlightRef = useRef<HTMLDivElement>(null)
+  const blurCheckRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(
+    () => () => {
+      if (blurCheckRef.current) clearTimeout(blurCheckRef.current)
+    },
+    []
+  )
 
   const isClarifying = clarifyingUI != null
 
@@ -183,9 +196,15 @@ export const F0AiChatTextArea = ({
   }, [recorder, tracking])
 
   useEffect(() => {
+    // A composer that asks to start collapsed must not focus itself: the focus
+    // is what opens the row, so autofocusing here would open it before the
+    // reader has touched anything and make the prop a no-op.
+    if (welcomeScreenSuggestionsCollapsedByDefault) return
     if (typeof window !== "undefined" && window.location.hash.length === 0) {
       textareaRef.current?.focus()
     }
+    // Mount only, deliberately: this is the initial autofocus, not something to
+    // re-run when a prop changes.
   }, [])
 
   useEffect(() => {
@@ -366,28 +385,131 @@ export const F0AiChatTextArea = ({
       // collision, so a field pinned to the bottom of a sidepanel is safe.
       side={suggestionsInside ? "bottom" : "top"}
       reserveTwoRows={!suggestionsInside}
+      // Inside, the row is one cell of the action band and shares its line with
+      // the send button, so it scrolls sideways instead of wrapping onto a
+      // second line and growing the field. Above, wrapping is free.
+      overflow={suggestionsInside ? "scroll" : "wrap"}
     />
   ) : null
 
-  // THE BAR SHAPE the `inside` placement implies: One's mark leading the field
-  // and the send button trailing the text, so the suggestions can have the band
-  // below them to themselves. Named apart from `suggestionsInside` because this
-  // is about the composer's own layout and it does NOT switch off with the
-  // welcome screen — a bar that put send back in the action row on the first
-  // message would change shape under the reader mid-conversation.
+  // OPEN vs COLLAPSED. Focus opens it and losing focus closes it again — but two
+  // things keep it open regardless of focus:
+  //
+  // - anything the reader has already put in the field. A half-typed prompt or an
+  //   attached file with no visible way to send it would be a trap, and a host
+  //   that forwards a dropped file (`onProcessFilesRef`) can put one there
+  //   without the textarea ever being focused.
+  // - a recording in flight. The waveform and its cancel · confirm pair live in
+  //   the control row, so collapsing mid-recording would leave a recording with
+  //   no way to end it.
+  const composerOpen =
+    !welcomeScreenSuggestionsCollapsedByDefault ||
+    focusWithin ||
+    hasDataToSend ||
+    recorder.status !== "idle"
+
+  /**
+   * Whether focus landing on `next` should count as still being in the composer.
+   *
+   * The form is the obvious part. The suggestion panel is the part that is easy
+   * to get wrong: Radix portals it to the body, so a reader who tabs from a chip
+   * into its own panel has left the form in DOM terms while plainly still using
+   * the composer — and collapsing there would unmount the panel from under their
+   * focus.
+   */
+  const focusStaysInComposer = (next: EventTarget | null) => {
+    if (!(next instanceof Node)) return false
+    if (formRef.current?.contains(next)) return true
+    return (
+      next instanceof Element &&
+      next.closest("[data-radix-popper-content-wrapper]") !== null
+    )
+  }
+
+  /**
+   * Closes the bar when focus leaves — but ASKS AGAIN ON THE NEXT TICK rather
+   * than trusting the event.
+   *
+   * `relatedTarget` is null for two very different things: focus landing outside
+   * the composer (close) and the focused control being removed from the DOM
+   * (don't). The second one happens for real here — opening the bar unmounts the
+   * collapsed line, and the welcome screen ending unmounts the chips — and
+   * treating it as "the reader left" would snap the bar shut under them. By the
+   * next tick `document.activeElement` has settled and can be trusted.
+   */
+  const handleComposerBlur = () => {
+    if (blurCheckRef.current) clearTimeout(blurCheckRef.current)
+    blurCheckRef.current = setTimeout(() => {
+      if (!focusStaysInComposer(document.activeElement)) setFocusWithin(false)
+    }, 0)
+  }
+
+  // THE BAR SHAPE the `inside` placement implies: One's mark leading the field,
+  // and the chips sharing the action row with the buttons rather than claiming a
+  // band of their own. Named apart from `suggestionsInside` because this is about
+  // the composer's own layout and it does NOT switch off with the welcome screen
+  // — a bar that dropped the mark on the first message would change shape under
+  // the reader mid-conversation.
   const inlineComposerBar = suggestionsInside
 
-  // Which controls the action row would still have to itself once the bar takes
-  // the send button away. With none of them the row is 24px of padding around
-  // nothing, so it isn't rendered at all and the field is just its two bands.
-  // `canRecord` covers the recording state too — the waveform's cancel · confirm
-  // pair lives in this row, and it can only be reached when recording is on.
-  const actionRowHasControls = !!onUploadFiles || !!toolbarStart || canRecord
-  const showActionRow = !inlineComposerBar || actionRowHasControls
-  // While recording, the row below owns the whole gesture (waveform + cancel ·
-  // confirm). A send button beside the text would be a second, live way out of a
-  // recording that the row is already handling.
-  const showInlineSubmit = inlineComposerBar && !isRecording
+  // THE COLLAPSED BAR IS ONE LINE, and the whole control row is what goes: the
+  // chips, and the attachment and host controls. A row emptied of its chips would
+  // still be 56px of padding around two buttons, which is not a quiet bar — it is
+  // the same two-band field with a hole in it.
+  //
+  // Two controls come along onto the text's own line (at `sm`, centred on it):
+  // send, because a bar you cannot send from is not a composer, and dictation,
+  // because talking is a way to start a prompt without typing one and a bar that
+  // hid it would be asking the reader to type first.
+  //
+  // Only the `inside` bar collapses. With the row `above`, the chips are their
+  // own block on the page and the field below them is a plain composer that has
+  // no business changing shape.
+  const barCollapsible =
+    inlineComposerBar && welcomeScreenSuggestionsCollapsedByDefault
+  const barCollapsed = barCollapsible && !composerOpen
+
+  // The chips go in the action row's middle cell, so the row is ONE line however
+  // many groups there are: attachment · host controls | chips | mic · send. The
+  // row drops its middle while recording, where the waveform and its cancel ·
+  // confirm pair need the full width.
+  const actionRowCenter =
+    inlineComposerBar && suggestionsRow ? (
+      // Clicks are STOPPED here rather than bubbling to the form, whose onClick
+      // focuses the textarea — the same guard `toolbarStart` takes. Without it,
+      // pressing a chip would pull focus off the trigger and break the popover's
+      // own Escape-restores-focus handling.
+      <div onClick={(event) => event.stopPropagation()}>{suggestionsRow}</div>
+    ) : undefined
+
+  // The open/close reveal, shared by the two things that can do it: the row
+  // above the composer, and the `inside` bar's own control row.
+  const collapseTransition = {
+    duration: shouldReduceMotion ? 0 : 0.32,
+    ease: [0.4, 0, 0.2, 1] as const,
+  }
+
+  const actionRow = (
+    <ActionBar
+      onUploadFiles={onUploadFiles}
+      toolbarStart={toolbarStart}
+      center={actionRowCenter}
+      isAtMaxFiles={isAtMaxFiles}
+      maxFiles={maxFiles}
+      acceptValue={acceptValue}
+      fileInputRef={fileInputRef}
+      handleFileSelect={handleFileSelect}
+      inProgress={inProgress}
+      hasDataToSend={hasDataToSend}
+      isPreSending={isPreSending || pendingSubmit}
+      canRecord={canRecord}
+      recordingStatus={recorder.status}
+      recordingStream={recorder.stream}
+      onStartRecording={handleStartRecording}
+      onStopRecording={recorder.stop}
+      onCancelRecording={handleCancelRecording}
+    />
+  )
 
   // Welcome cards sit below the composer on the fullscreen welcome screen
   // (same gate the footer slot uses). Each card carries its own `onClick`;
@@ -425,7 +547,32 @@ export const F0AiChatTextArea = ({
       {...(fullscreen ? composerReveal : {})}
     >
       <div className="flex w-full max-w-content flex-col gap-2">
-        {suggestionsRow && !suggestionsInside && <div>{suggestionsRow}</div>}
+        {suggestionsRow && !suggestionsInside && (
+          <div>
+            {/* The row above the composer has no bar to collapse — it IS the
+                thing that opens, so the reveal is its own height. Composers that
+                never collapse render it plainly: no wrapper, no inline styles,
+                nothing for a layout to trip over. */}
+            {welcomeScreenSuggestionsCollapsedByDefault ? (
+              <AnimatePresence initial={false}>
+                {composerOpen && (
+                  <motion.div
+                    key="welcome-suggestions"
+                    className="overflow-hidden"
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={collapseTransition}
+                  >
+                    {suggestionsRow}
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            ) : (
+              suggestionsRow
+            )}
+          </div>
+        )}
         <CreditWarningWrapper creditWarning={creditWarning}>
           <motion.form
             aria-busy={inProgress}
@@ -433,7 +580,13 @@ export const F0AiChatTextArea = ({
             className={cn(
               "relative isolate z-20",
               "flex flex-col items-stretch md:gap-3 gap-2",
-              "rounded-lg border border-solid border-f1-border has-[textarea:focus]:border-f1-background-tertiary",
+              // `border-secondary`, the subtle border, NOT the default one: the
+              // composer stands among widgets and cards that all use it, and at
+              // neutral-30 against their neutral-20 the field read as a heavier
+              // box than everything around it. Only the resting border is
+              // subtle — focus still takes the field to `background-tertiary`
+              // under the gradient glow, which is what makes the focus obvious.
+              "rounded-lg border border-solid border-f1-border-secondary has-[textarea:focus]:border-f1-background-tertiary",
               "transition-all hover:cursor-text",
               "p-0",
               "before:pointer-events-none before:absolute before:inset-0 before:z-[-1]",
@@ -466,6 +619,14 @@ export const F0AiChatTextArea = ({
                 textareaRef.current?.focus()
               }
             }}
+            // Focus is tracked on the FORM, not on the textarea: the collapsed
+            // bar opens for anything the reader addresses — tabbing to the mic
+            // counts — and, more to the point, closing on the textarea's own blur
+            // would close it the moment a chip took focus, which is every way of
+            // picking one. React's onFocus/onBlur are focusin/focusout, so they
+            // do reach here from the controls inside.
+            onFocus={() => setFocusWithin(true)}
+            onBlur={handleComposerBlur}
             onSubmit={handleSubmit}
           >
             <MentionPopover
@@ -565,17 +726,20 @@ export const F0AiChatTextArea = ({
                   />
 
                   {/* THE TEXT BAND. A flex row only in the `inside` layout,
-                      where One's mark leads the text and the send button trails
-                      it. `items-end` is what keeps the button on the LAST line
-                      as the textarea grows, instead of floating beside the
-                      middle of the text.
+                      where One's mark leads the text — and, while the bar is
+                      collapsed, the send button trails it. `items-end` is what
+                      keeps that button on the LAST line as the textarea grows,
+                      instead of floating beside the middle of the text.
 
                       `TextareaField` is `flex-1` already and its own layers
                       carry the field's 12px inset (top and bottom), so this row
-                      adds no vertical padding of its own — the two things beside
-                      the text align against that inset. */}
+                      adds no vertical padding of its own — the things beside the
+                      text align against that inset. */}
                   <div
-                    className={cn(inlineComposerBar && "flex items-end pr-3")}
+                    className={cn(
+                      inlineComposerBar && "flex items-end",
+                      barCollapsed && "pr-3"
+                    )}
                   >
                     {/* ONE'S MARK, leading the field. `pl-3` is the field's own
                         left inset; the 12px gap to the text after it is
@@ -623,8 +787,33 @@ export const F0AiChatTextArea = ({
                         taller than the line, visibly high against the top
                         border. Grown past one line the same 10px keeps it on the
                         last line. */}
-                    {showInlineSubmit && (
-                      <div className="shrink-0 pb-[10px] pl-2">
+                    {barCollapsed && (
+                      // `preventDefault` ON MOUSEDOWN IS LOAD-BEARING, and the
+                      // bug it fixes is worth spelling out: taking focus is the
+                      // browser's DEFAULT ACTION for mousedown, focus is what
+                      // opens the bar, and opening the bar unmounts this very
+                      // line — so the button was destroyed between mousedown and
+                      // mouseup and its `click` never fired. Pressing the
+                      // microphone did nothing at all.
+                      //
+                      // These buttons therefore refuse the pointer focus and let
+                      // the form's own onClick put it on the textarea instead,
+                      // which opens the bar AFTER the click has been handled.
+                      // Nothing is lost: keyboard users reach the textarea first
+                      // (it is the first tab stop), so by the time Tab could
+                      // arrive here the bar is already open and this line is gone.
+                      <div
+                        className="flex shrink-0 items-center gap-2 pb-[10px] pl-2"
+                        onMouseDown={(event) => event.preventDefault()}
+                      >
+                        {canRecord && (
+                          <DictationButton
+                            inProgress={inProgress}
+                            recordingStatus={recorder.status}
+                            onStartRecording={handleStartRecording}
+                            size="sm"
+                          />
+                        )}
                         <SubmitButton
                           inProgress={inProgress}
                           hasDataToSend={hasDataToSend}
@@ -636,52 +825,36 @@ export const F0AiChatTextArea = ({
                     )}
                   </div>
 
-                  {/* THE SUGGESTIONS BAND, inside the field. `px-3` is the
-                      field's own inset — the chips line up with the text above
-                      them and nothing indents them further, which is the point
-                      of putting them in here. `pb-3` closes the box.
+                  {/* THE CONTROL ROW, and whether it is there at all. The
+                      collapsed bar has none — see `barCollapsed`. A composer
+                      that cannot collapse skips the wrapper entirely and renders
+                      the row as it always has.
 
-                      `pt-1` ON TOP OF the text band's own 12px bottom slack, for
-                      16px between the two bands — which is v2's `gap-4` between
-                      the same two rows, arrived at from the other direction.
-                      12px alone read as cramped against the chips (Saul,
-                      2026-08-13): they are 32px tall against a 20px line, so the
-                      gap has to clear the taller thing to look like a gap.
+                      `initial={false}` keeps a collapsible composer that opens
+                      un-collapsed (it already had something to send) from
+                      animating its row in on load; one that opens later, on the
+                      first focus, does animate.
 
-                      Clicks are STOPPED here rather than bubbling to the form,
-                      whose onClick focuses the textarea — the same guard
-                      `toolbarStart` takes. Without it, pressing a chip would pull
-                      focus off the trigger and break the popover's own
-                      Escape-restores-focus handling. */}
-                  {suggestionsRow && suggestionsInside && (
-                    <div
-                      className="px-3 pb-3 pt-1"
-                      onClick={(event) => event.stopPropagation()}
-                    >
-                      {suggestionsRow}
-                    </div>
-                  )}
-
-                  {showActionRow && (
-                    <ActionBar
-                      onUploadFiles={onUploadFiles}
-                      toolbarStart={toolbarStart}
-                      isAtMaxFiles={isAtMaxFiles}
-                      maxFiles={maxFiles}
-                      acceptValue={acceptValue}
-                      fileInputRef={fileInputRef}
-                      handleFileSelect={handleFileSelect}
-                      inProgress={inProgress}
-                      hasDataToSend={hasDataToSend}
-                      isPreSending={isPreSending || pendingSubmit}
-                      canRecord={canRecord}
-                      recordingStatus={recorder.status}
-                      recordingStream={recorder.stream}
-                      onStartRecording={handleStartRecording}
-                      onStopRecording={recorder.stop}
-                      onCancelRecording={handleCancelRecording}
-                      showSubmit={!inlineComposerBar}
-                    />
+                      `overflow-hidden` clips at the ROW's border box, 12px of
+                      padding away from the chips, so the scroller's 4px bleed
+                      (its focus-ring room) is not clipped with it. */}
+                  {barCollapsible ? (
+                    <AnimatePresence initial={false}>
+                      {!barCollapsed && (
+                        <motion.div
+                          key="action-row"
+                          className="overflow-hidden"
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: "auto" }}
+                          exit={{ opacity: 0, height: 0 }}
+                          transition={collapseTransition}
+                        >
+                          {actionRow}
+                        </motion.div>
+                      )}
+                    </AnimatePresence>
+                  ) : (
+                    actionRow
                   )}
                 </motion.div>
               )}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -7,11 +7,16 @@ import type { F0AiChatTextAreaSubmitPayload } from "../types"
 
 import { F0SegmentedControl } from "@/experimental/Actions/F0SegmentedControl"
 import {
+  Calendar,
   ChartVerticalBars,
   File,
   Marketplace,
+  PalmTree,
   Pencil,
+  Person,
+  Receipt,
   Search,
+  Settings,
 } from "@/icons/app"
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
 
@@ -214,6 +219,61 @@ const LONG_WELCOME_SUGGESTIONS: WelcomeScreenSuggestion[] = [
   },
 ]
 
+// More groups than the field can show at once — the case the `inside` row's
+// sideways scroll and faded ends exist for. The items are deliberately thin:
+// what this fixture is testing is the ROW, not the panels.
+const MANY_WELCOME_SUGGESTIONS: WelcomeScreenSuggestion[] = [
+  ...WELCOME_SUGGESTIONS,
+  {
+    icon: PalmTree,
+    label: "Time off",
+    items: [
+      { title: "Request time off", prompt: "Request time off for next week." },
+      { title: "My remaining leave", prompt: "How much leave do I have left?" },
+    ],
+  },
+  {
+    icon: Receipt,
+    label: "Expenses",
+    items: [
+      { title: "Submit an expense", prompt: "Submit a new expense report." },
+      { title: "Pending reimbursements", prompt: "What am I owed?" },
+    ],
+  },
+  {
+    icon: Calendar,
+    label: "Schedule",
+    items: [
+      { title: "Book a meeting room", prompt: "Book a room for tomorrow." },
+      { title: "My shifts this week", prompt: "Show my shifts this week." },
+    ],
+  },
+  {
+    icon: File,
+    label: "Documents",
+    items: [
+      { title: "My last payslip", prompt: "Open my most recent payslip." },
+      { title: "My contract", prompt: "Show my current contract." },
+    ],
+  },
+  {
+    icon: Person,
+    label: "My team",
+    items: [
+      { title: "Who reports to me?", prompt: "List my direct reports." },
+      { title: "Team headcount", prompt: "What is my team's headcount?" },
+    ],
+  },
+  {
+    icon: Settings,
+    label: "Settings",
+    items: [
+      { title: "Change my language", prompt: "Change my language to Spanish." },
+      { title: "Notification preferences", prompt: "Open my notifications." },
+    ],
+  },
+]
+
 const noop = () => {}
 
 const buildClarifyingState = (
@@ -260,6 +320,7 @@ type WrapperProps = {
   footer?: React.ReactNode
   welcomeScreenSuggestions?: WelcomeScreenSuggestion[]
   welcomeScreenSuggestionsPlacement?: "above" | "inside"
+  welcomeScreenSuggestionsCollapsedByDefault?: boolean
   welcomeScreenCards?: F0AiChatWelcomeCard[]
   isWelcomeScreen?: boolean
   fullscreen?: boolean
@@ -281,6 +342,7 @@ const Wrapper = ({
   footer,
   welcomeScreenSuggestions,
   welcomeScreenSuggestionsPlacement,
+  welcomeScreenSuggestionsCollapsedByDefault,
   welcomeScreenCards,
   isWelcomeScreen,
   fullscreen,
@@ -350,6 +412,9 @@ const Wrapper = ({
         footer={footer}
         welcomeScreenSuggestions={welcomeScreenSuggestions}
         welcomeScreenSuggestionsPlacement={welcomeScreenSuggestionsPlacement}
+        welcomeScreenSuggestionsCollapsedByDefault={
+          welcomeScreenSuggestionsCollapsedByDefault
+        }
         onSuggestionClick={(item) => {
           // Suggestions always send a prompt (item.prompt, falling back to its
           // title) — unlike cards, the host doesn't branch on behavior.
@@ -550,9 +615,10 @@ export const WithWelcomeSuggestions: Story = {
 }
 
 // `welcomeScreenSuggestionsPlacement: "inside"` — the suggestions move INTO the
-// field, at its foot, and the send button moves onto the textarea's own line.
-// With no attachments, dictation or `toolbarStart` the composer is exactly two
-// bands (text + send, then the chips), which is the home-page "ask" bar shape.
+// field and take the middle of its ACTION row, between the attachment/host
+// controls and the dictation · send pair. That is what keeps the field two bands
+// tall (text, then one row of controls) instead of three, and it is the home-page
+// "ask" bar shape.
 // Note there is no `fullscreen`: this placement doesn't need the welcome screen's
 // vertical room, because it isn't claiming any space above the field.
 export const WithWelcomeSuggestionsInside: Story = {
@@ -561,6 +627,8 @@ export const WithWelcomeSuggestionsInside: Story = {
     welcomeScreenSuggestions: WELCOME_SUGGESTIONS,
     welcomeScreenSuggestionsPlacement: "inside",
     placeholders: ROTATING_PLACEHOLDERS,
+    fileAttachments: FILE_UPLOAD_CONFIG,
+    onTranscribe: mockTranscribe,
     disclaimer: DISCLAIMER,
   },
   play: async ({ canvasElement, step }) => {
@@ -582,18 +650,28 @@ export const WithWelcomeSuggestionsInside: Story = {
       ).toBeTruthy()
     })
 
-    await step("Send trails the text instead of sitting in its own row", () => {
+    await step("The chips share the action row with every button", () => {
       const textarea = canvasElement.querySelector(
         'textarea[name="one-ai-input"]'
       )!
       // The text band: TextareaField's grid, then the row that holds it.
       const textBand = textarea.parentElement!.parentElement!
-      const send = page.getByRole("button", { name: /send/i })
       const trigger = page.getByRole("button", { name: "Analyze" })
+      const send = page.getByRole("button", { name: /send/i })
+      const mic = page.getByRole("button", { name: /record/i })
+      const row = trigger.closest("form > div > div")!
 
-      expect(textBand.contains(send)).toBe(true)
-      // …and the chips are their own band under it, not in this one.
-      expect(textBand.contains(trigger)).toBe(false)
+      // Chips, dictation and send are all one row — and none of them is in the
+      // text band above it.
+      for (const control of [trigger, mic, send]) {
+        expect(row.contains(control)).toBe(true)
+        expect(textBand.contains(control)).toBe(false)
+      }
+      // Dictation sits immediately before send.
+      expect(mic.parentElement).toBe(send.parentElement)
+      expect(
+        mic.compareDocumentPosition(send) & Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy()
     })
 
     await step("Picking a group opens its panel", async () => {
@@ -605,6 +683,104 @@ export const WithWelcomeSuggestionsInside: Story = {
         page.getByRole("button", { name: "April leave and overtime summary" })
       ).toBeInTheDocument()
     })
+  },
+}
+
+// More groups than fit: the row keeps to ONE line and scrolls sideways, and the
+// end that has chips hidden past it is faded — that fade is the only scroll
+// affordance there is, since the scrollbar is hidden. Scroll to the end and the
+// trailing fade goes away while the leading one appears. Ten groups cost the
+// field exactly the height three do.
+export const WithManyWelcomeSuggestionsInside: Story = {
+  args: {
+    isWelcomeScreen: true,
+    welcomeScreenSuggestions: MANY_WELCOME_SUGGESTIONS,
+    welcomeScreenSuggestionsPlacement: "inside",
+    placeholders: ROTATING_PLACEHOLDERS,
+    fileAttachments: FILE_UPLOAD_CONFIG,
+    onTranscribe: mockTranscribe,
+    disclaimer: DISCLAIMER,
+  },
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+
+    await step("The row scrolls instead of wrapping", () => {
+      const scroller = page.getByRole("button", {
+        name: "Analyze",
+      }).parentElement!
+
+      // One line, and wider than the box showing it.
+      expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth)
+      // Which is what the fade is drawn from: only the end with something
+      // hidden past it is masked, so at rest that is the trailing edge alone.
+      expect(scroller.style.maskImage).toContain("transparent 100%")
+      expect(scroller.style.maskImage).not.toContain("transparent 0")
+    })
+
+    await step("The last group is reachable by scrolling", async () => {
+      const scroller = page.getByRole("button", {
+        name: "Analyze",
+      }).parentElement!
+
+      scroller.scrollLeft = scroller.scrollWidth
+      await userEvent.click(page.getByRole("button", { name: "Settings" }))
+      await expect(
+        page.getByRole("dialog", { name: "Settings" })
+      ).toBeInTheDocument()
+    })
+  },
+}
+
+// `welcomeScreenSuggestionsCollapsedByDefault` — the bar is ONE LINE until it is
+// addressed: One's mark, the placeholder, and send trailing the text. The whole
+// control row is gone, not just the chips (a row emptied of its chips would still
+// be 56px of padding around two buttons). Click or tab into the input and the row
+// opens with everything in it — attachments, the starter prompts, dictation, and
+// send back among its peers at `md`.
+//
+// It stays open: every way of picking a chip takes focus off the input, so a row
+// that closed on blur would close on its way to being used.
+export const WithCollapsedWelcomeSuggestions: Story = {
+  args: {
+    isWelcomeScreen: true,
+    welcomeScreenSuggestions: MANY_WELCOME_SUGGESTIONS,
+    welcomeScreenSuggestionsPlacement: "inside",
+    welcomeScreenSuggestionsCollapsedByDefault: true,
+    placeholders: ROTATING_PLACEHOLDERS,
+    fileAttachments: FILE_UPLOAD_CONFIG,
+    onTranscribe: mockTranscribe,
+    disclaimer: DISCLAIMER,
+  },
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+    const textarea = canvasElement.querySelector<HTMLTextAreaElement>(
+      'textarea[name="one-ai-input"]'
+    )!
+
+    await step("Collapsed: one line, dictation and send trailing it", () => {
+      // Unmounted rather than hidden: controls behind a zero height would still
+      // be in the tab order.
+      for (const name of [/analyze/i, /attach/i]) {
+        expect(page.queryByRole("button", { name })).not.toBeInTheDocument()
+      }
+      // Two controls come along: send (a bar you cannot send from is not a
+      // composer) and dictation (talking is a way to start a prompt without
+      // typing one). Both on the textarea's own line.
+      const textBand = textarea.parentElement!.parentElement!
+      for (const name of [/send/i, /record/i]) {
+        expect(textBand.contains(page.getByRole("button", { name }))).toBe(true)
+      }
+      // …and the bar does not steal focus to open itself.
+      expect(textarea).not.toHaveFocus()
+    })
+
+    // NOTHING IS CLICKED HERE, on purpose. A play function runs as soon as the
+    // story opens, so a step that focused the input to show the reveal would
+    // leave this story permanently open — the one state it exists to show would
+    // be the one you can never see. Click the field yourself to watch it open;
+    // that the focus opens the row, that the row holds every control, and that it
+    // stays open on blur are asserted in
+    // `__tests__/F0AiChatTextArea.suggestionsInside.test.tsx`.
   },
 }
 

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useRef, useState } from "react"
-import { expect, userEvent, within } from "storybook/test"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import { F0AiChatTextArea } from "../F0AiChatTextArea"
 import type { F0AiChatTextAreaSubmitPayload } from "../types"
@@ -704,7 +704,7 @@ export const WithManyWelcomeSuggestionsInside: Story = {
   play: async ({ canvasElement, step }) => {
     const page = within(canvasElement.closest("body")!)
 
-    await step("The row scrolls instead of wrapping", () => {
+    await step("The row scrolls instead of wrapping", async () => {
       const scroller = page.getByRole("button", {
         name: "Analyze",
       }).parentElement!
@@ -713,7 +713,15 @@ export const WithManyWelcomeSuggestionsInside: Story = {
       expect(scroller.scrollWidth).toBeGreaterThan(scroller.clientWidth)
       // Which is what the fade is drawn from: only the end with something
       // hidden past it is masked, so at rest that is the trailing edge alone.
-      expect(scroller.style.maskImage).toContain("transparent 100%")
+      //
+      // AWAITED, because the mask is measured rather than declared: the first
+      // read happens before the row has been laid out (a scroller that is 0px
+      // wide overflows by nothing), and the honest answer arrives with the
+      // ResizeObserver a frame later. Asserting straight after mount passed
+      // locally and failed in CI, which is exactly the tell.
+      await waitFor(() => {
+        expect(scroller.style.maskImage).toContain("transparent 100%")
+      })
       expect(scroller.style.maskImage).not.toContain("transparent 0")
     })
 

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.suggestionsInside.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.suggestionsInside.test.tsx
@@ -1,12 +1,57 @@
-import { describe, expect, it, vi } from "vitest"
+import { type RefObject } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { ChartVerticalBars } from "@/icons/app"
-import { userEvent, zeroRender as render, screen } from "@/testing/test-utils"
+import { ChartVerticalBars, Search } from "@/icons/app"
+import {
+  userEvent,
+  waitFor,
+  zeroRender as render,
+  screen,
+} from "@/testing/test-utils"
 
 import { type WelcomeScreenSuggestion } from "../../F0AiChat/types"
 
+// jsdom has no MediaRecorder, so dictation would report itself unsupported and
+// the microphone would never render. `start` is a spy: whether pressing the
+// microphone actually reaches it is the point of one of the tests below.
+const recorder = vi.hoisted(() => ({
+  start: vi.fn(),
+  stop: vi.fn(),
+  cancel: vi.fn(),
+}))
+
+vi.mock("../useAudioRecorder", () => ({
+  useAudioRecorder: () => ({
+    status: "idle",
+    stream: null,
+    isSupported: true,
+    ...recorder,
+  }),
+}))
+
+// A faithful-enough double: it keeps the props the composer own behavior depends
+// on — the ref (so the mount autofocus can land) and the controlled value (so
+// typing reaches `hasDataToSend`) — without the sizer, overlay and typewriter
+// layers. Focus is tracked on the form, so nothing extra is needed for that.
 vi.mock("../components/TextareaField", () => ({
-  TextareaField: () => <textarea aria-label="Message" readOnly />,
+  TextareaField: ({
+    textareaRef,
+    inputValue,
+    onInputChange,
+  }: {
+    textareaRef: RefObject<HTMLTextAreaElement>
+    inputValue: string
+    onInputChange: (value: string, cursorPos: number) => void
+  }) => (
+    <textarea
+      aria-label="Message"
+      ref={textareaRef}
+      value={inputValue}
+      onChange={(e) =>
+        onInputChange(e.target.value, e.target.selectionStart ?? 0)
+      }
+    />
+  ),
 }))
 
 import { F0AiChatTextArea } from "../F0AiChatTextArea"
@@ -17,11 +62,18 @@ const suggestions: WelcomeScreenSuggestion[] = [
     label: "Analyze",
     items: [{ title: "April leave summary" }],
   },
+  {
+    icon: Search,
+    label: "Find",
+    items: [{ title: "Who is out this week?" }],
+  },
 ]
 
 const sendButton = () => screen.getByRole("button", { name: /send/i })
 const trigger = () => screen.getByRole("button", { name: /analyze/i })
 const textarea = () => screen.getByRole("textbox", { name: "Message" })
+/** The band the chips share with the buttons — the action row. */
+const actionRow = () => trigger().closest("form > div > div")
 
 describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
   it("renders the suggestions inside the form, below the textarea", () => {
@@ -58,7 +110,7 @@ describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
     expect(textarea().closest("form")?.contains(trigger())).toBe(false)
   })
 
-  it("moves the send button onto the textarea's own band", () => {
+  it("puts the chips and the send button on the same row", () => {
     render(
       <F0AiChatTextArea
         onSubmit={() => {}}
@@ -69,14 +121,15 @@ describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
       />
     )
 
-    // The band is the row wrapping the mocked TextareaField.
-    const band = textarea().parentElement
-    expect(band?.contains(sendButton())).toBe(true)
-    // The chips are a separate band under it, not part of the text row.
-    expect(band?.contains(trigger())).toBe(false)
+    // One band holds both, so however many groups there are the field stays two
+    // bands tall.
+    expect(actionRow()?.contains(sendButton())).toBe(true)
+    // …and the text band holds neither.
+    expect(textarea().parentElement?.contains(sendButton())).toBe(false)
+    expect(textarea().parentElement?.contains(trigger())).toBe(false)
   })
 
-  it("renders exactly one send button (the action row gives its up)", () => {
+  it("renders exactly one send button", () => {
     render(
       <F0AiChatTextArea
         onSubmit={() => {}}
@@ -90,7 +143,7 @@ describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
     expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
   })
 
-  it("drops the action row when it has no controls left to hold", () => {
+  it("keeps every control on that one row, dictation next to send", async () => {
     render(
       <F0AiChatTextArea
         onSubmit={() => {}}
@@ -98,41 +151,53 @@ describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
         welcomeScreenSuggestions={suggestions}
         welcomeScreenSuggestionsPlacement="inside"
         onSuggestionClick={() => {}}
-      />
-    )
-
-    // No attachments, no dictation, no toolbarStart: an action row would be
-    // 24px of padding around nothing.
-    expect(
-      screen.queryByRole("button", { name: /attach/i })
-    ).not.toBeInTheDocument()
-    expect(
-      screen.queryByRole("button", { name: /record/i })
-    ).not.toBeInTheDocument()
-    // The chips band is the last thing in the form — nothing follows it.
-    const form = textarea().closest("form")!
-    const chipsBand = trigger().closest("form > div > div")
-    expect(form.contains(chipsBand)).toBe(true)
-  })
-
-  it("keeps the action row for the controls that stay in it", () => {
-    render(
-      <F0AiChatTextArea
-        onSubmit={() => {}}
-        isWelcomeScreen
-        welcomeScreenSuggestions={suggestions}
-        welcomeScreenSuggestionsPlacement="inside"
-        onSuggestionClick={() => {}}
+        fileAttachments={{ onUploadFiles: async () => [] }}
+        onTranscribe={async () => "hola"}
         toolbarStart={<button type="button">Pick a model</button>}
       />
     )
 
+    const row = actionRow()!
+    const attach = screen.getByRole("button", { name: /attach/i })
+    const model = screen.getByRole("button", { name: "Pick a model" })
+    const mic = screen.getByRole("button", { name: /record/i })
+
+    for (const control of [attach, model, mic, sendButton()]) {
+      expect(row.contains(control)).toBe(true)
+    }
+    // The chips take the middle: host controls lead, dictation · send trail.
     expect(
-      screen.getByRole("button", { name: "Pick a model" })
-    ).toBeInTheDocument()
-    // The send button did NOT come back with it.
-    expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
-    expect(textarea().parentElement?.contains(sendButton())).toBe(true)
+      model.compareDocumentPosition(trigger()) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(
+      trigger().compareDocumentPosition(mic) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    // Dictation sits immediately before send, not at the other end of the row.
+    expect(
+      mic.compareDocumentPosition(sendButton()) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+    expect(mic.parentElement).toBe(sendButton().parentElement)
+  })
+
+  it("scrolls the chips sideways instead of wrapping them", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    // A second line of chips would grow the field's whole bottom band, so the
+    // row is one line that scrolls — and each chip holds its width.
+    const row = trigger().parentElement!
+    expect(row.className).toMatch(/overflow-x-auto/)
+    expect(row.className).toMatch(/flex-nowrap/)
+    expect(trigger().className).toMatch(/shrink-0/)
   })
 
   it("opens the group popover on click without submitting the form", async () => {
@@ -161,7 +226,7 @@ describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
     expect(screen.getByText("April leave summary")).toBeInTheDocument()
   })
 
-  it("keeps the send button inline once the welcome screen is gone", () => {
+  it("keeps the bar's shape once the welcome screen is gone", () => {
     // The suggestions are welcome-screen-only, but the bar must not change
     // shape under the reader when the first message lands.
     render(
@@ -174,6 +239,188 @@ describe("F0AiChatTextArea welcomeScreenSuggestionsPlacement='inside'", () => {
     )
 
     expect(screen.queryByRole("button", { name: /analyze/i })).toBeNull()
-    expect(textarea().parentElement?.contains(sendButton())).toBe(true)
+    // Still one row with the send button in it, and still the text band above.
+    expect(sendButton().closest("form > div > div")).not.toBe(
+      textarea().parentElement
+    )
+    expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
+  })
+})
+
+describe("F0AiChatTextArea welcomeScreenSuggestionsCollapsedByDefault", () => {
+  beforeEach(() => {
+    recorder.start.mockClear()
+  })
+
+  const renderCollapsed = (placement: "above" | "inside" = "inside") =>
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement={placement}
+        welcomeScreenSuggestionsCollapsedByDefault
+        onSuggestionClick={() => {}}
+        fileAttachments={{ onUploadFiles: async () => [] }}
+        onTranscribe={async () => "hola"}
+      />
+    )
+
+  it("collapses the bar to ONE line: no control row at all", () => {
+    renderCollapsed()
+
+    // Not just the chips — the whole row goes. A row emptied of its chips would
+    // still be 56px of padding around two buttons, which is not a quiet bar.
+    expect(screen.queryByRole("button", { name: /analyze/i })).toBeNull()
+    expect(screen.queryByRole("button", { name: /attach/i })).toBeNull()
+    // Send and dictation come along onto the text's own line: a bar you cannot
+    // send from is not a composer, and one that hid the microphone would be
+    // asking the reader to type first.
+    const textBand = textarea().parentElement!
+    expect(textBand.contains(sendButton())).toBe(true)
+    expect(
+      textBand.contains(screen.getByRole("button", { name: /record/i }))
+    ).toBe(true)
+    expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
+    expect(screen.getAllByRole("button", { name: /record/i })).toHaveLength(1)
+  })
+
+  it("opens the full control row on focus, send back among its peers", async () => {
+    const user = userEvent.setup()
+    renderCollapsed()
+
+    await user.click(textarea())
+
+    const trigger = await screen.findByRole("button", { name: /analyze/i })
+    const row = trigger.closest("form > div > div")!
+    for (const control of [
+      screen.getByRole("button", { name: /attach/i }),
+      screen.getByRole("button", { name: /record/i }),
+      sendButton(),
+    ]) {
+      expect(row.contains(control)).toBe(true)
+    }
+    // …and the inline one is gone with the collapsed line it belonged to.
+    expect(screen.getAllByRole("button", { name: /send/i })).toHaveLength(1)
+    expect(textarea().parentElement?.contains(sendButton())).toBe(false)
+  })
+
+  it("does not focus itself on mount, which would open the bar at once", () => {
+    renderCollapsed()
+
+    expect(textarea()).not.toHaveFocus()
+    expect(screen.queryByRole("button", { name: /analyze/i })).toBeNull()
+  })
+
+  it("starts dictation from the collapsed line", async () => {
+    // Regression: taking focus is mousedown's default action, focus opens the
+    // bar, and opening the bar unmounts this line — so the microphone was
+    // destroyed between mousedown and mouseup and its click never fired.
+    // Pressing it did nothing at all.
+    const user = userEvent.setup()
+    renderCollapsed()
+
+    await user.click(screen.getByRole("button", { name: /record/i }))
+
+    expect(recorder.start).toHaveBeenCalledOnce()
+    // …and the bar opened around it, so the recording has controls to end it.
+    expect(
+      await screen.findByRole("button", { name: /analyze/i })
+    ).toBeVisible()
+  })
+
+  it("collapses again when focus leaves the composer", async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <F0AiChatTextArea
+          onSubmit={() => {}}
+          isWelcomeScreen
+          welcomeScreenSuggestions={suggestions}
+          welcomeScreenSuggestionsPlacement="inside"
+          welcomeScreenSuggestionsCollapsedByDefault
+          onSuggestionClick={() => {}}
+        />
+        <button type="button">Somewhere else</button>
+      </>
+    )
+
+    await user.click(textarea())
+    expect(
+      await screen.findByRole("button", { name: /analyze/i })
+    ).toBeVisible()
+
+    await user.click(screen.getByRole("button", { name: "Somewhere else" }))
+
+    await waitFor(() =>
+      expect(screen.queryByRole("button", { name: /analyze/i })).toBeNull()
+    )
+  })
+
+  it("stays open while focus moves onto its own chips", async () => {
+    const user = userEvent.setup()
+    renderCollapsed()
+
+    await user.click(textarea())
+    const chip = await screen.findByRole("button", { name: /analyze/i })
+
+    // Every way of picking a chip takes focus off the textarea, so closing on
+    // the textarea's own blur would close the row on its way to being used.
+    await user.click(chip)
+
+    expect(textarea()).not.toHaveFocus()
+    expect(screen.getByRole("button", { name: /analyze/i })).toBeVisible()
+    expect(screen.getByText("April leave summary")).toBeInTheDocument()
+  })
+
+  it("stays open with something already typed, focus or not", async () => {
+    const user = userEvent.setup()
+    render(
+      <>
+        <F0AiChatTextArea
+          onSubmit={() => {}}
+          isWelcomeScreen
+          welcomeScreenSuggestions={suggestions}
+          welcomeScreenSuggestionsPlacement="inside"
+          welcomeScreenSuggestionsCollapsedByDefault
+          onSuggestionClick={() => {}}
+        />
+        <button type="button">Somewhere else</button>
+      </>
+    )
+
+    await user.click(textarea())
+    await user.type(textarea(), "How much leave do I have left?")
+    await user.click(screen.getByRole("button", { name: "Somewhere else" }))
+
+    // A half-typed prompt with no visible way to send it would be a trap.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /analyze/i })).toBeVisible()
+    )
+  })
+
+  it("collapses the row above the composer too", async () => {
+    const user = userEvent.setup()
+    renderCollapsed("above")
+
+    expect(screen.queryByRole("button", { name: /analyze/i })).toBeNull()
+    await user.click(textarea())
+    expect(
+      await screen.findByRole("button", { name: /analyze/i })
+    ).toBeVisible()
+  })
+
+  it("renders the chips from the start without the prop", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={() => {}}
+        isWelcomeScreen
+        welcomeScreenSuggestions={suggestions}
+        welcomeScreenSuggestionsPlacement="inside"
+        onSuggestionClick={() => {}}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /analyze/i })).toBeVisible()
   })
 })

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
@@ -1,7 +1,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { ChartVerticalBars, Pencil, Search } from "@/icons/app"
-import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
+import {
+  act,
+  screen,
+  userEvent,
+  waitFor,
+  zeroRender,
+} from "@/testing/test-utils"
 
 import { type WelcomeScreenSuggestion } from "../../F0AiChat/types"
 import { WelcomeScreenSuggestionsRow } from "../components/WelcomeScreenSuggestionsRow"
@@ -472,5 +478,98 @@ describe("WelcomeScreenSuggestionsRow", () => {
 
       expect(label.style.transform).toBe("")
     })
+  })
+})
+
+describe("WelcomeScreenSuggestionsRow overflow='scroll'", () => {
+  /** jsdom has no layout, so the scroller's measurements are stubbed. */
+  const stubOverflow = (
+    el: HTMLElement,
+    { scrollWidth = 900, clientWidth = 400, scrollLeft = 0 } = {}
+  ) => {
+    Object.defineProperty(el, "scrollWidth", {
+      configurable: true,
+      value: scrollWidth,
+    })
+    Object.defineProperty(el, "clientWidth", {
+      configurable: true,
+      value: clientWidth,
+    })
+    el.scrollLeft = scrollLeft
+    act(() => {
+      el.dispatchEvent(new Event("scroll"))
+    })
+  }
+
+  const renderScroller = () => {
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+        overflow="scroll"
+        reserveTwoRows={false}
+      />
+    )
+    return screen.getByRole("button", { name: /analyze/i })
+      .parentElement as HTMLElement
+  }
+
+  it("keeps the chips on one scrollable line", () => {
+    const scroller = renderScroller()
+
+    expect(scroller.className).toMatch(/flex-nowrap/)
+    expect(scroller.className).toMatch(/overflow-x-auto/)
+    expect(scroller.className).not.toMatch(/flex-wrap/)
+    // A flex item shrinks before it overflows: without this the labels would
+    // squeeze instead of the row becoming scrollable.
+    expect(screen.getByRole("button", { name: /analyze/i }).className).toMatch(
+      /shrink-0/
+    )
+  })
+
+  it("fades only the end that has chips hidden past it", () => {
+    const scroller = renderScroller()
+
+    // At rest: more to the right, nothing to the left.
+    stubOverflow(scroller, { scrollLeft: 0 })
+    expect(scroller.style.maskImage).toBe(
+      "linear-gradient(to right, black 0, black calc(100% - 24px), transparent 100%)"
+    )
+
+    // Mid-scroll: cut off at both ends.
+    stubOverflow(scroller, { scrollLeft: 200 })
+    expect(scroller.style.maskImage).toBe(
+      "linear-gradient(to right, transparent 0, black 24px, black calc(100% - 24px), transparent 100%)"
+    )
+
+    // At the end: only the leading edge is still hiding anything.
+    stubOverflow(scroller, { scrollLeft: 500 })
+    expect(scroller.style.maskImage).toBe(
+      "linear-gradient(to right, transparent 0, black 24px, black 100%)"
+    )
+  })
+
+  it("does not fade a row that fits", () => {
+    const scroller = renderScroller()
+
+    stubOverflow(scroller, { scrollWidth: 400, clientWidth: 400 })
+
+    // A static mask would read as a visual treatment rather than as "there is
+    // more this way", so a row with nothing hidden is not masked at all.
+    expect(scroller.style.maskImage).toBe("")
+  })
+
+  it("wraps instead of scrolling by default", () => {
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+      />
+    )
+
+    const row = screen.getByRole("button", { name: /analyze/i }).parentElement
+    expect(row?.className).toMatch(/flex-wrap/)
+    expect(row?.className).not.toMatch(/overflow-x-auto/)
+    expect(row).not.toHaveAttribute("style")
   })
 })

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/ActionBar.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/ActionBar.tsx
@@ -1,16 +1,28 @@
 import { type ReactNode, type RefObject } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { Check, Cross, Microphone, Paperclip } from "@/icons/app"
+import { Check, Cross, Paperclip } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
 
 import { type RecorderStatus } from "../useAudioRecorder"
+import { DictationButton } from "./DictationButton"
 import { RecordingWaveform } from "./RecordingWaveform"
 import { SubmitButton } from "./SubmitButton"
 
 interface ActionBarProps {
   onUploadFiles: ((files: File[]) => Promise<unknown>) | undefined
   toolbarStart?: ReactNode
+  /**
+   * Content for the middle of the row, between the attachment/host controls and
+   * the dictation/send pair. Takes the row's slack (`flex-1`) and is expected to
+   * handle its own overflow — the `inside` suggestions layout puts the chips
+   * here, scrolled sideways.
+   *
+   * Dropped while recording: that row is the waveform plus its cancel · confirm
+   * pair, and it needs the whole width.
+   */
+  center?: ReactNode
   isAtMaxFiles: boolean
   maxFiles: number | undefined
   acceptValue: string | undefined
@@ -26,23 +38,12 @@ interface ActionBarProps {
   onStartRecording?: () => void
   onStopRecording?: () => void
   onCancelRecording?: () => void
-  /**
-   * Whether this row owns the send / stop button. False in the `inside`
-   * suggestions layout, where the button sits on the textarea's own line and
-   * this row is left with the attachment, host and dictation controls.
-   *
-   * Only the idle row honours it — the recording row's cancel · confirm pair is
-   * not the submit button and must never be dropped, or a recording would have
-   * no way to end.
-   *
-   * @default true
-   */
-  showSubmit?: boolean
 }
 
 export const ActionBar = ({
   onUploadFiles,
   toolbarStart,
+  center,
   isAtMaxFiles,
   maxFiles,
   acceptValue,
@@ -57,7 +58,6 @@ export const ActionBar = ({
   onStartRecording,
   onStopRecording,
   onCancelRecording,
-  showSubmit = true,
 }: ActionBarProps) => {
   const translation = useI18n()
 
@@ -96,69 +96,76 @@ export const ActionBar = ({
   }
 
   return (
-    <div className="flex shrink-0 items-center justify-between p-3">
-      <div className="flex min-w-0 items-center gap-2">
-        {onUploadFiles && (
-          <>
-            <ButtonInternal
-              label={translation.ai.attachFile}
-              hideLabel
-              type="button"
-              icon={Paperclip}
-              variant="outline"
-              size="md"
-              disabled={isAtMaxFiles || recordingStatus === "transcribing"}
-              onClick={(e) => {
-                e.preventDefault()
-                fileInputRef.current?.click()
-              }}
-            />
-            <input
-              ref={fileInputRef}
-              type="file"
-              // Native picker only honors a binary "single vs multiple"
-              // selection — no per-N cap. We still validate the count in JS.
-              multiple={maxFiles !== 1}
-              disabled={isAtMaxFiles}
-              accept={acceptValue}
-              className="hidden"
-              onChange={handleFileSelect}
-            />
-          </>
-        )}
-        {toolbarStart && (
-          // Host controls keep their own focus instead of bubbling to the
-          // form's click handler, which intentionally focuses the textarea.
-          <div
-            className="min-w-0 cursor-default"
-            onClick={(event) => event.stopPropagation()}
-          >
-            {toolbarStart}
-          </div>
-        )}
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
+    // Three cells: the start controls, the optional middle, and the dictation ·
+    // send pair. `ml-auto` on the last one is what pins it right — NOT
+    // `justify-between`, which would strand a lone send button on the left the
+    // moment the row has nothing else in it.
+    <div className="flex shrink-0 items-center gap-2 p-3">
+      {(onUploadFiles || toolbarStart) && (
+        <div
+          className={cn(
+            "flex items-center gap-2",
+            // The middle takes the slack, so the controls beside it hold their
+            // width; with no middle they keep the shrink that lets a wide
+            // `toolbarStart` truncate instead of pushing send off the row.
+            center ? "shrink-0" : "min-w-0"
+          )}
+        >
+          {onUploadFiles && (
+            <>
+              <ButtonInternal
+                label={translation.ai.attachFile}
+                hideLabel
+                type="button"
+                icon={Paperclip}
+                variant="outline"
+                size="md"
+                disabled={isAtMaxFiles || recordingStatus === "transcribing"}
+                onClick={(e) => {
+                  e.preventDefault()
+                  fileInputRef.current?.click()
+                }}
+              />
+              <input
+                ref={fileInputRef}
+                type="file"
+                // Native picker only honors a binary "single vs multiple"
+                // selection — no per-N cap. We still validate the count in JS.
+                multiple={maxFiles !== 1}
+                disabled={isAtMaxFiles}
+                accept={acceptValue}
+                className="hidden"
+                onChange={handleFileSelect}
+              />
+            </>
+          )}
+          {toolbarStart && (
+            // Host controls keep their own focus instead of bubbling to the
+            // form's click handler, which intentionally focuses the textarea.
+            <div
+              className="min-w-0 cursor-default"
+              onClick={(event) => event.stopPropagation()}
+            >
+              {toolbarStart}
+            </div>
+          )}
+        </div>
+      )}
+      {center && <div className="min-w-0 flex-1">{center}</div>}
+      <div className="ml-auto flex shrink-0 items-center gap-2">
         {canRecord && (
-          <ButtonInternal
-            label={translation.ai.recordAudio}
-            hideLabel
-            type="button"
-            icon={Microphone}
-            variant="outline"
-            size="md"
-            disabled={inProgress}
-            onClick={onStartRecording}
-            loading={recordingStatus === "transcribing"}
-          />
-        )}
-        {showSubmit && (
-          <SubmitButton
+          <DictationButton
             inProgress={inProgress}
-            hasDataToSend={hasDataToSend}
-            isPreSending={isPreSending}
             recordingStatus={recordingStatus}
+            onStartRecording={onStartRecording}
           />
         )}
+        <SubmitButton
+          inProgress={inProgress}
+          hasDataToSend={hasDataToSend}
+          isPreSending={isPreSending}
+          recordingStatus={recordingStatus}
+        />
       </div>
     </div>
   )

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/DictationButton.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/DictationButton.tsx
@@ -1,0 +1,50 @@
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { Microphone } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+
+import { type RecorderStatus } from "../useAudioRecorder"
+
+interface DictationButtonProps {
+  inProgress?: boolean
+  recordingStatus?: RecorderStatus
+  onStartRecording?: () => void
+  /**
+   * `md` (32px) in the action row, `sm` (24px) when it trails the text inline on
+   * the collapsed bar — see {@link SubmitButton} for why a 32px button cannot be
+   * centred on a 20px line of text.
+   *
+   * @default "md"
+   */
+  size?: "sm" | "md"
+}
+
+/**
+ * The composer's dictation control.
+ *
+ * Kept apart from `ActionBar` because the collapsed bar keeps this button and
+ * send while dropping every other control: talking is a way to start a prompt
+ * without typing one, so it earns its place on a one-line bar. Both placements
+ * must render the same button, so there is one definition rather than two.
+ */
+export const DictationButton = ({
+  inProgress,
+  recordingStatus = "idle",
+  onStartRecording,
+  size = "md",
+}: DictationButtonProps) => {
+  const translation = useI18n()
+
+  return (
+    <ButtonInternal
+      label={translation.ai.recordAudio}
+      hideLabel
+      type="button"
+      icon={Microphone}
+      variant="outline"
+      size={size}
+      disabled={inProgress}
+      onClick={onStartRecording}
+      loading={recordingStatus === "transcribing"}
+    />
+  )
+}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/SubmitButton.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/SubmitButton.tsx
@@ -11,9 +11,10 @@ interface SubmitButtonProps {
   recordingStatus?: RecorderStatus
   /**
    * `md` (32px) for the action row, where the button stands in a row of its own
-   * peers. `sm` (24px) when it trails the text inline: a 32px button beside a
-   * 20px line of text cannot be centred on that line without eating the field's
-   * top inset, which is what makes it look pinned to the border.
+   * peers. `sm` (24px) when it trails the text inline — the collapsed bar, which
+   * has no action row: a 32px button beside a 20px line of text cannot be centred
+   * on that line without eating the field's top inset, which is what makes it
+   * look pinned to the border.
    *
    * @default "md"
    */
@@ -23,8 +24,8 @@ interface SubmitButtonProps {
 /**
  * The composer's send / stop control.
  *
- * Extracted from `ActionBar` because the `inside` suggestions layout moves it
- * out of the action row and onto the textarea's own line — both placements must
+ * Kept apart from `ActionBar` because the collapsed bar has no action row and
+ * puts this button on the textarea's own line instead — both placements must
  * render the exact same button (same labels, same disabled rule, same
  * stop-while-streaming swap), so there is one definition rather than two.
  */

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -19,6 +19,7 @@ import type {
   WelcomeScreenSuggestion,
   WelcomeScreenSuggestionItem,
 } from "../../F0AiChat/types"
+import { useHorizontalScrollFade } from "../useHorizontalScrollFade"
 
 const MAX_ITEMS_PER_GROUP = 5
 
@@ -75,6 +76,20 @@ export type WelcomeScreenSuggestionsRowProps = {
    * @default true
    */
   reserveTwoRows?: boolean
+  /**
+   * What the row does when the groups do not fit its width.
+   *
+   * - `"wrap"` — they flow onto a second line. Right for the row standing above
+   *   the composer, which has the page's height to spend.
+   * - `"scroll"` — one line, scrolled sideways, with the overflowing ends faded
+   *   (see {@link useHorizontalScrollFade}). Right for the row sharing the
+   *   composer's action band with the send button: there the row is one cell of a
+   *   single-line flex row, and a second line of chips would grow the field's
+   *   whole bottom band. Ten groups then cost the same height as three.
+   *
+   * @default "wrap"
+   */
+  overflow?: "wrap" | "scroll"
 }
 
 /**
@@ -88,9 +103,12 @@ export const WelcomeScreenSuggestionsRow = ({
   onItemHover,
   side = "top",
   reserveTwoRows = true,
+  overflow = "wrap",
 }: WelcomeScreenSuggestionsRowProps) => {
   const [activeIdx, setActiveIdx] = useState<number | null>(null)
-  const rowRef = useRef<HTMLDivElement>(null)
+  const rowRef = useRef<HTMLDivElement | null>(null)
+  const scrolls = overflow === "scroll"
+  const fade = useHorizontalScrollFade()
   const lastTriggerRef = useRef<HTMLElement | null>(null)
   const shouldRestoreFocusRef = useRef(false)
   const popoverContentId = useId()
@@ -123,9 +141,35 @@ export const WelcomeScreenSuggestionsRow = ({
         )}
       >
         <PopoverAnchor asChild>
+          {/* The scroller and the popover anchor are the SAME element on
+              purpose: the panel spans the row's width
+              (`--radix-popover-trigger-width`) and opens from its leading edge,
+              which is the box the reader sees the chips in — not the wider
+              content they scroll through. Radix reads the anchor's border box,
+              so anchoring the content instead would size the panel to all ten
+              groups and hang it off the field. */}
           <div
-            ref={rowRef}
-            className="flex w-full flex-wrap items-center gap-2"
+            ref={(node) => {
+              rowRef.current = node
+              if (scrolls) fade.ref(node)
+            }}
+            style={scrolls ? fade.style : undefined}
+            className={cn(
+              "flex w-full items-center gap-2",
+              scrolls
+                ? cn(
+                    // No visible scrollbar: it would sit under the chips inside
+                    // a 32px-tall band, and the faded end is the affordance.
+                    "flex-nowrap overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+                    // `p-1 -m-1` is room for a focused chip's ring, which is
+                    // drawn 2px OUTSIDE its border box and would otherwise be
+                    // clipped by the scrollport (setting overflow on one axis
+                    // makes the other axis clip too). The negative margin gives
+                    // the padding back, so the chips sit exactly where they did.
+                    "p-1 -m-1"
+                  )
+                : "flex-wrap"
+            )}
           >
             {/* Plain buttons, NOT `PopoverTrigger`s: Radix registers a single
                 trigger per popover (the last one mounted), whose built-in
@@ -145,6 +189,10 @@ export const WelcomeScreenSuggestionsRow = ({
                 variant="outline"
                 label={group.label}
                 icon={group.icon}
+                // A flex item shrinks before it overflows, so without this the
+                // labels would squeeze and truncate instead of the row becoming
+                // scrollable.
+                className={scrolls ? "shrink-0" : undefined}
                 pressed={activeIdx === index}
                 aria-haspopup="dialog"
                 aria-expanded={activeIdx === index}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/types.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/types.ts
@@ -160,26 +160,60 @@ export type F0AiChatTextAreaProps = {
    *   single bar about two lines tall. Its popover opens downward, because up is
    *   now the text you are about to type.
    *
-   * ⚠️ `"inside"` IS A COMPOSER SHAPE, NOT JUST A POSITION. It also moves the
-   * send button onto the textarea's own line (at `sm`, centred on the text) and
-   * puts One's mark in front of the text. Neither is a feature bolted onto this
-   * prop — they are what make the placement possible and legible. The action row
-   * is full-width, so a chips row plus an action row inside one field is three
-   * stacked bands and the "single bar" is gone; with send trailing the text there
-   * are two, text then suggestions. The attachment, host (`toolbarStart`) and
-   * dictation controls keep their own row when the host enables them; with none
-   * of them the field is just the two bands.
+   * ⚠️ `"inside"` IS A COMPOSER SHAPE, NOT JUST A POSITION. The chips do not get
+   * a band of their own: they take the middle of the ACTION row, between the
+   * attachment/host controls and the dictation · send pair, and One's mark goes
+   * in front of the text. That is what keeps the field two bands tall — text,
+   * then one row of controls — instead of three. Because the chips share that
+   * line, they scroll sideways rather than wrapping, with the overflowing ends
+   * faded: ten groups cost the same height as three.
    *
-   * THE INLINE SEND FOLLOWS THE PROP, NOT THE WELCOME STATE. The suggestions
+   * THE SHAPE FOLLOWS THE PROP, NOT THE WELCOME STATE. The suggestions
    * themselves are welcome-screen-only as they always were, but a composer that
-   * put send back in the action row the moment the first message landed would
-   * change shape under the reader mid-conversation. `"inside"` therefore keeps
-   * the two-band bar for the whole thread; after the welcome screen it is simply
-   * a bar with no chips in it.
+   * dropped One's mark the moment the first message landed would change shape
+   * under the reader mid-conversation. `"inside"` therefore keeps the bar for the
+   * whole thread; after the welcome screen it is simply a bar with no chips in
+   * it.
    *
    * @default "above"
    */
   welcomeScreenSuggestionsPlacement?: "above" | "inside"
+
+  /**
+   * Start closed, and open when the reader focuses the input — with a motion
+   * reveal, the row growing into place.
+   *
+   * For hosts where the composer is not the thing the reader came for — a Home
+   * hero, say — so the bar sits quiet until it is addressed, and the starter
+   * prompts arrive at the moment they are useful.
+   *
+   * ⚠️ WITH `"inside"` THIS COLLAPSES THE WHOLE CONTROL ROW, not just the chips:
+   * the field becomes ONE LINE — One's mark, the text, then dictation and send
+   * trailing it at `sm` — and the chips, attachment and host controls arrive with
+   * the row on focus. A row emptied of its chips would still be 56px of padding
+   * around two buttons, which is not a quiet bar; it is the same two-band field
+   * with a hole in it. Send comes along because a bar you cannot send from is not
+   * a composer, and dictation because talking is a way to start a prompt without
+   * typing one. With the row `"above"`, only that row collapses — the field below
+   * it is a plain composer and does not change shape.
+   *
+   * FOCUS IS TRACKED ON THE WHOLE COMPOSER, not on the textarea: it closes when
+   * focus leaves the field AND everything in it, including the suggestion panel
+   * (which Radix portals outside the form). Closing on the textarea's own blur
+   * would close the row the moment a chip took focus, which is every way of
+   * picking one. Three things hold it open regardless of focus: anything already
+   * typed or attached (a half-written prompt with no visible way to send it would
+   * be a trap — and a host that forwards a dropped file can put one there without
+   * the textarea ever being focused), and a recording in flight (its cancel ·
+   * confirm pair lives in the row).
+   *
+   * ⚠️ It also suppresses the composer's own autofocus-on-mount, which would
+   * otherwise open everything before the reader had touched anything and make
+   * this prop a no-op. A collapsed composer starts unfocused.
+   *
+   * @default false
+   */
+  welcomeScreenSuggestionsCollapsedByDefault?: boolean
 
   /**
    * Cards rendered as a grid below the composer on the fullscreen welcome

--- a/packages/react/src/kits/ai/F0AiChatTextArea/useHorizontalScrollFade.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/useHorizontalScrollFade.ts
@@ -1,0 +1,72 @@
+import { type CSSProperties, useEffect, useMemo, useState } from "react"
+
+/** How far an overflowing end is faded out, in px. */
+export const SCROLL_FADE_PX = 24
+
+/**
+ * Fades a horizontal scroller's ends — but only the ends that have something
+ * hidden past them.
+ *
+ * The fade IS the scroll affordance: the row has no visible scrollbar, so a chip
+ * cut off by a soft edge is the only thing telling the reader there is more
+ * sideways. That only works if the mask is honest — a static gradient dims the
+ * first chip before you have scrolled anywhere and keeps dimming the last one
+ * once you have reached the end, at which point it reads as decoration rather
+ * than as "there is more this way". So each end is masked only while content is
+ * actually cut off there, and a row that fits is not masked at all.
+ *
+ * (The vertical sibling of this lives in `sds/Home/useScrollFade` — same idea,
+ * other axis. They are kept apart rather than shared because each is a few lines
+ * of measurement and neither domain should reach into the other's internals.)
+ */
+export function useHorizontalScrollFade(fade: number = SCROLL_FADE_PX) {
+  /**
+   * A CALLBACK ref held in state, not a `useRef`: the row can mount a render
+   * late (it sits behind a collapse animation), and an effect that read a plain
+   * ref once on mount would find nothing there, attach no listeners, and — with
+   * nothing to depend on — never look again.
+   */
+  const [el, setEl] = useState<HTMLElement | null>(null)
+  const [ends, setEnds] = useState({ start: false, end: false })
+
+  useEffect(() => {
+    if (!el) return
+
+    const read = () => {
+      // A pixel of slack: fractional scroll offsets and zoom leave sub-pixel
+      // remainders that would otherwise read as "still overflowing".
+      const overflowing = el.scrollWidth > el.clientWidth + 1
+      setEnds({
+        start: overflowing && el.scrollLeft > 1,
+        end: overflowing && el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+      })
+    }
+
+    read()
+    el.addEventListener("scroll", read, { passive: true })
+    // The container's own size AND its content's: swapping the suggestion set
+    // changes what overflows without either the container resizing or a scroll
+    // happening.
+    const observer =
+      typeof ResizeObserver === "function" ? new ResizeObserver(read) : null
+    observer?.observe(el)
+    for (const child of Array.from(el.children)) observer?.observe(child)
+
+    return () => {
+      el.removeEventListener("scroll", read)
+      observer?.disconnect()
+    }
+  }, [el])
+
+  const style = useMemo<CSSProperties>(() => {
+    if (!ends.start && !ends.end) return {}
+    const from = ends.start ? `transparent 0, black ${fade}px` : "black 0"
+    const to = ends.end
+      ? `black calc(100% - ${fade}px), transparent 100%`
+      : "black 100%"
+    const mask = `linear-gradient(to right, ${from}, ${to})`
+    return { maskImage: mask, WebkitMaskImage: mask }
+  }, [ends, fade])
+
+  return { ref: setEl, style }
+}


### PR DESCRIPTION
## Description

The `inside` suggestions placement gave the chips a band of their own, which made the field three bands tall as soon as a host enabled attachments or dictation — the "single ask bar" it exists to be was gone. The chips now take the middle of the action row instead (attachment · host controls | chips | dictation · send), so the field stays two bands however many groups there are, and they scroll sideways with faded ends rather than wrapping onto a second line. This also adds `welcomeScreenSuggestionsCollapsedByDefault` for hosts where the composer is not what the reader came for — Home's hero, say — where the bar sits as one quiet line until it is addressed.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Bug fix
