### PR TITLE
perf(F0AiChatTextArea): spin the glow in CSS instead of per-frame JS

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -574,7 +574,7 @@ export const F0AiChatTextArea = ({
           </div>
         )}
         <CreditWarningWrapper creditWarning={creditWarning}>
-          <motion.form
+          <form
             aria-busy={inProgress}
             ref={formRef}
             className={cn(
@@ -602,21 +602,14 @@ export const F0AiChatTextArea = ({
               "from-[#E55619] via-[#A1ADE5] to-[#E51943]",
               "after:transition-opacity after:delay-200 after:duration-300",
               "has-[textarea:focus]:after:opacity-100",
+              !shouldReduceMotion &&
+                !isClarifying &&
+                "after:[animation:rotate-gradient_6s_linear_infinite_paused] has-[textarea:focus]:after:[animation:rotate-gradient_6s_linear_infinite_running]",
+              !shouldReduceMotion &&
+                isClarifying &&
+                "after:[animation:rotate-gradient_6s_linear_infinite_running]",
               isClarifying && "after:opacity-100 border-f1-background-tertiary"
             )}
-            animate={{
-              "--gradient-angle": ["0deg", "360deg"],
-            }}
-            transition={{
-              duration: 6,
-              ease: "linear",
-              repeat: Infinity,
-            }}
-            style={
-              {
-                "--gradient-angle": "180deg",
-              } as React.CSSProperties
-            }
             onClick={() => {
               if (!isClarifying) {
                 textareaRef.current?.focus()
@@ -862,7 +855,7 @@ export const F0AiChatTextArea = ({
                 </motion.div>
               )}
             </AnimatePresence>
-          </motion.form>
+          </form>
         </CreditWarningWrapper>
       </div>
 

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.glowAnimation.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.glowAnimation.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest"
+
+let mockReducedMotion = false
+vi.mock("@/lib/a11y", () => ({
+  useReducedMotion: () => mockReducedMotion,
+}))
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+const SPIN = "rotate-gradient_6s_linear_infinite"
+const PAUSED = `after:[animation:${SPIN}_paused]`
+const RUNNING_ON_FOCUS = `has-[textarea:focus]:after:[animation:${SPIN}_running]`
+
+const renderForm = (props = {}) => {
+  const { container } = render(
+    <F0AiChatTextArea onSubmit={vi.fn()} {...props} />
+  )
+  const form = container.querySelector("form")
+  expect(form).not.toBeNull()
+  return form as HTMLFormElement
+}
+
+/**
+ * The glow's spin is CSS, not JS.
+ *
+ * It used to be a `repeat: Infinity` motion animation writing `--gradient-angle`
+ * to the form as an inline style every frame — 120/s on a 120Hz display, for as
+ * long as the composer was mounted — and none of it rendered: the property is
+ * registered `inherits: false` and the gradient is painted on the form's
+ * `::after`, which a value set on the form never reaches.
+ */
+describe("F0AiChatTextArea glow animation", () => {
+  it("writes no per-frame inline style to the form", () => {
+    mockReducedMotion = false
+
+    expect(renderForm().getAttribute("style")).toBeNull()
+  })
+
+  it("spins via CSS on the pseudo-element that paints the gradient", () => {
+    mockReducedMotion = false
+    const form = renderForm()
+
+    expect(form).toHaveClass(RUNNING_ON_FOCUS)
+    expect(form).toHaveClass(
+      "after:bg-[conic-gradient(from_var(--gradient-angle),var(--tw-gradient-stops))]"
+    )
+  })
+
+  /**
+   * Dropping `animation` on blur snaps `--gradient-angle` back to its registered
+   * `initial-value` at once, and the glow fades out over 300ms — so you watch the
+   * gradient jump home mid-fade. Pausing holds the angle where it stopped, and a
+   * paused animation does not tick, so resting still costs no frames.
+   */
+  it("pauses rather than drops the spin when the glow goes away", () => {
+    mockReducedMotion = false
+    const form = renderForm()
+
+    expect(form).toHaveClass(PAUSED)
+    expect(form).toHaveClass(RUNNING_ON_FOCUS)
+  })
+
+  /**
+   * The play state rides INSIDE the `animation` shorthand. As its own
+   * declaration it loses: the shorthand resets `animation-play-state` to
+   * `running`, and Tailwind gives no ordering guarantee between two arbitrary
+   * properties — which left the spin running at rest.
+   */
+  it("carries the play state inside the animation shorthand", () => {
+    mockReducedMotion = false
+    const form = renderForm()
+
+    expect(form.className).not.toContain("animation-play-state")
+  })
+
+  it("runs unpaused while clarifying, which shows the glow with no focus", () => {
+    mockReducedMotion = false
+    const form = renderForm({
+      clarifyingUI: <div>clarify</div>,
+    })
+
+    expect(form).toHaveClass(`after:[animation:${SPIN}_running]`)
+    expect(form).not.toHaveClass(PAUSED)
+  })
+
+  it("does not spin when the reader prefers reduced motion", () => {
+    mockReducedMotion = true
+    const form = renderForm()
+
+    expect(form.className).not.toContain("rotate-gradient")
+  })
+})


### PR DESCRIPTION
## Description

The composer drove `--gradient-angle` from 0deg to 360deg on a `repeat: Infinity` motion animation, which wrote an inline style to the form on every frame — 120/s on a 120Hz display, for as long as the composer was mounted. None of it rendered. This moves the spin to CSS, where the browser interpolates the registered angle natively with no JS, and where it finally lands on the element that actually paints the gradient.

## Notes for the reviewer

The same bug exists in `F0OneIcon`, `F0OneSwitch` and their two AiPromotionChat twins: each animates an ancestor while the gradient is painted on a descendant or a `::before`. Those are fixed in the stacked follow-up (#5296), which also adds a check script so the pattern cannot recur.

An earlier revision of this description claimed the `F0OneIcon` blobs were fine because they set the property on the painting element. That was wrong — it came from a probe that wrote the property onto the element before testing it. Measured passively, all eight painters were frozen.
