### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.75.0",
+  "packages/react": "6.76.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.76.0](https://github.com/factorialco/f0/compare/f0-react-v6.75.0...f0-react-v6.76.0) (2026-09-01)
+
+
+### Features
+
+* **NewHomeLayout:** fade the rail's cards into the strip ([#5336](https://github.com/factorialco/f0/issues/5336)) ([0629dfa](https://github.com/factorialco/f0/commit/0629dfa3e755c331397415e0f88a18eb36c4c8a7))
+
 ## [6.75.0](https://github.com/factorialco/f0/compare/f0-react-v6.74.3...f0-react-v6.75.0) (2026-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.75.0",
+  "version": "6.76.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.76.0</summary>

## [6.76.0](https://github.com/factorialco/f0/compare/f0-react-v6.75.0...f0-react-v6.76.0) (2026-09-01)


### Features

* **NewHomeLayout:** fade the rail's cards into the strip ([#5336](https://github.com/factorialco/f0/issues/5336)) ([0629dfa](https://github.com/factorialco/f0/commit/0629dfa3e755c331397415e0f88a18eb36c4c8a7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).