### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.78.0",
+  "packages/react": "6.78.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.78.1](https://github.com/factorialco/f0/compare/f0-react-v6.78.0...f0-react-v6.78.1) (2026-09-01)
+
+
+### Bug Fixes
+
+* **F0ClarifyingPanel:** prevent form submission ([#5332](https://github.com/factorialco/f0/issues/5332)) ([a61de49](https://github.com/factorialco/f0/commit/a61de492529d2c99577c595c2ee8399b5a987bac))
+
 ## [6.78.0](https://github.com/factorialco/f0/compare/f0-react-v6.77.0...f0-react-v6.78.0) (2026-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.78.0",
+  "version": "6.78.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.78.1</summary>

## [6.78.1](https://github.com/factorialco/f0/compare/f0-react-v6.78.0...f0-react-v6.78.1) (2026-09-01)


### Bug Fixes

* **F0ClarifyingPanel:** prevent form submission ([#5332](https://github.com/factorialco/f0/issues/5332)) ([a61de49](https://github.com/factorialco/f0/commit/a61de492529d2c99577c595c2ee8399b5a987bac))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).