### PR TITLE
feat(NewHomeLayout): stop widget drag at the pinned widgets

### DIFF
--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -439,12 +439,37 @@ describe("WidgetContainer", () => {
     test("skips the locked widget", () => {
       const { container } = zeroRender(
         <WidgetContainer
-          widgets={[widget("clock", { locked: true }), widget("events")]}
+          widgets={[
+            widget("clock", { locked: true }),
+            widget("events"),
+            widget("tasks"),
+          ]}
           onReorder={() => {}}
         />
       )
 
-      expect(container.querySelectorAll(".cursor-grab")).toHaveLength(1)
+      // The two free cards carry the grab cursor; the pinned one does not.
+      expect(container.querySelectorAll(".cursor-grab")).toHaveLength(2)
+    })
+
+    /**
+     * A COLUMN WITH ONE FREE CARD HAS ONE LEGAL ORDER. Its card used to get the
+     * grab cursor and a drag that could only ever end where it began — the pins
+     * cannot give up their slots, so there was nowhere for it to go.
+     */
+    test("is not offered when only one widget can move", () => {
+      const { container } = zeroRender(
+        <WidgetContainer
+          widgets={[
+            widget("clock", { locked: true }),
+            widget("payroll", { locked: true }),
+            widget("events"),
+          ]}
+          onReorder={() => {}}
+        />
+      )
+
+      expect(container.querySelectorAll(".cursor-grab")).toHaveLength(0)
     })
 
     test("is not offered in a disableEdition column", () => {

--- a/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
@@ -71,14 +71,49 @@ export const Default: Story = {}
  * displace it, and it offers no menu at all — being mandatory, removing it is
  * not a choice the user has.
  *
- * And because it is at the TOP of the column, a card dragged up STOPS at its
- * bottom edge rather than sailing over it to a slot it cannot have: there is no
- * order above a pinned widget for the drop to commit, so carrying a card up
- * there could only end in a spring back (`lockedCeiling`).
+ * AND NEITHER CAN THE OTHER ONE, in a column this short: with one free card
+ * among the pins there is a single legal order, so no card here has a grab
+ * cursor. A drag whose every outcome is the arrangement you already have is an
+ * offer of a refusal — see `PinnedWithRoomToMove` for the column that does
+ * have somewhere to put things.
  */
 export const WithLockedWidget: Story = {
   args: {
     widgets: [{ ...WIDGETS[0], locked: true }, WIDGETS[1]],
+  },
+}
+
+/**
+ * THE PINNED CEILING, which needs three widgets to see: Time off is `locked` at
+ * the top, and the two below it can be dragged past each other freely.
+ *
+ * Carry either one UP and it stops at the top of the first free slot — the
+ * pinned card's bottom edge plus the gap the column keeps between cards — rather
+ * than sailing over Time off to a place it cannot have. There is no order above
+ * a pinned widget for the drop to commit, so a card carried up there could only
+ * spring back (`lockedCeiling`).
+ */
+export const PinnedWithRoomToMove: Story = {
+  args: {
+    widgets: [
+      { ...WIDGETS[0], locked: true },
+      WIDGETS[1],
+      {
+        id: "tasks",
+        icon: Clock,
+        header: {
+          title: "Tasks",
+          count: 3,
+          link: { title: "Go to Tasks", onClick: () => {} },
+        },
+        slots: [
+          listSlot({ clickBehavior: "link" }, [
+            { id: "1", title: "Review the handbook", href: "/tasks/1" },
+            { id: "2", title: "Sign your contract", href: "/tasks/2" },
+          ]),
+        ],
+      },
+    ],
   },
 }
 

--- a/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.stories.tsx
@@ -70,6 +70,11 @@ export const Default: Story = {}
  * A `locked` widget (the first here) is inert: it can't be dragged, nothing can
  * displace it, and it offers no menu at all — being mandatory, removing it is
  * not a choice the user has.
+ *
+ * And because it is at the TOP of the column, a card dragged up STOPS at its
+ * bottom edge rather than sailing over it to a slot it cannot have: there is no
+ * order above a pinned widget for the drop to commit, so carrying a card up
+ * there could only end in a spring back (`lockedCeiling`).
  */
 export const WithLockedWidget: Story = {
   args: {

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -17,6 +17,7 @@ import {
   type CSSProperties,
   type PointerEvent,
   ReactNode,
+  useMemo,
   useRef,
   useState,
 } from "react"
@@ -46,6 +47,7 @@ import {
 import { SlotWidget } from "../SlotWidget"
 import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
 import { takeCardGhost } from "./dragGhost"
+import { lockedCeiling, noHigherThan, topPins } from "./lockedCeiling"
 import { SortableWidget } from "./SortableWidget"
 import {
   useWidgetVirtualizer,
@@ -113,12 +115,6 @@ const DROP_ANIMATION = {
   duration: 450,
   easing: "cubic-bezier(0.4, 0, 0.1, 1)",
 }
-
-/**
- * Hoisted rather than written inline: dnd-kit reads this on every pointer move,
- * and a fresh array each render is a fresh dependency for it.
- */
-const DRAG_MODIFIERS = [verticalOnly]
 
 /** Which column a container is: the growing main one, or the fixed side rail. */
 export type WidgetContainerSide = "main" | "right"
@@ -414,6 +410,23 @@ export function WidgetContainer({
   const columnRef = useRef<HTMLDivElement>(null)
   /** The static copy of the dragged card that rides the pointer — {@link takeCardGhost}. */
   const ghostRef = useRef<HTMLElement | null>(null)
+  /**
+   * HOW FAR UP THE CARD BEING DRAGGED MAY GO, measured when the drag starts and
+   * null the rest of the time — see `lockedCeiling`.
+   */
+  const ceilingRef = useRef<number | null>(null)
+  /**
+   * The dragged card goes up and down only (`verticalOnly`), and no higher than
+   * the widgets pinned to the top of the column (`noHigherThan`).
+   *
+   * Built ONCE: dnd-kit reads this on every pointer move, and a fresh array each
+   * render is a fresh dependency for it — which is why the ceiling arrives
+   * through a ref instead of being baked into the modifier.
+   */
+  const modifiers = useMemo(
+    () => [verticalOnly, noHigherThan(() => ceilingRef.current)],
+    []
+  )
 
   const takeGhost = (id: string) => {
     ghostRef.current = takeCardGhost(
@@ -486,9 +499,16 @@ export function WidgetContainer({
     >
     const x = start.clientX == null ? null : start.clientX + delta.x
     const y = start.clientY == null ? null : start.clientY + delta.y
+    // THE PINS AT THE TOP WERE NEVER REACHABLE: the drag was held below them
+    // (`noHigherThan`), so the card cannot have covered one, and refusing the
+    // drop because the POINTER strayed up into one would refuse a card that is
+    // sitting in the highest slot it was allowed to reach. Only when the ceiling
+    // could not be measured at all does the card get up there, and then the
+    // refusal is again the only thing that explains the spring back.
+    const unreachable = ceilingRef.current == null ? [] : topPins(widgets)
 
     return widgets.find((widget) => {
-      if (!widget.locked) return false
+      if (!widget.locked || unreachable.includes(widget)) return false
       const box = columnRef.current
         ?.querySelector(`[data-widget-id="${widget.id}"]`)
         ?.getBoundingClientRect()
@@ -784,22 +804,30 @@ export function WidgetContainer({
           sensors={sensors}
           collisionDetection={closestCenter}
           // The card the pointer carries goes up and down only, like the
-          // shuffle underneath it — see `verticalOnly`.
-          modifiers={DRAG_MODIFIERS}
+          // shuffle underneath it, and it stops at the widgets pinned to the top
+          // of the column — see `verticalOnly` and `lockedCeiling`.
+          modifiers={modifiers}
           onDragStart={({ active }) => {
             // BEFORE the card is told it is being dragged: what the ghost
-            // should look like is what is on screen right now.
+            // should look like — and where the pinned cards are — is what is on
+            // screen right now, while nothing has moved yet.
             takeGhost(String(active.id))
+            ceilingRef.current = lockedCeiling(widgets, columnRef.current)
             setActiveId(String(active.id))
           }}
           onDragCancel={() => {
             setActiveId(null)
             ghostRef.current = null
+            ceilingRef.current = null
           }}
           onDragEnd={(event) => {
             setActiveId(null)
             ghostRef.current = null
+            // The ceiling outlives the drag by one call: whether the card was
+            // held below the pins is what decides whether a drop up there is
+            // worth refusing out loud (`lockedTargetOf`).
             handleDragEnd(event)
+            ceilingRef.current = null
           }}
         >
           {/* EVERY WIDGET'S ID, mounted or not: the order a drop commits is the

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -390,7 +390,17 @@ export function WidgetContainer({
   const canEdit = !disableEdition
   const isHidden = (widget: HomeWidgetItem) =>
     visibleWidgetId !== undefined && widget.id !== visibleWidgetId
-  const canDrag = canEdit && onReorder != null && widgets.length > 1
+  /**
+   * WHETHER THERE IS AN ARRANGEMENT TO MAKE — two widgets that can actually
+   * move, not merely two widgets. A column of one free card among pinned ones
+   * has a single legal order, so its card is given no grab cursor and no drag:
+   * offering a gesture whose every outcome is the arrangement you already have
+   * is offering a refusal.
+   */
+  const canDrag =
+    canEdit &&
+    onReorder != null &&
+    widgets.filter((widget) => !widget.locked).length > 1
   // The widget being dragged: its in-list card hides while a copy of it rides
   // the pointer in the DragOverlay (see below).
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -812,7 +822,11 @@ export function WidgetContainer({
             // should look like — and where the pinned cards are — is what is on
             // screen right now, while nothing has moved yet.
             takeGhost(String(active.id))
-            ceilingRef.current = lockedCeiling(widgets, columnRef.current)
+            ceilingRef.current = lockedCeiling(
+              widgets,
+              columnRef.current,
+              GAP_PX[side]
+            )
             setActiveId(String(active.id))
           }}
           onDragCancel={() => {

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -855,6 +855,31 @@ export function WidgetContainer({
           >
             {list}
           </SortableContext>
+          {/* ONE CURSOR FOR THE WHOLE GESTURE. The pointer is not always over
+              the card it is carrying: the card stops at the pinned widgets
+              (`lockedCeiling`) while the pointer keeps going, and the moment it
+              leaves the card it is over whatever lies beneath — a pinned widget,
+              a link inside it, the page — and the cursor becomes that thing's.
+              A hand that turns into an arrow reads as the drag having ended, or
+              as the pointer having lost the card; neither happened, and the drag
+              is still live and still refusing to go up.
+
+              So while a drag is in flight the pointer is over THIS: a sheet the
+              size of the viewport whose only job is to own the cursor. It sits
+              under the DragOverlay (z-999 there, so the card stays on top) and
+              over everything else, and it takes the hover states of the cards
+              beneath it out of the gesture too, which is the same argument.
+
+              dnd-kit is unaffected: its sensor listens on the document, and the
+              column's collision detection is rect-based (`closestCenter`), so
+              nothing here depends on which element the pointer is over. */}
+          {activeId ? (
+            <div
+              aria-hidden
+              data-drag-cursor
+              className="fixed inset-0 z-50 cursor-grabbing"
+            />
+          ) : null}
           {/* The card that follows the pointer is a COPY of the real one's DOM
               (`takeGhost`) in an overlay — the in-list card hides meanwhile
               (SortableWidget). On release the copy GLIDES from where it was

--- a/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.spec.tsx
@@ -1,0 +1,262 @@
+import type { DragStartEvent, Modifier } from "@dnd-kit/core"
+import { afterEach, describe, expect, test, vi } from "vitest"
+
+import { Clock } from "@/icons/app"
+import { act, zeroRender } from "@/testing/test-utils"
+
+import type { HomeWidgetItem } from "../slotRenderers"
+import { WidgetContainer } from "./index"
+import { lockedCeiling, noHigherThan, topPins } from "./lockedCeiling"
+
+const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) =>
+  ({
+    id,
+    icon: Clock,
+    header: { title: id },
+    slots: [],
+    ...extra,
+  }) as HomeWidgetItem
+
+/** dnd-kit hands a modifier the whole drag context; these are the parts read. */
+const apply = (
+  modifier: Modifier,
+  { y, top, height = 100 }: { y: number; top: number; height?: number }
+) =>
+  modifier({
+    transform: { x: 0, y, scaleX: 1, scaleY: 1 },
+    draggingNodeRect: { top, bottom: top + height, height } as DOMRect,
+  } as unknown as Parameters<Modifier>[0])
+
+/**
+ * A column whose cards measure something, since jsdom gives every box a height
+ * of 0 — `heights` by widget id, laid out top to bottom from y = 0.
+ */
+const mockCards = (heights: Record<string, number>) => {
+  const tops: Record<string, number> = {}
+  let y = 0
+  for (const [id, height] of Object.entries(heights)) {
+    tops[id] = y
+    y += height
+  }
+
+  vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+    function (this: HTMLElement) {
+      const id = this.getAttribute("data-widget-id")
+      const top = id == null ? 0 : (tops[id] ?? 0)
+      const height = id == null ? 0 : (heights[id] ?? 0)
+      // Spelled out rather than a `DOMRect`: jsdom keeps a rect's fields on the
+      // prototype, so a spread one arrives with none of them.
+      return {
+        top,
+        bottom: top + height,
+        height,
+        left: 0,
+        right: 400,
+        width: 400,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      } as DOMRect
+    }
+  )
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("topPins", () => {
+  test("is the run of locked widgets before the first free one", () => {
+    expect(
+      topPins([
+        widget("clock", { locked: true }),
+        widget("payroll", { locked: true }),
+        widget("events"),
+        widget("tasks", { locked: true }),
+      ]).map((w) => w.id)
+    ).toEqual(["clock", "payroll"])
+  })
+
+  test("is empty when the top of the column is free", () => {
+    expect(
+      topPins([widget("events"), widget("clock", { locked: true })])
+    ).toEqual([])
+  })
+
+  test("is the whole column when every widget is locked", () => {
+    expect(
+      topPins([
+        widget("clock", { locked: true }),
+        widget("payroll", { locked: true }),
+      ]).map((w) => w.id)
+    ).toEqual(["clock", "payroll"])
+  })
+})
+
+describe("lockedCeiling", () => {
+  const column = (widgets: HomeWidgetItem[]) => {
+    const el = document.createElement("div")
+    for (const w of widgets) {
+      const card = document.createElement("div")
+      card.setAttribute("data-widget-id", w.id)
+      el.append(card)
+    }
+    return el
+  }
+
+  test("is the bottom edge of the pinned run", () => {
+    mockCards({ clock: 120, payroll: 80, events: 200 })
+    const widgets = [
+      widget("clock", { locked: true }),
+      widget("payroll", { locked: true }),
+      widget("events"),
+    ]
+
+    expect(lockedCeiling(widgets, column(widgets))).toBe(200)
+  })
+
+  test("is null when nothing pins the top", () => {
+    mockCards({ events: 200, clock: 120 })
+    const widgets = [widget("events"), widget("clock", { locked: true })]
+
+    expect(lockedCeiling(widgets, column(widgets))).toBeNull()
+  })
+
+  /** A virtualized column can have scrolled the pinned cards out of the DOM. */
+  test("is null when the pinned cards aren't there to measure", () => {
+    mockCards({ events: 200 })
+    const widgets = [widget("clock", { locked: true }), widget("events")]
+
+    expect(lockedCeiling(widgets, column([widget("events")]))).toBeNull()
+  })
+
+  test("is null without a column to measure in", () => {
+    expect(lockedCeiling([widget("clock", { locked: true })], null)).toBeNull()
+  })
+})
+
+describe("noHigherThan", () => {
+  test("stops the card where the pinned widgets end", () => {
+    const modifier = noHigherThan(() => 200)
+
+    // A card starting at 200 dragged 500px up: it goes no further than the
+    // ceiling, which is the top of the first slot it is allowed to have.
+    expect(apply(modifier, { y: -500, top: 200 }).y).toBe(0)
+  })
+
+  test("allows the travel that stays below them", () => {
+    const modifier = noHigherThan(() => 200)
+
+    // From 520, 300px up leaves the card's top at 220 — still under the pins.
+    expect(apply(modifier, { y: -300, top: 520 }).y).toBe(-300)
+    // And down is never restricted.
+    expect(apply(modifier, { y: 640, top: 520 }).y).toBe(640)
+  })
+
+  test("does nothing when the top of the column is free", () => {
+    expect(
+      apply(
+        noHigherThan(() => null),
+        { y: -900, top: 200 }
+      ).y
+    ).toBe(-900)
+  })
+
+  test("holds the card's TOP edge, not its middle", () => {
+    // A 400px-tall card: clamping its middle would let its top sit 200px into
+    // the pinned widgets.
+    expect(
+      apply(
+        noHigherThan(() => 200),
+        { y: -400, top: 400, height: 400 }
+      ).y
+    ).toBe(-200)
+  })
+})
+
+/**
+ * The wiring, which is the part that regressed: a column with pinned widgets at
+ * the top used to let the card sail over them for the whole drag and refuse the
+ * drop at the end.
+ */
+describe("a column with widgets pinned to the top", () => {
+  const captured = vi.hoisted(() => ({
+    modifiers: undefined as Modifier[] | undefined,
+    onDragStart: undefined as ((event: DragStartEvent) => void) | undefined,
+  }))
+
+  vi.mock("@dnd-kit/core", async () => {
+    const { createElement } = await import("react")
+    const actual =
+      await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core")
+
+    return {
+      ...actual,
+      DndContext: (props: React.ComponentProps<typeof actual.DndContext>) => {
+        captured.modifiers = props.modifiers as Modifier[]
+        captured.onDragStart = props.onDragStart
+        return createElement(actual.DndContext, props)
+      },
+    }
+  })
+
+  test("holds a dragged card below them for the whole gesture", () => {
+    mockCards({ clock: 120, events: 200, tasks: 200 })
+    zeroRender(
+      <WidgetContainer
+        widgets={[
+          widget("clock", { locked: true }),
+          widget("events"),
+          widget("tasks"),
+        ]}
+        onReorder={() => {}}
+      />
+    )
+
+    act(() => {
+      captured.onDragStart?.({
+        active: { id: "tasks" },
+      } as unknown as DragStartEvent)
+    })
+
+    // The card starts at 320 (under the 120px pin and the 200px widget) and is
+    // carried 400px up: it stops with its top on the pin's bottom edge, 120.
+    const chain = (captured.modifiers ?? []).reduce(
+      (transform, modifier) =>
+        modifier({
+          transform,
+          draggingNodeRect: { top: 320, bottom: 520, height: 200 } as DOMRect,
+        } as unknown as Parameters<Modifier>[0]),
+      { x: 0, y: -400, scaleX: 1, scaleY: 1 }
+    )
+
+    expect(chain.y).toBe(-200)
+  })
+
+  test("does not hold it back when the top is free", () => {
+    mockCards({ events: 200, tasks: 200 })
+    zeroRender(
+      <WidgetContainer
+        widgets={[widget("events"), widget("tasks")]}
+        onReorder={() => {}}
+      />
+    )
+
+    act(() => {
+      captured.onDragStart?.({
+        active: { id: "tasks" },
+      } as unknown as DragStartEvent)
+    })
+
+    const chain = (captured.modifiers ?? []).reduce(
+      (transform, modifier) =>
+        modifier({
+          transform,
+          draggingNodeRect: { top: 200, bottom: 400, height: 200 } as DOMRect,
+        } as unknown as Parameters<Modifier>[0]),
+      { x: 0, y: -400, scaleX: 1, scaleY: 1 }
+    )
+
+    expect(chain.y).toBe(-400)
+  })
+})

--- a/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.spec.tsx
@@ -104,7 +104,7 @@ describe("lockedCeiling", () => {
     return el
   }
 
-  test("is the bottom edge of the pinned run", () => {
+  test("is the top of the first free SLOT: the pinned run plus the gap", () => {
     mockCards({ clock: 120, payroll: 80, events: 200 })
     const widgets = [
       widget("clock", { locked: true }),
@@ -112,14 +112,23 @@ describe("lockedCeiling", () => {
       widget("events"),
     ]
 
-    expect(lockedCeiling(widgets, column(widgets))).toBe(200)
+    // The pins end at 200; the main column keeps 24px between cards.
+    expect(lockedCeiling(widgets, column(widgets), 24)).toBe(224)
+  })
+
+  test("takes the gap from the column it is measuring", () => {
+    mockCards({ clock: 120, events: 200 })
+    const widgets = [widget("clock", { locked: true }), widget("events")]
+
+    // The rail's cards sit 16px apart, not the main column's 24px.
+    expect(lockedCeiling(widgets, column(widgets), 16)).toBe(136)
   })
 
   test("is null when nothing pins the top", () => {
     mockCards({ events: 200, clock: 120 })
     const widgets = [widget("events"), widget("clock", { locked: true })]
 
-    expect(lockedCeiling(widgets, column(widgets))).toBeNull()
+    expect(lockedCeiling(widgets, column(widgets), 24)).toBeNull()
   })
 
   /** A virtualized column can have scrolled the pinned cards out of the DOM. */
@@ -127,11 +136,13 @@ describe("lockedCeiling", () => {
     mockCards({ events: 200 })
     const widgets = [widget("clock", { locked: true }), widget("events")]
 
-    expect(lockedCeiling(widgets, column([widget("events")]))).toBeNull()
+    expect(lockedCeiling(widgets, column([widget("events")]), 24)).toBeNull()
   })
 
   test("is null without a column to measure in", () => {
-    expect(lockedCeiling([widget("clock", { locked: true })], null)).toBeNull()
+    expect(
+      lockedCeiling([widget("clock", { locked: true })], null, 24)
+    ).toBeNull()
   })
 })
 
@@ -220,7 +231,8 @@ describe("a column with widgets pinned to the top", () => {
     })
 
     // The card starts at 320 (under the 120px pin and the 200px widget) and is
-    // carried 400px up: it stops with its top on the pin's bottom edge, 120.
+    // carried 400px up: it stops at the top of the first free slot — the pin's
+    // bottom edge, 120, plus the main column's 24px gap.
     const chain = (captured.modifiers ?? []).reduce(
       (transform, modifier) =>
         modifier({
@@ -230,7 +242,23 @@ describe("a column with widgets pinned to the top", () => {
       { x: 0, y: -400, scaleX: 1, scaleY: 1 }
     )
 
-    expect(chain.y).toBe(-200)
+    expect(chain.y).toBe(-176)
+  })
+
+  /**
+   * The other half of the same rule: with one free card among the pins there is
+   * a single legal order, so there is no drag to constrain in the first place.
+   */
+  test("offers no drag at all when only one card can move", () => {
+    mockCards({ clock: 120, events: 200 })
+    const { container } = zeroRender(
+      <WidgetContainer
+        widgets={[widget("clock", { locked: true }), widget("events")]}
+        onReorder={() => {}}
+      />
+    )
+
+    expect(container.querySelectorAll(".cursor-grab")).toHaveLength(0)
   })
 
   test("does not hold it back when the top is free", () => {

--- a/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.test.tsx
@@ -246,6 +246,40 @@ describe("a column with widgets pinned to the top", () => {
   })
 
   /**
+   * THE CURSOR DOES NOT REPORT THE CEILING. Once the card has stopped, the
+   * pointer carries on up and is over the pinned widget rather than the card it
+   * is dragging — and the cursor was becoming that widget's, which reads as the
+   * drag having ended when it is still live.
+   */
+  test("keeps one cursor for the gesture, wherever the pointer ends up", () => {
+    mockCards({ clock: 120, events: 200, tasks: 200 })
+    const { container } = zeroRender(
+      <WidgetContainer
+        widgets={[
+          widget("clock", { locked: true }),
+          widget("events"),
+          widget("tasks"),
+        ]}
+        onReorder={() => {}}
+      />
+    )
+
+    // Nothing owns the cursor while the column is idle.
+    expect(container.querySelector("[data-drag-cursor]")).toBeNull()
+
+    act(() => {
+      captured.onDragStart?.({
+        active: { id: "tasks" },
+      } as unknown as DragStartEvent)
+    })
+
+    const sheet = container.querySelector("[data-drag-cursor]")
+    expect(sheet).not.toBeNull()
+    // Over everything the pointer could otherwise pick a cursor up from.
+    expect(sheet).toHaveClass("fixed", "inset-0", "cursor-grabbing")
+  })
+
+  /**
    * The other half of the same rule: with one free card among the pins there is
    * a single legal order, so there is no drag to constrain in the first place.
    */

--- a/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.test.tsx
@@ -8,6 +8,35 @@ import type { HomeWidgetItem } from "../slotRenderers"
 import { WidgetContainer } from "./index"
 import { lockedCeiling, noHigherThan, topPins } from "./lockedCeiling"
 
+/**
+ * WHAT THE COLUMN HANDED DND-KIT. There is nothing in the DOM to read a
+ * modifier list off, so the context is stubbed and asked what it was given —
+ * and its `onDragStart` is kept so a gesture can be begun without a pointer.
+ *
+ * At the top of the file because `vi.mock` and `vi.hoisted` ARE hoisted to the
+ * top whatever their position: written inside the `describe` they read as its
+ * setup, which is not when they run (oxlint's `vitest/hoisted-apis-on-top`).
+ */
+const captured = vi.hoisted(() => ({
+  modifiers: undefined as Modifier[] | undefined,
+  onDragStart: undefined as ((event: DragStartEvent) => void) | undefined,
+}))
+
+vi.mock("@dnd-kit/core", async () => {
+  const { createElement } = await import("react")
+  const actual =
+    await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core")
+
+  return {
+    ...actual,
+    DndContext: (props: React.ComponentProps<typeof actual.DndContext>) => {
+      captured.modifiers = props.modifiers as Modifier[]
+      captured.onDragStart = props.onDragStart
+      return createElement(actual.DndContext, props)
+    },
+  }
+})
+
 const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) =>
   ({
     id,
@@ -188,29 +217,10 @@ describe("noHigherThan", () => {
 /**
  * The wiring, which is the part that regressed: a column with pinned widgets at
  * the top used to let the card sail over them for the whole drag and refuse the
- * drop at the end.
+ * drop at the end. Driven through the stubbed context above rather than a real
+ * pointer — jsdom has no drag.
  */
 describe("a column with widgets pinned to the top", () => {
-  const captured = vi.hoisted(() => ({
-    modifiers: undefined as Modifier[] | undefined,
-    onDragStart: undefined as ((event: DragStartEvent) => void) | undefined,
-  }))
-
-  vi.mock("@dnd-kit/core", async () => {
-    const { createElement } = await import("react")
-    const actual =
-      await vi.importActual<typeof import("@dnd-kit/core")>("@dnd-kit/core")
-
-    return {
-      ...actual,
-      DndContext: (props: React.ComponentProps<typeof actual.DndContext>) => {
-        captured.modifiers = props.modifiers as Modifier[]
-        captured.onDragStart = props.onDragStart
-        return createElement(actual.DndContext, props)
-      },
-    }
-  })
-
   test("holds a dragged card below them for the whole gesture", () => {
     mockCards({ clock: 120, events: 200, tasks: 200 })
     zeroRender(

--- a/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.ts
@@ -1,0 +1,74 @@
+import type { Modifier } from "@dnd-kit/core"
+
+import type { HomeWidgetItem } from "../slotRenderers"
+
+/**
+ * THE WIDGETS PINNED TO THE TOP of a column: the run of locked ones before the
+ * first free widget.
+ *
+ * A locked widget further down the column is deliberately not one of these.
+ * There are free slots above it, so there is still somewhere legal to drag a
+ * card to up there — only a run that starts at the very top has NOTHING behind
+ * it, and only then is "up" a direction with no meaning.
+ */
+export const topPins = (widgets: HomeWidgetItem[]): HomeWidgetItem[] => {
+  const firstFree = widgets.findIndex((widget) => !widget.locked)
+  return widgets.slice(0, firstFree < 0 ? widgets.length : firstFree)
+}
+
+/**
+ * HOW FAR UP A CARD MAY GO in this column: the bottom edge of that pinned run,
+ * in viewport coordinates. `null` when the top isn't pinned at all — and also
+ * when the pinned cards are not in the DOM to be measured, which a virtualized
+ * column that has scrolled them away can do; a limit guessed from cards that
+ * aren't there would be worse than no limit.
+ *
+ * Measured ONCE, as the drag starts, because that is the frame of reference the
+ * rest of the gesture is in: dnd-kit measures the dragged card's box then too
+ * and reports the travel as a delta on top of it, so a ceiling re-measured
+ * mid-drag would be compared against a box from before the column scrolled.
+ */
+export const lockedCeiling = (
+  widgets: HomeWidgetItem[],
+  column: HTMLElement | null
+): number | null => {
+  const bottoms = topPins(widgets).flatMap((widget) => {
+    const box = column
+      ?.querySelector(`[data-widget-id="${widget.id}"]`)
+      ?.getBoundingClientRect()
+    return box ? [box.bottom] : []
+  })
+
+  return bottoms.length > 0 ? Math.max(...bottoms) : null
+}
+
+/**
+ * THE CARD STOPS AT THE PINS RATHER THAN PASSING THEM. Widgets locked to the
+ * top of a column cannot give up their slots, so a card carried above them is
+ * being offered a move that will be refused: it drifts over the pinned cards,
+ * covers them, and then springs back to where it came from with a toast for an
+ * explanation. Refusing at the end of the gesture is refusing too late — the
+ * card should simply not go there, the way a scroll stops at the top of a page.
+ *
+ * `ceiling` is read through a getter rather than passed by value so the
+ * modifier can be built once per column and still see the limit measured at
+ * drag start: dnd-kit reads its `modifiers` prop on every pointer move, and a
+ * modifier rebuilt mid-gesture is a new dependency for it every frame.
+ */
+export const noHigherThan =
+  (ceiling: () => number | null): Modifier =>
+  ({ transform, draggingNodeRect, activeNodeRect }) => {
+    const limit = ceiling()
+    // The overlay clone is what the pointer carries, so it is the box being
+    // held above the pins; without an overlay dnd-kit hands the same rect for
+    // both, and `activeNodeRect` is the fallback for the frames before the
+    // clone has been measured.
+    const top = (draggingNodeRect ?? activeNodeRect)?.top
+
+    if (limit == null || top == null) return transform
+
+    // The card's TOP edge, not its middle: passing the pins means overlapping
+    // them at all, and a card whose top is exactly on the limit is sitting in
+    // the first slot it is allowed to have.
+    return { ...transform, y: Math.max(transform.y, limit - top) }
+  }

--- a/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/lockedCeiling.ts
@@ -17,11 +17,18 @@ export const topPins = (widgets: HomeWidgetItem[]): HomeWidgetItem[] => {
 }
 
 /**
- * HOW FAR UP A CARD MAY GO in this column: the bottom edge of that pinned run,
- * in viewport coordinates. `null` when the top isn't pinned at all — and also
- * when the pinned cards are not in the DOM to be measured, which a virtualized
- * column that has scrolled them away can do; a limit guessed from cards that
- * aren't there would be worse than no limit.
+ * HOW FAR UP A CARD MAY GO in this column: the TOP OF THE FIRST FREE SLOT, in
+ * viewport coordinates — the bottom edge of that pinned run plus the column's
+ * own `gap`. The gap is part of the answer, not a rounding error: a card held
+ * flush against a pinned one is not in a slot the column has, it is touching a
+ * widget it cannot displace, and the drop it would commit puts that same gap
+ * back anyway. Stopping at the slot means the card the pointer carries is
+ * already sitting where releasing it would leave it.
+ *
+ * `null` when the top isn't pinned at all — and also when the pinned cards are
+ * not in the DOM to be measured, which a virtualized column that has scrolled
+ * them away can do; a limit guessed from cards that aren't there would be worse
+ * than no limit.
  *
  * Measured ONCE, as the drag starts, because that is the frame of reference the
  * rest of the gesture is in: dnd-kit measures the dragged card's box then too
@@ -30,7 +37,8 @@ export const topPins = (widgets: HomeWidgetItem[]): HomeWidgetItem[] => {
  */
 export const lockedCeiling = (
   widgets: HomeWidgetItem[],
-  column: HTMLElement | null
+  column: HTMLElement | null,
+  gap: number
 ): number | null => {
   const bottoms = topPins(widgets).flatMap((widget) => {
     const box = column
@@ -39,7 +47,7 @@ export const lockedCeiling = (
     return box ? [box.bottom] : []
   })
 
-  return bottoms.length > 0 ? Math.max(...bottoms) : null
+  return bottoms.length > 0 ? Math.max(...bottoms) + gap : null
 }
 
 /**
@@ -67,8 +75,8 @@ export const noHigherThan =
 
     if (limit == null || top == null) return transform
 
-    // The card's TOP edge, not its middle: passing the pins means overlapping
-    // them at all, and a card whose top is exactly on the limit is sitting in
-    // the first slot it is allowed to have.
+    // The card's TOP edge, not its middle: passing the pins means closing the
+    // gap on them at all, and a card whose top is exactly on the limit is
+    // sitting in the first slot it is allowed to have.
     return { ...transform, y: Math.max(transform.y, limit - top) }
   }


### PR DESCRIPTION
## Description

A widget locked to the top of a rail cannot give up its slot, so a card carried above it was being offered a move that would always be refused: it drifted over the pinned cards for the whole gesture and sprang back on release with a toast for an explanation. The card now stops at the top of the first free slot — the pinned run's bottom edge plus the gap the column keeps between its cards — the way a scroll stops at the top of a page, and a column whose only movable card sits among pinned ones offers no drag at all.

## Screenshots (if applicable)

Not screenshot-able: the change is what the card does mid-gesture. The new `Home/WidgetContainer` → `Pinned With Room To Move` story is the place to feel it — drag either free card up and it stops one gap below the pinned one. `Home/NewHomeLayout` → `Default` is the real case: the rail's `clock-in` is `locked` and first, so dragging Communications up stops under it.

## Implementation details

- feat: hold a dragged card at the top of the first free slot when a column's top widgets are `locked`

  <details>
  <summary>Why the gap is part of the limit</summary>

  A card held flush against a pinned one is not in a slot the column has — it is touching a widget it cannot displace, and the drop it would commit puts the gap back anyway. Stopping at the slot means the card the pointer carries is already sitting where releasing it would leave it.

  The ceiling is measured once, at drag start, because that is the frame of reference dnd-kit reports the travel in: it measures the dragged card's box then and reports a delta on top of it, so a ceiling re-measured mid-drag would be compared against a box from before the column scrolled. It is `null` — no clamp — when the top isn't pinned, and also when the pinned cards aren't in the DOM to measure, which a virtualized column that has scrolled them away can do.
  </details>

- feat: offer no drag in a column where only one widget can move

  <details>
  <summary>Why?</summary>

  One free card among pinned ones has a single legal order, so the grab cursor and the gesture were an offer of a refusal. `canDrag` now counts the widgets that can actually move rather than the widgets there are.
  </details>

- fix: stop refusing a legal drop because the pointer strayed into a pinned card

  <details>
  <summary>Why?</summary>

  The refusal hit-test also asks where the pointer is, for the grab-near-the-bottom-edge case. With the ceiling in place that test could fire while the card sat in the highest slot it was allowed to reach — a spring back and a toast for a drop that was legal. Pinned-top widgets are now skipped in that test whenever a ceiling was applied; locked widgets further down a column, and the case where the ceiling can't be measured, keep the toast.
  </details>

- test: add `lockedCeiling` unit + wiring coverage, and a `PinnedWithRoomToMove` story

  <details>
  <summary>Red-green</summary>

  Each of the three rules fails without its fix: unwiring the modifier gives `expected -400 to be -176`, dropping the gap gives `expected 200 to be 224`, and restoring the old `canDrag` leaves a grab cursor on a column with one movable card. The story needs three widgets because the ceiling cannot be seen with fewer than two free cards.
  </details>

- fix: keep one cursor for the whole gesture

  <details>
  <summary>Why?</summary>

  The pointer is not always over the card it is carrying — the card stops at the pins while the pointer keeps going — and the moment it left the card the cursor became whatever lay beneath: the pinned widget's arrow, a link's hand. A hand that turns into an arrow reads as the drag having ended, or as the pointer having lost the card; neither happened, and the drag is still live and still refusing to go up.

  While a drag is in flight the pointer is now over a viewport-sized sheet whose only job is to own the cursor. It sits under the DragOverlay and over everything else, so the grab cursor holds wherever the pointer goes, and the cards beneath it keep their hover states out of the gesture. dnd-kit is unaffected: its sensor listens on the document and this column's collision detection is rect-based, so nothing depends on which element the pointer is over.

  Verified in a real browser on the new story — with the pointer 142px above the pinned card's bottom edge, the element under it is the sheet with `cursor: grabbing`, the dragged card is stopped at the first free slot (pin bottom 154 + 24px gap = 178), and no refusal toast fires for the legal drop.
  </details>
