### PR TITLE
feat(NewHomeLayout): lock widget drag to the vertical axis

### DIFF
--- a/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
@@ -52,9 +52,9 @@ const faceSize: Record<ButtonToggleGroupSize, string> = {
  * only: no fill, no border. Those are how a *chosen* answer is drawn, and five
  * tinted boxes would leave nothing for the answer to stand out against.
  *
- * Once an answer exists the row hands the colour back to `F0ButtonToggle`: the
- * answered face keeps its fill, border and glyph, and the four not chosen mute,
- * which is what makes the answer visible at a glance.
+ * Once an answer exists the answered face keeps its fill, border and glyph and
+ * the other four step back to {@link ANSWERED_FACE_MUTE}, which is what makes
+ * the answer visible at a glance.
  *
  * Written out per face because Tailwind only generates the utilities it can see
  * as literal strings.
@@ -66,6 +66,15 @@ const unansweredFaceColor: Record<Pulse, string> = {
   positive: "text-f1-icon-mood-positive",
   superPositive: "text-f1-icon-mood-super-positive",
 }
+
+/**
+ * The four faces that were not chosen, once one has been. A step back from
+ * `F0ButtonToggle`'s own muting (`text-f1-icon`): coming off five coloured
+ * glyphs, that stop is not far enough for the answer to be the obvious one —
+ * secondary reads as "not this one" without the faces going missing, which they
+ * must not, since any of them can still be pressed to change the answer.
+ */
+const ANSWERED_FACE_MUTE = "text-f1-icon-secondary"
 
 const isPulse = (value: string): value is Pulse =>
   (pulses as readonly string[]).includes(value)
@@ -104,10 +113,13 @@ export const F0ENPSButton = ({
           // from someone reading along it — the same call the Home rail makes.
           tooltip: { description: labels[pulse], instant: true },
           // The colour last: it has to land after `F0ButtonToggle`'s own
-          // unselected `text-f1-icon` for tailwind-merge to keep it.
+          // unselected `text-f1-icon` for tailwind-merge to keep it. Never on
+          // the ANSWERED face — that one's colour is the toggle's to draw.
           className: cn(
             faceSize[size],
-            answer === undefined && unansweredFaceColor[pulse]
+            answer === undefined
+              ? unansweredFaceColor[pulse]
+              : pulse !== answer && ANSWERED_FACE_MUTE
           ),
         })
       ),

--- a/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/F0ENPSButton.tsx
@@ -15,7 +15,8 @@ import type { F0ENPSButtonProps } from "./types"
  * Each face answers in the colour of the mood it stands for, so the scale reads
  * as a scale: the answer is recognisable from across the page, before any of the
  * copy is. `F0ButtonToggle` owns what a colour looks like — the fill, the border
- * and the glyph, and the muted glyph on the faces not chosen.
+ * and the glyph, and the muted glyph on the faces not chosen. The one place this
+ * row overrules it is the unanswered state (see `unansweredFaceColor`).
  */
 const moodColor: Record<Pulse, ButtonToggleColor> = {
   superNegative: "mood-super-negative",
@@ -38,6 +39,32 @@ const faceSize: Record<ButtonToggleGroupSize, string> = {
   sm: "[&_svg]:w-4",
   md: "[&_svg]:w-6",
   lg: "[&_svg]:w-7",
+}
+
+/**
+ * THE UNANSWERED SCALE IS ALREADY IN COLOUR — the glyph only. Read cold, five
+ * grey faces are five buttons; in colour they are a scale, and the answer you
+ * are looking for is findable by its colour before its shape resolves.
+ *
+ * `F0ButtonToggle` mutes an unselected coloured toggle by design (one coloured
+ * toggle among plain ones would shout), so this is the eNPS row overriding it
+ * for its own case rather than a change to that rule. It overrides the GLYPH
+ * only: no fill, no border. Those are how a *chosen* answer is drawn, and five
+ * tinted boxes would leave nothing for the answer to stand out against.
+ *
+ * Once an answer exists the row hands the colour back to `F0ButtonToggle`: the
+ * answered face keeps its fill, border and glyph, and the four not chosen mute,
+ * which is what makes the answer visible at a glance.
+ *
+ * Written out per face because Tailwind only generates the utilities it can see
+ * as literal strings.
+ */
+const unansweredFaceColor: Record<Pulse, string> = {
+  superNegative: "text-f1-icon-mood-super-negative",
+  negative: "text-f1-icon-mood-negative",
+  neutral: "text-f1-icon-mood-neutral",
+  positive: "text-f1-icon-mood-positive",
+  superPositive: "text-f1-icon-mood-super-positive",
 }
 
 const isPulse = (value: string): value is Pulse =>
@@ -76,10 +103,15 @@ export const F0ENPSButton = ({
           // only place its name is written, so a 700ms wait withholds the scale
           // from someone reading along it — the same call the Home rail makes.
           tooltip: { description: labels[pulse], instant: true },
-          className: cn(faceSize[size]),
+          // The colour last: it has to land after `F0ButtonToggle`'s own
+          // unselected `text-f1-icon` for tailwind-merge to keep it.
+          className: cn(
+            faceSize[size],
+            answer === undefined && unansweredFaceColor[pulse]
+          ),
         })
       ),
-    [labels, icons, size]
+    [labels, icons, size, answer]
   )
 
   const handleChange = (next: string) => {

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
@@ -49,9 +49,11 @@ looking for is findable by its colour before its shape resolves. Fills and
 borders stay off because those are how a _chosen_ answer is drawn, and five
 tinted boxes would leave nothing for the answer to stand out against.
 
-The moment there is an answer the row hands the colour back: the answered face
-keeps its fill, border and glyph, the other four mute, and one coloured face is
-an answer you can read from across the page.
+The moment there is an answer the answered face keeps its fill, border and
+glyph, and the other four step back to `f1-icon-secondary` — one stop further
+than `F0ButtonToggle`'s own muting, because coming off five coloured glyphs that
+stop is not far enough for the answer to be the obvious one. They stay legible,
+though: any of them can still be pressed to change the answer.
 
 <Canvas of={Stories.Answered} />
 

--- a/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__stories__/F0ENPSButton.mdx
@@ -9,8 +9,8 @@ import * as Stories from "./F0ENPSButton.stories"
 # ENPSButton
 
 Asks one eNPS question and takes the answer in a single press: five faces,
-worst to best, and the one that is pressed takes the colour of the mood it
-stands for.
+worst to best, each already in the colour of the mood it stands for — and once
+one is pressed, it is the only one that keeps it.
 
 It is the answer control for Home's engagement widgets — the pulse check, the
 recommendation question — and a sibling of
@@ -37,11 +37,21 @@ The face is sized past `F0Icon`'s scale — 28px at `lg`, 24px at `md` — becau
 it **is** the control: there is no label beside it to carry the meaning, so it
 takes the button, leaving 4px of room around it (6px at `lg`).
 
-Only the answered face is coloured, through `F0ButtonToggle`'s `color`: each face
-asks for its own mood (`mood-super-negative` through `mood-super-positive`) and
-the toggle draws what that colour means — a 0.1 fill, a 0.6 border, the glyph,
-and a muted glyph on the faces not chosen. Five coloured faces at once would be
-decoration; one coloured face is an answer you can read from across the page.
+Colour arrives in two steps, through `F0ButtonToggle`'s `color`: each face asks
+for its own mood (`mood-super-negative` through `mood-super-positive`) and the
+toggle draws what that colour means — a 0.1 fill, a 0.6 border and the glyph on
+the face that is chosen, a muted glyph on the ones that are not.
+
+**While the question is unanswered the row overrides the muting and colours every
+glyph** — the glyph only, never the fill or the border. Read cold, five grey
+faces are five buttons; in colour they are a scale, and the answer you are
+looking for is findable by its colour before its shape resolves. Fills and
+borders stay off because those are how a _chosen_ answer is drawn, and five
+tinted boxes would leave nothing for the answer to stand out against.
+
+The moment there is an answer the row hands the colour back: the answered face
+keeps its fill, border and glyph, the other four mute, and one coloured face is
+an answer you can read from across the page.
 
 <Canvas of={Stories.Answered} />
 

--- a/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
@@ -139,6 +139,23 @@ describe("F0ENPSButton", () => {
   })
 
   /**
+   * A step back from `F0ButtonToggle`'s own `text-f1-icon`: coming off five
+   * coloured glyphs, that stop is not far enough for the answer to be the
+   * obvious one.
+   */
+  it("mutes the faces not chosen to secondary", () => {
+    zeroRender(<F0ENPSButton labels={LABELS} value="neutral" />)
+
+    expect(face("Very bad")).toHaveClass("text-f1-icon-secondary")
+    expect(face("Bad")).toHaveClass("text-f1-icon-secondary")
+    expect(face("Good")).toHaveClass("text-f1-icon-secondary")
+    expect(face("Very good")).toHaveClass("text-f1-icon-secondary")
+    // Never the answered one — its colour is the toggle's to draw.
+    expect(face("Okay")).not.toHaveClass("text-f1-icon-secondary")
+    expect(face("Okay")).toHaveClass("text-f1-icon-mood-neutral")
+  })
+
+  /**
    * The tooltip is the only place a face's name is written, so it opens without
    * a wait — on the default 700ms it was a name you had to stop and ask for,
    * five times over, to read the scale.

--- a/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
+++ b/packages/react/src/sds/Home/F0ENPSButton/__tests__/F0ENPSButton.test.tsx
@@ -96,6 +96,49 @@ describe("F0ENPSButton", () => {
   })
 
   /**
+   * An unanswered row reads as a scale rather than five buttons, so every face
+   * is already in its own colour — the glyph only, and only until an answer
+   * makes one face the coloured one.
+   */
+  it("colours every face while the question is unanswered", () => {
+    zeroRender(<F0ENPSButton labels={LABELS} />)
+
+    expect(face("Very bad")).toHaveClass("text-f1-icon-mood-super-negative")
+    expect(face("Bad")).toHaveClass("text-f1-icon-mood-negative")
+    expect(face("Okay")).toHaveClass("text-f1-icon-mood-neutral")
+    expect(face("Good")).toHaveClass("text-f1-icon-mood-positive")
+    expect(face("Very good")).toHaveClass("text-f1-icon-mood-super-positive")
+  })
+
+  it("colours the glyph only — no fill and no border — while unanswered", () => {
+    zeroRender(<F0ENPSButton labels={LABELS} />)
+
+    // The fill and border are how an ANSWERED face is drawn; the class an
+    // answered face would carry is the assertion (jsdom applies no Tailwind).
+    expect(face("Bad").className).not.toContain("bg-[hsl(var(--mood-negative)")
+    expect(face("Bad").className).not.toContain(
+      "border-[hsl(var(--mood-negative)"
+    )
+    // Still the plain unselected chrome, which is what leaves an answer
+    // something to stand out against.
+    expect(face("Bad")).toHaveClass("bg-transparent")
+    expect(face("Bad")).toHaveClass("border-f1-border")
+  })
+
+  it("hands the colour back once a face is answered", async () => {
+    zeroRender(<F0ENPSButton labels={LABELS} />)
+
+    await userEvent.click(face("Good"))
+
+    expect(face("Good")).toHaveClass("text-f1-icon-mood-positive")
+    // The four not chosen mute, so the answer is the coloured one.
+    expect(face("Bad")).not.toHaveClass("text-f1-icon-mood-negative")
+    expect(face("Very good")).not.toHaveClass(
+      "text-f1-icon-mood-super-positive"
+    )
+  })
+
+  /**
    * The tooltip is the only place a face's name is written, so it opens without
    * a wait — on the default 700ms it was a name you had to stop and ask for,
    * five times over, to read the scale.

--- a/packages/react/src/sds/Home/WidgetContainer/SortableWidget.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/SortableWidget.tsx
@@ -42,9 +42,8 @@ export const SortableWidget = ({
 
   const style: CSSProperties = {
     // VERTICAL ONLY: a column is one dimension, so the neighbours' shuffles
-    // ignore any horizontal component. dnd-kit reports both axes; dropping x
-    // here is the same thing `restrictToVerticalAxis` does, without taking on
-    // @dnd-kit/modifiers for it.
+    // ignore any horizontal component. This is the shuffle; the card under the
+    // pointer is held to the same axis by the column's `verticalOnly` modifier.
     transform: CSS.Translate.toString(transform && { ...transform, x: 0 }),
     transition: transition ?? undefined,
   }

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -52,6 +52,7 @@ import {
   type WidgetPlacement,
   type WidgetVirtualization,
 } from "./useWidgetVirtualizer"
+import { verticalOnly } from "./verticalOnly"
 import { WidgetMotion, type WidgetStow } from "./WidgetMotion"
 
 export type { WidgetVirtualization } from "./useWidgetVirtualizer"
@@ -112,6 +113,12 @@ const DROP_ANIMATION = {
   duration: 450,
   easing: "cubic-bezier(0.4, 0, 0.1, 1)",
 }
+
+/**
+ * Hoisted rather than written inline: dnd-kit reads this on every pointer move,
+ * and a fresh array each render is a fresh dependency for it.
+ */
+const DRAG_MODIFIERS = [verticalOnly]
 
 /** Which column a container is: the growing main one, or the fixed side rail. */
 export type WidgetContainerSide = "main" | "right"
@@ -776,6 +783,9 @@ export function WidgetContainer({
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}
+          // The card the pointer carries goes up and down only, like the
+          // shuffle underneath it — see `verticalOnly`.
+          modifiers={DRAG_MODIFIERS}
           onDragStart={({ active }) => {
             // BEFORE the card is told it is being dragged: what the ghost
             // should look like is what is on screen right now.

--- a/packages/react/src/sds/Home/WidgetContainer/verticalOnly.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/verticalOnly.spec.tsx
@@ -1,0 +1,78 @@
+import type { Modifier } from "@dnd-kit/core"
+import { describe, expect, test, vi } from "vitest"
+
+import { Clock } from "@/icons/app"
+import { zeroRender } from "@/testing/test-utils"
+
+import { WidgetContainer } from "./index"
+import { verticalOnly } from "./verticalOnly"
+
+/**
+ * The one prop this file is about: dnd-kit's own DndContext is what applies a
+ * modifier, and there is nothing in the DOM to read the list off — so the
+ * context is stubbed and asked what it was handed.
+ */
+const modifiers = vi.hoisted(() => ({ current: undefined as unknown }))
+
+vi.mock("@dnd-kit/core", async () => {
+  const { createElement } = await import("react")
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core")
+
+  return {
+    ...actual,
+    DndContext: (props: React.ComponentProps<typeof actual.DndContext>) => {
+      modifiers.current = props.modifiers
+      return createElement(actual.DndContext, props)
+    },
+  }
+})
+
+const widget = (id: string) => ({
+  id,
+  icon: Clock,
+  header: { title: id },
+  slots: [],
+})
+
+/**
+ * dnd-kit hands a modifier the whole drag context; only `transform` decides
+ * where the card goes, so that is all this fills in.
+ */
+const at = (x: number, y: number) =>
+  verticalOnly({
+    transform: { x, y, scaleX: 1, scaleY: 1 },
+  } as unknown as Parameters<Modifier>[0])
+
+describe("verticalOnly", () => {
+  test("drops the horizontal half of the drag", () => {
+    expect(at(120, 40)).toEqual({ x: 0, y: 40, scaleX: 1, scaleY: 1 })
+  })
+
+  test("drops it whichever way the pointer went", () => {
+    expect(at(-200, -15).x).toBe(0)
+  })
+
+  test("leaves the vertical travel alone", () => {
+    expect(at(0, 0).y).toBe(0)
+    expect(at(80, -240).y).toBe(-240)
+  })
+
+  /**
+   * Without this the in-list shuffle was vertical but the card riding the
+   * pointer was not: it followed sideways out of the column it was reordering,
+   * offering a move between rails that the layout does not support.
+   */
+  test("is the modifier a draggable column drags under", () => {
+    zeroRender(
+      <WidgetContainer
+        widgets={[widget("clock"), widget("events")]}
+        onReorder={() => {}}
+      />
+    )
+
+    // `?? []` so an unwired column fails on the missing modifier rather than
+    // on `undefined` not being a list.
+    expect(modifiers.current ?? []).toContain(verticalOnly)
+  })
+})

--- a/packages/react/src/sds/Home/WidgetContainer/verticalOnly.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/verticalOnly.ts
@@ -1,0 +1,17 @@
+import type { Modifier } from "@dnd-kit/core"
+
+/**
+ * THE CARD ONLY EVER GOES UP AND DOWN. A widget belongs to its column — there is
+ * no dragging one from the rail into the main area — so the horizontal half of
+ * the pointer's travel has nothing it could mean: it would offer a move that
+ * cannot happen, and drift the card out from under the column it is reordering.
+ *
+ * dnd-kit reports both axes and the DragOverlay follows both; dropping x here is
+ * what `restrictToVerticalAxis` does, without taking on `@dnd-kit/modifiers` for
+ * one line. The in-list cards drop x for the same reason (see `SortableWidget`),
+ * which is the shuffle; this is the card under the pointer.
+ */
+export const verticalOnly: Modifier = ({ transform }) => ({
+  ...transform,
+  x: 0,
+})


### PR DESCRIPTION
## Description

Two related Home changes. Widget dragging in `NewHomeLayout` is now held to the vertical axis: the in-list shuffle already was, but the card riding the pointer in the `DragOverlay` followed both axes, so it drifted sideways out of the column it was reordering and offered a move between rails that the layout does not support. And `F0ENPSButton` now colours all five glyphs while the question is unanswered — read cold, five grey faces are five buttons; in colour they are a scale — handing the colour back to `F0ButtonToggle` the moment an answer exists, with the four faces not chosen stepping back to `f1-icon-secondary`.
