### PR TITLE
fix(dialog): stop the scrim swallowing the click that dismisses a dialog

### DIFF
--- a/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.outside-click-passthrough.test.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.outside-click-passthrough.test.tsx
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0Dialog } from "../index"
+
+/**
+ * A dismissible dialog closes when you click outside it — and that same click
+ * must land on whatever you clicked. Otherwise dismissing costs one click and
+ * acting costs a second, which reads as the app ignoring the first one.
+ *
+ * The scrim is what used to eat it: `showOverlay` (dim what is behind) was read
+ * as `modal` (trap the user), so every dialog that dimmed also became
+ * Radix-modal, and a modal's overlay captures pointer events by design.
+ */
+describe("dialog-alike F0Dialog outside click", () => {
+  let overlayRoot: HTMLElement
+
+  beforeEach(() => {
+    overlayRoot = document.createElement("div")
+    overlayRoot.id = "f0-overlay-root"
+    document.body.appendChild(overlayRoot)
+  })
+
+  afterEach(() => {
+    overlayRoot.remove()
+    vi.clearAllMocks()
+  })
+
+  const renderDialog = () =>
+    render(
+      <div>
+        <button data-testid="behind" type="button">
+          Another task
+        </button>
+        <F0Dialog isOpen onClose={vi.fn()} title="Group">
+          <div data-testid="inner">content</div>
+        </F0Dialog>
+      </div>
+    )
+
+  const scrim = () =>
+    Array.from(document.querySelectorAll<HTMLElement>("div")).find((node) =>
+      node.className.includes("bg-f1-background-overlay")
+    )
+
+  it("dims the background", () => {
+    renderDialog()
+
+    expect(scrim()).toBeDefined()
+  })
+
+  it("does not let the scrim capture the click that dismisses it", () => {
+    renderDialog()
+
+    const overlay = scrim()
+
+    // Both the class and the inline style: the inline one wins, so a fix that
+    // only changed the class would still swallow the click.
+    expect(overlay?.className).toContain("pointer-events-none")
+    expect(overlay?.style.pointerEvents).toBe("none")
+  })
+
+  it("leaves the content itself clickable", () => {
+    const innerHandler = vi.fn()
+
+    render(
+      <F0Dialog isOpen onClose={vi.fn()} title="Group">
+        <button data-testid="inner" onClick={innerHandler} type="button">
+          A task
+        </button>
+      </F0Dialog>
+    )
+
+    screen.getByTestId("inner").click()
+
+    expect(innerHandler).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/components/dialog-alike/common/Wrapper.tsx
+++ b/packages/react/src/components/dialog-alike/common/Wrapper.tsx
@@ -237,7 +237,6 @@ export const DialogWrapper = ({
           </DrawerContent>
         </Drawer>
       ) : (
-        // We force the modal as we dont want to allow the user to click outside the dialog to close it
         <Dialog
           open={isOpen}
           onOpenChange={handleOpenChange}

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogOverlay.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogOverlay.tsx
@@ -13,7 +13,12 @@ export const DialogOverlay = forwardRef<
 >(({ className, ...props }, ref) => {
   const context = useDialogPrimitiveContext()
 
-  const modal = context.modal || context.showOverlay
+  // `modal` and `showOverlay` are separate questions: one is whether the dialog
+  // TRAPS you (closable only through its actions), the other is whether it dims
+  // what is behind it. Reading the dim as a trap made every scrim-wearing
+  // dialog Radix-modal, which swallowed the very click that dismissed it -- so
+  // dismissing a dialog and clicking the thing underneath took two clicks.
+  const { modal } = context
 
   return (
     <>
@@ -23,12 +28,15 @@ export const DialogOverlay = forwardRef<
           ref={ref}
           className={cn(
             "fixed inset-0 z-50 bg-f1-background-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-            "pointer-events-auto",
+            // A trapping dialog's scrim is the thing you click to be told "no"
+            // (see the shake in `DialogContent`). A dismissible one's scrim is
+            // decoration, and must let the click reach whatever it is covering.
+            modal ? "pointer-events-auto" : "pointer-events-none",
             "transition-all duration-200",
             className
           )}
           {...props}
-          style={{ pointerEvents: "auto", ...props.style }}
+          style={{ pointerEvents: modal ? "auto" : "none", ...props.style }}
         />
       </DialogPrimitive.Root>
     </>


### PR DESCRIPTION
## The bug

Clicking outside a dialog dismisses it, but the click never reaches what you clicked — so dismissing costs one click and acting costs a second. It reads as the app ignoring the first one.

Reported against the Factorial home "Needs you" feed: opening a grouped row's drill-in dialog, then clicking another task, took two clicks.

## Cause

`DialogOverlay` computed its Radix modality as:

```ts
const modal = context.modal || context.showOverlay
```

So any dialog that merely **dimmed** its background became Radix-modal — and a modal overlay captures pointer events by design (plus Radix takes `pointer-events` off the rest of the document). `DialogInternal` passes `modal={modal}` (default `false`) but no `showOverlay`, so `Wrapper`'s `showOverlay = true` default silently made every `F0Dialog` modal.

The result was a hybrid that is neither: `runwayEventCallback` only `preventDefault`s when `modal`, so the dialog *did* dismiss on an outside click — while the scrim ate that same click.

## Fix

The two props answer separate questions, and are documented that way:

- `modal` — whether the dialog traps you (*"only closable by clicking the actions"*, default `false`)
- `showOverlay` — whether it paints a scrim (default `true`)

Only `modal` decides modality now, and the scrim's `pointer-events` follow it. A trapping dialog's scrim is the thing you click to be told "no" (the shake in `DialogContent`); a dismissible dialog's scrim is decoration and must let the click through.

Both the class and the inline style are switched — the inline one wins, so changing only the class would still swallow the click.

## Why this is a restore, not a behaviour change

`modal` already defaults to `false`, and the existing tests are already named *"in non-modal mode"* (`F0Dialog.inner-click-propagation`, `F0Dialog.file-input-click`). Non-modal is the documented, intended mode; the scrim was overriding it by accident.

Worth reviewers' attention: Radix non-modal means no focus trap and no scroll lock. That follows from the documented default rather than from this diff, but it is the practical consequence — a dialog that genuinely needs to trap should pass `modal`.

## Verification

- New `F0Dialog.outside-click-passthrough.test.tsx` — the scrim still paints, does not capture pointer events (class **and** inline style), and content stays clickable.
- 19/19 dialog-alike tests pass (6 files), including the two existing non-modal suites.

Also removed a stale comment in `Wrapper.tsx` (*"We force the modal as we dont want to allow the user to click outside the dialog to close it"*) that contradicted the `modal = false` default it sat above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)