### PR TITLE
fix(NewHomeLayout): leave the collapsed rail alone unless you mean it

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/collapsedRail.test.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/collapsedRail.test.tsx
@@ -1,0 +1,188 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+import { Calendar, Clock } from "@/icons/app"
+import {
+  act,
+  fireEvent,
+  screen,
+  userEvent,
+  zeroRender,
+} from "@/testing/test-utils"
+
+import { type HomeWidgetItem } from "../slotRenderers"
+import { NewHomeLayout } from "./index"
+
+/**
+ * WHAT THE COLLAPSED RAIL MUST NOT DO ON ITS OWN.
+ *
+ * Collapsed, the rail is a strip of 40px glyphs on the layout's right edge with
+ * one card floating out of whichever one you point at. Both of the things tested
+ * here were that presentation answering a gesture nobody made: a card you could
+ * DRAG though it had no visible neighbours to reorder against, and a panel that
+ * opened for a pointer merely CROSSING the strip on its way to the AI chat —
+ * which docks against that same edge.
+ */
+
+/** The layout decides everything responsive from its own measured width. */
+let layoutWidth = 1400
+
+/**
+ * Every live ResizeObserver callback, so a test can act like the box resized.
+ *
+ * Not only the layout's: an arrangeable column brings dnd-kit, which observes
+ * boxes of its own and reads the ENTRIES it is handed — hence the shape.
+ */
+let resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = []
+
+const resizeLayoutTo = (width: number) => {
+  layoutWidth = width
+  act(() => resizeCallbacks.forEach((notify) => notify([])))
+}
+
+const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) => ({
+  id,
+  icon: id === "clock" ? Clock : Calendar,
+  header: { title: id },
+  slots: [],
+  ...extra,
+})
+
+/** Three cards, none pinned: a rail with a real arrangement to make. */
+const RAIL = [widget("clock"), widget("events"), widget("tasks")]
+
+/**
+ * A body only the FLOATING CARD can show, so "is the panel out" is a question
+ * about one string. The glyphs carry the widget's title, never its body.
+ */
+const renderLayout = (width: number) => {
+  layoutWidth = width
+  return zeroRender(
+    <NewHomeLayout
+      rightWidgets={RAIL}
+      renderWidget={(item) => <div>{item.id} body</div>}
+      onReorderWidgets={() => {}}
+    >
+      <p>feed</p>
+    </NewHomeLayout>
+  )
+}
+
+const glyph = (id = "clock") => screen.getByRole("button", { name: id })
+const card = (id = "clock") => screen.getByText(`${id} body`)
+/** Every card the column is offering as a drag surface. */
+const grabbable = (container: HTMLElement) =>
+  container.querySelectorAll(".cursor-grab").length
+
+/**
+ * LONGER THAN THE STRIP'S HOVER INTENT (`PANEL_OPEN_MS`) — how long a pointer
+ * has to rest on a glyph before its widget floats. Nothing is pointed at here,
+ * only waited out, so a test that has already moved the pointer on is asserting
+ * that the strip let the crossing go.
+ */
+const holdHover = () =>
+  act(() => new Promise<void>((resolve) => setTimeout(resolve, 250)))
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => layoutWidth,
+  })
+  resizeCallbacks = []
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: (entries: ResizeObserverEntry[]) => void) {
+        resizeCallbacks.push(callback)
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+})
+
+describe("the collapsed rail's hover intent", () => {
+  test("floats the widget for a hover that is HELD", async () => {
+    renderLayout(1000)
+
+    await userEvent.hover(glyph())
+    await holdHover()
+
+    expect(card()).toBeVisible()
+    expect(glyph()).toHaveAttribute("aria-expanded", "true")
+  })
+
+  test("floats nothing for a pointer that is only PASSING", async () => {
+    renderLayout(1000)
+
+    // Entered and gone — the two events a crossing leaves behind, with no rest
+    // in between.
+    fireEvent.mouseEnter(glyph())
+    fireEvent.mouseLeave(glyph())
+    await holdHover()
+
+    expect(card()).not.toBeVisible()
+    expect(glyph()).toHaveAttribute("aria-expanded", "false")
+  })
+
+  test("abandons a hover the pointer has taken out of the strip", async () => {
+    renderLayout(1000)
+
+    await userEvent.hover(glyph())
+    // On out of the strip entirely: the trip to the chat, or back from it.
+    await userEvent.unhover(glyph())
+    await holdHover()
+
+    expect(card()).not.toBeVisible()
+  })
+
+  test("answers a CLICK at once — it cannot be an accident", async () => {
+    renderLayout(1000)
+
+    await userEvent.click(glyph())
+
+    expect(card()).toBeVisible()
+  })
+
+  test("leaves one glyph's hover to that glyph", async () => {
+    renderLayout(1000)
+
+    // Passed on the way down the strip, then rested on the one that was wanted.
+    fireEvent.mouseEnter(glyph())
+    fireEvent.mouseLeave(glyph())
+    await userEvent.hover(glyph("tasks"))
+    await holdHover()
+
+    expect(card("tasks")).toBeVisible()
+    expect(card()).not.toBeVisible()
+  })
+})
+
+describe("dragging the rail's widgets", () => {
+  test("is offered while the rail is a column", () => {
+    const { container } = renderLayout(1400)
+
+    expect(grabbable(container)).toBe(3)
+  })
+
+  test("is withdrawn once it collapses, floating card included", async () => {
+    const { container } = renderLayout(1400)
+
+    resizeLayoutTo(1000)
+    await userEvent.hover(glyph())
+    await holdHover()
+
+    // The card is out over the feed — and there is nothing to grab on it.
+    expect(card()).toBeVisible()
+    expect(grabbable(container)).toBe(0)
+  })
+
+  test("comes back when the rail expands again", () => {
+    const { container } = renderLayout(1400)
+
+    resizeLayoutTo(1000)
+    resizeLayoutTo(1400)
+
+    expect(grabbable(container)).toBe(3)
+  })
+})

--- a/packages/react/src/sds/Home/NewHomeLayout/collapsedRail.test.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/collapsedRail.test.tsx
@@ -12,26 +12,8 @@ import {
 import { type HomeWidgetItem } from "../slotRenderers"
 import { NewHomeLayout } from "./index"
 
-/**
- * WHAT THE COLLAPSED RAIL MUST NOT DO ON ITS OWN.
- *
- * Collapsed, the rail is a strip of 40px glyphs on the layout's right edge with
- * one card floating out of whichever one you point at. Both of the things tested
- * here were that presentation answering a gesture nobody made: a card you could
- * DRAG though it had no visible neighbours to reorder against, and a panel that
- * opened for a pointer merely CROSSING the strip on its way to the AI chat —
- * which docks against that same edge.
- */
-
-/** The layout decides everything responsive from its own measured width. */
 let layoutWidth = 1400
 
-/**
- * Every live ResizeObserver callback, so a test can act like the box resized.
- *
- * Not only the layout's: an arrangeable column brings dnd-kit, which observes
- * boxes of its own and reads the ENTRIES it is handed — hence the shape.
- */
 let resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = []
 
 const resizeLayoutTo = (width: number) => {
@@ -47,13 +29,8 @@ const widget = (id: string, extra: Partial<HomeWidgetItem> = {}) => ({
   ...extra,
 })
 
-/** Three cards, none pinned: a rail with a real arrangement to make. */
 const RAIL = [widget("clock"), widget("events"), widget("tasks")]
 
-/**
- * A body only the FLOATING CARD can show, so "is the panel out" is a question
- * about one string. The glyphs carry the widget's title, never its body.
- */
 const renderLayout = (width: number) => {
   layoutWidth = width
   return zeroRender(
@@ -69,16 +46,9 @@ const renderLayout = (width: number) => {
 
 const glyph = (id = "clock") => screen.getByRole("button", { name: id })
 const card = (id = "clock") => screen.getByText(`${id} body`)
-/** Every card the column is offering as a drag surface. */
 const grabbable = (container: HTMLElement) =>
   container.querySelectorAll(".cursor-grab").length
 
-/**
- * LONGER THAN THE STRIP'S HOVER INTENT (`PANEL_OPEN_MS`) — how long a pointer
- * has to rest on a glyph before its widget floats. Nothing is pointed at here,
- * only waited out, so a test that has already moved the pointer on is asserting
- * that the strip let the crossing go.
- */
 const holdHover = () =>
   act(() => new Promise<void>((resolve) => setTimeout(resolve, 250)))
 
@@ -115,8 +85,6 @@ describe("the collapsed rail's hover intent", () => {
   test("floats nothing for a pointer that is only PASSING", async () => {
     renderLayout(1000)
 
-    // Entered and gone — the two events a crossing leaves behind, with no rest
-    // in between.
     fireEvent.mouseEnter(glyph())
     fireEvent.mouseLeave(glyph())
     await holdHover()
@@ -129,7 +97,6 @@ describe("the collapsed rail's hover intent", () => {
     renderLayout(1000)
 
     await userEvent.hover(glyph())
-    // On out of the strip entirely: the trip to the chat, or back from it.
     await userEvent.unhover(glyph())
     await holdHover()
 
@@ -147,7 +114,6 @@ describe("the collapsed rail's hover intent", () => {
   test("leaves one glyph's hover to that glyph", async () => {
     renderLayout(1000)
 
-    // Passed on the way down the strip, then rested on the one that was wanted.
     fireEvent.mouseEnter(glyph())
     fireEvent.mouseLeave(glyph())
     await userEvent.hover(glyph("tasks"))
@@ -172,7 +138,6 @@ describe("dragging the rail's widgets", () => {
     await userEvent.hover(glyph())
     await holdHover()
 
-    // The card is out over the feed — and there is nothing to grab on it.
     expect(card()).toBeVisible()
     expect(grabbable(container)).toBe(0)
   })

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -57,17 +57,8 @@ const RAIL = [
   widget("events", { hasUpdates: true }),
 ]
 
-/**
- * LONGER THAN THE STRIP'S HOVER INTENT (`PANEL_OPEN_MS`), which is how long a
- * pointer has to rest on a glyph before its widget floats.
- */
 const DWELL_MS = 250
 
-/**
- * Holds the hover the way a pointer that MEANS it does. Nothing is pointed at
- * here — this is only the wait — so a test that has moved the pointer on in the
- * meantime is asserting that the strip let the crossing go.
- */
 const holdHover = () =>
   act(() => new Promise<void>((resolve) => setTimeout(resolve, DWELL_MS)))
 

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -58,6 +58,20 @@ const RAIL = [
 ]
 
 /**
+ * LONGER THAN THE STRIP'S HOVER INTENT (`PANEL_OPEN_MS`), which is how long a
+ * pointer has to rest on a glyph before its widget floats.
+ */
+const DWELL_MS = 250
+
+/**
+ * Holds the hover the way a pointer that MEANS it does. Nothing is pointed at
+ * here — this is only the wait — so a test that has moved the pointer on in the
+ * meantime is asserting that the strip let the crossing go.
+ */
+const holdHover = () =>
+  act(() => new Promise<void>((resolve) => setTimeout(resolve, DWELL_MS)))
+
+/**
  * An icon a test can NAME. The real ones are anonymous paths, and a glyph that
  * flashes between two of them is only testable if the two can be told apart.
  */
@@ -414,6 +428,7 @@ describe("NewHomeLayout", () => {
       renderLayout(1000, { rightWidgets: ACTION_RAIL })
 
       await userEvent.hover(glyph())
+      await holdHover()
 
       expect(screen.getByText("tracked today")).toBeVisible()
       expect(resumes).toBe(0)
@@ -448,6 +463,7 @@ describe("NewHomeLayout", () => {
       renderLayout(1000, { rightWidgets: ACTION_RAIL })
 
       await userEvent.hover(glyph())
+      await holdHover()
 
       vi.useFakeTimers()
       try {
@@ -550,6 +566,7 @@ describe("NewHomeLayout", () => {
         const before = paint()
 
         await userEvent.hover(button())
+        await holdHover()
 
         expect(screen.getByText("tracked today")).toBeVisible()
         expect(pill()).not.toHaveTextContent("7:12")
@@ -757,6 +774,7 @@ describe("NewHomeLayout", () => {
       await renderDeferredRail(1000)
 
       await userEvent.hover(screen.getByRole("button", { name: "clock" }))
+      await holdHover()
 
       expect(screen.getByText("08:00")).toBeVisible()
       // The rail's other widget is mounted beside it, not shown.
@@ -768,6 +786,7 @@ describe("NewHomeLayout", () => {
       await renderDeferredRail(1000)
 
       await userEvent.hover(screen.getByRole("button", { name: "clock" }))
+      await holdHover()
 
       expect(screen.queryByText("clocking in…")).not.toBeInTheDocument()
       expect(clockMounts).toBe(1)

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -301,13 +301,7 @@ const CollapsedGlyph = ({
   open: boolean
   /** When this strip's first glyph starts arriving. */
   delayMs: number
-  /**
-   * Asks for this widget to float. `instant` for the ways of asking that ARE the
-   * answer — a click, a focus — against a hover, which has to be held first (see
-   * `NewHomeLayout`'s `openFromAnchor`).
-   */
   onOpen: (id: string, anchor: HTMLElement, instant?: boolean) => void
-  /** The pointer left this glyph before a held hover had opened anything. */
   onCancelOpen: () => void
   onClose: () => void
 }) => {
@@ -405,8 +399,6 @@ const CollapsedGlyph = ({
           )}
           onMouseEnter={(event) => onOpen(widget.id, event.currentTarget)}
           onMouseLeave={onCancelOpen}
-          // FOCUS IS INSTANT. A hover is held first because a pointer crosses
-          // glyphs it isn't asking for; a focus lands on exactly one thing.
           onFocus={(event) => onOpen(widget.id, event.currentTarget, true)}
           {...glyphMotion}
         >
@@ -507,20 +499,6 @@ const COLUMN_GAP_PX = 16
 /** Tailwind's `md` — below it the layout is one column unless the rail is collapsed. */
 const TWO_COLUMN_MIN_PX = 768
 const PANEL_LEAVE_MS = 150
-/**
- * HOW LONG THE POINTER HAS TO REST ON A GLYPH before its widget floats — hover
- * intent, and the reason a pointer merely PASSING the strip leaves it alone.
- *
- * The strip lives on the layout's right edge, which is also the edge the AI chat
- * docks against and the edge you cross to reach it. Opening on the first
- * mouseenter, every trip in or out of the chat threw a card over the feed for as
- * long as the crossing took: a widget flashed up and went again, having been
- * asked for by nobody. Travelling DOWN the strip did the same thing to every
- * glyph on the way to the one you wanted.
- *
- * So a hover is a question the pointer has to hold. The ways of asking that
- * cannot be accidental — a click, a focus — are answered at once (`instant`).
- */
 const PANEL_OPEN_MS = 150
 /** How far the floating panel clears the strip it comes out of. */
 const PANEL_GAP_PX = 8
@@ -721,7 +699,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     // `showFromAnchor`.
     const [panelGlide, setPanelGlide] = useState(false)
     const leaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-    // The hover being HELD, if one is — see `PANEL_OPEN_MS`.
     const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     // The rail collapses when the grid can't give both columns their width —
@@ -878,14 +855,11 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     // moment the layout narrowed again.
     useEffect(() => {
       if (collapsed) return
-      // A hover still being held goes with it: whatever it was aimed at is a
-      // card in a column now, not a glyph with a panel behind it.
       if (openTimer.current) clearTimeout(openTimer.current)
       openTimer.current = null
       setOpenId(null)
     }, [collapsed])
 
-    // Neither timer outlives the layout.
     useEffect(
       () => () => {
         if (openTimer.current) clearTimeout(openTimer.current)
@@ -917,11 +891,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
      */
     const closingId = useRef<string | null>(null)
     if (openId) closingId.current = openId
-    /**
-     * WHAT THE PANEL IS SHOWING RIGHT NOW, for handlers that run outside the
-     * render they were made in — a held hover commits from a timeout, and the
-     * `openId` it closed over is whatever the render that scheduled it saw.
-     */
     const shownId = useRef<string | null>(null)
     shownId.current = openId
     const panelWidgetId =
@@ -997,12 +966,9 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     }
     const scheduleLeave = () => {
       cancelLeave()
-      // Leaving the strip abandons a hover that had not opened yet — otherwise a
-      // pointer that has already gone somewhere else would still be answered.
       cancelOpen()
       leaveTimer.current = setTimeout(() => setOpenId(null), PANEL_LEAVE_MS)
     }
-    /** Floats `id`'s widget out of the glyph at `anchor`, now. */
     const showFromAnchor = (id: string, anchor: HTMLElement) => {
       cancelOpen()
       const root = rootRef.current
@@ -1015,10 +981,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       // there before it fades in. Moving between glyphs while it is already open
       // is the opposite: there it GLIDES, and that glide is what says the panel
       // is one thing showing a different widget rather than two panels.
-      //
-      // Read off the REF, not the render's own `openId`: a held hover commits
-      // from a timeout, and the value it closed over is one the panel may have
-      // moved on from by the time it fires.
       setPanelGlide(shownId.current != null)
       setOpenId(id)
     }
@@ -1029,16 +991,11 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     ) => {
       cancelLeave()
       cancelOpen()
-      // Already out. Nothing to open, nothing to measure — and re-committing it
-      // would tell the panel to glide to where it already is.
       if (shownId.current === id) return
       if (instant) {
         showFromAnchor(id, anchor)
         return
       }
-      // HELD, NOT SCHEDULED-AND-FORGOTTEN: the anchor is measured when the hover
-      // is answered rather than when it started, so a strip that scrolled under a
-      // resting pointer still puts the panel level with its glyph.
       openTimer.current = setTimeout(
         () => showFromAnchor(id, anchor),
         PANEL_OPEN_MS
@@ -1386,16 +1343,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             className={cn(
               "min-h-0 overflow-y-auto",
               SCROLLBAR_HIDDEN,
-              // Above the feed it floats over, ON ITS OWN SURFACE. The card's
-              // 5% wash is what it wears in the column, so the panel is the same
-              // object that was in the rail rather than a solid tile standing in
-              // for it — which is the whole claim the genie makes.
-              //
-              // FROSTED, not merely translucent. At 5% over live feed content the
-              // panel's rows and the shortcuts underneath were two layers of text
-              // in one place; the blur is what separates them, and it is why this
-              // can keep the card's surface at all. An opaque backdrop was the
-              // other way to make it legible, and it cost the card its own look.
               railInPanel && "absolute z-10 rounded-xl backdrop-blur-md",
               // RETRACTING it is still in the grid, but it has lifted off the
               // column it is leaving: over the main column rather than beside it.
@@ -1454,14 +1401,6 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               // would rebuild every widget in it — the one thing this rail
               // exists to avoid.
               disableEdition={!canEditSide("right")}
-              // COLLAPSED THERE IS NO ORDER TO REARRANGE: the rail is a strip of
-              // glyphs with one card floating out of it, and that card is over the
-              // feed rather than in a column — dragging it moved a widget you
-              // could not see the neighbours of, by a gesture the strip gives no
-              // sign of offering.
-              //
-              // Frozen rather than opted out of edition, which would change the
-              // column's tree and rebuild every widget in it (see `disableDrag`).
               disableDrag={collapsed}
               onReorder={
                 onReorderWidgets

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -292,6 +292,7 @@ const CollapsedGlyph = ({
   open,
   delayMs,
   onOpen,
+  onCancelOpen,
   onClose,
 }: {
   widget: HomeWidgetItem
@@ -300,7 +301,14 @@ const CollapsedGlyph = ({
   open: boolean
   /** When this strip's first glyph starts arriving. */
   delayMs: number
-  onOpen: (id: string, anchor: HTMLElement) => void
+  /**
+   * Asks for this widget to float. `instant` for the ways of asking that ARE the
+   * answer — a click, a focus — against a hover, which has to be held first (see
+   * `NewHomeLayout`'s `openFromAnchor`).
+   */
+  onOpen: (id: string, anchor: HTMLElement, instant?: boolean) => void
+  /** The pointer left this glyph before a held hover had opened anything. */
+  onCancelOpen: () => void
   onClose: () => void
 }) => {
   const reducedMotion = useReducedMotion()
@@ -396,7 +404,10 @@ const CollapsedGlyph = ({
               : "rounded-lg"
           )}
           onMouseEnter={(event) => onOpen(widget.id, event.currentTarget)}
-          onFocus={(event) => onOpen(widget.id, event.currentTarget)}
+          onMouseLeave={onCancelOpen}
+          // FOCUS IS INSTANT. A hover is held first because a pointer crosses
+          // glyphs it isn't asking for; a focus lands on exactly one thing.
+          onFocus={(event) => onOpen(widget.id, event.currentTarget, true)}
           {...glyphMotion}
         >
           {text ? (
@@ -465,8 +476,9 @@ const CollapsedGlyph = ({
       aria-label={widgetTitle(widget)}
       aria-expanded={open}
       onMouseEnter={(event) => onOpen(widget.id, event.currentTarget)}
+      onMouseLeave={onCancelOpen}
       onClick={(event) =>
-        open ? onClose() : onOpen(widget.id, event.currentTarget)
+        open ? onClose() : onOpen(widget.id, event.currentTarget, true)
       }
       // See the strip: it takes no pointer events, so each glyph takes its own.
       className="pointer-events-auto rounded-lg"
@@ -495,6 +507,21 @@ const COLUMN_GAP_PX = 16
 /** Tailwind's `md` — below it the layout is one column unless the rail is collapsed. */
 const TWO_COLUMN_MIN_PX = 768
 const PANEL_LEAVE_MS = 150
+/**
+ * HOW LONG THE POINTER HAS TO REST ON A GLYPH before its widget floats — hover
+ * intent, and the reason a pointer merely PASSING the strip leaves it alone.
+ *
+ * The strip lives on the layout's right edge, which is also the edge the AI chat
+ * docks against and the edge you cross to reach it. Opening on the first
+ * mouseenter, every trip in or out of the chat threw a card over the feed for as
+ * long as the crossing took: a widget flashed up and went again, having been
+ * asked for by nobody. Travelling DOWN the strip did the same thing to every
+ * glyph on the way to the one you wanted.
+ *
+ * So a hover is a question the pointer has to hold. The ways of asking that
+ * cannot be accidental — a click, a focus — are answered at once (`instant`).
+ */
+const PANEL_OPEN_MS = 150
 /** How far the floating panel clears the strip it comes out of. */
 const PANEL_GAP_PX = 8
 // The add control's name comes from the PROVIDER (`t.widgets.addWidget`) — it is
@@ -691,9 +718,11 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     const [openId, setOpenId] = useState<string | null>(null)
     const [panelTop, setPanelTop] = useState(0)
     // Whether the panel should GLIDE to `panelTop` or simply be there — see
-    // `openFromAnchor`.
+    // `showFromAnchor`.
     const [panelGlide, setPanelGlide] = useState(false)
     const leaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+    // The hover being HELD, if one is — see `PANEL_OPEN_MS`.
+    const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
     // The rail collapses when the grid can't give both columns their width —
     // measured (clientWidth is a layout metric), not media-queried, because
@@ -848,8 +877,22 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     // the rail opens up: kept, it would reopen whatever was last hovered the
     // moment the layout narrowed again.
     useEffect(() => {
-      if (!collapsed) setOpenId(null)
+      if (collapsed) return
+      // A hover still being held goes with it: whatever it was aimed at is a
+      // card in a column now, not a glyph with a panel behind it.
+      if (openTimer.current) clearTimeout(openTimer.current)
+      openTimer.current = null
+      setOpenId(null)
     }, [collapsed])
+
+    // Neither timer outlives the layout.
+    useEffect(
+      () => () => {
+        if (openTimer.current) clearTimeout(openTimer.current)
+        if (leaveTimer.current) clearTimeout(leaveTimer.current)
+      },
+      []
+    )
 
     // How the rail moves, and the one number the grid template reads. The genie
     // lives in there; the geometry it moves through stays here.
@@ -874,6 +917,13 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
      */
     const closingId = useRef<string | null>(null)
     if (openId) closingId.current = openId
+    /**
+     * WHAT THE PANEL IS SHOWING RIGHT NOW, for handlers that run outside the
+     * render they were made in — a held hover commits from a timeout, and the
+     * `openId` it closed over is whatever the render that scheduled it saw.
+     */
+    const shownId = useRef<string | null>(null)
+    shownId.current = openId
     const panelWidgetId =
       openId ?? (rail.panelHidden ? null : closingId.current)
 
@@ -941,12 +991,20 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       if (leaveTimer.current) clearTimeout(leaveTimer.current)
       leaveTimer.current = null
     }
+    const cancelOpen = () => {
+      if (openTimer.current) clearTimeout(openTimer.current)
+      openTimer.current = null
+    }
     const scheduleLeave = () => {
       cancelLeave()
+      // Leaving the strip abandons a hover that had not opened yet — otherwise a
+      // pointer that has already gone somewhere else would still be answered.
+      cancelOpen()
       leaveTimer.current = setTimeout(() => setOpenId(null), PANEL_LEAVE_MS)
     }
-    const openFromAnchor = (id: string, anchor: HTMLElement) => {
-      cancelLeave()
+    /** Floats `id`'s widget out of the glyph at `anchor`, now. */
+    const showFromAnchor = (id: string, anchor: HTMLElement) => {
+      cancelOpen()
       const root = rootRef.current
       if (root) {
         const top =
@@ -957,8 +1015,34 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       // there before it fades in. Moving between glyphs while it is already open
       // is the opposite: there it GLIDES, and that glide is what says the panel
       // is one thing showing a different widget rather than two panels.
-      setPanelGlide(openId != null)
+      //
+      // Read off the REF, not the render's own `openId`: a held hover commits
+      // from a timeout, and the value it closed over is one the panel may have
+      // moved on from by the time it fires.
+      setPanelGlide(shownId.current != null)
       setOpenId(id)
+    }
+    const openFromAnchor = (
+      id: string,
+      anchor: HTMLElement,
+      instant = false
+    ) => {
+      cancelLeave()
+      cancelOpen()
+      // Already out. Nothing to open, nothing to measure — and re-committing it
+      // would tell the panel to glide to where it already is.
+      if (shownId.current === id) return
+      if (instant) {
+        showFromAnchor(id, anchor)
+        return
+      }
+      // HELD, NOT SCHEDULED-AND-FORGOTTEN: the anchor is measured when the hover
+      // is answered rather than when it started, so a strip that scrolled under a
+      // resting pointer still puts the panel level with its glyph.
+      openTimer.current = setTimeout(
+        () => showFromAnchor(id, anchor),
+        PANEL_OPEN_MS
+      )
     }
 
     return (
@@ -1241,6 +1325,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                   open={openId === widget.id}
                   delayMs={rail.glyphDelayMs}
                   onOpen={openFromAnchor}
+                  onCancelOpen={cancelOpen}
                   onClose={() => setOpenId(null)}
                 />
               ))}
@@ -1361,6 +1446,15 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               // would rebuild every widget in it — the one thing this rail
               // exists to avoid.
               disableEdition={!canEditSide("right")}
+              // COLLAPSED THERE IS NO ORDER TO REARRANGE: the rail is a strip of
+              // glyphs with one card floating out of it, and that card is over the
+              // feed rather than in a column — dragging it moved a widget you
+              // could not see the neighbours of, by a gesture the strip gives no
+              // sign of offering.
+              //
+              // Frozen rather than opted out of edition, which would change the
+              // column's tree and rebuild every widget in it (see `disableDrag`).
+              disableDrag={collapsed}
               onReorder={
                 onReorderWidgets
                   ? (ids) => onReorderWidgets("right", ids)

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1344,7 +1344,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               "min-h-0 overflow-y-auto",
               SCROLLBAR_HIDDEN,
               railInPanel &&
-                "absolute z-10 rounded-xl bg-f1-background/60 backdrop-blur-md",
+                "absolute z-10 rounded-xl backdrop-blur-md dark:backdrop-blur-2xl",
               // RETRACTING it is still in the grid, but it has lifted off the
               // column it is leaving: over the main column rather than beside it.
               rail.mode === "retracting" && "relative z-10"

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1386,9 +1386,17 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             className={cn(
               "min-h-0 overflow-y-auto",
               SCROLLBAR_HIDDEN,
-              // Above the feed it floats over, and opaque: the widget behind it
-              // must not read through the card.
-              railInPanel && "absolute z-10 rounded-xl bg-f1-background",
+              // Above the feed it floats over, ON ITS OWN SURFACE. The card's
+              // 5% wash is what it wears in the column, so the panel is the same
+              // object that was in the rail rather than a solid tile standing in
+              // for it — which is the whole claim the genie makes.
+              //
+              // FROSTED, not merely translucent. At 5% over live feed content the
+              // panel's rows and the shortcuts underneath were two layers of text
+              // in one place; the blur is what separates them, and it is why this
+              // can keep the card's surface at all. An opaque backdrop was the
+              // other way to make it legible, and it cost the card its own look.
+              railInPanel && "absolute z-10 rounded-xl backdrop-blur-md",
               // RETRACTING it is still in the grid, but it has lifted off the
               // column it is leaving: over the main column rather than beside it.
               rail.mode === "retracting" && "relative z-10"

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1067,6 +1067,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             belongs: under everything in this (isolated) layout. */}
         <div
           aria-hidden
+          data-page-surface
           className="pointer-events-none absolute -z-10 overflow-hidden bg-f1-special-page"
           style={{ top: -bleed, bottom: -bleed, left: -bleed, right: -bleed }}
         >
@@ -1184,6 +1185,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             ctx={ctx}
             virtualized={virtualizationFor("main")}
             disableEdition={!canEditSide("main")}
+            dragSurfaceSelector="[data-page-surface]"
             onReorder={
               onReorderWidgets
                 ? (ids) => onReorderWidgets("main", ids)
@@ -1344,7 +1346,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               "min-h-0 overflow-y-auto",
               SCROLLBAR_HIDDEN,
               railInPanel &&
-                "absolute z-10 rounded-xl backdrop-blur-md dark:backdrop-blur-2xl",
+                "absolute z-10 rounded-xl bg-f1-background dark:bg-f1-background-secondary dark:backdrop-blur-[100px] dark:backdrop-saturate-150",
               // RETRACTING it is still in the grid, but it has lifted off the
               // column it is leaving: over the main column rather than beside it.
               rail.mode === "retracting" && "relative z-10"
@@ -1403,6 +1405,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               // exists to avoid.
               disableEdition={!canEditSide("right")}
               disableDrag={collapsed}
+              dragSurfaceSelector="[data-page-surface]"
               onReorder={
                 onReorderWidgets
                   ? (ids) => onReorderWidgets("right", ids)

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1343,7 +1343,8 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             className={cn(
               "min-h-0 overflow-y-auto",
               SCROLLBAR_HIDDEN,
-              railInPanel && "absolute z-10 rounded-xl backdrop-blur-md",
+              railInPanel &&
+                "absolute z-10 rounded-xl bg-f1-background/60 backdrop-blur-md",
               // RETRACTING it is still in the grid, but it has lifted off the
               // column it is leaving: over the main column rather than beside it.
               rail.mode === "retracting" && "relative z-10"

--- a/packages/react/src/sds/Home/WidgetContainer/disableDrag.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/disableDrag.test.tsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, test } from "vitest"
+
+import { useEffect } from "react"
+
+import { Calendar, Clock } from "@/icons/app"
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { WidgetContainer } from "./index"
+
+/**
+ * A COLUMN THAT IS ONLY TEMPORARILY NOT ARRANGEABLE, which is what the collapsed
+ * rail is. `disableEdition` would do it by taking the sortables away — and that
+ * changes the tree's shape, which rebuilds every widget in the column.
+ */
+
+const widget = (id: string) => ({
+  id,
+  icon: id === "clock" ? Clock : Calendar,
+  header: { title: id },
+  slots: [],
+})
+
+const WIDGETS = [widget("clock"), widget("events")]
+
+/** How many times each widget's body has been built from scratch, by id. */
+let mounts: Record<string, number> = {}
+
+/**
+ * A widget body that COUNTS ITS MOUNTS, so a change in the column's tree — the
+ * thing that unmounts a render — is visible rather than silent.
+ */
+const Counted = ({ id }: { id: string }) => {
+  useEffect(() => {
+    mounts[id] = (mounts[id] ?? 0) + 1
+  }, [id])
+  return <span>{id} body</span>
+}
+
+/** The column, frozen or not, with every widget counting its own mounts. */
+const column = (frozen: boolean) => (
+  <WidgetContainer
+    widgets={WIDGETS}
+    disableDrag={frozen}
+    renderWidget={(item) => <Counted id={item.id} />}
+    onRemoveWidget={() => {}}
+    onReorder={() => {}}
+  />
+)
+
+beforeEach(() => {
+  mounts = {}
+})
+
+describe("disableDrag", () => {
+  test("takes the gesture away", () => {
+    const { container } = zeroRender(column(true))
+
+    expect(container.querySelectorAll(".cursor-grab")).toHaveLength(0)
+  })
+
+  test("leaves the sortables in place — the tree keeps its shape", () => {
+    const { container } = zeroRender(column(true))
+
+    // The box a sortable marks its card with is still there: the column is
+    // frozen, not unwrapped.
+    expect(
+      [...container.querySelectorAll("[data-widget-id]")].map((el) =>
+        el.getAttribute("data-widget-id")
+      )
+    ).toEqual(["clock", "events"])
+  })
+
+  test("freezing and thawing keeps every widget's own render", () => {
+    const { rerender } = zeroRender(column(false))
+    expect(mounts).toEqual({ clock: 1, events: 1 })
+
+    rerender(column(true))
+    rerender(column(false))
+
+    // Not one of them was built again on the way in or out.
+    expect(mounts).toEqual({ clock: 1, events: 1 })
+  })
+
+  test("keeps the rest of the arranging — the menus are untouched", () => {
+    zeroRender(column(true))
+
+    expect(screen.getAllByRole("button", { name: "Actions" })).toHaveLength(2)
+  })
+})

--- a/packages/react/src/sds/Home/WidgetContainer/disableDrag.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/disableDrag.test.tsx
@@ -7,12 +7,6 @@ import { screen, zeroRender } from "@/testing/test-utils"
 
 import { WidgetContainer } from "./index"
 
-/**
- * A COLUMN THAT IS ONLY TEMPORARILY NOT ARRANGEABLE, which is what the collapsed
- * rail is. `disableEdition` would do it by taking the sortables away — and that
- * changes the tree's shape, which rebuilds every widget in the column.
- */
-
 const widget = (id: string) => ({
   id,
   icon: id === "clock" ? Clock : Calendar,
@@ -22,13 +16,8 @@ const widget = (id: string) => ({
 
 const WIDGETS = [widget("clock"), widget("events")]
 
-/** How many times each widget's body has been built from scratch, by id. */
 let mounts: Record<string, number> = {}
 
-/**
- * A widget body that COUNTS ITS MOUNTS, so a change in the column's tree — the
- * thing that unmounts a render — is visible rather than silent.
- */
 const Counted = ({ id }: { id: string }) => {
   useEffect(() => {
     mounts[id] = (mounts[id] ?? 0) + 1
@@ -36,7 +25,6 @@ const Counted = ({ id }: { id: string }) => {
   return <span>{id} body</span>
 }
 
-/** The column, frozen or not, with every widget counting its own mounts. */
 const column = (frozen: boolean) => (
   <WidgetContainer
     widgets={WIDGETS}
@@ -61,8 +49,6 @@ describe("disableDrag", () => {
   test("leaves the sortables in place — the tree keeps its shape", () => {
     const { container } = zeroRender(column(true))
 
-    // The box a sortable marks its card with is still there: the column is
-    // frozen, not unwrapped.
     expect(
       [...container.querySelectorAll("[data-widget-id]")].map((el) =>
         el.getAttribute("data-widget-id")
@@ -77,7 +63,6 @@ describe("disableDrag", () => {
     rerender(column(true))
     rerender(column(false))
 
-    // Not one of them was built again on the way in or out.
     expect(mounts).toEqual({ clock: 1, events: 1 })
   })
 

--- a/packages/react/src/sds/Home/WidgetContainer/dragGhost.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/dragGhost.test.tsx
@@ -6,7 +6,7 @@ import { Calendar } from "@/icons/app"
 import { zeroRender } from "@/testing/test-utils"
 
 import { type HomeWidgetItem, type SlotRenderers } from "../slotRenderers"
-import { takeCardGhost } from "./dragGhost"
+import { takeCardGhost, takePageSurface } from "./dragGhost"
 import { WidgetContainer } from "./index"
 
 /**
@@ -131,5 +131,52 @@ describe("takeCardGhost", () => {
     // longer in the DOM: no ghost rather than a crash.
     expect(takeCardGhost(null)).toBeNull()
     expect(takeCardGhost(undefined)).toBeNull()
+  })
+})
+
+describe("takePageSurface", () => {
+  const at = (node: HTMLElement, top: number, left: number) => {
+    node.getBoundingClientRect = () =>
+      ({ top, left, width: 1200, height: 800 }) as DOMRect
+    return node
+  }
+
+  const surface = () => {
+    const node = document.createElement("div")
+    node.className = "-z-10 bg-f1-special-page"
+    node.innerHTML = '<div id="wash" class="bg-gradient-to-bl"></div>'
+    return at(node, 0, 0)
+  }
+
+  test("places the copy where the page's own surface is", () => {
+    const taken = takePageSurface(surface(), at(card(""), 300, 840))
+
+    expect(taken?.offset).toEqual({
+      top: -300,
+      left: -840,
+      width: 1200,
+      height: 800,
+    })
+  })
+
+  test("fills the box it is given, whatever the original was placed by", () => {
+    const taken = takePageSurface(surface(), at(card(""), 0, 0))
+
+    expect(taken?.node.style.width).toBe("100%")
+    expect(taken?.node.style.height).toBe("100%")
+    expect(taken?.node.className).not.toContain("-z-10")
+  })
+
+  test("is a picture, not a control — and takes no ids with it", () => {
+    const taken = takePageSurface(surface(), at(card(""), 0, 0))
+
+    expect(taken?.node.querySelector("#wash")).toBeNull()
+    expect(taken?.node.getAttribute("aria-hidden")).toBe("true")
+    expect(taken?.node.hasAttribute("inert")).toBe(true)
+  })
+
+  test("has nothing to copy without both halves", () => {
+    expect(takePageSurface(null, card(""))).toBeNull()
+    expect(takePageSurface(surface(), null)).toBeNull()
   })
 })

--- a/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
@@ -39,6 +39,8 @@ export const takeCardGhost = (
 export interface PageSurfaceGhost {
   node: HTMLElement
   offset: { top: number; left: number; width: number; height: number }
+  /** The colour the page is painted on, under its own wash. */
+  base: string | null
 }
 
 /** A copy of the page's own surface, placed so it lines up under `card`. */
@@ -76,5 +78,17 @@ export const takePageSurface = (
       width: from.width,
       height: from.height,
     },
+    base: opaqueBackgroundOf(surface),
   }
+}
+
+const TRANSPARENT = ["rgba(0, 0, 0, 0)", "transparent", ""]
+
+const opaqueBackgroundOf = (from: Element): string | null => {
+  if (typeof getComputedStyle !== "function") return null
+  for (let el: Element | null = from; el; el = el.parentElement) {
+    const colour = getComputedStyle(el).backgroundColor
+    if (!TRANSPARENT.includes(colour)) return colour
+  }
+  return null
 }

--- a/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
@@ -35,3 +35,46 @@ export const takeCardGhost = (
 
   return copy
 }
+
+export interface PageSurfaceGhost {
+  node: HTMLElement
+  offset: { top: number; left: number; width: number; height: number }
+}
+
+/** A copy of the page's own surface, placed so it lines up under `card`. */
+export const takePageSurface = (
+  surface: Element | null | undefined,
+  card: Element | null | undefined
+): PageSurfaceGhost | null => {
+  if (!surface || !card) return null
+
+  const copy = surface.cloneNode(true)
+  if (!(copy instanceof HTMLElement)) return null
+
+  copy.classList.remove("-z-10")
+  copy.style.position = "absolute"
+  copy.style.inset = "0"
+  copy.style.top = "0"
+  copy.style.left = "0"
+  copy.style.right = "auto"
+  copy.style.bottom = "auto"
+  copy.style.width = "100%"
+  copy.style.height = "100%"
+  copy.removeAttribute("id")
+  copy.querySelectorAll("[id]").forEach((node) => node.removeAttribute("id"))
+  copy.setAttribute("aria-hidden", "true")
+  copy.setAttribute("inert", "")
+
+  const from = surface.getBoundingClientRect()
+  const to = card.getBoundingClientRect()
+
+  return {
+    node: copy,
+    offset: {
+      top: from.top - to.top,
+      left: from.left - to.left,
+      width: from.width,
+      height: from.height,
+    },
+  }
+}

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -908,11 +908,18 @@ export function WidgetContainer({
               the real card's DOM slot and transform in one frame. */}
           <DragOverlay dropAnimation={DROP_ANIMATION}>
             {activeId ? (
-              // Solid backdrop: Card's own background is translucent, and the
-              // copy rides over whatever the column shows beneath it.
+              // NO BACKDROP OF ITS OWN: the copy keeps the card's translucent
+              // surface, so what the pointer carries looks like the widget rather
+              // than a solid tile of it.
+              //
+              // Frosted for the same reason the floating panel is — the card's
+              // own wash is 5%, and the card the ghost is over would otherwise
+              // read straight through it. What it is over is always another card
+              // in this column: `verticalOnly` discards the horizontal component,
+              // so the ghost never leaves the column it was picked up from.
               <div
                 ref={mountGhost}
-                className="h-full w-full cursor-grabbing rounded-xl bg-f1-background [&_*]:shadow-none"
+                className="h-full w-full cursor-grabbing rounded-xl backdrop-blur-md [&_*]:shadow-none"
               />
             ) : null}
           </DragOverlay>

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -480,6 +480,7 @@ export function WidgetContainer({
     host.style.left = `${surface.offset.left}px`
     host.style.width = `${surface.offset.width}px`
     host.style.height = `${surface.offset.height}px`
+    if (surface.base) host.style.backgroundColor = surface.base
 
     const overlay = host.parentElement?.parentElement
     if (!overlay || typeof DOMMatrix !== "function") return
@@ -934,10 +935,7 @@ export function WidgetContainer({
           <DragOverlay dropAnimation={DROP_ANIMATION}>
             {activeId ? (
               <div className="relative h-full w-full cursor-grabbing overflow-hidden rounded-xl bg-f1-background">
-                <div
-                  ref={mountSurface}
-                  className="absolute isolate hidden dark:block"
-                />
+                <div ref={mountSurface} className="absolute isolate" />
                 <div
                   ref={mountGhost}
                   className="relative h-full w-full [&_*]:shadow-none"

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -236,6 +236,22 @@ export interface WidgetContainerProps {
    */
   disableEdition?: boolean
   /**
+   * TAKES THE DRAG AWAY WITHOUT CHANGING THE TREE. Every widget stays the
+   * sortable it already was — so nothing in the column is rebuilt — and none of
+   * them can be picked up while this is set.
+   *
+   * `disableEdition` is the wrong tool for a column that is only TEMPORARILY not
+   * arrangeable: it decides the tree's SHAPE (a draggable column is wrapped in a
+   * DndContext, its cards in sortables), so toggling it remounts every widget in
+   * the column. This is the same refusal with nothing moving underneath it — for
+   * `NewHomeLayout`'s COLLAPSED RAIL, which is a strip of glyphs and one floating
+   * card rather than a column with an order to rearrange.
+   *
+   * The rest of the arranging stays: a widget's own menu still removes and
+   * configures it. Only the gesture that needs a column goes.
+   */
+  disableDrag?: boolean
+  /**
    * Called with a widget id when its "Remove widget" menu item is used. Omit it
    * and no widget offers removal.
    */
@@ -368,6 +384,7 @@ export function WidgetContainer({
   slotRenderers,
   renderWidget,
   disableEdition = false,
+  disableDrag = false,
   onRemoveWidget,
   onClickAddNewWidget,
   onReorder,
@@ -740,7 +757,10 @@ export function WidgetContainer({
       measureRef={virtual.measureRef}
     >
       {canDrag ? (
-        <SortableWidget id={widget.id} disabled={widget.locked}>
+        // FROZEN, NOT UNWRAPPED (`disableDrag`): the sortable stays, and with it
+        // this widget's render — a card that stopped being draggable by leaving
+        // the sortable behind would be built again from nothing.
+        <SortableWidget id={widget.id} disabled={widget.locked || disableDrag}>
           {/* The arrival wrapper sits INSIDE the sortable rather than around it:
               dnd-kit measures the element it holds the ref to, and a transformed
               ancestor would offset every rect it reads while a drag is in

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -893,7 +893,7 @@ export function WidgetContainer({
             {activeId ? (
               <div
                 ref={mountGhost}
-                className="h-full w-full cursor-grabbing rounded-xl bg-f1-background/60 backdrop-blur-md [&_*]:shadow-none"
+                className="h-full w-full cursor-grabbing rounded-xl backdrop-blur-md [&_*]:shadow-none dark:backdrop-blur-2xl"
               />
             ) : null}
           </DragOverlay>

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -893,7 +893,7 @@ export function WidgetContainer({
             {activeId ? (
               <div
                 ref={mountGhost}
-                className="h-full w-full cursor-grabbing rounded-xl backdrop-blur-md [&_*]:shadow-none"
+                className="h-full w-full cursor-grabbing rounded-xl bg-f1-background/60 backdrop-blur-md [&_*]:shadow-none"
               />
             ) : null}
           </DragOverlay>

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -235,21 +235,7 @@ export interface WidgetContainerProps {
    * are fixed (a curated feed, say) rather than user-arranged.
    */
   disableEdition?: boolean
-  /**
-   * TAKES THE DRAG AWAY WITHOUT CHANGING THE TREE. Every widget stays the
-   * sortable it already was — so nothing in the column is rebuilt — and none of
-   * them can be picked up while this is set.
-   *
-   * `disableEdition` is the wrong tool for a column that is only TEMPORARILY not
-   * arrangeable: it decides the tree's SHAPE (a draggable column is wrapped in a
-   * DndContext, its cards in sortables), so toggling it remounts every widget in
-   * the column. This is the same refusal with nothing moving underneath it — for
-   * `NewHomeLayout`'s COLLAPSED RAIL, which is a strip of glyphs and one floating
-   * card rather than a column with an order to rearrange.
-   *
-   * The rest of the arranging stays: a widget's own menu still removes and
-   * configures it. Only the gesture that needs a column goes.
-   */
+  /** Disables dragging without changing the tree: the sortables stay mounted. */
   disableDrag?: boolean
   /**
    * Called with a widget id when its "Remove widget" menu item is used. Omit it
@@ -757,9 +743,6 @@ export function WidgetContainer({
       measureRef={virtual.measureRef}
     >
       {canDrag ? (
-        // FROZEN, NOT UNWRAPPED (`disableDrag`): the sortable stays, and with it
-        // this widget's render — a card that stopped being draggable by leaving
-        // the sortable behind would be built again from nothing.
         <SortableWidget id={widget.id} disabled={widget.locked || disableDrag}>
           {/* The arrival wrapper sits INSIDE the sortable rather than around it:
               dnd-kit measures the element it holds the ref to, and a transformed
@@ -908,15 +891,6 @@ export function WidgetContainer({
               the real card's DOM slot and transform in one frame. */}
           <DragOverlay dropAnimation={DROP_ANIMATION}>
             {activeId ? (
-              // NO BACKDROP OF ITS OWN: the copy keeps the card's translucent
-              // surface, so what the pointer carries looks like the widget rather
-              // than a solid tile of it.
-              //
-              // Frosted for the same reason the floating panel is — the card's
-              // own wash is 5%, and the card the ghost is over would otherwise
-              // read straight through it. What it is over is always another card
-              // in this column: `verticalOnly` discards the horizontal component,
-              // so the ghost never leaves the column it was picked up from.
               <div
                 ref={mountGhost}
                 className="h-full w-full cursor-grabbing rounded-xl backdrop-blur-md [&_*]:shadow-none"

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -46,7 +46,7 @@ import {
 } from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
 import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
-import { takeCardGhost } from "./dragGhost"
+import { takeCardGhost, takePageSurface } from "./dragGhost"
 import { lockedCeiling, noHigherThan, topPins } from "./lockedCeiling"
 import { SortableWidget } from "./SortableWidget"
 import {
@@ -114,6 +114,14 @@ class WidgetDragSensor extends PointerSensor {
 const DROP_ANIMATION = {
   duration: 450,
   easing: "cubic-bezier(0.4, 0, 0.1, 1)",
+}
+
+const findUp = (from: Element | null, selector: string): Element | null => {
+  for (let el: Element | null = from; el; el = el.parentElement) {
+    const found = el.querySelector(selector)
+    if (found) return found
+  }
+  return null
 }
 
 /** Which column a container is: the growing main one, or the fixed side rail. */
@@ -237,6 +245,11 @@ export interface WidgetContainerProps {
   disableEdition?: boolean
   /** Disables dragging without changing the tree: the sortables stay mounted. */
   disableDrag?: boolean
+  /**
+   * Marks the element a dragged card should carry a copy of behind it — the
+   * page's own surface, so the card the pointer holds is the colour it was.
+   */
+  dragSurfaceSelector?: string
   /**
    * Called with a widget id when its "Remove widget" menu item is used. Omit it
    * and no widget offers removal.
@@ -371,6 +384,7 @@ export function WidgetContainer({
   renderWidget,
   disableEdition = false,
   disableDrag = false,
+  dragSurfaceSelector,
   onRemoveWidget,
   onClickAddNewWidget,
   onReorder,
@@ -423,6 +437,8 @@ export function WidgetContainer({
   const columnRef = useRef<HTMLDivElement>(null)
   /** The static copy of the dragged card that rides the pointer — {@link takeCardGhost}. */
   const ghostRef = useRef<HTMLElement | null>(null)
+  /** The page surface that copy sits on — {@link takePageSurface}. */
+  const surfaceRef = useRef<ReturnType<typeof takePageSurface>>(null)
   /**
    * HOW FAR UP THE CARD BEING DRAGGED MAY GO, measured when the drag starts and
    * null the rest of the time — see `lockedCeiling`.
@@ -442,14 +458,37 @@ export function WidgetContainer({
   )
 
   const takeGhost = (id: string) => {
-    ghostRef.current = takeCardGhost(
-      columnRef.current?.querySelector(`[data-widget-id="${id}"]`)
-    )
+    const card = columnRef.current?.querySelector(`[data-widget-id="${id}"]`)
+    ghostRef.current = takeCardGhost(card)
+    surfaceRef.current = dragSurfaceSelector
+      ? takePageSurface(findUp(columnRef.current, dragSurfaceSelector), card)
+      : null
   }
 
   /** Puts the copy in the overlay dnd-kit positions for us. */
   const mountGhost = (host: HTMLDivElement | null) => {
     if (host && ghostRef.current) host.replaceChildren(ghostRef.current)
+  }
+  const pinFrame = useRef(0)
+  const unpinSurface = () => cancelAnimationFrame(pinFrame.current)
+  const mountSurface = (host: HTMLDivElement | null) => {
+    unpinSurface()
+    const surface = surfaceRef.current
+    if (!host || !surface) return
+    host.replaceChildren(surface.node)
+    host.style.top = `${surface.offset.top}px`
+    host.style.left = `${surface.offset.left}px`
+    host.style.width = `${surface.offset.width}px`
+    host.style.height = `${surface.offset.height}px`
+
+    const overlay = host.parentElement?.parentElement
+    if (!overlay || typeof DOMMatrix !== "function") return
+    const pin = () => {
+      const { m41, m42 } = new DOMMatrix(getComputedStyle(overlay).transform)
+      host.style.transform = `translate3d(${-m41}px, ${-m42}px, 0)`
+      pinFrame.current = requestAnimationFrame(pin)
+    }
+    pin()
   }
   /**
    * WHICH WIDGETS ARE WORTH HAVING IN THE DOM — every one of them unless this
@@ -834,12 +873,15 @@ export function WidgetContainer({
           }}
           onDragCancel={() => {
             setActiveId(null)
+            unpinSurface()
             ghostRef.current = null
+            surfaceRef.current = null
             ceilingRef.current = null
           }}
           onDragEnd={(event) => {
             setActiveId(null)
             ghostRef.current = null
+            surfaceRef.current = null
             // The ceiling outlives the drag by one call: whether the card was
             // held below the pins is what decides whether a drop up there is
             // worth refusing out loud (`lockedTargetOf`).
@@ -891,10 +933,16 @@ export function WidgetContainer({
               the real card's DOM slot and transform in one frame. */}
           <DragOverlay dropAnimation={DROP_ANIMATION}>
             {activeId ? (
-              <div
-                ref={mountGhost}
-                className="h-full w-full cursor-grabbing rounded-xl backdrop-blur-md [&_*]:shadow-none dark:backdrop-blur-2xl"
-              />
+              <div className="relative h-full w-full cursor-grabbing overflow-hidden rounded-xl bg-f1-background">
+                <div
+                  ref={mountSurface}
+                  className="absolute isolate hidden dark:block"
+                />
+                <div
+                  ref={mountGhost}
+                  className="relative h-full w-full [&_*]:shadow-none"
+                />
+              </div>
             ) : null}
           </DragOverlay>
         </DndContext>


### PR DESCRIPTION
## Description

Two things the collapsed rail did without being asked: the card a glyph floats out over the feed was still draggable, and the panel opened for a pointer that was only crossing the strip on its way to (or back from) the AI chat, which docks against that same right edge. Plus a look fix that came out of testing them — a widget that leaves the column was being repainted opaque on the way out.
