### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.72.0",
+  "packages/react": "6.73.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.73.0](https://github.com/factorialco/f0/compare/f0-react-v6.72.0...f0-react-v6.73.0) (2026-08-29)
+
+
+### Features
+
+* **F0Chat:** a read-only announcement channel, with cards in messages ([#5309](https://github.com/factorialco/f0/issues/5309)) ([08f4ebb](https://github.com/factorialco/f0/commit/08f4ebb65c175fbf78381a6f12dba523b991c789))
+
 ## [6.72.0](https://github.com/factorialco/f0/compare/f0-react-v6.71.0...f0-react-v6.72.0) (2026-08-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.72.0",
+  "version": "6.73.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.73.0</summary>

## [6.73.0](https://github.com/factorialco/f0/compare/f0-react-v6.72.0...f0-react-v6.73.0) (2026-08-29)


### Features

* **F0Chat:** a read-only announcement channel, with cards in messages ([#5309](https://github.com/factorialco/f0/issues/5309)) ([08f4ebb](https://github.com/factorialco/f0/commit/08f4ebb65c175fbf78381a6f12dba523b991c789))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).