### PR TITLE
feat(Tooltip): accept a title, body and bullets in cell tooltips

### DIFF
--- a/packages/react/src/experimental/Overlays/Tooltip/__tests__/Tooltip.items.test.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/__tests__/Tooltip.items.test.tsx
@@ -1,0 +1,57 @@
+import { screen, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import "@testing-library/jest-dom/vitest"
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { TooltipInternal } from "../index"
+
+describe("TooltipInternal with a bulleted list", () => {
+  it("renders one bullet per item, with the object form's title as its lead", async () => {
+    const user = userEvent.setup()
+    render(
+      <TooltipInternal
+        instant
+        label="3 alerts"
+        description="Needs a look before submitting."
+        items={[
+          { title: "Not eligible", description: "Hired after the cut-off." },
+          { title: "Over the cap" },
+          "Missing effective date",
+        ]}
+      >
+        <button>Trigger</button>
+      </TooltipInternal>
+    )
+
+    await user.hover(screen.getByRole("button", { name: "Trigger" }))
+
+    const tooltip = await screen.findByRole("tooltip")
+    expect(tooltip).toHaveTextContent("3 alerts")
+    expect(tooltip).toHaveTextContent("Needs a look before submitting.")
+
+    // Radix mirrors the content into a visually-hidden copy, so the bullets
+    // are counted inside one tooltip node rather than across the document.
+    const items = within(tooltip).getAllByRole("listitem")
+    expect(items).toHaveLength(3)
+    expect(items[0]).toHaveTextContent("Not eligible Hired after the cut-off.")
+    expect(items[1]).toHaveTextContent("Over the cap")
+    expect(items[2]).toHaveTextContent("Missing effective date")
+  })
+
+  it("opens on items alone, with no label or description", async () => {
+    const user = userEvent.setup()
+    render(
+      <TooltipInternal instant items={["Budget exceeded"]}>
+        <button>Trigger</button>
+      </TooltipInternal>
+    )
+
+    await user.hover(screen.getByRole("button", { name: "Trigger" }))
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "Budget exceeded"
+    )
+  })
+})

--- a/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { expect, within } from "storybook/test"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
@@ -33,6 +33,53 @@ export const Basic: Story = {
 export const Snapshot: Story = {
   args: Basic.args,
   parameters: withSnapshot({}),
+}
+
+/**
+ * A title, a body and a bulleted list. Bullets keep a set of separate reasons
+ * legible — the same copy as one paragraph reads as a run-on sentence, since
+ * tooltip text does not preserve line breaks.
+ */
+export const WithBulletedItems: Story = {
+  args: {
+    label: "3 alerts",
+    description: "This row needs a look before it can be submitted.",
+    items: [
+      { title: "Not eligible", description: "Hired after the cycle cut-off." },
+      {
+        title: "Over the cap",
+        description: "Raise exceeds the 10% guideline.",
+      },
+      "Missing effective date",
+    ],
+    children: <F0Button variant="outline" label="3 alerts" />,
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.closest("body")!)
+
+    await userEvent.hover(
+      within(canvasElement).getByRole("button", { name: "3 alerts" })
+    )
+
+    const tooltip = await waitFor(() => body.getByRole("tooltip"))
+    await expect(tooltip).toHaveTextContent("3 alerts")
+    // Each bullet is its own list item, titles included.
+    await expect(within(tooltip).getAllByRole("listitem")).toHaveLength(3)
+    await expect(tooltip).toHaveTextContent(
+      "Not eligible Hired after the cycle cut-off."
+    )
+    await expect(tooltip).toHaveTextContent("Missing effective date")
+  },
+}
+
+/**
+ * Bullets alone, with no title or body — a plain list of reasons.
+ */
+export const ItemsOnly: Story = {
+  args: {
+    items: ["Budget exceeded", "Currency outside the budget"],
+    children: <F0Button variant="outline" label="2 alerts" />,
+  },
 }
 
 export const WithShortcut: Story = {

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -20,26 +20,34 @@ import {
 import { cn } from "../../../lib/utils"
 import { Shortcut } from "@/ui/Shortcut"
 
+/**
+ * One bullet of a tooltip's list. The object form gets a semibold lead so a
+ * list of named things (alerts, broken rules) reads as a list rather than a run
+ * of sentences.
+ */
+export type TooltipListItem = string | { title: string; description?: string }
+
+/**
+ * The copy a tooltip shows. At least one of the three must be present — a
+ * tooltip with nothing to say never opens.
+ */
+export type TooltipCopyProps =
+  | { label: string; description?: string; items?: TooltipListItem[] }
+  | { label?: string; description: string; items?: TooltipListItem[] }
+  | { label?: string; description?: string; items: TooltipListItem[] }
+
 type TooltipInternalProps = {
   children: React.ReactNode
   shortcut?: ComponentProps<typeof Shortcut>["keys"]
   delay?: number
   instant?: boolean
   onOpen?: () => void
-} & (
-  | {
-      label: string
-      description?: string
-    }
-  | {
-      label?: string
-      description: string
-    }
-)
+} & TooltipCopyProps
 
 export function TooltipInternal({
   label,
   description,
+  items,
   children,
   shortcut,
   instant = false,
@@ -56,7 +64,7 @@ export function TooltipInternal({
    * whose text can be empty keep it mounted — unmounting it instead changes the
    * element type above the trigger, and React then remounts the trigger.
    */
-  const hasContent = Boolean(label || description || shortcut)
+  const hasContent = Boolean(label || description || items?.length || shortcut)
 
   const clearOpenTimeout = useCallback(() => {
     if (openTimeoutRef.current) {
@@ -138,6 +146,24 @@ export function TooltipInternal({
               </div>
               {description && (
                 <p className="font-normal">{description.toString()}</p>
+              )}
+              {items && items.length > 0 && (
+                <ul className="m-0 flex list-disc flex-col gap-0.5 pl-4 font-normal">
+                  {items.map((item, index) => (
+                    <li
+                      key={`${index}-${typeof item === "string" ? item : item.title}`}
+                    >
+                      {typeof item === "string" ? (
+                        item
+                      ) : (
+                        <>
+                          <span className="font-semibold">{item.title}</span>
+                          {item.description && <> {item.description}</>}
+                        </>
+                      )}
+                    </li>
+                  ))}
+                </ul>
               )}
             </div>
           </TooltipContent>

--- a/packages/react/src/lib/tooltip-wrapper.tsx
+++ b/packages/react/src/lib/tooltip-wrapper.tsx
@@ -1,16 +1,73 @@
 import { type ReactNode } from "react"
 
 import {
-  TooltipContent,
-  Tooltip as TooltipPrimitive,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/ui/tooltip"
+  TooltipInternal,
+  type TooltipCopyProps,
+  type TooltipListItem,
+} from "@/experimental/Overlays/Tooltip"
 
-import { stripNativeTitle } from "./strip-native-title"
+/**
+ * Structured tooltip copy: a semibold title, a body paragraph and an optional
+ * bulleted list. A plain string is the title alone, which is what every caller
+ * passed before the structured form existed.
+ */
+export type TooltipContentValue = {
+  title?: string
+  description?: string
+  items?: TooltipListItem[]
+}
+
+export type TooltipValue = string | TooltipContentValue
+
+export type { TooltipListItem }
+
+const itemToText = (item: TooltipListItem): string =>
+  typeof item === "string"
+    ? item
+    : [item.title, item.description].filter(Boolean).join(" ")
+
+/** Reads the parts as sentences without doubling punctuation the copy already has. */
+const joinSentences = (parts: string[]): string =>
+  parts
+    .map((part) => part.trim())
+    .map((part) => (/[.!?:;]$/.test(part) ? part : `${part}.`))
+    .join(" ")
+
+/**
+ * Flattens tooltip copy into a single string for hosts that expose it to
+ * screen readers, which get no hover and so never see the tooltip itself.
+ */
+export const tooltipAccessibleText = (
+  tooltip?: TooltipValue
+): string | undefined => {
+  if (!tooltip) return undefined
+  if (typeof tooltip === "string") return tooltip
+
+  const parts = [
+    tooltip.title,
+    tooltip.description,
+    ...(tooltip.items ?? []).map(itemToText),
+  ].filter((part): part is string => Boolean(part && part.trim()))
+
+  return parts.length > 0 ? joinSentences(parts) : undefined
+}
+
+/** Returns undefined when the tooltip has nothing to say. */
+const toTooltipCopy = (
+  tooltip?: TooltipValue
+): TooltipCopyProps | undefined => {
+  if (!tooltip) return undefined
+  if (typeof tooltip === "string") return { label: tooltip }
+
+  const { title, description, items } = tooltip
+  if (title) return { label: title, description, items }
+  if (description) return { description, items }
+  if (items?.length) return { items }
+  return undefined
+}
 
 interface TooltipWrapperProps {
-  tooltip?: string
+  tooltip?: TooltipValue
   children: ReactNode
 }
 
@@ -18,19 +75,13 @@ export const TooltipWrapper: React.FC<TooltipWrapperProps> = ({
   tooltip,
   children,
 }) => {
-  if (tooltip) {
-    return (
-      <TooltipProvider delayDuration={100} disableHoverableContent>
-        <TooltipPrimitive>
-          <TooltipTrigger asChild className="pointer-events-auto">
-            {stripNativeTitle(children)}
-          </TooltipTrigger>
-          <TooltipContent className="pointer-events-none max-w-xs">
-            <p className="font-semibold">{tooltip}</p>
-          </TooltipContent>
-        </TooltipPrimitive>
-      </TooltipProvider>
-    )
-  }
-  return <>{children}</>
+  const copy = toTooltipCopy(tooltip)
+
+  if (!copy) return <>{children}</>
+
+  return (
+    <TooltipInternal instant {...copy}>
+      {children}
+    </TooltipInternal>
+  )
 }

--- a/packages/react/src/ui/value-display/types/icon/icon.tsx
+++ b/packages/react/src/ui/value-display/types/icon/icon.tsx
@@ -3,7 +3,7 @@
  * Used for visual representation of status or type indicators.
  */
 import { F0Icon, IconType } from "@/components/F0Icon"
-import { TooltipWrapper } from "@/lib/tooltip-wrapper"
+import { TooltipWrapper, type TooltipValue } from "@/lib/tooltip-wrapper"
 import { cn } from "@/lib/utils"
 
 import { tableDisplayClassNames } from "../../const"
@@ -12,7 +12,11 @@ import { ValueDisplayRendererContext } from "../../renderers"
 interface IconValue {
   icon: IconType
   label: string
-  tooltip?: string
+  /**
+   * A string is shown as a single title line. Pass an object for a title, a
+   * body and a bulleted list.
+   */
+  tooltip?: TooltipValue
   hideLabel?: boolean
 }
 export type IconCellValue = IconValue

--- a/packages/react/src/ui/value-display/types/status/__stories__/status.mdx
+++ b/packages/react/src/ui/value-display/types/status/__stories__/status.mdx
@@ -13,6 +13,12 @@ Renders a status tag
 type value = {
     status: StatusVariant
     label: string
+    icon?: IconType
+    tooltip?: string | {
+        title?: string
+        description?: string
+        items?: (string | { title: string; description?: string })[]
+    }
 }
 ```
 
@@ -26,6 +32,36 @@ render: (item) => ({
         status: 'active',
         label: item.name
     }
+})
+`,
+  }}
+/>
+
+#### Tooltip
+
+A string is shown as a single title line. Pass an object when the cell has to
+explain more than one thing: `title` is semibold, `description` is the body and
+`items` renders as a bulleted list. Tooltip text does not preserve line breaks,
+so bullets — not a joined paragraph — are how several reasons stay legible.
+
+<Canvas
+  of={StatusStories.WithStructuredTooltip}
+  source={{
+    code: `
+render: (item) => ({
+    type: 'status',
+    value: {
+        status: 'critical',
+        label: String(item.alerts.length),
+        tooltip: {
+            title: '3 alerts',
+            description: 'This row needs a look before it can be submitted.',
+            items: item.alerts.map((alert) => ({
+                title: alert.title,
+                description: alert.body,
+            })),
+        },
+    },
 })
 `,
   }}

--- a/packages/react/src/ui/value-display/types/status/__stories__/status.stories.tsx
+++ b/packages/react/src/ui/value-display/types/status/__stories__/status.stories.tsx
@@ -1,5 +1,7 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
 
+import { expect, userEvent, waitFor, within } from "storybook/test"
+
 import { Cell, mockItem } from "../../../__stories__/shared"
 
 const meta = {
@@ -56,5 +58,56 @@ export const WithTooltip: Story = {
         },
       }),
     },
+  },
+}
+
+/**
+ * The tooltip also takes structured copy — a title, a body and a bulleted list —
+ * for cells that must explain several things at once. A plain string still means
+ * "title only", so existing cells are untouched.
+ */
+export const WithStructuredTooltip: Story = {
+  parameters: {
+    layout: "centered",
+  },
+  args: {
+    item: mockItem,
+    property: {
+      label: "Alerts",
+      render: () => ({
+        type: "status",
+        value: {
+          status: "critical",
+          label: "3",
+          tooltip: {
+            title: "3 alerts",
+            description: "This row needs a look before it can be submitted.",
+            items: [
+              {
+                title: "Not eligible",
+                description: "Hired after the cycle cut-off.",
+              },
+              {
+                title: "Over the cap",
+                description: "Raise exceeds the 10% guideline.",
+              },
+              "Missing effective date",
+            ],
+          },
+        },
+      }),
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const body = within(canvasElement.closest("body")!)
+
+    await userEvent.hover(within(canvasElement).getByText("3"))
+
+    const tooltip = await waitFor(() => body.getByRole("tooltip"))
+    await expect(tooltip).toHaveTextContent("3 alerts")
+    await expect(tooltip).toHaveTextContent(
+      "Not eligible Hired after the cycle cut-off."
+    )
+    await expect(within(tooltip).getAllByRole("listitem")).toHaveLength(3)
   },
 }

--- a/packages/react/src/ui/value-display/types/status/status.test.tsx
+++ b/packages/react/src/ui/value-display/types/status/status.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react"
+import { render, screen, waitFor, within } from "@testing-library/react"
 import { userEvent } from "@testing-library/user-event"
 import { describe, expect, it } from "vitest"
 
@@ -59,6 +59,52 @@ describe("StatusCell", () => {
 
     const srText = screen.getByText(
       "The call ended before all information was collected"
+    )
+    expect(srText).toHaveClass("sr-only")
+  })
+
+  it("should render a structured tooltip with title, body and bullets", async () => {
+    const args: StatusCellValue = {
+      status: "critical",
+      label: "3",
+      tooltip: {
+        title: "3 alerts",
+        description: "This row needs a look before it can be submitted.",
+        items: [
+          { title: "Not eligible", description: "Hired after the cut-off." },
+          "Missing effective date",
+        ],
+      },
+    }
+
+    render(StatusCell(args))
+
+    await userEvent.hover(screen.getByText("3"))
+
+    const tooltip = await waitFor(() => screen.getByRole("tooltip"))
+    expect(tooltip).toHaveTextContent("3 alerts")
+    expect(tooltip).toHaveTextContent(
+      "This row needs a look before it can be submitted."
+    )
+    expect(tooltip).toHaveTextContent("Not eligible Hired after the cut-off.")
+    expect(within(tooltip).getAllByRole("listitem")).toHaveLength(2)
+  })
+
+  it("should flatten a structured tooltip for screen readers", () => {
+    const args: StatusCellValue = {
+      status: "critical",
+      label: "3",
+      tooltip: {
+        title: "3 alerts",
+        description: "Needs a look.",
+        items: [{ title: "Not eligible", description: "Hired late." }],
+      },
+    }
+
+    render(StatusCell(args))
+
+    const srText = screen.getByText(
+      "3 alerts. Needs a look. Not eligible Hired late."
     )
     expect(srText).toHaveClass("sr-only")
   })

--- a/packages/react/src/ui/value-display/types/status/status.tsx
+++ b/packages/react/src/ui/value-display/types/status/status.tsx
@@ -4,13 +4,21 @@
  */
 import { IconType } from "@/components/F0Icon"
 import { F0TagStatus, StatusVariant } from "@/components/tags/F0TagStatus"
-import { TooltipWrapper } from "@/lib/tooltip-wrapper"
+import {
+  TooltipWrapper,
+  tooltipAccessibleText,
+  type TooltipValue,
+} from "@/lib/tooltip-wrapper"
 
 interface StatusValue {
   status: StatusVariant
   label: string
   icon?: IconType
-  tooltip?: string
+  /**
+   * A string is shown as a single title line. Pass an object for a title, a
+   * body and a bulleted list.
+   */
+  tooltip?: TooltipValue
 }
 export type StatusCellValue = StatusValue
 
@@ -22,7 +30,7 @@ export const StatusCell = (args: StatusCellValue) => (
           variant={args.status}
           text={args.label}
           icon={args.icon}
-          additionalAccessibleText={args.tooltip}
+          additionalAccessibleText={tooltipAccessibleText(args.tooltip)}
         />
       </div>
     </TooltipWrapper>


### PR DESCRIPTION

<img width="1859" height="678" alt="Screenshot 2026-08-28 at 9 16 58 AM" src="https://github.com/user-attachments/assets/bf8aee99-d438-4905-baf6-1170714bcc9c" />


## Description

The `status` and `icon` cell tooltips took a single string and rendered all of it at title weight, so a cell that has to explain several things (a row's alerts, the rules a decision was judged against) had to join its sentences into one paragraph — the shape visible in a data-collection table today. Both now also accept structured copy — a title, a body and a bulleted list — while a plain string keeps rendering exactly as before, so no existing caller changes.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Implementation details

- feat: add `items` to `Tooltip`, rendered as a bulleted list below the description. Each bullet is a string, or `{ title, description }` for a semibold lead
- feat: accept `tooltip?: string | { title?, description?, items? }` on the `status` and `icon` value-display cells (`TooltipValue`)
- refactor: `TooltipWrapper` now delegates to `TooltipInternal` instead of wiring Radix a second time

  <details>
  <summary>Why?</summary>

  The wrapper duplicated the trigger/content setup, which is why it never gained the title/body split the Tooltip component already had. Delegating keeps one renderer for tooltip copy; `instant` preserves the wrapper's 100ms, non-hoverable behaviour. Keyboard focus now opens the tooltip only when focus is visible, matching every other F0 tooltip.
  </details>

- feat: expose structured copy to screen readers via `tooltipAccessibleText`, which flattens title, body and bullets into one sentence run for `additionalAccessibleText`
- test: cover bullets, items-only tooltips and the flattened a11y text (unit + play functions)
- docs: document the tooltip value type and add a `WithStructuredTooltip` canvas to the status cell MDX