### PR TITLE
fix(F0AiChatTextArea): match the composer surface to the widgets

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -590,16 +590,19 @@ export const F0AiChatTextArea = ({
               "transition-all hover:cursor-text",
               "p-0",
               "before:pointer-events-none before:absolute before:inset-0 before:z-[-1]",
-              "before:rounded-[inherit] before:bg-f1-background before:content-['']",
-              "after:pointer-events-none after:absolute after:inset-0.5 after:z-[-2]",
-              "after:rounded-md after:blur-[6px] after:content-['']",
-              "after:scale-90 after:opacity-0",
+              "before:rounded-[inherit] before:content-['']",
+              "before:bg-f1-background-inverse-secondary dark:before:bg-f1-background-tertiary",
+              "after:pointer-events-none after:absolute after:-inset-2.5 after:z-[-2]",
+              "after:rounded-3xl after:border-[10px] after:border-solid after:border-transparent",
+              "after:p-0.5 after:blur-[6px] after:content-['']",
+              "after:[background-clip:content-box]",
+              "after:[mask:linear-gradient(#000,#000)_padding-box_exclude,linear-gradient(#000,#000)]",
+              "after:opacity-0",
               "after:bg-[conic-gradient(from_var(--gradient-angle),var(--tw-gradient-stops))]",
               "from-[#E55619] via-[#A1ADE5] to-[#E51943]",
-              "after:transition-all after:delay-200 after:duration-300",
-              "has-[textarea:focus]:after:scale-100 has-[textarea:focus]:after:opacity-100",
-              isClarifying &&
-                "after:scale-100 after:opacity-100 border-f1-background-tertiary"
+              "after:transition-opacity after:delay-200 after:duration-300",
+              "has-[textarea:focus]:after:opacity-100",
+              isClarifying && "after:opacity-100 border-f1-background-tertiary"
             )}
             animate={{
               "--gradient-angle": ["0deg", "360deg"],

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.surface.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.surface.test.tsx
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+/**
+ * The composer stands among Home's widgets, so its surface has to BE theirs:
+ * `Card` — what every widget is drawn with — lifts the page translucently with
+ * `background-inverse-secondary`, `background-tertiary` in dark. Same tokens,
+ * so the page's wash runs under the composer exactly as it runs under a widget.
+ */
+const WIDGET_SURFACE = "before:bg-f1-background-inverse-secondary"
+const WIDGET_SURFACE_DARK = "dark:before:bg-f1-background-tertiary"
+
+const renderForm = () => {
+  const { container } = render(<F0AiChatTextArea onSubmit={vi.fn()} />)
+  const form = container.querySelector("form")
+  expect(form).not.toBeNull()
+  return form as HTMLFormElement
+}
+
+const classesMatching = (form: HTMLFormElement, needle: string) =>
+  Array.from(form.classList).filter((c) => c.includes(needle))
+
+describe("F0AiChatTextArea surface", () => {
+  it("wears the widgets' surface tokens", () => {
+    expect(renderForm()).toHaveClass(WIDGET_SURFACE, WIDGET_SURFACE_DARK)
+  })
+
+  it("is translucent — no opaque fill of its own to hide the page", () => {
+    expect(classesMatching(renderForm(), "before:bg-")).toEqual([
+      WIDGET_SURFACE,
+      WIDGET_SURFACE_DARK,
+    ])
+  })
+})
+
+/**
+ * What makes that translucency safe. The glow sits BEHIND the surface, so a
+ * filled gradient would wash straight through the field. It is masked to the
+ * spill beyond the field instead — the only part the old opaque surface ever
+ * let show.
+ */
+describe("F0AiChatTextArea focus glow", () => {
+  it("is masked out of the field's own box", () => {
+    const form = renderForm()
+
+    expect(form).toHaveClass("after:z-[-2]", "before:z-[-1]")
+    // The hole is the PADDING box — the field itself.
+    expect(form).toHaveClass(
+      "after:[mask:linear-gradient(#000,#000)_padding-box_exclude,linear-gradient(#000,#000)]"
+    )
+    // The gradient paints in the CONTENT box: the field inset by the padding,
+    // which keeps the ring at the old alpha instead of a hard outline.
+    expect(form).toHaveClass(
+      "after:[background-clip:content-box]",
+      "after:p-0.5"
+    )
+    // Border box = the field plus room for the blur's tail.
+    expect(form).toHaveClass("after:-inset-2.5", "after:border-[10px]")
+  })
+
+  /**
+   * The bug this guards: the glow used to grow in with `scale-90` → `scale-100`.
+   * The mask's hole is pinned to the field's box, so scaling the element shrinks
+   * the hole along with it and sweeps the ring across the textarea for the whole
+   * fade. Only opacity may animate.
+   */
+  it("animates opacity alone, so the mask can never leave the field", () => {
+    const form = renderForm()
+
+    expect(classesMatching(form, "after:scale")).toEqual([])
+    expect(form).toHaveClass("after:transition-opacity")
+    expect(form).not.toHaveClass("after:transition-all")
+    expect(form).toHaveClass(
+      "after:opacity-0",
+      "has-[textarea:focus]:after:opacity-100"
+    )
+  })
+})


### PR DESCRIPTION
## Description

The composer stands among Home's widgets, but drew itself on a plain `background` while `Card` — what every widget is drawn with — lifts the page translucently. In dark mode that made the field read as a solid slab about 19 points darker per channel than every card around it, and in light mode it never picked up the page's wash. It now wears the same tokens as `Card`, which means the surface is genuinely translucent; that exposed the focus glow sitting behind it, so the glow is masked to the spill beyond the field — the only part the old opaque surface ever let show.
