### PR TITLE
feat(F0Chat): add an optional events prop for host-side analytics

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -215,6 +215,65 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
   </table>
 </Unstyled>
 
+### Observing in-chat interactions
+
+`F0ChatProvider` takes an optional `events` object so the host can observe the
+interactions F0Chat resolves on its own. Everything in it is either invisible to
+`F0ChatRuntime` — because no runtime method is called — or carries provenance a
+runtime call cannot express.
+
+```tsx
+<F0ChatProvider
+  runtime={runtime}
+  events={{
+    onMessageCopied: () => {},
+    onReactionAdded: ({ emoji, source }) => {},
+    onFileAttached: ({ kind, source }) => {},
+  }}
+>
+  <F0Chat />
+</F0ChatProvider>
+```
+
+Every handler is optional and independent — wire only the ones you need.
+
+**Why some interactions are not here.** Sends, deletes and edits already reach
+you through `F0ChatRuntime`, and only there do you learn whether the transport
+accepted them; F0Chat fires them optimistically. Search query text is likewise
+absent — `runtime.searchMessages` receives every query, and F0Chat debounces it
+per keystroke.
+
+**What the events add that the runtime cannot give you:**
+
+- `onMessageCopied` — copying touches nothing but the clipboard.
+- `onReplyStarted` / `onReplyCancelled`, `onEditStarted` / `onEditCancelled` —
+  the runtime only ever sees replies and edits that were completed. Pair each
+  start with its cancel to measure abandonment. The cancel fires only on an
+  explicit dismissal, never when the message is sent.
+- `onReactionAdded` / `onReactionRemoved` — `toggleReaction` is one call for both
+  directions, and it is identical from all four affordances (`source`).
+- `onFileAttached` — `uploadFiles` cannot tell a button click from a drop or a
+  paste. Fires once per file, once the selection passes validation and before
+  the upload resolves, so it records the affordance even when the upload fails.
+- `onAttachmentDownloaded`, `onImageOpened`, `onDocumentOpened`,
+  `onLocationOpened`, `onLinkPreviewClicked`, `onVoiceNotePlayed` — consuming
+  shared content never calls the runtime at all.
+
+**No payload carries message content, a URL, coordinates, or a user id.**
+`onMentionInserted` reports only whether the mention was `@here`.
+
+**But eight payloads do carry `messageId`** — `onMessageCopied`,
+`onMessageInfoViewed`, `onReplyStarted`, `onReplyCancelled`, `onEditStarted`,
+`onEditCancelled`, `onReactionAdded` and `onReactionRemoved`. It is there because
+a host may legitimately need per-message context. It is an identifier for a
+specific, possibly private message, so decide deliberately whether it leaves your
+application — an analytics pipeline is usually the wrong destination for it.
+
+**Render cost is zero.** The object is held in a ref and exposed through a
+context whose value never changes identity, so wiring every handler costs the
+same as wiring none. Rebuild it inline on each render if you like — no
+memoization is required of the host.
+
 ## Guidelines
 
 ### Design best practices

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -17,6 +17,7 @@ import { ChatUIProvider } from "./providers/ChatUIProvider"
 import { F0ChatProvider } from "./providers/F0ChatProvider"
 import {
   f0ChatSenderColors,
+  type F0ChatEvents,
   type F0ChatMessage,
   type F0ChatRuntime,
   type F0ChatUser,
@@ -922,6 +923,97 @@ const meta = {
 
 export default meta
 type Story = StoryObj<typeof meta>
+
+/**
+ * Every interaction F0Chat resolves internally, logged as it happens. Reply,
+ * copy, react from any of the four affordances, attach by button/drop/paste,
+ * play a voice note, open an image — each one appears in the panel below.
+ */
+const ObservedConversation = (): ReactNode => {
+  const runtime = useMockChatRuntime({
+    channel: dmChannel,
+    me,
+    others: [ana],
+    initialCount: 8,
+    olderPages: 1,
+    ambientEveryMs: 0,
+  })
+  const [log, setLog] = useState<string[]>([])
+
+  // Rebuilt inline on every render on purpose: the provider holds it in a ref,
+  // so this must not re-render the transcript. No useMemo, no useCallback.
+  const events: F0ChatEvents = {
+    onMessageCopied: () => setLog((l) => ["Message copied", ...l]),
+    onReplyStarted: () => setLog((l) => ["Reply started", ...l]),
+    onReplyCancelled: () => setLog((l) => ["Reply cancelled", ...l]),
+    onEditStarted: () => setLog((l) => ["Edit started", ...l]),
+    onEditCancelled: () => setLog((l) => ["Edit cancelled", ...l]),
+    onMessageInfoViewed: () => setLog((l) => ["Info viewed", ...l]),
+    onReactionAdded: ({ emoji, source }) =>
+      setLog((l) => [`Reaction added ${emoji} (${source})`, ...l]),
+    onReactionRemoved: ({ emoji, source }) =>
+      setLog((l) => [`Reaction removed ${emoji} (${source})`, ...l]),
+    onFileAttached: ({ kind, source }) =>
+      setLog((l) => [`File attached ${kind} (${source})`, ...l]),
+    onAttachmentRemoved: ({ kind }) =>
+      setLog((l) => [`Attachment removed ${kind}`, ...l]),
+    onEmojiInserted: ({ emoji, source }) =>
+      setLog((l) => [`Emoji inserted ${emoji} (${source})`, ...l]),
+    onMentionInserted: ({ isEveryone }) =>
+      setLog((l) => [
+        `Mention inserted ${isEveryone ? "@here" : "person"}`,
+        ...l,
+      ]),
+    onVoiceRecordingStarted: () =>
+      setLog((l) => ["Voice recording started", ...l]),
+    onVoiceRecordingCancelled: () =>
+      setLog((l) => ["Voice recording cancelled", ...l]),
+    onVoiceNotePlayed: () => setLog((l) => ["Voice note played", ...l]),
+    onVoicePlaybackRateChanged: ({ rate }) =>
+      setLog((l) => [`Voice rate ${rate}x`, ...l]),
+    onImageOpened: ({ count }) =>
+      setLog((l) => [`Image opened (${count})`, ...l]),
+    onDocumentOpened: ({ kind }) =>
+      setLog((l) => [`Document opened ${kind}`, ...l]),
+    onAttachmentDownloaded: ({ kind }) =>
+      setLog((l) => [`Attachment downloaded ${kind}`, ...l]),
+    onLocationOpened: () => setLog((l) => ["Location opened", ...l]),
+    onLinkPreviewClicked: () => setLog((l) => ["Link preview clicked", ...l]),
+    onSearchOpened: () => setLog((l) => ["Search opened", ...l]),
+    onSearchResultNavigated: ({ direction }) =>
+      setLog((l) => [`Search ${direction}`, ...l]),
+    onJumpedToQuotedMessage: () => setLog((l) => ["Jumped to quote", ...l]),
+    onJumpedToBottom: () => setLog((l) => ["Jumped to bottom", ...l]),
+  }
+
+  return (
+    <div className="flex gap-4">
+      <Frame>
+        <F0ChatProvider runtime={runtime} events={events}>
+          <F0Chat />
+        </F0ChatProvider>
+      </Frame>
+      <div className="flex max-h-[600px] w-64 flex-col gap-1 overflow-y-auto rounded-lg border border-solid border-f1-border-secondary p-3">
+        <h3 className="mb-1 text-lg font-medium">Events</h3>
+        {log.length === 0 ? (
+          <p className="text-f1-foreground-secondary">
+            Interact with the chat…
+          </p>
+        ) : (
+          log.map((entry, i) => (
+            <code key={`${entry}-${i}`} className="text-sm">
+              {entry}
+            </code>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+export const ObservedInteractions: Story = {
+  render: () => <ObservedConversation />,
+}
 
 export const Default: Story = {
   render: () => <Conversation initialCount={40} />,

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.events.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.events.test.tsx
@@ -1,0 +1,316 @@
+import { memo } from "react"
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  fireEvent,
+  zeroRender as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+
+import { F0Chat } from "../F0Chat"
+import { F0ChatProvider, useF0ChatEmit } from "../providers/F0ChatProvider"
+import {
+  type F0ChatEvents,
+  type F0ChatMessage,
+  type F0ChatRuntime,
+} from "../types"
+
+// jsdom has no layout — wrap Virtuoso in its official mock context so every
+// row renders (see mocks/virtuoso-jsdom).
+vi.mock("react-virtuoso", async (importOriginal) => {
+  const { mockVirtuosoModule } = await import("../mocks/virtuoso-jsdom")
+  return mockVirtuosoModule(
+    await importOriginal<typeof import("react-virtuoso")>()
+  )
+})
+
+// jsdom ships no `navigator.clipboard`, and the copy event now waits on the
+// write to resolve — without a stub the optional chain short-circuits and
+// nothing is reported.
+const writeText = vi.fn<(text: string) => Promise<void>>()
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Object.assign(navigator, { clipboard: { writeText } })
+})
+
+beforeEach(() => {
+  writeText.mockReset()
+  writeText.mockResolvedValue(undefined)
+})
+
+const theirs: F0ChatMessage = {
+  id: "m1",
+  author: { id: "other", name: "María José" },
+  body: "Hello there",
+  createdAt: new Date().toISOString(),
+  isMine: false,
+}
+
+const makeRuntime = (
+  overrides: Partial<F0ChatRuntime> = {}
+): F0ChatRuntime => ({
+  currentUserId: "me",
+  channel: {
+    id: "c1",
+    type: "dm",
+    title: "María José",
+    avatar: { type: "person", firstName: "María", lastName: "José" },
+  },
+  status: "ready",
+  messages: [theirs],
+  typingUsers: [],
+  hasMoreOlder: false,
+  loadingOlder: false,
+  unreadCount: 0,
+  firstUnreadId: null,
+  sendMessage: vi.fn(),
+  retryMessage: vi.fn(),
+  loadOlder: vi.fn(),
+  toggleReaction: vi.fn(),
+  deleteMessage: vi.fn(),
+  onInputActivity: vi.fn(),
+  markRead: vi.fn(),
+  ...overrides,
+})
+
+const renderChat = (
+  runtime: F0ChatRuntime = makeRuntime(),
+  events?: F0ChatEvents
+) =>
+  render(
+    <F0ChatProvider runtime={runtime} events={events}>
+      <F0Chat />
+    </F0ChatProvider>
+  )
+
+/** Open the ellipsis menu on the only message in the transcript. */
+const openMessageMenu = async () => {
+  const menus = screen.getAllByRole("button", { name: /message actions/i })
+  await userEvent.click(menus[0])
+}
+
+/**
+ * Counts its own renders while consuming the emit context — the exact shape a
+ * memoized transcript row has. Node-identity assertions cannot do this job:
+ * React reuses host DOM nodes across re-renders, so `toBe(sameNode)` passes
+ * even when every row re-rendered.
+ */
+const probeRenders = { count: 0 }
+const EmitProbe = memo(function EmitProbe() {
+  useF0ChatEmit()
+  probeRenders.count++
+  return null
+})
+
+describe("F0Chat events — render isolation", () => {
+  beforeEach(() => {
+    probeRenders.count = 0
+  })
+
+  it("does not re-render an emit consumer when the events object identity changes", () => {
+    // Kills the mutant "put the emit value on F0ChatContext instead of its own
+    // constant-identity context" — that context changes on every runtime rebuild.
+    const runtime = makeRuntime()
+    const { rerender } = render(
+      <F0ChatProvider runtime={runtime} events={{ onMessageCopied: vi.fn() }}>
+        <EmitProbe />
+      </F0ChatProvider>
+    )
+    expect(probeRenders.count).toBe(1)
+
+    // A fresh inline object every render is what a host rebuilding its runtime
+    // on each transport event produces. It must not reach the tree.
+    for (let i = 0; i < 5; i++) {
+      rerender(
+        <F0ChatProvider runtime={runtime} events={{ onMessageCopied: vi.fn() }}>
+          <EmitProbe />
+        </F0ChatProvider>
+      )
+    }
+
+    expect(probeRenders.count).toBe(1)
+  })
+
+  it("does not re-render an emit consumer when the runtime churns", () => {
+    // One brand-new runtime object per render — a websocket packet each.
+    const events: F0ChatEvents = { onMessageCopied: vi.fn() }
+    const { rerender } = render(
+      <F0ChatProvider runtime={makeRuntime()} events={events}>
+        <EmitProbe />
+      </F0ChatProvider>
+    )
+    expect(probeRenders.count).toBe(1)
+
+    for (let i = 0; i < 5; i++) {
+      rerender(
+        <F0ChatProvider runtime={makeRuntime()} events={events}>
+          <EmitProbe />
+        </F0ChatProvider>
+      )
+    }
+
+    expect(probeRenders.count).toBe(1)
+  })
+
+  it("emits through the latest handler after the events object is replaced", async () => {
+    const stale = vi.fn()
+    const fresh = vi.fn()
+    const runtime = makeRuntime()
+
+    const { rerender } = render(
+      <F0ChatProvider runtime={runtime} events={{ onMessageCopied: stale }}>
+        <F0Chat />
+      </F0ChatProvider>
+    )
+    rerender(
+      <F0ChatProvider runtime={runtime} events={{ onMessageCopied: fresh }}>
+        <F0Chat />
+      </F0ChatProvider>
+    )
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /^Copy$/i }))
+
+    await waitFor(() => expect(fresh).toHaveBeenCalledWith({ messageId: "m1" }))
+    expect(stale).not.toHaveBeenCalled()
+  })
+
+  it("works with no events prop at all", async () => {
+    renderChat(makeRuntime())
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /^Copy$/i }))
+    expect(screen.getByText("Hello there")).toBeInTheDocument()
+  })
+})
+
+describe("F0Chat events — message actions", () => {
+  it("reports a copy, which reaches the host no other way", async () => {
+    const onMessageCopied = vi.fn()
+    renderChat(makeRuntime(), { onMessageCopied })
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /^Copy$/i }))
+
+    await waitFor(() =>
+      expect(onMessageCopied).toHaveBeenCalledWith({ messageId: "m1" })
+    )
+  })
+
+  it("does NOT report a copy the clipboard refused", async () => {
+    // Kills the mutant "emit next to writeText instead of on its resolution":
+    // a non-secure origin or a lost focus rejects, and nothing was copied.
+    const onMessageCopied = vi.fn()
+    writeText.mockRejectedValue(new Error("NotAllowedError"))
+    renderChat(makeRuntime(), { onMessageCopied })
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /^Copy$/i }))
+
+    await waitFor(() => expect(writeText).toHaveBeenCalled())
+    expect(onMessageCopied).not.toHaveBeenCalled()
+  })
+
+  it("reports starting a reply", async () => {
+    const onReplyStarted = vi.fn()
+    renderChat(makeRuntime(), { onReplyStarted })
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /^Reply$/i }))
+
+    expect(onReplyStarted).toHaveBeenCalledWith({ messageId: "m1" })
+  })
+
+  it("reports viewing the info panel", async () => {
+    const onMessageInfoViewed = vi.fn()
+    renderChat(makeRuntime(), { onMessageInfoViewed })
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /info/i }))
+
+    expect(onMessageInfoViewed).toHaveBeenCalledWith({ messageId: "m1" })
+  })
+})
+
+describe("F0Chat events — reactions", () => {
+  it("distinguishes removing from adding, which toggleReaction cannot", async () => {
+    const onReactionAdded = vi.fn()
+    const onReactionRemoved = vi.fn()
+    const toggleReaction = vi.fn()
+
+    renderChat(
+      makeRuntime({
+        toggleReaction,
+        messages: [
+          {
+            ...theirs,
+            reactions: [{ emoji: "👍", count: 1, reactedByMe: true }],
+          },
+        ],
+      }),
+      { onReactionAdded, onReactionRemoved }
+    )
+
+    // 👍 is already mine, so the quick row's 👍 is a REMOVE. The runtime call
+    // is byte-identical either way — only the event can say which happened.
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: "👍" }))
+
+    expect(toggleReaction).toHaveBeenCalledWith("m1", "👍")
+    expect(onReactionRemoved).toHaveBeenCalledWith({
+      messageId: "m1",
+      emoji: "👍",
+      source: "quickRow",
+    })
+    expect(onReactionAdded).not.toHaveBeenCalled()
+  })
+
+  it("reports which affordance produced the reaction", async () => {
+    const onReactionAdded = vi.fn()
+    renderChat(makeRuntime(), { onReactionAdded })
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: "❤️" }))
+
+    expect(onReactionAdded).toHaveBeenCalledWith({
+      messageId: "m1",
+      emoji: "❤️",
+      source: "quickRow",
+    })
+  })
+})
+
+describe("F0Chat events — reply abandonment", () => {
+  it("reports cancelling a reply from the chip", async () => {
+    const onReplyCancelled = vi.fn()
+    renderChat(makeRuntime(), { onReplyCancelled })
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /^Reply$/i }))
+    await userEvent.click(screen.getByRole("button", { name: /remove quote/i }))
+
+    await waitFor(() =>
+      expect(onReplyCancelled).toHaveBeenCalledWith({ messageId: "m1" })
+    )
+  })
+
+  it("does NOT report a cancellation when the reply is actually sent", async () => {
+    const onReplyCancelled = vi.fn()
+    const sendMessage = vi.fn()
+    renderChat(makeRuntime({ sendMessage }), { onReplyCancelled })
+
+    await openMessageMenu()
+    await userEvent.click(screen.getByRole("button", { name: /^Reply$/i }))
+
+    const textarea = screen.getByPlaceholderText("Write something here..")
+    fireEvent.change(textarea, { target: { value: "sure" } })
+    fireEvent.keyDown(textarea, { key: "Enter" })
+
+    // Sending clears the reply target too. Counting that as abandonment would
+    // make the metric meaningless.
+    expect(sendMessage).toHaveBeenCalled()
+    expect(onReplyCancelled).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -41,13 +41,14 @@ import {
   useChatEdit,
   useChatReply,
 } from "../providers/ChatUIProvider"
-import { useF0Chat } from "../providers/F0ChatProvider"
+import { useF0Chat, useF0ChatEmit } from "../providers/F0ChatProvider"
 import {
   type F0ChatAttachment,
+  type F0ChatAttachSource,
   type F0ChatFileAttachment,
   type F0ChatImageAttachment,
 } from "../types"
-import { formatFileSize } from "../utils/attachments"
+import { attachedKindOf, formatFileSize } from "../utils/attachments"
 import {
   EASE_OUT_SWIFT,
   layoutTransition,
@@ -121,6 +122,7 @@ export const ChatComposer = (): ReactNode => {
   const { replyTo, setReplyTo } = useChatReply()
   const { editingMessage, setEditingMessage } = useChatEdit()
   const { registerFileDropHandler } = useChatDrop()
+  const emit = useF0ChatEmit()
   const { reducedMotion: shouldReduceMotion } = useChatRenderConfig()
 
   const [value, setValue] = useState("")
@@ -369,7 +371,7 @@ export const ChatComposer = (): ReactNode => {
   }, [])
 
   const handleUpload = useCallback(
-    async (files: File[]) => {
+    async (files: File[], source: F0ChatAttachSource) => {
       if (files.length === 0 || !uploadFiles || !canUpload) return
       clearTransientError()
       // Reject the whole batch when it would exceed the cap — a transient banner
@@ -409,6 +411,15 @@ export const ChatComposer = (): ReactNode => {
           attachment: localAttachmentFromFile(file, url),
         }
       })
+      // One per file, and only once the batch passed validation — but BEFORE
+      // the upload resolves, so a failed upload still records which affordance
+      // the person reached for.
+      for (const item of pending) {
+        emit.onFileAttached({
+          kind: attachedKindOf(item.attachment),
+          source,
+        })
+      }
       setAttachments((prev) => [...prev, ...pending])
       const pendingIds = new Set(pending.map((p) => p.id))
       try {
@@ -448,12 +459,20 @@ export const ChatComposer = (): ReactNode => {
       i18n.chat.fileTooLargeError,
       i18n.chat.fileUploadError,
       releaseLocalPreview,
+      emit,
     ]
   )
 
   const removeAttachment = useCallback(
     (id: string) => {
       const item = attachments.find((attachment) => attachment.id === id)
+      // `F0ChatAttachedKind` has no voice/location member, so those two are not
+      // reportable. The strip does render both (ChatComposerAttachmentPreview),
+      // so this drops their removal rather than describing an impossible case.
+      const removed = item?.attachment
+      if (removed && removed.kind !== "voice" && removed.kind !== "location") {
+        emit.onAttachmentRemoved({ kind: attachedKindOf(removed) })
+      }
       const hasRemainingAttachments = attachments.some(
         (attachment) => attachment.id !== id
       )
@@ -468,7 +487,7 @@ export const ChatComposer = (): ReactNode => {
         else textareaRef.current?.focus()
       })
     },
-    [attachments, releaseLocalPreview]
+    [attachments, releaseLocalPreview, emit]
   )
 
   const releaseUploadingPreviews = useCallback(
@@ -484,7 +503,7 @@ export const ChatComposer = (): ReactNode => {
 
   // Files dropped anywhere on the panel (F0Chat owns the drop zone) land here.
   useEffect(() => {
-    registerFileDropHandler((files) => void handleUpload(files))
+    registerFileDropHandler((files) => void handleUpload(files, "drop"))
   }, [registerFileDropHandler, handleUpload])
 
   const handlePaste = useCallback(
@@ -496,7 +515,7 @@ export const ChatComposer = (): ReactNode => {
       // File pastes (Cmd/Ctrl+V) become attachments. Text-only clipboard
       // content keeps the textarea's native paste behavior.
       event.preventDefault()
-      void handleUpload(files)
+      void handleUpload(files, "paste")
     },
     [canUpload, handleUpload]
   )
@@ -623,6 +642,7 @@ export const ChatComposer = (): ReactNode => {
       setCursorPosition(caret)
       closeEmojiAutocomplete()
       onInputActivity()
+      emit.onEmojiInserted({ emoji, source: "picker" })
       requestAnimationFrame(() => {
         const node = textareaRef.current
         if (node) {
@@ -631,8 +651,21 @@ export const ChatComposer = (): ReactNode => {
         }
       })
     },
-    [closeEmojiAutocomplete, onInputActivity]
+    [closeEmojiAutocomplete, onInputActivity, emit]
   )
+
+  // `cancelEdit` also runs after a successful edit, and `setReplyTo(null)` after
+  // a successful send — neither is an abandonment. Only Escape and the chip's X
+  // route through these, so the abandonment counts stay meaningful.
+  const dismissEdit = useCallback(() => {
+    if (editingMessage) emit.onEditCancelled({ messageId: editingMessage.id })
+    cancelEdit()
+  }, [cancelEdit, editingMessage, emit])
+
+  const dismissReply = useCallback(() => {
+    if (replyTo) emit.onReplyCancelled({ messageId: replyTo.id })
+    setReplyTo(null)
+  }, [emit, replyTo, setReplyTo])
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
@@ -647,7 +680,7 @@ export const ChatComposer = (): ReactNode => {
       // Escape backs out of an edit (when the popover didn't claim it).
       if (e.key === "Escape" && isEditing) {
         e.preventDefault()
-        cancelEdit()
+        dismissEdit()
         return
       }
       if (e.key === "Enter" && !e.shiftKey) {
@@ -660,7 +693,7 @@ export const ChatComposer = (): ReactNode => {
       handleEmojiAutocompleteKeyDown,
       mentions,
       isEditing,
-      cancelEdit,
+      dismissEdit,
     ]
   )
 
@@ -668,6 +701,21 @@ export const ChatComposer = (): ReactNode => {
     baseValueRef.current = value
     void recorder.start()
   }, [recorder, value])
+
+  // Not on the button press: `recorder.start()` resolves whether or not the
+  // user granted the microphone. Only the transition into `recording` means
+  // capture actually began.
+  const reportedRecordingRef = useRef(false)
+  useEffect(
+    function reportRecordingStarted() {
+      const recording = recorder.status === "recording"
+      if (recording && !reportedRecordingRef.current) {
+        emit.onVoiceRecordingStarted()
+      }
+      reportedRecordingRef.current = recording
+    },
+    [recorder.status, emit]
+  )
 
   const placeholder = i18n.chat.placeholder
 
@@ -717,7 +765,7 @@ export const ChatComposer = (): ReactNode => {
                   ease: EASE_OUT_SWIFT,
                 }}
               >
-                <ChatEditChip message={editingMessage} onRemove={cancelEdit} />
+                <ChatEditChip message={editingMessage} onRemove={dismissEdit} />
               </motion.div>
             ) : replyTo ? (
               <motion.div
@@ -731,10 +779,7 @@ export const ChatComposer = (): ReactNode => {
                   ease: EASE_OUT_SWIFT,
                 }}
               >
-                <ChatReplyChip
-                  message={replyTo}
-                  onRemove={() => setReplyTo(null)}
-                />
+                <ChatReplyChip message={replyTo} onRemove={dismissReply} />
               </motion.div>
             ) : null}
           </AnimatePresence>
@@ -906,7 +951,10 @@ export const ChatComposer = (): ReactNode => {
                       hideLabel
                       label={i18n.chat.cancelRecording}
                       icon={Cross}
-                      onClick={recorder.cancel}
+                      onClick={() => {
+                        recorder.cancel()
+                        emit.onVoiceRecordingCancelled()
+                      }}
                     />
                     <ButtonInternal
                       variant="default"
@@ -937,7 +985,10 @@ export const ChatComposer = (): ReactNode => {
                     multiple
                     className="hidden"
                     onChange={(e) => {
-                      void handleUpload(Array.from(e.target.files ?? []))
+                      void handleUpload(
+                        Array.from(e.target.files ?? []),
+                        "button"
+                      )
                       e.target.value = ""
                     }}
                   />

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
@@ -12,6 +12,7 @@ import {
   isVideoFileAttachment,
   withinPreviewSizeLimit,
 } from "../utils/attachments"
+import { ChatSurfaceProvider } from "../providers/ChatSurfaceProvider"
 import { ChatDocumentAttachmentCard } from "./ChatDocumentAttachmentCard"
 import { ChatLocationAttachment } from "./ChatLocationAttachment"
 import { ChatVoiceAttachment } from "./ChatVoiceAttachment"
@@ -32,7 +33,7 @@ const PreviewProgress = (): ReactNode => (
  * and voice/location attachments keep their native representation. Unknown
  * files use the same square footprint with their file-type avatar.
  */
-export const ChatComposerAttachmentPreview = ({
+const ChatComposerAttachmentPreviewContent = ({
   attachment,
   uploading,
   onRemove,
@@ -236,3 +237,16 @@ export const ChatComposerAttachmentPreview = ({
     </div>
   )
 }
+
+/**
+ * Draft attachments reuse the transcript's leaf components, which report
+ * consumption events. Marking the surface stops "I previewed my own unsent
+ * file" being recorded as "I opened something someone shared with me".
+ */
+export const ChatComposerAttachmentPreview = (
+  props: Parameters<typeof ChatComposerAttachmentPreviewContent>[0]
+): ReactNode => (
+  <ChatSurfaceProvider surface="composer">
+    <ChatComposerAttachmentPreviewContent {...props} />
+  </ChatSurfaceProvider>
+)

--- a/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
@@ -14,8 +14,10 @@ import { Skeleton } from "@/ui/skeleton"
 import { useTranscriptHeavyPreview } from "../hooks/useTranscriptHeavyPreview"
 import { useChatRenderConfig } from "../providers/ChatRenderConfigProvider"
 import { useChatDocumentPreview } from "../providers/ChatUIProvider"
+import { useChatSurface } from "../providers/ChatSurfaceProvider"
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatFileAttachment } from "../types"
-import { type ChatDocumentKind } from "../utils/attachments"
+import { attachedKindOf, type ChatDocumentKind } from "../utils/attachments"
 import { triggerDownload } from "../utils/download"
 import { ClampText } from "./ClampText"
 
@@ -77,13 +79,18 @@ export const ChatDocumentAttachmentCard = ({
   const i18n = useI18n()
   const { reducedMotion } = useChatRenderConfig()
   const { openDocumentPreview } = useChatDocumentPreview()
+  const emit = useF0ChatEmit()
+  const surface = useChatSurface()
   const [failed, setFailed] = useState(false)
   const [rendered, setRendered] = useState(false)
   const { ref, shouldMount } = useTranscriptHeavyPreview(DOCUMENT_LOADERS[kind])
   const fallbackAction = action ?? {
     label: i18n.t("chat.downloadNamedFile", { name: file.name }),
     icon: Download,
-    onClick: () => triggerDownload(file.url, file.name),
+    onClick: () => {
+      triggerDownload(file.url, file.name)
+      emit.onAttachmentDownloaded({ kind: attachedKindOf(file) })
+    },
   }
   const cardWidth = compact ? 64 : CARD_WIDTH
   const thumbHeight = compact ? "100%" : THUMB_HEIGHT
@@ -162,7 +169,11 @@ export const ChatDocumentAttachmentCard = ({
       )}
       <button
         type="button"
-        onClick={() => openDocumentPreview(file)}
+        onClick={() => {
+          openDocumentPreview(file)
+          // Opening your own not-yet-sent draft is not consuming shared content.
+          if (surface === "transcript") emit.onDocumentOpened({ kind })
+        }}
         disabled={previewDisabled}
         aria-busy={!rendered ? true : undefined}
         aria-label={i18n.t("chat.openNamedDocument", { name: file.name })}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatImagePreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatImagePreview.tsx
@@ -11,6 +11,7 @@ import { Dialog, DialogContent, DialogTitle } from "@/ui/Dialog"
 
 import { useChatRenderConfig } from "../providers/ChatRenderConfigProvider"
 import { useChatImagePreview } from "../providers/ChatUIProvider"
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { EASE_OUT_SWIFT } from "../utils/chat-motion"
 import { triggerDownload } from "../utils/download"
 import { FadeInImage } from "./FadeInImage"
@@ -54,6 +55,7 @@ export const ChatImagePreview = (): ReactNode => {
   const { reducedMotion } = useChatRenderConfig()
   const { imagePreview, closeImagePreview, setImagePreviewIndex } =
     useChatImagePreview()
+  const emit = useF0ChatEmit()
 
   // Portal above the whole app: the chat panel owns the top stacking context, so
   // the dialog's default `#content` target renders the lightbox behind it. `body`
@@ -148,7 +150,10 @@ export const ChatImagePreview = (): ReactNode => {
             <PreviewControl
               icon={Download}
               label={i18n.chat.download}
-              onClick={() => triggerDownload(current.url, current.name)}
+              onClick={() => {
+                triggerDownload(current.url, current.name)
+                emit.onAttachmentDownloaded({ kind: "image" })
+              }}
             />
             <PreviewControl
               icon={Cross}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatLinkPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatLinkPreview.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from "react"
 
 import { cn, focusRing } from "@/lib/utils"
 
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatLinkPreview } from "../types"
 import { ClampText } from "./ClampText"
 import { FadeInImage } from "./FadeInImage"
@@ -84,6 +85,7 @@ export const ChatLinkPreview = ({
   /** Mirrors the bubble's tail-side top corner, like the reply quote. */
   isFirstOfRun?: boolean
 }): ReactNode => {
+  const emit = useF0ChatEmit()
   if (previews.length === 0) return null
   const compact = previews.length > 1
   return (
@@ -92,6 +94,7 @@ export const ChatLinkPreview = ({
         <a
           key={`${preview.url}-${index}`}
           href={preview.url}
+          onClick={() => emit.onLinkPreviewClicked()}
           target="_blank"
           rel="noopener noreferrer"
           className={cardClass(

--- a/packages/react/src/sds/chat/F0Chat/components/ChatLocationAttachment.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatLocationAttachment.tsx
@@ -10,6 +10,8 @@ import { cn, focusRing } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
 
 import { useTranscriptHeavyPreview } from "../hooks/useTranscriptHeavyPreview"
+import { useChatSurface } from "../providers/ChatSurfaceProvider"
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatLocationAttachment } from "../types"
 
 // maplibre-gl is heavy — it lives in its own chunk, fetched on first render of
@@ -42,11 +44,16 @@ export const ChatLocationAttachment = ({
   surfaceClassName?: string
 }): ReactNode => {
   const i18n = useI18n()
+  const emit = useF0ChatEmit()
+  const surface = useChatSurface()
   const { ref, shouldMount } = useTranscriptHeavyPreview(loadLocationMap)
   return (
     <a
       ref={ref}
       href={mapsUrl(location)}
+      onClick={() => {
+        if (surface === "transcript") emit.onLocationOpened()
+      }}
       target="_blank"
       rel="noopener noreferrer"
       aria-label={location.name ?? i18n.chat.location}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
@@ -20,9 +20,10 @@ import { Action } from "@/ui/Action"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
 import { useChatEdit, useChatReply } from "../providers/ChatUIProvider"
-import { useF0ChatStable } from "../providers/F0ChatProvider"
-import { type F0ChatMessage } from "../types"
+import { useF0ChatEmit, useF0ChatStable } from "../providers/F0ChatProvider"
+import { type F0ChatMessage, type F0ChatReactionSource } from "../types"
 import { formatClock } from "../utils/natural-time"
+import { emitReactionToggle } from "../utils/reactions"
 import { ChatMessageInfoView } from "./ChatMessageInfo"
 
 const QUICK_EMOJIS = ["👍", "❤️", "😂", "🎉", "😮", "🙏"]
@@ -88,6 +89,7 @@ export const ChatMessageActions = ({
   } = useF0ChatStable()
   const { setReplyTo } = useChatReply()
   const { setEditingMessage } = useChatEdit()
+  const emit = useF0ChatEmit()
   const [view, setView] = useState<"menu" | "info">("menu")
 
   // Editing is offered on non-deleted messages while the host allows it
@@ -120,7 +122,8 @@ export const ChatMessageActions = ({
     if (!next) setView("menu")
   }
 
-  const react = (emoji: string) => {
+  const react = (emoji: string, source: F0ChatReactionSource) => {
+    emitReactionToggle(emit, message, emoji, source)
     toggleReaction(message.id, emoji)
     handleOpenChange(false)
   }
@@ -210,7 +213,7 @@ export const ChatMessageActions = ({
                       emoji={emoji}
                       variant="ghost"
                       aria-label={emoji}
-                      onClick={() => react(emoji)}
+                      onClick={() => react(emoji, "quickRow")}
                       className="h-8 w-8 rounded text-base hover:bg-f1-background-secondary-hover"
                     />
                   ))}
@@ -218,7 +221,7 @@ export const ChatMessageActions = ({
                     size="md"
                     variant="ghost"
                     label={i18n.chat.react}
-                    onSelect={react}
+                    onSelect={(emoji) => react(emoji, "menuPicker")}
                     icon={Plus}
                   />
                 </div>
@@ -229,7 +232,10 @@ export const ChatMessageActions = ({
               <MenuItem
                 icon={AlertCircleLine}
                 label={i18n.chat.info}
-                onClick={() => setView("info")}
+                onClick={() => {
+                  emit.onMessageInfoViewed({ messageId: message.id })
+                  setView("info")
+                }}
                 trailing={
                   <F0Icon
                     icon={ChevronRight}
@@ -244,13 +250,17 @@ export const ChatMessageActions = ({
                 onClick={runAndClose(() => {
                   setEditingMessage(null)
                   setReplyTo(message)
+                  emit.onReplyStarted({ messageId: message.id })
                 })}
               />
               <MenuItem
                 icon={Files}
                 label={i18n.actions.copy}
                 onClick={runAndClose(() => {
-                  void navigator.clipboard?.writeText(message.body)
+                  void navigator.clipboard
+                    ?.writeText(message.body)
+                    .then(() => emit.onMessageCopied({ messageId: message.id }))
+                    .catch(() => {})
                 })}
               />
             </div>
@@ -265,6 +275,7 @@ export const ChatMessageActions = ({
                       onClick={runAndClose(() => {
                         setReplyTo(null)
                         setEditingMessage(message)
+                        emit.onEditStarted({ messageId: message.id })
                       })}
                     />
                   )}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
@@ -6,8 +6,9 @@ import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
 
 import { useChatImagePreview } from "../providers/ChatUIProvider"
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatMessage } from "../types"
-import { partitionChatAttachments } from "../utils/attachments"
+import { attachedKindOf, partitionChatAttachments } from "../utils/attachments"
 import { triggerDownload } from "../utils/download"
 import { messageSurfaceColorClass } from "../utils/sender-color"
 import { bubbleCornerClass } from "./ChatBubble"
@@ -41,6 +42,7 @@ export const ChatMessageAttachments = ({
 }): ReactNode => {
   const i18n = useI18n()
   const { openImagePreview } = useChatImagePreview()
+  const emit = useF0ChatEmit()
   const attachments = message.attachments
   if (!attachments || attachments.length === 0) return null
   const surfaceClassName = messageSurfaceColorClass(message.author, isMine)
@@ -142,7 +144,10 @@ export const ChatMessageAttachments = ({
             <button
               key={`${image.url}-${i}`}
               type="button"
-              onClick={() => openImagePreview(images, i)}
+              onClick={() => {
+                openImagePreview(images, i)
+                emit.onImageOpened({ count: images.length })
+              }}
               className={cn(
                 "flex overflow-hidden transition-opacity hover:opacity-90",
                 focusRing("focus-visible:ring-inset"),
@@ -227,7 +232,10 @@ export const ChatMessageAttachments = ({
                 {
                   label: i18n.chat.download,
                   icon: Download,
-                  onClick: () => triggerDownload(file.url, file.name),
+                  onClick: () => {
+                    triggerDownload(file.url, file.name)
+                    emit.onAttachmentDownloaded({ kind: attachedKindOf(file) })
+                  },
                 },
               ]}
             />

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageReactions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageReactions.tsx
@@ -7,13 +7,14 @@ import { Picker } from "@/sds/social/Reactions/Picker"
 import { Reaction } from "@/sds/social/Reactions/reaction"
 
 import { useChatRenderConfig } from "../providers/ChatRenderConfigProvider"
-import { useF0ChatStable } from "../providers/F0ChatProvider"
-import { type F0ChatMessage } from "../types"
+import { useF0ChatEmit, useF0ChatStable } from "../providers/F0ChatProvider"
+import { type F0ChatMessage, type F0ChatReactionSource } from "../types"
 import {
   layoutTransition,
   microEnterTransition,
   microExitTransition,
 } from "../utils/chat-motion"
+import { emitReactionToggle } from "../utils/reactions"
 
 /**
  * Reaction pills under a bubble (Social Reactions kit). Once a message has at
@@ -30,9 +31,16 @@ export const ChatMessageReactions = ({
   const i18n = useI18n()
   const { reducedMotion } = useChatRenderConfig()
   const { toggleReaction, loadReactionUsers, capabilities } = useF0ChatStable()
+  const emit = useF0ChatEmit()
   // Existing pills stay VISIBLE without the capability (the data is real) —
   // only adding/toggling is disabled.
   const canReact = capabilities?.canReact !== false
+
+  const react = (emoji: string, source: F0ChatReactionSource) => {
+    emitReactionToggle(emit, message, emoji, source)
+    void toggleReaction(message.id, emoji)
+  }
+
   if (!message.reactions || message.reactions.length === 0) return null
 
   return (
@@ -83,9 +91,7 @@ export const ChatMessageReactions = ({
                   : undefined
               }
               onInteraction={
-                canReact
-                  ? (emoji) => void toggleReaction(message.id, emoji)
-                  : undefined
+                canReact ? (emoji) => react(emoji, "existingPill") : undefined
               }
               size="sm"
             />
@@ -97,7 +103,7 @@ export const ChatMessageReactions = ({
           size="md"
           variant="outline"
           label={i18n.chat.react}
-          onSelect={(emoji) => void toggleReaction(message.id, emoji)}
+          onSelect={(emoji) => react(emoji, "inlinePicker")}
         />
       )}
     </div>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
 
 import { useTranscriptHeavyPreview } from "../hooks/useTranscriptHeavyPreview"
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatFileAttachment } from "../types"
 import { triggerDownload } from "../utils/download"
 import { FadeInImage } from "./FadeInImage"
@@ -36,13 +37,17 @@ export const ChatVideoAttachment = ({
   surfaceClassName?: string
 }): ReactNode => {
   const i18n = useI18n()
+  const emit = useF0ChatEmit()
   const [failed, setFailed] = useState(false)
   const [mediaReady, setMediaReady] = useState(false)
   const { ref, shouldMount } = useTranscriptHeavyPreview(loadVideoPlayer)
   const downloadAction = {
     label: i18n.t("chat.downloadNamedFile", { name: file.name }),
     icon: Download,
-    onClick: () => triggerDownload(file.url, file.name),
+    onClick: () => {
+      triggerDownload(file.url, file.name)
+      emit.onAttachmentDownloaded({ kind: "video" })
+    },
   }
 
   if (failed) {

--- a/packages/react/src/sds/chat/F0Chat/components/ChatViewportOverlays.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatViewportOverlays.tsx
@@ -6,6 +6,7 @@ import { ArrowDown } from "@/icons/app"
 import { ScrollShadow } from "@/kits/ai/F0AiMessagesContainer/components/ScrollShadow"
 import { useI18n } from "@/lib/providers/i18n"
 
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { CHAT_COMPOSER_HEIGHT } from "../utils/chat-layout"
 import { EASE_OUT_SWIFT } from "../utils/chat-motion"
 import { DateTimeSeparator } from "./DateTimeSeparator"
@@ -34,6 +35,7 @@ export const ChatViewportOverlays = ({
   onJumpToBottom: () => void
 }): ReactNode => {
   const i18n = useI18n()
+  const emit = useF0ChatEmit()
   const transitionDuration = reducedMotion ? 0 : 0.15
 
   return (
@@ -94,7 +96,10 @@ export const ChatViewportOverlays = ({
               }}
             >
               <ButtonInternal
-                onClick={onJumpToBottom}
+                onClick={() => {
+                  onJumpToBottom()
+                  emit.onJumpedToBottom()
+                }}
                 variant="neutral"
                 icon={ArrowDown}
                 label={

--- a/packages/react/src/sds/chat/F0Chat/components/ChatVoiceAttachment.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatVoiceAttachment.tsx
@@ -8,6 +8,11 @@ import { cn, focusRing } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
 
 import { useTranscriptHeavyPreview } from "../hooks/useTranscriptHeavyPreview"
+import { useChatSurface } from "../providers/ChatSurfaceProvider"
+import {
+  useF0ChatEmit,
+  useF0ChatVoicePlayLog,
+} from "../providers/F0ChatProvider"
 import { type F0ChatVoiceAttachment } from "../types"
 
 /** Speed cycle for the pill: tap to advance, wraps around. */
@@ -164,6 +169,9 @@ const ChatVoiceAttachmentContent = ({
   const levels = useVoiceWaveform(voice.url)
   const [rateIndex, setRateIndex] = useState(0)
   const barsRef = useRef<HTMLDivElement>(null)
+  const emit = useF0ChatEmit()
+  const surface = useChatSurface()
+  const voicePlayLog = useF0ChatVoicePlayLog()
 
   const duration =
     player.duration > 0 ? player.duration : (voice.durationSeconds ?? 0)
@@ -174,15 +182,33 @@ const ChatVoiceAttachmentContent = ({
       player.pause()
       return
     }
+    // Once per note, not once per mount: Virtuoso unmounts offscreen rows, so
+    // a component-local flag would re-report the same note on every scroll back.
+    // Resuming after a pause is the same listen. Draft notes are not consumption.
+    if (surface === "transcript" && !voicePlayLog.hasReported(voice.url)) {
+      voicePlayLog.markReported(voice.url)
+      emit.onVoiceNotePlayed({ durationSeconds: voice.durationSeconds })
+    }
     if (duration > 0 && player.currentTime >= duration) player.seek(0)
     player.play()
-  }, [player, duration])
+  }, [
+    player,
+    duration,
+    emit,
+    surface,
+    voicePlayLog,
+    voice.url,
+    voice.durationSeconds,
+  ])
 
   const handleCycleRate = useCallback(() => {
     const next = (rateIndex + 1) % PLAYBACK_RATES.length
     setRateIndex(next)
     player.setPlaybackRate(PLAYBACK_RATES[next])
-  }, [player, rateIndex])
+    if (surface === "transcript") {
+      emit.onVoicePlaybackRateChanged({ rate: PLAYBACK_RATES[next] })
+    }
+  }, [player, rateIndex, emit, surface])
 
   // Click anywhere on the waveform to seek to that point.
   const handleSeek = useCallback(

--- a/packages/react/src/sds/chat/F0Chat/components/ReplyQuote.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ReplyQuote.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils"
 
 import { useReplyPreview } from "../hooks/useReplyPreview"
 import { useChatJump } from "../providers/ChatUIProvider"
-import { useF0ChatStable } from "../providers/F0ChatProvider"
+import { useF0ChatEmit, useF0ChatStable } from "../providers/F0ChatProvider"
 import { type F0ChatMessage } from "../types"
 import { senderNameColorClass } from "../utils/sender-color"
 import { ClampText } from "./ClampText"
@@ -31,6 +31,7 @@ export const ReplyQuote = ({
   isFirstOfRun?: boolean
 }): ReactNode => {
   const { jumpToMessage } = useChatJump()
+  const emit = useF0ChatEmit()
   const { currentUserId } = useF0ChatStable()
   const i18n = useI18n()
   const { icon, label, thumbnailUrl } = useReplyPreview(reply)
@@ -41,7 +42,10 @@ export const ReplyQuote = ({
     <div className="p-1 pb-0">
       <button
         type="button"
-        onClick={() => jumpToMessage(reply.id)}
+        onClick={() => {
+          jumpToMessage(reply.id)
+          emit.onJumpedToQuotedMessage()
+        }}
         className={cn(
           "flex w-full items-center overflow-hidden rounded-xl text-left",
           "bg-f1-background-tertiary transition-colors hover:bg-f1-background-secondary",

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
@@ -1,6 +1,7 @@
 import data from "@emoji-mart/data/sets/15/twitter.json"
 import { useCallback, useEffect, useId, useMemo, useState } from "react"
 
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import {
   getTextareaCaretCoordinates,
   type PopoverPosition,
@@ -208,6 +209,7 @@ export function useEmojiAutocomplete({
   setCursorPosition,
   textareaRef,
 }: UseEmojiAutocompleteOptions): UseEmojiAutocompleteReturn {
+  const emit = useF0ChatEmit()
   const reactId = useId()
   const listboxId = `chat-emoji-autocomplete-${reactId.replace(/:/g, "")}`
   const [selectedIndex, setSelectedIndex] = useState(0)
@@ -254,6 +256,7 @@ export function useEmojiAutocomplete({
       setInputValue(nextValue)
       setCursorPosition(nextCursorPosition)
       close()
+      emit.onEmojiInserted({ emoji: candidate.native, source: "autocomplete" })
 
       requestAnimationFrame(() => {
         const textarea = textareaRef.current
@@ -270,6 +273,7 @@ export function useEmojiAutocomplete({
       setCursorPosition,
       close,
       textareaRef,
+      emit,
     ]
   )
 

--- a/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { type AvatarVariant } from "@/components/avatars/F0Avatar"
 
+import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatUser } from "../types"
 
 /** Sentinel id for the "everyone" (`@here`) option — never a real user id. */
@@ -220,6 +221,7 @@ export function useMentions({
   searchMembers,
   everyoneLabel,
 }: UseMentionsOptions): UseMentionsReturn {
+  const emit = useF0ChatEmit()
   const [isOpen, setIsOpen] = useState(false)
   const [query, setQuery] = useState("")
   const [memberResults, setMemberResults] = useState<F0ChatUser[]>([])
@@ -366,6 +368,7 @@ export function useMentions({
         return [...filtered, entry]
       })
 
+      emit.onMentionInserted({ isEveryone: candidate.kind === "everyone" })
       close()
 
       requestAnimationFrame(() => {
@@ -376,7 +379,7 @@ export function useMentions({
         }
       })
     },
-    [inputValue, cursorPosition, setInputValue, textareaRef, close]
+    [inputValue, cursorPosition, setInputValue, textareaRef, close, emit]
   )
 
   const handleKeyDown = useCallback(

--- a/packages/react/src/sds/chat/F0Chat/index.ts
+++ b/packages/react/src/sds/chat/F0Chat/index.ts
@@ -28,6 +28,11 @@ export type {
   F0ChatCapabilities,
   F0ChatSearchResult,
   F0ChatRuntime,
+  F0ChatEvents,
+  F0ChatReactionSource,
+  F0ChatAttachSource,
+  F0ChatAttachedKind,
+  F0ChatEmojiSource,
 } from "./types"
 export {
   f0ChatSenderColors,

--- a/packages/react/src/sds/chat/F0Chat/providers/ChatSurfaceProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/ChatSurfaceProvider.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { createContext, useContext, type ReactNode } from "react"
+
+/**
+ * Which side of the chat an attachment is being rendered on.
+ *
+ * The transcript and the composer's draft strip reuse the SAME leaf components
+ * (`ChatDocumentAttachmentCard`, `ChatVoiceAttachment`, `ChatLocationAttachment`),
+ * so a leaf cannot otherwise tell whether it is showing content someone shared
+ * with you or a file you have not sent yet. Only the transcript side reports
+ * consumption events — previewing your own draft is not consuming shared content.
+ */
+export type ChatSurface = "transcript" | "composer"
+
+// Defaults to `transcript`: a leaf added to a new surface reports until someone
+// says otherwise, which is the failure that shows up in a dashboard rather than
+// the one that silently loses data.
+const ChatSurfaceContext = createContext<ChatSurface>("transcript")
+
+export const ChatSurfaceProvider = ({
+  surface,
+  children,
+}: {
+  surface: ChatSurface
+  children: ReactNode
+}): ReactNode => (
+  <ChatSurfaceContext.Provider value={surface}>
+    {children}
+  </ChatSurfaceContext.Provider>
+)
+
+export function useChatSurface(): ChatSurface {
+  return useContext(ChatSurfaceContext)
+}

--- a/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
@@ -21,7 +21,7 @@ import {
   documentPreviewKind,
   type ChatDocumentKind,
 } from "../utils/attachments"
-import { useF0Chat } from "./F0ChatProvider"
+import { useF0Chat, useF0ChatEmit } from "./F0ChatProvider"
 
 /** Debounce before running a search as the user types. */
 const SEARCH_DEBOUNCE_MS = 200
@@ -121,6 +121,7 @@ export const ChatUIProvider = ({
   children: ReactNode
 }): ReactNode => {
   const { messages, searchMessages, loadMessageContext } = useF0Chat()
+  const emit = useF0ChatEmit()
 
   const [replyTo, setReplyTo] = useState<F0ChatMessage | null>(null)
   const [editingMessage, setEditingMessage] = useState<F0ChatMessage | null>(
@@ -297,7 +298,10 @@ export const ChatUIProvider = ({
     return () => clearTimeout(timer)
   }, [searchQuery, searchOpen, navigateToMatch])
 
-  const openSearch = useCallback(() => setSearchOpen(true), [])
+  const openSearch = useCallback(() => {
+    setSearchOpen(true)
+    emit.onSearchOpened()
+  }, [emit])
 
   const closeSearch = useCallback(() => {
     searchRunRef.current++ // cancel any in-flight result
@@ -312,14 +316,16 @@ export const ChatUIProvider = ({
   const goToNextMatch = useCallback(() => {
     const ids = matchIdsRef.current
     if (ids.length === 0) return
+    emit.onSearchResultNavigated({ direction: "next" })
     navigateToMatch((activeIndexRef.current + 1) % ids.length, ids)
-  }, [navigateToMatch])
+  }, [navigateToMatch, emit])
 
   const goToPrevMatch = useCallback(() => {
     const ids = matchIdsRef.current
     if (ids.length === 0) return
+    emit.onSearchResultNavigated({ direction: "prev" })
     navigateToMatch((activeIndexRef.current - 1 + ids.length) % ids.length, ids)
-  }, [navigateToMatch])
+  }, [navigateToMatch, emit])
 
   const matchTotal = matchIds.length
   const matchCurrent = activeMatchIndex >= 0 ? activeMatchIndex + 1 : 0

--- a/packages/react/src/sds/chat/F0Chat/providers/F0ChatProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/F0ChatProvider.tsx
@@ -3,6 +3,7 @@
 import {
   createContext,
   useContext,
+  useLayoutEffect,
   useMemo,
   useRef,
   type ReactNode,
@@ -11,6 +12,8 @@ import {
 import {
   type F0ChatCapabilities,
   type F0ChatEditInput,
+  type F0ChatEmit,
+  type F0ChatEvents,
   type F0ChatRuntime,
   type F0ChatUser,
 } from "../types"
@@ -45,6 +48,74 @@ export type F0ChatStable = {
 
 const F0ChatStableContext = createContext<F0ChatStable | null>(null)
 
+/**
+ * Always-callable mirror of {@link F0ChatEvents} — every handler present, each
+ * one forwarding to the host's if it supplied that one. Call sites emit
+ * unconditionally, with no optional chaining and no presence checks.
+ */
+const noop = (): void => {}
+
+/**
+ * The context default, so emitting works in the leaf components that are unit
+ * tested on their own (voice attachment, link preview, location) with no
+ * provider around them. A shared constant, so the no-provider case is
+ * referentially stable too.
+ */
+const NO_EMIT: F0ChatEmit = {
+  onMessageCopied: noop,
+  onMessageInfoViewed: noop,
+  onReplyStarted: noop,
+  onReplyCancelled: noop,
+  onEditStarted: noop,
+  onEditCancelled: noop,
+  onReactionAdded: noop,
+  onReactionRemoved: noop,
+  onFileAttached: noop,
+  onAttachmentRemoved: noop,
+  onEmojiInserted: noop,
+  onMentionInserted: noop,
+  onVoiceRecordingStarted: noop,
+  onVoiceRecordingCancelled: noop,
+  onVoiceNotePlayed: noop,
+  onVoicePlaybackRateChanged: noop,
+  onImageOpened: noop,
+  onDocumentOpened: noop,
+  onAttachmentDownloaded: noop,
+  onLocationOpened: noop,
+  onLinkPreviewClicked: noop,
+  onSearchOpened: noop,
+  onSearchResultNavigated: noop,
+  onJumpedToQuotedMessage: noop,
+  onJumpedToBottom: noop,
+}
+
+/**
+ * SEPARATE from the stable context, and its value is built once and never
+ * replaced. Emitting must be reachable from anywhere in the tree — including
+ * inside the `memo`ed transcript rows — without giving those components a
+ * subscription that can ever wake them. `F0ChatStable`'s identity legitimately
+ * changes (user, capabilities, edit window); this one's never does.
+ */
+const F0ChatEmitContext = createContext<F0ChatEmit>(NO_EMIT)
+
+/**
+ * "Has this voice note already been reported as played?" — kept above the
+ * transcript because Virtuoso unmounts offscreen rows, so a ref inside the
+ * row would forget on every scroll and re-report the same note.
+ */
+export type F0ChatVoicePlayLog = {
+  hasReported: (key: string) => boolean
+  markReported: (key: string) => void
+}
+
+const NO_VOICE_PLAY_LOG: F0ChatVoicePlayLog = {
+  hasReported: () => false,
+  markReported: () => {},
+}
+
+const F0ChatVoicePlayContext =
+  createContext<F0ChatVoicePlayLog>(NO_VOICE_PLAY_LOG)
+
 /** Keep the previous capabilities object while its fields are unchanged, so a
  * host rebuilding `{ canSend: false }` per render doesn't churn the context. */
 const useStableCapabilities = (
@@ -71,18 +142,45 @@ const useStableCapabilities = (
  */
 export const F0ChatProvider = ({
   runtime,
+  events,
   children,
 }: {
   runtime: F0ChatRuntime
+  /** Observe interactions F0Chat resolves internally — see {@link F0ChatEvents}.
+   * Rebuild it freely: it is read through a ref, never as a context value. */
+  events?: F0ChatEvents
   children: ReactNode
 }): ReactNode => {
   const runtimeRef = useRef(runtime)
   runtimeRef.current = runtime
+
+  // Assigned after commit rather than during render, unlike `runtimeRef` above:
+  // the runtime is READ during render so it has to be fresh synchronously,
+  // while these are only ever read from user-interaction handlers, which cannot
+  // fire before commit. So a render React discards can never leave its handlers
+  // behind here. LAYOUT effect, not passive: passive effects flush from a
+  // scheduler task after paint, leaving a window in which a click reads the
+  // PREVIOUS commit's handlers.
+  const eventsRef = useRef(events)
+  useLayoutEffect(function syncEventHandlers() {
+    eventsRef.current = events
+  })
+
+  const playedVoiceNotesRef = useRef(new Set<string>())
+  const voicePlayLog = useMemo<F0ChatVoicePlayLog>(
+    () => ({
+      hasReported: (key) => playedVoiceNotesRef.current.has(key),
+      markReported: (key) => playedVoiceNotesRef.current.add(key),
+    }),
+    []
+  )
+
   const reactionUsersCacheRef = useRef(new Map<string, Promise<F0ChatUser[]>>())
   const reactionUsersCacheChannelRef = useRef(runtime.channel.id)
 
   if (reactionUsersCacheChannelRef.current !== runtime.channel.id) {
     reactionUsersCacheRef.current.clear()
+    playedVoiceNotesRef.current.clear()
     reactionUsersCacheChannelRef.current = runtime.channel.id
   }
 
@@ -130,6 +228,63 @@ export const F0ChatProvider = ({
     []
   )
 
+  // Built once, never rebuilt: the context value is referentially constant for
+  // the provider's lifetime, so consuming it cannot re-render anything. Each
+  // wrapper reads the LATEST handler from the ref, so the host is free to pass
+  // a fresh inline object on every render.
+  const emit = useMemo<F0ChatEmit>(() => {
+    // A host's observer must never break the chat it observes. Without this,
+    // a throwing handler propagates out of the DOM event and aborts the rest
+    // of the click — at the recorder's cancel button that means `recorder.cancel()`
+    // never runs and the microphone keeps recording.
+    const call = (run: (events: F0ChatEvents) => void): void => {
+      const events = eventsRef.current
+      if (!events) return
+      try {
+        run(events)
+      } catch (error) {
+        console.error("F0Chat: an `events` handler threw", error)
+      }
+    }
+
+    return {
+      onMessageCopied: (p) => call((events) => events.onMessageCopied?.(p)),
+      onMessageInfoViewed: (p) =>
+        call((events) => events.onMessageInfoViewed?.(p)),
+      onReplyStarted: (p) => call((events) => events.onReplyStarted?.(p)),
+      onReplyCancelled: (p) => call((events) => events.onReplyCancelled?.(p)),
+      onEditStarted: (p) => call((events) => events.onEditStarted?.(p)),
+      onEditCancelled: (p) => call((events) => events.onEditCancelled?.(p)),
+      onReactionAdded: (p) => call((events) => events.onReactionAdded?.(p)),
+      onReactionRemoved: (p) => call((events) => events.onReactionRemoved?.(p)),
+      onFileAttached: (p) => call((events) => events.onFileAttached?.(p)),
+      onAttachmentRemoved: (p) =>
+        call((events) => events.onAttachmentRemoved?.(p)),
+      onEmojiInserted: (p) => call((events) => events.onEmojiInserted?.(p)),
+      onMentionInserted: (p) => call((events) => events.onMentionInserted?.(p)),
+      onVoiceRecordingStarted: () =>
+        call((events) => events.onVoiceRecordingStarted?.()),
+      onVoiceRecordingCancelled: () =>
+        call((events) => events.onVoiceRecordingCancelled?.()),
+      onVoiceNotePlayed: (p) => call((events) => events.onVoiceNotePlayed?.(p)),
+      onVoicePlaybackRateChanged: (p) =>
+        call((events) => events.onVoicePlaybackRateChanged?.(p)),
+      onImageOpened: (p) => call((events) => events.onImageOpened?.(p)),
+      onDocumentOpened: (p) => call((events) => events.onDocumentOpened?.(p)),
+      onAttachmentDownloaded: (p) =>
+        call((events) => events.onAttachmentDownloaded?.(p)),
+      onLocationOpened: () => call((events) => events.onLocationOpened?.()),
+      onLinkPreviewClicked: () =>
+        call((events) => events.onLinkPreviewClicked?.()),
+      onSearchOpened: () => call((events) => events.onSearchOpened?.()),
+      onSearchResultNavigated: (p) =>
+        call((events) => events.onSearchResultNavigated?.(p)),
+      onJumpedToQuotedMessage: () =>
+        call((events) => events.onJumpedToQuotedMessage?.()),
+      onJumpedToBottom: () => call((events) => events.onJumpedToBottom?.()),
+    }
+  }, [])
+
   const capabilities = useStableCapabilities(runtime.capabilities)
   // Optional callbacks gate UI affordances by PRESENCE — reflect presence, not
   // identity, in the memo.
@@ -166,9 +321,13 @@ export const F0ChatProvider = ({
 
   return (
     <F0ChatContext.Provider value={runtime}>
-      <F0ChatStableContext.Provider value={stable}>
-        {children}
-      </F0ChatStableContext.Provider>
+      <F0ChatEmitContext.Provider value={emit}>
+        <F0ChatVoicePlayContext.Provider value={voicePlayLog}>
+          <F0ChatStableContext.Provider value={stable}>
+            {children}
+          </F0ChatStableContext.Provider>
+        </F0ChatVoicePlayContext.Provider>
+      </F0ChatEmitContext.Provider>
     </F0ChatContext.Provider>
   )
 }
@@ -193,4 +352,19 @@ export function useF0ChatStable(): F0ChatStable {
     throw new Error("useF0ChatStable must be used within an F0ChatProvider")
   }
   return ctx
+}
+
+/**
+ * Report an interaction to the host (see {@link F0ChatEvents}). Every handler
+ * is always present — no optional chaining at the call site — and the value
+ * never changes identity, so reading it costs a `memo`ed row nothing. Outside a
+ * provider every handler is a no-op.
+ */
+export function useF0ChatEmit(): F0ChatEmit {
+  return useContext(F0ChatEmitContext)
+}
+
+/** See {@link F0ChatVoicePlayLog}. Constant identity, like the emit context. */
+export function useF0ChatVoicePlayLog(): F0ChatVoicePlayLog {
+  return useContext(F0ChatVoicePlayContext)
 }

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -1,5 +1,6 @@
 import { type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { type IconType } from "@/components/F0Icon"
+import { type F0DocumentKind } from "@/components/F0PdfViewer"
 import { type VideoPlayerContent } from "@/components/F0VideoPlayer"
 import { type TranscribeFn } from "@/kits/ai/F0AiChat/types"
 
@@ -437,6 +438,100 @@ export type F0ChatHeaderAction = {
   /** Restrict the action to a channel type. Omit for both. */
   channelTypes?: F0ChatChannelType[]
 }
+
+/** Which affordance produced a reaction — the four are indistinguishable from
+ * {@link F0ChatRuntime.toggleReaction}, which receives identical arguments from
+ * all of them. */
+export type F0ChatReactionSource =
+  | "quickRow"
+  | "menuPicker"
+  | "existingPill"
+  | "inlinePicker"
+
+/** How files reached the composer. Same story as {@link F0ChatReactionSource}:
+ * {@link F0ChatRuntime.uploadFiles} cannot tell these apart. */
+export type F0ChatAttachSource = "button" | "drop" | "paste"
+
+/** Attachment family, as the transcript classifies it (see
+ * `utils/attachments.ts`). Note `video` is not an {@link F0ChatAttachment}
+ * `kind` — videos are files with a video MIME type. */
+export type F0ChatAttachedKind = "image" | "video" | "document" | "file"
+
+export type F0ChatEmojiSource = "picker" | "autocomplete"
+
+/**
+ * Interactions F0Chat resolves internally, reported so the host can observe
+ * them. Everything here is either invisible to {@link F0ChatRuntime} (it calls
+ * no runtime method) or carries provenance a runtime call cannot express.
+ *
+ * F0 has no opinion on what these are for — it reports what the user did, not
+ * what it means. Anything whose truth depends on the server (a send that may
+ * still fail, a delete that may be rejected) is deliberately absent: the host
+ * already sees those through the runtime, and only there does it learn the
+ * outcome.
+ *
+ * Every handler is optional and independent — wire only the ones you need. No
+ * payload carries message content, a URL, coordinates or a user id.
+ *
+ * Passed to `F0ChatProvider`; the provider keeps the object behind a ref, so it
+ * may be rebuilt on every render without re-rendering the transcript.
+ */
+export type F0ChatEvents = {
+  onMessageCopied?: (p: { messageId: string }) => void
+  onMessageInfoViewed?: (p: { messageId: string }) => void
+  /** Pressing "Reply". Pair with `onReplyCancelled` to measure abandonment —
+   * the host only sees replies that were actually sent. */
+  onReplyStarted?: (p: { messageId: string }) => void
+  /** Dismissing the reply chip. NOT fired when the reply is sent, nor when
+   * switching to editing — only an explicit give-up counts. */
+  onReplyCancelled?: (p: { messageId: string }) => void
+  onEditStarted?: (p: { messageId: string }) => void
+  /** Dismissing the edit chip. Same rule as {@link F0ChatEvents.onReplyCancelled}. */
+  onEditCancelled?: (p: { messageId: string }) => void
+  onReactionAdded?: (p: {
+    messageId: string
+    emoji: string
+    source: F0ChatReactionSource
+  }) => void
+  onReactionRemoved?: (p: {
+    messageId: string
+    emoji: string
+    source: F0ChatReactionSource
+  }) => void
+  /** Once per file, when the selection passes validation — before the upload
+   * resolves, so it measures the affordance even when the upload then fails. */
+  onFileAttached?: (p: {
+    kind: F0ChatAttachedKind
+    source: F0ChatAttachSource
+  }) => void
+  onAttachmentRemoved?: (p: { kind: F0ChatAttachedKind }) => void
+  onEmojiInserted?: (p: { emoji: string; source: F0ChatEmojiSource }) => void
+  /** `isEveryone` distinguishes `@here` from a person. Who was mentioned is
+   * deliberately not reported. */
+  onMentionInserted?: (p: { isEveryone: boolean }) => void
+  onVoiceRecordingStarted?: () => void
+  onVoiceRecordingCancelled?: () => void
+  /** First play of a voice note only — resuming after a pause does not re-fire. */
+  onVoiceNotePlayed?: (p: { durationSeconds?: number }) => void
+  onVoicePlaybackRateChanged?: (p: { rate: number }) => void
+  /** Opening the image lightbox; `count` is how many images the group holds. */
+  onImageOpened?: (p: { count: number }) => void
+  onDocumentOpened?: (p: { kind: F0DocumentKind }) => void
+  onAttachmentDownloaded?: (p: { kind: F0ChatAttachedKind }) => void
+  onLocationOpened?: () => void
+  onLinkPreviewClicked?: () => void
+  onSearchOpened?: () => void
+  onSearchResultNavigated?: (p: { direction: "next" | "prev" }) => void
+  onJumpedToQuotedMessage?: () => void
+  onJumpedToBottom?: () => void
+}
+
+/**
+ * Always-callable mirror of {@link F0ChatEvents} — every handler present, each
+ * forwarding to the host's if it supplied that one. Call sites emit
+ * unconditionally, with no optional chaining and no presence checks.
+ */
+export type F0ChatEmit = Required<F0ChatEvents>
 
 /** Sentinel for {@link F0ChatRuntime.loadMessageContext} meaning "the live tail". */
 export const LATEST = "latest" as const

--- a/packages/react/src/sds/chat/F0Chat/utils/attachments.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/attachments.ts
@@ -1,6 +1,7 @@
 import { type F0DocumentKind } from "@/components/F0PdfViewer"
 
 import {
+  type F0ChatAttachedKind,
   type F0ChatAttachment,
   type F0ChatFileAttachment,
   type F0ChatImageAttachment,
@@ -102,6 +103,21 @@ export const withinPreviewSizeLimit = (
   file: F0ChatFileAttachment,
   kind: ChatDocumentKind
 ): boolean => (file.size ?? 0) <= PREVIEW_MAX_BYTES[kind]
+
+/**
+ * Attachment family for reporting, mirroring how the transcript renders it.
+ *
+ * Deliberately unlike {@link partitionChatAttachments} in one way: a document
+ * too large to preview is still a document here. Previewability is a rendering
+ * concern; "what kinds of files do people share" is not.
+ */
+export const attachedKindOf = (
+  attachment: F0ChatImageAttachment | F0ChatFileAttachment
+): F0ChatAttachedKind => {
+  if (attachment.kind === "image") return "image"
+  if (isVideoFileAttachment(attachment)) return "video"
+  return documentPreviewKind(attachment) ? "document" : "file"
+}
 
 export type PartitionedChatAttachments = {
   images: F0ChatImageAttachment[]

--- a/packages/react/src/sds/chat/F0Chat/utils/reactions.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/reactions.ts
@@ -1,0 +1,26 @@
+import {
+  type F0ChatEmit,
+  type F0ChatMessage,
+  type F0ChatReactionSource,
+} from "../types"
+
+/**
+ * Report a reaction toggle as the add or the remove it actually was.
+ *
+ * `F0ChatRuntime.toggleReaction` is one call for both directions, so the host
+ * cannot tell them apart from the runtime alone. Read the direction from the
+ * CURRENT message — do not call this after the host's state has advanced.
+ */
+export const emitReactionToggle = (
+  emit: F0ChatEmit,
+  message: F0ChatMessage,
+  emoji: string,
+  source: F0ChatReactionSource
+): void => {
+  const payload = { messageId: message.id, emoji, source }
+  const removing =
+    message.reactions?.some((r) => r.emoji === emoji && r.reactedByMe) === true
+
+  if (removing) emit.onReactionRemoved(payload)
+  else emit.onReactionAdded(payload)
+}


### PR DESCRIPTION
## What

F0Chat resolves a lot of interactions internally — a copy, a download, a lightbox open, and above all **which** of four affordances produced a reaction, or which of three produced an attachment. None of that reaches `F0ChatRuntime`, so a host currently has no way to observe it.

This adds an optional `events` prop with 25 optional handlers. f0 gains no dependency on any analytics vendor: it only emits, and the host decides what that means.

```tsx
<F0ChatProvider runtime={runtime} events={{ onReactionAdded: ({ emoji, source }) => … }}>
```

## Why it is shaped this way

**Render isolation.** The handlers live behind their own constant-identity context, not on `F0ChatContext`. A host that rebuilds its `events` object every render — the normal case, since the runtime rebuilds on every transport packet — must not re-render a memoized transcript row. Handlers are read through a ref synced in a layout effect, so an emit always reaches the latest one.

**A host bug must never break chat.** Every wrapper is guarded and logs rather than throwing. Without that, a throwing handler could stop `recorder.cancel()` from running and leave the microphone recording.

**Emit from the operation, on success.** A copy waits on the clipboard promise; a recording start waits on the recorder. Where intent is the thing worth measuring instead, `onFileAttached` fires before the upload resolves — and the docs say which rule each handler follows.

Two handlers need state the leaves do not have:

- **Reactions** report add vs remove, read from the message *before* the toggle runs. One runtime method serves both directions, so nothing downstream can tell them apart afterwards.
- **A voice note** reports its first play only. The reported set lives in the provider, keyed on url and cleared on channel change, because Virtuoso unmounts offscreen rows and a per-row ref re-fires on every scroll.

Composer drafts are excluded from the consumption events through a small surface context — previewing your own unsent PDF is not consuming shared content.

## Testing

`__tests__/F0Chat.events.test.tsx`. The render-isolation tests count renders of a memoized consumer rather than asserting DOM node identity, which survives re-renders and cannot fail. Mutation-tested: putting the emit value on `F0ChatContext`, or memoizing on `[events]`, turns exactly those tests red.

- 445 chat tests pass; full suite 7083 pass
- `tsc`, `lint` (now 97 rules after #5279), `format:check` all clean
- The 6 failures in `F0DataChart/__tests__/BarChart.test.tsx` are pre-existing on `main` — verified by stashing this branch's changes and re-running

## Notes for review

- New optional prop plus new exported types, so the api-surface check should classify SAFE.
- `F0ChatEvents` and the four source unions are exported from `index.ts`; the story has a live events panel and the MDX documents which handlers carry a `messageId` so hosts can decide whether to forward it.

## Follow-up, not in this PR

The PDF viewer's own Download button is still uninstrumented — it sits outside F0Chat, so `onAttachmentDownloaded` does not cover it.
