### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.70.0",
+  "packages/react": "6.71.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.1.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.71.0](https://github.com/factorialco/f0/compare/f0-react-v6.70.0...f0-react-v6.71.0) (2026-08-28)
+
+
+### Features
+
+* **Tooltip:** accept a title, body and bullets in cell tooltips ([#5289](https://github.com/factorialco/f0/issues/5289)) ([bf2836e](https://github.com/factorialco/f0/commit/bf2836eadd9f9671b6743d933e03363a92305aba))
+
 ## [6.70.0](https://github.com/factorialco/f0/compare/f0-react-v6.69.0...f0-react-v6.70.0) (2026-08-28)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.70.0",
+  "version": "6.71.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.71.0</summary>

## [6.71.0](https://github.com/factorialco/f0/compare/f0-react-v6.70.0...f0-react-v6.71.0) (2026-08-28)


### Features

* **Tooltip:** accept a title, body and bullets in cell tooltips ([#5289](https://github.com/factorialco/f0/issues/5289)) ([bf2836e](https://github.com/factorialco/f0/commit/bf2836eadd9f9671b6743d933e03363a92305aba))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).