### PR TITLE
fix(F0ClarifyingPanel): prevent form submission

### DIFF
--- a/packages/react/src/kits/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
@@ -41,6 +41,58 @@ function buildState(
 }
 
 describe("F0ClarifyingPanel", () => {
+  describe("inside a form", () => {
+    const renderInsideForm = (state: ClarifyingQuestionState) => {
+      const onSubmit = vi.fn()
+
+      render(
+        <form
+          onSubmit={(event) => {
+            event.preventDefault()
+            onSubmit()
+          }}
+        >
+          <F0ClarifyingPanel clarifyingQuestion={state} />
+        </form>
+      )
+
+      return onSubmit
+    }
+
+    it("confirms with Enter without submitting the form", async () => {
+      const state = buildState({}, { selectedOptionIds: ["this-month"] })
+      const onSubmit = renderInsideForm(state)
+      const submitButton = screen.getByRole("button", { name: "Submit" })
+
+      submitButton.focus()
+      await userEvent.keyboard("{Enter}")
+
+      expect(state.confirm).toHaveBeenCalledOnce()
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    it("does not submit the form from optional and navigation actions", async () => {
+      const state = buildState(
+        { currentStepIndex: 1, totalSteps: 3 },
+        { optional: true }
+      )
+      const onSubmit = renderInsideForm(state)
+      const nextButtons = screen.getAllByRole("button", { name: "Next" })
+
+      await userEvent.click(screen.getByRole("button", { name: "Skip" }))
+      await userEvent.click(screen.getByRole("button", { name: "Back" }))
+      await userEvent.click(nextButtons[0])
+      await userEvent.click(nextButtons[1])
+      await userEvent.click(screen.getByRole("button", { name: "Cancel" }))
+
+      expect(state.skip).toHaveBeenCalledOnce()
+      expect(state.back).toHaveBeenCalledOnce()
+      expect(state.confirm).toHaveBeenCalledTimes(2)
+      expect(state.cancel).toHaveBeenCalledOnce()
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+  })
+
   it("does not show Skip button when the step is required", () => {
     const state = buildState()
     render(<F0ClarifyingPanel clarifyingQuestion={state} />)

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/ConfirmFooter.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/ConfirmFooter.tsx
@@ -28,6 +28,7 @@ export const ConfirmFooter = ({
         {showSkip && onSkip && (
           <F0Button
             variant="outline"
+            type="button"
             label={translation.ai.clarifyingQuestion.skip}
             onClick={onSkip}
             disabled={submitDisabled}
@@ -37,6 +38,7 @@ export const ConfirmFooter = ({
       <F0Button
         disabled={!canProceed || submitDisabled}
         variant={"default"}
+        type="button"
         label={label}
         onClick={onConfirm}
       />

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/StepHeader.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/StepHeader.tsx
@@ -40,6 +40,7 @@ export const StepHeader = ({
           <F0Button
             variant="ghost"
             size="sm"
+            type="button"
             onClick={onBack}
             disabled={isFirstStep}
             label={translation.ai.clarifyingQuestion.back}
@@ -52,6 +53,7 @@ export const StepHeader = ({
           <F0Button
             variant="ghost"
             size="sm"
+            type="button"
             onClick={onNext}
             disabled={isFinalStep || !canProceed}
             label={translation.ai.clarifyingQuestion.next}
@@ -63,6 +65,7 @@ export const StepHeader = ({
       <F0Button
         variant="ghost"
         size="sm"
+        type="button"
         onClick={onCancel}
         label={translation.actions.cancel}
         hideLabel


### PR DESCRIPTION
## Description

Clarification actions currently submit the ancestor AI composer form by default. During the panel exit transition, repeated activation can reach the composer stop path and briefly show “Response stopped”; this PR gives each clarification action explicit non-submit button semantics.

## Implementation details

- fix: mark confirm, skip, back, next, and cancel as `type="button"` while preserving their callbacks
- test: cover keyboard confirmation and all clarification actions inside a form with red-green regression tests