### PR TITLE
fix(NewHomeLayout): stop clipping the composer's glow

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -821,6 +821,8 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
     // into the main column instead: the PINNED ones near the top, where a
     // mandatory widget belongs, and the rest at the very bottom.
     const stacked = rootWidth > 0 && rootWidth < TWO_COLUMN_MIN_PX
+    const hasRailColumn =
+      sideReady && !stacked && (collapsed || rootWidth >= TWO_COLUMN_MIN_PX)
     const loosePins = {
       pinned: stacked ? rightWidgets.filter((widget) => widget.locked) : [],
       rest: stacked ? rightWidgets.filter((widget) => !widget.locked) : [],
@@ -1055,12 +1057,9 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             // written the variable for the first time — an unresolvable `var()`
             // would invalidate the whole declaration and drop the rail's column
             // for that frame.
-            gridTemplateColumns:
-              sideReady &&
-              !stacked &&
-              (collapsed || rootWidth >= TWO_COLUMN_MIN_PX)
-                ? `minmax(0, 1fr) var(--home-aside-w, ${railWidth}px)`
-                : "minmax(0, 1fr)",
+            gridTemplateColumns: hasRailColumn
+              ? `minmax(0, 1fr) var(--home-aside-w, ${railWidth}px)`
+              : "minmax(0, 1fr)",
           } as CSSProperties
         }
       >
@@ -1177,6 +1176,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             marginBottom: -bleed,
             paddingTop: bleed,
             paddingBottom: bleed,
+            marginLeft: -bleed,
+            paddingLeft: bleed,
+            marginRight: hasRailColumn ? -COLUMN_GAP_PX : -bleed,
+            paddingRight: hasRailColumn ? COLUMN_GAP_PX : bleed,
             ...mainFade.style,
           }}
         >

--- a/packages/react/src/sds/Home/NewHomeLayout/sideBleed.test.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/sideBleed.test.tsx
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+import { Calendar, Clock } from "@/icons/app"
+import { act, zeroRender } from "@/testing/test-utils"
+
+import { type HomeWidgetItem } from "../slotRenderers"
+import { NewHomeLayout } from "./index"
+
+let layoutWidth = 1400
+
+let resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = []
+
+const widget = (id: string): HomeWidgetItem => ({
+  id,
+  icon: id === "clock" ? Clock : Calendar,
+  header: { title: id },
+  slots: [],
+})
+
+const renderLayout = (width: number, props = {}) => {
+  layoutWidth = width
+  return zeroRender(
+    <NewHomeLayout rightWidgets={[widget("clock")]} {...props}>
+      <p>feed</p>
+    </NewHomeLayout>
+  )
+}
+
+const mainColumn = (container: HTMLElement) =>
+  [...container.querySelectorAll<HTMLElement>("div")].find(
+    (el) => el.style.gridColumn === "1"
+  ) as HTMLElement
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => layoutWidth,
+  })
+  resizeCallbacks = []
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: (entries: ResizeObserverEntry[]) => void) {
+        resizeCallbacks.push(callback)
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+  act(() => resizeCallbacks.forEach((notify) => notify([])))
+})
+
+describe("the main column's side bleed", () => {
+  test("grows into the page gutter on both sides, content unmoved", () => {
+    const { container } = renderLayout(700)
+    const main = mainColumn(container)
+
+    expect(main.style.marginLeft).toBe("-24px")
+    expect(main.style.paddingLeft).toBe("24px")
+    expect(main.style.marginRight).toBe("-24px")
+    expect(main.style.paddingRight).toBe("24px")
+  })
+
+  test("takes the gutter's width from the layout's own `bleed`", () => {
+    const { container } = renderLayout(700, { bleed: 40 })
+    const main = mainColumn(container)
+
+    expect(main.style.marginLeft).toBe("-40px")
+    expect(main.style.paddingLeft).toBe("40px")
+  })
+
+  test("stops at the column gap while the rail has a column", () => {
+    const { container } = renderLayout(1000)
+    const main = mainColumn(container)
+
+    expect(main.style.marginRight).toBe("-16px")
+    expect(main.style.paddingRight).toBe("16px")
+    expect(main.style.marginLeft).toBe("-24px")
+  })
+})


### PR DESCRIPTION
## Description

On a narrow screen the F0AiChatTextArea's focus glow was cut to a hard vertical edge down both sides of the Home feed. The main column is a scroll region, and `overflow-y: auto` is never one axis only — the x axis computes to `auto` with it — so the column clips horizontally as well; it bled through the page gutter vertically but not sideways, and where the column is thinner than `mainWidth` the content fills it edge to edge, leaving the composer's ~16px of blurred gradient nothing to spill into. This bleeds the column sideways as it already does top and bottom.

## Type of change

- [x] Bug fix
