### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.74.0",
+  "packages/react": "6.74.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.74.1](https://github.com/factorialco/f0/compare/f0-react-v6.74.0...f0-react-v6.74.1) (2026-08-31)
+
+
+### Bug Fixes
+
+* **F0Chat:** leave the message body to text selection, not the reply quote ([#5322](https://github.com/factorialco/f0/issues/5322)) ([13b3a88](https://github.com/factorialco/f0/commit/13b3a88457d8fa3a54f11485d18fba2bee8c6b2b))
+
 ## [6.74.0](https://github.com/factorialco/f0/compare/f0-react-v6.73.0...f0-react-v6.74.0) (2026-08-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.74.0",
+  "version": "6.74.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.74.1</summary>

## [6.74.1](https://github.com/factorialco/f0/compare/f0-react-v6.74.0...f0-react-v6.74.1) (2026-08-31)


### Bug Fixes

* **F0Chat:** leave the message body to text selection, not the reply quote ([#5322](https://github.com/factorialco/f0/issues/5322)) ([13b3a88](https://github.com/factorialco/f0/commit/13b3a88457d8fa3a54f11485d18fba2bee8c6b2b))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).