### PR TITLE
feat(F0CommunityPostsCarousel): match the v3 tile height and spacing

### DIFF
--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.mdx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.mdx
@@ -19,27 +19,36 @@ with the pagination dots between them.
 
 <Canvas of={Stories.Default} />
 
-| Element    | Description                                                         | Required |
-| ---------- | ------------------------------------------------------------------- | -------- |
-| Cover      | The post's image, always in a 2:1 box sized from the column's width | No       |
-| Title      | The post's name, and the tile's only click target                   | Yes      |
-| Body       | The opening of the post, clamped to five lines                      | No       |
-| Author     | Avatar, name, and the date and counters on one line                 | No       |
-| Paging row | Previous / Next and the dots, always present, disabled at the ends  | Yes      |
+| Element    | Description                                                          | Required |
+| ---------- | -------------------------------------------------------------------- | -------- |
+| Cover      | The post's image, always in a 16:9 box sized from the column's width | No       |
+| Title      | The post's name, and the tile's only click target                    | Yes      |
+| Body       | The opening of the post, in the lines the tile has room for          | No       |
+| Author     | Avatar, name, and the date and counters on one line                  | No       |
+| Paging row | Previous / Next and the dots, always present, disabled at the ends   | Yes      |
 
 <Controls of={Stories.Default} />
 
 ## Guidelines
 
 **It is a wide-column widget.** Two tiles side by side is the whole reason it
-exists rather than a `list` slot — a post needs a title, four lines of its body
+exists rather than a `list` slot — a post needs a title, a few lines of its body
 and its author to be worth previewing, and that does not fit a 396px rail. In the
 `WidgetCatalog`, give it `areas: ["main"]`.
 
-**Covers are cropped, never fitted.** Every image is drawn at 2:1 (1200×600, the
-size these are authored at) with the height taken from the column's width. A tile
-that sized itself to its own image would put every title in the row on a different
-line and move them all when the page turned.
+**Every tile is 384px tall, and the body is what gives.** The height is declared
+rather than grown, so the widget is the same height on every page of the feed
+instead of taking the tallest post in the row. The cover keeps its ratio, the
+title is its own type and the author line is an avatar row — the body takes
+whatever those three leave and previews the whole lines that fit there. That is
+why a post with no cover shows more of itself than one with a picture, in a tile
+the same height as its neighbour.
+
+**Covers are cropped, never fitted.** Every image is drawn at 16:9 with the
+height taken from the column's width. A tile that sized itself to its own image
+would put every title in the row on a different line and move them all when the
+page turned — and since the cover and the body divide one fixed budget, it would
+change how much of every post you could read, too.
 
 **It pages, it does not virtualize.** Embla lays its slides out in a flex row and
 measures them, so every mounted tile stays in the DOM. What keeps that bounded is
@@ -61,7 +70,7 @@ reaches the end, so the DOM follows how far they actually walked.
     description: "Hand it the whole feed and hope.",
     guidelines: [
       "Don't pass two hundred posts as one array — that is two hundred tiles in the DOM.",
-      "Don't crop covers yourself; the tile's 2:1 box already does it.",
+      "Don't crop covers yourself; the tile's 16:9 box already does it.",
       "Don't use it in the rail, where a single tile is cramped and the point is lost.",
     ],
   }}

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
@@ -143,7 +143,7 @@ export const Loading: Story = {
 
 /**
  * COVER IMAGES, and the case that matters: a post WITH one beside a post
- * WITHOUT. Every cover is drawn in the same 2:1 box, sized from the column's
+ * WITHOUT. Every cover is drawn in the same 16:9 box, sized from the column's
  * width and cropped to fit, so the tiles in a row stay the same shape however
  * the pictures were authored — and the tile with no picture simply gives its
  * body the room instead.

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.test.tsx
@@ -98,7 +98,7 @@ describe("F0CommunityPostsCarousel", () => {
     expect(screen.getByRole("button", { name: "More posts" })).toBeDisabled()
   })
 
-  test("a cover image is drawn in a fixed 2:1 box, whatever its own shape", () => {
+  test("a cover image is drawn in a fixed 16:9 box, whatever its own shape", () => {
     render({
       posts: [{ ...POSTS[0], imageUrl: "/landscape01.jpg" }, POSTS[1]],
     })
@@ -108,7 +108,7 @@ describe("F0CommunityPostsCarousel", () => {
     // The BOX is what holds the ratio; the picture fills it and is cropped. A
     // tile that took its height from its own image would put every title in a
     // row on a different line.
-    expect(image.parentElement).toHaveClass("aspect-[2/1]")
+    expect(image.parentElement).toHaveClass("aspect-video")
     expect(image).toHaveClass("object-cover")
   })
 
@@ -116,6 +116,34 @@ describe("F0CommunityPostsCarousel", () => {
     render({ posts: [POSTS[1]] })
 
     expect(screen.queryByRole("presentation")).not.toBeInTheDocument()
+  })
+
+  test("every tile is the same declared height, cover or no cover", () => {
+    render({
+      posts: [{ ...POSTS[0], imageUrl: "/landscape01.jpg" }, POSTS[1]],
+    })
+
+    // THE REGRESSION: the tiles were `h-full`, so the row took the tallest post
+    // in it and the widget changed height every time the page turned. The
+    // height is declared now and the BODY is what gives — which is only true
+    // while every tile carries the same one.
+    const tiles = screen.getAllByRole("article")
+    expect(tiles).toHaveLength(2)
+    for (const tile of tiles) expect(tile).toHaveClass("h-96")
+  })
+
+  test("the body takes the room the rest of the tile left, not a fixed count", () => {
+    render({ posts: [POSTS[0]] })
+
+    // The wrapper is the mechanism: it claims the leftover height (`flex-1`,
+    // shrinkable via `min-h-0`) and clips, and the clamp inside it is measured
+    // against that box at runtime. A flat five-line clamp — which is what this
+    // replaced — overflows a tile with a cover and leaves a picture's worth of
+    // white in one without.
+    const body = screen.getByText("There is no deck to read afterwards.")
+    const room = body.closest("div.flex-1")
+    expect(room).not.toBeNull()
+    expect(room).toHaveClass("min-h-0", "overflow-hidden")
   })
 
   test("loading draws placeholder tiles instead of posts, as many as expected", () => {
@@ -128,11 +156,11 @@ describe("F0CommunityPostsCarousel", () => {
   })
 
   describe("the cover's seat in a placeholder tile", () => {
-    /** The 2:1 box a placeholder keeps for a cover, if it keeps one. */
+    /** The 16:9 box a placeholder keeps for a cover, if it keeps one. */
     const seats = () =>
       screen
         .getAllByTestId("skeleton")
-        .filter((el) => el.className.includes("aspect-[2/1]"))
+        .filter((el) => el.className.includes("aspect-video"))
 
     test("is kept while the FIRST page loads, when nothing is known yet", () => {
       render({ posts: [], loading: true, expectedItemsCount: 2 })

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useRef } from "react"
+
 import { format } from "date-fns"
 
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
@@ -29,7 +31,9 @@ export interface CommunityPostSummary {
   title: string
   /**
    * The post's body as the editor stored it (an HTML string), clamped to the
-   * first few lines. Whatever links it contains are NOT clickable here: the
+   * lines the tile has room for — see {@link PostBody}, and note that a post
+   * with no cover therefore previews more of itself than one with a picture.
+   * Whatever links it contains are NOT clickable here: the
    * whole tile is one target (see {@link CommunityPostCard}), and a link inside
    * a link is neither valid nor operable.
    */
@@ -66,9 +70,9 @@ export interface CommunityPostSummary {
 }
 
 /**
- * ONE TILE. Bordered, the width of its carousel column, and as tall as the
- * tallest one beside it (`h-full`) so a short post and a long one don't leave the
- * row ragged.
+ * ONE TILE. Bordered, the width of its carousel column, and always exactly
+ * {@link POST_CARD_HEIGHT} tall — so a short post and a long one leave the row
+ * neither ragged nor a different height from the page before it.
  *
  * THE TITLE IS THE TARGET, stretched over the whole tile: the anchor carries the
  * accessible name, and an `::after` covering the card makes the rest of it
@@ -77,13 +81,20 @@ export interface CommunityPostSummary {
  * H2, link" and a pointer can hit the card anywhere.
  */
 /**
- * THE COVER IMAGE'S RATIO — 1200×600, the size these are authored at, expressed
- * as the 2:1 box the tile reserves for them. The height is never given: it comes
- * out of the box's own width and this, so the same post is the same shape in a
- * 712px main column as in the catalog's preview — and it follows the bleed
- * (`-mx-3`) without being told, since the box widened and the ratio did not.
+ * THE COVER IMAGE'S RATIO — 16:9, the box the tile reserves for a cover however
+ * the picture itself was authored (`object-cover` crops the rest). The height is
+ * never given: it comes out of the box's own width and this, so the same post is
+ * the same shape in a 712px main column as in the catalog's preview — and it
+ * follows the bleed (`-mx-3`) without being told, since the box widened and the
+ * ratio did not.
+ *
+ * ⚠️ IT IS ALSO WHAT DECIDES HOW MUCH OF THE POST YOU READ. With the tile's
+ * height declared ({@link POST_CARD_HEIGHT}) the cover and the body divide one
+ * fixed budget between them, so a taller frame is directly a shorter preview:
+ * this was 2:1 and the body showed four lines, and 16:9 — 18px more picture in a
+ * 311px tile — is the three the design asks for.
  */
-const POST_IMAGE_RATIO = "aspect-[2/1]"
+const POST_IMAGE_RATIO = "aspect-video"
 
 /**
  * THE WHOLE TILE AS ONE TARGET: an overlay on the title's own anchor, covering
@@ -102,6 +113,142 @@ const POST_IMAGE_RATIO = "aspect-[2/1]"
  */
 const STRETCH =
   "after:absolute after:inset-0 after:z-[1] after:rounded-xl after:content-['']"
+
+/**
+ * HOW TALL A TILE IS — 384px, and the one number this file declares about height.
+ *
+ * DECLARED, NOT GROWN. Every other part of the tile already knows its own size:
+ * the cover keeps its ratio, the title is its own type, the author line is an
+ * avatar row. The BODY is the only part that gives, so it takes whatever those
+ * three leave and shows the lines that fit (see {@link PostBody}) — which is why
+ * a post with no cover previews more of itself than one with a picture, in a tile
+ * the same height as its neighbour.
+ *
+ * Before this the tile was `h-full` and the row took the tallest post in it, so
+ * turning the page moved the widget. Now the widget is the height it will still
+ * be four pages later.
+ *
+ * `h-96` is 24rem — F0's own scale, the step nearest the height the tiles had
+ * when the one with a cover showed three lines. A step off the scale rather than
+ * a number of our own, for the same reason every other measurement here is.
+ */
+const POST_CARD_HEIGHT = "h-96"
+
+/**
+ * HOW MANY WHOLE LINES FIT in `heightPx`, at `lineHeightPx` — the clamp, as
+ * arithmetic.
+ *
+ * Never less than one: a box too short for a single line still shows that line,
+ * cut by the wrapper's own `overflow`, because a tile that previews none of its
+ * post reads as broken rather than as short.
+ */
+const linesThatFit = (heightPx: number, lineHeightPx: number) =>
+  lineHeightPx > 0 ? Math.max(1, Math.floor(heightPx / lineHeightPx)) : 1
+
+/**
+ * The line height to clamp against, in px.
+ *
+ * The container's own is the answer when it has one. Rich text often does not —
+ * the lines that actually wrap live in a `<p>` inside it — so fall through to the
+ * first element child. Returns 0 when neither resolves, and `linesThatFit` then
+ * holds at one line rather than dividing by nothing.
+ */
+const lineHeightOf = (element: HTMLElement) => {
+  const own = Number.parseFloat(window.getComputedStyle(element).lineHeight)
+  if (own > 0) return own
+  const child = element.firstElementChild
+  const inner = child
+    ? Number.parseFloat(window.getComputedStyle(child).lineHeight)
+    : Number.NaN
+  return inner > 0 ? inner : 0
+}
+
+/**
+ * THE POST'S OPENING, in however many lines the tile has room for.
+ *
+ * WHY IT IS MEASURED AND NOT A NUMBER. `PostDescription collapsed` clamps at
+ * five, and five had nothing to do with the space a tile actually has: with the
+ * tile's height now declared ({@link POST_CARD_HEIGHT}), a post with a cover has
+ * room for about three and a post without one for twice that. A flat clamp gets
+ * one of those two wrong — either it overflows the tile or it leaves a picture's
+ * worth of white under the last line.
+ *
+ * The old objection to measuring — "the room IS the text's height, so the
+ * measurement feeds itself" — was true while the tile grew to its content. With
+ * the height fixed, the leftover no longer depends on the text and the loop is
+ * gone.
+ *
+ * TWO ELEMENTS, AND THAT IS THE FIX FOR THE UGLY CUT. One element cannot both
+ * TAKE a height and be clamped: `-webkit-line-clamp` puts its ellipsis at line N
+ * while the box, stretched taller by the flex layout, goes on to reveal a sliver
+ * of line N+1 underneath it. So the jobs are split — the WRAPPER takes the
+ * leftover height and clips, and the TEXT inside it is clamped at its natural
+ * height, where the clamp behaves as designed: the ellipsis ends the last line
+ * and nothing follows.
+ *
+ * `collapsed` IS STILL PASSED, and it is the fallback rather than the answer: it
+ * carries the `-webkit-box` display the clamp needs, and its five lines are what
+ * shows if this never measures — no `ResizeObserver`, or markup rendered on a
+ * server. The inline `-webkit-line-clamp` written below overrides the class the
+ * moment there is a real box to read.
+ */
+const PostBody = ({ content }: { content: string }) => {
+  const text = useRef<HTMLDivElement | null>(null)
+  const observer = useRef<ResizeObserver | null>(null)
+
+  /**
+   * Measure the leftover and set the clamp — straight to the DOM, from the
+   * observer. `ResizeObserver` callbacks run after layout and BEFORE paint, so
+   * the right line count lands in the same frame as the resize that changed the
+   * space. Through React state it would arrive a render later, and every tile
+   * would show its old clamp for a frame each time the carousel resized.
+   */
+  const fit = useCallback((room: HTMLDivElement | null) => {
+    observer.current?.disconnect()
+    observer.current = null
+    if (!room || typeof ResizeObserver === "undefined") return
+
+    const read = () => {
+      const body = text.current
+      if (!body) return
+      // The LINE HEIGHT is the text's own and the ROOM is the wrapper's — the two
+      // things this needs sit on two different elements, which is the same split
+      // that fixed the cut.
+      const available = room.clientHeight
+      let lines = linesThatFit(available, lineHeightOf(body))
+      body.style.webkitLineClamp = String(lines)
+      /**
+       * …THEN CORRECT IT AGAINST THE REAL BOX. The arithmetic above knows about
+       * line heights and nothing else, and a post's body is rich text: the
+       * paragraph MARGINS between its blocks mean N lines can occupy more than N
+       * line-heights, so the guess overflows and the wrapper's `overflow: hidden`
+       * cuts it mid-line — exactly the cut the two-element split exists to end.
+       * Step down until the clamped box really fits.
+       *
+       * Bounded and downward only, so it cannot cycle; the guard is a backstop
+       * against a pathological layout rather than an expected exit.
+       */
+      for (let guard = 0; lines > 1 && guard < 40; guard += 1) {
+        if (body.getBoundingClientRect().height <= available) break
+        lines -= 1
+        body.style.webkitLineClamp = String(lines)
+      }
+    }
+
+    read()
+    observer.current = new ResizeObserver(read)
+    observer.current.observe(room)
+  }, [])
+
+  return (
+    // `min-h-0` is what lets this be SHRUNK below its content: a flex child's
+    // default `min-height: auto` would size the tile to the whole post instead,
+    // which is the fixed height quietly not applying.
+    <div ref={fit} className="min-h-0 flex-1 overflow-hidden">
+      <PostDescription ref={text} content={content} collapsed />
+    </div>
+  )
+}
 
 const CommunityPostCard = ({ post }: { post: CommunityPostSummary }) => {
   const locale = useDateFnsLocale()
@@ -152,7 +299,12 @@ const CommunityPostCard = ({ post }: { post: CommunityPostSummary }) => {
     // `isolate` so its overlay can't escape the tile it belongs to.
     <article
       className={cn(
-        "relative isolate flex h-full flex-col gap-3 rounded-xl p-4",
+        // NO `gap` ON THE TILE. Its two parts are the cover and the column of
+        // words, and the air between them is the column's own `pt-3` — a tile
+        // with no cover has its title flush against the padding instead, which a
+        // gap here could not express.
+        "relative isolate flex flex-col rounded-xl p-4",
+        POST_CARD_HEIGHT,
         "border border-solid border-f1-border-secondary bg-f1-background",
         "transition-colors hover:border-f1-border-hover"
       )}
@@ -168,14 +320,18 @@ const CommunityPostCard = ({ post }: { post: CommunityPostSummary }) => {
             // 24px of card showing on the right. Stretched instead — the tile is
             // a flex column, so a block child fills it and the negative margins
             // extend it past both edges, which is the whole point of them.
-            "relative overflow-hidden rounded-lg",
+            // `rounded-md` (12px) INSIDE the tile's own `rounded-xl` (16px):
+            // the cover sits 4px in from the card's corners, so the two curves
+            // are concentric rather than the inner one being the tighter of the
+            // two. Same pairing F0Card uses for its own image band.
+            "relative overflow-hidden rounded-md",
             // IT REACHES PAST THE TEXT. The tile's padding is `p-4`, and 16px of
             // it on three sides made the picture read as an illustration dropped
             // into the copy rather than as the post's own cover. Pulling 12px
             // back leaves a 4px margin — enough for the rounded corners to sit
-            // inside the card's, not enough to be a gutter. The BOTTOM keeps its
-            // full 16px: that gap is the one between the cover and the title, and
-            // it is doing real work.
+            // inside the card's, not enough to be a gutter. NOTHING is pulled
+            // back at the bottom: the 12px between the cover and the title is the
+            // column's own `pt-3` below.
             "-mx-3 -mt-3",
             POST_IMAGE_RATIO
           )}
@@ -191,33 +347,51 @@ const CommunityPostCard = ({ post }: { post: CommunityPostSummary }) => {
           <Skeleton className="absolute inset-0 -z-10 h-full w-full" />
         </div>
       ) : null}
-      {title}
-      {post.description ? (
-        // `collapsed` is the five-line clamp — the tile shows the opening of the
-        // post, never the whole of it.
-        <PostDescription content={post.description} collapsed />
-      ) : null}
-      {/* PUSHED DOWN: the author line sits on the tile's floor whatever the body
-          did, so a row of tiles has its avatars on one line. */}
-      <div className="mt-auto flex flex-row items-center gap-2 pt-2">
-        {post.author ? (
-          <F0AvatarPerson
-            firstName={post.author.firstName}
-            lastName={post.author.lastName}
-            src={post.author.avatarUrl}
-          />
-        ) : null}
-        <div className="flex min-w-0 flex-col">
+      {/* THE COLUMN OF WORDS — title, body, author line, 8px apart, and the part
+          of the tile that absorbs whatever the cover left (`grow`, `min-h-0`).
+          `pt-3` ONLY UNDER A COVER: 12px is the gap between a picture and the
+          words it belongs to, and with no picture the title sits on the tile's
+          own padding instead. */}
+      <div
+        className={cn(
+          "flex min-h-0 grow flex-col gap-2",
+          post.imageUrl && "pt-3"
+        )}
+      >
+        {title}
+        {post.description ? <PostBody content={post.description} /> : null}
+        {/* PUSHED DOWN: the author line sits on the tile's floor whatever the
+            body did, so a row of tiles has its avatars on one line. `mt-auto` is
+            what does it for a post with NO body — with one, `PostBody` has
+            already taken the slack and this changes nothing. */}
+        {/* `pt-2` ON TOP OF THE COLUMN'S OWN `gap-2` — 16px between the last
+            line of the post and the face under it, twice the 8px that separates
+            the title from the body. The author line is a different KIND of
+            thing from the post's own words and reads as one, which is why the
+            air above it is not the column's default.
+            It costs the body 8px rather than moving the avatar: `mt-auto` pins
+            this box's BOTTOM to the tile's floor, so the padding grows upward
+            into the body's flexible space. */}
+        <div className="mt-auto flex flex-row items-center gap-3 pt-2">
           {post.author ? (
-            <span className="truncate font-medium text-f1-foreground">
-              {`${post.author.firstName} ${post.author.lastName}`}
-            </span>
+            <F0AvatarPerson
+              firstName={post.author.firstName}
+              lastName={post.author.lastName}
+              src={post.author.avatarUrl}
+            />
           ) : null}
-          {meta ? (
-            <span className="truncate text-f1-foreground-secondary">
-              {meta}
-            </span>
-          ) : null}
+          <div className="flex min-w-0 flex-col">
+            {post.author ? (
+              <span className="truncate font-medium text-f1-foreground">
+                {`${post.author.firstName} ${post.author.lastName}`}
+              </span>
+            ) : null}
+            {meta ? (
+              <span className="truncate text-f1-foreground-secondary">
+                {meta}
+              </span>
+            ) : null}
+          </div>
         </div>
       </div>
     </article>
@@ -227,26 +401,44 @@ const CommunityPostCard = ({ post }: { post: CommunityPostSummary }) => {
 /**
  * A tile's placeholder: the same box, the same floor, nothing written on it.
  *
- * `withImage` reserves the cover's seat. Its 2:1 box is most of a tile's height,
+ * `withImage` reserves the cover's seat. Its 16:9 box is most of a tile's height,
  * so getting this wrong shows: reserve it for a feed with no pictures and the row
  * shrinks when the posts land; skip it for a feed that has them and the row
  * lurches taller instead. What decides it is {@link reservesImageSeat}.
  */
 const CommunityPostCardSkeleton = ({ withImage }: { withImage: boolean }) => (
-  <div className="flex h-full flex-col gap-3 rounded-xl border border-solid border-f1-border-secondary p-4">
+  // THE SAME HEIGHT AND THE SAME COLUMN as a real tile — that is the whole job of
+  // a placeholder here. A skeleton that measured itself off its own grey bars
+  // would be a different height from the post that replaces it, and the widget
+  // would jump the moment the feed landed.
+  <div
+    className={cn(
+      "flex flex-col rounded-xl border border-solid border-f1-border-secondary p-4",
+      POST_CARD_HEIGHT
+    )}
+  >
     {withImage ? (
       // Same bleed as the real cover, so the two are the same shape.
-      <Skeleton className={cn("-mx-3 -mt-3 rounded-lg", POST_IMAGE_RATIO)} />
+      <Skeleton className={cn("-mx-3 -mt-3 rounded-md", POST_IMAGE_RATIO)} />
     ) : null}
-    <Skeleton className="h-5 w-3/4 rounded-2xs" />
-    <Skeleton className="h-3 w-full rounded-2xs" />
-    <Skeleton className="h-3 w-5/6 rounded-2xs" />
-    <Skeleton className="h-3 w-2/3 rounded-2xs" />
-    <div className="mt-auto flex flex-row items-center gap-2 pt-2">
-      <Skeleton className="h-8 w-8 rounded-full" />
-      <div className="flex flex-col gap-1">
-        <Skeleton className="h-3 w-24 rounded-2xs" />
-        <Skeleton className="h-3 w-32 rounded-2xs" />
+    <div
+      className={cn("flex min-h-0 grow flex-col gap-2", withImage && "pt-3")}
+    >
+      <Skeleton className="h-5 w-3/4 rounded-2xs" />
+      {/* The body's own bars, in the space the real body will take: a column
+          that grows, so they sit where the post's opening lines will be rather
+          than stacking under the title and leaving the rest blank. */}
+      <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+        <Skeleton className="h-3 w-full rounded-2xs" />
+        <Skeleton className="h-3 w-5/6 rounded-2xs" />
+        <Skeleton className="h-3 w-2/3 rounded-2xs" />
+      </div>
+      <div className="mt-auto flex flex-row items-center gap-3 pt-2">
+        <Skeleton className="h-8 w-8 rounded-full" />
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-3 w-24 rounded-2xs" />
+          <Skeleton className="h-3 w-32 rounded-2xs" />
+        </div>
       </div>
     </div>
   </div>
@@ -308,9 +500,14 @@ export interface F0CommunityPostsCarouselProps {
  * anything narrower.
  *
  * A WIDE-COLUMN WIDGET. Two tiles side by side is the whole reason this exists
- * rather than a `list` slot — a post needs a title, four lines of its body and
+ * rather than a `list` slot — a post needs a title, a few lines of its body and
  * its author to be worth previewing at all, and that does not fit a 396px rail.
  * Put it in the main column (`areas: ["main"]` in the catalog).
+ *
+ * THE HEIGHT IS DECLARED, NOT GROWN ({@link POST_CARD_HEIGHT}). Every tile is
+ * 384px, so the widget is the same height on every page of the feed, and the
+ * body is what gives: it takes whatever the cover, the title and the author line
+ * leave and previews the lines that fit there.
  *
  * THE PAGING IS UNDER THE TILES, not floating over them — `CarouselControls`,
  * the shared row: an arrow on each end, the dots between, its own `pt-4` above
@@ -321,7 +518,7 @@ export interface F0CommunityPostsCarouselProps {
  * transforms the track, so the slides off-screen are mounted and measured like
  * the ones you can see — there is no windowing here, and adding it would mean
  * the carousel could no longer measure its own snaps. That is the right trade
- * for what this shows: a handful of tiles, each one a title and four lines.
+ * for what this shows: a handful of tiles, each one a title and a few lines.
  *
  * It is `pagination` that keeps it a handful. A feed of two hundred posts is not
  * a longer carousel, it is a carousel that holds a PAGE and asks for the next

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -92,14 +92,28 @@ const GradientWash = ({
 /** Collapsed-rail geometry (mirrors the prototype's railMode). */
 const COLLAPSED_RAIL_WIDTH = 40
 /**
- * `max-w-content` in px — the reading column every F0 surface shares (the chat's
- * own composer and message list are capped by the same token). The layout needs
- * the NUMBER, not the class: the same width decides when the rail can no longer
- * have its column (`autoCollapsed`) and how wide a params preview is drawn, and
- * neither is a place a utility class can be read from. Keep it in step with
- * `maxWidth.content` in `packages/react/tailwind.config.ts`.
+ * HOW WIDE THE MAIN COLUMN IS — 672px. The layout needs the NUMBER, not a class:
+ * the same width decides when the rail can no longer have its column
+ * (`autoCollapsed`) and how wide a params preview is drawn, and neither is a
+ * place a utility class can be read from.
+ *
+ * ⚠️ IT WAS `max-w-content` (712px) AND IS NOT ANY MORE. A widget's content is
+ * sized from the column it lives in, so the column's width is a decision about
+ * WIDGETS; the reading column is a decision about PROSE — the measure a composer
+ * or a message list is comfortable at, and the one the chat caps itself to. The
+ * two were the same number by inheritance rather than by intent, and the
+ * two-tile widgets are what made the difference visible: at 712 the Communities
+ * carousel drew 331px tiles against the design's 311, because every tile is
+ * `(column − 32 padding + 16 gutter) / 2 − 16`. The column moved to the width
+ * the design is drawn at; the reading column stayed where the chat needs it.
+ *
+ * So a main-column surface that must line up with the chat now caps ITSELF at
+ * `max-w-content` rather than assuming the column is it.
+ *
+ * Still a DEFAULT and not a constant of the layout: `mainWidth` overrides it for
+ * a Home that wants another measure.
  */
-const CONTENT_WIDTH = 712
+const MAIN_WIDTH = 672
 /**
  * THE GLYPH'S SECOND — how long each face of a flashing glyph is up, and how long
  * a ticking readout's separator stays lit. One period, not two half-periods: a
@@ -617,9 +631,14 @@ export interface NewHomeLayoutProps {
   /** Fixed px width of the side rail. */
   asideWidth?: number
   /**
-   * Max px width of the (centered) main-column content. Defaults to
-   * `max-w-content` (712px), so a composer or a message list in the main column
-   * lines up with the same reading column the chat uses.
+   * Max px width of the (centered) main-column content. Defaults to 672px, the
+   * width the Home widgets are designed at — it is what decides a two-tile
+   * widget's tile size, since every tile is
+   * `(column − 32 padding + 16 gutter) / 2 − 16`.
+   *
+   * ⚠️ NOT `max-w-content` (712px) any more. A surface in the main column that
+   * has to line up with the chat's composer or message list should cap ITSELF at
+   * the reading column rather than assume the column is it.
    */
   mainWidth?: number
   /**
@@ -685,7 +704,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       onReorderWidgets,
       period = "morning",
       asideWidth = 396,
-      mainWidth = CONTENT_WIDTH,
+      mainWidth = MAIN_WIDTH,
       bleed = 24,
       stackedPinsAfter = 2,
       ctx = {},
@@ -1183,8 +1202,9 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           <WidgetContainer
             side="main"
             className="relative mx-auto w-full"
-            // `mainWidth` rather than the `max-w-content` utility, at the same
-            // 712px by default: the cap is a prop, and a class cannot take one.
+            // `mainWidth` rather than a utility class: the cap is a prop, and a
+            // class cannot take one. 672px by default (`MAIN_WIDTH`) — the
+            // column's own width, no longer the reading column's.
             style={{ maxWidth: `${mainWidth}px` }}
             widgets={
               stacked ? [...leftWidgets, ...loosePins.rest] : leftWidgets

--- a/packages/react/src/sds/Home/WidgetCatalog/index.tsx
+++ b/packages/react/src/sds/Home/WidgetCatalog/index.tsx
@@ -35,14 +35,19 @@ import { useWidgetDialogLayout, WidgetPreviewPane } from "../WidgetPreview"
 
 /**
  * The width each area gives a widget, used to cap the preview when the picker is
- * opened for one. The rail is the layout's `asideWidth` and the main column is
- * its `mainWidth` — f0's `max-w-content` reading column — so a widget previews at
- * the width the column it is headed for will really give it.
+ * opened for one. These are the layout's own `mainWidth` and `asideWidth`
+ * defaults, so a widget previews at the width the column it is headed for will
+ * really give it — which matters most for the widgets that divide their column
+ * into tiles, where 40px of preview is a visibly different tile.
+ *
+ * ⚠️ `main` IS 672, NOT `max-w-content` (712). The main column stopped borrowing
+ * the reading column's measure — see `MAIN_WIDTH` in `NewHomeLayout`. Keep the
+ * two in step: a preview drawn at the wrong width is a preview that lies.
  *
  * Override either with `previewWidth` when the app's own columns differ.
  */
 const AREA_PREVIEW_WIDTH: Record<WidgetContainerSide, number> = {
-  main: 712,
+  main: 672,
   right: 396,
 }
 

--- a/packages/react/src/ui/carousel.test.tsx
+++ b/packages/react/src/ui/carousel.test.tsx
@@ -1,0 +1,49 @@
+import { describe, expect, test } from "vitest"
+
+import { SPACE_FOR_WIDGET_SHADOW } from "@/experimental/Navigation/Carousel/DynamicCarousel"
+
+import { CAROUSEL_SHADOW_BLEED } from "./carousel"
+
+/**
+ * THE DRIFT GUARD for the carousel's shadow bleed.
+ *
+ * The bleed used to be an inline style computed from `SPACE_FOR_WIDGET_SHADOW`,
+ * so it could not disagree with it. As Tailwind classes the numbers have to be
+ * written out — a class built from a variable is never emitted by the scanner —
+ * and the link between the two is this file.
+ *
+ * It asserts the RENDERED numbers rather than the class strings, so retuning the
+ * constant fails here with the value it now wants instead of failing silently in
+ * the browser.
+ */
+describe("the carousel's shadow bleed", () => {
+  const bleed = SPACE_FOR_WIDGET_SHADOW
+
+  test("grows the viewport by the shadow's space and pulls it back", () => {
+    // 28px each side: `-m-7` / `p-7` off F0's spacing scale, where 7 is 28px.
+    expect(bleed).toBe(28)
+    expect(CAROUSEL_SHADOW_BLEED).toContain("-m-7")
+    expect(CAROUSEL_SHADOW_BLEED).toContain("p-7")
+  })
+
+  test("takes back the two sides it borrowed, in both axes", () => {
+    const pair = `calc(100%_+_${bleed * 2}px)`
+    expect(CAROUSEL_SHADOW_BLEED).toContain(`h-[${pair}]`)
+    expect(CAROUSEL_SHADOW_BLEED).toContain(`w-[${pair}]`)
+  })
+
+  test("fades that borrowed margin out, at the full stop and the half", () => {
+    // The gradient is opaque from `bleed` in, and starts fading at its half —
+    // so a slide's shadow disappears at the edge instead of being cut square.
+    for (const prefix of ["mask-image", "-webkit-mask-image"]) {
+      const rule = CAROUSEL_SHADOW_BLEED.split(" ").find((c) =>
+        c.startsWith(`[${prefix}:`)
+      )
+      expect(rule).toBeDefined()
+      expect(rule).toContain(`transparent_${bleed / 2}px`)
+      expect(rule).toContain(`black_${bleed}px`)
+      expect(rule).toContain(`black_calc(100%_-_${bleed}px)`)
+      expect(rule).toContain(`transparent_calc(100%_-_${bleed / 2}px)`)
+    }
+  })
+})

--- a/packages/react/src/ui/carousel.tsx
+++ b/packages/react/src/ui/carousel.tsx
@@ -7,9 +7,32 @@ import * as React from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { ButtonInternalProps } from "@/components/F0Button/internal-types"
-import { SPACE_FOR_WIDGET_SHADOW } from "@/experimental/Navigation/Carousel/DynamicCarousel"
 import { ArrowLeft, ArrowRight, ChevronLeft, ChevronRight } from "@/icons/app"
 import { cn } from "@/lib/utils"
+
+/**
+ * THE SHADOW BLEED, as classes.
+ *
+ * The viewport clips its slides, and a widget card's shadow is drawn OUTSIDE its
+ * box — so the box is grown by `SPACE_FOR_WIDGET_SHADOW` (28px) on every side and
+ * pulled back by the same amount, giving the shadow somewhere to land inside the
+ * clip. The mask then fades that borrowed margin out, so a slide's shadow
+ * disappears at the edge instead of being cut off square.
+ *
+ * ⚠️ THE NUMBERS ARE WRITTEN OUT, and that is forced rather than sloppy:
+ * Tailwind's scanner never sees a class built from a variable, so `m-[${N}px]`
+ * emits no CSS at all — the quiet kind of broken, since the markup still looks
+ * right. `SPACE_FOR_WIDGET_SHADOW` remains the single source of truth and
+ * `carousel.test.tsx` fails if these drift from it: 28px is `-m-7` / `p-7`, 56px
+ * is the pair, 14px is the half.
+ *
+ * Exported for that test alone — nothing else should need it.
+ */
+export const CAROUSEL_SHADOW_BLEED = cn(
+  "-m-7 h-[calc(100%_+_56px)] w-[calc(100%_+_56px)] p-7",
+  "[mask-image:linear-gradient(to_right,transparent_0px,transparent_14px,black_28px,black_calc(100%_-_28px),transparent_calc(100%_-_14px),transparent_100%)]",
+  "[-webkit-mask-image:linear-gradient(to_right,transparent_0px,transparent_14px,black_28px,black_calc(100%_-_28px),transparent_calc(100%_-_14px),transparent_100%)]"
+)
 
 type CarouselApi = UseEmblaCarouselType[1]
 type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
@@ -156,24 +179,19 @@ const CarouselContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => {
-  const maskImageStyle = `linear-gradient(to right, transparent 0px, transparent ${SPACE_FOR_WIDGET_SHADOW / 2}px, black ${SPACE_FOR_WIDGET_SHADOW}px, black calc(100% - ${SPACE_FOR_WIDGET_SHADOW}px), transparent calc(100% - ${SPACE_FOR_WIDGET_SHADOW / 2}px), transparent 100%)`
-
   const { carouselRef, orientation } = useCarousel()
 
   return (
     <div
       ref={carouselRef}
-      className="overflow-hidden"
-      style={{
-        scrollbarWidth: "none", // For Firefox
-        msOverflowStyle: "none", // For IE and Edge
-        margin: `-${SPACE_FOR_WIDGET_SHADOW}px`,
-        padding: `${SPACE_FOR_WIDGET_SHADOW}px`,
-        height: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
-        width: `calc(100% + ${SPACE_FOR_WIDGET_SHADOW * 2}px)`,
-        maskImage: maskImageStyle,
-        WebkitMaskImage: maskImageStyle,
-      }}
+      className={cn(
+        "overflow-hidden",
+        CAROUSEL_SHADOW_BLEED,
+        // The viewport scrolls but never shows a bar: embla drives it, and a
+        // native one over the slides is chrome nobody asked for. Firefox reads
+        // the first, old Edge the second.
+        "[scrollbar-width:none] [-ms-overflow-style:none]"
+      )}
     >
       <div
         ref={ref}
@@ -373,11 +391,7 @@ const CarouselDots = React.forwardRef<
       >
         <div
           ref={dotsContainerRef}
-          className="flex w-full gap-0 overflow-x-scroll"
-          style={{
-            scrollbarWidth: "none",
-            overscrollBehavior: "none",
-          }}
+          className="flex w-full gap-0 overflow-x-scroll [overscroll-behavior:none] [scrollbar-width:none]"
           tabIndex={0}
           aria-label="Carousel pagination"
           onKeyDown={(e) => {


### PR DESCRIPTION
## Description

Aligns `F0CommunityPostsCarousel` with the composer v3 prototype ([factorial-composer#99](https://github.com/factorialco/factorial-composer/pull/99), `custom-home/v3`): the tile's height, the spacing inside it, and how much of a post it previews. Measured against the deployed prototype rather than eyeballed — at the same container width the tile now comes out byte-identical.

## Implementation details

**The tile's height is declared, not grown.** Every tile is `h-96` (384px, `absoluteSpacing[96]` — the same step v3 uses). It was `h-full`, so the row took the tallest post in it and the widget changed height every time you paged.

**The body is what gives.** With the height fixed, the cover, the title and the author line all know their own size and the body takes what they leave: a wrapper claims the leftover (`flex-1 min-h-0 overflow-hidden`) and a `ResizeObserver` writes the line clamp measured against that box, then steps down until the clamped box really fits — rich text brings paragraph margins the line arithmetic alone can't see. The flat `line-clamp-5` stays as the no-JS fallback. This is why a post with no cover previews far more of itself than one with a picture, in a tile the same height.

The measurement is written straight to the DOM from the observer rather than through React state, so the right line count lands in the same frame as the resize that changed the space.

**Covers are 16:9 at `rounded-md`** (were `aspect-[2/1]` at `rounded-lg`). With the height declared, the cover and the body divide one fixed budget, so the frame's ratio is directly how much of the post you read.

**The Home main column drops from 712 to 672.** It had been borrowing `max-w-content` — the reading column the chat caps its composer and message list to. A widget's content is sized from the column it lives in, so the column's width is a decision about widgets and the reading column is a decision about prose; they were the same number by inheritance rather than by intent. The two-tile widgets made the difference visible: at 712 the carousel drew 331px tiles against the design's 311, because every tile is `(column − 32 padding + 16 gutter) / 2 − 16`. `WidgetCatalog`'s preview width follows so a preview keeps telling the truth.

⚠️ A main-column surface that must line up with the chat should now cap **itself** at `max-w-content` rather than assume the column is it.

**`ui/carousel`'s shadow bleed moves from inline styles to classes.** The numbers have to be written out — Tailwind never emits a class built from a variable, which is the quiet kind of broken — so `SPACE_FOR_WIDGET_SHADOW` stays the source of truth and `carousel.test.tsx` fails if they drift. What remains inline is the dots' measured width and embla's own `translate3d`, which is the scroll position itself and cannot be a class.

## Testing

- `pnpm vitest run` — **7492 passed**, 0 failed, across 592 files.
- Two new regression tests on the carousel (`h-96` on every tile; the leftover-height body wrapper), both verified failing on the pre-change component.
- Three new drift-guard tests on `ui/carousel`, asserting the bleed classes against `SPACE_FOR_WIDGET_SHADOW`.
- Typecheck, oxlint (97 rules) and oxfmt clean.
- Verified in the browser against the deployed prototype: `NewHomeLayout` now renders 311 × 384 tiles with 301 × 169 covers, and the carousel viewport's computed margin/padding/size/mask are unchanged by the class conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
