### PR TITLE
chore(F0AiProposalCard): meet the stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -2,7 +2,6 @@
   "note": "Stable-tagged components that do not yet meet the mechanical Definition of Done (see docs/definition-of-done.mdx). Enforced by .scripts/check-stable-dod.ts. This list may only shrink: remove a component once it clears the bar, never add one.",
   "components": [
     "AI/AiInsightCard",
-    "AI/F0AiProposalCard",
     "Avatars/AvatarAlert",
     "Avatars/AvatarCompany",
     "Avatars/AvatarDate",

--- a/packages/react/src/kits/ai/F0AiProposalCard/__stories__/F0AiProposalCard.mdx
+++ b/packages/react/src/kits/ai/F0AiProposalCard/__stories__/F0AiProposalCard.mdx
@@ -1,0 +1,456 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0AiProposalCard.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+<Meta of={Stories} />
+
+# AI proposal card
+
+Presents a single AI-generated proposal, such as a draft ticket or a suggested
+record, as a self-contained card the user can read and then accept with one
+primary action. Long details stay collapsed behind an inline "See more"
+control until the user asks for them.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>module</code>
+        </td>
+        <td>
+          <code>ModuleId</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Module avatar shown before the heading. Decorative: it is rendered
+          with <code>aria-hidden</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>heading</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Header label describing the proposal type. Renders as an{" "}
+          <code>h2</code> and truncates on one line.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>title</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Main proposal title. Renders as an <code>h3</code> in the card body
+          and wraps over several lines.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>subtitle</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Secondary metadata line under the heading. Truncates on one line.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>description</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Proposal details as plain text. Rendered with{" "}
+          <code>whitespace-pre-wrap</code>, so line breaks survive and markup
+          does not.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>seeMoreLabel</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Already-localized label for the inline expansion control. The
+          component ships no translation for it.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>maxCollapsedDescriptionLength</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>
+          <code>180</code>
+        </td>
+        <td>—</td>
+        <td>
+          Characters of <code>description</code> kept visible while collapsed.
+          Values are floored and clamped to zero; a non-finite value falls back
+          to 180.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>showActions</code>
+        </td>
+        <td>
+          <code>false | true</code>
+        </td>
+        <td>
+          <code>true</code>
+        </td>
+        <td>—</td>
+        <td>
+          Pass <code>false</code> to drop the footer entirely. Omit it, or pass{" "}
+          <code>true</code>, to render the primary action.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>primaryActionLabel</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>When actions are shown</td>
+        <td>
+          Already-localized label of the footer button that accepts the
+          proposal.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>primaryActionIcon</code>
+        </td>
+        <td>
+          <code>IconType</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Icon rendered before the primary action label.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onPrimaryAction</code>
+        </td>
+        <td>
+          <code>() =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>When actions are shown</td>
+        <td>
+          Command invoked when the primary action is activated. The card keeps
+          no pending or success state of its own.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+`F0AiProposalCardProps` is a discriminated union on `showActions`. The action
+props are only accepted when `showActions` is not `false`: pass
+`showActions: false` alongside `primaryActionLabel`, `primaryActionIcon`, or
+`onPrimaryAction` and TypeScript rejects it with TS2353, rather than silently
+ignoring the prop at runtime. Any `data-*` attribute you pass is forwarded to the
+root `section`.
+
+### Description length
+
+<Canvas of={Stories.Collapsed} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Description length</th>
+        <th className="text-left">Rendered result</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          Shorter than or equal to <code>maxCollapsedDescriptionLength</code>
+        </td>
+        <td>Full text, no expansion control.</td>
+      </tr>
+      <tr>
+        <td>
+          Longer than <code>maxCollapsedDescriptionLength</code>
+        </td>
+        <td>
+          Text cut at the limit, trailing whitespace trimmed, an ellipsis
+          appended, and the expansion control placed inline after it.
+        </td>
+      </tr>
+      <tr>
+        <td>After expansion</td>
+        <td>
+          Full text with its line breaks; the expansion control is removed from
+          the DOM.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Guidelines
+
+### Design best practices
+
+**When to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0AiProposalCard when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>AI drafted a record for review</td>
+        <td>
+          The user reads one proposal and accepts it with a single command, such
+          as sending a drafted ticket.
+        </td>
+      </tr>
+      <tr>
+        <td>Proposal shown inside a conversation or feed</td>
+        <td>
+          The details are long enough that a collapsed summary keeps the
+          surrounding flow readable.
+        </td>
+      </tr>
+      <tr>
+        <td>Read-only proposal recap</td>
+        <td>
+          The proposal was already resolved elsewhere; pass{" "}
+          <code>showActions: false</code> to keep the same card without a
+          footer.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          AI output that is a summary or finding, not an actionable proposal
+        </td>
+        <td>
+          <code>F0AiInsightCard</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>Non-AI content in a card shell</td>
+        <td>A plain F0 card composed by the product.</td>
+      </tr>
+      <tr>
+        <td>Two or more competing commands, or a destructive confirmation</td>
+        <td>
+          A product-owned layout, or <code>F0HILActionConfirmation</code> for a
+          human-in-the-loop confirmation step.
+        </td>
+      </tr>
+      <tr>
+        <td>Rich body content: links, lists, bold text, embedded fields</td>
+        <td>
+          A product-owned card. <code>description</code> is plain text only.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do's and don'ts**
+
+<DoDonts
+  do={{
+    description:
+      "Feed the card already-localized strings and treat the description as plain text.",
+    guidelines: [
+      "Translate seeMoreLabel in the host app; the component ships no i18n for it.",
+      "Use real line breaks in description to separate paragraphs; whitespace-pre-wrap preserves them.",
+      "Keep heading and subtitle short: both truncate on one line with no tooltip.",
+    ],
+  }}
+  dont={{
+    description:
+      "Do not treat maxCollapsedDescriptionLength as a layout control or the description as rich content.",
+    guidelines: [
+      "It counts characters, not rendered lines, so the collapsed height still varies with wrapping.",
+      "Markdown or HTML in description is rendered as literal text, never parsed.",
+      "Do not rely on the expansion control to fold the text back. Expanding is one-way.",
+    ],
+  }}
+/>
+
+### Content best practices
+
+- Make `heading` name the proposal type ("Review this ticket"), and `title` name
+  the subject ("Cannot access payroll documents").
+- Use `subtitle` for short provenance or routing metadata, such as the owning
+  team.
+- Label the primary action with the command it performs ("Send ticket"), not
+  with a generic "Confirm".
+
+### Behavior
+
+- WHEN `description` is longer than `maxCollapsedDescriptionLength` → THEN the
+  text is truncated with an ellipsis and the `seeMoreLabel` control appears
+  inline right after it.
+- WHEN the expansion control is activated → THEN the full description replaces
+  the truncated text, the control unmounts, and focus moves to the description.
+- WHEN `description` already fits → THEN no expansion control is rendered at
+  all.
+- WHEN `showActions` is `false` → THEN the footer and its top border are not
+  rendered.
+- WHEN `module` is omitted → THEN the header collapses to heading and subtitle
+  with no avatar slot.
+- WHEN `subtitle` is omitted → THEN the heading is the only line in the header.
+
+### Usage examples
+
+**Read-only proposal**
+
+Use when the card recaps a proposal the user cannot act on from here.
+
+<Canvas of={Stories.WithoutActions} />
+
+**Heading without metadata**
+
+Use when there is no provenance line worth showing.
+
+<Canvas of={Stories.WithoutSubtitle} />
+
+## Accessibility
+
+The card renders as a `section` containing an `h2` for the `heading` and an `h3`
+for the `title`. Those levels are fixed, so place the card where `h2` is correct
+for the surrounding document outline; the card cannot adapt to a deeper nesting
+level. The module avatar is `aria-hidden`, so anything it implies must also be
+said in `heading`, `title`, or `subtitle`.
+
+Axe reported no violations across all five stories at the rule scope CI enforces
+(wcag2a, wcag2aa, wcag21a, wcag21aa, wcag22a, wcag22aa), measured on 2026-08-31.
+The story file runs axe in blocking mode, so a regression fails the build rather
+than showing up as a warning.
+
+### Expanding the description is one-way
+
+Revealing the full description cannot be undone. The control that does it is
+removed from the DOM as soon as it is used, and the component exposes no way to
+collapse the text again. Announce it as a reveal, never as a toggle.
+
+Two consequences follow from that, and consumers should know both:
+
+- The control carries `aria-expanded`, but because it only exists while the
+  description is collapsed, assistive technology can only ever read it as
+  `false`. It never flips to `true`.
+- Its `aria-controls` points at the description paragraph, which is the element
+  that contains the control itself, so the reference is an ancestor rather than a
+  separate region.
+
+### Focus on reveal
+
+When the description expands, the paragraph receives a negative `tabIndex` and is
+focused programmatically. A keyboard or screen-reader user therefore lands on the
+newly revealed text, with a visible focus ring, instead of losing their place
+when the control they had focused disappears.
+
+### Keyboard interaction
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Key</th>
+        <th className="text-left">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>
+        </td>
+        <td>
+          Moves focus to the expansion control while collapsed, then to the
+          primary action.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Enter</kbd> / <kbd>Space</kbd>
+        </td>
+        <td>
+          Reveals the full description, or runs <code>onPrimaryAction</code>{" "}
+          when the footer button is focused.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Screen reader behavior
+
+- `heading` and `title` are real headings, so the card is reachable from a
+  headings list.
+- While collapsed, only the truncated description plus the ellipsis is exposed;
+  the hidden remainder is not in the accessibility tree.
+- `primaryActionIcon` renders an `svg` with no `title` and no `aria-label`, so it
+  contributes no text. `primaryActionLabel` is the footer button's whole
+  accessible name.

--- a/packages/react/src/kits/ai/F0AiProposalCard/__stories__/F0AiProposalCard.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiProposalCard/__stories__/F0AiProposalCard.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { fn } from "storybook/test"
+import { expect, fn, userEvent, within } from "storybook/test"
 
 import { modules } from "@/components/avatars/F0AvatarModule"
 import Check from "@/icons/app/Check"
@@ -14,6 +14,11 @@ const longDescription = `The employee cannot access payroll documents from their
 
 They already tried refreshing the browser, logging out, and using another device, but the payslip download still fails.`
 
+// Lives in meta.args, so every story shares this one spy. Collapsed.play
+// asserts an exact call count, and a CI retry or a second visit to the story
+// would otherwise inflate it, hence the mockClear in beforeEach below.
+const onPrimaryAction = fn()
+
 const defaultArgs: F0AiProposalCardProps = {
   module: "tasks",
   heading: "Review this ticket",
@@ -24,7 +29,7 @@ const defaultArgs: F0AiProposalCardProps = {
   primaryActionLabel: "Send ticket",
   primaryActionIcon: Check,
   showActions: true,
-  onPrimaryAction: fn(),
+  onPrimaryAction,
 } satisfies F0AiProposalCardProps
 
 const meta: Meta<F0AiProposalCardProps> = {
@@ -32,8 +37,12 @@ const meta: Meta<F0AiProposalCardProps> = {
   component: F0AiProposalCard,
   parameters: {
     layout: "centered",
+    a11y: { test: "error" },
   },
-  tags: ["autodocs", "stable"],
+  tags: ["!autodocs", "stable"],
+  beforeEach: () => {
+    onPrimaryAction.mockClear()
+  },
   argTypes: {
     module: {
       control: "select",
@@ -85,6 +94,30 @@ export const Snapshot: Story = {
 export const Collapsed: Story = {
   args: {
     maxCollapsedDescriptionLength: 90,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+
+    await step(
+      "Reveals the full description and moves focus to it",
+      async () => {
+        await userEvent.click(canvas.getByRole("button", { name: "See more" }))
+
+        // getNodeText only joins an element's *direct* child text nodes, so this
+        // resolves to the description <p> alone and not to its ancestors.
+        const description = canvas.getByText(/using another device/)
+        await expect(description).toHaveFocus()
+        // The reveal is one-way: the control unmounts rather than toggling back.
+        await expect(
+          canvas.queryByRole("button", { name: "See more" })
+        ).not.toBeInTheDocument()
+      }
+    )
+
+    await step("Invokes the primary action", async () => {
+      await userEvent.click(canvas.getByRole("button", { name: "Send ticket" }))
+      await expect(onPrimaryAction).toHaveBeenCalledOnce()
+    })
   },
 }
 


### PR DESCRIPTION
## Description

`AI/F0AiProposalCard` carried the `stable` tag but sat on the stable-DoD debt list missing four of the eight mechanical requirements: no MDX docs, no play function, docs at the `none` tier, and axe still on the repo-wide non-blocking `todo`. This closes all four and deletes the debt entry, which is the part that makes `check:stable-dod` count the component as truly stable. No component source change was needed.

## Implementation details

`pnpm check:stable-dod` scores eight requirements. Four of them were unmet on `main`:

| Requirement | On `main` | Here |
| --- | --- | --- |
| Named with the `F0` prefix | ✓ | unchanged |
| Has Storybook stories | ✓ | unchanged |
| Has unit tests | ✓ 8 cases | unchanged |
| Has a visual snapshot story | ✓ | unchanged |
| Has a play function | ✗ | ✓ on `Collapsed` |
| Has MDX documentation | ✗ | ✓ 456 lines |
| Docs reach `good` quality | ✗ `none` | ✓ `gold` |
| Accessibility enforced | ✗ `todo` | ✓ `error` |

#### Changes

| | Change |
| --- | --- |
| `docs:` | add gold-tier MDX: anatomy, the full 11-prop table, when to use / when not to use, do's and don'ts, a behavior table, and 4 Canvas examples |
| `chore:` | replace the `autodocs` tag with `!autodocs`, so the hand-written page takes over instead of adding a second docs entry for the same title |
| `test:` | add a play function to `Collapsed`: reveal the description, assert focus lands on the revealed paragraph and the control unmounts, then run the primary action |
| `chore:` | enforce blocking axe with `a11y: { test: "error" }` |
| `chore:` | drop `AI/F0AiProposalCard` from `stable-dod-debt.json`, taking the list from 30 entries to 29 |

<details>
<summary><b>Why the axe flip needed no visual change</b></summary>

<br>

An axe probe at CI's own rule scope (`wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22a`, `wcag22aa`, scanned at `#storybook-root`) reports 5/5 stories clean, on both a static build and a dev server.

9 enabled targets measure under 24x24 CSS px and axe flagged none of them, including the inline "See more" button. `target-size` is an ANY-of rule, so `target-offset` satisfies it on its own. Same result already recorded for `F0DurationInput` and `F0NumberInput`.

</details>

<details>
<summary><b>Why the spy moved out of the args literal</b></summary>

<br>

`F0AiProposalCardProps` is a discriminated union, so `defaultArgs.onPrimaryAction` does not narrow and the play function cannot reach the mock through `args`. Hoisting it to module scope fixes that.

It also gets a `beforeEach` `mockClear`, because `meta.args` shares one spy across all five stories and a CI retry would inflate the exact call count the play function asserts. Same shape as `F0AiChatHeader`.

</details>

<details>
<summary><b>Two ARIA smells, documented rather than fixed</b></summary>

<br>

The Accessibility section describes the expand control as it behaves rather than as a toggle, because the reveal is one-way. The button unmounts the moment `expanded` flips, so its `aria-expanded` can only ever be observed as `"false"`, and its `aria-controls` points at the paragraph that contains the button rather than at a separate region.

Axe flags neither. Both are still misleading to assistive tech, and the fix is a behavior change (drop both attributes and keep only the focus move, or make the control a real toggle that stays mounted), so this PR describes the behavior instead of changing it. Worth a follow-up with a design call.

The docs also state that `showActions: false` alongside an action prop is a type error. I verified that with a throwaway probe rather than assuming it: TypeScript narrows on the discriminant first, so excess-property checking runs against the narrowed member and reports TS2353.

</details>

## Verification

Run from `packages/react`:

- `pnpm tsc` clean; `oxlint src --max-warnings 0` reports 0/0 over 3437 files; `pnpm format:check` passes on 3638 files
- full unit suite: 588 files, 7474 passed, 13 skipped, 0 failed
- `pnpm test-storybook` against a dev server: 5/5 stories pass with axe blocking, including the new `play-test`
- `pnpm check:stable-dod` passes and now lists the component under "Truly stable"
- docs page loaded in a browser: the `Stable` badge renders, 4 Canvas previews, the Controls table plus 5 hand-written tables, no console errors