### PR TITLE
feat(SlotWidget): let a row's subtitle go critical

### DIFF
--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -20,6 +20,33 @@ describe("HomeListItem", () => {
     expect(screen.getByText("Requested 3 days off")).toBeInTheDocument()
   })
 
+  test("says a subtitle carrying bad news in the critical colour — muted by default", () => {
+    const { rerender } = zeroRender(
+      <HomeListItem title="Expenses report" subtitle="Due Friday" />
+    )
+
+    const subtitle = () => screen.getByText("· Due Friday")
+
+    expect(subtitle()).toHaveClass("text-f1-foreground-secondary")
+    expect(subtitle()).not.toHaveClass("text-f1-foreground-critical")
+
+    rerender(
+      <HomeListItem
+        title="Expenses report"
+        subtitle="Due Friday"
+        subtitleCritical
+      />
+    )
+
+    // The dot goes critical with the text rather than staying muted.
+    expect(subtitle()).toHaveClass("text-f1-foreground-critical")
+    expect(subtitle()).not.toHaveClass("text-f1-foreground-secondary")
+    // The title is untouched: it says what the row IS, not what's wrong with it.
+    expect(screen.getByText("Expenses report")).toHaveClass(
+      "text-f1-foreground"
+    )
+  })
+
   test("draws a left slot when given an avatar, none otherwise", () => {
     const { container, rerender } = zeroRender(
       <HomeListItem

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -100,7 +100,9 @@ const ACTIONS_PINNED_CLASS = "pointer-events-auto opacity-100"
  * module glyph, an alert).
  *
  * The text stack is three optional voices: `title` leads, `subtitle` murmurs on
- * the same line after a dot, `description` takes the second line.
+ * the same line after a dot, `description` takes the second line. A subtitle
+ * carrying BAD NEWS about the row — overdue, rejected, over budget — stops
+ * murmuring and says so (`subtitleCritical`).
  *
  * A row can also carry `actions` — what you can DO to it without leaving the
  * widget (snooze it, dismiss it). They stay out of the way until the row is
@@ -119,6 +121,15 @@ export interface HomeListItemProps {
   title: string
   /** Muted, on the title's line, dot-separated. */
   subtitle?: string
+  /**
+   * Draws the `subtitle` CRITICAL rather than muted — the row is overdue,
+   * rejected, over budget. Per row, because it is a state of THAT row's data:
+   * one list holds rows whose subtitle is bad news and rows whose isn't.
+   *
+   * The title reads the same either way — it says what the row IS, and the
+   * subtitle is what has gone wrong with it. Inert without a `subtitle`.
+   */
+  subtitleCritical?: boolean
   /** The second line. */
   description?: string
   /** Trailing slot: a tag, a counter, people. */
@@ -152,6 +163,7 @@ export function HomeListItem({
   left,
   title,
   subtitle,
+  subtitleCritical = false,
   description,
   right,
   actions,
@@ -186,7 +198,17 @@ export function HomeListItem({
             {title}
           </span>
           {subtitle ? (
-            <span className="truncate text-f1-foreground-secondary">
+            // The dot takes the subtitle's colour with it: it is the subtitle's
+            // own punctuation, and a muted separator against a critical phrase
+            // reads as a rendering slip at this size.
+            <span
+              className={cn(
+                "truncate",
+                subtitleCritical
+                  ? "text-f1-foreground-critical"
+                  : "text-f1-foreground-secondary"
+              )}
+            >
               · {subtitle}
             </span>
           ) : null}

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -332,6 +332,7 @@ listSlot(
 | `right`               | `counter`, one avatar type (e.g. a sender), or `<type>-list` (a strip of faces) — or omitted                   | each row supplies `count`, `rightAvatar`, or `avatars` (+ `remainingCount`)         |
 | `rightOptional`       | `true`                                                                                                         | the `right` data is allowed but not demanded — rows without it trail nothing        |
 | `subtitleRequired`    | `true`                                                                                                         | every row carries a `subtitle`, inline after the title                              |
+| `subtitleOptional`    | `true`                                                                                                         | an inline subtitle is allowed but not demanded — only some rows carry one           |
 | `descriptionRequired` | `true`                                                                                                         | every row carries a `description` — the second line                                 |
 | `descriptionOptional` | `true`                                                                                                         | a second line is allowed but not demanded — some rows are two-line, some one        |
 | `clickBehavior`       | `"link"` — or omitted for inert rows                                                                           | every row carries an `href` and renders as a REAL anchor (see Click handling)       |
@@ -341,15 +342,61 @@ listSlot(
 Rows may also carry `unread` for the accent dot on the left glyph, and
 `actions` for what can be done to that row (see **Row actions**).
 
+### A subtitle that carries bad news
+
+A subtitle normally **murmurs**: it is the muted half of the title's line, the
+department behind a name or the date behind a task. When what it says is what has
+gone **wrong** with the row — overdue, rejected, over budget — the row sets
+`subtitleCritical` and the subtitle (its leading dot included) draws in
+`text-f1-foreground-critical` instead:
+
+```tsx
+listSlot({ left: "icon", subtitleOptional: true, clickBehavior: "link" }, [
+  {
+    id: "expenses",
+    title: "Expenses report",
+    subtitle: "2 days overdue", // ← in critical red
+    subtitleCritical: true,
+    avatar: { icon: Receipt, color: "viridian" },
+    href: "/expenses",
+  },
+  {
+    id: "review",
+    title: "Performance review",
+    subtitle: "Due Friday", // ← still muted
+    avatar: { icon: Clock, color: "purple" },
+    href: "/reviews",
+  },
+  // Nothing to add: no subtitle, no separator. That's `subtitleOptional`.
+  {
+    id: "onboarding",
+    title: "Onboarding checklist",
+    avatar: { icon: PersonPlus, color: "army" },
+    href: "/onboarding",
+  },
+])
+```
+
+It is a **per-row** flag, not a schema one, for the same reason `unread` is:
+lateness is a state of that row's data, so one list holds rows that report it
+beside rows that have nothing to report. The title never changes colour with it —
+it says what the row **is**, and the subtitle is what carries the news.
+
+Keep it for what the reader has to act on. A list where every subtitle is red has
+said nothing: red is only loud while the row beside it is quiet.
+
+<Canvas of={SlotWidgetStories.CriticalSubtitles} />
+
 ### Even rows, and rows that aren't
 
 The schema's default is **evenness**: declaring `right: "person"` means every
 row supplies a `rightAvatar`, and `descriptionRequired` means every row supplies
 a second line. That is what makes a list read as a list rather than a pile.
 
-A **feed** is the exception, and the two `…Optional` flags are how you say so.
-`rightOptional` and `descriptionOptional` keep the schema's type checking — the
-data still has to be the kind that was declared — while letting rows go without:
+A **feed** is the exception, and the `…Optional` flags are how you say so.
+`rightOptional`, `subtitleOptional` and `descriptionOptional` keep the schema's
+type checking — the data still has to be the kind that was declared — while
+letting rows go without:
 
 ```tsx
 listSlot(

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -343,6 +343,37 @@ describe("list slot schema", () => {
     expect(container.querySelector(".size-6")).toBeNull()
   })
 
+  test("subtitleOptional lets only some rows carry an inline subtitle, each row deciding its tone", () => {
+    zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ subtitleOptional: true }, [
+            {
+              id: "1",
+              title: "Expenses report",
+              subtitle: "2 days overdue",
+              subtitleCritical: true,
+            },
+            { id: "2", title: "Performance review", subtitle: "Due Friday" },
+            { id: "3", title: "Onboarding" },
+          ]),
+        ]}
+      />
+    )
+
+    // The late row alone is critical; its neighbour still murmurs.
+    expect(screen.getByText("· 2 days overdue")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+    expect(screen.getByText("· Due Friday")).toHaveClass(
+      "text-f1-foreground-secondary"
+    )
+    // And a row with nothing to add says nothing — no stray separator.
+    expect(screen.getByText("Onboarding").parentElement?.textContent).toBe(
+      "Onboarding"
+    )
+  })
+
   test("a mixed list does NOT auto-compact — folding its few second lines away would hide the only thing telling those rows apart", () => {
     const many = Array.from({ length: LIST_COMPACT_AFTER + 1 }, (_, i) => ({
       id: String(i),

--- a/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
@@ -503,6 +503,64 @@ export const NeedsYouWide: Story = {
   parameters: { widgetWidth: "40rem" },
 }
 
+/**
+ * A SUBTITLE THAT CARRIES BAD NEWS. The subtitle is normally the muted half of
+ * the title's line; a row whose subtitle is what has gone WRONG with it —
+ * overdue, rejected, over budget — sets `subtitleCritical` and says it in red,
+ * the leading dot included.
+ *
+ * Per row, like `unread`: lateness is a state of that row's data, so the first
+ * row here reports it while the second one, with the same schema, still
+ * murmurs "Due Friday". The titles are the same colour in both — a title says
+ * what the row IS, not what's wrong with it.
+ *
+ * `subtitleOptional` is the other half of the story: the last row has nothing to
+ * add, so it carries no subtitle and no stray separator. Unlike an optional
+ * second line this changes no geometry — the subtitle shares the title's line,
+ * so the glyph column and the row heights are those of an even list.
+ *
+ * Keep the red for what the reader has to act on: a list where every subtitle is
+ * critical has said nothing.
+ */
+export const CriticalSubtitles: Story = {
+  args: {
+    header: { title: "Your tasks", count: 3 },
+    action: { label: "See all", onClick: () => {} },
+    slots: [
+      listSlot(
+        {
+          left: "icon",
+          subtitleOptional: true,
+          clickBehavior: "link",
+        },
+        [
+          {
+            id: "expenses",
+            title: "Expenses report",
+            subtitle: "2 days overdue",
+            subtitleCritical: true,
+            avatar: { icon: Receipt, color: "viridian" },
+            href: "/expenses",
+          },
+          {
+            id: "review",
+            title: "Performance review",
+            subtitle: "Due Friday",
+            avatar: { icon: Clock, color: "purple" },
+            href: "/reviews",
+          },
+          {
+            id: "onboarding",
+            title: "Onboarding checklist",
+            avatar: { icon: PersonPlus, color: "army" },
+            href: "/onboarding",
+          },
+        ]
+      ),
+    ],
+  },
+}
+
 /** The pool `ItemChurn` adds from, cycled so the button never runs out. */
 const CHURN_ITEMS = [
   { title: "You never clocked out yesterday", icon: Clock, color: "purple" },

--- a/packages/react/src/sds/Home/slotRenderers.test-d.ts
+++ b/packages/react/src/sds/Home/slotRenderers.test-d.ts
@@ -147,6 +147,28 @@ test("the OPTIONAL flags let a feed mix rows the schema would otherwise even out
     // @ts-expect-error a subtitle is still not allowed unless declared
     { id: 1, title: "x", subtitle: "y" },
   ])
+
+  // A subtitle only SOME rows have — the late ones say how late they are.
+  listSlot({ subtitleOptional: true }, [
+    { id: 1, title: "Expenses", subtitle: "2 days overdue" },
+    { id: 2, title: "Onboarding" },
+  ])
+})
+
+test("a row's subtitle may be critical — wherever a subtitle is declared at all", () => {
+  listSlot({ subtitleRequired: true }, [
+    { id: 1, title: "x", subtitle: "2 days overdue", subtitleCritical: true },
+    { id: 2, title: "y", subtitle: "Due Friday" },
+  ])
+  listSlot({ subtitleOptional: true }, [
+    { id: 1, title: "x", subtitle: "2 days overdue", subtitleCritical: true },
+    { id: 2, title: "y" },
+  ])
+
+  listSlot({}, [
+    // @ts-expect-error nothing to colour: this schema declares no subtitle
+    { id: 1, title: "x", subtitleCritical: true },
+  ])
 })
 
 test("an icon row may be tinted, and only with a colour from the palette", () => {

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -314,6 +314,15 @@ export interface ListSchema {
   rightOptional?: boolean
   /** Every row carries an inline subtitle (on the title's line, after a dot). */
   subtitleRequired?: boolean
+  /**
+   * An inline subtitle is ALLOWED but not demanded: some rows carry one and
+   * others don't — a list where only the late items say how late they are.
+   * Unlike a second line this changes no geometry (the subtitle shares the
+   * title's line), so such a list draws exactly like an even one.
+   *
+   * `subtitleRequired` wins when both are set: demanding it already allows it.
+   */
+  subtitleOptional?: boolean
   /** Every row carries a second line — this is what makes rows two-line. */
   descriptionRequired?: boolean
   /**
@@ -377,11 +386,30 @@ type ListRightData<R, Optional> = R extends "counter"
 
 type ListClickData<C> = C extends "link" ? { href: string } : object
 
+/**
+ * What a row may say ABOUT its subtitle — offered by every schema that declares
+ * a subtitle at all, required by none of them.
+ */
+type SubtitleTone = {
+  /**
+   * Draws THIS row's subtitle critical instead of muted — the row is overdue,
+   * rejected, over budget.
+   *
+   * Per ROW rather than per schema, like `unread` and `actions`: what has gone
+   * wrong is a state of the row's own data, so one list holds rows that say so
+   * beside rows that have nothing to report. The title reads the same either
+   * way — the subtitle is what carries the news.
+   */
+  subtitleCritical?: boolean
+}
+
 type ListTextData<S extends ListSchema> = {
   title: string
 } & (S["subtitleRequired"] extends true
-  ? { subtitle: string }
-  : { subtitle?: never }) &
+  ? { subtitle: string } & SubtitleTone
+  : S["subtitleOptional"] extends true
+    ? { subtitle?: string } & SubtitleTone
+    : { subtitle?: never; subtitleCritical?: never }) &
   (S["descriptionRequired"] extends true
     ? { description: string }
     : S["descriptionOptional"] extends true
@@ -879,6 +907,7 @@ type ListRow = {
   id: string | number
   title: string
   subtitle?: string
+  subtitleCritical?: boolean
   description?: string
   unread?: boolean
   avatar?: object & { icon?: IconType; color?: ListIconColor }
@@ -1020,6 +1049,7 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
             <HomeListItem
               title={row.title}
               subtitle={row.subtitle}
+              subtitleCritical={row.subtitleCritical}
               description={compact ? undefined : description}
               unread={row.unread}
               {...listLeft(schema.left, row, avatarSize)}


### PR DESCRIPTION
## Description

A Home `list` row can now say that its inline subtitle is what has gone **wrong** with the row — overdue, rejected, over budget — by drawing it in `text-f1-foreground-critical` instead of the muted secondary colour. Its companion, `subtitleOptional`, lets a list allow an inline subtitle without demanding one from every row, so the rows with nothing to add carry no stray separator.
