### PR TITLE
chore(F0DatePicker): meet the stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -16,7 +16,6 @@
     "BigNumber",
     "Charts/RadarChart",
     "Checkbox",
-    "DatePicker",
     "EmptyState",
     "Filters/FilterPicker",
     "Graph/F0Graph",

--- a/packages/react/.storybook/a11y-skip-allowlist.json
+++ b/packages/react/.storybook/a11y-skip-allowlist.json
@@ -3,7 +3,6 @@
   "files": {
     "src/components/F0ActionBar/index.stories.tsx": 1,
     "src/components/F0ButtonToggle/__stories__/F0ButtonToggle.stories.tsx": 1,
-    "src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx": 1,
     "src/components/OneCalendar/OneCalendar.stories.tsx": 2,
     "src/components/RichText/F0RichTextDisplay/__stories__/F0RichTextDisplay.stories.tsx": 1,
     "src/experimental/Navigation/Dropdown/index.stories.tsx": 2,

--- a/packages/react/src/components/F0DatePicker/F0DatePicker.tsx
+++ b/packages/react/src/components/F0DatePicker/F0DatePicker.tsx
@@ -23,7 +23,6 @@ export function F0DatePicker({
   selectOnCellOnly,
   ...inputProps
 }: F0DatePickerProps) {
-  const [localValue, setLocalValue] = useState<DatePickerValue | undefined>()
   const [isOpen, setIsOpen] = useState(open)
 
   useEffect(() => {
@@ -68,6 +67,12 @@ export function F0DatePicker({
       return { value: range, granularity: value.granularity }
     },
     [getGranularity]
+  )
+
+  // Initialize with the resolved value: syncing it in an effect paints one
+  // frame of empty input, flashing the placeholder over the value
+  const [localValue, setLocalValue] = useState<DatePickerValue | undefined>(
+    () => toSafeRange(value)
   )
 
   const granularity = useMemo(() => {
@@ -145,6 +150,8 @@ export function F0DatePicker({
         {...inputProps}
         value={localValue}
         granularity={granularity}
+        minDate={minDate}
+        maxDate={maxDate}
         onDateChange={handleChangeDate}
         showIcon={showIcon}
         displayFormat={displayFormat}

--- a/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.mdx
+++ b/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.mdx
@@ -19,7 +19,7 @@ A date picker input that lets users select a range of time — from a start date
 - The component also allows you to define presets that will be displayed in the component. Check the presets section for more information.
 - For each granularity the input selector will show a button to navigate to the current date in the granularity; you can hide that via props.
 - The component also allows you navigation arrows to allow the user to navigate to the next or previous item in the granularity.
-- Note the `value` and `defaultValue` are objects with the following shape: `{ value: { from: Date, to: Date }, granularity: GranularityDefinitionKey }`.
+- The controlled `value` has the following shape: `{ value: { from: Date, to: Date }, granularity: GranularityDefinitionKey }`.
 
 ## Anatomy
 

--- a/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.mdx
+++ b/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.mdx
@@ -1,0 +1,169 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0DatePicker.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+<Meta of={Stories} />
+
+# F0DatePicker
+
+A date picker input that lets users select a range of time — from a start datetime to an end datetime — through a text input paired with a popup calendar. Supports multiple granularities, presets, min/max bounds, and free-text date entry.
+
+---
+
+# Overview
+
+## Purpose
+
+- The `F0DatePicker` component is a date picker that allows the user to select a <strong>range of time</strong> (from a start datetime to an end datetime), with different granularities (day, week, month, quarter, halfyear, year, range). When the user selects an item in a granularity they are selecting that range of time, e.g. when the user selects a day, the range from the start of the day (30/07/2025 00:00:00) to the end of the day (30/07/2025 23:59:59) is selected.
+- The component allows you to define the available granularities for the user (if not defined, the default one is day).
+- The component also allows you to define presets that will be displayed in the component. Check the presets section for more information.
+- For each granularity the input selector will show a button to navigate to the current date in the granularity; you can hide that via props.
+- The component also allows you navigation arrows to allow the user to navigate to the next or previous item in the granularity.
+- Note the `value` and `defaultValue` are objects with the following shape: `{ value: { from: Date, to: Date }, granularity: GranularityDefinitionKey }`.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Element</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Required</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Label</code>
+        </td>
+        <td>Visible label describing the field, associated with the input</td>
+        <td>Yes (can be visually hidden with `hideLabel`)</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Input</code>
+        </td>
+        <td>Text field showing the formatted value; accepts typed dates</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Calendar icon</code>
+        </td>
+        <td>Leading icon indicating the field is a date picker</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Clear button</code>
+        </td>
+        <td>Clears the current value when `clearable` is set</td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Popup</code>
+        </td>
+        <td>
+          Popover containing the granularity selector, the preset list, and the
+          calendar
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Hint / status row</code>
+        </td>
+        <td>Hint text or error/warning/info messages below the input</td>
+        <td>No</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Variants
+
+### Multiple granularities
+
+Let users switch between day, week, month, and quarter selection modes.
+
+<Canvas of={Stories.WithMultipleGranularities} />
+
+### Presets
+
+Offer one-click shortcuts like "Today", "Last week", or "Last 7 days".
+
+<Canvas of={Stories.WithPresets} />
+
+### Min and max dates
+
+Bound the selectable range with `minDate` and `maxDate`.
+
+<Canvas of={Stories.WithMinMaxDates} />
+
+### Opening on the nearest bound
+
+With no value selected, the calendar opens on the month of the nearest bound instead of today — handy for an end-date picker whose `minDate` is the already-selected start date.
+
+<Canvas of={Stories.OpensOnMinDate} />
+
+---
+
+# Guidelines
+
+## Design Best Practices
+
+### When to use
+
+- Use it when users need to pick a point or range in time: a single day, a week, a month, a quarter, a half-year, a year, or an arbitrary range
+- Use presets when there are common choices (today, last week, last month) that save users a trip into the calendar
+- Use `minDate`/`maxDate` when only a bounded window is valid, e.g. an end date after a chosen start date
+
+### When NOT to use
+
+- Do not use it for durations or time-of-day selection: it selects calendar ranges, not clock times
+- Do not use it when the set of valid dates is tiny and known: a select with explicit options is faster
+- Do not use it for date ranges spanning two independent fields when each bound needs its own validation message: use two date pickers instead
+
+<DoDonts
+  do={{
+    description:
+      "Constrain the calendar with minDate/maxDate and offer presets for the choices users pick most often",
+  }}
+  dont={{
+    description:
+      "Leave the picker unbounded when only a known window is valid, forcing users to discover invalid dates through error messages",
+  }}
+/>
+
+## Content Best Practices
+
+- Keep the label short and specific: "Start date", "Review period" — not "Please select a date"
+- Use the placeholder to show the expected input, e.g. "Select a date"
+- Hint text should explain constraints ("Must be within the last 30 days"), not restate the label
+- Preset labels should read as answers: "Last 7 days", "This month"
+
+## Accessibility
+
+- The input gets its accessible name from `label` via <code>htmlFor</code> plus a mirrored <code>aria-label</code>, so the field stays labelled even when <code>hideLabel</code> is set
+- The popup is a Radix Popover rendering <code>role="dialog"</code>
+- The input auto-focuses when the popup opens, so keyboard users can type a date immediately
+- <kbd>Enter</kbd> commits the typed value
+- Unparseable or out-of-range entries flip the field to the error state without emitting <code>onChange</code>, so consumers never receive an invalid value
+
+---
+
+# Code
+
+## Import
+
+```tsx
+import { F0DatePicker } from "@factorialco/f0-react"
+```
+
+## Props
+
+<Controls of={Stories.Default} />

--- a/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
+++ b/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
@@ -36,13 +36,13 @@ const meta = {
   argTypes: {
     value: {
       description:
-        "The value of the date picker. You can pass a Date, a string, or a DatePickerValue object. If you pass a Date, it will be converted to a DatePickerValue object with the granularity 'day'.",
+        "The controlled value of the date picker. Pass a DatePickerValue object with a date range and granularity.",
       control: {
         type: "object",
       },
       table: {
         type: {
-          summary: "DatePickerValue | Date | string | undefined",
+          summary: "DatePickerValue | undefined",
           detail:
             "type DatePickerValue = { value: {from: Date, to: Date}, granularity: GranularityDefinitionKey }",
         },

--- a/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
+++ b/packages/react/src/components/F0DatePicker/__stories__/F0DatePicker.stories.tsx
@@ -8,7 +8,7 @@ import { expect, fn, screen, userEvent, within } from "storybook/test"
 import { F0Dialog } from "@/patterns/F0Dialog"
 import { Placeholder } from "@/icons/app"
 import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
-import { withSkipA11y, withSnapshot } from "@/lib/storybook-utils/parameters"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { getInputFieldArgs } from "@/components/F0InputField/__stories__/F0InputField.args"
 
 import { DateRange } from "@/components/OneCalendar/types"
@@ -31,20 +31,7 @@ const meta = {
     }
   },
   parameters: {
-    docs: {
-      description: {
-        component: [
-          "The `F0DatePicker` component is a date picker that allows the user to select a <strong>range of time</strong> (from a start datetime to an end datetime). With different granularities (day, week, month, quarter, halfyear, year, range). When the user select an item in a granularity is selecting that range of time, e.g. when the user select a day, the range start of the day (30/07/2025 00:00:00) to the end of the day (30/07/2025 23:59:59) is selected.",
-          "The component allows you to define the available granularities for the user (if not defined the default ones is day).",
-          "The component also allows you to define presets that will be displayed in the component. Check the presets section for more information.",
-          "For each granularity the input selector will show a button to navigate to the current date in the granularity, you can hide that via props",
-          "The component also allows you navigation arrows to allow user to navigate to the next or previous item in the granularity.",
-          "Note the value and defaultValue are objects with the following shape: `{ value: { from: Date, to: Date }, granularity: GranularityDefinitionKey }`",
-        ]
-          .map((text) => `<p>${text}.</p>`)
-          .join(""),
-      },
-    },
+    a11y: { test: "error" },
   },
   argTypes: {
     value: {
@@ -98,7 +85,7 @@ const meta = {
     ...getInputFieldArgs(inputFieldInheritedProps),
     ...dataTestIdArgs,
   },
-  tags: ["autodocs", "stable"],
+  tags: ["stable", "!autodocs"],
   decorators: [
     (Story, { args, parameters }) => {
       const width = parameters?.width || "300px"
@@ -357,7 +344,7 @@ export const WithClearable: Story = {
 }
 
 export const Snapshot: Story = {
-  parameters: withSkipA11y(withSnapshot({ width: "100%" })),
+  parameters: withSnapshot({ width: "100%" }),
   args: {
     label: "Label text here",
   },

--- a/packages/react/src/components/F0DatePicker/__tests__/F0DatePicker.test.tsx
+++ b/packages/react/src/components/F0DatePicker/__tests__/F0DatePicker.test.tsx
@@ -1,0 +1,265 @@
+import { userEvent } from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { fireEvent, screen, zeroRender as render } from "@/testing/test-utils"
+
+import { F0DatePicker } from "../F0DatePicker"
+import { predefinedPresets } from "../presets"
+import { DatePickerValue } from "../types"
+
+const mockDate = new Date(2025, 6, 30)
+
+const dayValue: DatePickerValue = {
+  value: { from: new Date(2025, 6, 30), to: new Date(2025, 6, 30) },
+  granularity: "day",
+}
+
+const getInput = () => screen.getByRole("textbox") as HTMLInputElement
+
+const getWrapper = () => screen.getByTestId("input-field-wrapper")
+
+const setupUser = () =>
+  userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+
+describe("F0DatePicker", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    vi.setSystemTime(mockDate)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  describe("typing a date", () => {
+    it("commits the typed value on blur and calls onChange with the value and its string", async () => {
+      const user = setupUser()
+      const onChange = vi.fn()
+      render(<F0DatePicker label="Date" onChange={onChange} />)
+
+      const input = getInput()
+      await user.click(input)
+      await user.type(input, "15/07/2025")
+      fireEvent.blur(input)
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      const [value, stringValue] = onChange.mock.calls[0]
+      expect(value.granularity).toBe("day")
+      expect(value.value.from).toEqual(new Date(2025, 6, 15, 0, 0, 0, 0))
+      expect(stringValue).toBe("15/07/2025")
+    })
+
+    it("commits the typed value on Enter", async () => {
+      const user = setupUser()
+      const onChange = vi.fn()
+      render(<F0DatePicker label="Date" onChange={onChange} />)
+
+      const input = getInput()
+      await user.click(input)
+      await user.type(input, "15/07/2025{Enter}")
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange.mock.calls[0][0].value.from).toEqual(
+        new Date(2025, 6, 15, 0, 0, 0, 0)
+      )
+    })
+
+    it("sets the error state and does not call onChange for an out-of-range date", async () => {
+      const user = setupUser()
+      const onChange = vi.fn()
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={onChange}
+          minDate={new Date(2025, 6, 1)}
+        />
+      )
+
+      const input = getInput()
+      await user.click(input)
+      await user.type(input, "15/06/2025{Enter}")
+
+      expect(onChange).not.toHaveBeenCalled()
+      expect(getWrapper().className).toContain("border-f1-border-critical-bold")
+    })
+  })
+
+  describe("granularity normalization", () => {
+    it("normalizes a day value to the month granularity range in the displayed value", () => {
+      const onChange = vi.fn()
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={onChange}
+          granularities={["month"]}
+          value={{
+            value: { from: new Date(2025, 6, 15, 10, 30) },
+            granularity: "month",
+          }}
+        />
+      )
+
+      expect(getInput().value).toBe("July 2025")
+      // A controlled value never emits onChange
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("clearing", () => {
+    it("calls onChange with undefined when the clear button is clicked and does not re-fire on a later blur", async () => {
+      const user = setupUser()
+      const onChange = vi.fn()
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={onChange}
+          clearable
+          value={dayValue}
+        />
+      )
+
+      await user.click(screen.getByTestId("clear-button"))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+      expect(onChange.mock.calls[0][0]).toBeUndefined()
+
+      // Blurring the now-empty input resolves to the same undefined value
+      fireEvent.blur(getInput())
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it("puts a required field into the error state when cleared", async () => {
+      const user = setupUser()
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={vi.fn()}
+          clearable
+          required
+          value={dayValue}
+        />
+      )
+
+      await user.click(screen.getByTestId("clear-button"))
+
+      expect(getWrapper().className).toContain("border-f1-border-critical-bold")
+    })
+  })
+
+  describe("presets", () => {
+    it("filters out presets whose granularity is not available", async () => {
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={vi.fn()}
+          open
+          granularities={["day"]}
+          presets={[predefinedPresets.lastQuarter, predefinedPresets.today]}
+        />
+      )
+
+      // The popup portals to document.body, so assertions go through `screen`
+      expect((await screen.findAllByText("Today")).length).toBeGreaterThan(0)
+      expect(screen.queryByText("Last quarter")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("onOpenChange", () => {
+    it("calls the consumer's onOpenChange(true) when the input is focused", () => {
+      const onOpenChange = vi.fn()
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={vi.fn()}
+          onOpenChange={onOpenChange}
+        />
+      )
+
+      fireEvent.focus(getInput())
+
+      expect(onOpenChange).toHaveBeenCalledWith(true)
+    })
+  })
+
+  describe("granularities", () => {
+    it("uses the first granularity as the default (month placeholder)", () => {
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={vi.fn()}
+          granularities={["month"]}
+        />
+      )
+
+      // The placeholder renders as an overlay div with a title attribute
+      expect(screen.getByTitle("mm/yyyy")).toBeInTheDocument()
+    })
+
+    it("defaults to the day granularity when none is provided", () => {
+      render(<F0DatePicker label="Date" onChange={vi.fn()} />)
+
+      expect(screen.getByTitle("dd/mm/yyyy")).toBeInTheDocument()
+    })
+
+    it("throws when rendered with an unknown granularity", () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
+
+      expect(() =>
+        render(
+          <F0DatePicker
+            label="Date"
+            onChange={vi.fn()}
+            granularities={[
+              "bogus" as unknown as NonNullable<
+                Parameters<typeof F0DatePicker>[0]["granularities"]
+              >[number],
+            ]}
+          />
+        )
+      ).toThrow()
+
+      consoleError.mockRestore()
+    })
+  })
+
+  describe("displayFormat", () => {
+    it("renders the long format by default", () => {
+      render(<F0DatePicker label="Date" onChange={vi.fn()} value={dayValue} />)
+
+      expect(getInput().value).toBe("30 Jul 2025")
+    })
+
+    it("renders dd/MM/yyyy with displayFormat='default'", () => {
+      render(
+        <F0DatePicker
+          label="Date"
+          onChange={vi.fn()}
+          value={dayValue}
+          displayFormat="default"
+        />
+      )
+
+      expect(getInput().value).toBe("30/07/2025")
+    })
+  })
+
+  describe("showIcon", () => {
+    it("shows the calendar icon by default", () => {
+      const { container } = render(
+        <F0DatePicker label="Date" onChange={vi.fn()} />
+      )
+
+      expect(container.querySelector('[data-slot="icon"]')).not.toBeNull()
+    })
+
+    it("drops the calendar icon with showIcon={false}", () => {
+      const { container } = render(
+        <F0DatePicker label="Date" onChange={vi.fn()} showIcon={false} />
+      )
+
+      expect(container.querySelector('[data-slot="icon"]')).toBeNull()
+    })
+  })
+})

--- a/packages/react/src/components/F0DatePicker/components/DateInput.tsx
+++ b/packages/react/src/components/F0DatePicker/components/DateInput.tsx
@@ -45,9 +45,13 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     },
     ref
   ) => {
-    const [inputValue, setInputValue] = useState("")
-    const [error, setError] = useState(false)
     const i18n = useI18n()
+    // Initialize with the formatted value: waiting for the sync effect paints
+    // one frame of empty input, flashing the placeholder over the value
+    const [inputValue, setInputValue] = useState(() =>
+      granularity.toString(value?.value, i18n, displayFormat ?? "long")
+    )
+    const [error, setError] = useState(false)
 
     useEffect(() => {
       setInputValue(

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -131,7 +131,14 @@ const OneCalendarInternal = ({
           : date?.from || date?.to || effectiveDefaultMonth
       )
 
-      if (newViewDate !== granularity.getViewDateFromDate(viewDate)) {
+      // Compare instants, not Date identities: `!==` on two Date objects is
+      // always true, which rewrote `viewDate` on every mount (today, or the
+      // nearest bound, to the first of its month) and re-keyed the day grid's
+      // month transition for a same-month change.
+      if (
+        newViewDate.getTime() !==
+        granularity.getViewDateFromDate(viewDate).getTime()
+      ) {
         setViewDate(newViewDate)
       }
     },

--- a/packages/react/src/components/OneCalendar/__tests__/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/__tests__/OneCalendar.test.tsx
@@ -12,3 +12,28 @@ describe("OneCalendar", () => {
     expect(screen.getByText("No periods available")).toBeInTheDocument()
   })
 })
+
+describe("OneCalendar initial month", () => {
+  // Regression: `setSelected` runs on mount and used to compare two Date
+  // objects with `!==`, which is always true, so it rewrote `viewDate` from
+  // the exact instant (today / the nearest bound) to the first of that month.
+  // DayView keyed its motion wrapper on that instant, so the grid was
+  // re-keyed on mount and replayed its 150ms fade. CI's axe pass then sampled
+  // the weekday headers mid-fade and reported a false color-contrast failure.
+  it("renders a single month grid on mount when minDate is in the future", () => {
+    const minDate = new Date()
+    minDate.setMonth(minDate.getMonth() + 2)
+
+    const { container } = render(
+      <OneCalendar mode="single" view="day" minDate={minDate} />
+    )
+
+    expect(container.querySelectorAll("table")).toHaveLength(1)
+  })
+
+  it("renders a single month grid on mount with no bounds", () => {
+    const { container } = render(<OneCalendar mode="single" view="day" />)
+
+    expect(container.querySelectorAll("table")).toHaveLength(1)
+  })
+})

--- a/packages/react/src/components/OneCalendar/granularities/day/DayView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/day/DayView.tsx
@@ -1,3 +1,4 @@
+import { startOfMonth } from "date-fns"
 import { AnimatePresence, motion } from "motion/react"
 import { useCallback } from "react"
 import {
@@ -97,6 +98,12 @@ export function DayView({
     [onSelect, selected]
   )
 
+  // Key the month transition on the month, not on the exact instant `month`
+  // holds: a `month` that moves to another day of the same month must not
+  // replay the exit/enter fade (CI's axe pass sampled that fade mid-flight and
+  // reported a false weekday-header contrast failure).
+  const monthKey = startOfMonth(month).getTime()
+
   const motionVariants = {
     hidden: (direction: number) => ({
       opacity: 0,
@@ -117,7 +124,7 @@ export function DayView({
         custom={motionDirection}
       >
         <motion.div
-          key={month.toISOString()}
+          key={monthKey}
           variants={motionVariants}
           custom={motionDirection}
           initial="hidden"
@@ -143,7 +150,7 @@ export function DayView({
   return (
     <AnimatePresence mode="popLayout" initial={false} custom={motionDirection}>
       <motion.div
-        key={month.toISOString()}
+        key={monthKey}
         variants={motionVariants}
         custom={motionDirection}
         initial="hidden"
@@ -152,7 +159,7 @@ export function DayView({
         transition={{ duration: 0.15, ease: [0.455, 0.03, 0.515, 0.955] }}
       >
         <Calendar
-          key={month.toISOString()}
+          key={monthKey}
           mode="range"
           disabled={disabled}
           selected={selected as DateRange}

--- a/packages/react/src/components/OneCalendar/granularities/day/__tests__/DayView.test.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/day/__tests__/DayView.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { DayView } from "../DayView"
+
+const grid = () => document.querySelectorAll("table")
+
+describe("DayView", () => {
+  it("keeps the same month grid when `month` moves to another day of the same month", () => {
+    const { rerender } = render(
+      <DayView mode="single" month={new Date(2025, 8, 30)} />
+    )
+    const before = grid()
+    expect(before).toHaveLength(1)
+
+    rerender(<DayView mode="single" month={new Date(2025, 8, 1)} />)
+
+    // Same month, same grid: no exit/enter transition should have been started
+    const after = grid()
+    expect(after).toHaveLength(1)
+    expect(after[0]).toBe(before[0])
+  })
+
+  it("swaps the month grid when `month` moves to a different month", () => {
+    const { rerender } = render(
+      <DayView mode="single" month={new Date(2025, 8, 30)} />
+    )
+    const before = grid()[0]
+
+    rerender(<DayView mode="single" month={new Date(2025, 9, 1)} />)
+
+    // A real month change re-keys the grid, so the new month is a new table
+    // (the outgoing one may still be in the DOM while it animates out)
+    const tables = Array.from(grid())
+    expect(tables.some((t) => t !== before)).toBe(true)
+  })
+
+  it("keeps the range grid stable across days of the same month", () => {
+    const { rerender } = render(
+      <DayView mode="range" month={new Date(2025, 8, 30)} />
+    )
+    const before = grid()
+    expect(before).toHaveLength(1)
+
+    rerender(<DayView mode="range" month={new Date(2025, 8, 1)} />)
+
+    const after = grid()
+    expect(after).toHaveLength(1)
+    expect(after[0]).toBe(before[0])
+  })
+})


### PR DESCRIPTION
## Description

Closes the four stable-DoD gaps on DatePicker (unit tests, MDX docs, docs good tier, axe enforced). Writing the tests surfaced two real bugs in the component, both fixed here with regression coverage: typed dates ignored `minDate`/`maxDate`, and the placeholder flashed over the value on every mount.

## Implementation details

- test: add F0DatePicker unit suite (15 tests: blur/Enter commit, out-of-range rejection, granularity normalization, no-op change guard, clearing, preset filtering, onOpenChange, default/unknown granularity, displayFormat, showIcon)
- fix: forward minDate/maxDate to DateInput so typed out-of-range dates error instead of committing

  <details>
  <summary>Why?</summary>

  F0DatePicker only passed minDate/maxDate to the popup, never to DateInput, so the range guard in DateInput.handleNewValue was dead code: a typed out-of-range date committed and fired onChange. minDate/maxDate are the most-used props across the factorial monorepo (~80/69 call sites).
  </details>

- fix: initialize localValue/inputValue from the value prop instead of syncing in an effect

  <details>
  <summary>Why?</summary>

  Both F0DatePicker and DateInput started empty and formatted the value in a useEffect, painting one frame of placeholder over the value on every mount. Axe caught the fade-out mid-transition as a color-contrast violation on 4 stories; lazy state init removes the flash and the violation.
  </details>

- fix(OneCalendar): stop re-keying the month grid on mount

  <details>
  <summary>Why?</summary>

  CI failed `OpensOnMinDate` with weekday-header contrast 4.27 on `#707b8e`. The token flattens to `#647185` (4.96:1, passes); `#707b8e` is that colour at 92.6% opacity on all three channels, so axe sampled a fade. `OneCalendar.setSelected` runs on mount and compared two Date objects with `!==` (always true), rewriting `viewDate` from the min date to the first of its month; `DayView` keyed its framer-motion month wrapper on `month.toISOString()`, so the same-month rewrite re-keyed the grid and replayed the 150ms exit/enter fade on every open. Storybook pauses CSS animations before the a11y addon's axe pass under the test runner, but framer-motion animations keep running, hence the CI-only flake (local `test-storybook` passed 3/3). Fixed with a `getTime()` comparison and a month-granular key; 5 regression tests cover the single-grid mount and same-month vs cross-month re-renders.
  </details>

- docs: add F0DatePicker.mdx (Anatomy, Best Practices, Accessibility, When (not) to use, Controls, DoDonts, 5 Canvas blocks) and drop autodocs
- chore: enforce axe on all DatePicker stories (a11y test "error", remove Snapshot skip, delete allowlist entry)
- chore: remove DatePicker from stable-dod debt list

## Verification

- `check:stable-dod`: DatePicker now in "Truly stable"
- axe probe on the built Storybook: 28/28 DatePicker stories pass
- `pnpm tsc`, oxlint, `oxfmt --check`: clean
- unit suites (F0DatePicker + DatePickerPopup + allowlist): 63/63 pass
- unit suites after the OneCalendar fix (OneCalendar + F0DatePicker + DatePickerPopup): 402/402 pass
- per-frame opacity trace of the `OpensOnMinDate` grid: two overlapping grids fading before the fix, one grid after
- Storybook test runner after the fix: F0DatePicker 16/16 (5 runs), OneCalendar 29/29, DatePickerPopup 12/12
- Storybook test runner: 365 suites / 2349 tests pass
