### PR TITLE
fix(F0Chat): drop the mention chip's font-weight so the caret tracks the glyphs

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/TextareaField.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/TextareaField.test.tsx
@@ -3,6 +3,8 @@ import { describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
+import { type HighlightSegment } from "../highlight-utils"
+
 import { TextareaField } from "../components/TextareaField"
 
 vi.mock("../components/TypewriterPlaceholder", () => ({
@@ -73,5 +75,36 @@ describe("TextareaField placeholder rendering", () => {
 
     expect(screen.queryByText("Custom placeholder")).not.toBeInTheDocument()
     expect(screen.queryByText("Ask me anything")).not.toBeInTheDocument()
+  })
+})
+
+// Anything heavier or lighter than the `font-normal` the three layers share.
+const OFF_WEIGHT =
+  /\bfont-(thin|extralight|light|medium|semibold|bold|extrabold|black)\b/
+
+describe("TextareaField overlay/textarea metric parity", () => {
+  // Same trap as the comms twin (ChatTextareaField): a `<textarea>` lays its
+  // entire run out at one weight, so a mention the overlay paints heavier
+  // drifts away from the transparent glyphs the caret is positioned from.
+  it("gives the mention span no weight of its own", () => {
+    const highlightSegments: HighlightSegment[] = [
+      { type: "text", text: "Hi " },
+      { type: "mention", text: "@Nora Vidal" },
+      { type: "text", text: " and then a tail" },
+    ]
+    const { container } = render(
+      <TextareaField
+        {...defaultProps}
+        inputValue="Hi @Nora Vidal and then a tail"
+        highlightSegments={highlightSegments}
+        hasOverlay
+      />
+    )
+
+    const mention = container.querySelector(
+      '[class*="text-f1-foreground-secondary"]'
+    )
+    expect(mention).not.toBeNull()
+    expect(mention?.className).not.toMatch(OFF_WEIGHT)
   })
 })

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
@@ -70,10 +70,13 @@ export const TextareaField = ({
         >
           {highlightSegments.map((seg, i) =>
             seg.type === "mention" ? (
-              <span
-                key={i}
-                className="font-medium text-f1-foreground-secondary"
-              >
+              // No weight change: a `<textarea>` lays its entire run out at
+              // one weight, so a heavier mention paints wider than the
+              // transparent glyphs the caret is positioned from and every
+              // character after it sits off its boundary. Colour alone carries
+              // the distinction. See the comms twin (ChatTextareaField) for the
+              // measurement.
+              <span key={i} className="text-f1-foreground-secondary">
                 {seg.text}
               </span>
             ) : seg.type === "ghost" ? (

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -93,12 +93,19 @@ export const ChatTextareaField = ({
           {highlightSegments.map((seg, i) =>
             seg.type === "mention" ? (
               // Same colour pattern as the bubble: you / @here amber, others
-              // info. No padding or weight change so the overlay stays aligned
-              // to the (transparent) textarea text character-for-character.
+              // info. Tone and background carry the whole distinction: no
+              // padding, and — load-bearing — no weight change. A `<textarea>`
+              // lays its entire run out at one weight, so a heavier mention
+              // here paints wider than the transparent glyphs the caret is
+              // positioned from, and every character from the mention onward
+              // sits off its boundary. Measured at 14px Inter, `font-medium`
+              // cost ~0.1px per mention character, plateauing at 1.25px (8.9%
+              // of an em) across the rest of the line — enough to park the
+              // caret inside a glyph instead of between two.
               <span
                 key={i}
                 className={cn(
-                  "rounded-xs font-medium",
+                  "rounded-xs",
                   seg.tone === "self" || seg.tone === "everyone"
                     ? "bg-f1-background-warning text-f1-foreground-warning"
                     : "bg-f1-background-info text-f1-foreground-info"

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
@@ -74,3 +74,54 @@ describe("ChatTextareaField emoji overlay", () => {
     expect(textarea?.className).not.toContain("text-transparent")
   })
 })
+
+// Anything heavier or lighter than the inherited 400. `font-normal` is allowed:
+// it matches what the textarea already lays out.
+const OFF_WEIGHT =
+  /\bfont-(thin|extralight|light|medium|semibold|bold|extrabold|black)\b/
+
+describe("ChatTextareaField overlay/textarea metric parity", () => {
+  // The textarea supplies the caret, the overlay supplies the glyphs, and a
+  // `<textarea>` lays its ENTIRE run out at a single weight — there is no way
+  // to make it match a per-range weight. So any weight the overlay applies to
+  // part of the text paints wider than the transparent glyphs the caret is
+  // positioned from, and every character from there on sits off its boundary.
+  // Measured at 14px Inter: `font-medium` on the chip cost ~0.1px per mention
+  // character, plateauing at 1.25px (8.9% of an em) across the rest of the line.
+  const withMention = (tone: "other" | "self") => {
+    const segments: HighlightSegment[] = [
+      { type: "text", text: "Hi " },
+      { type: "mention", text: "@Nora Vidal", tone },
+      { type: "text", text: " and then a tail" },
+    ]
+    return zeroRender(
+      <ChatTextareaField
+        {...baseProps()}
+        value="Hi @Nora Vidal and then a tail"
+        highlightSegments={segments}
+        hasOverlay
+      />
+    )
+  }
+
+  it("gives an info-toned mention chip no weight of its own", () => {
+    const { container } = withMention("other")
+    const chip = container.querySelector('[class*="bg-f1-background-info"]')
+    expect(chip).not.toBeNull()
+    expect(chip?.className).not.toMatch(OFF_WEIGHT)
+  })
+
+  it("gives a warning-toned mention chip no weight of its own", () => {
+    const { container } = withMention("self")
+    const chip = container.querySelector('[class*="bg-f1-background-warning"]')
+    expect(chip).not.toBeNull()
+    expect(chip?.className).not.toMatch(OFF_WEIGHT)
+  })
+
+  it("leaves the textarea itself on the inherited weight", () => {
+    const { container } = withMention("other")
+    expect(container.querySelector("textarea")?.className).not.toMatch(
+      OFF_WEIGHT
+    )
+  })
+})


### PR DESCRIPTION
## Description

The chat composer paints its text twice — a transparent `<textarea>` supplies the caret while an overlay `div` paints the glyphs. #5199 pinned container-level metrics on all three layers, which fixed the accumulating drift and made the end-of-text caret exact at any length. This closes the residual: the overlay's mention span still carried `font-medium` while the textarea lays its **entire run** out at a single weight, and there is no way to give a `<textarea>` a per-range weight. So the heavier mention painted wider than the transparent glyphs the caret is positioned from, and every character from the mention onward sat off its boundary — the caret landing *inside* a glyph rather than between two.

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [ ] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [ ] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [x] Bug fix
- [ ] Documentation only
- [ ] Refactor / internal change (no API or behavior change)
- [ ] Other:

## Implementation details

- fix: drop `font-medium` from the composer's mention chip so the overlay and the textarea agree character-for-character

  <details>
  <summary>Why a weight — and only a weight — could still move the caret</summary>

  The comment above the chip in `ChatTextareaField.tsx` already claimed "No padding or **weight change** so the overlay stays aligned to the (transparent) textarea text character-for-character." The code directly below it applied `font-medium`. The comment described the invariant; the class broke it.

  Inter 400 and Inter 500 are both real loaded faces (not synthesised), so their advance widths genuinely differ. Measured at 14px Inter on `Hi @Nora Vidal 😄 and then a tail of plain text`, comparing a collapsed `Range` at every index in the overlay's real DOM against the same index in a mirror carrying the textarea's exact computed metrics as one unsplit run — the technique the component itself uses in `getTextareaCaretCoordinates` (`hooks/useMentions.ts:167`):

  | | before | after |



  |---|---|---|
  | worst delta | **1.250px** (8.9% of an em) | **0.023px** (0.2%) |
  | delta at end of line | 1.250px | 0.023px |
  | indices off by ≥0.05px | **44 / 48** | **0 / 48** |

[BEFORE VIDEO (#5199)]:

https://github.com/user-attachments/assets/4fd727e1-791c-49a8-b95e-a72361f48a2a


[AFTER VIDEO (THIS PR)]:

https://github.com/user-attachments/assets/b831481b-b1f2-4261-847d-22303e64f699


  The per-index trace is what identifies the cause rather than merely detecting it. The delta is exactly **0** through `Hi @`, ramps ~0.1px per character *inside* the mention (`0.45 → 1.07px` across `@Nora Vidal`), then **plateaus at 1.25px** for the entire tail. That shape is a per-character advance difference confined to the mention — a weight, not a rounding or a wrap. The residual 0.023px is Chrome's LayoutUnit (1/64px).

  Tone and background already carry the whole distinction, so the chip reads the same.
  </details>

- fix: same removal on the `F0AiChatTextArea` twin, which has the identical divergence

  <details>
  <summary>Latent, not active</summary>

  Same transparent-textarea-plus-overlay pattern, same `font-medium` on the mention span, and here it is starker: the sizer, overlay and textarea all explicitly declare `font-normal`, so the mention span was the single element in the stack that deviated. Still latent — the twin's overlay only mounts when the host passes `searchPersons`, and no story does — so this is fixed by reasoning from the identical mechanism, not by browser measurement. Same caveat #5199 carried for this file.
  </details>

- test: pin that neither composer's mention span carries a weight of its own

  <details>
  <summary>Why a regex over weight utilities</summary>

  The assertion matches every Tailwind weight class **except** `font-normal` (which is what the textarea already lays out), so it fails on `font-medium`, `font-semibold`, `font-bold` or any future re-introduction — not just the one class removed here. Three cases on the comms twin (info chip, warning chip, and the textarea itself) and one on the AI twin.

  Verified red-green: with `font-medium` temporarily reinstated, exactly these assertions fail and the 8 pre-existing tests stay green.
  </details>

## Verification

- `pnpm vitest` — **506 tests / 61 files** green across `F0Chat` and `F0AiChatTextArea` (was 502; +4 new)
- `tsc --noEmit` — 0 errors
- `oxfmt` / `oxlint` — clean over all 161 files in both directories; all lefthook hooks passed
- **Red-green verified**: the new assertions fail with `font-medium` restored, pass without it
- **#5199's own guarantees re-checked on this branch and still hold**: letter-spacing parity `-0.07px` across textarea/overlay/sizer, width drift `0.00px` over 104 characters, wrap parity `84px == 84px`
- Measured in a standalone F0Chat harness driving React's real event path (native value setter + `input` / `keyup` / `click` / `keydown`), main and this branch served side by side on two ports

## Context

- [💻 #5199](https://github.com/factorialco/f0/pull/5199) — **direct predecessor**. Same origin, same files. It fixed the container-level metrics (the `text-md` → `text-base` letter-spacing hole); this fixes the per-segment override it left behind.
- [💻 #4951](https://github.com/factorialco/f0/pull/4951) — complementary: the other open PR inside `sds/chat/F0Chat`, adds forward-message support. No file overlap (it touches `ChatBubble`, `ChatForwardedTag`, `ChatMessageActions`).

## Side notes for the reviewer

- **A second hypothesis was measured and refuted, so the fix shrank.** The overlay splits one shaped run into many inline boxes — a span per segment, plus an `inline-block` per emoji in `renderTextWithEmojis` — which loses kerning pairs across box boundaries (Inter ships `kern` and `calt`, both on by default, and nothing in `packages/core` or `packages/react/src` sets `font-kerning`). An emoji-only string measures **0.016px** of drift on unfixed main: one LayoutUnit, i.e. noise. Pinning `font-kerning: none` / `font-variant-ligatures: none` on all three layers was implemented, measured, and **reverted** — it would change how all composer text renders for no measurable gain. Worth knowing so nobody re-proposes it.
- **The AI twin's mention now reads *less* prominent than body text.** Its span has no background, only `text-f1-foreground-secondary`, so without the weight it is greyer than the text around it. Metrically correct, but a designer should confirm the affordance is still strong enough — possibly by giving it a background like the comms twin's. Left alone here because it is latent and out of scope for a bug fix.
- **`renderTextWithEmojis`'s `inline-block` wrapper is confirmed innocent**, now with a number: 0.016px. #5199 suspected it and cleared it by measurement; this clears it again against the mention case.
- **The systemic fix would still be `textarea, input, select { letter-spacing: inherit }` in `reset.css`**, carried over from #5199's notes. Not done here — blast radius is every input in the design system and it wants Foundations sign-off.
- One unverified cosmetic nit, unchanged and pre-existing: the twemoji `<img>` is `absolute inset-0 h-full w-full`, so it stretches to the 20px line box rather than the glyph's own box.
