### PR TITLE
fix(SlotWidget): align View more with the widget title

### DIFF
--- a/packages/react/src/sds/Home/SlotWidget/viewMoreAlignment.test.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/viewMoreAlignment.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "vitest"
+
+import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+
+import { listSlot } from "../slotRenderers"
+import { SlotWidget } from "./index"
+
+/**
+ * WHERE "View more" SITS. A row-based slot bleeds 8px past the card's content
+ * box so its rows line up with the widget's title, and a button left in that
+ * bleed hangs its whole rectangle 8px further left than everything else on the
+ * card — worst on a wide card, where it is a bordered box overhanging the
+ * title. It belongs on the frame's footer-button edge instead: that is the same
+ * button one slot lower.
+ *
+ * jsdom computes no layout, so the assertion is on the offset CLASS. The 6px is
+ * the bleed cancelled (8px) minus the 2px nudge `SlotWidget`'s footer takes —
+ * change either and this is the test that says so.
+ */
+describe("the list slot's View more button", () => {
+  const rows = Array.from({ length: 5 }, (_, i) => ({
+    id: String(i),
+    title: `Person ${i}`,
+    description: `Detail ${i}`,
+    avatar: { firstName: `Person${i}`, lastName: "Doe" },
+  }))
+
+  const renderCappedList = () =>
+    zeroRender(
+      <SlotWidget
+        header={{ title: "Needs you" }}
+        action={{ label: "See all", onClick: () => {} }}
+        slots={[
+          listSlot(
+            { left: "person", descriptionRequired: true, maxVisibleItems: 2 },
+            rows
+          ),
+        ]}
+      />
+    )
+
+  const wrapperOf = (name: string | RegExp) =>
+    screen.getByRole("button", { name }).parentElement
+
+  test("sits on the footer button's left edge, not out in the slot's row bleed", async () => {
+    renderCappedList()
+
+    expect(wrapperOf(/View more/)).toHaveClass("ml-1.5")
+
+    // Expanded, the same button carries the same edge.
+    await userEvent.click(screen.getByRole("button", { name: /View more/ }))
+    expect(wrapperOf("View less")).toHaveClass("ml-1.5")
+  })
+})

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -899,6 +899,20 @@ export const SLOT_ROW_BLEED = "-m-2"
 export const slotRowBleed = (ctx: HomeRenderCtx) =>
   cn(SLOT_ROW_BLEED, "mt-0", !ctx.isLastSlot && "mb-0")
 
+/**
+ * WHERE "View more" SITS. Not where the rows above it start: a row-based slot
+ * bleeds 8px past the card's content box (`SLOT_ROW_BLEED`), and a button left
+ * in that bleed hangs its whole filled rectangle 8px to the left of the
+ * widget's TITLE — visible as a rectangle that overhangs the card's text.
+ *
+ * It sits exactly where the frame's own footer button sits instead, because it
+ * is the same button one slot higher (`SlotWidget`'s footer class): 8px back to
+ * the content box, then 2px out again — the nudge that makes a filled or
+ * bordered box read as aligned with the text above it rather than measuring
+ * 2px shy of it.
+ */
+export const LIST_MORE_BUTTON_CLASS = "ml-1.5 mt-1 self-start"
+
 /** The gap between rows of the `event-list` slot. */
 export const EVENT_LIST_GAP = "gap-2"
 
@@ -1074,7 +1088,7 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
         })}
       </HomeSlotItems>
       {overflows ? (
-        <div className="mt-1 self-start">
+        <div className={LIST_MORE_BUTTON_CLASS}>
           {/* `neutral`, the same button a widget's own call to action is (the
               frame's `action`): "View more" is something you press, and a ghost
               button under a dense list of rows reads as another row. Past the
@@ -1241,7 +1255,7 @@ const ListSlotSkeleton = ({
         </div>
       ))}
       {overflows ? (
-        <div className="mt-1 self-start">
+        <div className={LIST_MORE_BUTTON_CLASS}>
           {/* An `sm` neutral button — what "View more (n)" will be. */}
           <Skeleton className="h-6 w-24 rounded-sm" />
         </div>


### PR DESCRIPTION
## Description

A row-based slot bleeds 8px past the card's content box so its rows sit flush with the widget's title, and the `list` slot's "View more" / "View less" button was left sitting in that bleed — its whole rectangle hung 8px to the left of the title and of every row above it, which reads as a control overhanging the card's text. It is worst on a wide card, where the button is a bordered `outline` box rather than a filled `neutral` one. It now sits exactly where the frame's own footer button sits, since it is the same button one slot lower.
