### PR TITLE
refactor(F0EmptyState): meet the stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -17,7 +17,6 @@
     "Charts/RadarChart",
     "Checkbox",
     "DatePicker",
-    "EmptyState",
     "Filters/FilterPicker",
     "Graph/F0Graph",
     "Graph/F0GraphControls",

--- a/packages/react/src/components/F0EmptyState/F0EmptyState.tsx
+++ b/packages/react/src/components/F0EmptyState/F0EmptyState.tsx
@@ -6,14 +6,14 @@ import { UpsellingButton } from "@/sds/UpsellingKit/UpsellingButton"
 
 import * as Types from "./types"
 
-function _OneEmptyState({
+function _F0EmptyState({
   title,
   description,
   variant = "default",
   emoji,
   actions,
   ...rest
-}: Types.OneEmptyStateProps) {
+}: Types.F0EmptyStateProps) {
   return (
     <div
       className="flex flex-col items-center justify-center gap-5 p-8"
@@ -65,4 +65,4 @@ function _OneEmptyState({
   )
 }
 
-export const OneEmptyState = withDataTestId(_OneEmptyState)
+export const F0EmptyState = withDataTestId(_F0EmptyState)

--- a/packages/react/src/components/F0EmptyState/__stories__/F0EmptyState.mdx
+++ b/packages/react/src/components/F0EmptyState/__stories__/F0EmptyState.mdx
@@ -1,0 +1,104 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks"
+
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+import * as EmptyStateStories from "./F0EmptyState.stories"
+
+<Meta of={EmptyStateStories} />
+
+# F0EmptyState
+
+Communicates that a view has no content to show and, when possible, offers the
+next step to fill it. It covers first-use blank slates ("no items added yet")
+as well as error-shaped states ("we couldn't load the data") through its
+`variant` prop.
+
+> Renamed from `OneEmptyState`. The old name still works as a deprecated alias,
+> but new code should import `F0EmptyState`.
+
+---
+
+## Anatomy
+
+A centered vertical stack with four slots:
+
+1. **Avatar** — an emoji avatar for the `default` variant (`emoji` prop, falls
+   back to 🤔 when omitted), or an alert avatar for the `warning`, `info` and
+   `critical` variants. The `positive` alert type is deliberately excluded: an
+   empty state never celebrates.
+2. **Title** — required, always rendered.
+3. **Description** — optional, capped at `max-w-96` and centered.
+4. **Actions** — optional row of buttons. Each action takes a `label`,
+   `onClick`, optional `icon` and a button `variant` (`default`, `outline`,
+   `neutral`, `promote`). An action with `type: "upsell"` renders an upselling
+   button instead, with its own `errorMessage`, `successMessage`,
+   `loadingState`, `nextSteps` and `closeLabel` config.
+
+<Canvas of={EmptyStateStories.Basic} />
+
+<Controls of={EmptyStateStories.Basic} />
+
+## Guidelines
+
+#### When to use
+
+- A list, table or collection has no rows yet and you want to point at the
+  action that creates the first one.
+- A fetch failed or access was denied and the whole content area is empty —
+  use the `warning`, `info` or `critical` variant so the avatar signals
+  severity.
+- A feature is gated behind a plan and the empty area is the natural place to
+  offer the upgrade — use an `upsell` action.
+
+#### When NOT to use
+
+- Inline validation or partial failures inside a populated view — use `F0Alert`
+  there; this component assumes it owns the whole content area.
+- Loading states — show a skeleton instead; an empty state that flashes before
+  data arrives reads as data loss.
+- Celebratory confirmations ("all done!") — the `positive` variant is excluded
+  on purpose; use a dedicated success view.
+
+<Canvas of={EmptyStateStories.WithAlert} />
+
+<DoDonts
+  do={{
+    description:
+      "Pair the title with the action that resolves the emptiness, and keep the description to one sentence.",
+    guidelines: [
+      "Lead the title with the state, not the feature name",
+      "Offer at most two actions, primary first",
+      "Match the variant to severity: info for neutral, warning for recoverable, critical for blocked",
+    ],
+  }}
+  dont={{
+    description:
+      "Stack several actions or reuse the empty state as a generic error banner inside populated views.",
+    guidelines: [
+      "Don't add more than two actions — the row wraps and competes with the title",
+      "Don't use an emoji avatar for error states — the alert variants carry the severity",
+      "Don't leave error variants without a way out when a retry exists",
+    ],
+  }}
+/>
+
+An `upsell` action swaps the plain button for the upselling flow, which opens a
+request dialog and reports back through `successMessage` / `errorMessage`:
+
+<Canvas of={EmptyStateStories.WithUpsell} />
+
+All four variants side by side:
+
+<Canvas of={EmptyStateStories.Snapshot} />
+
+## Accessibility
+
+- The emoji avatar renders as an image whose `alt` is the emoji itself, so it
+  is announced without extra work; pass a meaningful `emoji` when the default
+  🤔 fallback would be confusing.
+- The alert variants (`warning`, `info`, `critical`) render a live `role="alert"`
+  region, so screen readers announce the state as soon as it mounts.
+- The title is a paragraph, not a heading. When the empty state fills a whole
+  page, make sure the page still provides its own heading structure around it.
+- Actions are regular buttons and inherit `F0Button`'s focus handling; every
+  action needs a `label` — there are no icon-only actions here.

--- a/packages/react/src/components/F0EmptyState/__stories__/F0EmptyState.stories.tsx
+++ b/packages/react/src/components/F0EmptyState/__stories__/F0EmptyState.stories.tsx
@@ -1,24 +1,27 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Plus } from "lucide-react"
-import { expect, fn, within } from "storybook/test"
+import { expect, fn, userEvent, within } from "storybook/test"
 
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
-import { OneEmptyState } from "../OneEmptyState"
+import { F0EmptyState } from "../F0EmptyState"
 
 const meta = {
-  component: OneEmptyState,
+  component: F0EmptyState,
   title: "EmptyState",
-  tags: ["autodocs", "stable"],
+  tags: ["stable", "!autodocs"],
+  parameters: {
+    a11y: { test: "error" },
+  },
   argTypes: {
     ...dataTestIdArgs,
   },
-} satisfies Meta<typeof OneEmptyState>
+} satisfies Meta<typeof F0EmptyState>
 
 export default meta
-type Story = StoryObj<typeof OneEmptyState>
+type Story = StoryObj<typeof F0EmptyState>
 
 export const Basic: Story = {
   args: {
@@ -33,6 +36,11 @@ export const Basic: Story = {
         icon: Plus,
       },
     ],
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(canvas.getByRole("button", { name: "New item" }))
+    await expect(args.actions![0].onClick).toHaveBeenCalledOnce()
   },
 }
 
@@ -55,11 +63,11 @@ export const WithAlert: Story = {
     )
     return (
       <div className="flex flex-col items-center gap-4">
-        <OneEmptyState variant="warning" title="We couldn't load the data" />
+        <F0EmptyState variant="warning" title="We couldn't load the data" />
         <Divider />
-        <OneEmptyState variant="info" title="No items added yet" />
+        <F0EmptyState variant="info" title="No items added yet" />
         <Divider />
-        <OneEmptyState variant="critical" title="Unauthorized" />
+        <F0EmptyState variant="critical" title="Unauthorized" />
       </div>
     )
   },
@@ -112,7 +120,7 @@ export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
     <div className="flex flex-col items-center gap-8">
-      <OneEmptyState
+      <F0EmptyState
         variant="default"
         emoji="📄"
         title="No items added yet"
@@ -121,17 +129,17 @@ export const Snapshot: Story = {
           { label: "New item", onClick: fn(), variant: "outline", icon: Plus },
         ]}
       />
-      <OneEmptyState
+      <F0EmptyState
         variant="info"
         title="Nothing to show here"
         description="Items you add will appear in this list."
       />
-      <OneEmptyState
+      <F0EmptyState
         variant="warning"
         title="We couldn't load the data"
         description="Please try again in a moment."
       />
-      <OneEmptyState
+      <F0EmptyState
         variant="critical"
         title="Unauthorized"
         description="You don't have access to this resource."

--- a/packages/react/src/components/F0EmptyState/__tests__/F0EmptyState.test.tsx
+++ b/packages/react/src/components/F0EmptyState/__tests__/F0EmptyState.test.tsx
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+
+import { F0EmptyState } from "../F0EmptyState"
+
+describe("F0EmptyState", () => {
+  it("renders the title, and the description only when passed", () => {
+    const { rerender } = zeroRender(<F0EmptyState title="No items yet" />)
+
+    expect(screen.getByText("No items yet")).toBeInTheDocument()
+
+    rerender(
+      <F0EmptyState title="No items yet" description="Add your first item." />
+    )
+    expect(screen.getByText("Add your first item.")).toBeInTheDocument()
+  })
+
+  it("renders the emoji avatar for the default variant", () => {
+    zeroRender(<F0EmptyState title="No items yet" emoji="📄" />)
+
+    expect(screen.getByAltText("📄")).toBeInTheDocument()
+  })
+
+  it("falls back to a neutral emoji when the default variant gets none", () => {
+    zeroRender(<F0EmptyState title="No items yet" />)
+
+    expect(screen.getByAltText("🤔")).toBeInTheDocument()
+  })
+
+  it("renders the alert avatar instead of the emoji for alert variants", () => {
+    const { container } = zeroRender(
+      <F0EmptyState variant="warning" title="We couldn't load the data" />
+    )
+
+    expect(container.querySelector("img")).not.toBeInTheDocument()
+    expect(screen.getByRole("alert")).toBeInTheDocument()
+  })
+
+  it("renders one button per action and fires that entry's onClick", async () => {
+    const onRetry = vi.fn()
+    const onBack = vi.fn()
+    zeroRender(
+      <F0EmptyState
+        title="No items yet"
+        actions={[
+          { label: "Retry", onClick: onRetry },
+          { label: "Go back", onClick: onBack, variant: "outline" },
+        ]}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Retry" }))
+
+    expect(onRetry).toHaveBeenCalledOnce()
+    expect(onBack).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("button")).toHaveLength(2)
+  })
+
+  it("renders an upsell action as an upselling button and calls its handler", async () => {
+    const onUpsell = vi.fn()
+    zeroRender(
+      <F0EmptyState
+        title="Upgrade to unlock"
+        actions={[
+          {
+            label: "Request information",
+            onClick: onUpsell,
+            type: "upsell",
+            errorMessage: { title: "Error", description: "Went wrong" },
+            successMessage: {
+              title: "Success",
+              description: "Went right",
+              buttonLabel: "Close",
+              buttonOnClick: vi.fn(),
+            },
+            loadingState: { label: "Loading..." },
+            nextSteps: { title: "Next steps", items: [{ text: "Step 1" }] },
+            closeLabel: "Close",
+          },
+        ]}
+      />
+    )
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Request information" })
+    )
+
+    expect(onUpsell).toHaveBeenCalledOnce()
+  })
+
+  it("forwards dataTestId", () => {
+    zeroRender(<F0EmptyState title="No items yet" dataTestId="empty-state" />)
+
+    expect(screen.getByTestId("empty-state")).toBeInTheDocument()
+  })
+
+  it("keeps the deprecated OneEmptyState alias pointing at F0EmptyState", async () => {
+    // Dynamic import: this suite exists specifically to verify the deprecated
+    // re-export, which consumers still rely on after the rename.
+    const barrel = await import("../index")
+
+    expect(barrel.OneEmptyState).toBe(F0EmptyState)
+  })
+})

--- a/packages/react/src/components/F0EmptyState/index.ts
+++ b/packages/react/src/components/F0EmptyState/index.ts
@@ -1,0 +1,12 @@
+export * from "./F0EmptyState"
+export type { F0EmptyStateProps } from "./types"
+/**
+ * @deprecated Renamed to F0EmptyState. Import F0EmptyState instead — this
+ * alias exists only so `@factorialco/f0-react`'s existing consumers don't
+ * break on the rename.
+ */
+export { F0EmptyState as OneEmptyState } from "./F0EmptyState"
+/**
+ * @deprecated Renamed to F0EmptyStateProps. Import F0EmptyStateProps instead.
+ */
+export type { F0EmptyStateProps as OneEmptyStateProps } from "./types"

--- a/packages/react/src/components/F0EmptyState/types.ts
+++ b/packages/react/src/components/F0EmptyState/types.ts
@@ -68,7 +68,7 @@ export type ActionProps = {
     }
 )
 
-export type OneEmptyStateProps = {
+export type F0EmptyStateProps = {
   /**
    * The title of the empty state
    */

--- a/packages/react/src/components/OneEmptyState/index.ts
+++ b/packages/react/src/components/OneEmptyState/index.ts
@@ -1,1 +1,0 @@
-export * from "./OneEmptyState"

--- a/packages/react/src/components/exports.ts
+++ b/packages/react/src/components/exports.ts
@@ -97,7 +97,7 @@ export * from "../lib/Await"
 export * from "../lib/F0GridStack"
 export * from "./F0TableOfContentPopover"
 export * from "./OneCalendar"
-export * from "./OneEmptyState"
+export * from "./F0EmptyState"
 export * from "./RichText/exports"
 /**
  * @deprecated Surveys has moved to @/kits/surveys. Import from there instead.

--- a/packages/react/src/experimental/Widgets/WidgetEmptyState/index.tsx
+++ b/packages/react/src/experimental/Widgets/WidgetEmptyState/index.tsx
@@ -2,7 +2,7 @@ import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 
 import { IconType } from "../../../components/F0Icon"
-import { OneEmptyState } from "@/components/OneEmptyState/OneEmptyState"
+import { F0EmptyState } from "@/components/F0EmptyState"
 
 type Action = {
   label: string
@@ -31,7 +31,7 @@ function _WidgetEmptyState({
   }
 
   return (
-    <OneEmptyState
+    <F0EmptyState
       title={title}
       description={description}
       {...(emoji ? { emoji } : { variant: "warning" as const })}

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -58,9 +58,9 @@ export * from "../patterns/OneDataCollection/exports"
  */
 export * from "../patterns/OneDateNavigator"
 /**
- * @deprecated OneEmptyState has moved to @/components/OneEmptyState. Import from there instead.
+ * @deprecated Renamed to F0EmptyState and moved to @/components/F0EmptyState. Import from there instead.
  */
-export * from "../components/OneEmptyState"
+export * from "../components/F0EmptyState"
 /**
  * @deprecated OnePagination has moved to @/ui/OnePagination. Import from there instead.
  */

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
@@ -3,7 +3,7 @@ import { useCallback, useRef, useState, useMemo } from "react"
 import type { DialogPosition } from "@/patterns/F0Dialog/types"
 import type { F0FormSubmitResult } from "@/patterns/F0Form/types"
 
-import { OneEmptyState } from "@/components/OneEmptyState"
+import { F0EmptyState } from "@/components/F0EmptyState"
 import { ArrowLeft, ArrowRight, Maximize, Minimize } from "@/icons/app"
 import { F0Box } from "@/lib/F0Box"
 import { useI18n } from "@/lib/providers/i18n"
@@ -345,7 +345,7 @@ function SurveyAnsweringFormDialog({
                 alignItems="center"
                 paddingX="lg"
               >
-                <OneEmptyState
+                <F0EmptyState
                   emoji={emptyLabels.emoji}
                   title={emptyLabels.title}
                   description={emptyLabels.description}
@@ -459,7 +459,7 @@ function SurveyAnsweringFormInline({
             alignItems="center"
             paddingX="lg"
           >
-            <OneEmptyState
+            <F0EmptyState
               emoji={emptyLabels.emoji}
               title={emptyLabels.title}
               description={emptyLabels.description}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -8,7 +8,7 @@ import type {
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0ButtonToggleGroup } from "@/components/F0ButtonToggleGroup"
 import { F0Icon, type IconType } from "@/components/F0Icon"
-import { OneEmptyState } from "@/components/OneEmptyState"
+import { F0EmptyState } from "@/components/F0EmptyState"
 import { F0RichTextDisplay } from "@/components/RichText/F0RichTextDisplay"
 import {
   type DropdownItem as DropdownItemType,
@@ -302,7 +302,7 @@ export function DashboardItem({
           )}
         </div>
         <div className="min-h-0 flex-1 overflow-auto">
-          <OneEmptyState
+          <F0EmptyState
             variant="critical"
             title={translations.ai.dashboardItem.errorTitle}
             description={error.message}

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatBlankState.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatBlankState.tsx
@@ -24,7 +24,7 @@ export type SidebarChatBlankStateProps = {
 /**
  * Compact blank state for a sidebar conversation list. Shared by the people
  * chat (`SidebarChatList`) and the AI history list so the two read identically.
- * Deliberately lighter than `OneEmptyState` — no emoji/avatar and tight
+ * Deliberately lighter than `F0EmptyState` — no emoji/avatar and tight
  * paddings — because it lives in a narrow sidebar column. The host (factorial)
  * supplies the copy + actions.
  */

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatList.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatList.tsx
@@ -20,7 +20,7 @@ import { useOffscreenUnreadChats } from "./useOffscreenUnreadChats"
 
 /**
  * Copy shown when there are no chats at all. Override via the `emptyState` prop.
- * Rendered through the shared `OneEmptyState`, so the AI history list and this
+ * Rendered through the shared `F0EmptyState`, so the AI history list and this
  * one read identically — the host (factorial) just supplies the copy + actions.
  */
 export type SidebarChatEmptyState = {

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -18,7 +18,7 @@ import type {
 } from "@/patterns/OneFilterPicker/types"
 
 import { F0ActionBar } from "@/components/F0ActionBar"
-import { OneEmptyState } from "@/components/OneEmptyState"
+import { F0EmptyState } from "@/components/F0EmptyState"
 import {
   GroupingDefinition,
   OnSelectItemsCallback,
@@ -1778,7 +1778,7 @@ const OneDataCollectionComp = <
       </div>
       {emptyState ? (
         <div className="flex flex-1 flex-col items-center justify-center">
-          <OneEmptyState
+          <F0EmptyState
             emoji={emptyState.emoji}
             title={emptyState.title}
             description={emptyState.description}

--- a/packages/react/src/patterns/OneDataCollection/hooks/useEmptyState.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useEmptyState.ts
@@ -2,10 +2,7 @@ import { useState } from "react"
 
 import { useI18n } from "@/lib/providers/i18n"
 
-import {
-  ActionProps,
-  OneEmptyStateProps,
-} from "@/components/OneEmptyState/types"
+import { ActionProps, F0EmptyStateProps } from "@/components/F0EmptyState/types"
 
 export type EmptyState = {
   emoji?: string
@@ -64,7 +61,7 @@ export const useEmptyState = (
 
   const [emptyState, setEmptyState] = useState<
     | (EmptyState & {
-        variant?: Exclude<OneEmptyStateProps["variant"], "positive">
+        variant?: Exclude<F0EmptyStateProps["variant"], "positive">
       })
     | undefined
   >(undefined)

--- a/packages/react/src/sds/chat/F0Chat/components/ChatStates.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatStates.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { OneEmptyState } from "@/components/OneEmptyState"
+import { F0EmptyState } from "@/components/F0EmptyState"
 import { ArrowCycle } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 
@@ -48,7 +48,7 @@ export const ChatEmptyState = (): ReactNode => {
   const i18n = useI18n()
   return (
     <div className="flex h-full flex-1 items-center justify-center p-6">
-      <OneEmptyState
+      <F0EmptyState
         emoji="💬"
         title={i18n.chat.emptyConversation}
         description={i18n.chat.emptyConversationDescription}


### PR DESCRIPTION
## Description

`EmptyState` was tagged stable while failing four of the mechanically checked stable-DoD requirements: the F0 name prefix, unit tests, MDX docs at the "good" tier, and enforced axe. This PR closes all four and removes it from the debt list, following the same recipe as the F0ResourceHeader rename (#5171). The public surface keeps `OneEmptyState` / `OneEmptyStateProps` as deprecated aliases with a regression test, so nothing breaks for existing consumers, and the story title stays "EmptyState" so story IDs and Chromatic keys are untouched.

## Implementation details

- refactor: rename `OneEmptyState` to `F0EmptyState` (folder, component, props type) and move all nine internal consumers to the new name

  <details>
  <summary>Why keep deprecated aliases?</summary>

  Factorial's frontend imports `OneEmptyState` today; a bare rename would break it on the next version bump. The component's `index.ts` re-exports `F0EmptyState as OneEmptyState` and `F0EmptyStateProps as OneEmptyStateProps` with `@deprecated` JSDoc, and a unit test pins the alias to the same component reference.
  </details>

- test: add a unit suite covering the description branch, the emoji/alert avatar split, the 🤔 fallback when the default variant gets no emoji, per-action onClick dispatch, the upsell action branch, dataTestId forwarding, and the deprecated alias
- test: Basic's play function now clicks the action and asserts its handler fired (was only a getByTestId check on another story)
- docs: new MDX page at gold tier — Anatomy with Controls, Guidelines with when/when-not-to-use and DoDonts, an upsell example, and an Accessibility section noting the live `role="alert"` region and the paragraph (non-heading) title; `!autodocs` replaces the autogenerated page
- feat: enforce axe with `a11y: { test: "error" }` on the story meta
- chore: drop `EmptyState` from `.scripts/stable-dod-debt.json` — `check:stable-dod` now lists it as truly stable

Verification: `tsc`, `oxlint` (0 warnings), `oxfmt --check`, the unit suites for the component and every touched consumer (1537 tests), a real axe probe over the 10 matching stories (clean), and `test-storybook` for F0EmptyState, WidgetEmptyState, SurveyAnsweringForm and OneDataCollection (253 story tests green).