### PR TITLE
feat(F0Chat): add edit-last and double-click-to-reply shortcuts

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -297,7 +297,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
 - WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
 - WHEN Arrow Up is pressed in an empty, idle composer → THEN F0 reopens the viewer's newest own message, prefilled as the Edit action does.
-- WHEN that newest own message cannot be edited — past the edit window, a voice note, or attachments with no text → THEN Arrow Up does nothing. It never reaches further back: a blind keystroke must not open a message other than the one the viewer is looking at, and the Edit action remains the way to reach older ones.
+- WHEN that newest own message cannot be edited — past the edit window, a voice note, or attachments with no text → THEN Arrow Up does nothing. It never looks further back: the viewer pressed a key without choosing a message, so opening any other one would surprise them. The Edit action still reaches older messages.
 - WHEN the newest own messages are outside the loaded window, as after jumping to a search hit (`hasMoreNewer`) → THEN Arrow Up does nothing rather than reopening an older message.
 - WHEN a host capability allows editing other people's messages → THEN Arrow Up still only reopens the viewer's own; the Edit action follows the capability.
 - WHEN nothing editable remains → THEN Arrow Up does nothing and keeps its ordinary caret behavior.
@@ -306,7 +306,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN a message is double-clicked → THEN F0 quotes it in the composer and moves focus there — anyone's message, including the viewer's own. This replaces the browser's double- and triple-click text selection inside a message; the Copy action copies the whole body.
 - WHEN a double-click lands on a part of the message that handles its own activation — an image, a file, a reply quote, a link, the voice waveform, the inline video — → THEN that element performs its own action and no quote is created.
 - WHEN a double-click lands in a popover a message owns, such as a profile hover card → THEN no quote is created; the card is not part of the message.
-- WHEN the double-clicked message is a deleted tombstone, still sending, or failed → THEN F0 creates no quote, matching the rows the menu offers no Reply on.
+- WHEN the double-clicked message is deleted, still sending, or failed → THEN F0 creates no quote, matching the rows the menu offers no Reply on.
 - WHEN the channel is read-only (`canSend: false`) → THEN neither a double-click nor the menu's Reply sets a quote, because no composer is rendered to hold one.
 - WHEN a compose target is set → THEN it replaces any other: a quote drops an edit in progress AND its draft text, attachments and mentions; an edit drops a pending quote.
 - WHEN the Edit action is re-picked on the message already open for editing → THEN F0 keeps what the viewer has typed instead of reloading the original body.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -296,15 +296,23 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN `maxFileSizeBytes` is omitted → THEN F0 does not impose a file-size limit.
 - WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
 - WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
-- WHEN Arrow Up is pressed in an empty, idle composer → THEN F0 reopens the newest of your own messages that is still editable, prefilling the composer exactly as the Edit action does.
-- WHEN none of your own messages is editable any more → THEN Arrow Up does nothing and the composer stays empty.
-- WHEN the composer holds text, an attachment, a pending reply quote, an edit in progress, or a live recording → THEN Arrow Up keeps its ordinary caret behavior and never reopens a message.
+- WHEN Arrow Up is pressed in an empty, idle composer → THEN F0 reopens the viewer's newest own message, prefilled as the Edit action does.
+- WHEN that newest own message cannot be edited — past the edit window, a voice note, or attachments with no text → THEN Arrow Up does nothing. It never reaches further back: a blind keystroke must not open a message other than the one the viewer is looking at, and the Edit action remains the way to reach older ones.
+- WHEN the newest own messages are outside the loaded window, as after jumping to a search hit (`hasMoreNewer`) → THEN Arrow Up does nothing rather than reopening an older message.
+- WHEN a host capability allows editing other people's messages → THEN Arrow Up still only reopens the viewer's own; the Edit action follows the capability.
+- WHEN nothing editable remains → THEN Arrow Up does nothing and keeps its ordinary caret behavior.
+- WHEN the composer holds text, an attachment, a pending reply quote, an edit in progress, a recording being requested or running, a transcription, or a voice note being sent → THEN Arrow Up keeps its ordinary caret behavior.
 - WHEN Arrow Up carries Shift, Alt, Cmd, or Ctrl → THEN F0 treats it as a text-selection gesture and never reopens a message.
-- WHEN a message is double-clicked → THEN F0 quotes it in the composer and moves focus there — anyone's message, including your own.
-- WHEN a double-click lands on an interactive part of a message, such as an image, a file, a reply quote, or a link → THEN that element performs its own action and no quote is created.
-- WHEN the double-clicked message is a deleted tombstone, still sending, or failed → THEN F0 creates no quote, matching the rows that offer no actions menu.
-- WHEN a reply quote is set by any route → THEN F0 drops any edit in progress, and starting an edit drops any pending quote.
-- WHEN a reply quote appears in the composer → THEN F0 focuses the textarea and places the caret at the end of the current draft.
+- WHEN a message is double-clicked → THEN F0 quotes it in the composer and moves focus there — anyone's message, including the viewer's own. This replaces the browser's double- and triple-click text selection inside a message; the Copy action copies the whole body.
+- WHEN a double-click lands on a part of the message that handles its own activation — an image, a file, a reply quote, a link, the voice waveform, the inline video — → THEN that element performs its own action and no quote is created.
+- WHEN a double-click lands in a popover a message owns, such as a profile hover card → THEN no quote is created; the card is not part of the message.
+- WHEN the double-clicked message is a deleted tombstone, still sending, or failed → THEN F0 creates no quote, matching the rows the menu offers no Reply on.
+- WHEN the channel is read-only (`canSend: false`) → THEN neither a double-click nor the menu's Reply sets a quote, because no composer is rendered to hold one.
+- WHEN a compose target is set → THEN it replaces any other: a quote drops an edit in progress AND its draft text, attachments and mentions; an edit drops a pending quote.
+- WHEN the Edit action is re-picked on the message already open for editing → THEN F0 keeps what the viewer has typed instead of reloading the original body.
+- WHEN a compose target is set by any route → THEN F0 focuses the textarea within the same interaction and places the caret at the end of the draft, without scrolling the host page.
+- WHEN the conversation changes → THEN F0 drops the compose target AND the whole composer draft, so neither an edit nor a half-typed reply can be sent to the channel the viewer switched to.
+- WHEN the composer is removed while a target is set, as when a channel becomes read-only → THEN F0 drops the target with it, so a returning composer never shows a chip over an empty draft.
 - WHEN `:` starts a token in the composer → THEN F0 opens a caret-anchored emoji list and filters it by shortcode, alias, keyword, or name as the query grows.
 - WHEN the emoji autocomplete is open → THEN Arrow Up and Arrow Down move through its options, Enter or Tab inserts the active emoji, and Escape dismisses the current trigger without sending.
 - WHEN an emoji autocomplete option is selected → THEN F0 replaces only the active `:query`, preserves surrounding message text, inserts one separating space, and restores the textarea focus and caret.
@@ -375,7 +383,7 @@ playback-speed slot can overflow.
 
 ### Keyboard interaction
 
-The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list. Arrow Up on an empty, idle composer reopens your last editable message; with any composer content, a pending quote, or a modifier held it keeps its ordinary caret meaning. Double-click to reply is a pointer shortcut for the menu's Reply action, which remains the keyboard path. The composer attachment strip is focusable and supports horizontal keyboard scrolling. After removing an attachment, focus stays on the strip when previews remain; removing the final preview returns focus to the composer textarea. Emoji suggestions keep focus in the textarea, expose the active option through `aria-activedescendant`, and use Arrow Up, Arrow Down, Enter, Tab, and Escape without intercepting ordinary message text.
+The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list. Arrow Up on an empty, idle composer reopens the viewer's last editable message; with any composer content, a pending quote, or a modifier held it keeps its ordinary caret meaning. Double-click to reply is a pointer-only shortcut for the menu's Reply action, which remains the keyboard path — and the only path on touch, where a double-tap is not a reliable gesture. The composer attachment strip is focusable and supports horizontal keyboard scrolling. After removing an attachment, focus stays on the strip when previews remain; removing the final preview returns focus to the composer textarea. Emoji suggestions keep focus in the textarea, expose the active option through `aria-activedescendant`, and use Arrow Up, Arrow Down, Enter, Tab, and Escape without intercepting ordinary message text.
 
 ### Screen reader behavior
 

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -296,6 +296,15 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN `maxFileSizeBytes` is omitted → THEN F0 does not impose a file-size limit.
 - WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
 - WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
+- WHEN Arrow Up is pressed in an empty, idle composer → THEN F0 reopens the newest of your own messages that is still editable, prefilling the composer exactly as the Edit action does.
+- WHEN none of your own messages is editable any more → THEN Arrow Up does nothing and the composer stays empty.
+- WHEN the composer holds text, an attachment, a pending reply quote, an edit in progress, or a live recording → THEN Arrow Up keeps its ordinary caret behavior and never reopens a message.
+- WHEN Arrow Up carries Shift, Alt, Cmd, or Ctrl → THEN F0 treats it as a text-selection gesture and never reopens a message.
+- WHEN a message is double-clicked → THEN F0 quotes it in the composer and moves focus there — anyone's message, including your own.
+- WHEN a double-click lands on an interactive part of a message, such as an image, a file, a reply quote, or a link → THEN that element performs its own action and no quote is created.
+- WHEN the double-clicked message is a deleted tombstone, still sending, or failed → THEN F0 creates no quote, matching the rows that offer no actions menu.
+- WHEN a reply quote is set by any route → THEN F0 drops any edit in progress, and starting an edit drops any pending quote.
+- WHEN a reply quote appears in the composer → THEN F0 focuses the textarea and places the caret at the end of the current draft.
 - WHEN `:` starts a token in the composer → THEN F0 opens a caret-anchored emoji list and filters it by shortcode, alias, keyword, or name as the query grows.
 - WHEN the emoji autocomplete is open → THEN Arrow Up and Arrow Down move through its options, Enter or Tab inserts the active emoji, and Escape dismisses the current trigger without sending.
 - WHEN an emoji autocomplete option is selected → THEN F0 replaces only the active `:query`, preserves surrounding message text, inserts one separating space, and restores the textarea focus and caret.
@@ -366,7 +375,7 @@ playback-speed slot can overflow.
 
 ### Keyboard interaction
 
-The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list. The composer attachment strip is focusable and supports horizontal keyboard scrolling. After removing an attachment, focus stays on the strip when previews remain; removing the final preview returns focus to the composer textarea. Emoji suggestions keep focus in the textarea, expose the active option through `aria-activedescendant`, and use Arrow Up, Arrow Down, Enter, Tab, and Escape without intercepting ordinary message text.
+The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list. Arrow Up on an empty, idle composer reopens your last editable message; with any composer content, a pending quote, or a modifier held it keeps its ordinary caret meaning. Double-click to reply is a pointer shortcut for the menu's Reply action, which remains the keyboard path. The composer attachment strip is focusable and supports horizontal keyboard scrolling. After removing an attachment, focus stays on the strip when previews remain; removing the final preview returns focus to the composer textarea. Emoji suggestions keep focus in the textarea, expose the active option through `aria-activedescendant`, and use Arrow Up, Arrow Down, Enter, Tab, and Escape without intercepting ordinary message text.
 
 ### Screen reader behavior
 

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1107,6 +1107,64 @@ export const EmojiAutocomplete: Story = {
   },
 }
 
+/** Composer shortcuts: Arrow Up on an empty composer reopens the last editable
+ * own message, and a double-click on any message quotes it.
+ *
+ * Runs in a real browser on purpose: the actions popover keeps its content
+ * mounted for a 150ms CSS exit animation, and only then does Radix decide
+ * whether to pull focus back to the trigger. jsdom runs no CSS animations, so
+ * a unit test unmounts the popover immediately and cannot observe that. */
+export const ComposerHotkeys: Story = {
+  name: "Composer hotkeys",
+  render: () => <Conversation initialCount={8} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const composer = canvas.getByRole("combobox", {
+      name: /write something here/i,
+    })
+    const surfaces = () =>
+      canvas.getAllByTestId("chat-message-surface") as HTMLElement[]
+    // Radix portals the popover to document.body, outside the story canvas.
+    const overlay = within(canvasElement.ownerDocument.body)
+
+    await step("Arrow Up reopens my last message", async () => {
+      await userEvent.click(composer)
+      await userEvent.keyboard("{ArrowUp}")
+      await expect(
+        canvas.getByRole("button", { name: /cancel edit/i })
+      ).toBeVisible()
+      await expect(composer).not.toHaveValue("")
+    })
+
+    await step("A quote replaces the edit and clears its draft", async () => {
+      await userEvent.dblClick(surfaces()[0])
+      await expect(
+        canvas.getByRole("button", { name: /remove quote/i })
+      ).toBeVisible()
+      await expect(composer).toHaveValue("")
+      await expect(composer).toHaveFocus()
+    })
+
+    await step("The menu's Reply hands focus to the composer", async () => {
+      await userEvent.click(
+        canvas.getByRole("button", { name: /remove quote/i })
+      )
+      const row = surfaces()[0]
+      // The row defers its real popover until interaction intent — hover first,
+      // or the click lands on the placeholder trigger instead.
+      await userEvent.hover(row)
+      const menu = await waitFor(
+        () => canvas.getAllByRole("button", { name: /message actions/i })[0]
+      )
+      await userEvent.click(menu)
+      await userEvent.click(overlay.getByRole("button", { name: /^Reply$/i }))
+      // Radix keeps the popover mounted for its exit animation and only then
+      // decides about focus — assert after that window, not before.
+      await waitFor(() => expect(composer).toHaveFocus(), { timeout: 3000 })
+    })
+  },
+}
+
 /** Group chat with functional `@`-mentions (`@here` for everyone + members). */
 export const Group: Story = {
   name: "Group with mentions",

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1214,25 +1214,34 @@ export const ComposerHotkeys: Story = {
     const composer = canvas.getByRole("combobox", {
       name: /write something here/i,
     })
+    // The transcript is virtualized and stays hidden until the browser reports
+    // the viewport stable, so rows appear well after the runtime has messages.
     const surfaces = () =>
-      canvas.getAllByTestId("chat-message-surface") as HTMLElement[]
+      canvas.findAllByTestId("chat-message-surface") as Promise<HTMLElement[]>
     // Radix portals the popover to document.body, outside the story canvas.
     const overlay = within(canvasElement.ownerDocument.body)
 
     await step("Arrow Up reopens my last message", async () => {
       await userEvent.click(composer)
       await userEvent.keyboard("{ArrowUp}")
-      await expect(
-        canvas.getByRole("button", { name: /cancel edit/i })
-      ).toBeVisible()
+      // The chip animates its height open, and animations are only skipped
+      // under Chromatic — so it is in the DOM before it is visible.
+      await waitFor(() =>
+        expect(
+          canvas.getByRole("button", { name: /cancel edit/i })
+        ).toBeVisible()
+      )
       await expect(composer).not.toHaveValue("")
     })
 
     await step("A quote replaces the edit and clears its draft", async () => {
-      await userEvent.dblClick(surfaces()[0])
-      await expect(
-        canvas.getByRole("button", { name: /remove quote/i })
-      ).toBeVisible()
+      const [firstMessage] = await surfaces()
+      await userEvent.dblClick(firstMessage)
+      await waitFor(() =>
+        expect(
+          canvas.getByRole("button", { name: /remove quote/i })
+        ).toBeVisible()
+      )
       await expect(composer).toHaveValue("")
       await expect(composer).toHaveFocus()
     })
@@ -1241,7 +1250,7 @@ export const ComposerHotkeys: Story = {
       await userEvent.click(
         canvas.getByRole("button", { name: /remove quote/i })
       )
-      const row = surfaces()[0]
+      const [row] = await surfaces()
       // The row defers its real popover until interaction intent — hover first,
       // or the click lands on the placeholder trigger instead.
       await userEvent.hover(row)

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -1,6 +1,8 @@
+import { StrictMode } from "react"
 import { beforeAll, describe, expect, it, vi } from "vitest"
 
 import {
+  fireEvent,
   zeroRender as render,
   screen,
   userEvent,
@@ -167,7 +169,10 @@ describe("F0Chat arrow-up editing", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("skips a message that can no longer be edited and takes the previous one", async () => {
+  // The shortcut targets only the NEWEST own message: walking back to find
+  // something editable would silently open a message the user is not looking
+  // at, which a blind keystroke must never do.
+  it("does nothing when the newest own message is no longer editable", async () => {
     const older: F0ChatMessage = { ...mine, id: "m0", body: "Older of mine" }
     renderChat(
       editable({
@@ -177,7 +182,86 @@ describe("F0Chat arrow-up editing", () => {
     )
     await pressArrowUp()
 
-    expect(composer()).toHaveValue("Older of mine")
+    expect(composer()).toHaveValue("")
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  // Discriminator: the loaded window is not always anchored to the live tail.
+  it("does nothing while newer messages are outside the loaded window", async () => {
+    renderChat(editable({ hasMoreNewer: true }))
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("")
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  // Discriminator: an attachment-only message has no text to edit, so loading
+  // it would turn the user's next Enter into a caption on the old image. The
+  // Edit action still offers it; only the blind shortcut declines.
+  it("does nothing when the newest own message carries only an attachment", async () => {
+    renderChat(
+      editable({
+        messages: [
+          { ...mine, id: "m0", body: "Older of mine" },
+          {
+            ...mine,
+            body: "",
+            attachments: [
+              {
+                kind: "image",
+                url: "https://example.test/a.png",
+                name: "a.png",
+              },
+            ],
+          },
+        ],
+      })
+    )
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("")
+  })
+
+  // Discriminator: the edit effect used to rebuild `attachments` from the
+  // message, so firing here would silently drop a pending upload.
+  it("does nothing while an attachment is pending", async () => {
+    const uploadFiles = vi
+      .fn()
+      .mockResolvedValue([
+        { kind: "image", url: "blob:img", name: "photo.png" },
+      ])
+    const { container } = renderChat(editable({ uploadFiles }))
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>("input[type=file]")!,
+      {
+        target: {
+          files: [new File(["img"], "photo.png", { type: "image/png" })],
+        },
+      }
+    )
+    await screen.findByRole("img", { name: /photo\.png/i })
+
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("")
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("img", { name: /photo\.png/i })).toBeInTheDocument()
+  })
+
+  // PIN: modifier chords have no native meaning on an empty composer, so this
+  // asserts the rule rather than catching a live regression.
+  it("ignores a modified arrow-up", async () => {
+    renderChat(editable())
+    await userEvent.click(composer())
+    await userEvent.keyboard("{Shift>}{ArrowUp}{/Shift}")
+
+    expect(composer()).toHaveValue("")
   })
 
   it("is not offered once my last message is past the edit window", async () => {
@@ -226,9 +310,73 @@ describe("F0Chat double-click reply", () => {
     ).not.toBeInTheDocument()
   })
 
+  // Discriminator for the draft leak: before the fix the edit chip was
+  // replaced by the reply chip while the edited body stayed in the box, so
+  // Enter re-sent the old message as a reply.
+  it("clears the edit draft when the quote replaces it", async () => {
+    renderChat(editable())
+    await pressArrowUp()
+    expect(composer()).toHaveValue("Hi back")
+
+    await userEvent.dblClick(screen.getByText("Hello there"))
+
+    expect(composer()).toHaveValue("")
+    expect(
+      screen.getByRole("button", { name: /remove quote/i })
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the typed draft when Edit is re-picked on the same message", async () => {
+    renderChat(editable())
+    await pressArrowUp()
+    await userEvent.type(composer(), " and more")
+
+    const menus = screen.getAllByRole("button", { name: /message actions/i })
+    await userEvent.click(menus[1])
+    await userEvent.click(screen.getByRole("button", { name: /^Edit$/i }))
+
+    expect(composer()).toHaveValue("Hi back and more")
+  })
+
   it("ignores a double-click on a deleted message", async () => {
     renderChat(makeRuntime({ messages: [{ ...theirs, deleted: true }, mine] }))
     await userEvent.dblClick(screen.getByText(/message deleted/i))
+
+    expect(
+      screen.queryByRole("button", { name: /remove quote/i })
+    ).not.toBeInTheDocument()
+  })
+
+  // Guards the bounded walk against being replaced by a plain `closest` over
+  // the focusability selector: react-virtuoso renders its scroller with
+  // tabIndex={0} (and ChatMessagesContainer forwards that onto the scroll
+  // viewport), so an unbounded lookup would match from any bubble text and no
+  // message would be quotable at all.
+  it("still quotes plain text when an ancestor of the row is focusable", async () => {
+    renderChat(makeRuntime())
+    screen.getByTestId("chat-message-viewport").setAttribute("tabindex", "0")
+
+    await userEvent.dblClick(screen.getByText("Hello there"))
+
+    expect(
+      screen.getByRole("button", { name: /remove quote/i })
+    ).toBeInTheDocument()
+  })
+
+  // SELECTOR PIN, not a behaviour test: it proves the rule treats a
+  // `[role="slider"]` descendant as self-handling. The real case is the voice
+  // waveform (ChatVoiceAttachment renders `role="slider"` with its own
+  // onClick), which cannot mount here — the transcript defers heavy previews
+  // until browser readiness — so the live widget is covered by the
+  // "Composer hotkeys" Storybook play function instead.
+  it("treats a role=slider descendant as self-handling", async () => {
+    renderChat(makeRuntime())
+    const slider = document.createElement("div")
+    slider.setAttribute("role", "slider")
+    slider.textContent = "seek"
+    screen.getByText("Hello there").append(slider)
+
+    await userEvent.dblClick(slider)
 
     expect(
       screen.queryByRole("button", { name: /remove quote/i })
@@ -258,5 +406,127 @@ describe("F0Chat double-click reply", () => {
     expect(
       screen.queryByRole("button", { name: /remove quote/i })
     ).not.toBeInTheDocument()
+  })
+})
+
+describe("F0Chat compose target lifecycle", () => {
+  // The composer registers its handle in an effect. StrictMode runs
+  // setup → cleanup → setup, and the cleanup nulls the ref, so a registration
+  // that does not re-register leaves the provider unable to drive the composer.
+  it("keeps the composer handle registered through a StrictMode replay", async () => {
+    render(
+      <StrictMode>
+        <F0ChatProvider runtime={editable()}>
+          <F0Chat />
+        </F0ChatProvider>
+      </StrictMode>
+    )
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("Hi back")
+  })
+
+  it("sets no quote on a read-only channel, where there is no composer", async () => {
+    renderChat(makeRuntime({ capabilities: { canSend: false } }))
+    await userEvent.dblClick(screen.getByText("Hello there"))
+
+    expect(
+      screen.queryByRole("button", { name: /remove quote/i })
+    ).not.toBeInTheDocument()
+  })
+
+  // Discriminator: the composer is unmounted on a read-only channel while the
+  // target lives in the provider. If the target survived, the composer would
+  // come back showing an edit chip over an EMPTY draft — one Enter from
+  // blanking the message it points at.
+  it("releases the target when the composer goes away and comes back", async () => {
+    const runtime = editable()
+    const { rerender } = render(
+      <F0ChatProvider runtime={runtime}>
+        <F0Chat />
+      </F0ChatProvider>
+    )
+    await pressArrowUp()
+    expect(composer()).toHaveValue("Hi back")
+
+    // The channel is frozen: F0Chat stops rendering the composer entirely.
+    rerender(
+      <F0ChatProvider
+        runtime={{ ...runtime, capabilities: { canSend: false } }}
+      >
+        <F0Chat />
+      </F0ChatProvider>
+    )
+    rerender(
+      <F0ChatProvider runtime={runtime}>
+        <F0Chat />
+      </F0ChatProvider>
+    )
+
+    expect(composer()).toHaveValue("")
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /cancel edit/i })
+      ).not.toBeInTheDocument()
+    )
+  })
+
+  // Discriminator: `retarget` only discards on the way OUT of edit mode, so a
+  // typed REPLY draft used to survive the switch and could be sent to whoever
+  // the viewer moved to.
+  it("abandons a typed reply draft when the channel changes", async () => {
+    const runtime = makeRuntime()
+    const { rerender } = render(
+      <F0ChatProvider runtime={runtime}>
+        <F0Chat />
+      </F0ChatProvider>
+    )
+    await userEvent.dblClick(screen.getByText("Hello there"))
+    await userEvent.type(composer(), "for your eyes only")
+    expect(composer()).toHaveValue("for your eyes only")
+
+    rerender(
+      <F0ChatProvider
+        runtime={{ ...runtime, channel: { ...runtime.channel, id: "c2" } }}
+      >
+        <F0Chat />
+      </F0ChatProvider>
+    )
+
+    expect(composer()).toHaveValue("")
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /remove quote/i })
+      ).not.toBeInTheDocument()
+    )
+  })
+
+  // Discriminator: the provider and the composer both survive a channel
+  // switch, so without this Save would edit a message in the channel you left.
+  it("drops the target and the edit draft when the channel changes", async () => {
+    const runtime = editable()
+    const { rerender } = render(
+      <F0ChatProvider runtime={runtime}>
+        <F0Chat />
+      </F0ChatProvider>
+    )
+    await pressArrowUp()
+    expect(composer()).toHaveValue("Hi back")
+
+    rerender(
+      <F0ChatProvider
+        runtime={{ ...runtime, channel: { ...runtime.channel, id: "c2" } }}
+      >
+        <F0Chat />
+      </F0ChatProvider>
+    )
+
+    expect(composer()).toHaveValue("")
+    // The chip animates out, so it leaves the DOM a tick after the target.
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /cancel edit/i })
+      ).not.toBeInTheDocument()
+    )
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -169,9 +169,8 @@ describe("F0Chat arrow-up editing", () => {
     ).not.toBeInTheDocument()
   })
 
-  // The shortcut targets only the NEWEST own message: walking back to find
-  // something editable would silently open a message the user is not looking
-  // at, which a blind keystroke must never do.
+  // The shortcut targets only the newest own message. The user pressed a key
+  // without choosing one, so opening an older message would surprise them.
   it("does nothing when the newest own message is no longer editable", async () => {
     const older: F0ChatMessage = { ...mine, id: "m0", body: "Older of mine" }
     renderChat(
@@ -188,7 +187,7 @@ describe("F0Chat arrow-up editing", () => {
     ).not.toBeInTheDocument()
   })
 
-  // Discriminator: the loaded window is not always anchored to the live tail.
+  // Discriminator: the loaded messages do not always end at the newest one.
   it("does nothing while newer messages are outside the loaded window", async () => {
     renderChat(editable({ hasMoreNewer: true }))
     await pressArrowUp()

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -1,0 +1,262 @@
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import {
+  zeroRender as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+
+import { F0Chat } from "../F0Chat"
+import { F0ChatProvider } from "../providers/F0ChatProvider"
+import { type F0ChatMessage, type F0ChatRuntime } from "../types"
+
+// jsdom has no layout — wrap Virtuoso in its official mock context so every
+// row renders (see mocks/virtuoso-jsdom).
+vi.mock("react-virtuoso", async (importOriginal) => {
+  const { mockVirtuosoModule } = await import("../mocks/virtuoso-jsdom")
+  return mockVirtuosoModule(
+    await importOriginal<typeof import("react-virtuoso")>()
+  )
+})
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const now = new Date().toISOString()
+
+const theirs: F0ChatMessage = {
+  id: "m1",
+  author: { id: "other", name: "María José" },
+  body: "Hello there",
+  createdAt: now,
+  isMine: false,
+}
+
+const mine: F0ChatMessage = {
+  id: "m2",
+  author: { id: "me", name: "Me" },
+  body: "Hi back",
+  createdAt: now,
+  isMine: true,
+  status: "read",
+}
+
+const makeRuntime = (
+  overrides: Partial<F0ChatRuntime> = {}
+): F0ChatRuntime => ({
+  currentUserId: "me",
+  channel: {
+    id: "c1",
+    type: "dm",
+    title: "María José",
+    avatar: { type: "person", firstName: "María", lastName: "José" },
+    presence: "online",
+  },
+  status: "ready",
+  messages: [theirs, mine],
+  typingUsers: [],
+  hasMoreOlder: false,
+  loadingOlder: false,
+  unreadCount: 0,
+  firstUnreadId: null,
+  sendMessage: vi.fn(),
+  retryMessage: vi.fn(),
+  loadOlder: vi.fn(),
+  toggleReaction: vi.fn(),
+  deleteMessage: vi.fn(),
+  onInputActivity: vi.fn(),
+  markRead: vi.fn(),
+  ...overrides,
+})
+
+/** A runtime where editing is allowed, so the shortcut has something to find. */
+const editable = (overrides: Partial<F0ChatRuntime> = {}) =>
+  makeRuntime({ editMessage: vi.fn(), editWindowMs: 60_000, ...overrides })
+
+const renderChat = (runtime: F0ChatRuntime) =>
+  render(
+    <F0ChatProvider runtime={runtime}>
+      <F0Chat />
+    </F0ChatProvider>
+  )
+
+const composer = () => screen.getByPlaceholderText(/write something here/i)
+
+const pressArrowUp = async () => {
+  await userEvent.click(composer())
+  await userEvent.keyboard("{ArrowUp}")
+}
+
+describe("F0Chat arrow-up editing", () => {
+  it("reopens my last message for editing from an empty composer", async () => {
+    renderChat(editable())
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("Hi back")
+    expect(
+      screen.getByRole("button", { name: /cancel edit/i })
+    ).toBeInTheDocument()
+  })
+
+  it("saves the reopened message through editMessage", async () => {
+    const editMessage = vi.fn()
+    renderChat(editable({ editMessage }))
+    await pressArrowUp()
+
+    await userEvent.type(composer(), " again")
+    await userEvent.click(screen.getByRole("button", { name: /^Save$/i }))
+
+    expect(editMessage).toHaveBeenCalledWith(
+      "m2",
+      expect.objectContaining({ body: "Hi back again" })
+    )
+  })
+
+  it("leaves arrow-up alone once the composer has text", async () => {
+    renderChat(editable())
+    await userEvent.type(composer(), "draft")
+    await userEvent.keyboard("{ArrowUp}")
+
+    expect(composer()).toHaveValue("draft")
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("leaves arrow-up alone while a reply quote is pending", async () => {
+    renderChat(editable())
+    const menus = screen.getAllByRole("button", { name: /message actions/i })
+    await userEvent.click(menus[0])
+    await userEvent.click(screen.getByRole("button", { name: /^Reply$/i }))
+    await pressArrowUp()
+
+    expect(
+      screen.getByRole("button", { name: /remove quote/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("does nothing when the host provides no editMessage", async () => {
+    renderChat(makeRuntime())
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("")
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("never reopens someone else's message", async () => {
+    // Only their message is left, and a moderator capability would let the menu
+    // edit it — the shortcut must still find nothing.
+    renderChat(
+      editable({
+        messages: [theirs],
+        capabilities: { canEditMessage: () => true },
+      })
+    )
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("")
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("skips a message that can no longer be edited and takes the previous one", async () => {
+    const older: F0ChatMessage = { ...mine, id: "m0", body: "Older of mine" }
+    renderChat(
+      editable({
+        messages: [older, mine],
+        capabilities: { canEditMessage: (message) => message.id !== "m2" },
+      })
+    )
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("Older of mine")
+  })
+
+  it("is not offered once my last message is past the edit window", async () => {
+    const old = new Date(Date.now() - 60 * 60 * 1000).toISOString()
+    renderChat(
+      editable({ messages: [{ ...mine, createdAt: old }], editWindowMs: 5000 })
+    )
+    await pressArrowUp()
+
+    expect(composer()).toHaveValue("")
+  })
+})
+
+describe("F0Chat double-click reply", () => {
+  it("quotes someone else's message and focuses the composer", async () => {
+    renderChat(makeRuntime())
+    await userEvent.dblClick(screen.getByText("Hello there"))
+
+    expect(
+      screen.getByRole("button", { name: /remove quote/i })
+    ).toBeInTheDocument()
+    await waitFor(() => expect(composer()).toHaveFocus())
+  })
+
+  it("quotes my own message too", async () => {
+    renderChat(makeRuntime())
+    await userEvent.dblClick(screen.getByText("Hi back"))
+
+    expect(
+      screen.getByRole("button", { name: /remove quote/i })
+    ).toBeInTheDocument()
+  })
+
+  it("replaces an edit in progress with the quote", async () => {
+    renderChat(editable())
+    await pressArrowUp()
+    expect(composer()).toHaveValue("Hi back")
+
+    await userEvent.dblClick(screen.getByText("Hello there"))
+
+    expect(
+      screen.getByRole("button", { name: /remove quote/i })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /cancel edit/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("ignores a double-click on a deleted message", async () => {
+    renderChat(makeRuntime({ messages: [{ ...theirs, deleted: true }, mine] }))
+    await userEvent.dblClick(screen.getByText(/message deleted/i))
+
+    expect(
+      screen.queryByRole("button", { name: /remove quote/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("leaves an interactive attachment to its own action", async () => {
+    renderChat(
+      makeRuntime({
+        messages: [
+          {
+            ...theirs,
+            body: "",
+            attachments: [
+              {
+                kind: "image",
+                url: "https://example.test/a.png",
+                name: "a.png",
+              },
+            ],
+          },
+        ],
+      })
+    )
+    await userEvent.dblClick(screen.getByTestId("chat-image-attachment"))
+
+    expect(
+      screen.queryByRole("button", { name: /remove quote/i })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -37,17 +37,20 @@ import {
 import { useTransientError } from "../hooks/useTransientError"
 import { useChatRenderConfig } from "../providers/ChatRenderConfigProvider"
 import {
+  useChatComposeTarget,
   useChatDrop,
   useChatEdit,
   useChatReply,
 } from "../providers/ChatUIProvider"
 import { useF0Chat } from "../providers/F0ChatProvider"
 import {
+  isUserMessage,
   type F0ChatAttachment,
   type F0ChatFileAttachment,
   type F0ChatImageAttachment,
 } from "../types"
 import { formatFileSize } from "../utils/attachments"
+import { canEditChatMessage } from "../utils/message-permissions"
 import {
   EASE_OUT_SWIFT,
   layoutTransition,
@@ -102,8 +105,10 @@ const localAttachmentFromFile = (
 export const ChatComposer = (): ReactNode => {
   const i18n = useI18n()
   const {
+    messages,
     sendMessage,
     editMessage,
+    editWindowMs,
     onInputActivity,
     stopTyping,
     uploadFiles,
@@ -120,6 +125,7 @@ export const ChatComposer = (): ReactNode => {
   const canUpload = !!uploadFiles && capabilities?.canUpload !== false
   const { replyTo, setReplyTo } = useChatReply()
   const { editingMessage, setEditingMessage } = useChatEdit()
+  const { startEdit } = useChatComposeTarget()
   const { registerFileDropHandler } = useChatDrop()
   const { reducedMotion: shouldReduceMotion } = useChatRenderConfig()
 
@@ -563,6 +569,45 @@ export const ChatComposer = (): ReactNode => {
     releaseUploadingPreviews,
   ])
 
+  // A new reply target (the actions menu, or a double-click on a message) hands
+  // focus to the composer — a quote is only useful with the caret ready to
+  // type. One frame later, so the chip has grown the composer first.
+  useEffect(() => {
+    if (!replyTo) return
+    const frame = requestAnimationFrame(() => {
+      const node = textareaRef.current
+      if (!node) return
+      node.focus()
+      const end = node.value.length
+      node.setSelectionRange(end, end)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [replyTo])
+
+  // Reopen your newest still-editable message. The transcript runs oldest →
+  // newest, so scan backwards; skip messages that can no longer be edited (a
+  // voice note, one past the edit window) and take the next one down. Own
+  // messages only, even where a host capability allows editing other people's:
+  // a shortcut fires blind, and must never open someone else's message.
+  const startEditingLastOwnMessage = useCallback(() => {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const item = messages[i]
+      if (!isUserMessage(item) || !item.isMine) continue
+      if (
+        !canEditChatMessage(item, {
+          hasEditMessage: !!editMessage,
+          capabilities,
+          editWindowMs,
+        })
+      ) {
+        continue
+      }
+      startEdit(item)
+      return true
+    }
+    return false
+  }, [messages, editMessage, capabilities, editWindowMs, startEdit])
+
   const handleSend = useCallback(() => {
     if (!canSend) return
     // Typing stopped by definition — the message is out (or the edit saved).
@@ -650,6 +695,28 @@ export const ChatComposer = (): ReactNode => {
         cancelEdit()
         return
       }
+      // ↑ on an idle, empty composer reopens your last message for editing.
+      // Anything else in the composer keeps ↑ meaning "move the caret": text,
+      // an attachment, a pending quote (the user is mid-reply), a live
+      // recording. A modifier is a text-selection/navigation gesture, never
+      // this shortcut. When there is nothing editable left, ↑ falls through.
+      if (
+        e.key === "ArrowUp" &&
+        !e.shiftKey &&
+        !e.altKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !isEditing &&
+        !replyTo &&
+        value === "" &&
+        attachments.length === 0 &&
+        !isRecording &&
+        !isTranscribing &&
+        startEditingLastOwnMessage()
+      ) {
+        e.preventDefault()
+        return
+      }
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault()
         handleSend()
@@ -661,6 +728,12 @@ export const ChatComposer = (): ReactNode => {
       mentions,
       isEditing,
       cancelEdit,
+      replyTo,
+      value,
+      attachments.length,
+      isRecording,
+      isTranscribing,
+      startEditingLastOwnMessage,
     ]
   )
 

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -243,8 +243,6 @@ export const ChatComposer = (): ReactNode => {
   // Partials stream into the textarea, appended to whatever was already typed.
   // The grid sizer in ChatTextareaField auto-grows the box, so no manual height.
   const baseValueRef = useRef("")
-  // Read inside the async recorder start, which must see the latest text
-  // rather than the value captured when the mic was pressed.
   const valueRef = useRef(value)
   valueRef.current = value
   const fillFromTranscript = useCallback((text: string) => {
@@ -323,11 +321,9 @@ export const ChatComposer = (): ReactNode => {
     !isUploading &&
     !isSendingVoiceNote
 
-  // Nothing in the composer to lose and no capture in flight — the only state
-  // in which ↑ may take over the key. `value === ""` rather than a trimmed
-  // check: with any character present ↑ has a caret meaning the user may be
-  // relying on, and stealing a key that already does something is worse than a
-  // missed shortcut.
+  // `value === ""`, not trimmed: with any character present ↑ already moves the
+  // caret, and stealing a key that does something is worse than a missed
+  // shortcut.
   const isComposerIdle =
     value === "" &&
     attachments.length === 0 &&
@@ -525,8 +521,7 @@ export const ChatComposer = (): ReactNode => {
   const editingMessage = target.kind === "edit" ? target.message : null
   const replyTo = target.kind === "reply" ? target.message : null
 
-  // Empty the composer: text, attachments and seeded mentions. Does NOT touch
-  // the target — the provider owns that, and calling back into it here would
+  // Must not touch the target: the provider owns it, and calling back would
   // recurse through `retarget`.
   const discardDraft = useCallback(() => {
     mentions.close()
@@ -542,8 +537,6 @@ export const ChatComposer = (): ReactNode => {
     attachments,
   ])
 
-  // Load a message into the composer: text, existing attachments (as ready
-  // chips) and its mentions.
   const loadEditDraft = useCallback(
     (message: F0ChatMessage) => {
       setValue(message.body)
@@ -580,22 +573,17 @@ export const ChatComposer = (): ReactNode => {
   const focusComposer = useCallback(() => {
     const node = textareaRef.current
     if (!node) return
-    // `preventScroll`: the panel can sit inside a longer host page, and taking
-    // a quote should never scroll it.
+    // preventScroll: the panel can sit in a longer host page, and taking a
+    // quote must not scroll it.
     node.focus({ preventScroll: true })
     const end = node.value.length
     node.setSelectionRange(end, end)
   }, [])
 
-  // How the composer follows the target. The provider calls this inside the
-  // user's gesture, so focus reaches the textarea in the same event (iOS only
-  // opens the keyboard for a focus inside a gesture) and the draft is reset
-  // before any paint.
   const retarget = useCallback(
     (previous: ChatComposeTarget, next: ChatComposeTarget) => {
       const leavingEdit = previous.kind === "edit" && next.kind !== "edit"
-      // Re-picking Edit on the message already open must not wipe what the user
-      // has typed into it.
+      // Re-picking Edit on the message already open must not wipe the typing.
       const sameEdit =
         previous.kind === "edit" &&
         next.kind === "edit" &&
@@ -613,19 +601,24 @@ export const ChatComposer = (): ReactNode => {
     [retarget, discardDraft]
   )
 
-  // Re-registered whenever the handle's closures change (`discardDraft` reads
-  // the current attachments).
-  useEffect(() => {
-    registerComposerHandle(handle)
-    return () => registerComposerHandle(null)
-  }, [registerComposerHandle, handle])
+  // Re-registers on closure change: `discardDraft` reads the current attachments.
+  useEffect(
+    function publishComposerHandle() {
+      registerComposerHandle(handle)
+      return () => registerComposerHandle(null)
+    },
+    [registerComposerHandle, handle]
+  )
 
-  // A target only means anything while a composer exists to hold its draft.
-  // The composer is unmounted on a read-only channel (see F0Chat), and a
-  // target that outlived it would come back to a fresh, EMPTY composer showing
-  // an edit chip — one Enter from blanking the message it points at. Releasing
-  // it here is why registration can stay a record of future transitions.
-  useEffect(() => clearComposeTarget, [clearComposeTarget])
+  // A read-only channel removes the composer. A target that outlived it would
+  // come back to an empty composer still showing an edit chip, and pressing
+  // Enter would then save that empty text over the message.
+  useEffect(
+    function releaseComposeTargetOnUnmount() {
+      return clearComposeTarget
+    },
+    [clearComposeTarget]
+  )
 
   const handleSend = useCallback(() => {
     if (!canSend) return
@@ -713,10 +706,9 @@ export const ChatComposer = (): ReactNode => {
         clearComposeTarget()
         return
       }
-      // ↑ on an idle, empty composer reopens your last message for editing.
-      // A modifier makes it a text-selection/navigation gesture, never this
-      // shortcut. When there is nothing editable left, ↑ falls through to its
-      // ordinary caret meaning — hence preventDefault only on a hit.
+      // A modifier makes ↑ a selection gesture, never this shortcut; and with
+      // nothing to reopen it must keep its caret meaning, hence preventDefault
+      // only on a hit.
       const isArrowUpShortcut =
         e.key === "ArrowUp" &&
         !e.shiftKey &&
@@ -744,18 +736,16 @@ export const ChatComposer = (): ReactNode => {
     ]
   )
 
-  // `recorder.start()` only reports "recording" AFTER the getUserMedia
-  // permission prompt resolves, so the composer stays idle-looking for as long
-  // as the prompt is open. `isStartingRecording` covers that window: without
-  // it, ↑ could load a message in the meantime and the first transcript partial
-  // would overwrite its body.
+  // `recorder.start()` reports "recording" only after the permission prompt
+  // resolves, so the composer looks idle while it is open — long enough for ↑
+  // to load a message the first transcript partial would then overwrite.
   const startRecording = useCallback(() => {
     setIsStartingRecording(true)
     void (async () => {
       try {
         await recorder.start()
-        // Captured here, not at button press: the transcript is appended to
-        // whatever the textarea holds once capture really starts.
+        // Captured at capture start, not at button press: the transcript is
+        // appended to whatever the textarea holds by then.
         baseValueRef.current = valueRef.current
       } catch {
         // The recorder reports its own failures through onError.
@@ -1071,10 +1061,9 @@ export const ChatComposer = (): ReactNode => {
                         }
                         icon={Microphone}
                         onClick={startRecording}
-                        // Spins while dictation transcribes or a voice note
-                        // uploads, and while the mic permission prompt is open —
-                        // a second press there opens a second getUserMedia and
-                        // orphans the first stream.
+                        // Includes the permission prompt: a second press
+                        // there opens a second getUserMedia and orphans the
+                        // first stream.
                         loading={
                           isStartingRecording ||
                           isTranscribing ||

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -29,28 +29,25 @@ import {
   replaceClosedEmojiShortcode,
   useEmojiAutocomplete,
 } from "../hooks/useEmojiAutocomplete"
-import {
-  MENTION_EVERYONE_ID,
-  type MentionEntry,
-  useMentions,
-} from "../hooks/useMentions"
+import { MENTION_EVERYONE_ID, useMentions } from "../hooks/useMentions"
+import { useEditLastOwnMessage } from "../hooks/useEditLastOwnMessage"
 import { useTransientError } from "../hooks/useTransientError"
 import { useChatRenderConfig } from "../providers/ChatRenderConfigProvider"
 import {
+  useChatComposeActions,
   useChatComposeTarget,
   useChatDrop,
-  useChatEdit,
-  useChatReply,
+  type ChatComposeTarget,
+  type ChatComposerHandle,
 } from "../providers/ChatUIProvider"
 import { useF0Chat } from "../providers/F0ChatProvider"
 import {
-  isUserMessage,
   type F0ChatAttachment,
   type F0ChatFileAttachment,
   type F0ChatImageAttachment,
+  type F0ChatMessage,
 } from "../types"
 import { formatFileSize } from "../utils/attachments"
-import { canEditChatMessage } from "../utils/message-permissions"
 import {
   EASE_OUT_SWIFT,
   layoutTransition,
@@ -105,10 +102,8 @@ const localAttachmentFromFile = (
 export const ChatComposer = (): ReactNode => {
   const i18n = useI18n()
   const {
-    messages,
     sendMessage,
     editMessage,
-    editWindowMs,
     onInputActivity,
     stopTyping,
     uploadFiles,
@@ -123,15 +118,16 @@ export const ChatComposer = (): ReactNode => {
   // Uploads need both the runtime hook AND the capability (a frozen channel
   // can forbid attachments even when the transport could upload them).
   const canUpload = !!uploadFiles && capabilities?.canUpload !== false
-  const { replyTo, setReplyTo } = useChatReply()
-  const { editingMessage, setEditingMessage } = useChatEdit()
-  const { startEdit } = useChatComposeTarget()
+  const { target } = useChatComposeTarget()
+  const { clearComposeTarget, registerComposerHandle } = useChatComposeActions()
+  const editLastOwnMessage = useEditLastOwnMessage()
   const { registerFileDropHandler } = useChatDrop()
   const { reducedMotion: shouldReduceMotion } = useChatRenderConfig()
 
   const [value, setValue] = useState("")
   const [cursorPosition, setCursorPosition] = useState(0)
   const [attachments, setAttachments] = useState<PendingAttachment[]>([])
+  const [isStartingRecording, setIsStartingRecording] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const highlightRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -247,6 +243,10 @@ export const ChatComposer = (): ReactNode => {
   // Partials stream into the textarea, appended to whatever was already typed.
   // The grid sizer in ChatTextareaField auto-grows the box, so no manual height.
   const baseValueRef = useRef("")
+  // Read inside the async recorder start, which must see the latest text
+  // rather than the value captured when the mic was pressed.
+  const valueRef = useRef(value)
+  valueRef.current = value
   const fillFromTranscript = useCallback((text: string) => {
     const base = baseValueRef.current
     const next = base ? `${base} ${text}` : text
@@ -321,6 +321,20 @@ export const ChatComposer = (): ReactNode => {
     (value.trim().length > 0 || attachments.length > 0) &&
     !isTranscribing &&
     !isUploading &&
+    !isSendingVoiceNote
+
+  // Nothing in the composer to lose and no capture in flight — the only state
+  // in which ↑ may take over the key. `value === ""` rather than a trimmed
+  // check: with any character present ↑ has a caret meaning the user may be
+  // relying on, and stealing a key that already does something is worse than a
+  // missed shortcut.
+  const isComposerIdle =
+    value === "" &&
+    attachments.length === 0 &&
+    target.kind === "none" &&
+    !isStartingRecording &&
+    !isRecording &&
+    !isTranscribing &&
     !isSendingVoiceNote
 
   // Activation pop for the send button: bump only on the false→true boundary
@@ -507,11 +521,14 @@ export const ChatComposer = (): ReactNode => {
     [canUpload, handleUpload]
   )
 
-  const isEditing = editingMessage !== null
+  const isEditing = target.kind === "edit"
+  const editingMessage = target.kind === "edit" ? target.message : null
+  const replyTo = target.kind === "reply" ? target.message : null
 
-  // Cancel an in-progress edit: drop the edit target and reset the composer.
-  const cancelEdit = useCallback(() => {
-    setEditingMessage(null)
+  // Empty the composer: text, attachments and seeded mentions. Does NOT touch
+  // the target — the provider owns that, and calling back into it here would
+  // recurse through `retarget`.
+  const discardDraft = useCallback(() => {
     mentions.close()
     mentions.seedMentions([])
     setValue("")
@@ -519,94 +536,96 @@ export const ChatComposer = (): ReactNode => {
     releaseUploadingPreviews(attachments)
     setAttachments([])
   }, [
-    setEditingMessage,
     mentions.close,
     mentions.seedMentions,
     releaseUploadingPreviews,
     attachments,
   ])
 
-  // Entering edit mode reloads the message into the composer — text, existing
-  // attachments (as ready chips) and its mentions — then focuses at the end.
-  useEffect(() => {
-    if (!editingMessage) return
-    setValue(editingMessage.body)
-    setCursorPosition(editingMessage.body.length)
-    setAttachments((prev) => {
-      releaseUploadingPreviews(prev)
-      return (editingMessage.attachments ?? []).map((attachment) => ({
-        id: `att-${attachmentSeq.current++}`,
-        status: "ready" as const,
-        attachment,
-      }))
-    })
-    const entries: MentionEntry[] = [
-      ...(editingMessage.mentions ?? []).map((m) => ({
-        id: m.id,
-        name: m.name,
-        avatar: m.avatar,
-        subtitle: m.subtitle,
-        profileHref: m.profileHref,
-      })),
-      ...(editingMessage.mentionedEveryone && channel.type === "group"
-        ? [{ id: MENTION_EVERYONE_ID, name: i18n.chat.mentionEveryone }]
-        : []),
+  // Load a message into the composer: text, existing attachments (as ready
+  // chips) and its mentions.
+  const loadEditDraft = useCallback(
+    (message: F0ChatMessage) => {
+      setValue(message.body)
+      setCursorPosition(message.body.length)
+      setAttachments((prev) => {
+        releaseUploadingPreviews(prev)
+        return (message.attachments ?? []).map((attachment) => ({
+          id: `att-${attachmentSeq.current++}`,
+          status: "ready" as const,
+          attachment,
+        }))
+      })
+      mentions.seedMentions([
+        ...(message.mentions ?? []).map((m) => ({
+          id: m.id,
+          name: m.name,
+          avatar: m.avatar,
+          subtitle: m.subtitle,
+          profileHref: m.profileHref,
+        })),
+        ...(message.mentionedEveryone && channel.type === "group"
+          ? [{ id: MENTION_EVERYONE_ID, name: i18n.chat.mentionEveryone }]
+          : []),
+      ])
+    },
+    [
+      channel.type,
+      i18n.chat.mentionEveryone,
+      mentions.seedMentions,
+      releaseUploadingPreviews,
     ]
-    mentions.seedMentions(entries)
-    requestAnimationFrame(() => {
-      const node = textareaRef.current
-      if (node) {
-        node.focus()
-        const end = editingMessage.body.length
-        node.setSelectionRange(end, end)
-      }
-    })
-  }, [
-    editingMessage,
-    channel.type,
-    i18n.chat.mentionEveryone,
-    mentions.seedMentions,
-    releaseUploadingPreviews,
-  ])
+  )
 
-  // A new reply target (the actions menu, or a double-click on a message) hands
-  // focus to the composer — a quote is only useful with the caret ready to
-  // type. One frame later, so the chip has grown the composer first.
+  const focusComposer = useCallback(() => {
+    const node = textareaRef.current
+    if (!node) return
+    // `preventScroll`: the panel can sit inside a longer host page, and taking
+    // a quote should never scroll it.
+    node.focus({ preventScroll: true })
+    const end = node.value.length
+    node.setSelectionRange(end, end)
+  }, [])
+
+  // How the composer follows the target. The provider calls this inside the
+  // user's gesture, so focus reaches the textarea in the same event (iOS only
+  // opens the keyboard for a focus inside a gesture) and the draft is reset
+  // before any paint.
+  const retarget = useCallback(
+    (previous: ChatComposeTarget, next: ChatComposeTarget) => {
+      const leavingEdit = previous.kind === "edit" && next.kind !== "edit"
+      // Re-picking Edit on the message already open must not wipe what the user
+      // has typed into it.
+      const sameEdit =
+        previous.kind === "edit" &&
+        next.kind === "edit" &&
+        previous.message.id === next.message.id
+
+      if (leavingEdit) discardDraft()
+      if (next.kind === "edit" && !sameEdit) loadEditDraft(next.message)
+      if (next.kind !== "none") focusComposer()
+    },
+    [discardDraft, loadEditDraft, focusComposer]
+  )
+
+  const handle = useMemo<ChatComposerHandle>(
+    () => ({ retarget, abandonDraft: discardDraft }),
+    [retarget, discardDraft]
+  )
+
+  // Re-registered whenever the handle's closures change (`discardDraft` reads
+  // the current attachments).
   useEffect(() => {
-    if (!replyTo) return
-    const frame = requestAnimationFrame(() => {
-      const node = textareaRef.current
-      if (!node) return
-      node.focus()
-      const end = node.value.length
-      node.setSelectionRange(end, end)
-    })
-    return () => cancelAnimationFrame(frame)
-  }, [replyTo])
+    registerComposerHandle(handle)
+    return () => registerComposerHandle(null)
+  }, [registerComposerHandle, handle])
 
-  // Reopen your newest still-editable message. The transcript runs oldest →
-  // newest, so scan backwards; skip messages that can no longer be edited (a
-  // voice note, one past the edit window) and take the next one down. Own
-  // messages only, even where a host capability allows editing other people's:
-  // a shortcut fires blind, and must never open someone else's message.
-  const startEditingLastOwnMessage = useCallback(() => {
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const item = messages[i]
-      if (!isUserMessage(item) || !item.isMine) continue
-      if (
-        !canEditChatMessage(item, {
-          hasEditMessage: !!editMessage,
-          capabilities,
-          editWindowMs,
-        })
-      ) {
-        continue
-      }
-      startEdit(item)
-      return true
-    }
-    return false
-  }, [messages, editMessage, capabilities, editWindowMs, startEdit])
+  // A target only means anything while a composer exists to hold its draft.
+  // The composer is unmounted on a read-only channel (see F0Chat), and a
+  // target that outlived it would come back to a fresh, EMPTY composer showing
+  // an edit chip — one Enter from blanking the message it points at. Releasing
+  // it here is why registration can stay a record of future transitions.
+  useEffect(() => clearComposeTarget, [clearComposeTarget])
 
   const handleSend = useCallback(() => {
     if (!canSend) return
@@ -626,7 +645,7 @@ export const ChatComposer = (): ReactNode => {
         mentions: mentioned.length > 0 ? mentioned : undefined,
         mentionedEveryone: mentionedEveryone || undefined,
       })
-      cancelEdit()
+      clearComposeTarget()
       return
     }
 
@@ -641,19 +660,18 @@ export const ChatComposer = (): ReactNode => {
     setValue("")
     setCursorPosition(0)
     setAttachments([])
-    setReplyTo(null)
+    clearComposeTarget()
   }, [
     attachments,
     canSend,
     mentions,
     replyTo,
     sendMessage,
-    setReplyTo,
+    clearComposeTarget,
     stopTyping,
     value,
     editingMessage,
     editMessage,
-    cancelEdit,
   ])
 
   // Insert a picked emoji at the caret (the textarea keeps its selection while
@@ -692,28 +710,21 @@ export const ChatComposer = (): ReactNode => {
       // Escape backs out of an edit (when the popover didn't claim it).
       if (e.key === "Escape" && isEditing) {
         e.preventDefault()
-        cancelEdit()
+        clearComposeTarget()
         return
       }
       // ↑ on an idle, empty composer reopens your last message for editing.
-      // Anything else in the composer keeps ↑ meaning "move the caret": text,
-      // an attachment, a pending quote (the user is mid-reply), a live
-      // recording. A modifier is a text-selection/navigation gesture, never
-      // this shortcut. When there is nothing editable left, ↑ falls through.
-      if (
+      // A modifier makes it a text-selection/navigation gesture, never this
+      // shortcut. When there is nothing editable left, ↑ falls through to its
+      // ordinary caret meaning — hence preventDefault only on a hit.
+      const isArrowUpShortcut =
         e.key === "ArrowUp" &&
         !e.shiftKey &&
         !e.altKey &&
         !e.metaKey &&
         !e.ctrlKey &&
-        !isEditing &&
-        !replyTo &&
-        value === "" &&
-        attachments.length === 0 &&
-        !isRecording &&
-        !isTranscribing &&
-        startEditingLastOwnMessage()
-      ) {
+        isComposerIdle
+      if (isArrowUpShortcut && editLastOwnMessage()) {
         e.preventDefault()
         return
       }
@@ -727,20 +738,32 @@ export const ChatComposer = (): ReactNode => {
       handleEmojiAutocompleteKeyDown,
       mentions,
       isEditing,
-      cancelEdit,
-      replyTo,
-      value,
-      attachments.length,
-      isRecording,
-      isTranscribing,
-      startEditingLastOwnMessage,
+      clearComposeTarget,
+      isComposerIdle,
+      editLastOwnMessage,
     ]
   )
 
+  // `recorder.start()` only reports "recording" AFTER the getUserMedia
+  // permission prompt resolves, so the composer stays idle-looking for as long
+  // as the prompt is open. `isStartingRecording` covers that window: without
+  // it, ↑ could load a message in the meantime and the first transcript partial
+  // would overwrite its body.
   const startRecording = useCallback(() => {
-    baseValueRef.current = value
-    void recorder.start()
-  }, [recorder, value])
+    setIsStartingRecording(true)
+    void (async () => {
+      try {
+        await recorder.start()
+        // Captured here, not at button press: the transcript is appended to
+        // whatever the textarea holds once capture really starts.
+        baseValueRef.current = valueRef.current
+      } catch {
+        // The recorder reports its own failures through onError.
+      } finally {
+        setIsStartingRecording(false)
+      }
+    })()
+  }, [recorder])
 
   const placeholder = i18n.chat.placeholder
 
@@ -790,7 +813,10 @@ export const ChatComposer = (): ReactNode => {
                   ease: EASE_OUT_SWIFT,
                 }}
               >
-                <ChatEditChip message={editingMessage} onRemove={cancelEdit} />
+                <ChatEditChip
+                  message={editingMessage}
+                  onRemove={clearComposeTarget}
+                />
               </motion.div>
             ) : replyTo ? (
               <motion.div
@@ -806,7 +832,7 @@ export const ChatComposer = (): ReactNode => {
               >
                 <ChatReplyChip
                   message={replyTo}
-                  onRemove={() => setReplyTo(null)}
+                  onRemove={clearComposeTarget}
                 />
               </motion.div>
             ) : null}
@@ -1045,8 +1071,15 @@ export const ChatComposer = (): ReactNode => {
                         }
                         icon={Microphone}
                         onClick={startRecording}
-                        // Spins while dictation transcribes or a voice note uploads.
-                        loading={isTranscribing || isSendingVoiceNote}
+                        // Spins while dictation transcribes or a voice note
+                        // uploads, and while the mic permission prompt is open —
+                        // a second press there opens a second getUserMedia and
+                        // orphans the first stream.
+                        loading={
+                          isStartingRecording ||
+                          isTranscribing ||
+                          isSendingVoiceNote
+                        }
                       />
                     )}
                     {/* The send button fades on ACTIVATION (boundary flip of

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
@@ -19,7 +19,7 @@ import { cn, focusRing } from "@/lib/utils"
 import { Action } from "@/ui/Action"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
-import { useChatComposeTarget } from "../providers/ChatUIProvider"
+import { useChatComposeActions } from "../providers/ChatUIProvider"
 import { useF0ChatStable } from "../providers/F0ChatProvider"
 import { type F0ChatMessage } from "../types"
 import { canEditChatMessage } from "../utils/message-permissions"
@@ -87,7 +87,7 @@ export const ChatMessageActions = ({
     retryMessage,
     capabilities,
   } = useF0ChatStable()
-  const { startReply, startEdit } = useChatComposeTarget()
+  const { startReply, startEdit } = useChatComposeActions()
   const [view, setView] = useState<"menu" | "info">("menu")
 
   // Same policy the composer's edit-last shortcut uses — see canEditChatMessage.

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
@@ -19,9 +19,10 @@ import { cn, focusRing } from "@/lib/utils"
 import { Action } from "@/ui/Action"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
-import { useChatEdit, useChatReply } from "../providers/ChatUIProvider"
+import { useChatComposeTarget } from "../providers/ChatUIProvider"
 import { useF0ChatStable } from "../providers/F0ChatProvider"
 import { type F0ChatMessage } from "../types"
+import { canEditChatMessage } from "../utils/message-permissions"
 import { formatClock } from "../utils/natural-time"
 import { ChatMessageInfoView } from "./ChatMessageInfo"
 
@@ -86,29 +87,16 @@ export const ChatMessageActions = ({
     retryMessage,
     capabilities,
   } = useF0ChatStable()
-  const { setReplyTo } = useChatReply()
-  const { setEditingMessage } = useChatEdit()
+  const { startReply, startEdit } = useChatComposeTarget()
   const [view, setView] = useState<"menu" | "info">("menu")
 
-  // Editing is offered on non-deleted messages while the host allows it
-  // (provides `editMessage`). The POLICY (whose messages, for how long) comes
-  // from `capabilities.canEditMessage` when provided, else the default: own
-  // messages within the edit window.
-  // `Date.now()` here is fine: the popover content only mounts when open.
-  const withinEditWindow =
-    editWindowMs == null ||
-    Date.now() - new Date(message.createdAt).getTime() <= editWindowMs
-  // Voice notes can't be edited (there's no text to change) — only deleted.
-  const isVoiceNote = (message.attachments ?? []).some(
-    (attachment) => attachment.kind === "voice"
-  )
-  const canEdit =
-    !message.deleted &&
-    !isVoiceNote &&
-    !!editMessage &&
-    (capabilities?.canEditMessage
-      ? capabilities.canEditMessage(message)
-      : isMine && withinEditWindow)
+  // Same policy the composer's edit-last shortcut uses — see canEditChatMessage.
+  // Its `Date.now()` is fine here: the popover content only mounts when open.
+  const canEdit = canEditChatMessage(message, {
+    hasEditMessage: !!editMessage,
+    capabilities,
+    editWindowMs,
+  })
   // Delete policy: capability override, else own messages only.
   const canDelete = capabilities?.canDeleteMessage
     ? capabilities.canDeleteMessage(message)
@@ -241,10 +229,7 @@ export const ChatMessageActions = ({
               <MenuItem
                 icon={Reply}
                 label={i18n.chat.reply}
-                onClick={runAndClose(() => {
-                  setEditingMessage(null)
-                  setReplyTo(message)
-                })}
+                onClick={runAndClose(() => startReply(message))}
               />
               <MenuItem
                 icon={Files}
@@ -262,10 +247,7 @@ export const ChatMessageActions = ({
                     <MenuItem
                       icon={Pencil}
                       label={i18n.chat.edit}
-                      onClick={runAndClose(() => {
-                        setReplyTo(null)
-                        setEditingMessage(message)
-                      })}
+                      onClick={runAndClose(() => startEdit(message))}
                     />
                   )}
                   {canDelete && (

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
@@ -128,6 +128,10 @@ export const ChatMessageAttachments = ({
 
   return (
     <div
+      // Marks the whole column as owning its own clicks — see
+      // SELF_HANDLING_DESCENDANTS in ChatMessageItem. Placeholders and mounted
+      // previews must behave the same, and a placeholder is not focusable.
+      data-chat-attachments=""
       className={cn(
         // w-full gives the column a definite width so the cards' `max-w-full`
         // resolves against real space (fit-content would ignore it and lock the

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
@@ -128,9 +128,9 @@ export const ChatMessageAttachments = ({
 
   return (
     <div
-      // Marks the whole column as owning its own clicks — see
-      // SELF_HANDLING_DESCENDANTS in ChatMessageItem. Placeholders and mounted
-      // previews must behave the same, and a placeholder is not focusable.
+      // Read by SELF_HANDLING_DESCENDANTS in ChatMessageItem: a deferred
+      // placeholder is not focusable, and must not quote where the mounted
+      // preview would not.
       data-chat-attachments=""
       className={cn(
         // w-full gives the column a definite width so the cards' `max-w-full`

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
@@ -160,7 +160,6 @@ export const ChatMessageItem = ({
     message.status !== "sending" &&
     message.status !== "failed"
 
-  // Focusing the composer clears the word the double-click selected.
   const handleDoubleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (!canQuote) return

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
@@ -15,7 +15,7 @@ import { cn } from "@/lib/utils"
 
 import { useChatRenderConfig } from "../providers/ChatRenderConfigProvider"
 import {
-  useChatComposeTarget,
+  useChatComposeActions,
   useChatHighlightedId,
 } from "../providers/ChatUIProvider"
 import { useF0ChatStable } from "../providers/F0ChatProvider"
@@ -32,10 +32,36 @@ import { SendingClock } from "./ChatMessageStatusIcon"
 const ARM_ACTIONS_ON_HOVER_MS = 150
 
 /** Descendants that own their own activation, so a double-click landing on one
- * must not also quote the message: the image lightbox, a file download, the
- * reply-quote jump, an autolinked URL. */
-const INTERACTIVE_DESCENDANTS =
-  'a, button, input, textarea, select, [role="button"], [role="link"]'
+ * must not also quote the message: attachment buttons, the reply-quote jump, an
+ * autolinked URL, the voice waveform, the inline video.
+ *
+ * Focusability rather than an element list: anything interactive inside a
+ * bubble carries a role or a tabindex, so the rule survives new attachment
+ * types. The consequence, which no test can catch: putting a tabindex on the
+ * ROW or the bubble (a roving-tabindex transcript) would make every message
+ * unquotable — only descendants may match, which is what `stopAt` below
+ * enforces. */
+const SELF_HANDLING_DESCENDANTS =
+  "a, button, input, textarea, select, video, audio, summary," +
+  ' [role="button"], [role="link"], [role="slider"], [contenteditable="true"],' +
+  ' [tabindex]:not([tabindex="-1"]), [data-chat-attachments]'
+
+/**
+ * Whether a double-clicked node sits inside something that handles its own
+ * activation. Walks up only as far as `stopAt` (the message's own wrapper):
+ * `closest` would climb past it and match the transcript viewport, which
+ * react-virtuoso renders with `tabIndex={0}` — that would make no message
+ * quotable at all. A node that never reaches `stopAt` came from a portal (a
+ * hover card): React routes its events here, but it is not part of this
+ * message, so it never quotes.
+ */
+const isSelfHandling = (target: Element, stopAt: Element): boolean => {
+  for (let node: Element | null = target; node; node = node.parentElement) {
+    if (node === stopAt) return false
+    if (node.matches(SELF_HANDLING_DESCENDANTS)) return true
+  }
+  return true
+}
 
 /** One message: bubble (with any reply quote nested inside) + reactions, with a
  * hover ellipsis menu. */
@@ -108,9 +134,9 @@ export const ChatMessageItem = ({
     actionsWrapperRef.current?.querySelector("button")?.focus()
   }, [actionsArmed])
   const { highlightedId } = useChatHighlightedId()
-  // Stable API (never re-renders this row when the target changes) — unlike the
-  // reply/edit VALUE contexts, which rows must stay out of.
-  const { startReply } = useChatComposeTarget()
+  // Stable API (never re-renders this row when the target changes) — unlike
+  // the compose-target VALUE context, which rows must stay out of.
+  const { startReply } = useChatComposeActions()
   // Stable slice — the full runtime context changes on every transport event
   // and would re-render every mounted row.
   const { currentUserId } = useF0ChatStable()
@@ -137,7 +163,8 @@ export const ChatMessageItem = ({
     Boolean(message.replyTo)
   const hasContent = hasBubble || hasAttachments
   // A tombstone has nothing to quote, and an unsettled message has no
-  // server-side id to point a reply at — the same rows that get no actions menu.
+  // server-side id to point a reply at. Same rows the menu offers no Reply on —
+  // note a failed message DOES get a menu, reduced to Retry / Delete.
   const canQuote =
     !message.deleted &&
     message.status !== "sending" &&
@@ -150,10 +177,7 @@ export const ChatMessageItem = ({
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (!canQuote) return
       if (!(event.target instanceof Element)) return
-      // Only a match INSIDE the message counts — `closest` would otherwise
-      // climb past this row into whatever chrome hosts the transcript.
-      const interactive = event.target.closest(INTERACTIVE_DESCENDANTS)
-      if (interactive && event.currentTarget.contains(interactive)) return
+      if (isSelfHandling(event.target, event.currentTarget)) return
       startReply(message)
     },
     [canQuote, message, startReply]
@@ -215,6 +239,7 @@ export const ChatMessageItem = ({
                 actionsOpen && "bg-f1-background-hover"
               )}
               onDoubleClick={handleDoubleClick}
+              data-testid="chat-message-surface"
             >
               {hasAttachments && (
                 <ChatMessageAttachments

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
@@ -31,29 +31,21 @@ import { SendingClock } from "./ChatMessageStatusIcon"
  * finish, well under the pointer travel time from row edge to the ellipsis. */
 const ARM_ACTIONS_ON_HOVER_MS = 150
 
-/** Descendants that own their own activation, so a double-click landing on one
- * must not also quote the message: attachment buttons, the reply-quote jump, an
- * autolinked URL, the voice waveform, the inline video.
- *
- * Focusability rather than an element list: anything interactive inside a
- * bubble carries a role or a tabindex, so the rule survives new attachment
- * types. The consequence, which no test can catch: putting a tabindex on the
- * ROW or the bubble (a roving-tabindex transcript) would make every message
- * unquotable — only descendants may match, which is what `stopAt` below
- * enforces. */
+/** Parts of a message that already do something when clicked, so a
+ * double-click on one must not also quote. The test is whether the element can
+ * take focus, not a list of tags, so new attachment types are covered — but a
+ * tabindex on the row or the bubble itself would stop every message quoting. */
 const SELF_HANDLING_DESCENDANTS =
   "a, button, input, textarea, select, video, audio, summary," +
   ' [role="button"], [role="link"], [role="slider"], [contenteditable="true"],' +
   ' [tabindex]:not([tabindex="-1"]), [data-chat-attachments]'
 
 /**
- * Whether a double-clicked node sits inside something that handles its own
- * activation. Walks up only as far as `stopAt` (the message's own wrapper):
- * `closest` would climb past it and match the transcript viewport, which
- * react-virtuoso renders with `tabIndex={0}` — that would make no message
- * quotable at all. A node that never reaches `stopAt` came from a portal (a
- * hover card): React routes its events here, but it is not part of this
- * message, so it never quotes.
+ * Searches up from the clicked element and stops at `stopAt`, the message's own
+ * wrapper. `closest` would keep going and match the scrolling container, which
+ * react-virtuoso gives `tabIndex={0}`, so nothing would ever quote. An element
+ * that never reaches `stopAt` is in a popover: React sends its events here, but
+ * it does not belong to this message.
  */
 const isSelfHandling = (target: Element, stopAt: Element): boolean => {
   for (let node: Element | null = target; node; node = node.parentElement) {
@@ -134,8 +126,7 @@ export const ChatMessageItem = ({
     actionsWrapperRef.current?.querySelector("button")?.focus()
   }, [actionsArmed])
   const { highlightedId } = useChatHighlightedId()
-  // Stable API (never re-renders this row when the target changes) — unlike
-  // the compose-target VALUE context, which rows must stay out of.
+  // Not the VALUE context: that would re-render the row on every target change.
   const { startReply } = useChatComposeActions()
   // Stable slice — the full runtime context changes on every transport event
   // and would re-render every mounted row.
@@ -162,17 +153,14 @@ export const ChatMessageItem = ({
     message.body.trim().length > 0 ||
     Boolean(message.replyTo)
   const hasContent = hasBubble || hasAttachments
-  // A tombstone has nothing to quote, and an unsettled message has no
-  // server-side id to point a reply at. Same rows the menu offers no Reply on —
-  // note a failed message DOES get a menu, reduced to Retry / Delete.
+  // A deleted message has nothing to quote, and one that has not been sent
+  // yet has no server id for a reply to point at.
   const canQuote =
     !message.deleted &&
     message.status !== "sending" &&
     message.status !== "failed"
 
-  // Double-clicking a message quotes it in the composer — a shortcut for the
-  // menu's Reply, on anyone's message including your own. The word selection
-  // the double-click makes is dropped when the composer takes focus.
+  // Focusing the composer clears the word the double-click selected.
   const handleDoubleClick = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
       if (!canQuote) return

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
@@ -14,7 +14,10 @@ import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
 import { useChatRenderConfig } from "../providers/ChatRenderConfigProvider"
-import { useChatHighlightedId } from "../providers/ChatUIProvider"
+import {
+  useChatComposeTarget,
+  useChatHighlightedId,
+} from "../providers/ChatUIProvider"
 import { useF0ChatStable } from "../providers/F0ChatProvider"
 import { type F0ChatMessage, type F0ChatUser } from "../types"
 import { microEnterTransition } from "../utils/chat-motion"
@@ -27,6 +30,12 @@ import { SendingClock } from "./ChatMessageStatusIcon"
 /** See armActionsSoon: long enough for a click burst on the placeholder to
  * finish, well under the pointer travel time from row edge to the ellipsis. */
 const ARM_ACTIONS_ON_HOVER_MS = 150
+
+/** Descendants that own their own activation, so a double-click landing on one
+ * must not also quote the message: the image lightbox, a file download, the
+ * reply-quote jump, an autolinked URL. */
+const INTERACTIVE_DESCENDANTS =
+  'a, button, input, textarea, select, [role="button"], [role="link"]'
 
 /** One message: bubble (with any reply quote nested inside) + reactions, with a
  * hover ellipsis menu. */
@@ -99,6 +108,9 @@ export const ChatMessageItem = ({
     actionsWrapperRef.current?.querySelector("button")?.focus()
   }, [actionsArmed])
   const { highlightedId } = useChatHighlightedId()
+  // Stable API (never re-renders this row when the target changes) — unlike the
+  // reply/edit VALUE contexts, which rows must stay out of.
+  const { startReply } = useChatComposeTarget()
   // Stable slice — the full runtime context changes on every transport event
   // and would re-render every mounted row.
   const { currentUserId } = useF0ChatStable()
@@ -124,6 +136,28 @@ export const ChatMessageItem = ({
     message.body.trim().length > 0 ||
     Boolean(message.replyTo)
   const hasContent = hasBubble || hasAttachments
+  // A tombstone has nothing to quote, and an unsettled message has no
+  // server-side id to point a reply at — the same rows that get no actions menu.
+  const canQuote =
+    !message.deleted &&
+    message.status !== "sending" &&
+    message.status !== "failed"
+
+  // Double-clicking a message quotes it in the composer — a shortcut for the
+  // menu's Reply, on anyone's message including your own. The word selection
+  // the double-click makes is dropped when the composer takes focus.
+  const handleDoubleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (!canQuote) return
+      if (!(event.target instanceof Element)) return
+      // Only a match INSIDE the message counts — `closest` would otherwise
+      // climb past this row into whatever chrome hosts the transcript.
+      const interactive = event.target.closest(INTERACTIVE_DESCENDANTS)
+      if (interactive && event.currentTarget.contains(interactive)) return
+      startReply(message)
+    },
+    [canQuote, message, startReply]
+  )
 
   return (
     <div
@@ -180,6 +214,7 @@ export const ChatMessageItem = ({
                   "group-hover:bg-f1-background-secondary focus-within:bg-f1-background-secondary",
                 actionsOpen && "bg-f1-background-hover"
               )}
+              onDoubleClick={handleDoubleClick}
             >
               {hasAttachments && (
                 <ChatMessageAttachments

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEditLastOwnMessage.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEditLastOwnMessage.ts
@@ -1,0 +1,103 @@
+import { useCallback, useRef } from "react"
+
+import { useChatComposeActions } from "../providers/ChatUIProvider"
+import { useF0Chat } from "../providers/F0ChatProvider"
+import {
+  isUserMessage,
+  type F0ChatCapabilities,
+  type F0ChatItem,
+  type F0ChatMessage,
+} from "../types"
+import { canEditChatMessage } from "../utils/message-permissions"
+
+type EditPolicy = {
+  hasEditMessage: boolean
+  capabilities?: F0ChatCapabilities
+  editWindowMs?: number
+}
+
+/**
+ * The message a keyboard shortcut may reopen: the viewer's NEWEST own message,
+ * and only if it is editable as text.
+ *
+ * Deliberately does not scan past it. "Reopen my last message" has to mean the
+ * message the user is looking at — walking further back to find something
+ * editable silently opens a different message than the one they expect, which
+ * a blind keystroke must never do. When the newest own message does not
+ * qualify, the shortcut does nothing and the actions menu remains the way in.
+ *
+ * Stricter than the menu on two further points:
+ * - own messages only, even where `capabilities.canEditMessage` allows editing
+ *   other people's (a moderator must not reopen a colleague's by reflex);
+ * - text only. An attachment-only message would load an empty textarea plus its
+ *   image, so the user's next Enter would caption that image instead of sending
+ *   the message they just typed.
+ */
+export const findShortcutEditTarget = (
+  messages: F0ChatItem[],
+  policy: EditPolicy
+): F0ChatMessage | null => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const item = messages[i]
+    if (!isUserMessage(item) || !item.isMine) continue
+    if (item.body.trim() === "") return null
+    return canEditChatMessage(item, policy) ? item : null
+  }
+  return null
+}
+
+/**
+ * Reopen the viewer's last editable message. Returns whether it found one, so
+ * the caller only swallows the keystroke when something actually happened.
+ */
+export const useEditLastOwnMessage = (): (() => boolean) => {
+  const { messages, hasMoreNewer, editMessage, capabilities, editWindowMs } =
+    useF0Chat()
+  const { startEdit } = useChatComposeActions()
+  // What a scan already came up empty for. A held-down key repeats the keydown
+  // ~30x/s and only a MISS repeats the scan (a hit opens an edit, which the
+  // caller's own guard then blocks). The policy is part of the key: a
+  // `channel.updated` event can hand over new capabilities while reusing the
+  // same memoized message array, and the shortcut has to notice.
+  const missRef = useRef<{ messages: F0ChatItem[]; policy: EditPolicy } | null>(
+    null
+  )
+
+  return useCallback(() => {
+    if (!editMessage) return false
+    // The loaded window is not always anchored to the live tail: after jumping
+    // to a search hit its last message can be months old, and "your last
+    // message" would silently mean the wrong one.
+    if (hasMoreNewer === true) return false
+
+    const policy: EditPolicy = {
+      hasEditMessage: true,
+      capabilities,
+      editWindowMs,
+    }
+    const miss = missRef.current
+    if (
+      miss &&
+      miss.messages === messages &&
+      miss.policy.capabilities === capabilities &&
+      miss.policy.editWindowMs === editWindowMs
+    ) {
+      return false
+    }
+
+    const found = findShortcutEditTarget(messages, policy)
+    if (!found) {
+      missRef.current = { messages, policy }
+      return false
+    }
+    startEdit(found)
+    return true
+  }, [
+    messages,
+    hasMoreNewer,
+    editMessage,
+    capabilities,
+    editWindowMs,
+    startEdit,
+  ])
+}

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEditLastOwnMessage.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEditLastOwnMessage.ts
@@ -20,18 +20,18 @@ type EditPolicy = {
  * The message a keyboard shortcut may reopen: the viewer's NEWEST own message,
  * and only if it is editable as text.
  *
- * Deliberately does not scan past it. "Reopen my last message" has to mean the
- * message the user is looking at — walking further back to find something
- * editable silently opens a different message than the one they expect, which
- * a blind keystroke must never do. When the newest own message does not
- * qualify, the shortcut does nothing and the actions menu remains the way in.
+ * It does not look further back on purpose. The user presses a key without
+ * choosing a message, so opening anything other than their newest one is a
+ * surprise. When that message does not qualify the shortcut does nothing, and
+ * the actions menu is still there for older messages.
  *
- * Stricter than the menu on two further points:
+ * Stricter than the menu in two ways:
  * - own messages only, even where `capabilities.canEditMessage` allows editing
- *   other people's (a moderator must not reopen a colleague's by reflex);
- * - text only. An attachment-only message would load an empty textarea plus its
- *   image, so the user's next Enter would caption that image instead of sending
- *   the message they just typed.
+ *   other people's, so a moderator cannot open a colleague's message by
+ *   accident;
+ * - text only. A message with just an image would load an empty box plus that
+ *   image, and the next Enter would add a caption to it instead of sending the
+ *   message the user typed.
  */
 export const findShortcutEditTarget = (
   messages: F0ChatItem[],
@@ -54,20 +54,20 @@ export const useEditLastOwnMessage = (): (() => boolean) => {
   const { messages, hasMoreNewer, editMessage, capabilities, editWindowMs } =
     useF0Chat()
   const { startEdit } = useChatComposeActions()
-  // What a scan already came up empty for. A held-down key repeats the keydown
-  // ~30x/s and only a MISS repeats the scan (a hit opens an edit, which the
-  // caller's own guard then blocks). The policy is part of the key: a
-  // `channel.updated` event can hand over new capabilities while reusing the
-  // same memoized message array, and the shortcut has to notice.
+  // What a search already found nothing in. Holding the key down repeats it
+  // about 30 times a second, and only a failed search repeats the work — a
+  // successful one opens an edit, which the caller's guard then blocks. The
+  // policy is part of the key because a permission change can arrive with the
+  // same message array, and the shortcut has to notice.
   const missRef = useRef<{ messages: F0ChatItem[]; policy: EditPolicy } | null>(
     null
   )
 
   return useCallback(() => {
     if (!editMessage) return false
-    // The loaded window is not always anchored to the live tail: after jumping
-    // to a search hit its last message can be months old, and "your last
-    // message" would silently mean the wrong one.
+    // The loaded messages do not always end at the newest one: after jumping to
+    // a search result the last one loaded can be months old, so "your last
+    // message" would mean the wrong message.
     if (hasMoreNewer === true) return false
 
     const policy: EditPolicy = {

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEditLastOwnMessage.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEditLastOwnMessage.ts
@@ -17,21 +17,14 @@ type EditPolicy = {
 }
 
 /**
- * The message a keyboard shortcut may reopen: the viewer's NEWEST own message,
- * and only if it is editable as text.
+ * Stops at the newest own message instead of searching past it: the user
+ * pressed a key without choosing a message, so opening an older one surprises
+ * them. The actions menu still reaches those.
  *
- * It does not look further back on purpose. The user presses a key without
- * choosing a message, so opening anything other than their newest one is a
- * surprise. When that message does not qualify the shortcut does nothing, and
- * the actions menu is still there for older messages.
- *
- * Stricter than the menu in two ways:
- * - own messages only, even where `capabilities.canEditMessage` allows editing
- *   other people's, so a moderator cannot open a colleague's message by
- *   accident;
- * - text only. A message with just an image would load an empty box plus that
- *   image, and the next Enter would add a caption to it instead of sending the
- *   message the user typed.
+ * Stricter than that menu in two ways. Own messages only, even where
+ * `capabilities.canEditMessage` allows editing other people's. And text only —
+ * a message with just an image loads an empty box plus the image, so the next
+ * Enter captions it rather than sending what the user typed.
  */
 export const findShortcutEditTarget = (
   messages: F0ChatItem[],
@@ -46,19 +39,15 @@ export const findShortcutEditTarget = (
   return null
 }
 
-/**
- * Reopen the viewer's last editable message. Returns whether it found one, so
- * the caller only swallows the keystroke when something actually happened.
- */
+/** Returns whether it found one, so the caller only swallows the key when
+ * something happened. */
 export const useEditLastOwnMessage = (): (() => boolean) => {
   const { messages, hasMoreNewer, editMessage, capabilities, editWindowMs } =
     useF0Chat()
   const { startEdit } = useChatComposeActions()
-  // What a search already found nothing in. Holding the key down repeats it
-  // about 30 times a second, and only a failed search repeats the work — a
-  // successful one opens an edit, which the caller's guard then blocks. The
-  // policy is part of the key because a permission change can arrive with the
-  // same message array, and the shortcut has to notice.
+  // Held keys repeat ~30 times a second, and only a failed search repeats the
+  // work. The policy is part of the key because a permission change can arrive
+  // with the same message array.
   const missRef = useRef<{ messages: F0ChatItem[]; policy: EditPolicy } | null>(
     null
   )
@@ -66,8 +55,7 @@ export const useEditLastOwnMessage = (): (() => boolean) => {
   return useCallback(() => {
     if (!editMessage) return false
     // The loaded messages do not always end at the newest one: after jumping to
-    // a search result the last one loaded can be months old, so "your last
-    // message" would mean the wrong message.
+    // a search result the last one can be months old.
     if (hasMoreNewer === true) return false
 
     const policy: EditPolicy = {

--- a/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
@@ -48,12 +48,8 @@ type ChatHighlightedIdContextValue = {
   highlightedId: string | null
 }
 
-/**
- * What the composer is aimed at. One value rather than a reply target plus an
- * edit target: replying and editing are mutually exclusive, and as two
- * independent nullable states "both set" stays representable and has to be
- * prevented by hand at every call site.
- */
+/** One value, not a reply target plus an edit target: as two nullable states
+ * "both set" is representable and has to be prevented by hand at each caller. */
 export type ChatComposeTarget =
   | { kind: "none" }
   | { kind: "reply"; message: F0ChatMessage }
@@ -64,14 +60,9 @@ type ChatComposeTargetContextValue = {
 }
 
 /**
- * How the composer reacts to the target moving. The provider announces the
- * transition; the composer decides what happens to its draft — the provider
- * never learns what a draft is.
- *
- * Registered rather than derived because every transition originates in a user
- * gesture: doing this in an effect would run a frame late, which loses the
- * gesture (no iOS keyboard) and cannot see the PREVIOUS target, so leaving edit
- * mode could not discard the edit draft.
+ * Called on every target move, inside the user's gesture. Not an effect: an
+ * effect runs a frame late (losing the gesture, so iOS opens no keyboard) and
+ * cannot see the previous target, which is what says whether to discard.
  */
 export type ChatComposerHandle = {
   retarget: (previous: ChatComposeTarget, next: ChatComposeTarget) => void
@@ -79,11 +70,8 @@ export type ChatComposerHandle = {
   abandonDraft: () => void
 }
 
-/**
- * Moving the composer's target. Identity-stable for the provider's whole
- * lifetime, so per-message rows can start a reply or an edit without
- * subscribing to — and re-rendering on — the current target.
- */
+/** Identity-stable for the provider's lifetime, so message rows can move the
+ * target without subscribing to it and re-rendering on every change. */
 type ChatComposeActionsContextValue = {
   /** Quote a message in the composer. */
   startReply: (message: F0ChatMessage) => void
@@ -171,8 +159,8 @@ export const ChatUIProvider = ({
   const scrollFnRef = useRef<((id: string) => void) | null>(null)
   const dropFnRef = useRef<((files: File[]) => void) | null>(null)
   const composerHandleRef = useRef<ChatComposerHandle | null>(null)
-  // The transition needs the OUTGOING target, and the setters must stay
-  // dependency-free so the actions context never changes identity.
+  // Read by the setters below, which have no dependencies on purpose: a
+  // dependency here would change the actions context and re-render every row.
   const targetRef = useRef(target)
   targetRef.current = target
   const canSendRef = useRef(capabilities?.canSend)
@@ -257,10 +245,9 @@ export const ChatUIProvider = ({
     []
   )
 
-  // The single writer of the target. The provider's own state moves first, so
-  // a throw inside the composer's transition cannot leave the two disagreeing;
-  // both land in one commit either way, because a gesture's setState calls are
-  // flushed together in a microtask at the end of the event.
+  // State first: a throw inside the composer's transition must not leave the
+  // two disagreeing. Both still land in one commit — a gesture's setState calls
+  // flush together in a microtask at the end of the event.
   const setComposeTarget = useCallback((next: ChatComposeTarget) => {
     const previous = targetRef.current
     targetRef.current = next
@@ -270,9 +257,8 @@ export const ChatUIProvider = ({
 
   const startReply = useCallback(
     (message: F0ChatMessage) => {
-      // A read-only channel renders no composer (see F0Chat), so a quote there
-      // would be invisible and unclearable. Refused here rather than at each
-      // entry point, so the actions menu is covered too.
+      // A read-only channel renders no composer, so a target set there is
+      // invisible and unclearable.
       if (canSendRef.current === false) return
       setComposeTarget({ kind: "reply", message })
     },
@@ -290,12 +276,10 @@ export const ChatUIProvider = ({
     [setComposeTarget]
   )
 
-  // A draft belongs to the conversation it was written in. The transcript is
-  // keyed by channel and remounts, but this provider and the composer do not —
-  // without this, Save would edit a message in the channel you just left, and a
-  // half-typed reply would go to whoever you switched to. Layout, not passive:
-  // a passive effect can let one frame paint the old draft under the new
-  // channel.
+  // Only the transcript is keyed by channel; this provider and the composer
+  // survive the switch, so the draft has to be dropped by hand or it is sent to
+  // the next conversation. Layout, not passive: a passive effect lets a frame
+  // paint the old draft under the new channel.
   const channelIdRef = useRef(channel.id)
   useLayoutEffect(
     function abandonDraftOnChannelChange() {
@@ -444,8 +428,6 @@ export const ChatUIProvider = ({
     () => ({ target }),
     [target]
   )
-  // Stable for the provider's lifetime, so consuming it from a message row
-  // costs no extra render.
   const composeActionsValue = useMemo<ChatComposeActionsContextValue>(
     () => ({
       startReply,
@@ -539,13 +521,11 @@ export const useChatJump = (): ChatJumpContextValue =>
 export const useChatHighlightedId = (): ChatHighlightedIdContextValue =>
   useCtx(ChatHighlightedIdContext, "useChatHighlightedId")
 
-/** The current compose target. Consumed by the composer only — a row reading
- * this would re-render on every target change. */
+/** Composer only: a row reading this re-renders on every target change. */
 export const useChatComposeTarget = (): ChatComposeTargetContextValue =>
   useCtx(ChatComposeTargetContext, "useChatComposeTarget")
 
-/** Move the compose target. Stable identity — consumed by message rows and the
- * actions menu, neither of which should re-render when the target changes. */
+/** Stable identity, so message rows and the actions menu can consume it. */
 export const useChatComposeActions = (): ChatComposeActionsContextValue =>
   useCtx(ChatComposeActionsContext, "useChatComposeActions")
 

--- a/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useContext,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -47,29 +48,51 @@ type ChatHighlightedIdContextValue = {
   highlightedId: string | null
 }
 
-type ChatReplyContextValue = {
-  /** Message being replied to (quoted in the composer), or null. */
-  replyTo: F0ChatMessage | null
-  setReplyTo: (message: F0ChatMessage | null) => void
-}
+/**
+ * What the composer is aimed at. One value rather than a reply target plus an
+ * edit target: replying and editing are mutually exclusive, and as two
+ * independent nullable states "both set" stays representable and has to be
+ * prevented by hand at every call site.
+ */
+export type ChatComposeTarget =
+  | { kind: "none" }
+  | { kind: "reply"; message: F0ChatMessage }
+  | { kind: "edit"; message: F0ChatMessage }
 
-type ChatEditContextValue = {
-  /** Message being edited (reloaded into the composer), or null. */
-  editingMessage: F0ChatMessage | null
-  setEditingMessage: (message: F0ChatMessage | null) => void
+type ChatComposeTargetContextValue = {
+  target: ChatComposeTarget
 }
 
 /**
- * Setting the composer's target. Split from the reply/edit VALUE contexts and
- * identity-stable for the provider's whole lifetime, so per-message rows can
- * start a reply or an edit without subscribing to — and re-rendering on — the
- * current target. Both entry points enforce the exclusivity rule.
+ * How the composer reacts to the target moving. The provider announces the
+ * transition; the composer decides what happens to its draft — the provider
+ * never learns what a draft is.
+ *
+ * Registered rather than derived because every transition originates in a user
+ * gesture: doing this in an effect would run a frame late, which loses the
+ * gesture (no iOS keyboard) and cannot see the PREVIOUS target, so leaving edit
+ * mode could not discard the edit draft.
  */
-type ChatComposeTargetContextValue = {
-  /** Quote a message in the composer, dropping any edit in progress. */
+export type ChatComposerHandle = {
+  retarget: (previous: ChatComposeTarget, next: ChatComposeTarget) => void
+  /** Drop the whole draft — text, attachments, mentions — not just an edit's. */
+  abandonDraft: () => void
+}
+
+/**
+ * Moving the composer's target. Identity-stable for the provider's whole
+ * lifetime, so per-message rows can start a reply or an edit without
+ * subscribing to — and re-rendering on — the current target.
+ */
+type ChatComposeActionsContextValue = {
+  /** Quote a message in the composer. */
   startReply: (message: F0ChatMessage) => void
-  /** Reload a message into the composer for editing, dropping any reply quote. */
+  /** Reload a message into the composer for editing. */
   startEdit: (message: F0ChatMessage) => void
+  /** Drop the current target (the chip's remove button, Escape, a channel switch). */
+  clearComposeTarget: () => void
+  /** The composer registers how it follows the target. */
+  registerComposerHandle: (handle: ChatComposerHandle | null) => void
 }
 
 type ChatDropContextValue = {
@@ -118,10 +141,10 @@ type ChatSearchContextValue = {
 const ChatJumpContext = createContext<ChatJumpContextValue | null>(null)
 const ChatHighlightedIdContext =
   createContext<ChatHighlightedIdContextValue | null>(null)
-const ChatReplyContext = createContext<ChatReplyContextValue | null>(null)
-const ChatEditContext = createContext<ChatEditContextValue | null>(null)
 const ChatComposeTargetContext =
   createContext<ChatComposeTargetContextValue | null>(null)
+const ChatComposeActionsContext =
+  createContext<ChatComposeActionsContextValue | null>(null)
 const ChatDropContext = createContext<ChatDropContextValue | null>(null)
 const ChatImagePreviewContext =
   createContext<ChatImagePreviewContextValue | null>(null)
@@ -135,15 +158,25 @@ export const ChatUIProvider = ({
 }: {
   children: ReactNode
 }): ReactNode => {
-  const { messages, searchMessages, loadMessageContext } = useF0Chat()
+  const {
+    messages,
+    searchMessages,
+    loadMessageContext,
+    channel,
+    capabilities,
+  } = useF0Chat()
 
-  const [replyTo, setReplyTo] = useState<F0ChatMessage | null>(null)
-  const [editingMessage, setEditingMessage] = useState<F0ChatMessage | null>(
-    null
-  )
+  const [target, setTarget] = useState<ChatComposeTarget>({ kind: "none" })
   const [highlightedId, setHighlightedId] = useState<string | null>(null)
   const scrollFnRef = useRef<((id: string) => void) | null>(null)
   const dropFnRef = useRef<((files: File[]) => void) | null>(null)
+  const composerHandleRef = useRef<ChatComposerHandle | null>(null)
+  // The transition needs the OUTGOING target, and the setters must stay
+  // dependency-free so the actions context never changes identity.
+  const targetRef = useRef(target)
+  targetRef.current = target
+  const canSendRef = useRef(capabilities?.canSend)
+  canSendRef.current = capabilities?.canSend
   const highlightTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const [imagePreview, setImagePreview] = useState<{
@@ -217,16 +250,62 @@ export const ChatUIProvider = ({
   }, [])
   const closeDocumentPreview = useCallback(() => setDocumentPreview(null), [])
 
-  // Replying and editing are mutually exclusive; the rule lives HERE rather
-  // than at every call site (actions menu, double-click, composer shortcut).
-  const startReply = useCallback((message: F0ChatMessage) => {
-    setEditingMessage(null)
-    setReplyTo(message)
+  const registerComposerHandle = useCallback(
+    (handle: ChatComposerHandle | null) => {
+      composerHandleRef.current = handle
+    },
+    []
+  )
+
+  // The single writer of the target. The provider's own state moves first, so
+  // a throw inside the composer's transition cannot leave the two disagreeing;
+  // both land in one commit either way, because a gesture's setState calls are
+  // flushed together in a microtask at the end of the event.
+  const setComposeTarget = useCallback((next: ChatComposeTarget) => {
+    const previous = targetRef.current
+    targetRef.current = next
+    setTarget(next)
+    composerHandleRef.current?.retarget(previous, next)
   }, [])
-  const startEdit = useCallback((message: F0ChatMessage) => {
-    setReplyTo(null)
-    setEditingMessage(message)
-  }, [])
+
+  const startReply = useCallback(
+    (message: F0ChatMessage) => {
+      // A read-only channel renders no composer (see F0Chat), so a quote there
+      // would be invisible and unclearable. Refused here rather than at each
+      // entry point, so the actions menu is covered too.
+      if (canSendRef.current === false) return
+      setComposeTarget({ kind: "reply", message })
+    },
+    [setComposeTarget]
+  )
+  const startEdit = useCallback(
+    (message: F0ChatMessage) => {
+      if (canSendRef.current === false) return
+      setComposeTarget({ kind: "edit", message })
+    },
+    [setComposeTarget]
+  )
+  const clearComposeTarget = useCallback(
+    () => setComposeTarget({ kind: "none" }),
+    [setComposeTarget]
+  )
+
+  // A draft belongs to the conversation it was written in. The transcript is
+  // keyed by channel and remounts, but this provider and the composer do not —
+  // without this, Save would edit a message in the channel you just left, and a
+  // half-typed reply would go to whoever you switched to. Layout, not passive:
+  // a passive effect can let one frame paint the old draft under the new
+  // channel.
+  const channelIdRef = useRef(channel.id)
+  useLayoutEffect(
+    function abandonDraftOnChannelChange() {
+      if (channelIdRef.current === channel.id) return
+      channelIdRef.current = channel.id
+      composerHandleRef.current?.abandonDraft()
+      clearComposeTarget()
+    },
+    [channel.id, clearComposeTarget]
+  )
 
   /** Scroll to a message and highlight it; `persist` keeps the ring (search). */
   const scrollAndHighlight = useCallback((id: string, persist: boolean) => {
@@ -361,19 +440,20 @@ export const ChatUIProvider = ({
     () => ({ highlightedId }),
     [highlightedId]
   )
-  const replyValue = useMemo<ChatReplyContextValue>(
-    () => ({ replyTo, setReplyTo }),
-    [replyTo]
-  )
-  const editValue = useMemo<ChatEditContextValue>(
-    () => ({ editingMessage, setEditingMessage }),
-    [editingMessage]
-  )
-  // Stable for the provider's lifetime (state setters never change identity),
-  // so consuming it from a message row costs no extra render.
   const composeTargetValue = useMemo<ChatComposeTargetContextValue>(
-    () => ({ startReply, startEdit }),
-    [startReply, startEdit]
+    () => ({ target }),
+    [target]
+  )
+  // Stable for the provider's lifetime, so consuming it from a message row
+  // costs no extra render.
+  const composeActionsValue = useMemo<ChatComposeActionsContextValue>(
+    () => ({
+      startReply,
+      startEdit,
+      clearComposeTarget,
+      registerComposerHandle,
+    }),
+    [startReply, startEdit, clearComposeTarget, registerComposerHandle]
   )
   const dropValue = useMemo<ChatDropContextValue>(
     () => ({ registerFileDropHandler, dropFiles }),
@@ -419,27 +499,25 @@ export const ChatUIProvider = ({
   )
 
   return (
-    <ChatComposeTargetContext.Provider value={composeTargetValue}>
+    <ChatComposeActionsContext.Provider value={composeActionsValue}>
       <ChatJumpContext.Provider value={jumpValue}>
         <ChatHighlightedIdContext.Provider value={highlightedIdValue}>
-          <ChatReplyContext.Provider value={replyValue}>
-            <ChatEditContext.Provider value={editValue}>
-              <ChatDropContext.Provider value={dropValue}>
-                <ChatImagePreviewContext.Provider value={imagePreviewValue}>
-                  <ChatDocumentPreviewContext.Provider
-                    value={documentPreviewValue}
-                  >
-                    <ChatSearchContext.Provider value={searchValue}>
-                      {children}
-                    </ChatSearchContext.Provider>
-                  </ChatDocumentPreviewContext.Provider>
-                </ChatImagePreviewContext.Provider>
-              </ChatDropContext.Provider>
-            </ChatEditContext.Provider>
-          </ChatReplyContext.Provider>
+          <ChatComposeTargetContext.Provider value={composeTargetValue}>
+            <ChatDropContext.Provider value={dropValue}>
+              <ChatImagePreviewContext.Provider value={imagePreviewValue}>
+                <ChatDocumentPreviewContext.Provider
+                  value={documentPreviewValue}
+                >
+                  <ChatSearchContext.Provider value={searchValue}>
+                    {children}
+                  </ChatSearchContext.Provider>
+                </ChatDocumentPreviewContext.Provider>
+              </ChatImagePreviewContext.Provider>
+            </ChatDropContext.Provider>
+          </ChatComposeTargetContext.Provider>
         </ChatHighlightedIdContext.Provider>
       </ChatJumpContext.Provider>
-    </ChatComposeTargetContext.Provider>
+    </ChatComposeActionsContext.Provider>
   )
 }
 
@@ -461,20 +539,15 @@ export const useChatJump = (): ChatJumpContextValue =>
 export const useChatHighlightedId = (): ChatHighlightedIdContextValue =>
   useCtx(ChatHighlightedIdContext, "useChatHighlightedId")
 
-/** Reply-target state. Consumed by the composer and message actions. */
-export const useChatReply = (): ChatReplyContextValue =>
-  useCtx(ChatReplyContext, "useChatReply")
-
-/** Edit-target state. Consumed by the composer and message actions. Editing and
- * replying are mutually exclusive — the action handlers clear one when setting
- * the other. */
-export const useChatEdit = (): ChatEditContextValue =>
-  useCtx(ChatEditContext, "useChatEdit")
-
-/** Start a reply / an edit. Stable identity — consumed by message rows and the
- * actions menu, neither of which should re-render when the target changes. */
+/** The current compose target. Consumed by the composer only — a row reading
+ * this would re-render on every target change. */
 export const useChatComposeTarget = (): ChatComposeTargetContextValue =>
   useCtx(ChatComposeTargetContext, "useChatComposeTarget")
+
+/** Move the compose target. Stable identity — consumed by message rows and the
+ * actions menu, neither of which should re-render when the target changes. */
+export const useChatComposeActions = (): ChatComposeActionsContextValue =>
+  useCtx(ChatComposeActionsContext, "useChatComposeActions")
 
 /** Window-wide file-drop routing. Consumed by the shell and composer. */
 export const useChatDrop = (): ChatDropContextValue =>

--- a/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
@@ -60,9 +60,9 @@ type ChatComposeTargetContextValue = {
 }
 
 /**
- * Called on every target move, inside the user's gesture. Not an effect: an
- * effect runs a frame late (losing the gesture, so iOS opens no keyboard) and
- * cannot see the previous target, which is what says whether to discard.
+ * Called on every target move, inside the user's gesture. Not an effect: that
+ * runs a frame late, losing the gesture so iOS opens no keyboard, and cannot
+ * see the previous target — which is what says whether to discard the draft.
  */
 export type ChatComposerHandle = {
   retarget: (previous: ChatComposeTarget, next: ChatComposeTarget) => void
@@ -73,13 +73,9 @@ export type ChatComposerHandle = {
 /** Identity-stable for the provider's lifetime, so message rows can move the
  * target without subscribing to it and re-rendering on every change. */
 type ChatComposeActionsContextValue = {
-  /** Quote a message in the composer. */
   startReply: (message: F0ChatMessage) => void
-  /** Reload a message into the composer for editing. */
   startEdit: (message: F0ChatMessage) => void
-  /** Drop the current target (the chip's remove button, Escape, a channel switch). */
   clearComposeTarget: () => void
-  /** The composer registers how it follows the target. */
   registerComposerHandle: (handle: ChatComposerHandle | null) => void
 }
 
@@ -525,7 +521,6 @@ export const useChatHighlightedId = (): ChatHighlightedIdContextValue =>
 export const useChatComposeTarget = (): ChatComposeTargetContextValue =>
   useCtx(ChatComposeTargetContext, "useChatComposeTarget")
 
-/** Stable identity, so message rows and the actions menu can consume it. */
 export const useChatComposeActions = (): ChatComposeActionsContextValue =>
   useCtx(ChatComposeActionsContext, "useChatComposeActions")
 

--- a/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/ChatUIProvider.tsx
@@ -59,6 +59,19 @@ type ChatEditContextValue = {
   setEditingMessage: (message: F0ChatMessage | null) => void
 }
 
+/**
+ * Setting the composer's target. Split from the reply/edit VALUE contexts and
+ * identity-stable for the provider's whole lifetime, so per-message rows can
+ * start a reply or an edit without subscribing to — and re-rendering on — the
+ * current target. Both entry points enforce the exclusivity rule.
+ */
+type ChatComposeTargetContextValue = {
+  /** Quote a message in the composer, dropping any edit in progress. */
+  startReply: (message: F0ChatMessage) => void
+  /** Reload a message into the composer for editing, dropping any reply quote. */
+  startEdit: (message: F0ChatMessage) => void
+}
+
 type ChatDropContextValue = {
   /** The composer registers how to attach dropped files (window-wide drop). */
   registerFileDropHandler: (fn: (files: File[]) => void) => void
@@ -107,6 +120,8 @@ const ChatHighlightedIdContext =
   createContext<ChatHighlightedIdContextValue | null>(null)
 const ChatReplyContext = createContext<ChatReplyContextValue | null>(null)
 const ChatEditContext = createContext<ChatEditContextValue | null>(null)
+const ChatComposeTargetContext =
+  createContext<ChatComposeTargetContextValue | null>(null)
 const ChatDropContext = createContext<ChatDropContextValue | null>(null)
 const ChatImagePreviewContext =
   createContext<ChatImagePreviewContextValue | null>(null)
@@ -201,6 +216,17 @@ export const ChatUIProvider = ({
     if (kind) setDocumentPreview({ file, kind })
   }, [])
   const closeDocumentPreview = useCallback(() => setDocumentPreview(null), [])
+
+  // Replying and editing are mutually exclusive; the rule lives HERE rather
+  // than at every call site (actions menu, double-click, composer shortcut).
+  const startReply = useCallback((message: F0ChatMessage) => {
+    setEditingMessage(null)
+    setReplyTo(message)
+  }, [])
+  const startEdit = useCallback((message: F0ChatMessage) => {
+    setReplyTo(null)
+    setEditingMessage(message)
+  }, [])
 
   /** Scroll to a message and highlight it; `persist` keeps the ring (search). */
   const scrollAndHighlight = useCallback((id: string, persist: boolean) => {
@@ -343,6 +369,12 @@ export const ChatUIProvider = ({
     () => ({ editingMessage, setEditingMessage }),
     [editingMessage]
   )
+  // Stable for the provider's lifetime (state setters never change identity),
+  // so consuming it from a message row costs no extra render.
+  const composeTargetValue = useMemo<ChatComposeTargetContextValue>(
+    () => ({ startReply, startEdit }),
+    [startReply, startEdit]
+  )
   const dropValue = useMemo<ChatDropContextValue>(
     () => ({ registerFileDropHandler, dropFiles }),
     [registerFileDropHandler, dropFiles]
@@ -387,25 +419,27 @@ export const ChatUIProvider = ({
   )
 
   return (
-    <ChatJumpContext.Provider value={jumpValue}>
-      <ChatHighlightedIdContext.Provider value={highlightedIdValue}>
-        <ChatReplyContext.Provider value={replyValue}>
-          <ChatEditContext.Provider value={editValue}>
-            <ChatDropContext.Provider value={dropValue}>
-              <ChatImagePreviewContext.Provider value={imagePreviewValue}>
-                <ChatDocumentPreviewContext.Provider
-                  value={documentPreviewValue}
-                >
-                  <ChatSearchContext.Provider value={searchValue}>
-                    {children}
-                  </ChatSearchContext.Provider>
-                </ChatDocumentPreviewContext.Provider>
-              </ChatImagePreviewContext.Provider>
-            </ChatDropContext.Provider>
-          </ChatEditContext.Provider>
-        </ChatReplyContext.Provider>
-      </ChatHighlightedIdContext.Provider>
-    </ChatJumpContext.Provider>
+    <ChatComposeTargetContext.Provider value={composeTargetValue}>
+      <ChatJumpContext.Provider value={jumpValue}>
+        <ChatHighlightedIdContext.Provider value={highlightedIdValue}>
+          <ChatReplyContext.Provider value={replyValue}>
+            <ChatEditContext.Provider value={editValue}>
+              <ChatDropContext.Provider value={dropValue}>
+                <ChatImagePreviewContext.Provider value={imagePreviewValue}>
+                  <ChatDocumentPreviewContext.Provider
+                    value={documentPreviewValue}
+                  >
+                    <ChatSearchContext.Provider value={searchValue}>
+                      {children}
+                    </ChatSearchContext.Provider>
+                  </ChatDocumentPreviewContext.Provider>
+                </ChatImagePreviewContext.Provider>
+              </ChatDropContext.Provider>
+            </ChatEditContext.Provider>
+          </ChatReplyContext.Provider>
+        </ChatHighlightedIdContext.Provider>
+      </ChatJumpContext.Provider>
+    </ChatComposeTargetContext.Provider>
   )
 }
 
@@ -436,6 +470,11 @@ export const useChatReply = (): ChatReplyContextValue =>
  * the other. */
 export const useChatEdit = (): ChatEditContextValue =>
   useCtx(ChatEditContext, "useChatEdit")
+
+/** Start a reply / an edit. Stable identity — consumed by message rows and the
+ * actions menu, neither of which should re-render when the target changes. */
+export const useChatComposeTarget = (): ChatComposeTargetContextValue =>
+  useCtx(ChatComposeTargetContext, "useChatComposeTarget")
 
 /** Window-wide file-drop routing. Consumed by the shell and composer. */
 export const useChatDrop = (): ChatDropContextValue =>

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -394,9 +394,11 @@ export type F0ChatStatus =
  * - `canUpload` (default: whether `uploadFiles` exists): false disables the
  *   attach button, drag & drop and voice notes even when `uploadFiles` exists.
  * - `canEditMessage` (default: own message within {@link F0ChatRuntime.editWindowMs}):
- *   overrides the edit policy per message. Structural gates still apply (the
- *   host must provide `editMessage`; deleted messages and voice notes are
- *   never editable).
+ *   overrides the edit policy per message, INCLUDING the edit window — a host
+ *   that supplies this and wants a time limit must apply it here. Structural
+ *   gates still apply and cannot be overridden (the host must provide
+ *   `editMessage`; deleted messages, voice notes, and messages that have not
+ *   settled server-side — `sending` / `failed` — are never editable).
  * - `canDeleteMessage` (default: own message): overrides the delete policy per
  *   message (e.g. moderators deleting others' messages). Failed local echoes
  *   are always discardable — they don't exist server-side.

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/message-permissions.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/message-permissions.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+
+import { type F0ChatMessage } from "../../types"
+import { canEditChatMessage } from "../message-permissions"
+
+const message = (overrides: Partial<F0ChatMessage> = {}): F0ChatMessage => ({
+  id: "m1",
+  author: { id: "me", name: "Me" },
+  body: "Hi",
+  createdAt: new Date().toISOString(),
+  isMine: true,
+  ...overrides,
+})
+
+const withHandler = { hasEditMessage: true }
+
+describe("canEditChatMessage", () => {
+  it("allows editing my own recent message", () => {
+    expect(canEditChatMessage(message(), withHandler)).toBe(true)
+  })
+
+  it("refuses when the host provides no editMessage handler", () => {
+    expect(canEditChatMessage(message(), { hasEditMessage: false })).toBe(false)
+  })
+
+  it("refuses someone else's message by default", () => {
+    expect(canEditChatMessage(message({ isMine: false }), withHandler)).toBe(
+      false
+    )
+  })
+
+  it("refuses a tombstone", () => {
+    expect(canEditChatMessage(message({ deleted: true }), withHandler)).toBe(
+      false
+    )
+  })
+
+  it("refuses a message that has not settled server-side", () => {
+    expect(
+      canEditChatMessage(message({ status: "sending" }), withHandler)
+    ).toBe(false)
+    expect(canEditChatMessage(message({ status: "failed" }), withHandler)).toBe(
+      false
+    )
+  })
+
+  it("refuses a voice note — there is no text to change", () => {
+    const voiceNote = message({
+      body: "",
+      attachments: [{ kind: "voice", url: "https://example.test/a.ogg" }],
+    })
+    expect(canEditChatMessage(voiceNote, withHandler)).toBe(false)
+  })
+
+  it("applies the edit window to my own messages", () => {
+    const old = new Date(Date.now() - 10 * 60 * 1000).toISOString()
+    expect(
+      canEditChatMessage(message({ createdAt: old }), {
+        ...withHandler,
+        editWindowMs: 5 * 60 * 1000,
+      })
+    ).toBe(false)
+    expect(
+      canEditChatMessage(message({ createdAt: old }), {
+        ...withHandler,
+        editWindowMs: 30 * 60 * 1000,
+      })
+    ).toBe(true)
+  })
+
+  it("has no time limit when no edit window is set", () => {
+    const ancient = new Date(2020, 0, 1).toISOString()
+    expect(
+      canEditChatMessage(message({ createdAt: ancient }), withHandler)
+    ).toBe(true)
+  })
+
+  it("lets a host capability replace the owner and window policy", () => {
+    const old = new Date(2020, 0, 1).toISOString()
+    const theirs = message({ isMine: false, createdAt: old })
+    expect(
+      canEditChatMessage(theirs, {
+        ...withHandler,
+        editWindowMs: 1000,
+        capabilities: { canEditMessage: () => true },
+      })
+    ).toBe(true)
+    expect(
+      canEditChatMessage(message(), {
+        ...withHandler,
+        capabilities: { canEditMessage: () => false },
+      })
+    ).toBe(false)
+  })
+
+  it("keeps the voice-note and tombstone rules above any capability", () => {
+    const capabilities = { canEditMessage: () => true }
+    expect(
+      canEditChatMessage(message({ deleted: true }), {
+        ...withHandler,
+        capabilities,
+      })
+    ).toBe(false)
+    expect(
+      canEditChatMessage(
+        message({
+          attachments: [{ kind: "voice", url: "https://example.test/a.ogg" }],
+        }),
+        { ...withHandler, capabilities }
+      )
+    ).toBe(false)
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/message-permissions.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/message-permissions.test.ts
@@ -29,7 +29,7 @@ describe("canEditChatMessage", () => {
     )
   })
 
-  it("refuses a tombstone", () => {
+  it("refuses a deleted message", () => {
     expect(canEditChatMessage(message({ deleted: true }), withHandler)).toBe(
       false
     )
@@ -93,7 +93,7 @@ describe("canEditChatMessage", () => {
     ).toBe(false)
   })
 
-  it("keeps the voice-note and tombstone rules above any capability", () => {
+  it("keeps the voice-note and deleted rules above any capability", () => {
     const capabilities = { canEditMessage: () => true }
     expect(
       canEditChatMessage(message({ deleted: true }), {

--- a/packages/react/src/sds/chat/F0Chat/utils/message-permissions.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/message-permissions.ts
@@ -1,0 +1,40 @@
+import { type F0ChatCapabilities, type F0ChatMessage } from "../types"
+
+/**
+ * Whether a message can still be edited.
+ *
+ * The POLICY (whose messages, for how long) comes from
+ * `capabilities.canEditMessage` when the host provides one, else the default:
+ * own messages within `editWindowMs`. Independent of the policy, editing needs
+ * a host `editMessage` handler, a message that still exists (not a tombstone)
+ * and has settled server-side, and text to change — a voice note has none.
+ *
+ * Shared by the actions menu and the composer's edit-last shortcut so both
+ * offer editing on exactly the same messages.
+ */
+export const canEditChatMessage = (
+  message: F0ChatMessage,
+  {
+    hasEditMessage,
+    capabilities,
+    editWindowMs,
+  }: {
+    /** Whether the runtime provides an `editMessage` handler at all. */
+    hasEditMessage: boolean
+    capabilities?: F0ChatCapabilities
+    editWindowMs?: number
+  }
+): boolean => {
+  if (!hasEditMessage) return false
+  if (message.deleted) return false
+  if (message.status === "sending" || message.status === "failed") return false
+  const isVoiceNote = (message.attachments ?? []).some(
+    (attachment) => attachment.kind === "voice"
+  )
+  if (isVoiceNote) return false
+  if (capabilities?.canEditMessage) return capabilities.canEditMessage(message)
+  const withinEditWindow =
+    editWindowMs == null ||
+    Date.now() - new Date(message.createdAt).getTime() <= editWindowMs
+  return message.isMine && withinEditWindow
+}

--- a/packages/react/src/sds/chat/F0Chat/utils/message-permissions.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/message-permissions.ts
@@ -1,8 +1,6 @@
 import { type F0ChatCapabilities, type F0ChatMessage } from "../types"
 
 /**
- * Whether a message can still be edited.
- *
  * Whose messages, and for how long, comes from `capabilities.canEditMessage`
  * when the host provides one, else the default: own messages within
  * `editWindowMs`. Whatever that says, editing also needs a host `editMessage`
@@ -19,7 +17,6 @@ export const canEditChatMessage = (
     capabilities,
     editWindowMs,
   }: {
-    /** Whether the runtime provides an `editMessage` handler at all. */
     hasEditMessage: boolean
     capabilities?: F0ChatCapabilities
     editWindowMs?: number

--- a/packages/react/src/sds/chat/F0Chat/utils/message-permissions.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/message-permissions.ts
@@ -3,14 +3,14 @@ import { type F0ChatCapabilities, type F0ChatMessage } from "../types"
 /**
  * Whether a message can still be edited.
  *
- * The POLICY (whose messages, for how long) comes from
- * `capabilities.canEditMessage` when the host provides one, else the default:
- * own messages within `editWindowMs`. Independent of the policy, editing needs
- * a host `editMessage` handler, a message that still exists (not a tombstone)
- * and has settled server-side, and text to change — a voice note has none.
+ * Whose messages, and for how long, comes from `capabilities.canEditMessage`
+ * when the host provides one, else the default: own messages within
+ * `editWindowMs`. Whatever that says, editing also needs a host `editMessage`
+ * handler, a message that has not been deleted and has reached the server, and
+ * some text to change — a voice note has none.
  *
- * Shared by the actions menu and the composer's edit-last shortcut so both
- * offer editing on exactly the same messages.
+ * Shared by the actions menu and the arrow-up shortcut so both offer editing on
+ * the same messages.
  */
 export const canEditChatMessage = (
   message: F0ChatMessage,


### PR DESCRIPTION
## Description

Two keyboard/pointer shortcuts for the most frequent actions in a conversation. Arrow Up on an empty, idle composer reopens the viewer's newest own message for editing, and double-clicking a message quotes it in the composer — anyone's message, including the viewer's own. Both reach the same code paths as the existing Edit and Reply actions in the message menu, which stay in place as the discoverable and keyboard-accessible route. The second commit rebuilds the compose-target state model in response to review, so the shortcuts cannot leave a draft pointed at the wrong message.

## Implementation details

- feat: reopen the newest own message with Arrow Up on an empty, idle composer

  <details>
  <summary>What it declines to do, and why</summary>

  It fires only when the composer holds no text and no attachment, has no compose target, and no capture is in flight (recording requested, recording, transcribing, or a voice note uploading), with no modifier held. In every other case Arrow Up keeps its ordinary caret meaning, so the shortcut cannot eat a text-navigation gesture or discard a draft.

  It targets **only** the newest own message. If that message cannot be edited — past the edit window, a voice note, or attachments with no text — it does nothing rather than reaching further back: a blind keystroke must not open a message other than the one the viewer is looking at. The actions menu remains the way to reach older messages, and follows the host capability where the shortcut does not (own messages only, even when `capabilities.canEditMessage` allows editing other people's).

  It also declines while newer messages sit outside the loaded window (`hasMoreNewer`), which happens after jumping to a search hit — otherwise "your last message" would silently mean the last one *loaded*, which can be months old.
  </details>

- feat: quote a message in the composer on double-click, own messages included

  <details>
  <summary>Which parts of a message it leaves alone</summary>

  The target test walks up from the clicked node as far as the message's own wrapper, over a focusability selector. That covers attachment buttons, the reply-quote jump, autolinked URLs, the `<video>` element and the voice waveform's `role="slider"`; the whole attachment column is marked self-handling so the gesture behaves the same whether a heavy preview has mounted yet or not. A portaled hover card is a React child but not a DOM descendant, so it never reaches the wrapper and never quotes.

  The walk stops at the wrapper deliberately: `closest` over the same selector would match the transcript viewport, which react-virtuoso renders with `tabIndex={0}`, and no message would be quotable at all. There is a test for that.

  Tombstones and messages that have not settled server-side get no quote, matching the rows the menu offers no Reply on.
  </details>

- refactor: model the compose target as one discriminated union

  <details>
  <summary>Why?</summary>

  A reply target and an edit target as two independent nullable states leaves "both set" representable and prevented by hand at each call site — which is how the defect below existed. One `ChatComposeTarget` makes exclusivity a type-level fact and collapses two contexts into one, split into a value context and an identity-stable actions context so message rows can start a reply without re-rendering the transcript on every target change.
  </details>

- fix: discard the edit draft when the target moves off an edit

  <details>
  <summary>The defect</summary>

  Setting a reply target cleared `editingMessage` but nothing reset the composer's text, attachments or mentions. Entering an edit and then replying left the edited body in the box, and Enter re-sent it, with its attachments, as a new message. Reachable before this branch through the menu's Reply; the branch adds two much easier routes to it. The reset is now a consequence of the target transition rather than a call each entry point has to remember.
  </details>

- refactor: replace the edit-load and reply-focus effects with a registered composer handle

  <details>
  <summary>Why an imperative call beats the effects here</summary>

  The provider calls `retarget(previous, next)` inside the user's gesture. Deriving focus from state instead put it a frame late, which meant: no refocus when the new target was identity-equal to the old one, focus stolen whenever the composer remounted with a stale target, and no iOS keyboard, because a `requestAnimationFrame` callback is outside the gesture call stack. Two effects and two `requestAnimationFrame`s go away; the one that remains is a mount-time registration.

  A target is released when the composer unmounts. Without that, a channel going read-only unmounts the composer while the target lives on, and the returning composer shows an edit chip over an empty draft — one Enter from blanking the message it points at.
  </details>

- fix: abandon the whole draft on a channel switch

  <details>
  <summary>Why the whole draft</summary>

  The provider and the composer both survive a conversation change; only the transcript is keyed by channel. Clearing just the target would remove the quote and leave the text, so a half-typed reply could go to whoever the viewer switched to.
  </details>

- fix: cover the microphone permission window

  <details>
  <summary>Two problems in one window</summary>

  `recorder.start()` only reports `"recording"` after the `getUserMedia` prompt resolves, so the composer looked idle for as long as the prompt was open. Arrow Up could load a message in the meantime, and the first transcript partial would overwrite its body, because the base value was captured at button press. The base value is now captured when capture actually begins, and the mic button is disabled while starting — two presses during the prompt otherwise open two `getUserMedia` calls and orphan the first stream.
  </details>

- fix: refuse a compose target on a read-only channel

  A frozen channel renders no composer, so a quote or an edit set there is invisible and unclearable. Refused in the provider, which also closes the pre-existing dead Reply action in the menu.

- refactor: extract the message edit policy into `canEditChatMessage`, and the shortcut's target selection into `useEditLastOwnMessage`

  <details>
  <summary>Why?</summary>

  The policy was inline in `ChatMessageActions` and the shortcut needs the identical answer; two copies would drift. The selection is a separate question — *which* message a blind shortcut may open — and carries shortcut-specific rules, so it lives in a hook next to the composer's other behaviour rather than beside the per-message predicate. Its miss cache is keyed on the policy as well as the message array, so a `channel.updated` permission change cannot leave the shortcut permanently disabled while the menu updates correctly.
  </details>

- test: 26 unit tests plus a browser play function

  <details>
  <summary>What each class of test is for</summary>

  The discriminators were verified by disabling each fix and confirming exactly those tests fail: the edit-draft discard, the channel-switch abandon, the target release on unmount, the bounded walk, `hasMoreNewer`, the attachment-only skip, and the pending-attachment guard. Two tests are labelled as pins rather than counted as coverage. A StrictMode test pins the handle registration, following three existing precedents in this package.

  The "Composer hotkeys" play function covers what jsdom cannot: the actions popover stays mounted for a 150ms CSS exit animation, and only then does Radix decide about focus.
  </details>

- docs: correct the capability contract and the behaviour lines

  `types.ts` now documents that `canEditMessage` overrides the edit window, and that the settled-server-side gate cannot be overridden. The MDX gains the new rules and loses two claims that were false.

## Notes for the reviewer

Arrow Up is scoped to the composer textarea, not the whole panel. Extending it would mean intercepting Arrow Up while the transcript has focus — react-virtuoso makes it a focusable, arrow-scrollable region — which takes scrolling away from keyboard users.

Double-click-to-reply replaces the browser's double- and triple-click text selection inside a message. The menu's Copy copies the whole body, so there is no longer a way to copy part of a message by selection. Flagged by four reviewers and documented in the MDX; an opt-out prop is a design-system API decision rather than a review fix, so it is not in this PR.

No visual changes. On the consumer side, `factorial/frontend`'s GetStream adapter already provides `editMessage` and `editWindowMs`, so both shortcuts work on a version bump with no change there.

**Two pre-existing issues found during review, deliberately not fixed here** — both host-side and worth their own tickets:

1. The adapter's 15-minute `editWindowMs` never applies. `toF0Capabilities` always returns a `canEditMessage` once a channel is watched, and it has no time component, so it short-circuits the window — for the existing Edit action as much as for the new shortcut.
2. `editMessage` rejections are silent (`void partialUpdateMessage(...)` with no catch), and `editingMessage` is a snapshot that nothing reconciles, so saving an edit to a message deleted from another device discards the text with no error.

**Unrelated flake:** `pnpm vitest:ci` exits 1 on this branch from 2 unhandled `document is not defined` errors thrown by `prosemirror-view` in `RichText/…/EnhanceHighlight`, a file this PR does not touch. It passes in isolation (109 tests) and the error count varies between runs, so the gate is flaky independently of this change. 7113 tests pass.
