### PR TITLE
fix(F0Chat): keep the emoji list through a blur, and stop a still pointer stealing the highlight

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1055,8 +1055,12 @@ const findEmojiListbox = async (
       activeElement: document.activeElement?.tagName ?? null,
       documentHasFocus: document.hasFocus(),
     }
+    // Ahead of the original message, not after it: `findByRole` prints the
+    // whole canvas on failure, and anything appended to that lands so far down
+    // the panel that it may as well not exist. This is the line that says which
+    // failure mode it was.
     throw new Error(
-      `${(error as Error).message}\n\ncomposer state: ${JSON.stringify(state)}`
+      `composer state: ${JSON.stringify(state)}\n\n${(error as Error).message}`
     )
   }
 }
@@ -1196,6 +1200,13 @@ export const EmojiAutocomplete: Story = {
 
     await step("Search and select with the keyboard", async () => {
       const composer = findComposer(canvas)
+      // Clear first, like every step below. Storybook re-runs `play` on an HMR
+      // update by re-rendering rather than remounting, so the composer keeps
+      // whatever a person typed into it while the story was open — and a `:`
+      // that lands mid-word is deliberately not a trigger (`http://`, `12:30`).
+      // Typing onto leftover text reported a missing listbox from a component
+      // that was working perfectly.
+      await userEvent.clear(composer)
       await userEvent.type(composer, ":smil")
       const listbox = await findEmojiListbox(canvas, composer)
       const selectedOption = within(listbox).getByRole("option", {

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1020,6 +1020,47 @@ export const Default: Story = {
   render: () => <Conversation initialCount={40} />,
 }
 
+/** The composer's textarea. Re-read per step rather than held across the whole
+ * play: a node captured before a remount still takes events, it just no longer
+ * has React on the other end, and the resulting failure looks like the widget
+ * broke rather than like the handle went stale. */
+const findComposer = (scope: ReturnType<typeof within>): HTMLTextAreaElement =>
+  scope.getByRole("combobox", {
+    name: /write something here/i,
+  }) as HTMLTextAreaElement
+
+/**
+ * The emoji listbox, waited for rather than read once.
+ *
+ * `findBy*` covers the ordinary case where the commit lands a frame after
+ * `userEvent.type` resolves. The reporting is the other half: this list is
+ * derived from four separate pieces of state, and a bare "unable to find an
+ * accessible element" — which is all a CI failure here used to say — is
+ * every one of those failure modes at once. Reporting the value, the caret and
+ * where focus actually is turns the next occurrence into a diagnosis instead
+ * of a re-run.
+ */
+const findEmojiListbox = async (
+  scope: ReturnType<typeof within>,
+  composer: HTMLTextAreaElement
+): Promise<HTMLElement> => {
+  try {
+    return await scope.findByRole("listbox", { name: "Add emoji" })
+  } catch (error) {
+    const state = {
+      value: composer.value,
+      caret: composer.selectionStart,
+      ariaExpanded: composer.getAttribute("aria-expanded"),
+      composerHasFocus: document.activeElement === composer,
+      activeElement: document.activeElement?.tagName ?? null,
+      documentHasFocus: document.hasFocus(),
+    }
+    throw new Error(
+      `${(error as Error).message}\n\ncomposer state: ${JSON.stringify(state)}`
+    )
+  }
+}
+
 export const Snapshot: Story = {
   render: () => (
     <div className="flex flex-col gap-8 bg-f1-background p-4">
@@ -1062,14 +1103,10 @@ export const Snapshot: Story = {
     const canvas = within(canvasElement)
     await step("Open emoji autocomplete", async () => {
       const defaultChat = within(canvas.getByTestId("snapshot-default-chat"))
-      const composer = defaultChat.getByRole("combobox", {
-        name: /write something here/i,
-      })
+      const composer = findComposer(defaultChat)
       await userEvent.clear(composer)
       await userEvent.type(composer, ":smil")
-      await expect(
-        defaultChat.getByRole("listbox", { name: "Add emoji" })
-      ).toBeVisible()
+      await expect(await findEmojiListbox(defaultChat, composer)).toBeVisible()
     })
 
     await step("Render the compact voice attachment", async () => {
@@ -1156,13 +1193,11 @@ export const EmojiAutocomplete: Story = {
   render: () => <Conversation initialCount={8} />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
-    const composer = canvas.getByRole("combobox", {
-      name: /write something here/i,
-    })
 
     await step("Search and select with the keyboard", async () => {
+      const composer = findComposer(canvas)
       await userEvent.type(composer, ":smil")
-      const listbox = canvas.getByRole("listbox", { name: "Add emoji" })
+      const listbox = await findEmojiListbox(canvas, composer)
       const selectedOption = within(listbox).getByRole("option", {
         name: /:smile:.*Grinning Face with Smiling Eyes/,
       })
@@ -1186,16 +1221,40 @@ export const EmojiAutocomplete: Story = {
     })
 
     await step("Convert a complete alias", async () => {
+      const composer = findComposer(canvas)
       await userEvent.clear(composer)
       await userEvent.type(composer, ":thumbsup:")
       await expect(composer).toHaveValue("👍")
     })
 
+    // Regression guard for a real bug, and for the CI flake it caused: the list
+    // used to record the token as *dismissed* on blur, which meant one stray
+    // focus change mid-word killed it for the rest of that word — refocusing
+    // and typing on did not bring it back.
+    await step("Survive losing and regaining focus mid-token", async () => {
+      const composer = findComposer(canvas)
+      await userEvent.clear(composer)
+      await userEvent.type(composer, ":smi")
+      await findEmojiListbox(canvas, composer)
+
+      composer.blur()
+      await waitFor(() =>
+        expect(
+          canvas.queryByRole("listbox", { name: "Add emoji" })
+        ).not.toBeInTheDocument()
+      )
+
+      composer.focus()
+      await findEmojiListbox(canvas, composer)
+      await userEvent.type(composer, "l")
+      await expect(await findEmojiListbox(canvas, composer)).toBeVisible()
+    })
+
     await step("Leave the visual example open", async () => {
-      await userEvent.type(composer, " :joy")
-      await expect(
-        canvas.getByRole("listbox", { name: "Add emoji" })
-      ).toBeVisible()
+      const composer = findComposer(canvas)
+      await userEvent.clear(composer)
+      await userEvent.type(composer, "👍 :joy")
+      await expect(await findEmojiListbox(canvas, composer)).toBeVisible()
     })
   },
 }

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -744,6 +744,32 @@ describe("F0Chat", () => {
     ).toBeInTheDocument()
   })
 
+  it("keeps the best match highlighted when the list opens under a still pointer", async () => {
+    renderChat(makeRuntime({}))
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, ":smil")
+    const listbox = screen.getByRole("listbox", { name: /add emoji/i })
+    const options = within(listbox).getAllByRole("option")
+    const best = options[0]
+    expect(best).toHaveAttribute("aria-selected", "true")
+
+    // The list opens above the caret, which is often where the pointer already
+    // is. A row arriving under a cursor that never moved still gets
+    // `mouseenter`, and that used to hand it the highlight — so Enter inserted
+    // an emoji nobody picked.
+    fireEvent.mouseEnter(options[3])
+
+    expect(best).toHaveAttribute("aria-selected", "true")
+    expect(options[3]).toHaveAttribute("aria-selected", "false")
+    expect(input).toHaveAttribute("aria-activedescendant", best.id)
+
+    // A pointer that genuinely moves still drives the highlight.
+    fireEvent.pointerMove(options[3])
+    expect(options[3]).toHaveAttribute("aria-selected", "true")
+    expect(input).toHaveAttribute("aria-activedescendant", options[3].id)
+  })
+
   it("does not select or send when Enter confirms an IME composition", async () => {
     const sendMessage = vi.fn()
     renderChat(makeRuntime({ sendMessage }))

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -687,6 +687,63 @@ describe("F0Chat", () => {
     )
   })
 
+  it("restores the emoji list when the composer is focused again", async () => {
+    renderChat(makeRuntime({}))
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, ":smi")
+    expect(
+      screen.getByRole("listbox", { name: /add emoji/i })
+    ).toBeInTheDocument()
+
+    // Focus moving somewhere else in the page hides the list: it is anchored to
+    // a caret the reader is no longer at.
+    fireEvent.blur(input, { relatedTarget: document.body })
+    expect(
+      screen.queryByRole("listbox", { name: /add emoji/i })
+    ).not.toBeInTheDocument()
+
+    // Coming back has to bring it back. It used to record the token as
+    // dismissed instead, so the list stayed gone for the rest of that word
+    // however much more the reader typed — which is also what made the
+    // Storybook play test flaky.
+    fireEvent.focus(input)
+    expect(
+      screen.getByRole("listbox", { name: /add emoji/i })
+    ).toBeInTheDocument()
+
+    await userEvent.type(input, "l")
+    expect(input).toHaveValue(":smil")
+    expect(
+      screen.getByRole("listbox", { name: /add emoji/i })
+    ).toBeInTheDocument()
+  })
+
+  it("brings the emoji list back on the next keystroke after a blur", async () => {
+    renderChat(makeRuntime({}))
+    const input = screen.getByPlaceholderText(
+      /write something here/i
+    ) as HTMLTextAreaElement
+
+    await userEvent.type(input, ":smi")
+    fireEvent.blur(input, { relatedTarget: document.body })
+    expect(
+      screen.queryByRole("listbox", { name: /add emoji/i })
+    ).not.toBeInTheDocument()
+
+    // No `focus` event on the way back in — the window regaining focus does not
+    // reliably send one, and that gap is what left the list stranded closed for
+    // the rest of the word. A keystroke is proof enough that the composer has
+    // focus, so it resumes on its own.
+    input.selectionStart = 5
+    fireEvent.change(input, { target: { value: ":smil" } })
+
+    expect(input).toHaveValue(":smil")
+    expect(
+      screen.getByRole("listbox", { name: /add emoji/i })
+    ).toBeInTheDocument()
+  })
+
   it("does not select or send when Enter confirms an IME composition", async () => {
     const sendMessage = vi.fn()
     renderChat(makeRuntime({ sendMessage }))

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -159,6 +159,8 @@ export const ChatComposer = (): ReactNode => {
       channel.type === "group" ? i18n.chat.mentionEveryone : undefined,
   })
   const closeEmojiAutocomplete = emojiAutocomplete.close
+  const suspendEmojiAutocomplete = emojiAutocomplete.suspend
+  const resumeEmojiAutocomplete = emojiAutocomplete.resume
   const handleEmojiAutocompleteKeyDown = emojiAutocomplete.handleKeyDown
   const mentionReactId = useId()
   const mentionListboxId = `chat-mention-autocomplete-${mentionReactId.replace(/:/g, "")}`
@@ -352,6 +354,11 @@ export const ChatComposer = (): ReactNode => {
       const nextCursorPosition = replacement?.cursorPosition ?? cursorPos
       setValue(nextValue)
       setCursorPosition(nextCursorPosition)
+      // A keystroke is proof the composer has focus — a reader cannot type into
+      // a field they have left. Resuming from the change, and not from `focus`
+      // alone, is what caps the cost of a blur at the one keystroke it landed
+      // on, whether or not a matching `focus` ever arrives.
+      resumeEmojiAutocomplete()
       onInputActivity()
       if (replacement) {
         requestAnimationFrame(() => {
@@ -365,7 +372,7 @@ export const ChatComposer = (): ReactNode => {
       // counterpart's dots hanging until the transport's timeout.
       if (nextValue.trim().length === 0) void stopTyping?.()
     },
-    [onInputActivity, stopTyping]
+    [onInputActivity, resumeEmojiAutocomplete, stopTyping]
   )
 
   // Leaving the conversation mid-type must also drop the dots immediately.
@@ -998,7 +1005,8 @@ export const ChatComposer = (): ReactNode => {
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
-            onBlur={closeEmojiAutocomplete}
+            onBlur={suspendEmojiAutocomplete}
+            onFocus={resumeEmojiAutocomplete}
             onCursorUpdate={updateCursorPosition}
             onScroll={syncHighlightScroll}
             highlightSegments={highlightSegments}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatEmojiAutocomplete.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatEmojiAutocomplete.tsx
@@ -90,7 +90,13 @@ export function ChatEmojiAutocomplete({
                 ? "bg-f1-background-secondary"
                 : "hover:bg-f1-background-secondary-hover"
             )}
-            onMouseEnter={() => onHighlight(index)}
+            // `pointermove`, not `mouseenter`: the list opens above the caret,
+            // which is often exactly where the pointer already is, and
+            // `mouseenter` fires on a row that arrives under a cursor that
+            // never moved. That handed the highlight to whatever happened to
+            // land under the mouse, so Enter inserted an emoji nobody picked.
+            // `pointermove` only fires when the pointer actually moves.
+            onPointerMove={() => onHighlight(index)}
             onMouseDown={(event) => event.preventDefault()}
             onClick={() => onSelect(candidate)}
           >

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -14,6 +14,7 @@ type ChatTextareaFieldProps = {
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
   onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => void
+  onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void
   onCursorUpdate: () => void
   onScroll: () => void
   highlightSegments: HighlightSegment[]
@@ -54,6 +55,7 @@ export const ChatTextareaField = ({
   onKeyDown,
   onPaste,
   onBlur,
+  onFocus,
   onCursorUpdate,
   onScroll,
   highlightSegments,
@@ -137,6 +139,7 @@ export const ChatTextareaField = ({
         onKeyDown={onKeyDown}
         onPaste={onPaste}
         onBlur={onBlur}
+        onFocus={onFocus}
         onKeyUp={onCursorUpdate}
         onClick={onCursorUpdate}
         onSelect={onCursorUpdate}

--- a/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/EmojiGrid.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/EmojiGrid.tsx
@@ -212,7 +212,12 @@ export const EmojiGrid = forwardRef<GroupedVirtuosoHandle, EmojiGridProps>(
                     // The search box owns focus; stealing it on mousedown would
                     // close the caret's home and break type-then-click.
                     onMouseDown={(event) => event.preventDefault()}
-                    onMouseEnter={() => onActivate(index)}
+                    // `pointermove`, not `mouseenter`: this grid is
+                    // virtualized, so a scroll pulls fresh rows under a cursor
+                    // that never moved and every one of them fires
+                    // `mouseenter`. The active option would chase the scroll
+                    // instead of the reader. Same reason the `:` list uses it.
+                    onPointerMove={() => onActivate(index)}
                     onClick={() => onSelect(emoji)}
                     className={emojiButtonClass(isActive)}
                     style={{

--- a/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
@@ -381,10 +381,21 @@ describe("EmojiPicker", () => {
 
   it("hides emoji the platform cannot draw", () => {
     // Emoji 13 predates the melting face (14) and the shaking face (15).
-    render(<EmojiPicker onSelect={() => {}} emojiVersion={13} />)
+    const { container } = render(
+      <EmojiPicker onSelect={() => {}} emojiVersion={13} />
+    )
 
-    expect(screen.queryByLabelText("Melting Face")).not.toBeInTheDocument()
-    expect(screen.getByLabelText("Grinning Face")).toBeInTheDocument()
+    // Selected by attribute rather than `getByLabelText`. The grid mounts ~1800
+    // cells here, and testing-library resolves label association across every
+    // one of them: measured at 983ms for these two queries against 435ms for
+    // the render, and 9ms for the same two as selectors. That second was enough
+    // to time this test out on CI, where coverage instrumentation is on.
+    // `EmojiGrid` puts the name in an explicit `aria-label`, so the selector
+    // asks precisely what the assertion means.
+    expect(container.querySelector('[aria-label="Melting Face"]')).toBeNull()
+    expect(
+      container.querySelector('[aria-label="Grinning Face"]')
+    ).not.toBeNull()
   })
 
   it("offers a jump-to bar for every category", () => {

--- a/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
@@ -7,7 +7,12 @@ import {
 } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { screen, zeroRender as render, within } from "@/testing/test-utils"
+import {
+  fireEvent,
+  screen,
+  zeroRender as render,
+  within,
+} from "@/testing/test-utils"
 
 // jsdom has no layout, so Virtuoso would render zero rows and every assertion
 // here would pass against an empty grid. The official mock context gives it a
@@ -284,6 +289,27 @@ describe("EmojiPicker", () => {
     const last = activeOption()
     await user.keyboard("{ArrowRight}{ArrowDown}")
     expect(activeOption()).toBe(last)
+  })
+
+  it("keeps the active cell where the keyboard left it under a still pointer", async () => {
+    const user = userEvent.setup()
+    renderPicker()
+
+    await user.keyboard("{ArrowRight}")
+    const active = activeOption()
+    const elsewhere = within(grid())
+      .getAllByRole("option")
+      .find((option) => option !== active)!
+
+    // The grid is virtualized: a scroll pulls fresh rows under a cursor that
+    // never moved, and each one fires `mouseenter`. The active cell would chase
+    // the scroll instead of the reader.
+    fireEvent.mouseEnter(elsewhere)
+    expect(activeOption()).toBe(active)
+
+    // A pointer that genuinely moves still drives it.
+    fireEvent.pointerMove(elsewhere)
+    expect(activeOption()).toBe(elsewhere)
   })
 
   it("selects the active emoji with Enter", async () => {

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useEmojiAutocomplete.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useEmojiAutocomplete.test.ts
@@ -233,6 +233,35 @@ describe("useEmojiAutocomplete", () => {
     expect(result.current.isOpen).toBe(true)
   })
 
+  it("hides on blur without dismissing the token, and comes back on focus", () => {
+    const props = makeProps({ inputValue: ":fir", cursorPosition: 4 })
+    const { result, rerender } = renderHook(
+      (nextProps: Props) => useEmojiAutocomplete(nextProps),
+      { initialProps: props }
+    )
+
+    expect(result.current.isOpen).toBe(true)
+    const highlighted = result.current.results[1]
+    act(() => result.current.setSelectedIndex(1))
+
+    act(() => result.current.suspend())
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.activeDescendantId).toBeUndefined()
+
+    // The token is hidden, not dismissed: focus alone brings it back, with the
+    // row the reader had highlighted still highlighted. Escape is the gesture
+    // that survives further typing (see the test above); a blur is not.
+    act(() => result.current.resume())
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.results[result.current.selectedIndex]).toBe(
+      highlighted
+    )
+
+    // And typing on after the round trip keeps working.
+    rerender({ ...props, inputValue: ":fire", cursorPosition: 5 })
+    expect(result.current.isOpen).toBe(true)
+  })
+
   it("preserves backward focus navigation and IME composition", () => {
     const setInputValue = vi.fn()
     const { result } = renderHook(() =>

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
@@ -48,6 +48,10 @@ export type UseEmojiAutocompleteReturn = {
   selectCandidate: (candidate: EmojiAutocompleteCandidate) => void
   setSelectedIndex: (index: number) => void
   close: () => void
+  /** Focus left the composer: hide the list without dismissing the token. */
+  suspend: () => void
+  /** Focus came back: show the list again if the token is still live. */
+  resume: () => void
 }
 
 /**
@@ -130,6 +134,15 @@ export function useEmojiAutocomplete({
   const listboxId = `chat-emoji-autocomplete-${reactId.replace(/:/g, "")}`
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [dismissedTrigger, setDismissedTrigger] = useState<number | null>(null)
+  // Hidden because focus left, NOT because the reader dismissed the token.
+  // The two are deliberately separate state: a dismissal outlives every later
+  // keystroke on the same `:` — that is what Escape means, and
+  // `useEmojiAutocomplete.test.ts` pins it — while a blur must outlive nothing.
+  // The caret is still sitting inside the token, so the list has to be back the
+  // moment focus is. Folding blur into `close()` meant one stray focus change
+  // mid-token killed the list for the rest of that word, however much more the
+  // reader typed.
+  const [isSuspended, setIsSuspended] = useState(false)
 
   // The same localized layer the picker uses, so `:` and the picker's search
   // box agree in every language, not just in English.
@@ -145,6 +158,7 @@ export function useEmojiAutocomplete({
   )
   const isOpen =
     trigger !== null &&
+    !isSuspended &&
     trigger.colonIndex !== dismissedTrigger &&
     results.length > 0
   const effectiveSelectedIndex = results[selectedIndex] ? selectedIndex : 0
@@ -158,6 +172,11 @@ export function useEmojiAutocomplete({
     setDismissedTrigger(trigger?.colonIndex ?? null)
     setSelectedIndex(0)
   }, [trigger?.colonIndex])
+
+  // The highlighted row survives a blur on purpose: coming back to the composer
+  // should land where you left it, not on the first option.
+  const suspend = useCallback(() => setIsSuspended(true), [])
+  const resume = useCallback(() => setIsSuspended(false), [])
 
   const selectCandidate = useCallback(
     (candidate: EmojiAutocompleteCandidate) => {
@@ -280,5 +299,7 @@ export function useEmojiAutocomplete({
     selectCandidate,
     setSelectedIndex,
     close,
+    suspend,
+    resume,
   }
 }


### PR DESCRIPTION
## Description

Two bugs in F0Chat's emoji lists, both found while chasing the intermittent `F0Chat › EmojiAutocomplete › play-test` failure on Storybook Tests shard 1/8.

**1. A blur dismissed the token permanently.** The suggestion list never came back — not on refocus, not on further typing. Reproduce on `main`: type `:smi` in the composer, click anywhere else, click back in, keep typing. The list is gone until you delete the `:`. This is the likeliest cause of the CI flake.

**2. A list opening under a still pointer stole the highlight.** Both emoji lists highlighted on `mouseenter`, which fires when a row arrives under a cursor that never moved. Reproduce on `main`: rest your mouse where the popover appears, type `:smil`, press Enter — you get an emoji you never picked.

## Type of change

- [x] Bug fix

## Implementation details

### 1. Blur no longer dismisses the token

`ChatTextareaField` wired `onBlur` straight to the autocomplete's `close()`, and `close()` records the trigger's `colonIndex` in `dismissedTrigger`. That flag only cleared when the `:` token disappeared entirely, so a blur poisoned the token for the rest of the word.

Blur and dismissal are now separate state in `useEmojiAutocomplete`:

- **Dismissal** (Escape, or picking an option) still outlives further typing on the same `:`. That is what Escape means, and `useEmojiAutocomplete.test.ts` already pinned it. Unchanged.
- **Blur** outlives nothing. `suspend()` hides the list, `resume()` shows it again, and `handleChange` resumes as well — a keystroke is proof the composer has focus, so the list comes back whether or not a matching `focus` event arrives.

`ChatTextareaField` gains an `onFocus` prop to carry the other half.

### 2. The highlight follows pointer movement, not `mouseenter`

`mouseenter` fires whenever a row arrives under the pointer, including when the pointer never moved. The `:` list opens directly above the caret, which is often exactly where the mouse is resting. `EmojiGrid` has it worse: it is virtualized, so every scroll pulls fresh rows under a still cursor and the active cell chases the scroll instead of the reader.

`pointermove` only fires on real movement, so hover-to-highlight still works and a list appearing under a stationary cursor no longer hijacks the keyboard selection. Same guard Radix uses on menu items. Two call sites: `ChatEmojiAutocomplete.tsx` and `EmojiPicker/EmojiGrid.tsx`.

This is also why the play function's `aria-activedescendant` assertion can fail when you open the story by hand but never in CI: a headless pointer sits at 0,0, far from the popover.

### On the CI flake

The failure signature is correct value, correct caret, `aria-expanded="false"`, no listbox. Nothing else among the widget's inputs can produce that: localized emoji terms only ever widen the result set (`scoreCandidate` ORs them with the English ones), and `:smile:` is Emoji release 1, below the glyph probe's floor, which fails open anyway. A stray blur produces it exactly.

I could not prove a blur actually happens on a GitHub runner, so this link is inferential. Two guards in case it is wrong:

- The three listbox queries go through a `findEmojiListbox` helper. It waits (`findByRole`), so a plain commit race cannot fail it, and on failure it reports the composer's value, caret, `aria-expanded`, `document.activeElement` and `document.hasFocus()`. The next occurrence says which failure mode it was instead of "no listbox".
- The composer handle is read per step. A node captured before a remount still takes events, it just no longer has React on the other end.

### Verification

Red/green driven in a real browser with a Playwright probe that blurs mid-token deliberately:

| case | before | after |
| --- | --- | --- |
| type `:smil`, no blur | open | open |
| blur after `:sm`, refocus, type `il` | **missing** | open |
| blur after `:sm`, keep typing, never refocus | **missing** | open |

The third case is the shape a play function is in: `userEvent.type` dispatches at the element whether or not it holds focus.

And for the highlight steal, driving the pointer to where the popover opens before typing:

| pointer | before | after |
| --- | --- | --- |
| parked away from the popover | `smile` highlighted | `smile` highlighted |
| parked where the popover opens | **`smiling_face_with_tear` highlighted** | `smile` highlighted |

- `pnpm tsc`, `npx oxlint src`, `npx oxfmt --check src` — clean
- `npx vitest --project=unit run src/sds/chat/F0Chat` — 70 files, 684 tests
- `pnpm test-storybook src/sds/chat/F0Chat/F0Chat.stories.tsx` — `EmojiAutocomplete` green in all 16 runs of the file (see the note below for the one story that is not)
- 300 iterations of the story's play function under 2x CPU oversubscription — 0 failures, before and after. The natural flake does not reproduce that way, which is why the fix is argued from the mechanism rather than from a rate.

Tests added: the blur/refocus and blur/keep-typing contracts and the stationary-pointer contract in `F0Chat.test.tsx`, the suspend/resume contract in `useEmojiAutocomplete.test.ts`, the virtualized-grid equivalent in `EmojiPicker.test.tsx`, and a play step that drives the blur round trip in a browser.

### Unrelated, found on the way

`F0Chat › ComposerHotkeys › play-test` is flaky on unmodified `main`: 2 failures in 5 local runs of the file, and 3 in 6 on this branch, so the rate is unchanged by this PR. It fails on `Unable to find an accessible element with the role "button" and name /^Reply$/i` — the hover-actions row, which the story's own comment notes stays mounted for a 150ms CSS exit animation before Radix decides where focus goes. Untouched here, and worth its own pass. If CI shows it on this PR, that is why.
