### PR TITLE
feat(OneDataCollection): add selectionDisabled and disableSelectAll to the source

### DIFF
--- a/packages/react/src/components/F0ActionBar/index.tsx
+++ b/packages/react/src/components/F0ActionBar/index.tsx
@@ -50,7 +50,11 @@ const WithReason = ({
 }) =>
   reason ? (
     <TooltipInternal label={reason}>
-      <span className="inline-flex">{children}</span>
+      {/* Focusable: the button inside is natively disabled, so without this the
+          reason is mouse-only and a keyboard user never learns why. */}
+      <span className="inline-flex" tabIndex={0}>
+        {children}
+      </span>
     </TooltipInternal>
   ) : (
     children

--- a/packages/react/src/components/F0ActionBar/index.tsx
+++ b/packages/react/src/components/F0ActionBar/index.tsx
@@ -37,10 +37,7 @@ type ActionType = {
   tooltip?: string
 }
 
-/**
- * A native `disabled` button emits no pointer events, so a tooltip explaining
- * WHY an action is unavailable has to hang off a wrapper instead.
- */
+/** A native `disabled` button emits no pointer events, hence the wrapper. */
 const WithReason = ({
   reason,
   children,
@@ -50,8 +47,7 @@ const WithReason = ({
 }) =>
   reason ? (
     <TooltipInternal label={reason}>
-      {/* Focusable: the button inside is natively disabled, so without this the
-          reason is mouse-only and a keyboard user never learns why. */}
+      {/* Focusable, or the reason is mouse-only. */}
       <span className="inline-flex" tabIndex={0}>
         {children}
       </span>

--- a/packages/react/src/components/F0ActionBar/index.tsx
+++ b/packages/react/src/components/F0ActionBar/index.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/components/F0ButtonDropdown"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { Dropdown, MobileDropdown } from "@/experimental/Navigation/Dropdown"
+import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
+
 import CheckCircleAnimated from "@/icons/animated/CheckCircle"
 import { AlertCircle, AlertCircleLine } from "@/icons/app"
 import { withDataTestId } from "@/lib/data-testid"
@@ -31,7 +33,28 @@ type ActionType = {
   critical?: boolean
   description?: string
   loading?: boolean
+  /** Shown on hover. Its reason for existing is a disabled action. */
+  tooltip?: string
 }
+
+/**
+ * A native `disabled` button emits no pointer events, so a tooltip explaining
+ * WHY an action is unavailable has to hang off a wrapper instead.
+ */
+const WithReason = ({
+  reason,
+  children,
+}: {
+  reason?: string
+  children: React.ReactNode
+}) =>
+  reason ? (
+    <TooltipInternal label={reason}>
+      <span className="inline-flex">{children}</span>
+    </TooltipInternal>
+  ) : (
+    children
+  )
 
 export type ActionBarGroup = {
   label?: string
@@ -424,18 +447,20 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
                       loading={hasLoadingAction}
                     />
                   ) : (
-                    <F0Button
-                      label={singlePrimaryAction.label}
-                      icon={singlePrimaryAction.icon}
-                      onClick={singlePrimaryAction.onClick}
-                      disabled={
-                        isInteractionDisabled || singlePrimaryAction.disabled
-                      }
-                      loading={
-                        singlePrimaryAction.loading ?? status === "loading"
-                      }
-                      size="lg"
-                    />
+                    <WithReason reason={singlePrimaryAction.tooltip}>
+                      <F0Button
+                        label={singlePrimaryAction.label}
+                        icon={singlePrimaryAction.icon}
+                        onClick={singlePrimaryAction.onClick}
+                        disabled={
+                          isInteractionDisabled || singlePrimaryAction.disabled
+                        }
+                        loading={
+                          singlePrimaryAction.loading ?? status === "loading"
+                        }
+                        size="lg"
+                      />
+                    </WithReason>
                   )}
                 </Fragment>
               </div>
@@ -475,17 +500,19 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
                       />
                     </>
                   ) : (
-                    <F0Button
-                      label={singlePrimaryAction.label}
-                      icon={singlePrimaryAction.icon}
-                      onClick={singlePrimaryAction.onClick}
-                      disabled={
-                        isInteractionDisabled || singlePrimaryAction.disabled
-                      }
-                      loading={
-                        singlePrimaryAction.loading ?? status === "loading"
-                      }
-                    />
+                    <WithReason reason={singlePrimaryAction.tooltip}>
+                      <F0Button
+                        label={singlePrimaryAction.label}
+                        icon={singlePrimaryAction.icon}
+                        onClick={singlePrimaryAction.onClick}
+                        disabled={
+                          isInteractionDisabled || singlePrimaryAction.disabled
+                        }
+                        loading={
+                          singlePrimaryAction.loading ?? status === "loading"
+                        }
+                      />
+                    </WithReason>
                   )}
                 </Fragment>
               </div>

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -81,6 +81,24 @@ export type DataSourceDefinition<
 
   /** Selectable items value under the checkbox column (undefined if not selectable) */
   selectable?: (item: R) => string | number | undefined
+  /**
+   * Marks a selectable item as not selectable *for now*: its checkbox renders
+   * disabled instead of vanishing, so the row keeps its place while a consumer
+   * rule blocks it (mutually-exclusive kinds, a permission, a pending state).
+   * Rows `selectable` already skipped never reach this predicate.
+   *
+   * A disabled row is also left out of "select all" and of the selection
+   * counts, so the header checkbox can still reach a fully-checked state.
+   */
+  selectionDisabled?: (item: R) => boolean
+  /**
+   * Removes the header "select all" checkbox and the cross-page
+   * "Select all N items" CTA, forcing row-by-row selection. Use it when a
+   * valid selection is narrower than "everything on the page" — a rule the
+   * header checkbox has no way to honor. Mirrors `F0Select`'s prop of the
+   * same name.
+   */
+  disableSelectAll?: boolean
   /** Default selected items */
   defaultSelectedItems?: SelectedItemsState<R>
   /**

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -82,33 +82,20 @@ export type DataSourceDefinition<
   /** Selectable items value under the checkbox column (undefined if not selectable) */
   selectable?: (item: R) => string | number | undefined
   /**
-   * Marks a selectable item as not selectable *for now*: its checkbox renders
-   * disabled instead of vanishing, so the row keeps its place while a consumer
-   * rule blocks it (mutually-exclusive kinds, a permission, a pending state).
-   * Rows `selectable` already skipped never reach this predicate.
-   *
-   * A disabled row is also left out of "select all" and of the selection
-   * counts, so the header checkbox can still reach a fully-checked state.
+   * Renders the row's checkbox disabled instead of hiding it. A disabled row is
+   * left out of "select all" and of the selection counts, so the header
+   * checkbox can still reach a fully-checked state.
    */
   selectionDisabled?: (item: R) => boolean
   /**
-   * Marks a row as selected *through something else* — the usual case being a
-   * tree where picking a node takes everything under it. Its checkbox renders
-   * in the indeterminate state and disabled, so an inherited row reads as
-   * included without looking like a row the user ticked, and cannot be
-   * unticked on its own. Implies `selectionDisabled`.
-   *
-   * The row does NOT enter the selection: the payload keeps naming only what
-   * the user actually picked, which is what an API that acts on subtrees
-   * expects.
+   * A row selected through something else — a tree node picked above it, say.
+   * Renders indeterminate and disabled, and never enters the selection, so the
+   * payload keeps naming only real picks. Implies `selectionDisabled`.
    */
   selectionInherited?: (item: R) => boolean
   /**
-   * Removes the header "select all" checkbox and the cross-page
-   * "Select all N items" CTA, forcing row-by-row selection. Use it when a
-   * valid selection is narrower than "everything on the page" — a rule the
-   * header checkbox has no way to honor. Mirrors `F0Select`'s prop of the
-   * same name.
+   * Removes the header select-all and the cross-page "Select all N items" CTA,
+   * forcing row-by-row selection. Mirrors `F0Select`'s prop of the same name.
    */
   disableSelectAll?: boolean
   /** Default selected items */

--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -92,6 +92,18 @@ export type DataSourceDefinition<
    */
   selectionDisabled?: (item: R) => boolean
   /**
+   * Marks a row as selected *through something else* — the usual case being a
+   * tree where picking a node takes everything under it. Its checkbox renders
+   * in the indeterminate state and disabled, so an inherited row reads as
+   * included without looking like a row the user ticked, and cannot be
+   * unticked on its own. Implies `selectionDisabled`.
+   *
+   * The row does NOT enter the selection: the payload keeps naming only what
+   * the user actually picked, which is what an API that acts on subtrees
+   * expects.
+   */
+  selectionInherited?: (item: R) => boolean
+  /**
    * Removes the header "select all" checkbox and the cross-page
    * "Select all N items" CTA, forcing row-by-row selection. Use it when a
    * valid selection is narrower than "everything on the page" — a rule the

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -51,7 +51,14 @@ export function useSelectable<
   const isGrouped = data.type === "grouped"
   const isMultiSelection = selectionMode === "multi"
   const getSelectable = source.selectable
-  const getSelectionDisabled = source.selectionDisabled
+  // `selectionInherited` implies disabled: an inherited row is never the user's
+  // own pick, so nothing may put it in the selection.
+  const getSelectionDisabled = useCallback(
+    (item: R) =>
+      source.selectionInherited?.(item) === true ||
+      source.selectionDisabled?.(item) === true,
+    [source]
+  )
   // Same precedence as `allPagesSelection`: the hook prop wins, the source is
   // the fallback.
   const disableSelectAll =
@@ -596,7 +603,7 @@ export function useSelectable<
   // present (covers nested children), else `data.records`.
   const collectSelectableEntries = useCallback((): Array<[SelectionId, R]> => {
     const isDisabled = ([, item]: [SelectionId, R]) =>
-      getSelectionDisabled?.(item) === true
+      getSelectionDisabled(item) === true
 
     const rendered = getRenderedSelectableEntries?.() ?? []
     if (rendered.length > 0)
@@ -625,7 +632,7 @@ export function useSelectable<
   const handleSelectItemChange = useCallback(
     (itemOrId: R | SelectionId | readonly SelectionId[], checked: boolean) => {
       if (isRecordItem(itemOrId, getSelectable !== undefined)) {
-        if (getSelectionDisabled?.(itemOrId)) return
+        if (getSelectionDisabled(itemOrId)) return
         const id = getSelectable?.(itemOrId)
         if (id !== undefined) {
           handleSelectItemChangeInternal(id, checked, false, itemOrId)

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -239,14 +239,21 @@ export function useSelectable<
   const { itemsStatus, selectedIds } = useMemo(() => {
     const items = localSelectedState.items || new Map()
 
-    // In page-only selection mode, only include items from current page
-    const currentPageItemIds = isPageOnlySelection
-      ? new Set(
-          data.records
-            .map((record) => getSelectable?.(record))
-            .filter((id): id is SelectionId => id !== undefined)
-        )
-      : null
+    // In page-only selection mode, only include items from current page.
+    // A tree's `data.records` holds the ROOTS only — its nested rows arrive
+    // through `fetchChildren` and never appear there — so page-scoping the
+    // payload would drop every selected child and hand the consumer an empty
+    // `itemsStatus` (which also keeps the action bar shut). A tree has no pages
+    // to scope to, so it is exempt.
+    const isTree = source.fetchChildren !== undefined
+    const currentPageItemIds =
+      isPageOnlySelection && !isTree
+        ? new Set(
+            data.records
+              .map((record) => getSelectable?.(record))
+              .filter((id): id is SelectionId => id !== undefined)
+          )
+        : null
 
     const itemsStatus = Array.from(items.values())
       .filter((itemState) => {
@@ -276,6 +283,7 @@ export function useSelectable<
     isPageOnlySelection,
     data.records,
     getSelectable,
+    source.fetchChildren,
   ])
 
   const groupsStatus = useMemo(

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -51,16 +51,13 @@ export function useSelectable<
   const isGrouped = data.type === "grouped"
   const isMultiSelection = selectionMode === "multi"
   const getSelectable = source.selectable
-  // `selectionInherited` implies disabled: an inherited row is never the user's
-  // own pick, so nothing may put it in the selection.
+  // Inherited implies disabled: nothing may put such a row in the selection.
   const getSelectionDisabled = useCallback(
     (item: R) =>
       source.selectionInherited?.(item) === true ||
       source.selectionDisabled?.(item) === true,
     [source]
   )
-  // Same precedence as `allPagesSelection`: the hook prop wins, the source is
-  // the fallback.
   const disableSelectAll =
     disableSelectAllProp ?? source.disableSelectAll ?? false
   // Use allPagesSelection from props, falling back to source.allPagesSelection, default false

--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -36,7 +36,7 @@ export function useSelectable<
   selectionMode = "multi",
   selectedState,
   onSelectItems,
-  disableSelectAll = false,
+  disableSelectAll: disableSelectAllProp,
   isSearchActive = false,
   allPagesSelection,
   resetOnPageChange = true,
@@ -51,6 +51,11 @@ export function useSelectable<
   const isGrouped = data.type === "grouped"
   const isMultiSelection = selectionMode === "multi"
   const getSelectable = source.selectable
+  const getSelectionDisabled = source.selectionDisabled
+  // Same precedence as `allPagesSelection`: the hook prop wins, the source is
+  // the fallback.
+  const disableSelectAll =
+    disableSelectAllProp ?? source.disableSelectAll ?? false
   // Use allPagesSelection from props, falling back to source.allPagesSelection, default false
   // When allPagesSelection is false (default), selection is scoped to the current page only
   const isPageOnlySelection = !(
@@ -590,8 +595,12 @@ export function useSelectable<
   // Selectable rows a "select all" can act on: rendered-row registry when
   // present (covers nested children), else `data.records`.
   const collectSelectableEntries = useCallback((): Array<[SelectionId, R]> => {
+    const isDisabled = ([, item]: [SelectionId, R]) =>
+      getSelectionDisabled?.(item) === true
+
     const rendered = getRenderedSelectableEntries?.() ?? []
-    if (rendered.length > 0) return rendered
+    if (rendered.length > 0)
+      return rendered.filter((entry) => !isDisabled(entry))
 
     return data.records
       .map((record): [SelectionId, R] | undefined => {
@@ -599,7 +608,13 @@ export function useSelectable<
         return id === undefined ? undefined : [id, record]
       })
       .filter((entry): entry is [SelectionId, R] => entry !== undefined)
-  }, [getRenderedSelectableEntries, data.records, getSelectable])
+      .filter((entry) => !isDisabled(entry))
+  }, [
+    getRenderedSelectableEntries,
+    data.records,
+    getSelectable,
+    getSelectionDisabled,
+  ])
 
   // Public Selection Handlers
 
@@ -610,6 +625,7 @@ export function useSelectable<
   const handleSelectItemChange = useCallback(
     (itemOrId: R | SelectionId | readonly SelectionId[], checked: boolean) => {
       if (isRecordItem(itemOrId, getSelectable !== undefined)) {
+        if (getSelectionDisabled?.(itemOrId)) return
         const id = getSelectable?.(itemOrId)
         if (id !== undefined) {
           handleSelectItemChangeInternal(id, checked, false, itemOrId)
@@ -619,7 +635,7 @@ export function useSelectable<
 
       handleSelectItemChangeInternal(itemOrId, checked)
     },
-    [getSelectable, handleSelectItemChangeInternal]
+    [getSelectable, getSelectionDisabled, handleSelectItemChangeInternal]
   )
 
   /**

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -825,8 +825,7 @@ const OneDataCollectionComp = <
       const bulkAction = action as BulkActionDefinition
       return {
         ...bulkAction,
-        // The action bar speaks of a generic `tooltip`; a bulk action only ever
-        // has one to explain why it is unavailable.
+        // The bar speaks of a generic `tooltip`; here it is always the reason.
         tooltip: bulkAction.disabled ? bulkAction.disabledTooltip : undefined,
         onClick: () => {
           const result = onBulkAction?.(

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -598,7 +598,7 @@ const OneDataCollectionComp = <
    * Bulk actions
    */
   type MappedBulkAction =
-    | (BulkActionDefinition & { onClick: () => void })
+    | (BulkActionDefinition & { onClick: () => void; tooltip?: string })
     | { type: "separator" }
 
   const [bulkActions, setBulkActions] = useState<
@@ -825,6 +825,9 @@ const OneDataCollectionComp = <
       const bulkAction = action as BulkActionDefinition
       return {
         ...bulkAction,
+        // The action bar speaks of a generic `tooltip`; a bulk action only ever
+        // has one to explain why it is unavailable.
+        tooltip: bulkAction.disabled ? bulkAction.disabledTooltip : undefined,
         onClick: () => {
           const result = onBulkAction?.(
             bulkAction.id,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -886,12 +886,17 @@ export const WithSelectableAndBulkActions: Story = {
  * other row goes disabled until the selection is cleared. `disableSelectAll`
  * removes the header checkbox, which would otherwise tick every department at
  * once and break the rule before it can lock anything.
+ *
+ * `selectionInherited` then shows the consequence of a pick: everyone reporting
+ * to a selected person is marked as coming along — the indeterminate mark,
+ * disabled — without joining the selection itself.
  */
 export const WithDisabledSelection: Story = {
   render: () => {
     const [lockedDepartment, setLockedDepartment] = useState<string | null>(
       null
     )
+    const [selectedManagers, setSelectedManagers] = useState<string[]>([])
 
     const mockVisualizations = getMockVisualizations({ frozenColumns: 0 })
 
@@ -901,6 +906,10 @@ export const WithDisabledSelection: Story = {
       selectable: (item) => item.id,
       selectionDisabled: (item) =>
         lockedDepartment !== null && item.department !== lockedDepartment,
+      // Everyone reporting to a picked manager travels with them: shown as
+      // included, never as the user's own pick.
+      selectionInherited: (item) =>
+        selectedManagers.length > 0 && selectedManagers.includes(item.manager),
       disableSelectAll: true,
       bulkActions: () => ({
         primary: [{ label: "Move", id: "move" }],
@@ -915,10 +924,11 @@ export const WithDisabledSelection: Story = {
       <OneDataCollection
         source={source}
         onSelectItems={(selectedItems) => {
-          const firstChecked = selectedItems.itemsStatus.find(
+          const checked = selectedItems.itemsStatus.filter(
             (status) => status.checked
           )
-          setLockedDepartment(firstChecked?.item.department ?? null)
+          setLockedDepartment(checked[0]?.item.department ?? null)
+          setSelectedManagers(checked.map((status) => status.item.name))
         }}
         onBulkAction={() => {}}
         visualizations={[mockVisualizations.table]}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -879,6 +879,54 @@ export const WithSelectableAndBulkActions: Story = {
   ),
 }
 
+/**
+ * `selectionDisabled` greys out a row's checkbox instead of hiding it, so the
+ * row keeps its place while a consumer rule blocks it. Here the rule is
+ * "one department at a time": the first pick locks the department and every
+ * other row goes disabled until the selection is cleared. `disableSelectAll`
+ * removes the header checkbox, which would otherwise tick every department at
+ * once and break the rule before it can lock anything.
+ */
+export const WithDisabledSelection: Story = {
+  render: () => {
+    const [lockedDepartment, setLockedDepartment] = useState<string | null>(
+      null
+    )
+
+    const mockVisualizations = getMockVisualizations({ frozenColumns: 0 })
+
+    const source = useDataCollectionSource({
+      filters,
+      sortings,
+      selectable: (item) => item.id,
+      selectionDisabled: (item) =>
+        lockedDepartment !== null && item.department !== lockedDepartment,
+      disableSelectAll: true,
+      bulkActions: () => ({
+        primary: [{ label: "Move", id: "move" }],
+      }),
+      dataAdapter: createDataAdapter({
+        data: generateMockUsers(10),
+        paginationType: "pages",
+      }),
+    })
+
+    return (
+      <OneDataCollection
+        source={source}
+        onSelectItems={(selectedItems) => {
+          const firstChecked = selectedItems.itemsStatus.find(
+            (status) => status.checked
+          )
+          setLockedDepartment(firstChecked?.item.department ?? null)
+        }}
+        onBulkAction={() => {}}
+        visualizations={[mockVisualizations.table]}
+      />
+    )
+  },
+}
+
 export const WithAsyncBulkActions: Story = {
   render: () => {
     const paginatedMockUsers = generateMockUsers(10)

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -880,16 +880,10 @@ export const WithSelectableAndBulkActions: Story = {
 }
 
 /**
- * `selectionDisabled` greys out a row's checkbox instead of hiding it, so the
- * row keeps its place while a consumer rule blocks it. Here the rule is
- * "one department at a time": the first pick locks the department and every
- * other row goes disabled until the selection is cleared. `disableSelectAll`
- * removes the header checkbox, which would otherwise tick every department at
- * once and break the rule before it can lock anything.
- *
- * `selectionInherited` then shows the consequence of a pick: everyone reporting
- * to a selected person is marked as coming along — the indeterminate mark,
- * disabled — without joining the selection itself.
+ * One department at a time: the first pick locks it and `selectionDisabled`
+ * greys out the rest, `disableSelectAll` removes the header checkbox that would
+ * break the rule before it can lock, and `selectionInherited` marks everyone
+ * reporting to a picked person as coming along without selecting them.
  */
 export const WithDisabledSelection: Story = {
   render: () => {
@@ -906,8 +900,7 @@ export const WithDisabledSelection: Story = {
       selectable: (item) => item.id,
       selectionDisabled: (item) =>
         lockedDepartment !== null && item.department !== lockedDepartment,
-      // Everyone reporting to a picked manager travels with them: shown as
-      // included, never as the user's own pick.
+      // Everyone reporting to a picked manager travels with them.
       selectionInherited: (item) =>
         selectedManagers.length > 0 && selectedManagers.includes(item.manager),
       disableSelectAll: true,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -203,6 +203,28 @@ const { source } = useDataCollectionSource({
   visualizations. Card and Kanban enforce the exclusion but do not grey the
   control.
 
+### Selected through something else (`selectionInherited`)
+
+In a tree, picking a node usually takes everything under it. Those descendants
+are _included_ but they are not the user's own picks, and they must not enter the
+selection — an API that moves or deletes subtrees expects to be told only the
+node the user chose.
+
+`selectionInherited` renders exactly that: the row's checkbox shows the
+indeterminate mark, disabled, so it reads as "included, but not something you
+ticked" and cannot be unticked on its own. It implies `selectionDisabled`, and
+the row never joins the selection, so the payload keeps naming only real picks.
+
+```tsx
+const { source } = useDataCollectionSource({
+  ...
+  selectable: (item) => item.id,
+  // Anything below a picked node travels with it
+  selectionInherited: (item) => hasSelectedAncestor(item),
+  ...
+})
+```
+
 ### Removing "select all" (`disableSelectAll`)
 
 The header checkbox starts from an empty selection, so a rule that only locks
@@ -285,6 +307,30 @@ This works in the same way for the groups.
   of={DataCollectionStories.WithPagesPagination}
   meta={DataCollectionStories}
 />
+
+### Explaining an unavailable action (`disabledTooltip`)
+
+A `disabled` bulk action says nothing about _why_, and a native disabled button
+emits no pointer events, so a plain `title` never appears either. Give the action
+`disabledTooltip` and the bar hangs the reason off a wrapper that does receive
+hover:
+
+```tsx
+bulkActions: (selectedItems) => ({
+  primary: [
+    {
+      id: "move",
+      label: "Move to",
+      disabled: mixesKinds(selectedItems),
+      disabledTooltip: "You can't bulk move two nodes of different types",
+    },
+  ],
+})
+```
+
+It is only rendered while the action is disabled — an action the user can click
+explains itself by doing the thing. Prefer this over `warningMessage` when only
+_one_ action is unavailable: the warning form replaces the whole action set.
 
 ## Bulk actions
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -169,6 +169,67 @@ once every loaded row is checked.
   meta={DataCollectionStories}
 />
 
+### Blocking a row (`selectionDisabled`)
+
+`selectable` can only render a checkbox or hide it, and hiding is the wrong
+answer when a row is selectable _in principle_ but blocked _right now_ — by a
+mutually-exclusive rule, a permission, a pending state. Making a checkbox
+disappear as the user ticks the first row reads as the table breaking.
+
+`selectionDisabled` renders that checkbox **disabled** instead, so the row keeps
+its place:
+
+```tsx
+const { source } = useDataCollectionSource({
+  ...
+  selectable: (item) => item.id,
+  // Once a kind is picked, the other kinds are out of reach — visibly so
+  selectionDisabled: (item) => lockedKind !== null && item.kind !== lockedKind,
+  ...
+})
+```
+
+- Rows `selectable` already skipped (it returned `undefined`) never reach the
+  predicate.
+- A disabled row is **excluded from "select all" and from the selection
+  counts**, so the header checkbox still reaches a fully-checked state instead
+  of hanging in the indeterminate state forever.
+- The exclusion is enforced in the selection layer, not in the markup: a
+  disabled item cannot enter the selection through any visualization, nor
+  through a programmatic `handleSelectItemChange`.
+- The predicate is read on every render, so it can close over your own state
+  (as above) — no need to rebuild the source.
+- The **disabled affordance** renders in the **table** and **list**
+  visualizations. Card and Kanban enforce the exclusion but do not grey the
+  control.
+
+### Removing "select all" (`disableSelectAll`)
+
+The header checkbox starts from an empty selection, so a rule that only locks
+in _after_ the first pick cannot constrain it — it selects every row on the
+page and produces exactly the invalid set the rule exists to prevent. Set
+`disableSelectAll` on the source to drop it:
+
+```tsx
+const { source } = useDataCollectionSource({
+  ...
+  selectable: (item) => item.id,
+  disableSelectAll: true,
+  ...
+})
+```
+
+It removes the header select-all checkbox, the per-group select-all checkbox,
+and the cross-page "Select all N items" CTA, forcing row-by-row selection. The
+checkbox column keeps its width, so the columns stay aligned. Mirrors
+[`F0Select`](?path=/docs/components-select--documentation)'s prop of the same
+name.
+
+<Canvas
+  of={DataCollectionStories.WithDisabledSelection}
+  meta={DataCollectionStories}
+/>
+
 #### Examples
 
 **Default selected items**

--- a/packages/react/src/patterns/OneDataCollection/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/types.ts
@@ -36,6 +36,11 @@ export type BulkActionDefinition = {
   critical?: boolean
   description?: string
   disabled?: boolean
+  /**
+   * Why the action is disabled, shown on hover. Only rendered while `disabled`
+   * — an action the user can click explains itself by doing the thing.
+   */
+  disabledTooltip?: string
 }
 
 /**

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -126,6 +126,7 @@ export type SelectCellConfig<R extends RecordType> = {
         >,
         | "selectable"
         | "selectionDisabled"
+        | "selectionInherited"
         | "disableSelectAll"
         | "grouping"
         | "defaultGrouping"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -125,6 +125,8 @@ export type SelectCellConfig<R extends RecordType> = {
           GroupingDefinition<RecordType>
         >,
         | "selectable"
+        | "selectionDisabled"
+        | "disableSelectAll"
         | "grouping"
         | "defaultGrouping"
         | "currentGrouping"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -86,6 +86,8 @@ export const Row = <
   const itemOnClick = source.itemOnClick ? source.itemOnClick(item) : undefined
   const isClickable = !!itemHref || !!itemOnClick
   const id = source.selectable ? source.selectable(item) : undefined
+  const selectionDisabled =
+    id !== undefined && source.selectionDisabled?.(item) === true
   const itemDef = itemDefinition(item)
 
   const {
@@ -119,6 +121,7 @@ export const Row = <
               onCheckedChange={(checked) =>
                 handleSelectItemChange(item, checked)
               }
+              disabled={selectionDisabled}
               title={`Select ${source.selectable(item)}`}
               hideLabel
             />
@@ -190,6 +193,7 @@ export const Row = <
           <F0Checkbox
             checked={selectedItems.has(id)}
             onCheckedChange={(checked) => handleSelectItemChange(item, checked)}
+            disabled={selectionDisabled}
             title={`Select ${source.selectable(item)}`}
             hideLabel
           />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -86,8 +86,11 @@ export const Row = <
   const itemOnClick = source.itemOnClick ? source.itemOnClick(item) : undefined
   const isClickable = !!itemHref || !!itemOnClick
   const id = source.selectable ? source.selectable(item) : undefined
+  const selectionInherited =
+    id !== undefined && source.selectionInherited?.(item) === true
   const selectionDisabled =
-    id !== undefined && source.selectionDisabled?.(item) === true
+    id !== undefined &&
+    (selectionInherited || source.selectionDisabled?.(item) === true)
   const itemDef = itemDefinition(item)
 
   const {
@@ -122,7 +125,8 @@ export const Row = <
             )}
           >
             <F0Checkbox
-              checked={selectedItems.has(id)}
+              checked={selectionInherited || selectedItems.has(id)}
+              indeterminate={selectionInherited}
               onCheckedChange={(checked) =>
                 handleSelectItemChange(item, checked)
               }
@@ -196,7 +200,8 @@ export const Row = <
           )}
         >
           <F0Checkbox
-            checked={selectedItems.has(id)}
+            checked={selectionInherited || selectedItems.has(id)}
+            indeterminate={selectionInherited}
             onCheckedChange={(checked) => handleSelectItemChange(item, checked)}
             disabled={selectionDisabled}
             title={`Select ${source.selectable(item)}`}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -115,7 +115,12 @@ export const Row = <
       <div className="pointer-events-none flex flex-1 flex-row items-center gap-2">
         {source.selectable && id !== undefined && (
           // z-10 is needed here to prevent the checkbox from not being selectable when itemHref is provided
-          <div className="pointer-events-auto z-10 hidden items-center justify-end md:flex">
+          <div
+            className={cn(
+              "pointer-events-auto z-10 hidden items-center justify-end md:flex",
+              selectionDisabled && "cursor-not-allowed"
+            )}
+          >
             <F0Checkbox
               checked={selectedItems.has(id)}
               onCheckedChange={(checked) =>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -407,8 +407,7 @@ export const TableCollection = <
     selectionRegistry.ids.length > 0
       ? selectionRegistry.ids
       : (data?.records ?? [])
-          // Disabled rows never register, so the registry branch is already
-          // free of them; this fallback over `data.records` is not.
+          // The registry is already free of them; this fallback is not.
           .filter((record) => !source.selectionDisabled?.(record))
           .map((record) => source.selectable?.(record))
           .filter((id): id is SelectionId => id !== undefined)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -407,8 +407,13 @@ export const TableCollection = <
     selectionRegistry.ids.length > 0
       ? selectionRegistry.ids
       : (data?.records ?? [])
+          // Disabled rows never register, so the registry branch is already
+          // free of them; this fallback over `data.records` is not.
+          .filter((record) => !source.selectionDisabled?.(record))
           .map((record) => source.selectable?.(record))
           .filter((id): id is SelectionId => id !== undefined)
+
+  const selectAllDisabled = source.disableSelectAll ?? false
 
   const allPageRowsSelected =
     currentPageSelectableIds.length > 0 &&
@@ -428,6 +433,7 @@ export const TableCollection = <
     allPageRowsSelected
 
   const showSelectAllOption =
+    !selectAllDisabled &&
     !!source.allPagesSelection &&
     (!allSelectedStatus.checked || allSelectedStatus.indeterminate) &&
     paginationInfo?.total !== undefined &&
@@ -617,16 +623,18 @@ export const TableCollection = <
                         : undefined
                     }
                   >
-                    <div className="ml-3.5 flex w-full items-center justify-start">
-                      <F0Checkbox
-                        checked={isAllSelected}
-                        indeterminate={hasSelection && !isAllSelected}
-                        onCheckedChange={handleSelectAll}
-                        title={i18n.actions.selectAll}
-                        hideLabel
-                        disabled={data?.records.length === 0}
-                      />
-                    </div>
+                    {!selectAllDisabled && (
+                      <div className="ml-3.5 flex w-full items-center justify-start">
+                        <F0Checkbox
+                          checked={isAllSelected}
+                          indeterminate={hasSelection && !isAllSelected}
+                          onCheckedChange={handleSelectAll}
+                          title={i18n.actions.selectAll}
+                          hideLabel
+                          disabled={data?.records.length === 0}
+                        />
+                      </div>
+                    )}
                   </TableHead>
                 )}
                 {columns.map(({ sorting, label, ...column }, index) => {
@@ -761,23 +769,26 @@ export const TableCollection = <
                             sticky={{ left: 0 }}
                           >
                             <div className="pointer-events-auto ml-1.5 flex items-center justify-start">
-                              <F0Checkbox
-                                checked={
-                                  !!statusToChecked(
-                                    groupAllSelectedStatus[group.key]
-                                  )
-                                }
-                                indeterminate={
-                                  statusToChecked(
-                                    groupAllSelectedStatus[group.key]
-                                  ) === "indeterminate"
-                                }
-                                title={i18n.actions.selectAll}
-                                hideLabel
-                                onCheckedChange={(checked) =>
-                                  handleSelectGroupChange(group, checked)
-                                }
-                              />
+                              {/* A group checkbox selects the whole group. */}
+                              {!selectAllDisabled && (
+                                <F0Checkbox
+                                  checked={
+                                    !!statusToChecked(
+                                      groupAllSelectedStatus[group.key]
+                                    )
+                                  }
+                                  indeterminate={
+                                    statusToChecked(
+                                      groupAllSelectedStatus[group.key]
+                                    ) === "indeterminate"
+                                  }
+                                  title={i18n.actions.selectAll}
+                                  hideLabel
+                                  onCheckedChange={(checked) =>
+                                    handleSelectGroupChange(group, checked)
+                                  }
+                                />
+                              )}
                             </div>
                           </TableCell>
                         )}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/DisabledSelection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/DisabledSelection.test.tsx
@@ -57,7 +57,8 @@ type Source = DataCollectionSource<
 
 const createSource = ({
   disableSelectAll = false,
-}: { disableSelectAll?: boolean } = {}): Source => ({
+  inherited = false,
+}: { disableSelectAll?: boolean; inherited?: boolean } = {}): Source => ({
   currentFilters: {},
   setCurrentFilters: vi.fn(),
   currentSortings: null,
@@ -74,6 +75,7 @@ const createSource = ({
   setCurrentGrouping: vi.fn(),
   selectable: (item: Node) => item.id,
   selectionDisabled: (item: Node) => item.kind === "level",
+  selectionInherited: (item: Node) => inherited && item.kind === "level",
   disableSelectAll,
   dataAdapter: {
     fetchData: async (_options: BaseFetchOptions<FiltersDefinition>) => ({
@@ -100,6 +102,34 @@ const renderTable = (source: Source) =>
       onLoadError={vi.fn()}
     />
   )
+
+describe("Table selectionInherited", () => {
+  it("renders an inherited row as indeterminate, disabled and unselectable", async () => {
+    const user = userEvent.setup()
+    renderTable(createSource({ inherited: true }))
+
+    await waitFor(() =>
+      expect(screen.getByTitle("Select 3")).toBeInTheDocument()
+    )
+
+    const markOf = (title: string) =>
+      screen.getByTitle(title).querySelector("svg")?.innerHTML
+
+    expect(screen.getByTitle("Select 3")).toBeDisabled()
+
+    // Tick a row for real, so there is a genuine check to compare against: an
+    // inherited row must not look like a row the user picked.
+    await user.click(screen.getByTitle("Select 1"))
+    await waitFor(() => expect(screen.getByTitle("Select 1")).toBeChecked())
+    expect(markOf("Select 3")).toBeDefined()
+    expect(markOf("Select 3")).not.toEqual(markOf("Select 1"))
+
+    // And it stays out of the selection: select-all cannot reach it either.
+    await user.click(screen.getAllByRole("checkbox")[0] as HTMLElement)
+    await waitFor(() => expect(screen.getByTitle("Select 2")).toBeChecked())
+    expect(markOf("Select 3")).not.toEqual(markOf("Select 1"))
+  })
+})
 
 describe("Table selectionDisabled", () => {
   it("disables the blocked row's checkbox and leaves the others alone", async () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/DisabledSelection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/DisabledSelection.test.tsx
@@ -1,0 +1,162 @@
+import { waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  BaseFetchOptions,
+  GroupingDefinition,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+
+import { FiltersDefinition } from "@/hooks/datasource"
+import { screen, zeroRender as render } from "@/testing/test-utils"
+import { TextCell } from "@/ui/value-display/types/text"
+import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { SummariesDefinition } from "../../../../summary"
+import { TableCollection } from "../index"
+
+vi.mock("../../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+class MockIntersectionObserver implements IntersectionObserver {
+  root: Document | Element | null = null
+  rootMargin = ""
+  thresholds: readonly number[] = []
+  disconnect = vi.fn()
+  observe = vi.fn()
+  takeRecords = vi.fn()
+  unobserve = vi.fn()
+}
+window.IntersectionObserver = MockIntersectionObserver
+
+type Node = { id: number; name: string; kind: "role" | "level" }
+
+const nodes: Node[] = [
+  { id: 1, name: "Engineer", kind: "role" },
+  { id: 2, name: "Designer", kind: "role" },
+  { id: 3, name: "Engineer L2", kind: "level" },
+]
+
+const columns = [{ label: "name", render: (item: Node) => item.name }]
+
+type Source = DataCollectionSource<
+  Node,
+  FiltersDefinition,
+  SortingsDefinition,
+  SummariesDefinition,
+  ItemActionsDefinition<Node>,
+  NavigationFiltersDefinition,
+  GroupingDefinition<Node>
+>
+
+const createSource = ({
+  disableSelectAll = false,
+}: { disableSelectAll?: boolean } = {}): Source => ({
+  currentFilters: {},
+  setCurrentFilters: vi.fn(),
+  currentSortings: null,
+  setCurrentSortings: vi.fn(),
+  currentNavigationFilters: {},
+  setCurrentNavigationFilters: vi.fn(),
+  navigationFilters: undefined,
+  currentSearch: undefined,
+  debouncedCurrentSearch: undefined,
+  setCurrentSearch: vi.fn(),
+  isLoading: false,
+  setIsLoading: vi.fn(),
+  currentGrouping: undefined,
+  setCurrentGrouping: vi.fn(),
+  selectable: (item: Node) => item.id,
+  selectionDisabled: (item: Node) => item.kind === "level",
+  disableSelectAll,
+  dataAdapter: {
+    fetchData: async (_options: BaseFetchOptions<FiltersDefinition>) => ({
+      records: nodes,
+    }),
+  },
+})
+
+const renderTable = (source: Source) =>
+  render(
+    <TableCollection<
+      Node,
+      FiltersDefinition,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Node>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<Node>
+    >
+      columns={columns}
+      source={source}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+
+describe("Table selectionDisabled", () => {
+  it("disables the blocked row's checkbox and leaves the others alone", async () => {
+    renderTable(createSource())
+
+    await waitFor(() =>
+      expect(screen.getByTitle("Select 3")).toBeInTheDocument()
+    )
+
+    expect(screen.getByTitle("Select 3")).toBeDisabled()
+    expect(screen.getByTitle("Select 1")).toBeEnabled()
+    expect(screen.getByTitle("Select 2")).toBeEnabled()
+  })
+
+  it("does not select a disabled row", async () => {
+    const user = userEvent.setup()
+    renderTable(createSource())
+
+    await waitFor(() =>
+      expect(screen.getByTitle("Select 3")).toBeInTheDocument()
+    )
+
+    await user.click(screen.getByTitle("Select 3"))
+
+    expect(screen.getByTitle("Select 3")).not.toBeChecked()
+  })
+
+  it("select-all checks every enabled row, skips the disabled one, and still reads as fully checked", async () => {
+    const user = userEvent.setup()
+    renderTable(createSource())
+
+    await waitFor(() =>
+      expect(screen.getByTitle("Select 1")).toBeInTheDocument()
+    )
+
+    const headerCheckbox = screen.getAllByRole("checkbox")[0]
+    await user.click(headerCheckbox)
+
+    await waitFor(() => {
+      expect(screen.getByTitle("Select 1")).toBeChecked()
+      expect(screen.getByTitle("Select 2")).toBeChecked()
+    })
+
+    expect(screen.getByTitle("Select 3")).not.toBeChecked()
+    // Not "mixed": the disabled row is out of the count, so every row the user
+    // can tick is ticked.
+    expect(headerCheckbox).toBeChecked()
+  })
+
+  it("disableSelectAll drops the header checkbox and keeps the row ones", async () => {
+    renderTable(createSource({ disableSelectAll: true }))
+
+    await waitFor(() =>
+      expect(screen.getByTitle("Select 1")).toBeInTheDocument()
+    )
+
+    // One per row, none for the header.
+    expect(screen.getAllByRole("checkbox")).toHaveLength(nodes.length)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
@@ -52,7 +52,8 @@ const parents: Person[] = [
 const columns = [{ label: "name", render: (item: Person) => item.name }]
 
 const createSource = (
-  onSelectItems: () => void
+  onSelectItems: () => void,
+  { allPagesSelection = true }: { allPagesSelection?: boolean } = {}
 ): DataCollectionSource<
   Person,
   FiltersDefinition,
@@ -78,7 +79,7 @@ const createSource = (
     currentGrouping: undefined,
     setCurrentGrouping: vi.fn(),
     selectable: (item: Person) => (item.children?.length ? undefined : item.id),
-    allPagesSelection: true,
+    allPagesSelection,
     itemsWithChildren: (item: Person) => !!item.children?.length,
     fetchChildren: ({ item }: { item: Person }) => ({
       records: item.children ?? [],
@@ -145,7 +146,9 @@ describe("Table nested-row selection (registry-backed select all)", () => {
     render(
       <EditableTableCollection
         columns={columns}
-        source={createSource(vi.fn())}
+        // Page-only selection (the default) is where the page filter — and the
+        // bug — lives: `allPagesSelection` switches that path off entirely.
+        source={createSource(vi.fn(), { allPagesSelection: false })}
         onSelectItems={onSelectItems}
         onLoadData={vi.fn()}
         onLoadError={vi.fn()}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
@@ -139,6 +139,35 @@ describe("Table nested-row selection (registry-backed select all)", () => {
     })
   })
 
+  it("reports the selected nested child to onSelectItems (page-only selection)", async () => {
+    const user = userEvent.setup()
+    const onSelectItems = vi.fn()
+    render(
+      <EditableTableCollection
+        columns={columns}
+        source={createSource(vi.fn())}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText("Parent")).toBeInTheDocument())
+    await expandParent(user)
+
+    await user.click(screen.getByTitle("Select c1"))
+
+    // A tree's `data.records` holds only the roots, so page-scoping the payload
+    // used to drop the child and hand the consumer an empty selection.
+    await waitFor(() => {
+      const lastCall = onSelectItems.mock.calls.at(-1)
+      expect(lastCall?.[0].selectedIds).toEqual(["c1"])
+      expect(lastCall?.[0].itemsStatus).toEqual([
+        { item: expect.objectContaining({ id: "c1" }), checked: true },
+      ])
+    })
+  })
+
   it("'Select all N items' selects nested children without wiping the existing selection", async () => {
     const user = userEvent.setup()
     render(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -184,8 +184,13 @@ const RowComponentInner = <
   // A selectable row the consumer is blocking right now: the checkbox renders
   // disabled and the row stays out of the selection registry, so "select all"
   // can reach a fully-checked state without it.
+  // Selected through an ancestor: shown, but not the user's own pick and not
+  // part of the selection.
+  const selectionInherited =
+    id !== undefined && source.selectionInherited?.(item) === true
   const selectionDisabled =
-    id !== undefined && source.selectionDisabled?.(item) === true
+    id !== undefined &&
+    (selectionInherited || source.selectionDisabled?.(item) === true)
   const rowWithChildren = !!source.itemsWithChildren?.(item)
 
   const i18n = useI18n()
@@ -349,7 +354,8 @@ const RowComponentInner = <
               )}
             >
               <Checkbox
-                checked={selectedItems.has(id)}
+                checked={selectionInherited || selectedItems.has(id)}
+                indeterminate={selectionInherited}
                 onCheckedChange={onCheckedChange}
                 disabled={selectionDisabled}
                 title={`Select ${source.selectable(item)}`}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -181,6 +181,11 @@ const RowComponentInner = <
   const itemHref = source.itemUrl ? source.itemUrl(item) : undefined
   const itemOnClick = source.itemOnClick ? source.itemOnClick(item) : undefined
   const id = source.selectable ? source.selectable(item) : undefined
+  // A selectable row the consumer is blocking right now: the checkbox renders
+  // disabled and the row stays out of the selection registry, so "select all"
+  // can reach a fully-checked state without it.
+  const selectionDisabled =
+    id !== undefined && source.selectionDisabled?.(item) === true
   const rowWithChildren = !!source.itemsWithChildren?.(item)
 
   const i18n = useI18n()
@@ -242,6 +247,7 @@ const RowComponentInner = <
   useEffect(() => {
     if (
       id === undefined ||
+      selectionDisabled ||
       !willRenderOwnRow ||
       !registerSelectable ||
       !isPresent
@@ -252,6 +258,7 @@ const RowComponentInner = <
   }, [
     id,
     item,
+    selectionDisabled,
     willRenderOwnRow,
     registerSelectable,
     unregisterSelectable,
@@ -337,6 +344,7 @@ const RowComponentInner = <
               <Checkbox
                 checked={selectedItems.has(id)}
                 onCheckedChange={onCheckedChange}
+                disabled={selectionDisabled}
                 title={`Select ${source.selectable(item)}`}
                 hideLabel
               />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -181,11 +181,8 @@ const RowComponentInner = <
   const itemHref = source.itemUrl ? source.itemUrl(item) : undefined
   const itemOnClick = source.itemOnClick ? source.itemOnClick(item) : undefined
   const id = source.selectable ? source.selectable(item) : undefined
-  // A selectable row the consumer is blocking right now: the checkbox renders
-  // disabled and the row stays out of the selection registry, so "select all"
-  // can reach a fully-checked state without it.
-  // Selected through an ancestor: shown, but not the user's own pick and not
-  // part of the selection.
+  // Out of the registry too, so "select all" can still reach fully-checked.
+  // Shown as included, but not a pick and not part of the selection.
   const selectionInherited =
     id !== undefined && source.selectionInherited?.(item) === true
   const selectionDisabled =
@@ -348,8 +345,7 @@ const RowComponentInner = <
             <div
               className={cn(
                 "pointer-events-auto ml-3.5 flex h-full items-center justify-start",
-                // The row itself is clickable, so without this the padding
-                // around a disabled checkbox still shows the row's hand cursor.
+                // The row is clickable, so the padding would show its hand.
                 selectionDisabled && "cursor-not-allowed"
               )}
             >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -340,7 +340,14 @@ const RowComponentInner = <
           referenceRowType={referenceRowType}
         >
           {id !== undefined && (
-            <div className="pointer-events-auto ml-3.5 flex h-full items-center justify-start">
+            <div
+              className={cn(
+                "pointer-events-auto ml-3.5 flex h-full items-center justify-start",
+                // The row itself is clickable, so without this the padding
+                // around a disabled checkbox still shows the row's hand cursor.
+                selectionDisabled && "cursor-not-allowed"
+              )}
+            >
               <Checkbox
                 checked={selectedItems.has(id)}
                 onCheckedChange={onCheckedChange}


### PR DESCRIPTION
## Description

A selection is not always "any subset of the page", and a source had no way to say so. `selectable` can only render a checkbox or hide it; the header "select all" could not be turned off at all; a row that is included *because of another row* had no way to look like it; and a disabled bulk action could not say why it was disabled. This adds three optional props on `DataSourceDefinition` — `selectionDisabled`, `selectionInherited`, `disableSelectAll` — plus `disabledTooltip` on a bulk action. All additive and backward-compatible.

The Job Catalog nested table is the first consumer, and the two screenshots below are it: picking a node marks its whole subtree as coming along (the greyed mixed mark, never a real pick), and a selection its backend would reject — a move only accepts one kind of node at a time — leaves Move disabled with the reason on hover instead of taking checkboxes away.

<img width="987" height="491" alt="Screenshot 2026-08-28 at 12 27 02" src="https://github.com/user-attachments/assets/9d85ef36-5b93-424b-a749-27a456aa4186" />

<img width="421" height="99" alt="Screenshot 2026-08-28 at 12 55 24" src="https://github.com/user-attachments/assets/9a8a5179-be16-43d0-a1dc-4ca87a0dc3a9" />


## Type of change

- [x] Variant or improvement of existing pattern

## Implementation details

- feat: add `selectionDisabled?: (item: R) => boolean` to the source — renders that row's checkbox disabled instead of hiding it, keeps the row in place, and leaves it out of "select all" and of the selection counts so the header checkbox can still reach a fully-checked state instead of hanging indeterminate forever

  <details>
  <summary>Where it is enforced</summary>

  In `useSelectable`, not in the markup: `collectSelectableEntries` filters disabled rows out of every select-all path, and `handleSelectItemChange` refuses one. Every visualization passes the item (not the id) to that handler, so table, list, card and kanban are all covered — a disabled item cannot enter the selection through any of them.

  In the table, a disabled row also stays out of the selection registry, so the registry-backed select-all (including lazily-loaded nested children) never reaches it.
  </details>

- feat: add `disableSelectAll?: boolean` to the source — drops the header select-all checkbox, the per-group select-all checkbox and the cross-page "Select all N items" CTA, forcing row-by-row selection. Mirrors the `F0Select` prop of the same name

  <details>
  <summary>Why this was mostly plumbing</summary>

  `useSelectable` already accepted `disableSelectAll` as a hook prop (used by `F0Select`); it was just unreachable from a DataCollection source and no visualization honoured it. Precedence follows `allPagesSelection`: the hook prop wins, the source is the fallback.

  The checkbox cells still render (empty) when the affordance is gone, so column widths and tree indentation are unchanged.
  </details>

- feat: render the disabled state in the table and list rows

  <details>
  <summary>Card and Kanban</summary>

  They enforce the exclusion but do not grey the control — that would need a new prop on the stable `F0Card` public API, which requires a design review. No consumer needs it today.
  </details>

- feat: add `selectionInherited?: (item: R) => boolean` — a row selected *through something else*, which in a tree is everything under a picked node. Renders the indeterminate mark, disabled, so it reads as included without looking like a row the user ticked, and never joins the selection, so the payload keeps naming only real picks. Implies `selectionDisabled`

- feat: add `disabledTooltip` to `BulkActionDefinition` — a disabled action explaining why

  <details>
  <summary>Why a wrapper</summary>

  A native `disabled` button emits no pointer events, so neither a `title` nor a tooltip on the button itself ever appears. The bar hangs the reason off a wrapper element that does receive hover, and only while the action is disabled — an action the user can click explains itself by doing the thing.
  </details>

- fix: keep the hand cursor off a disabled checkbox — the box already had `cursor-not-allowed`, the padding around it inherited the row's, and a row with `itemOnClick` is a hand

- chore: exclude the three source props from `SelectCellConfig`'s `Omit` in the editable table, alongside `selectable` — a select cell has no row selection
- test: add `Table/__tests__/DisabledSelection.test.tsx` — the disabled affordance, a disabled row refusing selection, select-all skipping it while still reading as fully checked, `disableSelectAll` dropping the header checkbox, and an inherited row carrying a mark that is not the one a real pick gets
- docs: add a `WithDisabledSelection` story (a "one department at a time" rule with its inherited rows, which is the real shape of the use case) and document all four additions on the Selectable and bulk actions page

## On the API-breaking check

The bot flags `downloadAsCSV` and `generateCSVContent` because the three new prop names were added to the `Omit` list of `SelectCellConfig`'s `source` — the editable table's select cell, which has no row selection (`selectable` was already omitted there for the same reason). Adding to that list only ever makes an assignment **more** permissive: the omitted props stop being checked, so nothing that compiled before stops compiling. The only way to hit it is to pass one of these props inside a select cell config — and they did not exist before this PR. So no major bump, and no `feat!`.

The omission is required, not cosmetic: `SelectCellConfig` pins its source to a concrete `RecordType`, so a consumer's `(item: TheirRecord) => boolean` fails contravariance against `(item: RecordType) => boolean`. Making that config generic over the record is the real fix and a much larger refactor of the editable table's types.

## Accessibility

- The wrapper carrying a disabled action's reason is **focusable**, so the tooltip opens on focus too. A natively disabled button takes no focus, which would have made the reason mouse-only.
- No axe skips added; the skip allowlist is untouched.
- **Known gap, pre-existing, not fixed here:** `ui/checkbox` carries the indeterminate state in the *icon only* — it passes a boolean `checked` to Radix, so a partially-selected header checkbox and an inherited row both announce as plain "checked". Setting `aria-checked="mixed"` there is a two-line change, but it breaks **9 existing tests** across `F0Checkbox`, `Kanban` and `Table` that encode today's contract (one is literally named *"shows header checkbox as indeterminate (unchecked + minus icon)"*). It changes the accessible semantics of a component every collection uses, so it deserves its own PR with Foundations rather than riding along here.

## For review

`disabledTooltip` reaches into `F0ActionBar`, which is **stable**, to wrap a disabled action in a hoverable element (~70 lines, the only way a reason can show at all: a native `disabled` button emits no pointer events). It is additive and opt-in, but if Foundations would rather see it on its own, it lifts out cleanly — everything else here is the row-level selection story and does not depend on it.



