### PR TITLE
feat(charts): connect line series that continue another

### DIFF
--- a/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
@@ -370,3 +370,92 @@ export const StackedBySignWithLine: Meta<
     legend: true,
   },
 }
+
+const continuationConfig = {
+  actuals: {
+    label: "Actuals",
+    color: "categorical-1",
+  },
+  forecast: {
+    label: "Forecast",
+    color: "categorical-1",
+    dashed: true,
+    continues: "actuals",
+  },
+  planned: {
+    label: "Planned",
+    color: "categorical-2",
+    dashed: true,
+  },
+}
+
+export const LineContinuation: Meta<
+  typeof ComboChart<typeof continuationConfig>
+> = {
+  args: {
+    dataConfig: continuationConfig,
+    data: [
+      {
+        label: "January",
+        values: { actuals: 27000, forecast: null, planned: 27000 },
+      },
+      {
+        label: "February",
+        values: { actuals: 22000, forecast: null, planned: 27000 },
+      },
+      {
+        label: "March",
+        values: { actuals: 25500, forecast: null, planned: 31500 },
+      },
+      {
+        label: "April",
+        values: { actuals: 31000, forecast: null, planned: 35500 },
+      },
+      {
+        label: "May",
+        values: { actuals: 35500, forecast: null, planned: 35500 },
+      },
+      {
+        label: "June",
+        values: { actuals: 49000, forecast: null, planned: 52500 },
+      },
+      {
+        label: "July",
+        values: { actuals: 51000, forecast: null, planned: 56000 },
+      },
+      {
+        label: "August",
+        values: { actuals: null, forecast: 60000, planned: 56000 },
+      },
+      {
+        label: "September",
+        values: { actuals: null, forecast: 42500, planned: 49000 },
+      },
+      {
+        label: "October",
+        values: { actuals: null, forecast: 27000, planned: 30000 },
+      },
+      {
+        label: "November",
+        values: { actuals: null, forecast: 11000, planned: 16500 },
+      },
+      {
+        label: "December",
+        values: { actuals: null, forecast: 11000, planned: 16500 },
+      },
+    ],
+    line: {
+      categories: ["actuals", "forecast", "planned"],
+      lineType: "linear",
+    },
+    xAxis: {
+      hide: false,
+      tickFormatter: (value: string) => value,
+    },
+    yAxis: {
+      hide: false,
+      tickFormatter: (value: string) => `${Number(value) / 1000}k`,
+    },
+    legend: true,
+  },
+}

--- a/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
@@ -386,6 +386,7 @@ const continuationConfig = {
     label: "Planned",
     color: "categorical-2",
     dashed: true,
+    legendIndicator: "dot",
   },
 }
 

--- a/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
@@ -375,18 +375,20 @@ const continuationConfig = {
   actuals: {
     label: "Actuals",
     color: "categorical-1",
+    legendIndicator: "line" as const,
   },
   forecast: {
     label: "Forecast",
     color: "categorical-1",
     dashed: true,
     continues: "actuals",
+    legendIndicator: "line" as const,
   },
   planned: {
     label: "Planned",
     color: "categorical-2",
     dashed: true,
-    legendIndicator: "dot",
+    legendIndicator: "line" as const,
   },
 }
 

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -472,7 +472,7 @@ const _ComboChart = <K extends ChartConfig>(
         ))}
         {legend && (
           <ChartLegend
-            content={<ChartLegendContent nameKey="label" lineIndicators />}
+            content={<ChartLegendContent nameKey="label" />}
             align={"center"}
             verticalAlign={"bottom"}
             layout="vertical"

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -30,7 +30,7 @@ import {
   yAxisProps,
 } from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
-import { prepareData } from "../utils/muncher"
+import { bridgeContinuedSeries, prepareData } from "../utils/muncher"
 import { ProjectedBar } from "../utils/ProjectedBar"
 import { ChartPropsBase } from "../utils/types"
 
@@ -193,7 +193,7 @@ const _ComboChart = <K extends ChartConfig>(
   }: ComboChartProps<K>,
   ref: ForwardedRef<HTMLDivElement>
 ) => {
-  const preparedData = prepareData(data)
+  const preparedData = prepareData(bridgeContinuedSeries(data, dataConfig))
 
   const barCategories = bar?.categories
     ? Array.isArray(bar.categories)

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -472,7 +472,7 @@ const _ComboChart = <K extends ChartConfig>(
         ))}
         {legend && (
           <ChartLegend
-            content={<ChartLegendContent nameKey="label" />}
+            content={<ChartLegendContent nameKey="label" lineIndicators />}
             align={"center"}
             verticalAlign={"bottom"}
             layout="vertical"

--- a/packages/react/src/kits/Charts/LineChart/index.tsx
+++ b/packages/react/src/kits/Charts/LineChart/index.tsx
@@ -23,7 +23,7 @@ import {
   yAxisProps,
 } from "../utils/elements"
 import { fixedForwardRef } from "../utils/forwardRef"
-import { prepareData } from "../utils/muncher"
+import { bridgeContinuedSeries, prepareData } from "../utils/muncher"
 import { LineChartPropsBase } from "../utils/types"
 
 export type LineChartProps<K extends LineChartConfig = LineChartConfig> =
@@ -45,7 +45,7 @@ export const _LineChart = <K extends LineChartConfig>(
   ref: ForwardedRef<HTMLDivElement>
 ) => {
   const lines = Object.keys(dataConfig) as (keyof LineChartConfig)[]
-  const preparedData = prepareData(data)
+  const preparedData = prepareData(bridgeContinuedSeries(data, dataConfig))
   const maxLabelWidth = Math.max(
     ...preparedData.flatMap((el) =>
       lines.map((key) =>

--- a/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
@@ -29,7 +29,7 @@ import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, ChartPropsBase } from "../utils/types"
 
 const getMaxValueByKey = (
-  data: ({ x: unknown } & Record<string, number>)[]
+  data: ({ x: unknown } & Record<string, number | null>)[]
 ): string => {
   const clonedData = cloneDeep(data)
 
@@ -39,9 +39,9 @@ const getMaxValueByKey = (
   clonedData.forEach((datapoint) => {
     delete datapoint.x
 
-    Object.entries(datapoint as Record<string, number>).forEach(
+    Object.entries(datapoint as Record<string, number | null>).forEach(
       ([newLabel, value]) => {
-        if (max < value) {
+        if (value !== null && max < value) {
           max = value
           label = newLabel
         }

--- a/packages/react/src/kits/Charts/utils/muncher.ts
+++ b/packages/react/src/kits/Charts/utils/muncher.ts
@@ -3,3 +3,44 @@ import { ChartConfig, ChartItem } from "./types"
 export function prepareData<K extends ChartConfig>(data: ChartItem<K>[]) {
   return data.map((item) => ({ x: item.label, ...item.values }))
 }
+
+/**
+ * Gives every series that `continues` another one the last value of the
+ * continued series, so consecutive lines (e.g. a forecast extending the
+ * actuals) connect instead of leaving a gap. Only bridges when the continuing
+ * series starts after the continued one ends.
+ */
+export function bridgeContinuedSeries<K extends ChartConfig>(
+  data: ChartItem<K>[],
+  dataConfig: Record<string, { continues?: string }>
+): ChartItem<K>[] {
+  const links = Object.entries(dataConfig).flatMap(([key, config]) =>
+    config.continues ? [[key, config.continues] as const] : []
+  )
+
+  if (links.length === 0) {
+    return data
+  }
+
+  const bridged = data.map((item) => ({ ...item, values: { ...item.values } }))
+  const hasValue = (item: ChartItem<K>, key: string) =>
+    typeof item.values[key as keyof K] === "number"
+
+  for (const [series, base] of links) {
+    const firstOwn = bridged.findIndex((item) => hasValue(item, series))
+    let lastBase = -1
+    for (let index = bridged.length - 1; index >= 0; index--) {
+      if (hasValue(bridged[index], base)) {
+        lastBase = index
+        break
+      }
+    }
+
+    if (lastBase !== -1 && firstOwn > lastBase) {
+      bridged[lastBase].values[series as keyof K] =
+        bridged[lastBase].values[base as keyof K]
+    }
+  }
+
+  return bridged
+}

--- a/packages/react/src/kits/Charts/utils/muncher.ts
+++ b/packages/react/src/kits/Charts/utils/muncher.ts
@@ -4,7 +4,6 @@ export function prepareData<K extends ChartConfig>(data: ChartItem<K>[]) {
   return data.map((item) => ({ x: item.label, ...item.values }))
 }
 
-// Array.prototype.findLastIndex needs ES2023; the build targets ES2020.
 const findLastIndex = <T>(items: T[], matches: (item: T) => boolean) => {
   for (let index = items.length - 1; index >= 0; index--) {
     if (matches(items[index])) {
@@ -14,13 +13,6 @@ const findLastIndex = <T>(items: T[], matches: (item: T) => boolean) => {
   return -1
 }
 
-/**
- * Connects a series marked with `continues` to the series it extends (e.g. a
- * forecast continuing the actuals): the continuing series receives the last
- * value of the continued one, so both lines share that point instead of
- * leaving a gap. Only applies when the continuing series starts after the
- * continued one ends.
- */
 export function bridgeContinuedSeries<K extends ChartConfig>(
   data: ChartItem<K>[],
   dataConfig: K

--- a/packages/react/src/kits/Charts/utils/muncher.ts
+++ b/packages/react/src/kits/Charts/utils/muncher.ts
@@ -4,41 +4,43 @@ export function prepareData<K extends ChartConfig>(data: ChartItem<K>[]) {
   return data.map((item) => ({ x: item.label, ...item.values }))
 }
 
+// Array.prototype.findLastIndex needs ES2023; the build targets ES2020.
+const findLastIndex = <T>(items: T[], matches: (item: T) => boolean) => {
+  for (let index = items.length - 1; index >= 0; index--) {
+    if (matches(items[index])) {
+      return index
+    }
+  }
+  return -1
+}
+
 /**
- * Gives every series that `continues` another one the last value of the
- * continued series, so consecutive lines (e.g. a forecast extending the
- * actuals) connect instead of leaving a gap. Only bridges when the continuing
- * series starts after the continued one ends.
+ * Connects a series marked with `continues` to the series it extends (e.g. a
+ * forecast continuing the actuals): the continuing series receives the last
+ * value of the continued one, so both lines share that point instead of
+ * leaving a gap. Only applies when the continuing series starts after the
+ * continued one ends.
  */
 export function bridgeContinuedSeries<K extends ChartConfig>(
   data: ChartItem<K>[],
-  dataConfig: Record<string, { continues?: string }>
+  dataConfig: K
 ): ChartItem<K>[] {
-  const links = Object.entries(dataConfig).flatMap(([key, config]) =>
-    config.continues ? [[key, config.continues] as const] : []
-  )
-
-  if (links.length === 0) {
-    return data
-  }
-
   const bridged = data.map((item) => ({ ...item, values: { ...item.values } }))
-  const hasValue = (item: ChartItem<K>, key: string) =>
-    typeof item.values[key as keyof K] === "number"
 
-  for (const [series, base] of links) {
-    const firstOwn = bridged.findIndex((item) => hasValue(item, series))
-    let lastBase = -1
-    for (let index = bridged.length - 1; index >= 0; index--) {
-      if (hasValue(bridged[index], base)) {
-        lastBase = index
-        break
-      }
+  const hasValue = (item: ChartItem<K>, key: keyof K) =>
+    typeof item.values[key] === "number"
+
+  for (const series of Object.keys(dataConfig) as (keyof K)[]) {
+    const base = dataConfig[series].continues as keyof K | undefined
+    if (!base) {
+      continue
     }
 
-    if (lastBase !== -1 && firstOwn > lastBase) {
-      bridged[lastBase].values[series as keyof K] =
-        bridged[lastBase].values[base as keyof K]
+    const seriesStart = bridged.findIndex((item) => hasValue(item, series))
+    const baseEnd = findLastIndex(bridged, (item) => hasValue(item, base))
+
+    if (baseEnd !== -1 && seriesStart > baseEnd) {
+      bridged[baseEnd].values[series] = bridged[baseEnd].values[base]
     }
   }
 

--- a/packages/react/src/kits/Charts/utils/types.ts
+++ b/packages/react/src/kits/Charts/utils/types.ts
@@ -9,7 +9,8 @@ import type {
 export type ChartItem<K extends ChartConfig> = {
   label: string
   values: {
-    [key in keyof K]: number
+    // null renders as a gap, letting a series start or end mid-chart.
+    [key in keyof K]: number | null
   }
 }
 

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -360,6 +360,11 @@ const ChartLegendContent = React.forwardRef<
       nameKey?: string
       leftShift?: number
       hiddenKey?: string
+      /**
+       * Render line series with a line-stroke swatch (dashed when the series
+       * is dashed) instead of the round dot.
+       */
+      lineIndicators?: boolean
     }
 >(
   (
@@ -371,6 +376,7 @@ const ChartLegendContent = React.forwardRef<
       nameKey,
       hiddenKey,
       leftShift = 0,
+      lineIndicators = false,
     },
     ref
   ) => {
@@ -408,7 +414,7 @@ const ChartLegendContent = React.forwardRef<
             >
               {itemConfig?.icon && !hideIcon ? (
                 <itemConfig.icon />
-              ) : itemConfig && item.type === "line" ? (
+              ) : itemConfig && lineIndicators && item.type === "line" ? (
                 <div
                   className="w-4 shrink-0 border-t-2"
                   style={{

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -34,6 +34,12 @@ export type ChartConfig = {
      * gradient instead of using a solid fill.
      */
     projected?: boolean
+    /**
+     * Key of the series this one continues, e.g. a forecast extending the
+     * actuals. The chart bridges the gap by giving this series the last value
+     * of the continued one, so both lines connect.
+     */
+    continues?: string
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
@@ -44,6 +50,7 @@ type ChartConfigValue = {
   label?: React.ReactNode
   icon?: React.ComponentType
   dashed?: boolean
+  continues?: string
 } & (
   | { color?: string; theme?: never }
   | { color?: never; theme: Record<keyof typeof THEMES, string> }

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -407,6 +407,14 @@ const ChartLegendContent = React.forwardRef<
             >
               {itemConfig?.icon && !hideIcon ? (
                 <itemConfig.icon />
+              ) : itemConfig && item.type === "line" ? (
+                <div
+                  className="w-4 shrink-0 border-t-2"
+                  style={{
+                    borderColor: item.color,
+                    borderTopStyle: itemConfig.dashed ? "dashed" : "solid",
+                  }}
+                />
               ) : (
                 itemConfig && (
                   <div

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -37,7 +37,8 @@ export type ChartConfig = {
     /**
      * Key of the series this one continues, e.g. a forecast extending the
      * actuals. The chart bridges the gap by giving this series the last value
-     * of the continued one, so both lines connect.
+     * of the continued one, so both lines connect. Consumed by the chart
+     * kits via `bridgeContinuedSeries` before rendering.
      */
     continues?: string
   } & (

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -42,9 +42,8 @@ export type ChartConfig = {
      */
     continues?: string
     /**
-     * Swatch drawn for this series in the legend: a round dot or a line
-     * stroke (dashed when the series is dashed). Overrides the chart's own
-     * mapping.
+     * Swatch drawn for this series in the legend: a round dot (the default)
+     * or a line stroke (dashed when the series is dashed).
      */
     legendIndicator?: "dot" | "line"
   } & (
@@ -366,11 +365,6 @@ const ChartLegendContent = React.forwardRef<
       nameKey?: string
       leftShift?: number
       hiddenKey?: string
-      /**
-       * Render line series with a line-stroke swatch (dashed when the series
-       * is dashed) instead of the round dot.
-       */
-      lineIndicators?: boolean
     }
 >(
   (
@@ -382,7 +376,6 @@ const ChartLegendContent = React.forwardRef<
       nameKey,
       hiddenKey,
       leftShift = 0,
-      lineIndicators = false,
     },
     ref
   ) => {
@@ -410,9 +403,7 @@ const ChartLegendContent = React.forwardRef<
             key,
             hiddenKey
           )
-          const indicator =
-            itemConfig?.legendIndicator ??
-            (lineIndicators && item.type === "line" ? "line" : "dot")
+          const indicator = itemConfig?.legendIndicator ?? "dot"
 
           return (
             <div

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -41,6 +41,12 @@ export type ChartConfig = {
      * kits via `bridgeContinuedSeries` before rendering.
      */
     continues?: string
+    /**
+     * Swatch drawn for this series in the legend: a round dot or a line
+     * stroke (dashed when the series is dashed). Overrides the chart's own
+     * mapping.
+     */
+    legendIndicator?: "dot" | "line"
   } & (
     | { color?: string; theme?: never }
     | { color?: never; theme: Record<keyof typeof THEMES, string> }
@@ -404,6 +410,9 @@ const ChartLegendContent = React.forwardRef<
             key,
             hiddenKey
           )
+          const indicator =
+            itemConfig?.legendIndicator ??
+            (lineIndicators && item.type === "line" ? "line" : "dot")
 
           return (
             <div
@@ -414,7 +423,7 @@ const ChartLegendContent = React.forwardRef<
             >
               {itemConfig?.icon && !hideIcon ? (
                 <itemConfig.icon />
-              ) : itemConfig && lineIndicators && item.type === "line" ? (
+              ) : itemConfig && indicator === "line" ? (
                 <div
                   className="w-4 shrink-0 border-t-2"
                   style={{


### PR DESCRIPTION
## Description

A line series that extends another one (e.g. a forecast continuing the actuals) rendered as a disconnected line, leaving a gap between the last actual point and the first forecast point. A series can now declare `continues: "<key>"` in the `dataConfig` and the chart bridges the gap automatically. The PR also renders legend swatches of line series as line strokes (dashed when the series is dashed), so the legend mirrors what the chart draws.

## Implementation details

- feat: add `continues` to `ChartConfig` series — the chart injects the last value of the continued series into the continuing one (`bridgeContinuedSeries`, wired in ComboChart and LineChart), only when the continuing series starts after the continued one ends
- feat: allow `null` in chart data values so a series can start or end mid-chart (renders as a gap)
- feat: add per-series `legendIndicator` ("dot" or "line") to `ChartConfig` — legend swatches default to the round dot everywhere, and a series can opt into a line-stroke swatch (dashed when the series is dashed)
- fix: guard `VerticalBarChart` max-value helper against null values
- feat: add `LineContinuation` story reproducing the actuals → forecast scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<img width="871" height="284" alt="Captura de pantalla 2026-09-01 a las 11 23 16" src="https://github.com/user-attachments/assets/64a0343d-8546-41e5-967b-196f888e860b" />

