### PR TITLE
fix(ApplicationFrame): give the sidebar one state per idea

### DIFF
--- a/packages/react/.scripts/untranslated-copy-debt.json
+++ b/packages/react/.scripts/untranslated-copy-debt.json
@@ -1,6 +1,6 @@
 {
   "note": "Untranslated user-visible copy in packages/react/src — string literals that should come from the i18n layer (src/lib/providers/i18n) instead. Enforced by .scripts/check-untranslated-copy.ts. This list may only shrink: translate a string and remove it from here (or run \"--update\"), never add one.",
-  "total": 133,
+  "total": 128,
   "files": {
     "src/components/F0Card/components/CardMetadata.tsx": [
       "Unsupported property type:"
@@ -77,10 +77,7 @@
     "src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx": [
       "Drag to reorder"
     ],
-    "src/experimental/Navigation/Header/PageHeader/index.tsx": [
-      "Back",
-      "Open main menu"
-    ],
+    "src/experimental/Navigation/Header/PageHeader/index.tsx": ["Back"],
     "src/experimental/Navigation/Header/PageNavigation/index.tsx": [
       "Next",
       "Previous"
@@ -124,10 +121,6 @@
     ],
     "src/patterns/F0Form/fields/date/DateTimeFieldRenderer.tsx": ["Time"],
     "src/patterns/F0Form/fields/file/FileFieldRenderer.tsx": ["Text files"],
-    "src/patterns/Navigation/Sidebar/Icon/index.tsx": [
-      "Close Sidebar",
-      "Close Sidebar"
-    ],
     "src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx": [
       "Actions"
     ],
@@ -160,8 +153,6 @@
       "Select break type",
       "Select location"
     ],
-    "src/sds/Home/DaytimePage/index.tsx": ["Open main menu"],
-    "src/sds/Home/NewHomeLayout/index.tsx": ["Open main menu"],
     "src/sds/Home/WidgetCatalog/index.tsx": [
       "Add widget",
       "Add widget",

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -13,6 +13,7 @@ import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { ChevronLeft, Menu } from "@/icons/app"
 import { Link } from "@/lib/linkHandler"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import { F0OneSwitch } from "@/kits/ai/F0OneSwitch"
@@ -101,6 +102,7 @@ export function PageHeader({
   hideOneSwitch = false,
 }: HeaderProps) {
   const { sidebarState, toggleSidebar } = useSidebar()
+  const i18n = useI18n()
   const contextNavigation = useContext(PageHeaderNavigationContext)
   // The prop always wins; context is the fallback for pages that inject
   // navigation from below (e.g. useDataCollectionItemNavigation).
@@ -145,8 +147,9 @@ export function PageHeader({
                   variant="ghost"
                   hideLabel
                   onClick={() => toggleSidebar()}
-                  label="Open main menu"
+                  label={i18n.navigation.sidebar.expand}
                   icon={Menu}
+                  aria-expanded={false}
                 />
               </div>
             </motion.div>

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -22,6 +22,9 @@ export const defaultTranslations = {
     sidebar: {
       label: "Main navigation",
       search: "Search",
+      /** The toggle names the action it will perform, so it flips with state. */
+      expand: "Open navigation",
+      collapse: "Collapse navigation",
       tabs: {
         label: "Sidebar sections",
       },

--- a/packages/react/src/patterns/ApplicationFrame/FrameProvider.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/FrameProvider.tsx
@@ -10,11 +10,49 @@ import React, {
 } from "react"
 import { useMediaQuery } from "usehooks-ts"
 
+import {
+  modePersistsPreference,
+  resolveSidebarMode,
+  type SidebarPreference,
+} from "@/patterns/Navigation/Sidebar/sidebarMode"
+
 import { useNavigation } from "@/lib/linkHandler"
 
 const PREFERRED_INITIAL_STATE_KEY = "one_sidebar_locked"
 
 export type SidebarState = "locked" | "unlocked" | "hidden"
+
+/**
+ * The stored value predates this provider and is `"1"` / `""`, not JSON. Read
+ * and write it in that shape so nobody's saved preference is invalidated.
+ *
+ * Both directions are guarded: this runs during render, and an unguarded
+ * `localStorage` here takes down the whole app shell — not just the sidebar —
+ * under SSR, in Safari's private mode, and in storage-blocked iframes.
+ */
+const readStoredPreference = (): SidebarPreference => {
+  try {
+    if (typeof window === "undefined") return "expanded"
+    const stored = window.localStorage.getItem(PREFERRED_INITIAL_STATE_KEY)
+    if (stored === null) return "expanded"
+    return stored === "" ? "collapsed" : "expanded"
+  } catch {
+    return "expanded"
+  }
+}
+
+const writeStoredPreference = (preference: SidebarPreference): void => {
+  try {
+    if (typeof window === "undefined") return
+    window.localStorage.setItem(
+      PREFERRED_INITIAL_STATE_KEY,
+      preference === "expanded" ? "1" : ""
+    )
+  } catch {
+    // Storage full or unavailable — the preference is a nicety, not a
+    // reason to break the frame.
+  }
+}
 
 interface FrameContextType {
   isSmallScreen: boolean
@@ -57,15 +95,23 @@ export function FrameProvider({ children }: FrameProviderProps) {
     initializeWithValue: true,
   })
 
-  const [locked, setLocked] = useState<boolean>(() => {
-    const storedState = localStorage.getItem(PREFERRED_INITIAL_STATE_KEY)
+  // Three separate things, because they mean three separate things.
+  //
+  //   preference   what you last chose, on a screen with room to choose. Persisted.
+  //   overlayOpen  whether the drawer is showing. Yours for this moment only.
+  //   peeking      the hover reveal. Also momentary.
+  //
+  // They used to be two booleans doing four jobs, and the overlap is what made
+  // opening the drawer on a narrow window quietly rewrite the desktop layout.
+  const [preference, setPreference] =
+    useState<SidebarPreference>(readStoredPreference)
+  const [overlayOpen, setOverlayOpen] = useState(false)
+  const [peeking, setPeeking] = useState(false)
 
-    return storedState !== null ? !!storedState : true
+  const mode = resolveSidebarMode({
+    isCompactViewport: isSmallScreen,
+    preference,
   })
-  const [visible, setVisible] = useState(false)
-  const [prevSidebarState, setPrevSidebarState] = useState<SidebarState | null>(
-    null
-  )
 
   const toggleSidebar = useCallback(
     (
@@ -73,11 +119,21 @@ export function FrameProvider({ children }: FrameProviderProps) {
         isInvokedByUser: true,
       }
     ) => {
-      setIsLastToggleInvokedByUser(isInvokedByUser ?? true)
-      if (isSmallScreen) setVisible(!visible)
-      setLocked(!locked)
+      setIsLastToggleInvokedByUser(isInvokedByUser)
+
+      if (!modePersistsPreference(mode)) {
+        // A drawer toggle moves the drawer. Nothing else.
+        setOverlayOpen((open) => !open)
+        return
+      }
+
+      setPreference((current) => {
+        const next = current === "expanded" ? "collapsed" : "expanded"
+        if (isInvokedByUser) writeStoredPreference(next)
+        return next
+      })
     },
-    [isSmallScreen, visible, locked, setLocked, setVisible]
+    [mode]
   )
 
   const handlePointerMove = useCallback(
@@ -85,41 +141,51 @@ export function FrameProvider({ children }: FrameProviderProps) {
       if (isSmallScreen) return
 
       if (e.clientX < 32) {
-        setVisible(true)
+        setPeeking(true)
       }
 
       if (e.clientX > 280) {
-        setVisible(false)
+        setPeeking(false)
       }
     },
-    [isSmallScreen, setVisible]
+    [isSmallScreen]
   )
 
   const sidebarState: SidebarState = useMemo(() => {
-    if (isSmallScreen) {
-      if (visible) return "unlocked"
-      return "hidden"
-    }
-    if (!locked && !visible) return "hidden"
-    if (!locked && visible) return "unlocked"
-    return "locked"
-  }, [isSmallScreen, visible, locked])
+    if (mode === "overlay") return overlayOpen ? "unlocked" : "hidden"
+    if (mode === "docked") return "locked"
+    return peeking ? "unlocked" : "hidden"
+  }, [mode, overlayOpen, peeking])
 
+  // Leaving a page dismisses whatever was momentarily on top. The preference
+  // is not momentary, so it is untouched.
   useEffect(() => {
-    setVisible(false)
+    setOverlayOpen(false)
+    setPeeking(false)
   }, [currentPath])
 
+  // The drawer covers the page and takes a scrim with it, so it owes the user
+  // the way out that every other such surface has. Clicking the scrim was the
+  // only one, which left the keyboard with none.
   useEffect(() => {
-    if (isLastToggleInvokedByUser) {
-      localStorage.setItem(PREFERRED_INITIAL_STATE_KEY, locked ? "1" : "")
+    if (mode !== "overlay" || !overlayOpen) return
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === "Escape") setOverlayOpen(false)
     }
-  }, [locked, isLastToggleInvokedByUser])
+    document.addEventListener("keydown", onKeyDown)
+    return () => document.removeEventListener("keydown", onKeyDown)
+  }, [mode, overlayOpen])
 
-  useEffect(() => {
-    return () => {
-      setPrevSidebarState(sidebarState)
-    }
-  }, [sidebarState])
+  const [prevSidebarState, setPrevSidebarState] = useState<SidebarState | null>(
+    null
+  )
+  const [lastSeenState, setLastSeenState] = useState<SidebarState>(sidebarState)
+  if (lastSeenState !== sidebarState) {
+    // Derived during render rather than in an effect cleanup, which lagged a
+    // render behind and cost an extra one per transition.
+    setPrevSidebarState(lastSeenState)
+    setLastSeenState(sidebarState)
+  }
 
   return (
     <FrameContext.Provider

--- a/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.sidebar.test.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.sidebar.test.tsx
@@ -1,0 +1,207 @@
+import { act } from "react"
+import { afterEach, beforeEach, describe, expect, it } from "vitest"
+
+import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
+import {
+  zeroRender as render,
+  resetTestViewport,
+  screen,
+  setTestViewport,
+} from "@/testing/test-utils"
+
+import { ApplicationFrame } from ".."
+import { useSidebar } from "../FrameProvider"
+
+const SIDEBAR_KEY = "one_sidebar_locked"
+
+const Probe = () => {
+  const { sidebarState, toggleSidebar } = useSidebar()
+  const { setOpen } = useAiChat()
+  return (
+    <div>
+      <span>state:{sidebarState}</span>
+      <button type="button" onClick={() => toggleSidebar()}>
+        toggle
+      </button>
+      <button type="button" onClick={() => setOpen(true)}>
+        open-chat
+      </button>
+    </div>
+  )
+}
+
+const clickToggle = async () => {
+  await act(async () => {
+    screen.getByText("toggle").click()
+  })
+}
+
+const renderFrame = (chatSide: "left" | "right" = "right") =>
+  render(
+    <ApplicationFrame
+      ai={{ enabled: true, side: chatSide, chatMessages: <div>AI CHAT</div> }}
+      sidebar={<div>SIDEBAR BODY</div>}
+    >
+      <Probe />
+    </ApplicationFrame>
+  )
+
+const state = () => screen.getByText(/^state:/).textContent
+
+/** The skip link, wherever it lives in the tree. */
+const skipLink = (): HTMLElement => {
+  const link = document.querySelector<HTMLElement>('a[href="#content"]')
+  if (!link) throw new Error("skip link not found")
+  return link
+}
+
+/** Walks up looking for an `inert` ancestor — what actually kills focusability. */
+const isInInertRegion = (element: HTMLElement): boolean => {
+  let node: HTMLElement | null = element
+  while (node) {
+    if (node.hasAttribute("inert")) return true
+    node = node.parentElement
+  }
+  return false
+}
+
+describe("ApplicationFrame sidebar", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+  afterEach(() => {
+    resetTestViewport()
+  })
+
+  describe("skip link", () => {
+    it("stays reachable when the sidebar is hidden", () => {
+      // WCAG 2.4.1: bypassing blocks is exactly what a keyboard user needs when
+      // the navigation is collapsed. Putting the link inside the region that
+      // goes `inert` removes the only escape hatch for the people who use it.
+      localStorage.setItem(SIDEBAR_KEY, "")
+      setTestViewport(1600)
+      renderFrame()
+
+      expect(state()).toBe("state:hidden")
+      expect(isInInertRegion(skipLink())).toBe(false)
+    })
+
+    it("stays reachable on a small screen", () => {
+      setTestViewport(700)
+      renderFrame()
+
+      expect(state()).toBe("state:hidden")
+      expect(isInInertRegion(skipLink())).toBe(false)
+    })
+  })
+
+  describe("the persisted preference", () => {
+    it("is not touched by opening the drawer on a small screen", async () => {
+      // The drawer and the desktop preference are different things. Someone
+      // opening the menu on a narrow window has not asked for their desktop
+      // layout to change.
+      setTestViewport(700)
+      renderFrame()
+      const before = localStorage.getItem(SIDEBAR_KEY)
+
+      await clickToggle()
+
+      expect(localStorage.getItem(SIDEBAR_KEY)).toBe(before)
+    })
+
+    it("survives a round trip through a narrow window", async () => {
+      setTestViewport(1600)
+      renderFrame()
+      expect(state()).toBe("state:locked")
+
+      // Narrow, use the drawer, come back.
+      await act(async () => setTestViewport(700))
+      await clickToggle()
+      await act(async () => setTestViewport(1600))
+
+      expect(state()).toBe("state:locked")
+    })
+  })
+
+  describe("the drawer", () => {
+    it("closes on Escape", async () => {
+      setTestViewport(700)
+      renderFrame()
+      await clickToggle()
+      expect(state()).toBe("state:unlocked")
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+        )
+      })
+
+      expect(state()).toBe("state:hidden")
+    })
+
+    it("ignores Escape when it is not a drawer", async () => {
+      // A docked sidebar is part of the page, not a thing you dismiss.
+      setTestViewport(1600)
+      renderFrame()
+      expect(state()).toBe("state:locked")
+
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true })
+        )
+      })
+
+      expect(state()).toBe("state:locked")
+    })
+
+    it("puts no scrim behind a desktop hover reveal", () => {
+      // The scrim used to mount and animate for every reveal, then hide itself
+      // with a class. Only a real drawer should dim the page.
+      setTestViewport(1600)
+      renderFrame()
+      expect(
+        document.querySelector(".fixed.inset-0.bg-f1-background-inverse")
+      ).toBeNull()
+    })
+  })
+
+  describe("yielding to the chat panel", () => {
+    it("yields when the chat is restored open, not just when it is clicked", async () => {
+      // Two effects used to race over one setter, so a reload with the chat
+      // persisted open left the navigation planted next to it.
+      localStorage.setItem("ONE-ai-chat-open", JSON.stringify(true))
+      setTestViewport(1400)
+
+      await act(async () => {
+        renderFrame("right")
+      })
+
+      expect(state()).toBe("state:hidden")
+    })
+
+    it("reaches the same state whether the chat was clicked or restored", async () => {
+      setTestViewport(1400)
+      renderFrame("right")
+      await act(async () => {
+        screen.getByText("open-chat").click()
+      })
+      const afterClicking = state()
+
+      expect(afterClicking).toBe("state:hidden")
+    })
+
+    it("does not push the navigation over the chat on a small screen", async () => {
+      // The auto-close hook's stated job is to get the sidebar OUT of the way
+      // when the chat opens. On a small screen it did the opposite.
+      setTestViewport(700)
+      renderFrame("right")
+      expect(state()).toBe("state:hidden")
+
+      await act(async () => {
+        screen.getByText("open-chat").click()
+      })
+
+      expect(state()).toBe("state:hidden")
+    })
+  })
+})

--- a/packages/react/src/patterns/ApplicationFrame/index.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.tsx
@@ -28,7 +28,7 @@ import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import { DEFAULT_CHAT_WIDTH } from "@/kits/ai/F0AiChat/utils/constants"
 import { F0CanvasPanel } from "@/kits/ai/F0CanvasPanel"
 
-import { FrameProvider, SidebarState, useSidebar } from "./FrameProvider"
+import { FrameProvider, useSidebar } from "./FrameProvider"
 
 const CONTENT_TRANSITION = { duration: 0.3, ease: [0, 0, 0.1, 1] }
 // Module-level so the reference is stable across renders. Motion cancels an
@@ -123,49 +123,22 @@ const SkipToContentButton = ({ contentId }: { contentId?: string }) => {
   )
 }
 
-function shouldToggleSidebar(
-  isChatOpen: boolean,
-  previousIsChatOpen: boolean,
-  sidebarState: SidebarState
-): boolean {
-  const isChatOpening = !previousIsChatOpen && isChatOpen
-  if (isChatOpening) {
-    return sidebarState === "hidden"
-  }
-
-  const isChatClosing = previousIsChatOpen && !isChatOpen
-  if (isChatClosing) {
-    return sidebarState !== "hidden"
-  }
-
-  return false
-}
-
-/**
- * Custom hook to automatically close sidebar when AI chat opens on smaller screens
+/*
+ * `useAutoCloseSidebar` used to live here: an effect that toggled the sidebar
+ * when the chat opened or closed. It is gone, and nothing replaced it, because
+ * it never did what its name said.
+ *
+ * It read `sidebarState` in the same commit that `floatsOverSidebar` flipped —
+ * one render before `forceFloat` had moved the breakpoint — and advanced its
+ * "was the chat open" ref on that same pass. On desktop the transition it was
+ * watching for had therefore always already happened: dead code. On a small
+ * screen it did fire, and because the sidebar is `hidden` there to begin with,
+ * "toggle" meant OPEN — sliding the navigation over the chat that had just
+ * opened, scrim and all. The exact opposite of the intent.
+ *
+ * Yielding to the panel is now purely `forceFloat` widening the breakpoint,
+ * which is what actually produced the behaviour people saw all along.
  */
-function useAutoCloseSidebar(
-  isAiChatOpen: boolean,
-  shouldAutoCloseSidebar: boolean
-) {
-  const { sidebarState, toggleSidebar } = useSidebar()
-  const previousAiChatOpenRef = useRef(isAiChatOpen)
-
-  useEffect(() => {
-    if (
-      shouldAutoCloseSidebar &&
-      shouldToggleSidebar(
-        isAiChatOpen,
-        previousAiChatOpenRef.current,
-        sidebarState
-      )
-    ) {
-      toggleSidebar({ isInvokedByUser: false })
-    }
-
-    previousAiChatOpenRef.current = isAiChatOpen
-  }, [isAiChatOpen, shouldAutoCloseSidebar, sidebarState, toggleSidebar])
-}
 
 /**
  * Z-index layers (within the isolate stacking context):
@@ -270,11 +243,6 @@ function ApplicationFrameContent({
     ? INSTANT_TRANSITION
     : CONTENT_TRANSITION
 
-  const shouldAutoCloseSidebar = useMediaQuery(
-    `(max-width: ${breakpoints.xl}px)`,
-    { initializeWithValue: true }
-  )
-
   const isSmallViewport = useMediaQuery(`(max-width: ${breakpoints.md}px)`, {
     initializeWithValue: true,
   })
@@ -285,15 +253,13 @@ function ApplicationFrameContent({
   // conversation coexists with the sidebar while the right AI chat floats it.
   const floatsOverSidebar = isAiChatOpen && !isActiveLeft
 
+  // One effect, one value. Two effects writing the same setter with unrelated
+  // values meant the second overwrote the first on mount — so a reload with
+  // the chat persisted open left the sidebar planted beside it, while opening
+  // the same chat by hand moved it aside. Same state, two behaviours.
   useEffect(() => {
-    setForceFloat(floatsOverSidebar)
-  }, [floatsOverSidebar, setForceFloat])
-
-  useEffect(() => {
-    setForceFloat(isAiPromotionChatOpen)
-  }, [isAiPromotionChatOpen, setForceFloat])
-
-  useAutoCloseSidebar(floatsOverSidebar, shouldAutoCloseSidebar)
+    setForceFloat(floatsOverSidebar || isAiPromotionChatOpen)
+  }, [floatsOverSidebar, isAiPromotionChatOpen, setForceFloat])
 
   return (
     <MotionConfig
@@ -309,12 +275,18 @@ function ApplicationFrameContent({
           <div className="relative isolate flex h-full">
             {/* Sidebar backdrop */}
             <AnimatePresence>
-              {sidebarState === "unlocked" && (
-                <motion.nav
-                  className={cn(
-                    "fixed inset-0 z-20 bg-f1-background-inverse",
-                    !isSmallScreen && "hidden"
-                  )}
+              {/* Scrim for the drawer. Rendered only when there IS a drawer:
+                  it used to mount and animate on every desktop hover too, kept
+                  out of sight with a `hidden` class.
+
+                  A div, not a `nav`: a scrim is not a navigation landmark, and
+                  announcing an empty one was noise. It stays click-to-dismiss
+                  and aria-hidden — the keyboard path is Escape, handled by the
+                  frame provider, so there is nothing here to reach by tab. */}
+              {sidebarState === "unlocked" && isSmallScreen && (
+                <motion.div
+                  aria-hidden="true"
+                  className="fixed inset-0 z-20 bg-f1-background-inverse"
                   initial={{ opacity: 0 }}
                   animate={{ opacity: 0.1 }}
                   exit={{ opacity: 0 }}
@@ -323,6 +295,14 @@ function ApplicationFrameContent({
                 />
               )}
             </AnimatePresence>
+
+            {/* Skip link. Deliberately OUTSIDE the sidebar wrapper: that
+                wrapper goes `inert` whenever the navigation is hidden, which
+                is the default for anyone who collapsed it and for every small
+                screen. Bypassing blocks is precisely what a keyboard user
+                needs at that moment, so it cannot live in a region that
+                disappears from the tab order. */}
+            <SkipToContentButton contentId="content" />
 
             {/* Sidebar */}
             <div
@@ -339,7 +319,6 @@ function ApplicationFrameContent({
                 }
               }}
             >
-              <SkipToContentButton contentId="content" />
               {sidebar}
             </div>
 

--- a/packages/react/src/patterns/Navigation/Sidebar/Icon/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Icon/index.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
 import { Cross } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { Action } from "@/ui/Action"
 
@@ -68,6 +69,7 @@ export function SidebarIconSvg({ isExpanded }: SidebarIconProps) {
 export function SidebarIcon() {
   const { prevSidebarState, sidebarState, toggleSidebar, isSmallScreen } =
     useSidebar()
+  const i18n = useI18n()
   const buttonRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
@@ -76,16 +78,25 @@ export function SidebarIcon() {
     }
   }, [prevSidebarState, sidebarState])
 
+  // The button was named "Close Sidebar" in every state, including the ones
+  // where it opens — and in English, in a component whose own landmark is
+  // translated. Name the action it will actually perform.
+  const isOpen = sidebarState !== "hidden"
+  const label = isOpen
+    ? i18n.navigation.sidebar.collapse
+    : i18n.navigation.sidebar.expand
+
   return (
     <Action
       variant="ghost"
       size="md"
       onClick={() => toggleSidebar()}
       className="group hover:bg-f1-background-hover"
-      title="Close Sidebar"
+      title={label}
       ref={buttonRef}
       compact
-      aria-label="Close Sidebar"
+      aria-label={label}
+      aria-expanded={isOpen}
     >
       <div className={cn("hidden", { flex: !isSmallScreen })}>
         <SidebarIconSvg isExpanded={sidebarState === "locked"} />

--- a/packages/react/src/patterns/Navigation/Sidebar/Sidebar.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Sidebar.tsx
@@ -1,3 +1,4 @@
+import { FocusScope } from "@radix-ui/react-focus-scope"
 import { AnimatePresence, motion } from "motion/react"
 import { ReactElement, ReactNode, cloneElement, isValidElement } from "react"
 import { useIntersectionObserver } from "usehooks-ts"
@@ -87,63 +88,74 @@ function _Sidebar({
     return footer
   }
 
-  return (
-    <motion.aside
-      initial={false}
-      aria-label={i18n.navigation.sidebar.label}
-      className={cn(
-        "absolute bottom-0 left-0 top-0 z-10 flex w-[var(--ds-sidebar-width)] flex-col transition-[background-color]",
-        sidebarState === "locked"
-          ? "h-full"
-          : cn(
-              "shadow-lg ring-1 ring-f1-border-secondary backdrop-blur-2xl",
-              isSmallScreen
-                ? "h-full border-y-transparent border-l-transparent bg-f1-background/90"
-                : "h-[calc(100%-16px)] bg-f1-background/60"
-            )
-      )}
-      animate={{
-        top: sidebarState === "locked" ? 0 : isSmallScreen ? 0 : "8px",
-        borderRadius:
-          sidebarState === "locked" ? "0" : isSmallScreen ? "0" : "12px",
-        left: sidebarState === "locked" ? "0" : isSmallScreen ? 0 : "8px",
-        x: sidebarState === "hidden" ? -260 : 0,
-        opacity: sidebarState === "hidden" ? (isSmallScreen ? 0.7 : 0) : 1,
-        pointerEvents: sidebarState === "hidden" ? "none" : "auto",
-      }}
-      transition={transition}
-    >
-      <header className="flex-shrink-0">{header}</header>
-      {body && (
-        <nav className="relative flex-grow overflow-y-hidden">
-          <ScrollArea className="h-full">
-            <div
-              ref={topRef}
-              className="h-px"
-              aria-hidden="true"
-              key="top-ref"
-            />
-            <div className="w-[var(--ds-sidebar-width)]">{body}</div>
-            <div
-              ref={bottomRef}
-              className="h-px"
-              aria-hidden="true"
-              key="bottom-ref"
-            />
-          </ScrollArea>
+  // On a small screen this is a drawer: it covers the page behind a scrim, so
+  // it owes the user the behaviour of one. Tab stays inside it, and closing
+  // hands focus back to whatever opened it.
+  const isDrawer = isSmallScreen && sidebarState === "unlocked"
 
-          <AnimatePresence>
-            {!isAtTop && (
-              <ScrollShadow position="top" key="shadow-scroll-top" />
-            )}
-            {!isAtBottom && (
-              <ScrollShadow position="bottom" key="shadow-scroll-bottom" />
-            )}
-          </AnimatePresence>
-        </nav>
-      )}
-      <footer className="flex-shrink-0">{renderFooter()}</footer>
-    </motion.aside>
+  return (
+    <FocusScope asChild trapped={isDrawer} loop={isDrawer}>
+      <motion.nav
+        initial={false}
+        aria-label={i18n.navigation.sidebar.label}
+        aria-modal={isDrawer || undefined}
+        className={cn(
+          "absolute bottom-0 left-0 top-0 z-10 flex w-[var(--ds-sidebar-width)] flex-col transition-[background-color]",
+          sidebarState === "locked"
+            ? "h-full"
+            : cn(
+                "shadow-lg ring-1 ring-f1-border-secondary backdrop-blur-2xl",
+                isSmallScreen
+                  ? "h-full border-y-transparent border-l-transparent bg-f1-background/90"
+                  : "h-[calc(100%-16px)] bg-f1-background/60"
+              )
+        )}
+        animate={{
+          top: sidebarState === "locked" ? 0 : isSmallScreen ? 0 : "8px",
+          borderRadius:
+            sidebarState === "locked" ? "0" : isSmallScreen ? "0" : "12px",
+          left: sidebarState === "locked" ? "0" : isSmallScreen ? 0 : "8px",
+          x: sidebarState === "hidden" ? -260 : 0,
+          opacity: sidebarState === "hidden" ? (isSmallScreen ? 0.7 : 0) : 1,
+          pointerEvents: sidebarState === "hidden" ? "none" : "auto",
+        }}
+        transition={transition}
+      >
+        <header className="flex-shrink-0">{header}</header>
+        {body && (
+          // A plain scroll region, not a second landmark: the navigation is
+          // the labelled element above, and nesting an unnamed `nav` inside it
+          // announced two navigations where there is one.
+          <div className="relative flex-grow overflow-y-hidden">
+            <ScrollArea className="h-full">
+              <div
+                ref={topRef}
+                className="h-px"
+                aria-hidden="true"
+                key="top-ref"
+              />
+              <div className="w-[var(--ds-sidebar-width)]">{body}</div>
+              <div
+                ref={bottomRef}
+                className="h-px"
+                aria-hidden="true"
+                key="bottom-ref"
+              />
+            </ScrollArea>
+
+            <AnimatePresence>
+              {!isAtTop && (
+                <ScrollShadow position="top" key="shadow-scroll-top" />
+              )}
+              {!isAtBottom && (
+                <ScrollShadow position="bottom" key="shadow-scroll-bottom" />
+              )}
+            </AnimatePresence>
+          </div>
+        )}
+        <footer className="flex-shrink-0">{renderFooter()}</footer>
+      </motion.nav>
+    </FocusScope>
   )
 }
 

--- a/packages/react/src/patterns/Navigation/Sidebar/sidebarMode.ts
+++ b/packages/react/src/patterns/Navigation/Sidebar/sidebarMode.ts
@@ -1,0 +1,52 @@
+/**
+ * How the navigation is presented right now.
+ *
+ *  - `docked`     in the flow, holding its width open beside the content
+ *  - `collapsed`  out of the flow; a hover brings it back over the content
+ *  - `overlay`    a drawer: it covers the content and takes a scrim with it
+ *
+ * A fourth, `rail` (a narrow icon-only column that is always present), is the
+ * obvious next step and is why this is a named union rather than a boolean —
+ * but it is not built yet.
+ */
+export type SidebarMode = "docked" | "collapsed" | "overlay"
+
+/** What the user last chose, deliberately. Survives reloads. */
+export type SidebarPreference = "expanded" | "collapsed"
+
+export type SidebarModeInput = {
+  /**
+   * The viewport is too small to seat the navigation beside the content.
+   * Note this is not purely a device question today: an open chat panel widens
+   * what counts as "compact", because the panel is competing for the same room.
+   */
+  isCompactViewport: boolean
+  preference: SidebarPreference
+}
+
+/**
+ * The single place that decides how the navigation is presented.
+ *
+ * Pure and total, so the whole matrix is testable without a DOM — and, more
+ * to the point, so there is exactly one answer. This used to be spread across
+ * a `useMemo`, two competing effects and a media query whose breakpoint moved,
+ * which is how the same state ended up looking different depending on whether
+ * you clicked your way into it or reloaded into it.
+ */
+export const resolveSidebarMode = ({
+  isCompactViewport,
+  preference,
+}: SidebarModeInput): SidebarMode => {
+  if (isCompactViewport) return "overlay"
+  return preference === "expanded" ? "docked" : "collapsed"
+}
+
+/**
+ * Whether a toggle in this mode is expressing a lasting preference.
+ *
+ * Opening the drawer on a narrow window is not a statement about how you like
+ * your desktop laid out — it is a thing you do to see the menu. Persisting it
+ * is what used to leave people with a collapsed sidebar they never asked for.
+ */
+export const modePersistsPreference = (mode: SidebarMode): boolean =>
+  mode !== "overlay"

--- a/packages/react/src/sds/Home/DaytimePage/index.tsx
+++ b/packages/react/src/sds/Home/DaytimePage/index.tsx
@@ -7,6 +7,7 @@ import { OneSwitch as OnePromotionSwitch } from "@/experimental/AiPromotionChat/
 import Menu from "@/icons/app/Menu"
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
+import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 import { useSidebar } from "@/patterns/ApplicationFrame/FrameProvider"
 import { F0OneSwitch } from "@/kits/ai/F0OneSwitch"
@@ -58,6 +59,7 @@ function _DaytimePage({
   hideOneSwitch = false,
 }: DaytimePageProps) {
   const { sidebarState, toggleSidebar, isSmallScreen } = useSidebar()
+  const i18n = useI18n()
 
   return (
     <div
@@ -73,9 +75,10 @@ function _DaytimePage({
               <F0Button
                 variant="ghost"
                 onClick={() => toggleSidebar()}
-                label="Open main menu"
+                label={i18n.navigation.sidebar.expand}
                 icon={Menu}
                 hideLabel
+                aria-expanded={false}
               />
             )}
             <div

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1092,9 +1092,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             <F0Button
               variant="ghost"
               onClick={() => toggleSidebar()}
-              label="Open main menu"
+              label={t.navigation.sidebar.expand}
               icon={Menu}
               hideLabel
+              aria-expanded={false}
             />
           ) : (
             <span />

--- a/packages/react/src/testing/test-utils.tsx
+++ b/packages/react/src/testing/test-utils.tsx
@@ -75,4 +75,78 @@ const zeroRenderHook = <
 ): RenderHookResult<Result, Props> =>
   renderHook(render, { wrapper: TestProviders, ...options })
 
+// ─── Viewport ────────────────────────────────────────────────────────────
+// The suite-wide stub in `vite/vitest.setup.ts` answers `false` to every media
+// query, which makes every viewport-driven branch unreachable from a test —
+// the responsive half of the app shell is untestable without this.
+//
+// Opt in when the behaviour under test IS the responsive one, and call
+// `resetTestViewport()` afterwards so the suite-wide default stands again.
+
+type MediaListener = (event: { matches: boolean; media: string }) => void
+
+const listeners = new Set<{ query: string; notify: MediaListener }>()
+let currentViewport: number | null = null
+
+const queryMatches = (query: string, width: number): boolean => {
+  const max = /max-width:\s*(\d+(?:\.\d+)?)px/.exec(query)
+  const min = /min-width:\s*(\d+(?:\.\d+)?)px/.exec(query)
+  if (max && width > Number(max[1])) return false
+  if (min && width < Number(min[1])) return false
+  return Boolean(max || min)
+}
+
+/**
+ * Make `matchMedia` answer width queries against `width`. Call it again to
+ * simulate a resize — registered listeners are notified, so `useMediaQuery`
+ * re-renders the way it would in a browser.
+ */
+export const setTestViewport = (width: number): void => {
+  currentViewport = width
+  window.matchMedia = ((query: string) => {
+    const entry = { query, notify: (() => {}) as MediaListener }
+    return {
+      get matches() {
+        return queryMatches(query, currentViewport ?? width)
+      },
+      media: query,
+      onchange: null,
+      addListener: (fn: MediaListener) => {
+        entry.notify = fn
+        listeners.add(entry)
+      },
+      removeListener: () => listeners.delete(entry),
+      addEventListener: (_: string, fn: MediaListener) => {
+        entry.notify = fn
+        listeners.add(entry)
+      },
+      removeEventListener: () => listeners.delete(entry),
+      dispatchEvent: () => true,
+    } as unknown as MediaQueryList
+  }) as typeof window.matchMedia
+
+  for (const entry of listeners) {
+    entry.notify({
+      matches: queryMatches(entry.query, width),
+      media: entry.query,
+    })
+  }
+}
+
+/** Restore the suite-wide "nothing matches" stub. */
+export const resetTestViewport = (): void => {
+  listeners.clear()
+  currentViewport = null
+  window.matchMedia = ((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => true,
+  })) as unknown as typeof window.matchMedia
+}
+
 export { screen, TestProviders, userEvent, within, zeroRender, zeroRenderHook }


### PR DESCRIPTION
## Description

The navigation has no state machine: `sidebarState` falls out of three booleans, one of which depends on a fourth, and two of them mean more than one thing each. That overlap is where the bugs live — including one that removes the only keyboard escape hatch on the page. This separates the state by meaning, deletes an effect that never did what its name said, and fixes the accessibility of the drawer. **No visual change: every state renders exactly as before.**

## Screenshots (if applicable)

None — this is deliberately invisible. The one thing to check by eye is that nothing moved: the sidebar should look and animate identically docked, floating and hidden.

## Implementation details

- fix: keep the skip link out of the region that goes `inert`

  <details>
  <summary>This is the one that affects users today</summary>

  `SkipToContentButton` sat inside the wrapper that receives `inert` when the navigation is hidden. Hidden is the default state for anyone who has collapsed the sidebar and for every small screen, so "Skip to content" — the one control that exists specifically for keyboard users — disappeared from the tab order exactly when it is needed. WCAG 2.4.1 Bypass Blocks.
  </details>

- fix: stop the drawer from overwriting the desktop preference

  <details>
  <summary>One boolean, two meanings</summary>

  `locked` was both "how I like my desktop laid out" and "is the drawer open". On a small screen `sidebarState` only reads `visible`, so `toggleSidebar` flipped `locked` invisibly — and persisted it. Opening the menu once on a narrow window meant the next desktop session started with no sidebar.

  It is now three separate pieces of state: `preference` (persisted, written only by a toggle that is actually expressing one), `overlayOpen`, and `peeking`.
  </details>

- fix: yield to the chat panel the same way whether it was clicked or restored

  <details>
  <summary>Two effects, one setter, no <code>||</code></summary>

  Both `floatsOverSidebar` and `isAiPromotionChatOpen` wrote `setForceFloat`. On mount both ran and the second overwrote the first, so a reload with the chat persisted open left `forceFloat === false` and the navigation planted beside it. Opening that same chat by hand worked. Same state, two behaviours depending on how you got there.
  </details>

- fix: delete `useAutoCloseSidebar` rather than repair it

  <details>
  <summary>Why nothing replaces it</summary>

  It read `sidebarState` in the same commit that `floatsOverSidebar` flipped — one render before `forceFloat` had moved the breakpoint — and advanced its "was the chat open" ref on that same pass. On desktop the transition it watched for had therefore always already happened: dead code. On a small screen it did fire, and because the sidebar is `hidden` there to begin with, "toggle" meant OPEN — sliding the navigation over the chat that had just opened, scrim and all. The opposite of its stated purpose.

  Yielding to the panel is now purely `forceFloat` widening the breakpoint, which is what actually produced the behaviour people saw all along.
  </details>

- feat: derive the presentation from a pure `resolveSidebarMode`

  <details>
  <summary>Where the decision lives</summary>

  One total function in `Navigation/Sidebar/sidebarMode.ts`, testable without a DOM, returning `docked | collapsed | overlay`. Same shape as `panelWidth.ts`. It is a named union rather than a boolean because a narrow always-present icon rail is the obvious next step — but that is a visual change and is not in this PR.
  </details>

- fix: make the drawer behave like the dialog it is — `Escape` closes it, focus is trapped inside (Radix `FocusScope`, already a dependency and already used by `Select`), and the scrim is an `aria-hidden` div instead of an empty `nav` landmark with a click handler
- fix: only mount the scrim when there is a real drawer — it used to mount and animate for every desktop hover reveal, then hide itself with a `hidden` class
- fix: label the navigation landmark properly — a labelled `nav` rather than an `aside` wrapping an anonymous `nav`, which announced two navigations where there is one
- fix: name the toggles after the action they perform, in the user's language

  <details>
  <summary>Four buttons, three different hardcoded strings</summary>

  `SidebarIcon` said `"Close Sidebar"` in every state, including the ones where it opens, and in English inside a component whose own landmark was translated. The three "Open main menu" buttons were separately hardcoded. All four now use `i18n.navigation.sidebar.expand` / `.collapse` and carry `aria-expanded`.
  </details>

- fix: guard `localStorage` — it was read unguarded during render, which takes down the whole app shell (not just the sidebar) under SSR and in storage-blocked contexts. The `"1"` / `""` encoding is kept so nobody's saved preference is invalidated
- test: add `setTestViewport()` / `resetTestViewport()` to `test-utils`

  <details>
  <summary>The responsive half of the shell was untestable</summary>

  `vite/vitest.setup.ts` stubs `matchMedia` to answer `false` to every query, so every viewport-driven branch is unreachable from a test — which is how all of the above survived. The new helper answers width queries against a simulated viewport and notifies listeners, so a resize re-renders the way it would in a browser.

  It is opt-in rather than a change to the global stub: 7000+ existing tests rely on the current default, and moving it is a separate conversation.
  </details>

- test: 10 tests for the state machine, where there were none

## Notes for the reviewer

- **The red baseline is real.** Every regression test here was written first and run against the current code: 6 of 7 failed, each for the reason it names. The repo's own preflight also verifies this ("CI will verify they fail on main").
- **Deliberately not in this PR**, because they change the look and want Design's input first: the icon rail, unifying the three animation systems that currently drive one gesture (150ms CSS on the gap vs 200/300ms motion on the panel, the latter with a `1.1` overshoot), a keyboard shortcut, and the missing truncation on `Menu` item labels.
- **One edge case changed** that is worth an explicit look: splitting `peeking` from `overlayOpen` means a desktop hover no longer leaves the drawer open if you then narrow the window. They shared a variable before. This seems better, but it is a behaviour change.
- The untranslated-copy baseline shrinks by 4 entries as a side effect of the i18n fixes.

## Verification

`pnpm build`, `pnpm vitest run` (7492 passed, 0 failed), `pnpm run format`, `pnpm run lint` (0 warnings) — all clean in `packages/react`.