### PR TITLE
fix(OneDataCollection): report selected nested rows to the selection callbacks

### DIFF
--- a/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
+++ b/packages/react/src/hooks/datasource/useSelectable/useSelectable.ts
@@ -239,14 +239,21 @@ export function useSelectable<
   const { itemsStatus, selectedIds } = useMemo(() => {
     const items = localSelectedState.items || new Map()
 
-    // In page-only selection mode, only include items from current page
-    const currentPageItemIds = isPageOnlySelection
-      ? new Set(
-          data.records
-            .map((record) => getSelectable?.(record))
-            .filter((id): id is SelectionId => id !== undefined)
-        )
-      : null
+    // In page-only selection mode, only include items from current page.
+    // A tree's `data.records` holds the ROOTS only — its nested rows arrive
+    // through `fetchChildren` and never appear there — so page-scoping the
+    // payload would drop every selected child and hand the consumer an empty
+    // `itemsStatus` (which also keeps the action bar shut). A tree has no pages
+    // to scope to, so it is exempt.
+    const isTree = source.fetchChildren !== undefined
+    const currentPageItemIds =
+      isPageOnlySelection && !isTree
+        ? new Set(
+            data.records
+              .map((record) => getSelectable?.(record))
+              .filter((id): id is SelectionId => id !== undefined)
+          )
+        : null
 
     const itemsStatus = Array.from(items.values())
       .filter((itemState) => {
@@ -276,6 +283,7 @@ export function useSelectable<
     isPageOnlySelection,
     data.records,
     getSelectable,
+    source.fetchChildren,
   ])
 
   const groupsStatus = useMemo(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
@@ -52,7 +52,8 @@ const parents: Person[] = [
 const columns = [{ label: "name", render: (item: Person) => item.name }]
 
 const createSource = (
-  onSelectItems: () => void
+  onSelectItems: () => void,
+  { allPagesSelection = true }: { allPagesSelection?: boolean } = {}
 ): DataCollectionSource<
   Person,
   FiltersDefinition,
@@ -78,7 +79,7 @@ const createSource = (
     currentGrouping: undefined,
     setCurrentGrouping: vi.fn(),
     selectable: (item: Person) => (item.children?.length ? undefined : item.id),
-    allPagesSelection: true,
+    allPagesSelection,
     itemsWithChildren: (item: Person) => !!item.children?.length,
     fetchChildren: ({ item }: { item: Person }) => ({
       records: item.children ?? [],
@@ -145,7 +146,9 @@ describe("Table nested-row selection (registry-backed select all)", () => {
     render(
       <EditableTableCollection
         columns={columns}
-        source={createSource(vi.fn())}
+        // Page-only selection (the default) is where the page filter — and the
+        // bug — lives: `allPagesSelection` switches that path off entirely.
+        source={createSource(vi.fn(), { allPagesSelection: false })}
         onSelectItems={onSelectItems}
         onLoadData={vi.fn()}
         onLoadError={vi.fn()}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedSelection.test.tsx
@@ -139,6 +139,35 @@ describe("Table nested-row selection (registry-backed select all)", () => {
     })
   })
 
+  it("reports the selected nested child to onSelectItems (page-only selection)", async () => {
+    const user = userEvent.setup()
+    const onSelectItems = vi.fn()
+    render(
+      <EditableTableCollection
+        columns={columns}
+        source={createSource(vi.fn())}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText("Parent")).toBeInTheDocument())
+    await expandParent(user)
+
+    await user.click(screen.getByTitle("Select c1"))
+
+    // A tree's `data.records` holds only the roots, so page-scoping the payload
+    // used to drop the child and hand the consumer an empty selection.
+    await waitFor(() => {
+      const lastCall = onSelectItems.mock.calls.at(-1)
+      expect(lastCall?.[0].selectedIds).toEqual(["c1"])
+      expect(lastCall?.[0].itemsStatus).toEqual([
+        { item: expect.objectContaining({ id: "c1" }), checked: true },
+      ])
+    })
+  })
+
   it("'Select all N items' selects nested children without wiping the existing selection", async () => {
     const user = userEvent.setup()
     render(


### PR DESCRIPTION
## Description

In page-only selection — the default — `itemsStatus` and `selectedIds` were filtered against `data.records`. A tree's `data.records` holds the **roots only**: its nested rows arrive through `fetchChildren` and never appear there, so every selected child was dropped from the payload. The consumer saw an empty `itemsStatus` next to a non-zero `selectedCount`, and since `OneDataCollection` opens the action bar from `itemsStatus.some(checked)`, **bulk actions on a nested table were unreachable altogether**: you could tick a child row and nothing ever appeared to act with it. A tree has no pages to scope a selection to, so it is now exempt from the page filter.

Found while wiring multi-select + bulk move onto the Job Catalog nested table (FCT-58658). Split out of #5281 because it stands on its own: it needs none of that PR's new props, and anyone putting bulk actions on a nested table hits it today.

## Type of change

- [x] Bug fix

## Implementation details

- fix: exempt a tree (`source.fetchChildren !== undefined`) from the page-only filter that builds `itemsStatus` / `selectedIds`
- test: extend `Table/__tests__/NestedSelection.test.tsx` — a selected nested child now reaches `onSelectItems` in both `selectedIds` and `itemsStatus`