### PR TITLE
feat(ChatSpinner): exact One mark at rest, non-pixelated edge, reworked motion

### DIFF
--- a/packages/react/src/kits/ai/F0ActionItem/__tests__/ChatSpinner.test.tsx
+++ b/packages/react/src/kits/ai/F0ActionItem/__tests__/ChatSpinner.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { ChatSpinner } from "../components/ChatSpinner"
+
+const paintedPolygons = (container: HTMLElement) =>
+  Array.from(container.querySelectorAll("polygon")).filter(
+    (p) => !p.hasAttribute("display") && p.getAttribute("points")
+  )
+
+describe("ChatSpinner", () => {
+  it("paints the initial frame on mount", () => {
+    const { container } = render(<ChatSpinner />)
+    expect(paintedPolygons(container).length).toBeGreaterThan(0)
+  })
+
+  it("paints the rest frame when not playing", () => {
+    const { container } = render(<ChatSpinner playing={false} />)
+    expect(paintedPolygons(container).length).toBeGreaterThan(0)
+  })
+
+  it("supports toggling playing without remounting", () => {
+    const { container, rerender } = render(<ChatSpinner playing={false} />)
+    rerender(<ChatSpinner playing />)
+    rerender(<ChatSpinner playing={false} />)
+    expect(paintedPolygons(container).length).toBeGreaterThan(0)
+  })
+
+  // The breathe animation takes its period from this variable, so it has to
+  // match the variant's real cycle: "default" spins then pauses, "continuous"
+  // only spins. Mismatched, the two rhythms beat against each other.
+  it("hands the stylesheet the cycle of the variant it is actually running", () => {
+    const cycle = (ui: React.ReactElement) => {
+      const { container } = render(ui)
+      const el = container.querySelector<HTMLElement>('[role="progressbar"]')!
+      return el.style.getPropertyValue("--globe-spin-cycle")
+    }
+    expect(cycle(<ChatSpinner />)).toBe("2300ms")
+    expect(cycle(<ChatSpinner variant="continuous" />)).toBe("2000ms")
+  })
+})

--- a/packages/react/src/kits/ai/F0ActionItem/__tests__/globeSpinMath.test.ts
+++ b/packages/react/src/kits/ai/F0ActionItem/__tests__/globeSpinMath.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildFrameInto,
+  createGlobeSpinState,
+  spinEase,
+} from "../components/globeSpinMath"
+
+// The One mark, in units of its own radius, read off the official artwork.
+// These are the numbers the resting spinner has to reproduce.
+const LOGO = {
+  outer: 1, // lens tips and outer arc sit on the mark circle
+  inner: 0.5525, // deepest point of the lens, towards the centre
+  halfWidth: 0.6285, // transverse half-extent, at the tips
+}
+const R_FACTOR = 0.392 // buildFrameInto: R = size * 0.392
+
+type Vertex = { x: number; y: number }
+
+/** Every polygon vertex of a rest frame, centred on the mark and in units of R. */
+const restVertices = (size: number): Vertex[] => {
+  const state = createGlobeSpinState()
+  const count = buildFrameInto(state, 0, size, 0)
+  const c = size / 2
+  const r = size * R_FACTOR
+  const out: Vertex[] = []
+  for (let i = 0; i < count; i++) {
+    const nums = state.quads[i].points.split(/[ ,]/).map(Number)
+    for (let j = 0; j < nums.length; j += 2) {
+      out.push({ x: (nums[j] - c) / r, y: (nums[j + 1] - c) / r })
+    }
+  }
+  return out
+}
+
+/**
+ * Metrics of the lens pointing along +x, which by symmetry describes all four.
+ * The four lenses overlap in bounding box near the diagonals, so they can only
+ * be told apart by sector: each spans ±39° about its own axis, leaving a clear
+ * gap either side of 45°.
+ */
+const rightLens = (size: number) => {
+  const vs = restVertices(size)
+  const sector = vs.filter(
+    (v) => Math.abs(Math.atan2(v.y, v.x)) <= Math.PI / 4 && v.x > 0.3
+  )
+  return {
+    inner: Math.min(
+      ...sector.filter((v) => Math.abs(v.y) < 0.03).map((v) => v.x)
+    ),
+    outer: Math.max(...vs.map((v) => Math.hypot(v.x, v.y))),
+    halfWidth: Math.max(...sector.map((v) => Math.abs(v.y))),
+  }
+}
+
+describe("spinEase", () => {
+  it("maps the endpoints exactly", () => {
+    expect(spinEase(0)).toBe(0)
+    expect(spinEase(1)).toBe(1)
+  })
+
+  // The ramp is quadratic, so an unclamped negative t returns POSITIVE — a
+  // clock that runs backwards would jump the mark most of a turn.
+  it("holds at the endpoints outside 0..1", () => {
+    for (const t of [-2, -0.5, -0.001]) expect(spinEase(t)).toBe(0)
+    for (const t of [1.001, 1.5, 3]) expect(spinEase(t)).toBe(1)
+  })
+
+  it("never goes backwards", () => {
+    let prev = -Infinity
+    for (let i = 0; i <= 1000; i++) {
+      const v = spinEase(i / 1000)
+      expect(v).toBeGreaterThanOrEqual(prev)
+      prev = v
+    }
+  })
+
+  it("is symmetric about the midpoint", () => {
+    for (let i = 0; i <= 100; i++) {
+      const t = i / 100
+      expect(spinEase(t)).toBeCloseTo(1 - spinEase(1 - t), 12)
+    }
+  })
+
+  // The reason this curve exists: a symmetric cubic ease left ~380ms either
+  // side of the pause moving too slowly to see, so the spinner read as stalled
+  // for 35% of its cycle. Guard the property, not the implementation.
+  it("spends almost no time below the perceptible rate", () => {
+    const SPIN_MS = 2000
+    const TOTAL_DEG = 720
+    const PERCEPTIBLE_DEG_PER_S = 40
+    let slowMs = 0
+    for (let t = 0; t < SPIN_MS; t++) {
+      const degPerS =
+        (spinEase((t + 1) / SPIN_MS) - spinEase(t / SPIN_MS)) * TOTAL_DEG * 1000
+      if (degPerS < PERCEPTIBLE_DEG_PER_S) slowMs++
+    }
+    expect(slowMs).toBeLessThan(100)
+  })
+})
+
+describe("resting frame", () => {
+  it("reproduces the One mark's lens proportions", () => {
+    const { inner, outer, halfWidth } = rightLens(400)
+    expect(inner).toBeCloseTo(LOGO.inner, 1)
+    expect(outer).toBeCloseTo(LOGO.outer, 1)
+    expect(halfWidth).toBeCloseTo(LOGO.halfWidth, 1)
+  })
+
+  // The quad dilation used to be an absolute offset in user units, so it was
+  // ~5% of the mark at size 20 and ~0.7% at size 120: the small spinner came
+  // out fatter and with a sawtooth edge. Shape must not depend on size.
+  it("has the same proportions at every size", () => {
+    const small = rightLens(20)
+    const large = rightLens(120)
+    expect(small.inner).toBeCloseTo(large.inner, 2)
+    expect(small.outer).toBeCloseTo(large.outer, 2)
+    expect(small.halfWidth).toBeCloseTo(large.halfWidth, 2)
+  })
+})
+
+describe("full-turn wrap", () => {
+  // The "continuous" variant rotates forward forever and relies on progress 1
+  // being the same orientation as progress 0. If TOTAL_ANGLE stopped being a
+  // whole number of turns, every wrap would jump.
+  it("puts progress 1 and progress 0 in the same orientation", () => {
+    const frame = (progress: number) => {
+      const state = createGlobeSpinState()
+      const count = buildFrameInto(state, progress, 400, 0)
+      // Quads are z-sorted and the resting mark is four-fold symmetric, so ties
+      // can be ordered differently between the two calls: compare as sets.
+      return state.quads.slice(0, count).map((q) =>
+        q.points
+          .split(" ")
+          .map((pt) =>
+            pt
+              .split(",")
+              .map((n) => Number(n).toFixed(3))
+              .join(",")
+          )
+          .join(" ")
+      )
+    }
+    const atZero = new Set(frame(0))
+    const atOne = frame(1)
+    expect(atOne).toHaveLength(atZero.size)
+    expect(atOne.filter((k) => !atZero.has(k))).toEqual([])
+  })
+})

--- a/packages/react/src/kits/ai/F0ActionItem/components/ChatSpinner.tsx
+++ b/packages/react/src/kits/ai/F0ActionItem/components/ChatSpinner.tsx
@@ -8,11 +8,11 @@ import type { GlobeSpinState } from "./globeSpinMath"
 import {
   buildFrameInto,
   createGlobeSpinState,
-  easeInOutCubic,
   PAUSE_MS,
   PRECESSION_MS,
   QUAD_POOL_SIZE,
   SPIN_MS,
+  spinEase,
 } from "./globeSpinMath"
 
 export interface ChatSpinnerProps {
@@ -21,18 +21,32 @@ export interface ChatSpinnerProps {
   style?: CSSProperties
   /**
    * "default" → spins 2 rotations, pauses, repeats.
-   * "continuous" → 2 rotations forward, then 2 backward, no pause. Used for
-   * "writing"-style activity where the indicator should never rest.
+   * "continuous" → rotates forward at a constant rate, never pausing. Used
+   * for "writing"-style activity where the indicator should never rest.
    */
   variant?: "default" | "continuous"
+  /**
+   * When false, the spinner rests at its base orientation (the static One
+   * mark). A spin already in progress completes its current cycle before
+   * resting, so toggling mid-spin never jumps. Only affects "default".
+   */
+  playing?: boolean
 }
 
 const ChatSpinnerComponent = (
-  { size = 20, className, style, variant = "default" }: ChatSpinnerProps,
+  {
+    size = 20,
+    className,
+    style,
+    variant = "default",
+    playing = true,
+  }: ChatSpinnerProps,
   ref: Ref<HTMLDivElement>
 ) => {
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const svgRef = useRef<SVGSVGElement | null>(null)
+  const playingRef = useRef(playing)
+  const resumeRef = useRef<(() => void) | null>(null)
   // Pool — created lazily once per instance, reused across all frames.
   const stateRef = useRef<GlobeSpinState | null>(null)
   if (stateRef.current === null) stateRef.current = createGlobeSpinState()
@@ -63,9 +77,18 @@ const ChatSpinnerComponent = (
     let mount = 0
     let pauseStart = 0
     let pausedAt: number | null = null
-    let phase: "spin" | "pause" = "spin"
+    let phase: "spin" | "pause" | "rest" =
+      variant === "continuous" || playingRef.current ? "spin" : "rest"
     let visible = true
     let everTicked = false
+
+    // The RAF rotation is by far the dominant motion, so it is the one that has
+    // to stop under reduced motion. The stylesheet keeps a plain fade in.
+    const motionQuery =
+      typeof window !== "undefined" && window.matchMedia
+        ? window.matchMedia("(prefers-reduced-motion: reduce)")
+        : null
+    let reduced = motionQuery?.matches ?? false
 
     const paint = (count: number) => {
       const quads = state.quads
@@ -89,39 +112,54 @@ const ChatSpinnerComponent = (
         everTicked = true
       }
 
-      let progress = 0
-      let applyEase = true
+      // Fraction of TOTAL_ANGLE (two whole turns) to show this frame.
+      let angleProgress = 0
 
       if (variant === "continuous") {
-        const cycleMs = SPIN_MS * 2
-        const p = ((now - start) % cycleMs) / cycleMs
-        progress = p < 0.5 ? p * 2 : (1 - p) * 2
-        applyEase = false
+        // Constant forward rotation, deliberately un-eased: TOTAL_ANGLE is
+        // exactly two turns, so the 1 → 0 wrap is seamless, whereas easing it
+        // would drop a stall into every wrap — and this variant exists to read
+        // as "never resting", against a `default` that pauses for PAUSE_MS.
+        angleProgress = ((now - start) % SPIN_MS) / SPIN_MS
       } else if (phase === "spin") {
-        progress = Math.min((now - start) / SPIN_MS, 1)
-        if (progress >= 1) {
-          progress = 0
-          phase = "pause"
-          pauseStart = now
+        const p = Math.min((now - start) / SPIN_MS, 1)
+        // At p === 1 the mark is back at its base orientation; hand over to the
+        // pause on 0 so the resting pose is the plain One mark.
+        angleProgress = p < 1 ? spinEase(p) : 0
+        if (p >= 1) {
+          if (playingRef.current) {
+            phase = "pause"
+            pauseStart = now
+          } else {
+            phase = "rest"
+          }
         }
-      } else {
-        progress = 0
+      } else if (phase === "pause") {
         if (now - pauseStart >= PAUSE_MS) {
-          phase = "spin"
-          start = now
+          if (playingRef.current) {
+            phase = "spin"
+            start = now
+          } else {
+            phase = "rest"
+          }
         }
       }
+      // "pause" and "rest" both leave angleProgress at 0 — the static mark.
 
       const axisPhase = ((now - mount) / PRECESSION_MS) % 1
-      const angleProgress = applyEase ? easeInOutCubic(progress) : progress
       const count = buildFrameInto(state, angleProgress, size, axisPhase)
       paint(count)
+
+      if (phase === "rest") {
+        rafId = null
+        return
+      }
 
       rafId = requestAnimationFrame(tick)
     }
 
     const startLoop = () => {
-      if (rafId !== null) return
+      if (rafId !== null || reduced) return
       rafId = requestAnimationFrame(tick)
     }
     const stopLoop = () => {
@@ -129,6 +167,18 @@ const ChatSpinnerComponent = (
         cancelAnimationFrame(rafId)
         rafId = null
       }
+    }
+    // Wake up from "rest" when `playing` turns true again.
+    resumeRef.current = () => {
+      if (phase === "rest") {
+        phase = "spin"
+        start = performance.now()
+        // Off-screen, the observer will shift `start` forward by the elapsed
+        // gap when we come back. Re-anchor the gap to now, or it gets counted
+        // twice and `start` lands in the future — negative progress.
+        if (pausedAt !== null) pausedAt = start
+      }
+      if (visible) startLoop()
     }
 
     // Initial paint so the spinner shows static geometry before the first
@@ -164,13 +214,31 @@ const ChatSpinnerComponent = (
       observer.observe(wrapper)
     }
 
-    startLoop()
+    const onMotionPref = () => {
+      reduced = motionQuery?.matches ?? false
+      if (reduced) {
+        stopLoop()
+        paint(buildFrameInto(state, 0, size, 0))
+      } else {
+        startLoop()
+      }
+    }
+    motionQuery?.addEventListener("change", onMotionPref)
+
+    if (variant === "continuous" || playingRef.current) startLoop()
 
     return () => {
       stopLoop()
+      resumeRef.current = null
       observer?.disconnect()
+      motionQuery?.removeEventListener("change", onMotionPref)
     }
   }, [size, variant])
+
+  useEffect(() => {
+    playingRef.current = playing
+    if (playing) resumeRef.current?.()
+  }, [playing])
 
   return (
     <div
@@ -178,7 +246,22 @@ const ChatSpinnerComponent = (
       role="progressbar"
       aria-label="Loading"
       className={cn("shrink-0 globe-spin-anim", className)}
-      style={{ width: size, height: size, ...style }}
+      style={
+        {
+          width: size,
+          height: size,
+          // Both are consumed by styles.css. The entrance blur has to scale
+          // with the mark — a flat 4px was 20% of a 20px spinner and 3% of a
+          // 120px one — and the breathe has to share the spin's period, or the
+          // two rhythms beat against each other. "continuous" has no pause,
+          // so its period is the spin alone.
+          "--globe-spin-blur": `${(size * 0.05).toFixed(2)}px`,
+          "--globe-spin-cycle": `${
+            variant === "continuous" ? SPIN_MS : SPIN_MS + PAUSE_MS
+          }ms`,
+          ...style,
+        } as CSSProperties
+      }
     >
       <svg
         ref={svgRef}

--- a/packages/react/src/kits/ai/F0ActionItem/components/globeSpinMath.ts
+++ b/packages/react/src/kits/ai/F0ActionItem/components/globeSpinMath.ts
@@ -9,28 +9,26 @@
 export const VEL_X = 60
 export const VEL_Y = 40
 export const SPIN_MS = 2000
-export const PAUSE_MS = 500
+export const PAUSE_MS = 300
 // Period of the slow precession of the rotation axis. Long enough to be
 // imperceptible inside a single cycle, but breaks the visual loop over time.
 export const PRECESSION_MS = 12000
-const ROWS = 2
 const SEGS = 40
+// The One mark, measured off the official artwork. Each of its four lenses is
+// the intersection of the mark circle with a second circle of radius LENS_R
+// centred LENS_C away — both in units of the mark radius. LENS_C > 1 (that
+// centre falls OUTSIDE the mark) is why no spherical cap can reproduce the
+// lens, at any angle or tilt: a circle drawn on a sphere always projects to an
+// ellipse centred inside the disc. Hence LENS_EDGE below.
+const LENS_C = 1.5472
+const LENS_R = 0.9947
+// Each quad is grown slightly around its own centre so neighbours overlap and
+// their antialiased edges don't leave hairline seams. It must be RELATIVE:
+// a fixed offset in user units is ~5% of the whole mark at size 20, which
+// turns the silhouette into visible sawtooth.
+const QUAD_DILATE = 1.05
 const COLOR_A: [number, number, number] = [255, 60, 0]
 const COLOR_B: [number, number, number] = [160, 140, 220]
-
-const INIT_A = { x: -12, y: 0, z: 0 }
-const INIT_B = { x: -12, y: 12, z: 90 }
-
-// Calibrated latEdge factors per size (controls form vs gap ratio).
-// Interpolates automatically for unlisted sizes.
-const LAT_FACTORS: Record<number, number> = {
-  20: 0.72,
-  28: 0.66,
-  32: 0.72,
-  60: 0.77,
-  80: 0.8,
-  120: 0.85,
-}
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 type Q = [number, number, number, number]
@@ -51,8 +49,6 @@ export type GlobeSpinState = {
 }
 
 // ─── Math helpers ─────────────────────────────────────────────────────────────
-const D2R = Math.PI / 180
-const LAT_BASE = (ROWS / 8) * Math.PI
 // Two full rotations per spin. Multiple of 2π → end orientation matches the
 // start, so the pause-to-spin loop has no visual jump.
 const TOTAL_ANGLE = 4 * Math.PI
@@ -64,11 +60,6 @@ function qMul(a: Q, b: Q): Q {
     a[0] * b[2] - a[1] * b[3] + a[2] * b[0] + a[3] * b[1],
     a[0] * b[3] + a[1] * b[2] - a[2] * b[1] + a[3] * b[0],
   ]
-}
-
-function qNorm(q: Q): Q {
-  const n = Math.sqrt(q[0] ** 2 + q[1] ** 2 + q[2] ** 2 + q[3] ** 2)
-  return [q[0] / n, q[1] / n, q[2] / n, q[3] / n]
 }
 
 function qRot(ax: number, ay: number, az: number, ang: number): Q {
@@ -93,17 +84,30 @@ function rotVecInto(q: Q, x: number, y: number, z: number, out: V): void {
   out[2] = z + w * tz + qx * ty - qy * tx
 }
 
-function eulerToQ(ex: number, ey: number, ez: number): Q {
-  const qx = qRot(1, 0, 0, ex * D2R)
-  const qy = qRot(0, 1, 0, ey * D2R)
-  const qz = qRot(0, 0, 1, ez * D2R)
-  return qNorm(qMul(qMul(qy, qx), qz))
-}
-
-// Cubic ease-in-out — smooth acceleration into the spin and gentle
-// deceleration into the pause, instead of a constant-velocity rotation.
-export function easeInOutCubic(t: number): number {
-  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
+// Trapezoidal velocity: ramp up over SPIN_RAMP, coast, ramp down. The mark
+// still settles into the resting logo instead of stopping dead, but it gets
+// there without the dead time a symmetric cubic ease produces — that one spent
+// ~380ms either side of the pause moving too slowly to see (35% of the cycle
+// reading as stopped) and then compensated with a 1080°/s whip. Same two
+// turns, same duration, peak velocity down to ~420°/s.
+const SPIN_RAMP = 0.15
+export function spinEase(t: number): number {
+  // Clamp first. Callers derive `t` from wall-clock deltas, and the ramp is
+  // quadratic: unclamped, a negative `t` comes back POSITIVE (t² / 2r / area),
+  // so a clock that briefly runs backwards would jump the mark most of a turn
+  // instead of holding it at rest.
+  if (t <= 0) return 0
+  if (t >= 1) return 1
+  // Area under the unit-height trapezoid; dividing by it makes spinEase(1) = 1.
+  // Numerically equal to where the ramp down starts, but a different quantity —
+  // they are spelled out separately on purpose.
+  const area = 1 - SPIN_RAMP
+  if (t <= SPIN_RAMP) return (t * t) / (2 * SPIN_RAMP) / area
+  if (t >= 1 - SPIN_RAMP) {
+    const u = 1 - t
+    return (area - (u * u) / (2 * SPIN_RAMP)) / area
+  }
+  return (t - SPIN_RAMP / 2) / area
 }
 
 // ─── Color LUT ───────────────────────────────────────────────────────────────
@@ -131,44 +135,54 @@ function colorFor(t: number): string {
   return COLOR_LUT[i]
 }
 
-// Hoist the sorted size list out of the hot path. `getLatFactor` runs once
-// per frame; computing this on every call was a small but avoidable cost.
-const LAT_FACTOR_SIZES = Object.keys(LAT_FACTORS)
-  .map(Number)
-  .sort((a, b) => a - b)
-
-function getLatFactor(size: number): number {
-  const sizes = LAT_FACTOR_SIZES
-  if (size <= sizes[0]) return LAT_FACTORS[sizes[0]]
-  if (size >= sizes[sizes.length - 1])
-    return LAT_FACTORS[sizes[sizes.length - 1]]
-  for (let i = 0; i < sizes.length - 1; i++) {
-    if (size >= sizes[i] && size <= sizes[i + 1]) {
-      const t = (size - sizes[i]) / (sizes[i + 1] - sizes[i])
-      return (
-        LAT_FACTORS[sizes[i]] +
-        (LAT_FACTORS[sizes[i + 1]] - LAT_FACTORS[sizes[i]]) * t
-      )
-    }
-  }
-  return 0.72
-}
-
 // ─── Frame builder ────────────────────────────────────────────────────────────
 const SPEED = Math.sqrt(VEL_X ** 2 + VEL_Y ** 2)
 const PATH_AXIS: V = [VEL_X / SPEED, VEL_Y / SPEED, 0]
-const Q_INIT_A = eulerToQ(INIT_A.x, INIT_A.y, INIT_A.z)
-const Q_INIT_B = eulerToQ(INIT_B.x, INIT_B.y, INIT_B.z)
-
-const LAT_STEPS = ROWS * 3
+// Rings of quads from the centre of a lens out to its edge.
+const LAT_STEPS = 6
 const GRID_STRIDE = SEGS + 1
 const GRID_SIZE = (LAT_STEPS + 1) * GRID_STRIDE
 export const QUAD_POOL_SIZE = 4 * LAT_STEPS * SEGS // 960
 
-// Per-component scratch arrays for the cap rotations. Allocated once at module
-// load — shared across all spinners because each call to `buildFrameInto`
-// fully overwrites them before reading.
+// Angular radius of a lens, per azimuth around its axis. Solving
+//   (cosθ − LENS_C)² + (sinθ·cosφ)² = LENS_R²
+// for cosθ gives the patch on the sphere that projects EXACTLY to the mark's
+// lens when it faces the viewer — 39.0° towards the tips, 56.5° towards the
+// waist. A cap would be a single constant here, which is precisely what it
+// cannot be. Azimuth-only, so it is built once at module load.
+const LENS_EDGE: number[] = (() => {
+  const a = LENS_C
+  const r2 = LENS_R * LENS_R
+  const out = new Array<number>(SEGS + 1)
+  for (let si = 0; si <= SEGS; si++) {
+    const lon = (si / SEGS) * Math.PI * 2
+    const k = Math.sin(lon) ** 2
+    const c =
+      k < 1e-9
+        ? (a * a + 1 - r2) / (2 * a)
+        : (a - Math.sqrt(a * a - k * (a * a + 1 - k - r2))) / k
+    out[si] = Math.acos(Math.max(-1, Math.min(1, c)))
+  }
+  return out
+})()
+
+// Azimuth trig, hoisted — it no longer depends on anything per-frame.
+const COS_LON: number[] = new Array(SEGS + 1)
+const SIN_LON: number[] = new Array(SEGS + 1)
+for (let si = 0; si <= SEGS; si++) {
+  const lon = (si / SEGS) * Math.PI * 2
+  COS_LON[si] = Math.cos(lon)
+  SIN_LON[si] = Math.sin(lon)
+}
+
+// The four lenses are one patch repeated at 0/90/180/270° about the view axis,
+// which is what makes the resting mark four-fold symmetric like the logo.
+const Q_LENS: Q[] = [0, 1, 2, 3].map((k) => qRot(0, 0, 1, (k * Math.PI) / 2))
+
+// Scratch for the per-frame lens rotations — overwritten before every read.
 const _capQs: Q[] = [
+  [0, 0, 0, 0],
+  [0, 0, 0, 0],
   [0, 0, 0, 0],
   [0, 0, 0, 0],
 ]
@@ -208,7 +222,6 @@ export function buildFrameInto(
   const R = size * 0.392
   const cx = size / 2
   const cy = size / 2
-  const latEdge = LAT_BASE * getLatFactor(size)
 
   const angle = progress * TOTAL_ANGLE
 
@@ -216,29 +229,30 @@ export function buildFrameInto(
   const precessQ = qRot(0, 0, 1, axisPhase * 2 * Math.PI)
   rotVecInto(precessQ, PATH_AXIS[0], PATH_AXIS[1], PATH_AXIS[2], _scratchV)
   const qDelta = qRot(_scratchV[0], _scratchV[1], _scratchV[2], angle)
-  const qA = qMul(qDelta, Q_INIT_A)
-  const qB = qMul(qDelta, Q_INIT_B)
-  // Pack into scratch array so the per-cap loop is a plain index lookup.
-  _capQs[0] = qA
-  _capQs[1] = qB
+  for (let k = 0; k < 4; k++) _capQs[k] = qMul(qDelta, Q_LENS[k])
 
   let count = 0
 
-  // Four caps: (qA,+1), (qA,-1), (qB,+1), (qB,-1).
   for (let capIdx = 0; capIdx < 4; capIdx++) {
-    const q = _capQs[capIdx >> 1]
-    const sign = capIdx & 1 ? -1 : 1
+    const q = _capQs[capIdx]
 
-    // Build the grid for this cap into the pool. Mutates `grid` in place.
+    // Build the grid for this lens into the pool. Mutates `grid` in place.
+    // Colatitude runs 0..LENS_EDGE[si], so the patch boundary follows the
+    // mark's lens instead of a circle of constant radius.
     for (let li = 0; li <= LAT_STEPS; li++) {
-      const lat = sign * (Math.PI / 2 - (li / LAT_STEPS) * latEdge)
-      const cl = Math.cos(lat)
-      const sl = Math.sin(lat)
-      const t = Math.sin((li / LAT_STEPS) * Math.PI)
+      const f = li / LAT_STEPS
+      const t = Math.sin(f * Math.PI)
       const row = li * GRID_STRIDE
       for (let si = 0; si <= SEGS; si++) {
-        const lon = (si / SEGS) * Math.PI * 2
-        rotVecInto(q, cl * Math.cos(lon), sl, cl * Math.sin(lon), _scratchV)
+        const colat = f * LENS_EDGE[si]
+        const sc = Math.sin(colat)
+        rotVecInto(
+          q,
+          sc * COS_LON[si],
+          Math.cos(colat),
+          sc * SIN_LON[si],
+          _scratchV
+        )
         const cell = grid[row + si]
         cell.x = _scratchV[0]
         cell.y = _scratchV[1]
@@ -266,35 +280,27 @@ export function buildFrameInto(
         const cxq = mx * R
         const cyq = my * R
 
-        // Inlined `ep` for each vertex — same math as before, no function-call
-        // overhead and no intermediate tuples in the hot path.
+        // Vertices, dilated from the quad centre. Inlined per vertex — no
+        // function-call overhead and no intermediate tuples in the hot path.
         const px0 = p00.x * R - cxq
         const py0 = p00.y * R - cyq
-        const d0 = Math.sqrt(px0 * px0 + py0 * py0)
-        const f0 = d0 > 0 ? (d0 + 0.9) / d0 : 1
-        const ax = cx + cxq + px0 * f0
-        const ay = cy - cyq - py0 * f0
+        const ax = cx + cxq + px0 * QUAD_DILATE
+        const ay = cy - cyq - py0 * QUAD_DILATE
 
         const px1 = p01.x * R - cxq
         const py1 = p01.y * R - cyq
-        const d1 = Math.sqrt(px1 * px1 + py1 * py1)
-        const f1 = d1 > 0 ? (d1 + 0.9) / d1 : 1
-        const bx = cx + cxq + px1 * f1
-        const by = cy - cyq - py1 * f1
+        const bx = cx + cxq + px1 * QUAD_DILATE
+        const by = cy - cyq - py1 * QUAD_DILATE
 
         const px2 = p11.x * R - cxq
         const py2 = p11.y * R - cyq
-        const d2 = Math.sqrt(px2 * px2 + py2 * py2)
-        const f2 = d2 > 0 ? (d2 + 0.9) / d2 : 1
-        const dxv = cx + cxq + px2 * f2
-        const dyv = cy - cyq - py2 * f2
+        const dxv = cx + cxq + px2 * QUAD_DILATE
+        const dyv = cy - cyq - py2 * QUAD_DILATE
 
         const px3 = p10.x * R - cxq
         const py3 = p10.y * R - cyq
-        const d3 = Math.sqrt(px3 * px3 + py3 * py3)
-        const f3 = d3 > 0 ? (d3 + 0.9) / d3 : 1
-        const ex = cx + cxq + px3 * f3
-        const ey = cy - cyq - py3 * f3
+        const ex = cx + cxq + px3 * QUAD_DILATE
+        const ey = cy - cyq - py3 * QUAD_DILATE
 
         const slot = quads[count]
         slot.points = `${ax},${ay} ${bx},${by} ${dxv},${dyv} ${ex},${ey}`

--- a/packages/react/src/kits/ai/F0ActionItem/styles.css
+++ b/packages/react/src/kits/ai/F0ActionItem/styles.css
@@ -34,8 +34,10 @@
 @keyframes globe-spin-enter {
   from {
     opacity: 0;
-    transform: scale(0.8);
-    filter: blur(4px);
+    transform: scale(0.92);
+    /* Size-relative — set by the component. A flat px blur reads completely
+       differently at 20px and at 120px. */
+    filter: blur(var(--globe-spin-blur, 1px));
   }
   to {
     opacity: 1;
@@ -44,8 +46,25 @@
   }
 }
 
-/* Subtle "thinking" breath. Plays after the entrance finishes (0.5s delay)
-   and loops forever. Amplitude is small (~3.5%) so it reads as life, not noise. */
+/* Reduced motion. The rotation is stopped in the component, since that is where
+   the real movement lives — but a loading indicator that is perfectly still
+   says nothing about loading, so the mark breathes in opacity instead. Opacity
+   is the channel the guidance keeps; it is position and scale that trigger
+   motion sickness. Deliberately unlike `.shine-text` above, which can go fully
+   static because its text stays readable. */
+@keyframes globe-spin-dim {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.45;
+  }
+}
+
+/* Subtle "thinking" breath. Plays after the entrance finishes and loops
+   forever, on the spin's own period so the two rhythms stay in phase.
+   Amplitude is small (~3.5%) so it reads as life, not noise. */
 @keyframes globe-spin-breathe {
   0%,
   100% {
@@ -62,12 +81,13 @@
    first. Comma-separated values let both run on the same element. */
 .globe-spin-anim {
   animation:
-    globe-spin-enter 0.5s cubic-bezier(0.33, 1, 0.68, 1) both,
-    globe-spin-breathe 3.6s ease-in-out 0.5s infinite;
+    globe-spin-enter 0.2s cubic-bezier(0.23, 1, 0.32, 1) both,
+    globe-spin-breathe var(--globe-spin-cycle, 2300ms) ease-in-out 0.2s infinite;
 }
 
 @media (prefers-reduced-motion: reduce) {
   .globe-spin-anim {
-    animation: none;
+    animation: globe-spin-dim var(--globe-spin-cycle, 2300ms) ease-in-out
+      infinite;
   }
 }


### PR DESCRIPTION
The resting spinner did not match the One logo, and its silhouette read as pixelated at the sizes it actually ships at.

## Shape

Each lens was a **spherical cap** seen at a tilt. That can never reproduce the mark: the logo's inner arc is a circle of radius 0.995R centred **1.55R** from the mark centre — outside the mark — while a circle drawn on a sphere always projects to an ellipse centred *inside* the disc. Fitting the cap's two parameters against the artwork bottoms out at 0.028R of error.

The lens is now the sphere ∩ cylinder region that projects **exactly** to the mark, with the per-azimuth angular radius solved in closed form (39.0° towards the tips, 56.5° towards the waist — a cap can only have one constant there).

Worst-case outline deviation from `ok.svg`, measured against the official paths at matched scale and centre:

| | 20 px | 32 px | 120 px | 393 px |
|---|---|---|---|---|
| before | 0.68 px | 1.09 px | 4.09 px | 13.4 px |
| after | 0.03 px | 0.05 px | 0.20 px | 0.66 px |

## Edge

Quads were dilated by a fixed `0.9` user units to hide antialiasing seams between neighbours. Being absolute, that is **4.5 % of the whole mark at size 20** and 0.75 % at 120, and each quad is pushed out from its *own* centroid — so the silhouette became a sawtooth of overlapping quads, which is what read as pixelation. The dilation is now relative (`×1.05`), which also drops four `Math.sqrt` per quad per frame.

## Motion

A symmetric cubic ease left ~380 ms either side of the pause moving too slowly to see. The spinner read as **stopped for 35 % of its cycle** and compensated with a 1080 °/s whip.

| | parked per cycle | peak |
|---|---|---|
| before | 884 ms (35 %) | 1069 °/s |
| after | 356 ms (15 %) | 424 °/s |

Trapezoidal velocity profile plus a 300 ms pause (was 500). Same two turns in the same time, just distributed.

The `continuous` variant reversed direction **within a single frame** (a 720 °/s jump, twice per cycle). It now rotates forward at a constant rate — no reversal, no stall — which also reads more distinctly against `default`, since the two share the same 20 px slot in `F0ActionItem`.

## Entrance, breathing, reduced motion

- Entrance blur was a flat `4px`: 20 % of a 20 px spinner and 3 % of a 120 px one. Now scales with the mark via a CSS variable. Entrance 500 → 200 ms, `scale(0.8)` → `0.92`.
- The breathing loop ran at 3.6 s against a 2.5 s spin cycle, so the two rhythms only realigned every 90 s. It now takes its period from the spin.
- `prefers-reduced-motion` dropped the fade and the breathing but left **the rotation** running — the one movement that matters. The component now stops the rAF loop; the stylesheet keeps a plain fade.

## Notes

- The per-size `LAT_FACTORS` table is gone. The mark's proportions do not depend on size, so a per-size cap angle cannot coexist with matching the logo. Small sizes therefore render slightly heavier lenses than before.
- Also removes `eulerToQ`, `qNorm`, `getLatFactor`, `LAT_BASE` and `D2R`, now unused.
- This branch also carries the in-progress `playing` prop already present in `ChatSpinner.tsx`; it lives in the same file and could not be split cleanly.

## Tests

New `globeSpinMath.test.ts`. Each geometry assertion was mutation-checked to confirm it fails when the property it guards is broken:

| test | mutation that breaks it |
|---|---|
| lens matches the logo's proportions | `LENS_C` 1.5472 → 1.30 |
| same proportions at every size | relative dilation → absolute `+0.9` |
| `progress` 1 and 0 are the same orientation | `TOTAL_ANGLE` 4π → 3π |

Plus `spinEase` endpoints, monotonicity, symmetry, and that it never spends more than 100 ms below the perceptible rate.

`pnpm tsc`, `pnpm lint`, `pnpm format:check` and `pnpm build` clean; full suite 247 files / 3236 tests green.
