### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.67.1",
+  "packages/react": "6.68.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.68.0](https://github.com/factorialco/f0/compare/f0-react-v6.67.1...f0-react-v6.68.0) (2026-08-28)
+
+
+### Features
+
+* **F0Button:** show a counter on buttons, styled right ([#5225](https://github.com/factorialco/f0/issues/5225)) ([2075450](https://github.com/factorialco/f0/commit/2075450abfae7bb88e88d2ec42a3f4be5a163d17))
+
 ## [6.67.1](https://github.com/factorialco/f0/compare/f0-react-v6.67.0...f0-react-v6.67.1) (2026-08-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.67.1",
+  "version": "6.68.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.68.0</summary>

## [6.68.0](https://github.com/factorialco/f0/compare/f0-react-v6.67.1...f0-react-v6.68.0) (2026-08-28)


### Features

* **F0Button:** show a counter on buttons, styled right ([#5225](https://github.com/factorialco/f0/issues/5225)) ([2075450](https://github.com/factorialco/f0/commit/2075450abfae7bb88e88d2ec42a3f4be5a163d17))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).