### PR TITLE
feat(WidgetCatalog): configure a widget's params before adding it

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -1004,6 +1004,13 @@ export const defaultTranslations = {
     editParamsTitle: "Edit widget params",
     removeWidget: "Remove widget",
     addWidget: "Add widget",
+    /**
+     * Heads the picker's SECOND STEP, where the params of the widget being added
+     * are set. `{{title}}` is that widget's name.
+     */
+    configureWidget: "Configure {{title}}",
+    /** Back to the widget list from that step. */
+    back: "Back",
     /** Heads the widgets a Home suggests, at the top of the picker. */
     recommended: "Recommended",
     /** Why a drop onto a pinned widget was refused. `{{title}}` is its name. */

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -115,8 +115,6 @@ export const defaultTranslations = {
     copy: "Copy",
     paste: "Paste",
     close: "Close",
-    /** Returns to where you came from WITHOUT leaving — a step, a list, a
-        previous view. Closing is `close`. */
     back: "Back",
     collapse: "Collapse",
     collapseItem: "Collapse {{title}}",
@@ -1007,11 +1005,6 @@ export const defaultTranslations = {
     editParamsTitle: "Edit widget params",
     removeWidget: "Remove widget",
     addWidget: "Add widget",
-    /**
-     * Heads the picker's SECOND STEP, where the params of the widget being added
-     * are set. `{{title}}` is that widget's name. Going BACK from it is the
-     * common `actions.back`.
-     */
     configureWidget: "Configure {{title}}",
     /** Heads the widgets a Home suggests, at the top of the picker. */
     recommended: "Recommended",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -115,6 +115,9 @@ export const defaultTranslations = {
     copy: "Copy",
     paste: "Paste",
     close: "Close",
+    /** Returns to where you came from WITHOUT leaving — a step, a list, a
+        previous view. Closing is `close`. */
+    back: "Back",
     collapse: "Collapse",
     collapseItem: "Collapse {{title}}",
     expand: "Expand",
@@ -1006,11 +1009,10 @@ export const defaultTranslations = {
     addWidget: "Add widget",
     /**
      * Heads the picker's SECOND STEP, where the params of the widget being added
-     * are set. `{{title}}` is that widget's name.
+     * are set. `{{title}}` is that widget's name. Going BACK from it is the
+     * common `actions.back`.
      */
     configureWidget: "Configure {{title}}",
-    /** Back to the widget list from that step. */
-    back: "Back",
     /** Heads the widgets a Home suggests, at the top of the picker. */
     recommended: "Recommended",
     /** Why a drop onto a pinned widget was refused. `{{title}}` is its name. */

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1509,13 +1509,25 @@ const Home = () => {
         onClose={() => setOpen(false)}
         widgets={CATALOG}
         groups={CATALOG_GROUPS}
-        onAdd={(id) => {
+        onAdd={(id, params) => {
+          // A CONFIGURABLE widget arrives already set up: the picker walked the
+          // user through its params before adding it, and they are persisted
+          // exactly where its "Edit params" dialog persists them. Nothing here
+          // has to open a second dialog on a half-built card.
+          if (id === "events" && params) setEventsParams(params as EventsParams)
           // The picker only offers what the column can hold, so "which column"
           // is already decided — it is the side it was opened for.
           if (side === "main" && !mainIds.includes(id))
             setMainIds((ids) => [...ids, id])
           setOpen(false)
         }}
+        // The same rebuild the layout gets, for the params step's preview: the
+        // events follow the fields, not just the title that names them.
+        rebuildPreview={(item, params) =>
+          item.id === "events"
+            ? eventsWidget(params as EventsParams)
+            : item.preview
+        }
         // ONE LIST, TWO COLUMNS. The side the layout handed back is passed
         // straight through: the picker then drops the widgets that column can't
         // hold (Communities is `main`-only, Clock in is rail-only) and previews

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1510,10 +1510,6 @@ const Home = () => {
         widgets={CATALOG}
         groups={CATALOG_GROUPS}
         onAdd={(id, params) => {
-          // A CONFIGURABLE widget arrives already set up: the picker walked the
-          // user through its params before adding it, and they are persisted
-          // exactly where its "Edit params" dialog persists them. Nothing here
-          // has to open a second dialog on a half-built card.
           if (id === "events" && params) setEventsParams(params as EventsParams)
           // The picker only offers what the column can hold, so "which column"
           // is already decided — it is the side it was opened for.
@@ -1521,8 +1517,6 @@ const Home = () => {
             setMainIds((ids) => [...ids, id])
           setOpen(false)
         }}
-        // The same rebuild the layout gets, for the params step's preview: the
-        // events follow the fields, not just the title that names them.
         rebuildPreview={(item, params) =>
           item.id === "events"
             ? eventsWidget(params as EventsParams)

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -157,8 +157,6 @@ left column turns into these very fields, and the preview stays put beside them,
 following every valid edit. `onAdd` then receives the params along with the id:
 
 ```tsx
-// Each entry's `preview` IS the widget, so the catalog already knows which
-// widgets are configurable — their `paramsSchema` is nothing to repeat here.
 <WidgetCatalog
   widgets={CATALOG}
   onAdd={(id, params) => add(id, params)}

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -149,6 +149,29 @@ What the params CAN'T do by themselves is rebuild the widget's slots — only th
 app knows where that data comes from. Persist what `onChangeWidgetParams` hands
 you, pass it back as the widget's `params`, and rebuild the slots from it.
 
+### It is also how the widget is ADDED
+
+The same schema gives the widget a **second step in the catalog**. Picking a
+configurable widget doesn't add it: the CTA reads **"Continue"**, the picker's
+left column turns into these very fields, and the preview stays put beside them,
+following every valid edit. `onAdd` then receives the params along with the id:
+
+```tsx
+<WidgetCatalog
+  widgets={CATALOG}          // `preview` is the widget, so it already declares
+  onAdd={(id, params) => add(id, params)}   // its `paramsSchema` — nothing to repeat
+  rebuildPreview={(item, params) =>
+    item.id === "events" ? eventsWidget(params) : item.preview
+  }
+  isOpen={open}
+  onClose={close}
+/>
+```
+
+So a widget whose params are required is never on the Home half-built, and the
+app never has to open "Edit params" itself on a card the user just added. A
+widget that declares no schema is added in one press, as it always was.
+
 ## Previews: hand over the widget, not a render of it
 
 A widget is previewed twice — in the "Add widget" catalog and in "Edit params" —

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -157,9 +157,11 @@ left column turns into these very fields, and the preview stays put beside them,
 following every valid edit. `onAdd` then receives the params along with the id:
 
 ```tsx
+// Each entry's `preview` IS the widget, so the catalog already knows which
+// widgets are configurable — their `paramsSchema` is nothing to repeat here.
 <WidgetCatalog
-  widgets={CATALOG}          // `preview` is the widget, so it already declares
-  onAdd={(id, params) => add(id, params)}   // its `paramsSchema` — nothing to repeat
+  widgets={CATALOG}
+  onAdd={(id, params) => add(id, params)}
   rebuildPreview={(item, params) =>
     item.id === "events" ? eventsWidget(params) : item.preview
   }

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -172,6 +172,16 @@ So a widget whose params are required is never on the Home half-built, and the
 app never has to open "Edit params" itself on a card the user just added. A
 widget that declares no schema is added in one press, as it always was.
 
+**Defaults**: a catalog entry's `params` — or, when `preview` is the widget
+itself, the widget's own `params` — are what that step opens with, so the fields
+and the preview say something before anything is touched.
+
+**Skipping the step**: `addWithDefaults` on the entry adds the widget straight
+from the list, handing those defaults to `onAdd`. Use it for a widget whose
+defaults are the right answer for nearly everyone. If its defaults do **not**
+satisfy the schema — a required param with nothing to fall back on — the step is
+shown anyway rather than adding a widget that cannot render.
+
 ## Previews: hand over the widget, not a render of it
 
 A widget is previewed twice — in the "Add widget" catalog and in "Edit params" —

--- a/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
@@ -335,6 +335,44 @@ describe("WidgetCatalog", () => {
       expect(screen.getByText("Configure Events")).toBeInTheDocument()
     })
 
+    test("a widget flagged to add with its defaults skips the step", async () => {
+      const onAdd = vi.fn()
+      render({
+        widgets: [
+          { ...configurable, addWithDefaults: true, params: { rows: 4 } },
+        ],
+        groups: undefined,
+        onAdd,
+      })
+
+      expect(screen.queryByRole("button", { name: "Continue" })).toBeNull()
+      await userEvent.click(cta("Add widget"))
+
+      expect(onAdd).toHaveBeenCalledWith("events", { rows: 4 })
+    })
+
+    test("the flag decides, not whether the defaults are complete", async () => {
+      render({
+        widgets: [{ ...configurable, params: { rows: 4 } }],
+        groups: undefined,
+      })
+
+      expect(cta("Continue")).toBeInTheDocument()
+    })
+
+    test("the flag still asks when its defaults can't satisfy the schema", async () => {
+      const onAdd = vi.fn()
+      render({
+        widgets: [{ ...configurable, addWithDefaults: true, params: {} }],
+        groups: undefined,
+        onAdd,
+      })
+
+      await startConfiguring()
+
+      expect(onAdd).not.toHaveBeenCalled()
+    })
+
     test("a widget with nothing to configure is still one press", async () => {
       const onAdd = vi.fn()
       render({ widgets: withParams, groups: undefined, onAdd })

--- a/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
@@ -1,9 +1,16 @@
 import { describe, expect, test, vi } from "vitest"
+import { z } from "zod"
 
 import { Calendar, Clock, File } from "@/icons/app"
-import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+import { f0FormField } from "@/patterns/F0Form"
+import { screen, userEvent, waitFor, zeroRender } from "@/testing/test-utils"
 
-import { EVENT_LIST_GAP, homeSlot, type HomeWidgetItem } from "../slotRenderers"
+import {
+  EVENT_LIST_GAP,
+  homeSlot,
+  type HomeWidgetItem,
+  type WidgetParams,
+} from "../slotRenderers"
 import { WidgetCatalog, type WidgetCatalogGroup } from "./index"
 
 const GROUPS: WidgetCatalogGroup[] = [
@@ -286,6 +293,247 @@ describe("WidgetCatalog", () => {
       render({ widgets: WIDGETS, groups: undefined })
 
       expect(screen.getByText("clock")).toBeInTheDocument()
+    })
+  })
+  describe("a widget with params is added in two steps", () => {
+    /** One required param and one that isn't: enough to test both refusals. */
+    const schema = z.object({
+      rows: f0FormField(z.number().min(1).max(10), { label: "Rows" }),
+      note: f0FormField(z.string().optional(), { label: "Note" }),
+    })
+
+    /** The configurable entry, and one that isn't, to keep both paths in view. */
+    const configurable = {
+      id: "events",
+      title: "Events",
+      icon: Calendar,
+      preview: <p>events</p>,
+      paramsSchema: schema,
+      params: { rows: 3 },
+    }
+    const withParams = [configurable, WIDGETS[0]]
+
+    /** The dialog's own CTA, which changes what it says between the steps. */
+    const cta = (name: string) => screen.getByRole("button", { name })
+
+    const startConfiguring = async () => {
+      await userEvent.click(cta("Continue"))
+      await waitFor(() =>
+        expect(screen.getByLabelText(/Rows/)).toBeInTheDocument()
+      )
+    }
+
+    test("picking it opens its params instead of adding it", async () => {
+      const onAdd = vi.fn()
+      render({ widgets: withParams, groups: undefined, onAdd })
+
+      // The press that adds a plain widget only CONTINUES here, and the CTA
+      // says so before it is pressed.
+      expect(screen.queryByRole("button", { name: "Add widget" })).toBeNull()
+      await startConfiguring()
+
+      expect(onAdd).not.toHaveBeenCalled()
+      // The list it came from is gone; the widget it is configuring is named.
+      expect(screen.queryByRole("searchbox")).toBeNull()
+      expect(screen.getByText("Configure Events")).toBeInTheDocument()
+    })
+
+    test("a widget with nothing to configure is still one press", async () => {
+      const onAdd = vi.fn()
+      render({ widgets: withParams, groups: undefined, onAdd })
+
+      await userEvent.click(screen.getByText("Clock in"))
+      await userEvent.click(cta("Add widget"))
+
+      expect(onAdd).toHaveBeenCalledWith("clock")
+    })
+
+    test("adds it with the params it was configured with", async () => {
+      const onAdd = vi.fn()
+      render({ widgets: withParams, groups: undefined, onAdd })
+      await startConfiguring()
+
+      const rows = screen.getByLabelText(/Rows/)
+      await userEvent.clear(rows)
+      await userEvent.type(rows, "5")
+      await userEvent.click(cta("Add widget"))
+
+      await waitFor(() =>
+        expect(onAdd).toHaveBeenCalledWith(
+          "events",
+          expect.objectContaining({ rows: 5 })
+        )
+      )
+    })
+
+    test("it opens on the params the entry declares", async () => {
+      render({ widgets: withParams, groups: undefined })
+      await startConfiguring()
+
+      expect(screen.getByLabelText(/Rows/)).toHaveValue("3")
+    })
+
+    test("what the schema requires is what stops it being added", async () => {
+      const onAdd = vi.fn()
+      render({ widgets: withParams, groups: undefined, onAdd })
+      await startConfiguring()
+
+      await userEvent.clear(screen.getByLabelText(/Rows/))
+      await userEvent.click(cta("Add widget"))
+
+      // The form refuses on the widget's OWN schema — nothing here says which
+      // params are mandatory, and nothing here should.
+      await waitFor(() => expect(onAdd).not.toHaveBeenCalled())
+    })
+
+    test("Back returns to the list, keeping the values you typed", async () => {
+      render({ widgets: withParams, groups: undefined })
+      await startConfiguring()
+
+      const rows = screen.getByLabelText(/Rows/)
+      await userEvent.clear(rows)
+      await userEvent.type(rows, "7")
+      await userEvent.click(cta("Back"))
+
+      // The list is back, on the row it was left on.
+      expect(screen.getByRole("searchbox")).toBeInTheDocument()
+      expect(listed()).toEqual(["Events", "Clock in"])
+
+      await startConfiguring()
+      // Not the entry's 3: the form is where it was left, so stepping out to
+      // check the list against it costs nothing.
+      expect(screen.getByLabelText(/Rows/)).toHaveValue("7")
+    })
+
+    test("another widget's params start from its own, not the last one's", async () => {
+      render({
+        widgets: [
+          configurable,
+          {
+            ...configurable,
+            id: "tasks",
+            title: "Tasks",
+            preview: <p>tasks</p>,
+            params: { rows: 1 },
+          },
+        ],
+        groups: undefined,
+      })
+      await startConfiguring()
+      await userEvent.clear(screen.getByLabelText(/Rows/))
+      await userEvent.type(screen.getByLabelText(/Rows/), "9")
+      await userEvent.click(cta("Back"))
+
+      await userEvent.click(screen.getByText("Tasks"))
+      await startConfiguring()
+
+      expect(screen.getByLabelText(/Rows/)).toHaveValue("1")
+    })
+
+    test("a widget handed over as DATA needs no schema of its own", async () => {
+      const asData: HomeWidgetItem = {
+        id: "events",
+        header: { title: "Events" },
+        paramsSchema: schema,
+        params: { rows: 4 },
+        slots: [homeSlot("indicators", { items: [] })],
+      }
+      render({
+        widgets: [
+          { id: "events", title: "Events", icon: Calendar, preview: asData },
+        ],
+        groups: undefined,
+      })
+
+      // The entry declares nothing: the widget already says what it can be
+      // configured into, and repeating it is how the two disagree.
+      await startConfiguring()
+      expect(screen.getByLabelText(/Rows/)).toHaveValue("4")
+    })
+
+    test("the sentence under it is read off the SAME widget as the card", async () => {
+      // THE REGRESSION THIS GUARDS: the info line was resolved from the entry's
+      // DECLARED preview while the card came from the app's rebuild, so a
+      // preview showed three events over a line that said two.
+      const events = (count: number): HomeWidgetItem => ({
+        id: "events",
+        header: { title: "Events", info: `The next ${count} events.` },
+        paramsSchema: schema,
+        params: { rows: count },
+        slots: [homeSlot("indicators", { items: [] })],
+      })
+      render({
+        widgets: [
+          { id: "events", title: "Events", icon: Calendar, preview: events(3) },
+        ],
+        groups: undefined,
+        rebuildPreview: (_item: unknown, params: WidgetParams) =>
+          events(Number(params.rows)),
+      })
+      await startConfiguring()
+
+      const rows = screen.getByLabelText(/Rows/)
+      await userEvent.clear(rows)
+      await userEvent.type(rows, "5")
+
+      await waitFor(() =>
+        expect(
+          screen.getAllByText("The next 5 events.").length
+        ).toBeGreaterThan(0)
+      )
+      expect(screen.queryByText("The next 3 events.")).toBeNull()
+    })
+
+    test("the preview follows the params being tried out", async () => {
+      render({
+        widgets: withParams,
+        groups: undefined,
+        rebuildPreview: (_item: unknown, params: WidgetParams) => (
+          <p>showing {String(params.rows)} rows</p>
+        ),
+      })
+
+      // Only while they are being tried out: the list previews the widget as
+      // the catalog declared it.
+      expect(screen.getByText("events")).toBeInTheDocument()
+      await startConfiguring()
+      expect(screen.getByText(/showing 3 rows/)).toBeInTheDocument()
+
+      const rows = screen.getByLabelText(/Rows/)
+      await userEvent.clear(rows)
+      await userEvent.type(rows, "6")
+
+      await waitFor(() =>
+        expect(screen.getByText(/showing 6 rows/)).toBeInTheDocument()
+      )
+    })
+
+    test("reopening the picker starts at the list again", async () => {
+      const { rerender } = render({ widgets: withParams, groups: undefined })
+      await startConfiguring()
+
+      rerender(
+        <WidgetCatalog
+          isOpen={false}
+          onClose={() => {}}
+          onAdd={() => {}}
+          widgets={withParams}
+        />
+      )
+      rerender(
+        <WidgetCatalog
+          isOpen
+          onClose={() => {}}
+          onAdd={() => {}}
+          widgets={withParams}
+        />
+      )
+
+      // A form for a widget you walked away from is a question nobody asked
+      // twice.
+      await waitFor(() =>
+        expect(screen.getByRole("searchbox")).toBeInTheDocument()
+      )
     })
   })
 })

--- a/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
@@ -296,13 +296,11 @@ describe("WidgetCatalog", () => {
     })
   })
   describe("a widget with params is added in two steps", () => {
-    /** One required param and one that isn't: enough to test both refusals. */
     const schema = z.object({
       rows: f0FormField(z.number().min(1).max(10), { label: "Rows" }),
       note: f0FormField(z.string().optional(), { label: "Note" }),
     })
 
-    /** The configurable entry, and one that isn't, to keep both paths in view. */
     const configurable = {
       id: "events",
       title: "Events",
@@ -313,14 +311,8 @@ describe("WidgetCatalog", () => {
     }
     const withParams = [configurable, WIDGETS[0]]
 
-    /** The dialog's own CTA, which changes what it says between the steps. */
     const cta = (name: string) => screen.getByRole("button", { name })
 
-    /**
-     * THE STEP COLUMN around something in it — the box the slide is put on. The
-     * form's own scroll box shares its `min-h-0` but is not a flex column, so
-     * the pair of classes names one element either way.
-     */
     const stepColumn = (inside: HTMLElement) =>
       inside.closest(".min-h-0.flex-col") as HTMLElement
 
@@ -335,13 +327,10 @@ describe("WidgetCatalog", () => {
       const onAdd = vi.fn()
       render({ widgets: withParams, groups: undefined, onAdd })
 
-      // The press that adds a plain widget only CONTINUES here, and the CTA
-      // says so before it is pressed.
       expect(screen.queryByRole("button", { name: "Add widget" })).toBeNull()
       await startConfiguring()
 
       expect(onAdd).not.toHaveBeenCalled()
-      // The list it came from is gone; the widget it is configuring is named.
       expect(screen.queryByRole("searchbox")).toBeNull()
       expect(screen.getByText("Configure Events")).toBeInTheDocument()
     })
@@ -389,17 +378,12 @@ describe("WidgetCatalog", () => {
       await userEvent.clear(screen.getByLabelText(/Rows/))
       await userEvent.click(cta("Add widget"))
 
-      // The form refuses on the widget's OWN schema — nothing here says which
-      // params are mandatory, and nothing here should.
       await waitFor(() => expect(onAdd).not.toHaveBeenCalled())
     })
 
     test("opening the picker doesn't slide the list in", async () => {
       render({ widgets: withParams, groups: undefined })
 
-      // The dialog has an entrance of its own; a column sliding in behind it
-      // reads as a second animation competing with it, not as the list
-      // arriving. The slide belongs to the STEP.
       expect(stepColumn(screen.getByRole("searchbox"))).not.toHaveClass(
         "animate-in"
       )
@@ -416,7 +400,6 @@ describe("WidgetCatalog", () => {
 
       await userEvent.click(cta("Back"))
 
-      // Coming back, from the other side.
       expect(stepColumn(screen.getByRole("searchbox"))).toHaveClass(
         "animate-in",
         "slide-in-from-left-4"
@@ -432,13 +415,10 @@ describe("WidgetCatalog", () => {
       await userEvent.type(rows, "7")
       await userEvent.click(cta("Back"))
 
-      // The list is back, on the row it was left on.
       expect(screen.getByRole("searchbox")).toBeInTheDocument()
       expect(listed()).toEqual(["Events", "Clock in"])
 
       await startConfiguring()
-      // Not the entry's 3: the form is where it was left, so stepping out to
-      // check the list against it costs nothing.
       expect(screen.getByLabelText(/Rows/)).toHaveValue("7")
     })
 
@@ -482,16 +462,11 @@ describe("WidgetCatalog", () => {
         groups: undefined,
       })
 
-      // The entry declares nothing: the widget already says what it can be
-      // configured into, and repeating it is how the two disagree.
       await startConfiguring()
       expect(screen.getByLabelText(/Rows/)).toHaveValue("4")
     })
 
     test("the sentence under it is read off the SAME widget as the card", async () => {
-      // THE REGRESSION THIS GUARDS: the info line was resolved from the entry's
-      // DECLARED preview while the card came from the app's rebuild, so a
-      // preview showed three events over a line that said two.
       const events = (count: number): HomeWidgetItem => ({
         id: "events",
         header: { title: "Events", info: `The next ${count} events.` },
@@ -530,8 +505,6 @@ describe("WidgetCatalog", () => {
         ),
       })
 
-      // Only while they are being tried out: the list previews the widget as
-      // the catalog declared it.
       expect(screen.getByText("events")).toBeInTheDocument()
       await startConfiguring()
       expect(screen.getByText(/showing 3 rows/)).toBeInTheDocument()
@@ -566,8 +539,6 @@ describe("WidgetCatalog", () => {
         />
       )
 
-      // A form for a widget you walked away from is a question nobody asked
-      // twice.
       await waitFor(() =>
         expect(screen.getByRole("searchbox")).toBeInTheDocument()
       )

--- a/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.spec.tsx
@@ -316,6 +316,14 @@ describe("WidgetCatalog", () => {
     /** The dialog's own CTA, which changes what it says between the steps. */
     const cta = (name: string) => screen.getByRole("button", { name })
 
+    /**
+     * THE STEP COLUMN around something in it — the box the slide is put on. The
+     * form's own scroll box shares its `min-h-0` but is not a flex column, so
+     * the pair of classes names one element either way.
+     */
+    const stepColumn = (inside: HTMLElement) =>
+      inside.closest(".min-h-0.flex-col") as HTMLElement
+
     const startConfiguring = async () => {
       await userEvent.click(cta("Continue"))
       await waitFor(() =>
@@ -384,6 +392,35 @@ describe("WidgetCatalog", () => {
       // The form refuses on the widget's OWN schema — nothing here says which
       // params are mandatory, and nothing here should.
       await waitFor(() => expect(onAdd).not.toHaveBeenCalled())
+    })
+
+    test("opening the picker doesn't slide the list in", async () => {
+      render({ widgets: withParams, groups: undefined })
+
+      // The dialog has an entrance of its own; a column sliding in behind it
+      // reads as a second animation competing with it, not as the list
+      // arriving. The slide belongs to the STEP.
+      expect(stepColumn(screen.getByRole("searchbox"))).not.toHaveClass(
+        "animate-in"
+      )
+    })
+
+    test("a step you take does slide, each way", async () => {
+      render({ widgets: withParams, groups: undefined })
+      await startConfiguring()
+
+      expect(stepColumn(screen.getByLabelText(/Rows/))).toHaveClass(
+        "animate-in",
+        "slide-in-from-right-4"
+      )
+
+      await userEvent.click(cta("Back"))
+
+      // Coming back, from the other side.
+      expect(stepColumn(screen.getByRole("searchbox"))).toHaveClass(
+        "animate-in",
+        "slide-in-from-left-4"
+      )
     })
 
     test("Back returns to the list, keeping the values you typed", async () => {

--- a/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
@@ -291,7 +291,14 @@ const eventsWidget = (params: WidgetParams): HomeWidgetItem => {
 const CONFIGURABLE_CATALOG: WidgetCatalogItem[] = GROUPED_CATALOG.map((item) =>
   item.id === "events"
     ? { ...item, preview: eventsWidget({ period: "week", maxEvents: 2 }) }
-    : item
+    : item.id === "goals"
+      ? {
+          ...item,
+          paramsSchema: EVENTS_PARAMS,
+          params: { period: "month", maxEvents: 3 },
+          addWithDefaults: true,
+        }
+      : item
 )
 
 const TwoStepCatalog = () => {

--- a/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
@@ -1,8 +1,18 @@
+import { useState } from "react"
+
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { z } from "zod"
 
 import { Calendar, Clock, File, PalmTree, Receipt, Target } from "@/icons/app"
+import { f0FormField } from "@/patterns/F0Form"
 
-import { homeSlot, listSlot } from "../slotRenderers"
+import {
+  fromParams,
+  homeSlot,
+  listSlot,
+  type HomeWidgetItem,
+  type WidgetParams,
+} from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
 import {
   WidgetCatalog,
@@ -205,3 +215,136 @@ export const Default: Story = {}
 export const Flat: Story = {
   args: { widgets: CATALOG, groups: undefined },
 }
+
+/**
+ * The Events widget's params, as an F0Form schema — the SAME `paramsSchema` its
+ * "Edit params" dialog would use. What is required is just what zod says:
+ * `period` and `maxEvents` are, `onlyMine` isn't.
+ */
+const EVENTS_PARAMS = z.object({
+  period: f0FormField(z.enum(["week", "month"]), {
+    label: "Period",
+    options: [
+      { value: "week", label: "This week" },
+      { value: "month", label: "This month" },
+    ],
+  }),
+  maxEvents: f0FormField(z.number().min(1).max(3), {
+    label: "Events to show",
+  }),
+  onlyMine: f0FormField(z.boolean().optional(), {
+    label: "Only the ones I'm invited to",
+  }),
+})
+
+const EVENTS = [
+  {
+    title: "Design sync",
+    description: "Weekly, 30 min",
+    color: "#5596F6",
+    isPending: false,
+    fromDate: new Date("2026-07-24T09:30:00"),
+  },
+  {
+    title: "All hands",
+    description: "Q3 roadmap update",
+    color: "#10B881",
+    isPending: false,
+    fromDate: new Date("2026-07-30T16:00:00"),
+  },
+  {
+    title: "Team offsite",
+    description: "Two days in Costa Brava",
+    color: "#14B8A6",
+    isPending: false,
+    fromDate: new Date("2026-08-03T09:00:00"),
+  },
+]
+
+/**
+ * The widget the params produce — the app's own job, because only it knows where
+ * the events come from. Handed back as DATA, so the picker draws it through the
+ * same `SlotWidget` the rail will.
+ */
+const eventsWidget = (params: WidgetParams): HomeWidgetItem => {
+  const {
+    maxEvents = 2,
+    period = "week",
+    onlyMine,
+  } = params as {
+    maxEvents?: number
+    period?: string
+    onlyMine?: boolean
+  }
+  return {
+    id: "events",
+    header: {
+      title: "Events",
+      count: Math.min(maxEvents, EVENTS.length),
+      info: fromParams(
+        EVENTS_PARAMS,
+        () =>
+          `The next ${maxEvents} events ${period === "week" ? "this week" : "this month"}${onlyMine ? " you're invited to" : ""}.`
+      ),
+    },
+    paramsSchema: EVENTS_PARAMS,
+    params,
+    slots: [
+      homeSlot("event-list", {
+        showAllItems: true,
+        events: EVENTS.slice(0, maxEvents),
+      }),
+    ],
+  }
+}
+
+/** The catalog above, with Events made CONFIGURABLE. */
+const CONFIGURABLE_CATALOG: WidgetCatalogItem[] = GROUPED_CATALOG.map((item) =>
+  item.id === "events"
+    ? { ...item, preview: eventsWidget({ period: "week", maxEvents: 2 }) }
+    : item
+)
+
+/**
+ * The picker as a Home really wires it: `onAdd` receives the widget AND the
+ * params it was set up with, which is the whole point of the second step.
+ */
+const TwoStepCatalog = () => {
+  const [added, setAdded] = useState<string | null>(null)
+  return (
+    <>
+      <WidgetCatalog
+        isOpen
+        onClose={() => {}}
+        widgets={CONFIGURABLE_CATALOG}
+        groups={GROUPS}
+        // The preview rebuilds the widget the way the rail would, so the events
+        // in it are the events those params will really produce — not just the
+        // title following along.
+        rebuildPreview={(item, params) =>
+          item.id === "events" ? eventsWidget(params) : item.preview
+        }
+        onAdd={(id, params) =>
+          setAdded(`${id} ${params ? JSON.stringify(params) : "(no params)"}`)
+        }
+      />
+      {added ? <p>{added}</p> : null}
+    </>
+  )
+}
+
+/**
+ * A WIDGET WITH PARAMS IS ADDED IN TWO STEPS. Pick Events and the CTA reads
+ * "Continue": pressing it turns the left column into the widget's params — its
+ * own `paramsSchema` as F0Form fields, the same ones "Edit params" shows once it
+ * is on the page — while the PREVIEW STAYS PUT and follows every valid edit.
+ *
+ * So the widget is configured where it is chosen, and `onAdd` gets it already
+ * set up: no second dialog, and no moment where a half-built card is on the
+ * Home. "Back" returns to the list with the selection, the search and the values
+ * you had typed intact.
+ *
+ * Every other widget here declares no params and is still added in ONE press —
+ * the step exists only where there is something to fill in.
+ */
+export const WithParams: Story = { render: () => <TwoStepCatalog /> }

--- a/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.stories.tsx
@@ -216,11 +216,6 @@ export const Flat: Story = {
   args: { widgets: CATALOG, groups: undefined },
 }
 
-/**
- * The Events widget's params, as an F0Form schema — the SAME `paramsSchema` its
- * "Edit params" dialog would use. What is required is just what zod says:
- * `period` and `maxEvents` are, `onlyMine` isn't.
- */
 const EVENTS_PARAMS = z.object({
   period: f0FormField(z.enum(["week", "month"]), {
     label: "Period",
@@ -261,11 +256,6 @@ const EVENTS = [
   },
 ]
 
-/**
- * The widget the params produce — the app's own job, because only it knows where
- * the events come from. Handed back as DATA, so the picker draws it through the
- * same `SlotWidget` the rail will.
- */
 const eventsWidget = (params: WidgetParams): HomeWidgetItem => {
   const {
     maxEvents = 2,
@@ -298,17 +288,12 @@ const eventsWidget = (params: WidgetParams): HomeWidgetItem => {
   }
 }
 
-/** The catalog above, with Events made CONFIGURABLE. */
 const CONFIGURABLE_CATALOG: WidgetCatalogItem[] = GROUPED_CATALOG.map((item) =>
   item.id === "events"
     ? { ...item, preview: eventsWidget({ period: "week", maxEvents: 2 }) }
     : item
 )
 
-/**
- * The picker as a Home really wires it: `onAdd` receives the widget AND the
- * params it was set up with, which is the whole point of the second step.
- */
 const TwoStepCatalog = () => {
   const [added, setAdded] = useState<string | null>(null)
   return (
@@ -318,9 +303,6 @@ const TwoStepCatalog = () => {
         onClose={() => {}}
         widgets={CONFIGURABLE_CATALOG}
         groups={GROUPS}
-        // The preview rebuilds the widget the way the rail would, so the events
-        // in it are the events those params will really produce — not just the
-        // title following along.
         rebuildPreview={(item, params) =>
           item.id === "events" ? eventsWidget(params) : item.preview
         }
@@ -333,18 +315,4 @@ const TwoStepCatalog = () => {
   )
 }
 
-/**
- * A WIDGET WITH PARAMS IS ADDED IN TWO STEPS. Pick Events and the CTA reads
- * "Continue": pressing it turns the left column into the widget's params — its
- * own `paramsSchema` as F0Form fields, the same ones "Edit params" shows once it
- * is on the page — while the PREVIEW STAYS PUT and follows every valid edit.
- *
- * So the widget is configured where it is chosen, and `onAdd` gets it already
- * set up: no second dialog, and no moment where a half-built card is on the
- * Home. "Back" returns to the list with the selection, the search and the values
- * you had typed intact.
- *
- * Every other widget here declares no params and is still added in ONE press —
- * the step exists only where there is something to fill in.
- */
 export const WithParams: Story = { render: () => <TwoStepCatalog /> }

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -23,6 +23,7 @@ import { F0Form, useF0Form } from "@/patterns/F0Form"
 import {
   resolveWidgetHeader,
   widgetChrome,
+  widgetParamsAreComplete,
   type HomeWidgetItem,
   type SlotRenderers,
   type WidgetParams,
@@ -100,6 +101,7 @@ export interface WidgetCatalogItem {
   areas?: WidgetContainerSide[]
   paramsSchema?: WidgetParamsSchema
   params?: WidgetParams
+  addWithDefaults?: boolean
 }
 
 /**
@@ -362,7 +364,13 @@ export function WidgetCatalog({
     ordered.find((w) => w.id === selectedId) ?? ordered[0] ?? null
 
   const schema = selected ? itemParamsSchema(selected) : undefined
-  const configuring = step === "configure" && schema !== undefined
+  const needsStep =
+    schema !== undefined &&
+    !(
+      selected?.addWithDefaults &&
+      widgetParamsAreComplete(schema, itemParams(selected))
+    )
+  const configuring = step === "configure" && needsStep
   const params =
     selected && draft?.id === selected.id
       ? draft.params
@@ -383,8 +391,8 @@ export function WidgetCatalog({
   }, [isOpen])
 
   useEffect(() => {
-    if (step === "configure" && !schema) setStep("pick")
-  }, [step, schema])
+    if (step === "configure" && !needsStep) setStep("pick")
+  }, [step, needsStep])
 
   return (
     <F0Dialog
@@ -409,11 +417,12 @@ export function WidgetCatalog({
               },
             }
           : {
-              label: schema ? t.wizard.next : "Add widget",
+              label: needsStep ? t.wizard.next : "Add widget",
               disabled: !selected,
               onClick: () => {
                 if (!selected) return
-                if (schema) goToStep("configure")
+                if (needsStep) goToStep("configure")
+                else if (schema) onAdd(selected.id, params)
                 else onAdd(selected.id)
               },
             }

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -98,24 +98,7 @@ export interface WidgetCatalogItem {
    * retire an entry without deleting it.
    */
   areas?: WidgetContainerSide[]
-  /**
-   * THE WIDGET IS CONFIGURABLE: adding it goes through a SECOND STEP where these
-   * params are set, and they are handed back with the widget's id from
-   * `onAdd`. The schema is the widget's own `paramsSchema` — the same F0Form
-   * schema its "Edit params" dialog uses — so the fields, their types and what
-   * is required are declared once and read in both places.
-   *
-   * Taken from the widget itself when `preview` is a `HomeWidgetItem`, so for
-   * those it is usually nothing to pass: a widget the column can configure is
-   * already a widget the picker can configure.
-   */
   paramsSchema?: WidgetParamsSchema
-  /**
-   * What that step OPENS WITH. Defaults the user would have chosen anyway are
-   * what make the preview worth looking at before a field is touched — and, for
-   * a schema whose params are all optional, what makes "Add widget" the only
-   * press needed. Falls back to the widget's own `params` when the preview is one.
-   */
   params?: WidgetParams
 }
 
@@ -139,12 +122,7 @@ export interface WidgetCatalogProps {
   onClose: () => void
   /** The widgets that can be added, in the order to list them. */
   widgets: WidgetCatalogItem[]
-  /**
-   * Called with the chosen widget id when the CTA is pressed — and, for a widget
-   * that declares a `paramsSchema`, with the PARAMS it was configured with in
-   * the step before. Add the widget with them: they are what the user has just
-   * been previewing.
-   */
+  /** Called with the chosen widget id when the CTA is pressed. */
   onAdd: (id: string, params?: WidgetParams) => void
   /**
    * The DOMAINS the picker is organised into, in the order to show them. Omit it
@@ -176,16 +154,6 @@ export interface WidgetCatalogProps {
    * "No renderer for slot …" and then render properly once added.
    */
   slotRenderers?: SlotRenderers
-  /**
-   * REBUILDS a preview for the params being tried out in the configure step —
-   * the twin of `WidgetContainer`'s `rebuildWidget`, and there for the same
-   * reason: the picker resolves whatever the params merely SAY (the widget's
-   * title, its info) on its own, while SLOTS that depend on them can only be
-   * rebuilt by the app, which knows where their data comes from.
-   *
-   * Give back the widget as DATA (a `HomeWidgetItem`) and the picker draws it
-   * through the same `SlotWidget` a column would.
-   */
   rebuildPreview?: (
     item: WidgetCatalogItem,
     params: WidgetParams
@@ -193,18 +161,8 @@ export interface WidgetCatalogProps {
   title?: string
 }
 
-/**
- * The picker's two steps. The second one EXISTS ONLY for a widget with params to
- * set: everything else is added from the list, in one press, as it always was.
- */
 type WidgetCatalogStep = "pick" | "configure"
 
-/**
- * How long after the last keystroke the preview catches up — the same debounce
- * `WidgetUpdateDialog` puts on it, and for the same reason: F0Form's autosubmit
- * says the values changed AND validate, which is what a preview wants and a save
- * does not.
- */
 const PREVIEW_DELAY_MS = 250
 
 /**
@@ -233,7 +191,6 @@ const CatalogPreview = ({
   slotRenderers,
 }: {
   preview: WidgetCatalogItem["preview"]
-  /** The params being tried out, when the picker is configuring the widget. */
   params?: WidgetParams
   slotRenderers?: SlotRenderers
 }) => {
@@ -251,16 +208,7 @@ const CatalogPreview = ({
   )
 }
 
-/**
- * The sentence under a preview: the item's own, else the widget's — resolved
- * against the params in hand, so it is REWRITTEN as the widget is configured,
- * which is the fastest way to see what a param actually does.
- *
- * It reads the preview BEING DRAWN rather than the one the entry declared: while
- * params are being tried out that is the app's rebuild, and taking the sentence
- * from the original would leave the card saying one thing and the line under it
- * another.
- */
+/** The sentence under a preview: the item's own, else the widget's. */
 const previewInfo = (
   item: WidgetCatalogItem,
   preview: WidgetCatalogItem["preview"],
@@ -271,16 +219,10 @@ const previewInfo = (
     ? resolveWidgetHeader(preview.header, params ?? preview.params)?.info
     : undefined)
 
-/**
- * What the entry says about its params, else what the WIDGET says: a preview
- * handed over as data already declares the `paramsSchema` its column reads, and
- * a catalog that had to repeat it is a catalog that can disagree with the column.
- */
 const itemParamsSchema = (item: WidgetCatalogItem) =>
   item.paramsSchema ??
   (isWidgetItem(item.preview) ? item.preview.paramsSchema : undefined)
 
-/** The params that step opens with — same fallback. */
 const itemParams = (item: WidgetCatalogItem): WidgetParams =>
   item.params ??
   (isWidgetItem(item.preview) ? item.preview.params : undefined) ??
@@ -324,15 +266,6 @@ const SectionHeader = ({ label, icon }: { label: string; icon?: IconType }) => (
  * where they fit, entries that declare none are shown in both, and the preview
  * takes that column's width. So a Home keeps one list — the widgets it offers —
  * rather than two that have to be kept in step.
- *
- * A WIDGET WITH PARAMS IS ADDED IN TWO STEPS. Picking it doesn't add it: the CTA
- * reads "Continue" and the left column turns into its params — the widget's own
- * `paramsSchema` as F0Form fields, the same ones "Edit params" would show —
- * while the preview STAYS PUT beside them and follows every valid edit. So a
- * widget is configured where it is chosen, and `onAdd` receives it already set
- * up rather than the app having to open a second dialog on a half-built card.
- * "Back" returns to the list with the selection, the search and the values you
- * had typed intact.
  */
 export function WidgetCatalog({
   isOpen,
@@ -352,28 +285,11 @@ export function WidgetCatalog({
   const [query, setQuery] = useState("")
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [step, setStep] = useState<WidgetCatalogStep>("pick")
-  /**
-   * WHETHER A STEP HAS BEEN TAKEN since the picker opened. The column slides
-   * when you move between the steps, and ONLY then: opening the picker is the
-   * dialog's own entrance, and a list sliding in behind it read as a second
-   * animation competing with it rather than as the list arriving.
-   */
   const [stepped, setStepped] = useState(false)
-  /** Moving between the steps — the one thing that makes the column slide. */
   const goToStep = (next: WidgetCatalogStep) => {
     setStepped(true)
     setStep(next)
   }
-  /**
-   * The params being filled in, KEPT AGAINST THE WIDGET THEY BELONG TO: stepping
-   * back to the list and forward again finds the form as it was left, while
-   * landing on another widget starts from that widget's own defaults rather than
-   * from the last one's values.
-   *
-   * Only ever the last values that VALIDATED (F0Form's autosubmit), because this
-   * is also what the preview is drawn from — a half-typed number is not something
-   * to redraw a widget for.
-   */
   const [draft, setDraft] = useState<{
     id: string
     params: WidgetParams
@@ -447,28 +363,17 @@ export function WidgetCatalog({
 
   const schema = selected ? itemParamsSchema(selected) : undefined
   const configuring = step === "configure" && schema !== undefined
-  // What the widget is being previewed WITH: the values in hand while they are
-  // being set, the widget's own defaults before that.
   const params =
     selected && draft?.id === selected.id
       ? draft.params
       : selected
         ? itemParams(selected)
         : {}
-  /**
-   * THE WIDGET ACTUALLY DRAWN — the app's rebuild while params are being tried
-   * out, the entry's own preview otherwise. Taken once so the card and the
-   * sentence under it are read off the SAME widget: computing them apart is how
-   * a preview ends up showing three events over a line that says two.
-   */
   const previewed =
     configuring && selected && rebuildPreview
       ? rebuildPreview(selected, params)
       : selected?.preview
 
-  // REOPENING STARTS AT THE LIST. The picker can be closed from the second step
-  // — on params that were never added — and coming back into a form for a widget
-  // you had walked away from would be answering a question nobody asked again.
   useEffect(() => {
     if (isOpen) {
       setStep("pick")
@@ -477,10 +382,6 @@ export function WidgetCatalog({
     }
   }, [isOpen])
 
-  // A step that has LOST ITS WIDGET is not a step: if the offered list changes
-  // under the form (the app swaps `widgets`, or the `area` does), the selection
-  // moves to a widget that may have nothing to configure, and the picker falls
-  // back to what it can always do — show the list.
   useEffect(() => {
     if (step === "configure" && !schema) setStep("pick")
   }, [step, schema])
@@ -489,8 +390,6 @@ export function WidgetCatalog({
     <F0Dialog
       isOpen={isOpen}
       onClose={onClose}
-      // The second step says WHICH widget is being set up, because its own row is
-      // no longer on screen to say it.
       title={
         configuring && selected
           ? t.widgets.configureWidget.replace("{{title}}", selected.title)
@@ -503,21 +402,13 @@ export function WidgetCatalog({
       primaryAction={
         configuring && selected
           ? {
-              // The end of the flow, whichever step it took to get here: the CTA
-              // is "Add widget" in both, so the second step reads as part of
-              // adding rather than as a dialog of its own.
               label: "Add widget",
-              // Validation before adding is the FORM's, not ours: `trigger`
-              // surfaces the same errors the fields would, and the schema is the
-              // only place "you must set this" is written down.
               onClick: async () => {
                 if (!(await trigger())) return
                 onAdd(selected.id, getValues())
               },
             }
           : {
-              // A widget with params isn't added by this press — it is opened.
-              // Saying "Continue" is what keeps that from being a surprise.
               label: schema ? t.wizard.next : "Add widget",
               disabled: !selected,
               onClick: () => {
@@ -527,8 +418,6 @@ export function WidgetCatalog({
               },
             }
       }
-      // BACK, not Cancel: the list is where you came from and the picker is
-      // still open on it. Closing is what the dialog's own close button does.
       secondaryAction={
         configuring && selected
           ? {
@@ -536,10 +425,6 @@ export function WidgetCatalog({
               icon: ArrowLeft,
               iconPosition: "left",
               onClick: () => {
-                // What is IN THE FIELDS right now, not just what last settled
-                // and validated: stepping out to check the list against the
-                // widget shouldn't cost the value typed a moment before, and a
-                // half-filled form is still the form you were filling.
                 setDraft({ id: selected.id, params: getValues() })
                 goToStep("pick")
               },
@@ -548,16 +433,6 @@ export function WidgetCatalog({
       }
     >
       <div className={bodyClassName}>
-        {/* THE LEFT COLUMN IS THE STEP — the widgets to choose from, or the
-            params of the one chosen. Keyed by the step so the swap SLIDES (in
-            from the right going forward, from the left coming back) while the
-            preview beside it holds still: the widget you were looking at is the
-            widget you are now configuring, and it should not have to re-arrive
-            to say so.
-
-            The slide belongs to the STEP, not to the picker: on the way in the
-            dialog has an entrance of its own, and the list is simply already
-            there (`stepped`). */}
         <div
           key={step}
           className={cn(
@@ -571,28 +446,18 @@ export function WidgetCatalog({
           )}
         >
           {configuring && selected && schema ? (
-            /* The params, as FIELDS: the widget's own schema handed to F0Form, so
-             a `z.date()` gets a date picker, a `z.enum()` a select, and a param
-             that isn't `.optional()` simply cannot be left empty — the same
-             fields "Edit params" shows once the widget is on the page. */
             <div className="min-h-0 flex-1 overflow-y-auto">
               <F0Form
-                // Keyed by the widget so switching to another one starts a fresh
-                // form rather than carrying the last one's values into it.
                 key={selected.id}
                 formRef={formRef}
                 name="widget-params"
                 schema={schema}
                 defaultValues={params}
-                // Autosubmit is the CHANGE SIGNAL, not an add: it hands us the
-                // values every time they settle and validate, which is what the
-                // preview wants. Nothing reaches the Home until the CTA.
                 submitConfig={{
                   type: "autosubmit",
                   delay: PREVIEW_DELAY_MS,
                   hideActionBar: true,
                 }}
-                // The dialog already provides the padding around this column.
                 styling={{ noPadding: true }}
                 onSubmit={(values: WidgetParams) => {
                   setDraft({ id: selected.id, params: values })
@@ -602,6 +467,7 @@ export function WidgetCatalog({
             </div>
           ) : (
             <>
+              {/* The picker: a search field leading the widget rows. */}
               <F0SearchInput
                 value={query}
                 onChange={setQuery}
@@ -652,10 +518,7 @@ export function WidgetCatalog({
         </div>
         {/* The preview: the real widget, centered on the page grey, at the width
             the target column will really give it — and it JUMPS in as you move
-            down the list, so each row you land on announces its widget.
-            Keyed by the WIDGET rather than by the step, so configuring one keeps
-            the card that is already there and only its content follows the
-            fields. */}
+            down the list, so each row you land on announces its widget. */}
         <WidgetPreviewPane
           previewKey={selected?.id}
           info={

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -532,7 +532,7 @@ export function WidgetCatalog({
       secondaryAction={
         configuring && selected
           ? {
-              label: t.widgets.back,
+              label: t.actions.back,
               icon: ArrowLeft,
               iconPosition: "left",
               onClick: () => {

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -1,4 +1,11 @@
-import { Fragment, isValidElement, ReactNode, useMemo, useState } from "react"
+import {
+  Fragment,
+  isValidElement,
+  ReactNode,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 
 import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import {
@@ -7,16 +14,19 @@ import {
 } from "@/components/avatars/F0AvatarModule/modules"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { F0SearchInput } from "@/components/F0SearchInput"
-import { Star } from "@/icons/app"
+import { ArrowLeft, Star } from "@/icons/app"
 import { cn } from "@/lib/utils"
 import { useI18n } from "@/lib/providers/i18n"
 import { F0Dialog } from "@/patterns/F0Dialog"
+import { F0Form, useF0Form } from "@/patterns/F0Form"
 
 import {
   resolveWidgetHeader,
   widgetChrome,
   type HomeWidgetItem,
   type SlotRenderers,
+  type WidgetParams,
+  type WidgetParamsSchema,
 } from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
 import type { WidgetContainerSide } from "../WidgetContainer"
@@ -88,6 +98,25 @@ export interface WidgetCatalogItem {
    * retire an entry without deleting it.
    */
   areas?: WidgetContainerSide[]
+  /**
+   * THE WIDGET IS CONFIGURABLE: adding it goes through a SECOND STEP where these
+   * params are set, and they are handed back with the widget's id from
+   * `onAdd`. The schema is the widget's own `paramsSchema` — the same F0Form
+   * schema its "Edit params" dialog uses — so the fields, their types and what
+   * is required are declared once and read in both places.
+   *
+   * Taken from the widget itself when `preview` is a `HomeWidgetItem`, so for
+   * those it is usually nothing to pass: a widget the column can configure is
+   * already a widget the picker can configure.
+   */
+  paramsSchema?: WidgetParamsSchema
+  /**
+   * What that step OPENS WITH. Defaults the user would have chosen anyway are
+   * what make the preview worth looking at before a field is touched — and, for
+   * a schema whose params are all optional, what makes "Add widget" the only
+   * press needed. Falls back to the widget's own `params` when the preview is one.
+   */
+  params?: WidgetParams
 }
 
 /**
@@ -110,8 +139,13 @@ export interface WidgetCatalogProps {
   onClose: () => void
   /** The widgets that can be added, in the order to list them. */
   widgets: WidgetCatalogItem[]
-  /** Called with the chosen widget id when the CTA is pressed. */
-  onAdd: (id: string) => void
+  /**
+   * Called with the chosen widget id when the CTA is pressed — and, for a widget
+   * that declares a `paramsSchema`, with the PARAMS it was configured with in
+   * the step before. Add the widget with them: they are what the user has just
+   * been previewing.
+   */
+  onAdd: (id: string, params?: WidgetParams) => void
   /**
    * The DOMAINS the picker is organised into, in the order to show them. Omit it
    * and the list is flat — grouping is an offer, not a requirement.
@@ -142,8 +176,36 @@ export interface WidgetCatalogProps {
    * "No renderer for slot …" and then render properly once added.
    */
   slotRenderers?: SlotRenderers
+  /**
+   * REBUILDS a preview for the params being tried out in the configure step —
+   * the twin of `WidgetContainer`'s `rebuildWidget`, and there for the same
+   * reason: the picker resolves whatever the params merely SAY (the widget's
+   * title, its info) on its own, while SLOTS that depend on them can only be
+   * rebuilt by the app, which knows where their data comes from.
+   *
+   * Give back the widget as DATA (a `HomeWidgetItem`) and the picker draws it
+   * through the same `SlotWidget` a column would.
+   */
+  rebuildPreview?: (
+    item: WidgetCatalogItem,
+    params: WidgetParams
+  ) => WidgetCatalogItem["preview"]
   title?: string
 }
+
+/**
+ * The picker's two steps. The second one EXISTS ONLY for a widget with params to
+ * set: everything else is added from the list, in one press, as it always was.
+ */
+type WidgetCatalogStep = "pick" | "configure"
+
+/**
+ * How long after the last keystroke the preview catches up — the same debounce
+ * `WidgetUpdateDialog` puts on it, and for the same reason: F0Form's autosubmit
+ * says the values changed AND validate, which is what a preview wants and a save
+ * does not.
+ */
+const PREVIEW_DELAY_MS = 250
 
 /**
  * Which of the two things a `preview` is. A `HomeWidgetItem` is a plain object
@@ -167,9 +229,12 @@ const isWidgetItem = (
  */
 const CatalogPreview = ({
   preview,
+  params,
   slotRenderers,
 }: {
   preview: WidgetCatalogItem["preview"]
+  /** The params being tried out, when the picker is configuring the widget. */
+  params?: WidgetParams
   slotRenderers?: SlotRenderers
 }) => {
   if (!isWidgetItem(preview)) return <>{preview}</>
@@ -177,7 +242,7 @@ const CatalogPreview = ({
     <SlotWidget
       {...widgetChrome(preview)}
       header={preview.header}
-      params={preview.params}
+      params={params ?? preview.params}
       fullHeight={preview.fullHeight}
       slots={preview.slots}
       loading={preview.loading}
@@ -186,12 +251,40 @@ const CatalogPreview = ({
   )
 }
 
-/** The sentence under a preview: the item's own, else the widget's. */
-const previewInfo = (item: WidgetCatalogItem) =>
+/**
+ * The sentence under a preview: the item's own, else the widget's — resolved
+ * against the params in hand, so it is REWRITTEN as the widget is configured,
+ * which is the fastest way to see what a param actually does.
+ *
+ * It reads the preview BEING DRAWN rather than the one the entry declared: while
+ * params are being tried out that is the app's rebuild, and taking the sentence
+ * from the original would leave the card saying one thing and the line under it
+ * another.
+ */
+const previewInfo = (
+  item: WidgetCatalogItem,
+  preview: WidgetCatalogItem["preview"],
+  params?: WidgetParams
+) =>
   item.info ??
-  (isWidgetItem(item.preview)
-    ? resolveWidgetHeader(item.preview.header, item.preview.params)?.info
+  (isWidgetItem(preview)
+    ? resolveWidgetHeader(preview.header, params ?? preview.params)?.info
     : undefined)
+
+/**
+ * What the entry says about its params, else what the WIDGET says: a preview
+ * handed over as data already declares the `paramsSchema` its column reads, and
+ * a catalog that had to repeat it is a catalog that can disagree with the column.
+ */
+const itemParamsSchema = (item: WidgetCatalogItem) =>
+  item.paramsSchema ??
+  (isWidgetItem(item.preview) ? item.preview.paramsSchema : undefined)
+
+/** The params that step opens with — same fallback. */
+const itemParams = (item: WidgetCatalogItem): WidgetParams =>
+  item.params ??
+  (isWidgetItem(item.preview) ? item.preview.params : undefined) ??
+  {}
 
 /**
  * A section's heading: its glyph and its name.
@@ -231,6 +324,15 @@ const SectionHeader = ({ label, icon }: { label: string; icon?: IconType }) => (
  * where they fit, entries that declare none are shown in both, and the preview
  * takes that column's width. So a Home keeps one list — the widgets it offers —
  * rather than two that have to be kept in step.
+ *
+ * A WIDGET WITH PARAMS IS ADDED IN TWO STEPS. Picking it doesn't add it: the CTA
+ * reads "Continue" and the left column turns into its params — the widget's own
+ * `paramsSchema` as F0Form fields, the same ones "Edit params" would show —
+ * while the preview STAYS PUT beside them and follows every valid edit. So a
+ * widget is configured where it is chosen, and `onAdd` receives it already set
+ * up rather than the app having to open a second dialog on a half-built card.
+ * "Back" returns to the list with the selection, the search and the values you
+ * had typed intact.
  */
 export function WidgetCatalog({
   isOpen,
@@ -241,6 +343,7 @@ export function WidgetCatalog({
   area,
   previewWidth,
   slotRenderers,
+  rebuildPreview,
   title = "Add widget",
 }: WidgetCatalogProps) {
   const t = useI18n()
@@ -248,6 +351,22 @@ export function WidgetCatalog({
     useWidgetDialogLayout()
   const [query, setQuery] = useState("")
   const [selectedId, setSelectedId] = useState<string | null>(null)
+  const [step, setStep] = useState<WidgetCatalogStep>("pick")
+  /**
+   * The params being filled in, KEPT AGAINST THE WIDGET THEY BELONG TO: stepping
+   * back to the list and forward again finds the form as it was left, while
+   * landing on another widget starts from that widget's own defaults rather than
+   * from the last one's values.
+   *
+   * Only ever the last values that VALIDATED (F0Form's autosubmit), because this
+   * is also what the preview is drawn from — a half-typed number is not something
+   * to redraw a widget for.
+   */
+  const [draft, setDraft] = useState<{
+    id: string
+    params: WidgetParams
+  } | null>(null)
+  const { formRef, getValues, trigger } = useF0Form()
 
   const needle = query.trim().toLowerCase()
   // The column decides the preview's width unless the app overrides it — a rail
@@ -314,78 +433,226 @@ export function WidgetCatalog({
   const selected =
     ordered.find((w) => w.id === selectedId) ?? ordered[0] ?? null
 
+  const schema = selected ? itemParamsSchema(selected) : undefined
+  const configuring = step === "configure" && schema !== undefined
+  // What the widget is being previewed WITH: the values in hand while they are
+  // being set, the widget's own defaults before that.
+  const params =
+    selected && draft?.id === selected.id
+      ? draft.params
+      : selected
+        ? itemParams(selected)
+        : {}
+  /**
+   * THE WIDGET ACTUALLY DRAWN — the app's rebuild while params are being tried
+   * out, the entry's own preview otherwise. Taken once so the card and the
+   * sentence under it are read off the SAME widget: computing them apart is how
+   * a preview ends up showing three events over a line that says two.
+   */
+  const previewed =
+    configuring && selected && rebuildPreview
+      ? rebuildPreview(selected, params)
+      : selected?.preview
+
+  // REOPENING STARTS AT THE LIST. The picker can be closed from the second step
+  // — on params that were never added — and coming back into a form for a widget
+  // you had walked away from would be answering a question nobody asked again.
+  useEffect(() => {
+    if (isOpen) {
+      setStep("pick")
+      setDraft(null)
+    }
+  }, [isOpen])
+
+  // A step that has LOST ITS WIDGET is not a step: if the offered list changes
+  // under the form (the app swaps `widgets`, or the `area` does), the selection
+  // moves to a widget that may have nothing to configure, and the picker falls
+  // back to what it can always do — show the list.
+  useEffect(() => {
+    if (step === "configure" && !schema) setStep("pick")
+  }, [step, schema])
+
   return (
     <F0Dialog
       isOpen={isOpen}
       onClose={onClose}
-      title={title}
+      // The second step says WHICH widget is being set up, because its own row is
+      // no longer on screen to say it.
+      title={
+        configuring && selected
+          ? t.widgets.configureWidget.replace("{{title}}", selected.title)
+          : title
+      }
       // Fullscreen unless the display is big enough for a centered box to be
       // worth it — these two columns want the room (`useWidgetDialogLayout`).
       position={position}
       width={width}
-      primaryAction={{
-        label: "Add widget",
-        disabled: !selected,
-        onClick: () => selected && onAdd(selected.id),
-      }}
+      primaryAction={
+        configuring && selected
+          ? {
+              // The end of the flow, whichever step it took to get here: the CTA
+              // is "Add widget" in both, so the second step reads as part of
+              // adding rather than as a dialog of its own.
+              label: "Add widget",
+              // Validation before adding is the FORM's, not ours: `trigger`
+              // surfaces the same errors the fields would, and the schema is the
+              // only place "you must set this" is written down.
+              onClick: async () => {
+                if (!(await trigger())) return
+                onAdd(selected.id, getValues())
+              },
+            }
+          : {
+              // A widget with params isn't added by this press — it is opened.
+              // Saying "Continue" is what keeps that from being a surprise.
+              label: schema ? t.wizard.next : "Add widget",
+              disabled: !selected,
+              onClick: () => {
+                if (!selected) return
+                if (schema) setStep("configure")
+                else onAdd(selected.id)
+              },
+            }
+      }
+      // BACK, not Cancel: the list is where you came from and the picker is
+      // still open on it. Closing is what the dialog's own close button does.
+      secondaryAction={
+        configuring && selected
+          ? {
+              label: t.widgets.back,
+              icon: ArrowLeft,
+              iconPosition: "left",
+              onClick: () => {
+                // What is IN THE FIELDS right now, not just what last settled
+                // and validated: stepping out to check the list against the
+                // widget shouldn't cost the value typed a moment before, and a
+                // half-filled form is still the form you were filling.
+                setDraft({ id: selected.id, params: getValues() })
+                setStep("pick")
+              },
+            }
+          : undefined
+      }
     >
       <div className={bodyClassName}>
-        {/* The picker: a search field leading the widget rows. */}
-        <div className={cn("flex flex-col gap-2", asideClassName)}>
-          <F0SearchInput
-            value={query}
-            onChange={setQuery}
-            placeholder="Search widgets"
-          />
-          <div className="flex flex-col gap-1 overflow-y-auto">
-            {sections.map((section) => (
-              <Fragment key={section.id}>
-                {section.label ? (
-                  <SectionHeader label={section.label} icon={section.icon} />
-                ) : null}
-                {section.items.map((w) => (
-                  <button
-                    key={w.id}
-                    type="button"
-                    onClick={() => setSelectedId(w.id)}
-                    className={
-                      "flex items-center gap-3 rounded-md p-2 text-left " +
-                      (selected?.id === w.id
-                        ? "bg-f1-background-selected"
-                        : "hover:bg-f1-background-tertiary")
-                    }
-                  >
-                    <F0AvatarIcon icon={w.icon} size="lg" />
-                    <span className="truncate font-medium text-f1-foreground">
-                      {w.title}
-                    </span>
-                  </button>
+        {/* THE LEFT COLUMN IS THE STEP — the widgets to choose from, or the
+            params of the one chosen. Keyed by the step so the swap SLIDES (in
+            from the right going forward, from the left coming back) while the
+            preview beside it holds still: the widget you were looking at is the
+            widget you are now configuring, and it should not have to re-arrive
+            to say so. */}
+        <div
+          key={step}
+          className={cn(
+            "flex min-h-0 flex-col gap-2",
+            asideClassName,
+            "duration-300 ease-out animate-in fade-in motion-reduce:animate-none",
+            configuring ? "slide-in-from-right-4" : "slide-in-from-left-4"
+          )}
+        >
+          {configuring && selected && schema ? (
+            /* The params, as FIELDS: the widget's own schema handed to F0Form, so
+             a `z.date()` gets a date picker, a `z.enum()` a select, and a param
+             that isn't `.optional()` simply cannot be left empty — the same
+             fields "Edit params" shows once the widget is on the page. */
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <F0Form
+                // Keyed by the widget so switching to another one starts a fresh
+                // form rather than carrying the last one's values into it.
+                key={selected.id}
+                formRef={formRef}
+                name="widget-params"
+                schema={schema}
+                defaultValues={params}
+                // Autosubmit is the CHANGE SIGNAL, not an add: it hands us the
+                // values every time they settle and validate, which is what the
+                // preview wants. Nothing reaches the Home until the CTA.
+                submitConfig={{
+                  type: "autosubmit",
+                  delay: PREVIEW_DELAY_MS,
+                  hideActionBar: true,
+                }}
+                // The dialog already provides the padding around this column.
+                styling={{ noPadding: true }}
+                onSubmit={(values: WidgetParams) => {
+                  setDraft({ id: selected.id, params: values })
+                  return { success: true }
+                }}
+              />
+            </div>
+          ) : (
+            <>
+              <F0SearchInput
+                value={query}
+                onChange={setQuery}
+                placeholder="Search widgets"
+              />
+              <div className="flex flex-col gap-1 overflow-y-auto">
+                {sections.map((section) => (
+                  <Fragment key={section.id}>
+                    {section.label ? (
+                      <SectionHeader
+                        label={section.label}
+                        icon={section.icon}
+                      />
+                    ) : null}
+                    {section.items.map((w) => (
+                      <button
+                        key={w.id}
+                        type="button"
+                        onClick={() => setSelectedId(w.id)}
+                        className={
+                          "flex items-center gap-3 rounded-md p-2 text-left " +
+                          (selected?.id === w.id
+                            ? "bg-f1-background-selected"
+                            : "hover:bg-f1-background-tertiary")
+                        }
+                      >
+                        <F0AvatarIcon icon={w.icon} size="lg" />
+                        <span className="truncate font-medium text-f1-foreground">
+                          {w.title}
+                        </span>
+                      </button>
+                    ))}
+                  </Fragment>
                 ))}
-              </Fragment>
-            ))}
-            {ordered.length === 0 ? (
-              <div className="p-2 text-f1-foreground-secondary">
-                {/* Two ways to end up with nothing, and they are not the same
+                {ordered.length === 0 ? (
+                  <div className="p-2 text-f1-foreground-secondary">
+                    {/* Two ways to end up with nothing, and they are not the same
                     problem: a search that matched none can be cleared, while a
                     column with nothing left to offer cannot. */}
-                {needle
-                  ? "No widgets match your search."
-                  : "No widgets to add here."}
+                    {needle
+                      ? "No widgets match your search."
+                      : "No widgets to add here."}
+                  </div>
+                ) : null}
               </div>
-            ) : null}
-          </div>
+            </>
+          )}
         </div>
         {/* The preview: the real widget, centered on the page grey, at the width
             the target column will really give it — and it JUMPS in as you move
-            down the list, so each row you land on announces its widget. */}
+            down the list, so each row you land on announces its widget.
+            Keyed by the WIDGET rather than by the step, so configuring one keeps
+            the card that is already there and only its content follows the
+            fields. */}
         <WidgetPreviewPane
           previewKey={selected?.id}
-          info={selected ? previewInfo(selected) : undefined}
+          info={
+            selected
+              ? previewInfo(
+                  selected,
+                  previewed,
+                  configuring ? params : undefined
+                )
+              : undefined
+          }
           previewWidth={resolvedPreviewWidth}
         >
           {selected ? (
             <CatalogPreview
-              preview={selected.preview}
+              preview={previewed}
+              params={configuring ? params : undefined}
               slotRenderers={slotRenderers}
             />
           ) : null}

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -353,6 +353,18 @@ export function WidgetCatalog({
   const [selectedId, setSelectedId] = useState<string | null>(null)
   const [step, setStep] = useState<WidgetCatalogStep>("pick")
   /**
+   * WHETHER A STEP HAS BEEN TAKEN since the picker opened. The column slides
+   * when you move between the steps, and ONLY then: opening the picker is the
+   * dialog's own entrance, and a list sliding in behind it read as a second
+   * animation competing with it rather than as the list arriving.
+   */
+  const [stepped, setStepped] = useState(false)
+  /** Moving between the steps — the one thing that makes the column slide. */
+  const goToStep = (next: WidgetCatalogStep) => {
+    setStepped(true)
+    setStep(next)
+  }
+  /**
    * The params being filled in, KEPT AGAINST THE WIDGET THEY BELONG TO: stepping
    * back to the list and forward again finds the form as it was left, while
    * landing on another widget starts from that widget's own defaults rather than
@@ -460,6 +472,7 @@ export function WidgetCatalog({
   useEffect(() => {
     if (isOpen) {
       setStep("pick")
+      setStepped(false)
       setDraft(null)
     }
   }, [isOpen])
@@ -509,7 +522,7 @@ export function WidgetCatalog({
               disabled: !selected,
               onClick: () => {
                 if (!selected) return
-                if (schema) setStep("configure")
+                if (schema) goToStep("configure")
                 else onAdd(selected.id)
               },
             }
@@ -528,7 +541,7 @@ export function WidgetCatalog({
                 // widget shouldn't cost the value typed a moment before, and a
                 // half-filled form is still the form you were filling.
                 setDraft({ id: selected.id, params: getValues() })
-                setStep("pick")
+                goToStep("pick")
               },
             }
           : undefined
@@ -540,14 +553,21 @@ export function WidgetCatalog({
             from the right going forward, from the left coming back) while the
             preview beside it holds still: the widget you were looking at is the
             widget you are now configuring, and it should not have to re-arrive
-            to say so. */}
+            to say so.
+
+            The slide belongs to the STEP, not to the picker: on the way in the
+            dialog has an entrance of its own, and the list is simply already
+            there (`stepped`). */}
         <div
           key={step}
           className={cn(
             "flex min-h-0 flex-col gap-2",
             asideClassName,
-            "duration-300 ease-out animate-in fade-in motion-reduce:animate-none",
-            configuring ? "slide-in-from-right-4" : "slide-in-from-left-4"
+            stepped &&
+              cn(
+                "duration-300 ease-out animate-in fade-in motion-reduce:animate-none",
+                configuring ? "slide-in-from-right-4" : "slide-in-from-left-4"
+              )
           )}
         >
           {configuring && selected && schema ? (


### PR DESCRIPTION
## Description

Adding a widget that has params used to drop it onto the Home unconfigured, leaving the app to open "Edit params" itself on a card the user had just added. The picker now carries that second step: an entry that declares a `paramsSchema` — or whose `preview` is a `HomeWidgetItem` that already declares one — is added in two steps, and `onAdd` receives the params along with the id. An entry can opt out with `addWithDefaults` and be added straight from the list with its declared defaults.
