### PR TITLE
feat(NewHomeLayout): fade the rail's cards into the strip

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/collapsedRail.test.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/collapsedRail.test.tsx
@@ -6,6 +6,7 @@ import {
   fireEvent,
   screen,
   userEvent,
+  waitFor,
   zeroRender,
 } from "@/testing/test-utils"
 
@@ -51,6 +52,13 @@ const grabbable = (container: HTMLElement) =>
 
 const holdHover = () =>
   act(() => new Promise<void>((resolve) => setTimeout(resolve, 250)))
+/**
+ * The panel's hover bridge — the strip's column, covered so the gap between a
+ * glyph and its widget is not a way out. `z-10` tells it from the page's own
+ * background wash, which is the layout's other `aria-hidden` absolute box.
+ */
+const bridgeIn = (container: HTMLElement) =>
+  container.querySelector<HTMLElement>("[aria-hidden].absolute.z-10")
 
 beforeEach(() => {
   Object.defineProperty(HTMLElement.prototype, "clientWidth", {
@@ -111,6 +119,49 @@ describe("the collapsed rail's hover intent", () => {
     expect(card()).toBeVisible()
   })
 
+  /**
+   * THE GAP BETWEEN THE GLYPH AND ITS WIDGET IS NOT A WAY OUT. The panel stands
+   * clear of the strip, and that clearance used to be unhoverable ground: a
+   * pointer crossing it slowly — which is what a pointer aiming at something
+   * does — spent longer there than the leave delay, and the widget it was on its
+   * way to closed in front of it. `NewHomeLayout`'s bridge covers that ground
+   * with the panel's own hover, so the only thing that closes a panel is leaving
+   * the rail.
+   */
+  test("holds the panel while the pointer crosses to it", async () => {
+    const { container } = renderLayout(1000)
+
+    await userEvent.hover(glyph())
+    await holdHover()
+    const bridge = bridgeIn(container)
+    expect(bridge).not.toBeNull()
+
+    await userEvent.unhover(glyph())
+    await userEvent.hover(bridge!)
+    // Twice over the window the panel used to close inside — the leave delay and
+    // the close animation it hides behind.
+    await holdHover()
+    await holdHover()
+
+    expect(card()).toBeVisible()
+  })
+
+  test("and closes once the pointer leaves the rail altogether", async () => {
+    const { container } = renderLayout(1000)
+
+    await userEvent.hover(glyph())
+    await holdHover()
+    const bridge = bridgeIn(container)
+
+    await userEvent.unhover(glyph())
+    await userEvent.hover(bridge!)
+    await userEvent.unhover(bridge!)
+
+    // The panel is put back before it is dropped, so this is the leave delay AND
+    // the close it plays after it.
+    await waitFor(() => expect(card()).not.toBeVisible())
+  })
+
   test("leaves one glyph's hover to that glyph", async () => {
     renderLayout(1000)
 
@@ -121,6 +172,46 @@ describe("the collapsed rail's hover intent", () => {
 
     expect(card("tasks")).toBeVisible()
     expect(card()).not.toBeVisible()
+  })
+})
+
+describe("the collapse's gesture", () => {
+  /**
+   * The card's own motion box — the one `WidgetMotion` writes the stow onto. Found
+   * by the opacity it carries rather than by its position in the tree, which is
+   * the one thing about a widget's wrapping this file should not have an opinion
+   * about.
+   */
+  const motionBoxOf = (id = "clock") =>
+    card(id).closest<HTMLElement>("[style*='opacity']")
+
+  /**
+   * THE CARDS FADE WHERE THEY STAND. Each one used to scale down onto its own
+   * glyph, which meant a whole widget drawn at a tenth of its width — every
+   * heading and every row rasterized at a size nothing in it was laid out for —
+   * sliding across the column it was leaving. The strip's glyphs sliding in over a
+   * plain fade is the gesture now, so what this holds is that the collapse puts NO
+   * transform on a card at all.
+   */
+  test("takes the cards out on a fade, with nothing scaled onto the glyph", async () => {
+    renderLayout(1400)
+
+    await userEvent.click(screen.getByLabelText("Collapse widgets panel"))
+
+    await waitFor(() => expect(motionBoxOf()?.style.opacity).toBe("0"))
+    expect(motionBoxOf()?.style.transform).toBe("none")
+  })
+
+  /** …and are simply back when it opens again, by the same one value. */
+  test("brings them back the same way", async () => {
+    renderLayout(1400)
+
+    await userEvent.click(screen.getByLabelText("Collapse widgets panel"))
+    await waitFor(() => expect(motionBoxOf()?.style.opacity).toBe("0"))
+    await userEvent.click(screen.getByLabelText("Expand widgets panel"))
+
+    await waitFor(() => expect(motionBoxOf()?.style.opacity).toBe("1"))
+    expect(motionBoxOf()?.style.transform).toBe("none")
   })
 })
 

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -567,6 +567,25 @@ describe("NewHomeLayout", () => {
         expect(button().className).toContain("ring-1")
       })
 
+      /**
+       * …AND NEITHER DOES ANYTHING UNDER IT. The pill's `p-1` band is drawing, not
+       * layout: paid for in flow it made the pill a 48px item in a column of 40px
+       * ones, so dropping the reading on hover shrank it back to 40 and shunted
+       * every glyph below it up by 8px — the strip rearranging itself under the
+       * pointer aiming at it. The band is taken back out of the flow at each edge
+       * it overhangs, which is what holds the pill to the glyph's own slot.
+       *
+       * jsdom lays nothing out, so the margins themselves are what can be asserted
+       * here; the geometry they buy was measured in the browser.
+       */
+      test("keeps the pill inside the glyph's slot, so nothing below it moves", () => {
+        renderLayout(1000, { rightWidgets: TICKING_RAIL })
+
+        // Vertical for the strip's rhythm, horizontal for its right edge.
+        expect(pill().className).toContain("-my-1")
+        expect(pill().className).toContain("-mr-1")
+      })
+
       test("blinks the separator once a second, digits held still", () => {
         vi.useFakeTimers()
         try {
@@ -806,11 +825,11 @@ describe("NewHomeLayout", () => {
     })
 
     /**
-     * The cards have a JOURNEY TO MAKE when the rail collapses: each one scales
-     * down onto its own glyph (`WidgetMotion`'s stow). The panel's one-widget
+     * The cards have a FADE TO FINISH when the rail collapses — the whole of
+     * `GENIE_RETRACT_MS` of it (`WidgetMotion`'s stow). The panel's one-widget
      * filter therefore has to wait for the retract to finish — applied on the frame
      * the collapse begins, as it once was, every card is `display: none` before it
-     * has moved a pixel and the whole animation plays on an empty box.
+     * has faded at all, and the whole animation plays on an empty box.
      */
     test("keeps the cards drawn while they retract into the strip", async () => {
       await renderDeferredRail(1400)

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -30,8 +30,7 @@ import { Action } from "@/ui/Action"
 import {
   entranceDelay,
   entranceTransition,
-  GENIE_GLYPH_ENTER_SCALE,
-  GENIE_GLYPH_EXIT_SCALE,
+  GENIE_GLYPH_SLIDE_PX,
   GENIE_GLYPH_TAP_SCALE,
   GENIE_ORIGIN,
   GENIE_RETRACTED_OFFSET_PX,
@@ -101,12 +100,6 @@ const COLLAPSED_RAIL_WIDTH = 40
  * `maxWidth.content` in `packages/react/tailwind.config.ts`.
  */
 const CONTENT_WIDTH = 712
-/**
- * The gap between the strip's glyphs — `gap-2` on the strip below, and the number
- * a stowing widget needs to know where its own glyph is. Keep the two in step.
- */
-const GLYPH_GAP_PX = 8
-
 /**
  * THE GLYPH'S SECOND — how long each face of a flashing glyph is up, and how long
  * a ticking readout's separator stays lit. One period, not two half-periods: a
@@ -329,20 +322,27 @@ const CollapsedGlyph = ({
   /**
    * The genie, identical whichever face the glyph wears.
    *
-   * EVERY SCALE HERE IS TRANSIENT — arriving, leaving, the press — and none of
-   * them is HELD. A held fractional scale is rasterized once and then stretched:
-   * the glyph's icon and a pill's figures go soft, and they stay soft for as long
-   * as you keep the pointer there, which is exactly when they are being read. The
-   * hover and open states say what they have to say with the panel they open, the
-   * tooltip, and the button's own hover border.
+   * THE ARRIVAL IS A SLIDE, NOT A SCALE. A glyph used to come in from 1.18 and
+   * leave at 1.3, which was the card's own retract read at glyph size — and that
+   * only meant anything while the cards were really shrinking onto them. They fade
+   * where they stand now (`WidgetMotion`), so the strip does the one thing left
+   * that says the two states are changing places rather than one replacing the
+   * other: it slides in off the column that is closing, and back out the same way.
+   *
+   * THE PRESS IS THE ONLY SCALE, and it is TRANSIENT. A held fractional scale is
+   * rasterized once and then stretched: the glyph's icon and a pill's figures go
+   * soft, and they stay soft for as long as you keep the pointer there, which is
+   * exactly when they are being read. The hover and open states say what they have
+   * to say with the panel they open, the tooltip, and the button's own hover
+   * border.
    */
   const glyphMotion = {
     initial: {
       opacity: 0,
-      scale: reducedMotion ? 1 : GENIE_GLYPH_ENTER_SCALE,
+      x: reducedMotion ? 0 : -GENIE_GLYPH_SLIDE_PX,
     },
-    animate: { opacity: 1, scale: 1 },
-    exit: { opacity: 0, scale: reducedMotion ? 1 : GENIE_GLYPH_EXIT_SCALE },
+    animate: { opacity: 1, x: 0 },
+    exit: { opacity: 0, x: reducedMotion ? 0 : -GENIE_GLYPH_SLIDE_PX },
     whileTap: reducedMotion ? undefined : { scale: GENIE_GLYPH_TAP_SCALE },
     transition: withReducedMotion(
       { ...glyphTransition, delay: entranceDelay(order, delayMs) },
@@ -366,9 +366,9 @@ const CollapsedGlyph = ({
     // to the widget's own controls — they are the next thing in the tab order.
     //
     // With a `text` the whole thing becomes a PILL: the reading, then the same
-    // button at the end of it. The pill keeps the strip's 40px HEIGHT — the one
-    // dimension the strip's rhythm and the cards' stow are built on — and takes
-    // the width it needs off the left, out over the feed.
+    // button at the end of it. The pill costs the strip NO ROOM it would not have
+    // spent on the plain glyph — 40px of the column's rhythm, and the width it
+    // needs taken off the left, out over the feed.
     //
     // The tooltip is `instant`: it is the only place the action's NAME is
     // written, and the glyph is a control you point at on your way past. The
@@ -385,14 +385,23 @@ const CollapsedGlyph = ({
             // `group` so the BUTTON can answer this whole box's hover — see its
             // border below.
             "group pointer-events-auto relative shrink-0",
-            // The pill is the GLYPH'S OWN geometry, grown sideways: the 40px
-            // height every glyph has, the button unchanged inside it, and
-            // `rounded-lg` — one step up from the button's `rounded-md`, which is
-            // what the radius scale says a container holding an `lg` control
-            // takes. Nothing here is a shape the strip doesn't already use.
+            // The pill is the GLYPH'S OWN geometry, grown sideways: the button
+            // unchanged inside it, a `p-1` band around it, and `rounded-lg` — one
+            // step up from the button's `rounded-md`, which is what the radius
+            // scale says a container holding an `lg` control takes. Nothing here
+            // is a shape the strip doesn't already use.
+            //
+            // `-my-1 -mr-1` IS WHAT KEEPS IT A GLYPH. That band is drawing, not
+            // layout: paid for in flow it made the pill a 48px item in a column of
+            // 40px ones, and since the reading is DROPPED while the widget floats
+            // (`text` above), pointing at the pill shrank it back to 40 and shunted
+            // every glyph under it up by 8px — the strip rearranging itself under
+            // the pointer that was aiming at it. Taken back out of the flow at each
+            // edge the band overhangs, the pill occupies exactly the glyph's slot
+            // whether it is carrying a reading or not, and nothing below it moves.
             text
               ? cn(
-                  "-mr-1 flex flex-row items-center gap-1 rounded-lg p-1",
+                  "-mr-1 -my-1 flex flex-row items-center gap-1 rounded-lg p-1",
                   tone.pill
                 )
               : "rounded-lg"
@@ -1227,6 +1236,15 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             // 4px (padding puts the glyphs back) so the dot stays inside it.
             // The bleed is where the fade starts, too, so it opens on the gap
             // above the first glyph rather than on the glyph itself.
+            //
+            // `-ml-3 pl-3` is the same trick at the width the GLYPHS' OWN ARRIVAL
+            // needs: they come in from `GENIE_GLYPH_SLIDE_PX` to the left, and a
+            // scrollport is not a scrollport on one axis only — `overflow-y-auto`
+            // makes the x axis `auto` too, and overflow to the LEFT of a box is
+            // the one direction that can never be scrolled to. At 4px the slide's
+            // first frames were clipped in half. The box grows leftward over the
+            // feed to make the room, which costs nothing: it takes no pointer
+            // events (below) and paints nothing of its own.
             <motion.aside
               key="collapsed-strip"
               ref={stripFade.ref}
@@ -1244,7 +1262,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 // pill's width it would otherwise be a dead margin down the side
                 // of the feed, eating clicks meant for the cards under it. Each
                 // glyph turns them back on for its own 40px (`pointer-events-auto`).
-                "-m-1 flex min-h-0 flex-col items-end gap-2 overflow-y-auto p-1",
+                "-m-1 -ml-3 flex min-h-0 flex-col items-end gap-2 overflow-y-auto p-1 pl-3",
                 // ABOVE THE PANEL (`z-10`): a glyph is what the floating card
                 // came out of, so it stays in front of it — and a pill overhangs
                 // far enough to be half-covered otherwise.
@@ -1378,16 +1396,13 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
               // cards were `display: none` before they had moved a pixel, and the
               // retract animated an empty box while they simply blinked out. The
               // panel's one-widget filter belongs to the panel; while the rail is
-              // still retracting the column is still a column, and its cards have a
-              // journey to make (`stow`).
+              // still retracting the column is still a column, and its cards have
+              // a fade to finish (`stow`).
               visibleWidgetId={railInPanel ? panelWidgetId : undefined}
-              // The strip they are going into: glyphs a fixed pitch apart, and how
-              // small a card has to get to be one of them.
-              stow={{
-                stowed: collapsed,
-                pitch: COLLAPSED_RAIL_WIDTH + GLYPH_GAP_PX,
-                scale: COLLAPSED_RAIL_WIDTH / asideWidth,
-              }}
+              // Whether the strip owns them yet. Nothing about the strip's
+              // geometry comes with it: the cards fade where they stand, so
+              // there is nothing for them to be mapped onto.
+              stow={{ stowed: collapsed }}
               slotRenderers={slotRenderers}
               renderWidget={renderWidget}
               ctx={ctx}
@@ -1436,6 +1451,39 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             </WidgetContainer>
           </motion.aside>
         )}
+        {/* THE BRIDGE. The panel stands `PANEL_GAP_PX` clear of the strip it came
+            out of, and that clearance was UNHOVERABLE GROUND: crossing it slowly
+            on the way from a glyph to its own widget took longer than
+            `PANEL_LEAVE_MS`, so the panel closed in front of the pointer that was
+            on its way into it. A leave delay cannot fix that — whatever the delay
+            is, it is a race against how fast the reader happens to be moving, and
+            the reader who loses is the one moving carefully.
+
+            So the gap stops being a gap: this covers it, and the strip's column
+            below it, with the panel's own hover handlers. It is the pointer's
+            floor from the glyph to the widget and back.
+
+            UNDER THE STRIP (`z-10`, against its `z-20`): the glyphs keep their own
+            hover and their own clicks — switching widgets from the strip has to go
+            on working while a panel is open, and it is a bridge, not a lid. It is
+            drawn only while there is something to reach, so nothing about a rail
+            with no panel open changes. */}
+        {railInPanel && openWidget ? (
+          <div
+            aria-hidden
+            className="absolute z-10"
+            style={{
+              // Level with the panel's top and down to the foot of the column:
+              // everything beside the widget, and nothing above it.
+              top: panelTop,
+              bottom: 0,
+              right: 0,
+              width: COLLAPSED_RAIL_WIDTH + PANEL_GAP_PX,
+            }}
+            onMouseEnter={cancelLeave}
+            onMouseLeave={scheduleLeave}
+          />
+        ) : null}
       </motion.div>
     )
   }

--- a/packages/react/src/sds/Home/NewHomeLayout/useRailMotion.ts
+++ b/packages/react/src/sds/Home/NewHomeLayout/useRailMotion.ts
@@ -38,9 +38,9 @@ export interface RailMotion {
    * Whether the rail BODY should be at full size and opacity.
    *
    * Only the floating panel is ever anything else. Collapsing is not the body's
-   * animation to play: its cards go into their own glyphs one by one (see
-   * `WidgetMotion`'s stow), and a block that also shrank would be the same
-   * gesture happening twice at two scales.
+   * animation to play: its cards fade out where they stand as the strip's glyphs
+   * slide in (see `WidgetMotion`'s stow), and a block that also shrank would be a
+   * second gesture drawn on top of theirs.
    */
   bodyOut: boolean
   /** `display: none`, which arrives only once the retract has played out. */

--- a/packages/react/src/sds/Home/WidgetContainer/WidgetMotion.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/WidgetMotion.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useLayoutEffect, useRef, useState } from "react"
+import { type ReactNode } from "react"
 
 import { motion } from "motion/react"
 
@@ -8,7 +8,6 @@ import { cn } from "@/lib/utils"
 import {
   ENTRANCE_RISE_PX,
   entranceTransition,
-  GENIE_ORIGIN,
   INSTANT_TRANSITION,
   stowInTransition,
   stowOutTransition,
@@ -32,10 +31,6 @@ export interface WidgetArrival {
 export interface WidgetStow {
   /** Whether this widget belongs in the strip rather than in the column. */
   stowed: boolean
-  /** Vertical distance between the glyphs widgets stow onto. */
-  pitch: number
-  /** How small a widget has to get to be a glyph. */
-  scale: number
   /**
    * Whether to take the position without animating. True while the rail is
    * ALREADY collapsed, when a widget leaving or joining the strip means the
@@ -59,19 +54,23 @@ export interface WidgetMotionProps {
 
 /**
  * Everything one widget does that isn't its content: how it ARRIVES, and how it
- * goes into and comes out of its glyph.
+ * goes into and comes out of the strip.
  *
- * THE STOW is what makes a card and its glyph read as one object. The card scales
- * down onto its OWN glyph — not toward the strip in general — and fades as the
- * glyph fades in underneath it; opening the rail runs it backwards, so each glyph
- * looks like it grows into the widget it stands for.
+ * THE STOW IS A FADE, IN PLACE. The card used to travel: it scaled down onto its
+ * OWN glyph, which meant measuring where the card sat (`offsetTop`) and being told
+ * the strip's geometry (a `pitch`, a target `scale`) so the two could be mapped
+ * onto each other. It read as the card being posted into the strip — but a card is
+ * an order of magnitude wider than the 40px glyph it was shrinking onto, so most
+ * of that journey was a widget's whole contents drawn at sizes nothing in it was
+ * laid out for, sliding across the column it was leaving.
  *
- * The mapping needs no measuring of the strip, because the strip's geometry is
- * known: glyphs are a fixed `pitch` apart from the top of this column, and their
- * right edge is this column's right edge (both are pinned there by
- * `NewHomeLayout`). So the widget's right edge is already where it needs to be —
- * scaling from that corner leaves only a vertical distance to cover, and the only
- * thing to look up is where this widget currently sits.
+ * What replaced it is the CROSSOVER: the cards fade out where they are while the
+ * glyphs slide into the strip on the same beat (`GENIE_GLYPH_DELAY_MS` starts them
+ * before this has finished), and neither state is ever drawn at a size it was not
+ * designed at. Expanding runs the same fade the other way.
+ *
+ * Nothing is measured here any more, and nothing about the strip is passed in:
+ * opacity is the whole of it, so there is no geometry left to get wrong.
  *
  * ONE wrapper, not one per behaviour: a second box would be a second flex item to
  * reason about, and adding or removing either of them mid-life would change the
@@ -84,23 +83,9 @@ export const WidgetMotion = ({
   children,
 }: WidgetMotionProps) => {
   const reducedMotion = useReducedMotion()
-  const ref = useRef<HTMLDivElement>(null)
-  const [stowY, setStowY] = useState(0)
 
   const stowed = stow?.stowed ?? false
   const order = arrival?.order ?? 0
-
-  useLayoutEffect(() => {
-    if (!stow?.stowed) return
-    const el = ref.current
-    // A widget the strip already owns is `display: none` and has no box to
-    // measure — and the offset it came in on is exactly where it grows back FROM,
-    // so keeping it is right as well as necessary.
-    if (!el?.offsetParent) return
-    // `offsetTop` rather than a rect: it is a LAYOUT value, so it reports where
-    // the widget belongs even once this very element is scaled away from there.
-    setStowY(order * stow.pitch - el.offsetTop)
-  }, [stow?.stowed, stow?.pitch, order])
 
   const transition = reducedMotion
     ? INSTANT_TRANSITION
@@ -114,21 +99,16 @@ export const WidgetMotion = ({
 
   return (
     <motion.div
-      ref={ref}
       className={cn(fullHeight && "h-full")}
-      // The glyph is at this corner of the column, so this is the corner a widget
-      // shrinks onto and grows out of.
-      style={{ transformOrigin: GENIE_ORIGIN }}
       initial={
         arrival?.arriving
           ? { opacity: 0, y: reducedMotion ? 0 : ENTRANCE_RISE_PX }
           : false
       }
-      animate={{
-        opacity: stowed ? 0 : 1,
-        y: stowed ? stowY : 0,
-        scale: stowed ? (stow?.scale ?? 1) : 1,
-      }}
+      // `y` is the ARRIVAL's, and it is written here as well as there because the
+      // two share this one element: left out, a card that stowed while its own
+      // entrance was still running would keep the rise it came in on forever.
+      animate={{ opacity: stowed ? 0 : 1, y: 0 }}
       transition={transition}
     >
       {children}

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -297,15 +297,15 @@ export interface WidgetContainerProps {
    */
   virtualized?: boolean | WidgetVirtualization
   /**
-   * THE STOW: where this column's widgets go when the rail collapses. Each card
-   * scales down onto its own glyph and fades, and grows back out of it when the
-   * rail opens, so a card and its glyph read as one object rather than two
-   * representations that replace each other. See `WidgetMotion`.
+   * THE STOW: whether this column's widgets belong to the collapsed strip rather
+   * than to the column. Stowed, each card fades out where it stands while the
+   * strip's glyphs slide in over the same beat, and fades back when the rail
+   * opens. See `WidgetMotion`.
    *
-   * `pitch` and `scale` describe the strip the widgets are going into — only
-   * `NewHomeLayout` knows those, which is why they come in from outside.
+   * `instant` is this component's own to decide (the floating panel is the case),
+   * so all that comes in from outside is the state of the rail.
    */
-  stow?: Omit<WidgetStow, "stowed" | "instant"> & { stowed: boolean }
+  stow?: { stowed: boolean }
   /**
    * Tooltip and accessible name for the add placeholder, which shows no text.
    * Defaults to the provider's `t.widgets.addWidget`.

--- a/packages/react/src/sds/Home/home-motion.tsx
+++ b/packages/react/src/sds/Home/home-motion.tsx
@@ -14,10 +14,11 @@ import { cn } from "@/lib/utils"
  * context that arrives with the content it is context for reads as noise.
  *
  * THE GENIE — collapsing the rail must not read as one thing being swapped for
- * another. The column of cards RETRACTS toward the strip — scaled from its top
- * right corner, which is exactly where the strip is — while the glyphs shrink
- * into place; hovering a glyph sends the same widget back out of that corner.
- * Expanding reverses it: the glyphs bloom outward as the cards grow back in.
+ * another. The cards FADE WHERE THEY STAND while the glyphs slide into the strip
+ * over the same beat, so the two states cross over in place rather than one of
+ * them being replaced by the other; hovering a glyph then sends that widget back
+ * out of the strip's corner. Expanding reverses it: the glyphs slide out as the
+ * cards come back up in their column.
  *
  * Every value here is a TRANSFORM or an OPACITY, so the whole gesture is
  * composited: nothing in this file animates a width, a height or an offset. Two
@@ -94,10 +95,22 @@ export const GENIE_GLYPH_DELAY_MS = 90
 export const GENIE_RETRACTED_SCALE = 0.9
 /** …and how far toward the strip it slides while it shrinks. */
 export const GENIE_RETRACTED_OFFSET_PX = 10
-/** A glyph arrives from LARGER than life: a card that just shrank into it. */
-export const GENIE_GLYPH_ENTER_SCALE = 1.18
-/** Expanding, it leaves the other way — blooming out into the card it becomes. */
-export const GENIE_GLYPH_EXIT_SCALE = 1.3
+/**
+ * How far a glyph travels on its way into the strip, and back out of it.
+ *
+ * The glyphs used to arrive SCALED — from 1.18, as though each one were the card
+ * that had just shrunk into it, and out again at 1.3. That reading only held
+ * while the cards really were shrinking onto them; now that a card simply fades
+ * where it stands (see `WidgetMotion`), a glyph blooming out of nothing was the
+ * only thing left on the page still playing the old gesture. What replaces it is
+ * a short slide along the axis the column is closing on: the strip arrives as the
+ * cards go, and nothing on either side of the swap is drawn at a size it was
+ * never designed at.
+ *
+ * NEGATIVE on the way in — the glyph comes from the cards' side of the rail and
+ * settles at its edge — and it leaves the same way.
+ */
+export const GENIE_GLYPH_SLIDE_PX = 8
 /** A glyph whose widget is floating, held slightly forward. */
 export const GENIE_GLYPH_OPEN_SCALE = 1.06
 /** …and the pointer's own feedback on it, under the open state. */
@@ -135,18 +148,19 @@ export const geniePanelGlideTransition: Transition = {
   mass: 0.8,
 }
 /**
- * A widget going INTO its glyph. It ACCELERATES away — a card being stowed should
- * leave, not be set down — and it has to be gone by the time the strip owns it
- * (`GENIE_RETRACT_MS`), because that is when the column stops drawing it at all.
+ * A widget going INTO the strip — the fade it leaves on. It ACCELERATES away — a
+ * card being stowed should leave, not be set down — and it has to be gone by the
+ * time the strip owns it (`GENIE_RETRACT_MS`), because that is when the column
+ * stops drawing it at all.
  */
 export const stowInTransition: Transition = {
   duration: GENIE_RETRACT_MS / 1000,
   ease: "easeIn",
 }
 /**
- * …and coming back OUT of it. The same spring the floating panel uses, so a
- * widget growing out of a glyph and a widget springing out of a glyph are visibly
- * the same gesture at two sizes.
+ * …and coming back OUT. Still the spring the floating panel uses: the card only
+ * fades back in now, but it does it on the beat a widget springs out of a glyph
+ * on, so opening the rail and floating one of its widgets stay the same page.
  */
 export const stowOutTransition: Transition = genieOpenTransition
 


### PR DESCRIPTION
## Description

Collapsing the rail read as one gesture played at two scales — every card shrinking onto its own 40px glyph while the glyphs bloomed in from 1.18× — so this brings it in line with the version [factorial-composer's v3 ships](https://github.com/factorialco/factorial-composer/pull/99/files), which patches both out of the shipped f0-react bundle: the cards fade where they stand and the strip's glyphs slide into place over the same beat, so the two states cross over instead of one replacing the other. Two things the collapsed rail got wrong come with it — a floating widget that closed in front of the pointer heading for it, and an action pill that shunted the strip when you pointed at it. The floating panel's own genie is untouched.

## Fixes

**The cards no longer scale onto their glyphs.** A card is an order of magnitude wider than the 40px glyph it was shrinking onto, so most of that journey was a widget's whole contents drawn at sizes nothing in it was laid out for, sliding across the column it was leaving. The stow is opacity alone now, which also means it measures nothing: `WidgetStow` loses the strip geometry it was mapped onto (`pitch`, `scale`) and the `offsetTop` layout effect that read it.

> Regression tests — `collapsedRail.test.tsx`: _"takes the cards out on a fade, with nothing scaled onto the glyph"_ and _"brings them back the same way"_. On `main` the first fails with `expected 'scale(0.10101010101010101)' to be 'none'`.

**The strip's glyphs slide in and out instead of scaling.** A glyph arriving from 1.18× and leaving at 1.3× was the card's own retract read at glyph size, and that only meant anything while the cards really were shrinking onto them. `GENIE_GLYPH_SLIDE_PX` replaces both.

> Covered indirectly (motion's targets are jumped in jsdom, so the slide itself is not observable there); verified in Storybook.

**The glyphs' arrival was being clipped.** `overflow-y-auto` makes the x axis `auto` too, and overflow to the LEFT of a box is the one direction that can never be scrolled to — so at 4px of padding the first frames of every glyph's slide were cut in half. The strip's left bleed grows to make the room.

> No test: jsdom lays nothing out. Measured in the browser instead — 4px of the glyph clipped before, 0 after.

**A floating widget no longer closes in front of the pointer heading for it.** The panel stands `PANEL_GAP_PX` clear of the strip, and that clearance was unhoverable ground: crossing it slowly — which is what a pointer aiming at something does — took longer than the 150ms leave delay. Raising the delay only changes who wins the race, so the gap stops being a gap: a bridge covers it and the strip's column with the panel's own hover, under the glyphs (`z-10` against their `z-20`) so switching widgets from the strip still works.

> Regression tests — `collapsedRail.test.tsx`: _"holds the panel while the pointer crosses to it"_ and _"and closes once the pointer leaves the rail altogether"_. Both fail without the bridge.

**A `railAction` pill no longer shunts the strip when you point at it.** The pill's `p-1` band was paid for in flow, making it a 48px item in a column of 40px ones. Since the reading is dropped while the widget floats, pointing at the pill shrank it back to 40 and shunted every glyph below it up by 8px. The band is taken back out of the flow at each edge it overhangs; the button itself is pixel-identical in both states.

> Regression test — `index.spec.tsx`: _"keeps the pill inside the glyph's slot, so nothing below it moves"_. It asserts the margins rather than the geometry, because jsdom lays nothing out; the 8px jump it stands for was measured in the browser.