### PR TITLE
perf(react): spin the AI gradients in CSS, not per-frame JS

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -74,6 +74,8 @@ jobs:
         run: pnpm --filter @factorialco/f0-core build
       - name: Check linting with oxlint
         run: pnpm --filter @factorialco/f0-react run lint
+      - name: Check no CSS custom properties are animated through motion
+        run: pnpm exec tsx packages/react/.scripts/check-animated-css-variables.ts
   lint-react-native:
     needs: detect-changes
     # Prevents running on the release-please branch

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -35,6 +35,10 @@ pre-commit:
     cycle-dependencies:
       run: pnpm exec tsx packages/react/.scripts/check-cycle-dependencies.ts --pre-commit
 
+    animated-css-variables:
+      glob: "packages/react/src/**/*.tsx"
+      run: pnpm exec tsx packages/react/.scripts/check-animated-css-variables.ts --staged
+
     ownership:
       glob: "{CODEOWNERS,ownership/*,packages/react/src/sds/**}"
       run: pnpm --filter @factorialco/f0-ownership run check

--- a/packages/react/.scripts/check-animated-css-variables.ts
+++ b/packages/react/.scripts/check-animated-css-variables.ts
@@ -1,0 +1,128 @@
+/**
+ * Bans animating a CSS custom property through motion's `animate` prop.
+ *
+ * Motion animates by writing an inline style to a real DOM node on every frame.
+ * That is expensive — 120 writes/second per element on a 120Hz display, for as
+ * long as the component is mounted — and for custom properties it is usually
+ * broken as well:
+ *
+ *   - `@property` registrations in this repo declare `inherits: false`, so a
+ *     value written to a parent never reaches a descendant, and
+ *   - a pseudo-element has no inline style at all, so motion can never reach an
+ *     `::after`/`::before` that paints with `var(--…)`.
+ *
+ * Every occurrence found so far animated a property that nothing could read, so
+ * the animation cost a style write per frame and rendered nothing. See
+ * `F0AiChatTextArea`, `F0OneIcon` and `F0OneSwitch` for the fix: declare the
+ * animation as a CSS keyframe and apply it, in CSS, to the element that
+ * actually paints — `after:[animation:rotate-gradient_6s_linear_infinite]`.
+ *
+ * Run over the whole tree, or with `--staged` for staged files only.
+ */
+import { consola } from "consola"
+import { execSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import { globSync } from "node:fs"
+import { relative, resolve } from "node:path"
+
+const ROOT = resolve(import.meta.dirname, "..")
+
+/** Extracts the balanced `{{ … }}` body of a prop starting at `open`. */
+const balancedBlock = (source: string, open: number): string => {
+  let depth = 0
+  for (let i = open; i < source.length; i++) {
+    if (source[i] === "{") depth++
+    else if (source[i] === "}") {
+      depth--
+      if (depth === 0) return source.slice(open, i + 1)
+    }
+  }
+  return source.slice(open)
+}
+
+const CUSTOM_PROPERTY_KEY = /["'](--[\w-]+)["']\s*:/
+
+/**
+ * Opt-out for the cases where motion is genuinely the right tool: the property
+ * is written to, and read by, the SAME element, and its value is dynamic enough
+ * that a static keyframe cannot express it. Requires a reason, so the next
+ * reader knows it was considered rather than silenced.
+ */
+const ALLOW = /\/\/\s*f0-allow-animated-css-var:\s*\S/
+
+type Finding = { file: string; line: number; property: string; prop: string }
+
+const inspect = (file: string): Finding[] => {
+  const source = readFileSync(file, "utf8")
+  const lines = source.split("\n")
+  const findings: Finding[] = []
+
+  for (const prop of ["animate", "transition"]) {
+    const opener = new RegExp(`\\b${prop}=\\{\\{`, "g")
+    let match: RegExpExecArray | null
+    while ((match = opener.exec(source)) !== null) {
+      // Step back to the `{{` so the brace matcher starts balanced.
+      const open = source.indexOf("{", match.index + prop.length)
+      const block = balancedBlock(source, open)
+      const hit = block.match(CUSTOM_PROPERTY_KEY)
+      if (!hit) continue
+
+      const line = source.slice(0, match.index).split("\n").length
+      // Walk up through the comment block immediately above the prop, however
+      // many lines it runs to, plus the prop's own line.
+      let cursor = line - 2
+      let preceding = lines[line - 1] ?? ""
+      while (cursor >= 0 && lines[cursor].trim().startsWith("//")) {
+        preceding += "\n" + lines[cursor]
+        cursor--
+      }
+      if (ALLOW.test(preceding)) continue
+
+      findings.push({ file, line, property: hit[1], prop })
+    }
+  }
+  return findings
+}
+
+const stagedFiles = (): string[] =>
+  execSync("git diff --cached --name-only --diff-filter=ACMR", {
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter((f) => f.endsWith(".tsx"))
+    .map((f) => resolve(ROOT, "../..", f))
+
+const files = process.argv.includes("--staged")
+  ? stagedFiles()
+  : globSync(`${ROOT}/src/**/*.tsx`)
+
+const findings = files
+  .filter(
+    (f) => f.includes(`${ROOT}/src/`) || process.argv.includes("--staged")
+  )
+  .flatMap((f) => {
+    try {
+      return inspect(f)
+    } catch {
+      return []
+    }
+  })
+
+if (findings.length > 0) {
+  consola.error(
+    `\n✗ Animating a CSS custom property through motion writes an inline style every frame,\n` +
+      `  and cannot reach a pseudo-element or (with \`inherits: false\`) a descendant.\n` +
+      `  Use a CSS keyframe on the element that paints instead — see the theme's\n` +
+      `  \`rotate-gradient\` and its use in F0AiChatTextArea / F0OneIcon.\n`
+  )
+  for (const f of findings) {
+    consola.error(
+      `  ${relative(resolve(ROOT, "../.."), f.file)}:${f.line}  ${f.prop}={{ "${f.property}": … }}`
+    )
+  }
+  process.exit(1)
+}
+
+consola.success(
+  `No CSS custom properties animated through motion (${files.length} files checked).`
+)

--- a/packages/react/src/experimental/AiPromotionChat/OneIcon.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/OneIcon.tsx
@@ -85,32 +85,13 @@ const OneIcon = (
         transformStyle: spin ? "preserve-3d" : undefined,
       }}
     >
-      <motion.svg
+      <svg
         width="100%"
         height="100%"
         viewBox="0 0 32 32"
         xmlns="http://www.w3.org/2000/svg"
         ref={ref}
-        animate={{
-          "--gradient-angle": ["0deg", "360deg"],
-        }}
-        transition={
-          !background
-            ? {
-                "--gradient-angle": {
-                  duration: 6,
-                  ease: "linear",
-                  repeat: Infinity,
-                },
-              }
-            : undefined
-        }
-        style={
-          {
-            "--gradient-angle": "0deg",
-            ...safeSvgProps.style,
-          } as React.CSSProperties
-        }
+        style={safeSvgProps.style}
         {...(({ style: _style, ...rest }) => rest)(safeSvgProps)}
       >
         <defs>
@@ -133,6 +114,10 @@ const OneIcon = (
               width="32"
               height="32"
               clipPath={`url(#${clipPathId}-${piece.id})`}
+              // f0-allow-animated-css-var: written and read by this same
+              // element (its own `transform`), and the value depends on hover
+              // and the per-piece spin sequence, which a static keyframe cannot
+              // express.
               animate={{
                 "--rotate3d-angle": ["0deg", "180deg", "180deg", "360deg"],
                 "--scale": hover ? 8 : 1,
@@ -142,6 +127,7 @@ const OneIcon = (
                   ? ["blur(0px)", "blur(8px)", "blur(0px)"]
                   : undefined,
               }}
+              // f0-allow-animated-css-var: see above.
               transition={{
                 "--rotate3d-angle": {
                   delay: spin ? piece.delay : 0,
@@ -182,6 +168,10 @@ const OneIcon = (
               }
             >
               <div
+                className={cn(
+                  !background &&
+                    "[animation:rotate-gradient_6s_linear_infinite] motion-reduce:[animation:none]"
+                )}
                 style={{
                   width: "100%",
                   height: "100%",
@@ -193,7 +183,7 @@ const OneIcon = (
             </motion.foreignObject>
           ))}
         </g>
-      </motion.svg>
+      </svg>
     </div>
   )
 }

--- a/packages/react/src/experimental/AiPromotionChat/OneSwitch.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/OneSwitch.tsx
@@ -1,5 +1,4 @@
 import * as SwitchPrimitive from "@radix-ui/react-switch"
-import { motion } from "motion/react"
 import { useState } from "react"
 
 import { useI18n } from "@/lib/providers/i18n"
@@ -31,23 +30,7 @@ export const OneSwitch = ({
       <TooltipProvider>
         <Tooltip delayDuration={850} disableHoverableContent>
           <TooltipTrigger asChild>
-            <motion.div
-              animate={{
-                "--gradient-angle": ["0deg", "360deg"],
-              }}
-              transition={{
-                default: {
-                  duration: 8,
-                  ease: "linear",
-                  repeat: Infinity,
-                },
-              }}
-              style={
-                {
-                  "--gradient-angle": "180deg",
-                } as React.CSSProperties
-              }
-            >
+            <div>
               <SwitchPrimitive.Root
                 onCheckedChange={(val) => {
                   setOpen(val)
@@ -61,6 +44,7 @@ export const OneSwitch = ({
                   "shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_0_4px_rgba(13,22,37,.04)] data-[state=checked]:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_0_4px_rgba(13,22,37,.6)]",
                   "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] data-[state=checked]:after:ring-f1-border-inverse",
                   "before:absolute before:inset-0 before:rounded-full before:bg-[conic-gradient(from_var(--gradient-angle),hsla(229,57%,76%,0.7),hsla(348,80%,50%,0.7),hsla(348,80%,50%,0.7),hsla(18,80%,50%,0.7),hsla(229,57%,76%,0.7),hsla(229,57%,76%,0.7))] before:opacity-0 before:transition-all before:duration-300 before:content-[''] data-[state=checked]:before:opacity-100",
+                  "before:[animation:rotate-gradient_8s_linear_infinite_paused] data-[state=checked]:before:[animation:rotate-gradient_8s_linear_infinite_running] motion-reduce:before:[animation:none]",
                   disabled && "cursor-not-allowed opacity-50",
                   focusRing(),
                   className
@@ -87,7 +71,7 @@ export const OneSwitch = ({
                   </div>
                 </SwitchPrimitive.Thumb>
               </SwitchPrimitive.Root>
-            </motion.div>
+            </div>
           </TooltipTrigger>
           {!open && (
             <TooltipContent side="left" className="font-medium">

--- a/packages/react/src/experimental/AiPromotionChat/components/ChatTextarea.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/ChatTextarea.tsx
@@ -15,23 +15,9 @@ export const ChatTextarea = () => {
         "after:pointer-events-none after:absolute after:inset-0.5 after:z-[-2] after:rounded-[inherit] after:bg-f1-foreground-secondary after:opacity-0 after:blur-[5px] after:content-['']",
         "from-[#E55619] via-[#A1ADE5] to-[#E51943] after:scale-90 after:bg-[conic-gradient(from_var(--gradient-angle),var(--tw-gradient-stops))]",
         "after:transition-all after:delay-200 after:duration-300",
+        "after:[animation:rotate-gradient_6s_linear_infinite] motion-reduce:after:[animation:none]",
         "before:bg-white before:pointer-events-none before:absolute before:inset-0 before:z-[-1] before:rounded-[inherit] before:content-['']"
       )}
-      animate={{
-        "--gradient-angle": ["0deg", "360deg"],
-      }}
-      transition={{
-        default: {
-          duration: 6,
-          ease: "linear",
-          repeat: Infinity,
-        },
-      }}
-      style={
-        {
-          "--gradient-angle": "180deg",
-        } as React.CSSProperties
-      }
     >
       <div className="grid grid-cols-1 grid-rows-1">
         <textarea

--- a/packages/react/src/kits/ai/F0OneIcon/F0OneIcon.tsx
+++ b/packages/react/src/kits/ai/F0OneIcon/F0OneIcon.tsx
@@ -79,32 +79,13 @@ const F0OneIconComponent = (
         transformStyle: spin ? "preserve-3d" : undefined,
       }}
     >
-      <motion.svg
+      <svg
         width="100%"
         height="100%"
         viewBox="0 0 32 32"
         xmlns="http://www.w3.org/2000/svg"
         ref={ref}
-        animate={{
-          "--gradient-angle": ["0deg", "360deg"],
-        }}
-        transition={
-          !background
-            ? {
-                "--gradient-angle": {
-                  duration: 6,
-                  ease: "linear",
-                  repeat: Infinity,
-                },
-              }
-            : undefined
-        }
-        style={
-          {
-            "--gradient-angle": "0deg",
-            ...safeSvgProps.style,
-          } as React.CSSProperties
-        }
+        style={safeSvgProps.style}
         {...(({ style: _style, ...rest }) => rest)(safeSvgProps)}
       >
         <defs>
@@ -127,6 +108,10 @@ const F0OneIconComponent = (
               width="32"
               height="32"
               clipPath={`url(#${clipPathId}-${piece.id})`}
+              // f0-allow-animated-css-var: written and read by this same
+              // element (its own `transform`), and the value depends on hover
+              // and the per-piece spin sequence, which a static keyframe cannot
+              // express.
               animate={{
                 "--rotate3d-angle": ["0deg", "180deg", "180deg", "360deg"],
                 "--scale": hover ? 8 : 1,
@@ -136,6 +121,7 @@ const F0OneIconComponent = (
                   ? ["blur(0px)", "blur(8px)", "blur(0px)"]
                   : undefined,
               }}
+              // f0-allow-animated-css-var: see above.
               transition={{
                 "--rotate3d-angle": {
                   delay: spin ? piece.delay : 0,
@@ -180,6 +166,10 @@ const F0OneIconComponent = (
               }
             >
               <div
+                className={cn(
+                  !background &&
+                    "[animation:rotate-gradient_6s_linear_infinite] motion-reduce:[animation:none]"
+                )}
                 style={{
                   width: "100%",
                   height: "100%",
@@ -191,7 +181,7 @@ const F0OneIconComponent = (
             </motion.foreignObject>
           ))}
         </g>
-      </motion.svg>
+      </svg>
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0OneSwitch/F0OneSwitch.tsx
+++ b/packages/react/src/kits/ai/F0OneSwitch/F0OneSwitch.tsx
@@ -1,5 +1,4 @@
 import * as SwitchPrimitive from "@radix-ui/react-switch"
-import { motion } from "motion/react"
 import { useEffect, useState } from "react"
 
 import { useI18n } from "@/lib/providers/i18n"
@@ -63,18 +62,7 @@ export const F0OneSwitch = ({
           onOpenChange={autoOpen ? () => {} : setTooltipOpen}
         >
           <TooltipTrigger asChild>
-            <motion.div
-              animate={{
-                "--gradient-angle": ["0deg", "360deg"],
-              }}
-              transition={{
-                default: {
-                  duration: 8,
-                  ease: "linear",
-                  repeat: Infinity,
-                },
-              }}
-            >
+            <div>
               <SwitchPrimitive.Root
                 onCheckedChange={(val) => {
                   setOpen(val)
@@ -89,6 +77,7 @@ export const F0OneSwitch = ({
                   "shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_0_4px_rgba(13,22,37,.04)] data-[state=checked]:shadow-[0_2px_6px_-1px_rgba(13,22,37,.04),inset_0_0_4px_rgba(13,22,37,.6)]",
                   "after:pointer-events-none after:absolute after:inset-0 after:rounded-full after:ring-1 after:ring-inset after:ring-f1-border after:transition-all after:content-[''] data-[state=checked]:after:ring-f1-border-inverse",
                   "before:absolute before:inset-0 before:rounded-full before:bg-[conic-gradient(from_var(--gradient-angle),hsla(229,57%,76%,0.7),hsla(348,80%,50%,0.7),hsla(348,80%,50%,0.7),hsla(18,80%,50%,0.7),hsla(229,57%,76%,0.7),hsla(229,57%,76%,0.7))] before:opacity-0 before:transition-all before:duration-300 before:content-[''] data-[state=checked]:before:opacity-100",
+                  "before:[animation:rotate-gradient_8s_linear_infinite_paused] data-[state=checked]:before:[animation:rotate-gradient_8s_linear_infinite_running] motion-reduce:before:[animation:none]",
                   disabled && "cursor-not-allowed opacity-50",
                   focusRing(),
                   className
@@ -115,7 +104,7 @@ export const F0OneSwitch = ({
                   </div>
                 </SwitchPrimitive.Thumb>
               </SwitchPrimitive.Root>
-            </motion.div>
+            </div>
           </TooltipTrigger>
           {!open && (
             <TooltipContent


### PR DESCRIPTION
## Description

`F0OneIcon`, `F0OneSwitch` and their two AiPromotionChat twins each drove `--gradient-angle` on a `repeat: Infinity` motion animation, writing an inline style every frame for as long as they were mounted. None of it rendered. Each now applies the theme's existing `rotate-gradient` keyframe, in CSS, to the element that actually paints — so the rotation appears for the first time and the per-frame writes are gone. A check script, wired into pre-commit and CI, stops the pattern coming back.

## Notes for the reviewer

This corrects something I got wrong in #5293's description, which claimed the `F0OneIcon` blobs already worked because they set the property on the painting element. They do not — that reading came from a probe that wrote the property onto the element before testing it. Measured passively, all eight were frozen. #5293's body has been corrected.