### PR TITLE
fix(Home): a frameless list is not a narrow card

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -189,11 +189,19 @@ const useIsWide = (ref: React.RefObject<HTMLElement | null>) => {
  * renders and cannot be told, but it renders INSIDE it and can therefore ask.
  * One observer on the card answers for everything in it.
  *
- * `false` outside a `Widget`, so a row rendered on its own is the narrow one.
+ * `undefined` outside a `Widget`: NOT the narrow card, just no card at all. The
+ * two differ for anything sizing itself off the answer — a row in a dialog has
+ * the room of a wide one, so it must not inherit the narrow card compromise.
  */
-const WidgetIsWideContext = React.createContext(false)
+const WidgetIsWideContext = React.createContext<boolean | undefined>(undefined)
 
-export const useWidgetIsWide = () => React.useContext(WidgetIsWideContext)
+/** Whether the surrounding card is wide; `false` when there is no card. */
+export const useWidgetIsWide = () =>
+  React.useContext(WidgetIsWideContext) ?? false
+
+/** As {@link useWidgetIsWide}, but `undefined` tells you there is NO card. */
+export const useWidgetIsWideOrUnset = () =>
+  React.useContext(WidgetIsWideContext)
 
 /**
  * The TITLE AS A LINK: title text plus a chevron, in one target that behaves like

--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -143,7 +143,7 @@ describe("HomeListItem", () => {
       expect(button).toBeInTheDocument()
       expect(button.closest("[class*='opacity-0']")).not.toBeNull()
       expect(
-        button.closest("[class*='group-focus-within:opacity-100']")
+        button.closest("[class*='group-focus-within/row:opacity-100']")
       ).not.toBeNull()
     })
 
@@ -204,7 +204,7 @@ describe("HomeListItem", () => {
         />
       )
 
-      // `classList`, not the class STRING: `group-hover:opacity-100` contains
+      // `classList`, not the class STRING: `group-hover/row:opacity-100` contains
       // "opacity-100" as a substring, and the unprefixed class is the pin.
       const pinned = () =>
         container
@@ -236,7 +236,7 @@ describe("HomeListItem", () => {
 
       expect(
         container.querySelector(
-          "[class*='group-hover:bg-f1-background-tertiary']"
+          "[class*='group-hover/row:bg-f1-background-tertiary']"
         )
       ).not.toBeNull()
 

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -7,7 +7,7 @@ import { F0Icon, type IconType } from "@/components/F0Icon"
 import { ChevronRight } from "@/icons/app"
 import { isExternalHref, Link } from "@/lib/linkHandler"
 import { cn } from "@/lib/utils"
-import { useWidgetIsWide } from "@/experimental/Widgets/Widget"
+import { useWidgetIsWideOrUnset } from "@/experimental/Widgets/Widget"
 import {
   DropdownInternal,
   type DropdownItem,
@@ -73,8 +73,8 @@ const ACTIONS_CLASS = cn(
   // Hidden but still in the DOM and still focusable, so Tab reaches them —
   // and reaching them is what reveals the strip (`group-focus-within`).
   "opacity-0 transition-opacity motion-reduce:transition-none",
-  "group-hover:pointer-events-auto group-hover:opacity-100",
-  "group-focus-within:pointer-events-auto group-focus-within:opacity-100"
+  "group-hover/row:pointer-events-auto group-hover/row:opacity-100",
+  "group-focus-within/row:pointer-events-auto group-focus-within/row:opacity-100"
 )
 
 /**
@@ -161,7 +161,8 @@ export function HomeListItem({
 }: HomeListItemProps) {
   const hasActions = Boolean(actions?.length)
   // The card the row landed in — the row's controls step up with it.
-  const isWide = useWidgetIsWide()
+  // `undefined` = no card at all (a row in a dialog), which has a wide row's room.
+  const isWide = useWidgetIsWideOrUnset()
   // Which action's menu is up, by label — `null` for none. Not a boolean, so
   // one menu closing can never hide a strip another one is still holding open.
   const [openMenu, setOpenMenu] = useState<string | null>(null)
@@ -217,7 +218,7 @@ export function HomeListItem({
     // the group version the row would go dark the moment the pointer crossed
     // into the strip on its way to a button.
     hasActions
-      ? "group-hover:bg-f1-background-tertiary group-focus-within:bg-f1-background-tertiary"
+      ? "group-hover/row:bg-f1-background-tertiary group-focus-within/row:bg-f1-background-tertiary"
       : href && "hover:bg-f1-background-tertiary",
     // With a menu up the pointer is off the row entirely, but the row is still
     // the thing being acted on — so it stays lit under its own open menu.
@@ -239,7 +240,12 @@ export function HomeListItem({
   if (!hasActions) return row
 
   return (
-    <div className="group relative">
+    // A NAMED group: `F0Button` is itself a `.group` and colours its glyph with
+    // unnamed `group-hover:` rules. An unnamed group here would be an ancestor
+    // match for those, so hovering the ROW painted every action button as if it
+    // were hovered — a critical action never showed its red rest state, because
+    // the strip is only visible on row hover.
+    <div className="group/row relative">
       {row}
       <div className={cn(ACTIONS_CLASS, openMenu && ACTIONS_PINNED_CLASS)}>
         {actions?.map((action) => {
@@ -255,7 +261,7 @@ export function HomeListItem({
               variant={action.critical ? "critical" : "outline"}
               // Up a step with the card, like everything else the row draws — a
               // 24px button beside a 40px glyph is a control you have to aim at.
-              size={isWide ? "md" : "sm"}
+              size={isWide === false ? "sm" : "md"}
               onClick={action.onClick}
             />
           )

--- a/packages/react/src/sds/Home/SlotWidget/frameless-sizing.test.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/frameless-sizing.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest"
+
+import { Clock } from "@/icons/app"
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { listSlot, SLOT_SKELETON_ITEM_TESTID } from "../slotRenderers"
+import { SlotWidget, SlotWidgetContent } from "./index"
+
+/**
+ * `SlotWidgetContent` is the widget's content WITHOUT its card — what a dialog
+ * showing the same list uses. No card is not the same as a narrow card: the
+ * dialog has a wide row's room, and taking the narrow card's compromise there
+ * made the very same list visibly smaller than the one in the widget beside it.
+ */
+describe("a frameless list is not a narrow card", () => {
+  const rows = [
+    {
+      id: "1",
+      title: "One",
+      description: "first",
+      href: "/1",
+      avatar: { icon: Clock },
+    },
+    {
+      id: "2",
+      title: "Two",
+      description: "second",
+      href: "/2",
+      avatar: { icon: Clock },
+    },
+  ]
+
+  const schema = { left: "icon", descriptionRequired: true } as const
+
+  const glyphOf = (container: HTMLElement) =>
+    container.querySelector("[class*='size-']")
+
+  test("draws the wide row's glyph with no card around it", () => {
+    const { container } = zeroRender(
+      <SlotWidgetContent slots={[listSlot(schema, rows)]} />
+    )
+
+    // Two-line rows draw `lg` (size-10) at a wide row's size, `md` (size-8) at
+    // a narrow card's. Outside a card it must be the former.
+    expect(glyphOf(container)?.className).toContain("size-10")
+  })
+
+  test("sizes its placeholder the same way, so the list does not resize on load", () => {
+    const { container } = zeroRender(
+      <SlotWidgetContent loading slots={[listSlot(schema, [])]} />
+    )
+
+    expect(
+      screen.getAllByTestId(SLOT_SKELETON_ITEM_TESTID).length
+    ).toBeGreaterThan(0)
+    expect(glyphOf(container)?.className).toContain("size-10")
+  })
+
+  test("still takes the narrow card's size INSIDE a widget", () => {
+    // The other half of the distinction: a real card that has not been measured
+    // as wide is narrow, and its rows stay narrow. Only "no card" is wide.
+    const { container } = zeroRender(
+      <SlotWidget header={{ title: "Team" }} slots={[listSlot(schema, rows)]} />
+    )
+
+    expect(glyphOf(container)?.className).toContain("size-8")
+  })
+})

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -28,7 +28,10 @@ import {
   IndicatorsListProps,
 } from "@/experimental/Widgets/Content/IndicatorsList"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
-import { useWidgetIsWide, WidgetProps } from "@/experimental/Widgets/Widget"
+import {
+  useWidgetIsWideOrUnset,
+  WidgetProps,
+} from "@/experimental/Widgets/Widget"
 import { type F0FormSchema } from "@/patterns/F0Form"
 
 import { HomeListItem, type HomeListItemAction } from "./HomeListItem"
@@ -989,8 +992,10 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
   const [expanded, setExpanded] = useState(false)
   // ASKED, not measured: the slot is built before the frame renders but drawn
   // inside it, so the card it landed in is the one thing it can only learn from
-  // context. `false` for a list rendered outside a `Widget`.
-  const isWide = useWidgetIsWide()
+  // context.
+  // `undefined` = no card at all (a list drawn frameless, e.g. in a dialog):
+  // that has a wide card's room, so it must not take the narrow card compromise.
+  const isWide = useWidgetIsWideOrUnset() !== false
 
   const max = schema.maxVisibleItems
   const overflows = max != null && allRows.length > max
@@ -1161,7 +1166,9 @@ const ListSlotSkeleton = ({
   ctx: HomeSkeletonCtx
 }) => {
   const schema = params.schema ?? {}
-  const isWide = useWidgetIsWide()
+  // `undefined` = no card at all (a list drawn frameless, e.g. in a dialog):
+  // that has a wide card's room, so it must not take the narrow card compromise.
+  const isWide = useWidgetIsWideOrUnset() !== false
   // Rows past `maxVisibleItems` fold behind "View more", so the loaded list
   // never shows more than that — nor should the placeholder.
   const count = Math.max(


### PR DESCRIPTION
## The bug

`SlotWidgetContent` (#5179) draws a widget's content **without its card** — what a dialog showing the same list uses. Those rows came out visibly smaller than the identical list in the widget beside them: `sm` glyphs, `sm` action buttons, and a placeholder sized to match.

Reported from the Factorial home "Needs you" feed, where a grouped row opens a dialog listing the same rows the widget just drew.

## Cause

```ts
const WidgetIsWideContext = React.createContext(false)
```

`false` meant two different things: *this card is narrow* and *there is no card*. Everything sizing itself off the answer took the narrow card's compromise, including in a dialog that has a wide row's room.

## Fix

The context holds `boolean | undefined`, and the two questions are separated:

- `useWidgetIsWide()` — is the surrounding card wide? `false` when there is no card. Unchanged for existing callers.
- `useWidgetIsWideOrUnset()` — `undefined` tells you there is **no card**.

`ListSlot`, `ListSlotSkeleton` and `HomeListItem` ask the second. The skeleton matters as much as the rows: sized differently, the list resized the moment it loaded.

## Also: the row's hover group is now named

`F0Button` is itself a `.group` and tints its glyph with unnamed `group-hover:` rules. An unnamed `.group` on the row was an ancestor match for those, so hovering the **row** painted every action button as if it were hovered — a critical action could never show its red rest state, because the strip is only visible on row hover. `group/row` scopes it, and `HomeListItem`'s spec follows the class names.

## Verification

New `frameless-sizing.test.tsx`, a real red-green:

- **Red** (against `origin/main`): 2 of 3 fail — `expected 'animate-pulse … size-8 …' to contain 'size-10'`.
- **Green** (with the fix): 3 of 3 pass.

It pins both halves of the distinction: frameless draws the wide glyph, its placeholder draws the same, and a list **inside** an unmeasured card still draws narrow — so this does not quietly turn every widget wide.

Full suite: 383/383 across `src/sds/Home` and `src/experimental/Widgets`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)