### PR TITLE
fix(F0DataChart): show tooltip over a bar's target gradient to see target

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -161,7 +161,9 @@ export const StackedWithMissingCategories: Story = {
 
 /**
  * Each bar has a `target` value — the gap between the actual value and the
- * target is rendered as a faded "ghost" bar above the solid one.
+ * target is rendered as a faded "ghost" bar above the solid one. A month with
+ * nothing attained yet is that gradient and nothing else, and hovering it
+ * reports the month's target all the same.
  */
 export const WithTargets: Story = {
   render: (args) => <F0DataChart {...args} />,
@@ -171,9 +173,9 @@ export const WithTargets: Story = {
     series: [
       {
         name: "Revenue",
-        data: [
-          9_200_000, 10_800_000, 8_100_000, 5_400_000, 3_200_000, 2_400_000,
-        ].map((value) => ({ value, target: 12_000_000 })),
+        data: [9_200_000, 10_800_000, 8_100_000, 5_400_000, 3_200_000, 0].map(
+          (value) => ({ value, target: 12_000_000 })
+        ),
       },
     ],
     showLegend: false,
@@ -205,33 +207,6 @@ export const WithOverachievement: Story = {
       },
     ],
     highlightOverachievement: true,
-    showTargetProgress: true,
-    showLegend: false,
-    valueFormatter: (v) => `${v / 1000}k €`,
-  },
-}
-
-/**
- * A plan whose later periods have yet to start: the gradient is the whole column
- * there, and hovering it reports that period's target and how far along it is —
- * the card belongs to the bar, not to the gap.
- */
-export const TargetsBeforeAnyProgress: Story = {
-  render: (args) => <F0DataChart {...args} />,
-  args: {
-    type: "bar",
-    categories: ["Q1", "Q2", "Q3", "Q4"],
-    series: [
-      {
-        name: "Attainment",
-        data: [
-          { value: 125_000, target: 185_000 },
-          { value: 40_000, target: 185_000 },
-          { value: 0, target: 185_000 },
-          { value: 0, target: 185_000 },
-        ],
-      },
-    ],
     showTargetProgress: true,
     showLegend: false,
     valueFormatter: (v) => `${v / 1000}k €`,

--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -211,6 +211,33 @@ export const WithOverachievement: Story = {
   },
 }
 
+/**
+ * A plan whose later periods have yet to start: the gradient is the whole column
+ * there, and hovering it reports that period's target and how far along it is —
+ * the card belongs to the bar, not to the gap.
+ */
+export const TargetsBeforeAnyProgress: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Q1", "Q2", "Q3", "Q4"],
+    series: [
+      {
+        name: "Attainment",
+        data: [
+          { value: 125_000, target: 185_000 },
+          { value: 40_000, target: 185_000 },
+          { value: 0, target: 185_000 },
+          { value: 0, target: 185_000 },
+        ],
+      },
+    ],
+    showTargetProgress: true,
+    showLegend: false,
+    valueFormatter: (v) => `${v / 1000}k €`,
+  },
+}
+
 /** Multiple series stacked into a single bar per category. */
 export const Stacked: Story = {
   render: (args) => <F0DataChart {...args} />,

--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -184,11 +184,12 @@ export const WithTargets: Story = {
 }
 
 /**
- * `highlightOverachievement` splits a bar that ran past its target at the target
- * itself, drawing the stretch beyond it in a darker shade — without it, Q2 and
- * Q4 would read the same as a quarter that landed exactly on its number.
- * `showTargetProgress` adds what that comes to (`value / target`) to the
- * tooltip, under the target row.
+ * A year in progress, with every state a target can be in. `highlightOverachievement`
+ * splits a bar that ran past its target at the target itself, drawing the stretch
+ * beyond it in a darker shade — without it, Q2 and Q3 would read the same as a
+ * quarter that landed exactly on its number. `showTargetProgress` adds what that
+ * comes to (`value / target`) to the tooltip, under the target row. Q4 has not
+ * started, and hovering its gradient still reports the target it is measured against.
  */
 export const WithOverachievement: Story = {
   render: (args) => <F0DataChart {...args} />,
@@ -201,8 +202,8 @@ export const WithOverachievement: Story = {
         data: [
           { value: 125_000, target: 185_000 },
           { value: 200_000, target: 185_000 },
-          { value: 92_000, target: 185_000 },
           { value: 268_000, target: 185_000 },
+          { value: 0, target: 185_000 },
         ],
       },
     ],

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -88,7 +88,7 @@ Compare values across categories. Supports vertical/horizontal orientation, stac
 
 ### With Targets
 
-Renders a gradient fade from the bar top up to the target value.
+Renders a gradient fade from the bar top up to the target value. Hovering that gradient shows the bar's own tooltip, so a period with nothing attained yet — where the gradient is the whole column — still reports its target.
 
 <Canvas of={BarStories.WithTargets} />
 

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1038,7 +1038,7 @@ describe("BarChart — item tooltip", () => {
     expect(html).not.toContain("107505.8632") // no raw float precision
   })
 
-  it("formats and escapes values in target tooltips, and hides ghost series", () => {
+  it("formats and escapes values in target tooltips, gradient included", () => {
     render(
       <F0DataChart
         type="bar"
@@ -1071,14 +1071,47 @@ describe("BarChart — item tooltip", () => {
     expect(html).toContain("&lt;em&gt;107,505&lt;/em&gt;")
     expect(html).toContain("&lt;em&gt;125,000&lt;/em&gt;") // target row
     expect(html).not.toContain("<script>")
-    // Hovering the ghost gradient bar renders no tooltip.
-    expect(
-      formatter?.({
-        seriesName: "<strong>Revenue</strong> (target)",
-        value: 17495,
-        dataIndex: 0,
-      })
-    ).toBe("")
+    // Hovering the gradient reads as hovering its bar: same card, and the
+    // value is the bar's, not the height of the gap.
+    const overGradient = formatter?.({
+      name: "<script>category</script>",
+      seriesName: "<strong>Revenue</strong> (target)",
+      value: 17495,
+      dataIndex: 0,
+    })
+    expect(overGradient).toContain("&lt;strong&gt;Revenue&lt;/strong&gt;")
+    expect(overGradient).toContain("&lt;em&gt;107,505&lt;/em&gt;")
+    expect(overGradient).not.toContain("17,495")
+  })
+
+  it("answers over a bar that has attained nothing, where the gradient is all there is", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["Q3"]}
+        series={[{ name: "Attainment", data: [{ value: 0, target: 185_000 }] }]}
+        showTargetProgress
+        valueFormatter={(value) => (value === 0 ? "nothing yet" : `${value}!`)}
+      />
+    )
+
+    // A zero-height bar has no rectangle to hover, so ECharts reports the
+    // gradient — the whole column, in this case.
+    const html = getTooltipFormatter()?.({
+      name: "Q3",
+      seriesName: "Attainment (target)",
+      value: 185_000,
+      dataIndex: 0,
+    })
+
+    expect(html).toContain("Attainment")
+    expect(html).toContain("Q3")
+    expect(html).toContain("nothing yet")
+    expect(html).toContain("185000!")
+    expect(html).toContain("0.0%")
+    // The dot is drawn from the series colour: ECharts' own marker for the
+    // gradient item is not a colour the card can use.
+    expect(html).toContain("background-color:#")
   })
 
   it("shows share of total only for multi-series charts", () => {

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -19,6 +19,7 @@ import {
   buildBaseChartOptions,
   buildItemTooltip,
   labelWidthCap,
+  renderMarker,
   renderValueTooltip,
   tooltipValueFormat,
 } from "../../utils/options"
@@ -78,6 +79,13 @@ const INSIDE_LABEL_COLOR = "#ffffff"
  * renders as a hairline at 1x and a crisp single device pixel at 2x.
  */
 const STACK_GAP_BORDER_WIDTH = 0.5
+
+/**
+ * Suffix marking the internal series that draws the gap up to a target. It names
+ * a series ECharts needs but the reader never chose, so the legend leaves it out
+ * and the tooltip resolves it back to the bar it belongs to.
+ */
+const TARGET_SERIES_SUFFIX = " (target)"
 
 /** Opacity of the series that are *not* hovered, while one series has focus. */
 const BLUR_OPACITY = 0.4
@@ -667,15 +675,14 @@ function buildSeriesEntries(
   })
 
   const targetSeries: echarts.BarSeriesOption = {
-    name: `${series.name} (target)`,
+    name: `${series.name}${TARGET_SERIES_SUFFIX}`,
     type: "bar",
     data: targetData,
     stack: stackId,
-    // Hide from legend and tooltip
+    // Out of the legend, but not out of the tooltip: until a bar attains
+    // something, this gradient is all there is to hover, and the card it
+    // resolves to is the one for its own bar.
     legendHoverLink: false,
-    tooltip: {
-      show: false,
-    },
     itemStyle: {
       color: new echarts.graphic.LinearGradient(
         // Gradient direction: offset 0 is the far end from the solid bar
@@ -1131,6 +1138,13 @@ export function useBarChartOptions(
     // Legend should only show the main series (not the target ghost bars)
     const legendData = series.map((s) => s.name)
 
+    // The colour each series is actually painted in, for the dot on a card the
+    // gradient resolved: ECharts' own marker there is the gradient, not a colour.
+    const seriesColors = new Map<string, string>()
+    series.forEach((s, index) =>
+      seriesColors.set(s.name, resolveColor(s, index))
+    )
+
     // Build a lookup of targets per series/category for the tooltip
     const targetMap = new Map<string, (number | undefined)[]>()
     for (const s of series) {
@@ -1273,11 +1287,23 @@ export function useBarChartOptions(
             dataIndex?: number
             marker?: string
           }
-          const seriesName = String(p.seriesName ?? "")
-          if (seriesName.endsWith(" (target)")) return ""
-
-          const value = Number(p.value)
+          const hovered = String(p.seriesName ?? "")
           const dataIndex = p.dataIndex ?? 0
+          // Hovering the gradient reads as hovering the bar it tops, so the card
+          // is the bar's: its own name, its own value — not the gap's height.
+          const overTarget = hovered.endsWith(TARGET_SERIES_SUFFIX)
+          const seriesName = overTarget
+            ? hovered.slice(0, -TARGET_SERIES_SUFFIX.length)
+            : hovered
+          const point = overTarget
+            ? series.find((s) => s.name === seriesName)?.data[dataIndex]
+            : undefined
+          if (overTarget && point === undefined) return ""
+
+          const value = point === undefined ? Number(p.value) : getValue(point)
+          const marker = overTarget
+            ? renderMarker(seriesColors.get(seriesName) ?? "")
+            : p.marker
           const target = targetMap.get(seriesName)?.[dataIndex]
           // Only a stack has a total this component can be sure of: its
           // segments are parts of the very bar being hovered. Grouped bars
@@ -1318,7 +1344,7 @@ export function useBarChartOptions(
           // to its left is only meaningful on a trend — i.e. a line chart.
           return renderValueTooltip(
             {
-              marker: p.marker,
+              marker,
               title: seriesName,
               subtitle: String(p.name ?? ""),
               value: formatTooltipValue(value),


### PR DESCRIPTION
## Description

A bar with a `target` is drawn in two parts: a solid stretch for the value attained, and a faded gradient on top of it reaching up to the target. Hovering the solid part showed a tooltip. Hovering the gradient showed nothing.

That is worst for a period that has attained nothing yet: its solid part is zero pixels tall, so the gradient is the entire column and there is nothing else to point at. On a chart with one bar per period — a quota by month, a goal by quarter — every period still ahead was unreadable. You could not see the target it is going to be measured against.

Two things suppressed it. The gradient is a separate stacked ECharts series, named `"<series> (target)"`, and it carried `tooltip: { show: false }`; on top of that, the tooltip formatter returned an empty string for any series whose name ended in `" (target)"`.

Hovering the gradient now shows the same card as hovering the bar itself: the series name, the category, the value the bar attained, the target, and — with `showTargetProgress` on — the percentage of it. The value shown is the bar's own, not the height of the gap, which is what ECharts reports for that item.

This is a change to shared tooltip behaviour rather than a new prop. It applies to every bar that has a target, whether or not `highlightOverachievement` is on.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)
<img width="624" height="381" alt="Screenshot 2026-08-31 at 15 02 39" src="https://github.com/user-attachments/assets/b8414ac8-b1b5-4b8b-88c6-85a9ad5b4160" />
<img width="615" height="373" alt="image" src="https://github.com/user-attachments/assets/844b45e4-c1cd-44f6-af63-bdba289772d4" />

No story of its own: this is neither a prop nor a variant — every chart with a target answers the hover now — so the two canonical target stories carry the case instead.

**F0DataChart/Bar → With Targets** now ends on a month with nothing attained (Jul), where the gradient is the whole column. Hovering it reports `0M` and its `12M target`; before this, nothing.

**F0DataChart/Bar → With Overachievement** becomes a year in progress, covering every state a target can be in — and exercising the corner where the two features meet, a bar with `highlightOverachievement` on and nothing to darken:

| Quarter | Bar | Hover |
| --- | --- | --- |
| Q1 | 125k, short of target | `125k € / 185k € target / 67.6% of target` |
| Q2 | 200k, past it | `200k € / 185k € target / 108.1% of target` |
| Q3 | 268k, well past it | `268k € / 185k € target / 144.9% of target` |
| Q4 | not started | `0k € / 185k € target / 0.0% of target` |

Q4 answered nothing before this change; Q1's gradient answered nothing either. The darker stretch on Q2 and Q3 was never affected — it is a gradient on the bar's own item, not a second series, so it was always the same mark to hover.

Both stories therefore carry an intentional Chromatic diff.

## Implementation details

- The target series stops opting out of the tooltip.
- The formatter resolves a hovered `… (target)` back to its owner: the owner's name, the owner's value — not the height of the gap, which is what ECharts reports for that item — and the target and progress rows that belong to it.
- Its dot comes from `renderMarker` and the series' resolved colour: ECharts' own marker for a gradient item is not a colour a card can use.
- The `" (target)"` suffix was spelled out in three places; it is now one constant.

## Checks

`pnpm tsc`, `pnpm lint` and `pnpm format:check` clean. 342 tests in the kit pass, `BarChart.test.tsx` at 127 — one new, covering a bar with nothing attained, and one rewritten: it asserted the old silence (`"…and hides ghost series"`), and now asserts the card carries the bar's value rather than the gap's.
