### PR TITLE
feat(F0CommunityPostsCarousel): load the next page on a drag

### DIFF
--- a/packages/react/src/experimental/Navigation/Carousel/index.tsx
+++ b/packages/react/src/experimental/Navigation/Carousel/index.tsx
@@ -46,13 +46,15 @@ interface CarouselProps {
   /** The arrows' accessible names. Defaults to "Previous" / "Next". */
   arrowLabels?: { previous?: string; next?: string }
   /**
-   * The slides are ONE PAGE of a longer list. Next then stays live at the end
-   * and fetches the rest instead of going dead — see {@link CarouselPaging}, and
-   * append the new records to `children` as they arrive.
+   * The slides are ONE PAGE of a longer list. Reaching the end then fetches the
+   * rest instead of going dead — see {@link CarouselPaging}, and append the new
+   * records to `children` as they arrive.
    *
-   * `arrowsPlacement: "bottom"` only: the overlay arrows are a hover affordance
-   * over the slides, and a fetch you can't see you triggered is worse than no
-   * fetch at all.
+   * DRAGGING past the last slide asks for the next page whatever the arrows are
+   * doing: it is the reader's own gesture, and nothing about it is hidden. The
+   * ARROW that fetches, though, is `arrowsPlacement: "bottom"`'s only — the
+   * overlay arrows are a hover affordance over the slides, and a fetch you can't
+   * see you triggered is worse than no fetch at all.
    */
   paging?: CarouselPaging
   autoplay?: boolean
@@ -126,6 +128,7 @@ const _Carousel = ({
         containScroll: false,
       }}
       plugins={[plugin.current, WheelGesturesPlugin()].filter(Boolean)}
+      paging={paging}
       onMouseEnter={autoplay ? handleMouseEnter : undefined}
       onMouseLeave={autoplay ? handleMouseLeave : undefined}
     >
@@ -181,11 +184,7 @@ const _Carousel = ({
           )}
         </div>
         {inRow ? (
-          <CarouselControls
-            labels={arrowLabels}
-            showDots={showDots}
-            paging={paging}
-          />
+          <CarouselControls labels={arrowLabels} showDots={showDots} />
         ) : (
           showDots && <CarouselDots />
         )}

--- a/packages/react/src/experimental/Navigation/Carousel/index.tsx
+++ b/packages/react/src/experimental/Navigation/Carousel/index.tsx
@@ -48,13 +48,12 @@ interface CarouselProps {
   /**
    * The slides are ONE PAGE of a longer list. Reaching the end then fetches the
    * rest instead of going dead — see {@link CarouselPaging}, and append the new
-   * records to `children` as they arrive.
+   * records to `children` as they arrive. Dragging past the last slide fetches
+   * in either placement.
    *
-   * DRAGGING past the last slide asks for the next page whatever the arrows are
-   * doing: it is the reader's own gesture, and nothing about it is hidden. The
-   * ARROW that fetches, though, is `arrowsPlacement: "bottom"`'s only — the
-   * overlay arrows are a hover affordance over the slides, and a fetch you can't
-   * see you triggered is worse than no fetch at all.
+   * The ARROW that fetches is `arrowsPlacement: "bottom"`'s only: the overlay
+   * arrows are a hover affordance over the slides, and a fetch you can't see you
+   * triggered is worse than no fetch at all.
    */
   paging?: CarouselPaging
   autoplay?: boolean

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.mdx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.mdx
@@ -19,13 +19,14 @@ with the pagination dots between them.
 
 <Canvas of={Stories.Default} />
 
-| Element    | Description                                                          | Required |
-| ---------- | -------------------------------------------------------------------- | -------- |
-| Cover      | The post's image, always in a 16:9 box sized from the column's width | No       |
-| Title      | The post's name, and the tile's only click target                    | Yes      |
-| Body       | The opening of the post, in the lines the tile has room for          | No       |
-| Author     | Avatar, name, and the date and counters on one line                  | No       |
-| Paging row | Previous / Next and the dots, always present, disabled at the ends   | Yes      |
+| Element      | Description                                                          | Required |
+| ------------ | -------------------------------------------------------------------- | -------- |
+| Cover        | The post's image, always in a 16:9 box sized from the column's width | No       |
+| Title        | The post's name, and the tile's only click target                    | Yes      |
+| Body         | The opening of the post, in the lines the tile has room for          | No       |
+| Author       | Avatar, name, and the date and counters on one line                  | No       |
+| Paging row   | Previous / Next and the dots, always present, disabled at the ends   | Yes      |
+| Placeholders | Tiles for a page that is on its way — the first, or one asked for    | No       |
 
 <Controls of={Stories.Default} />
 
@@ -54,6 +55,18 @@ change how much of every post you could read, too.
 measures them, so every mounted tile stays in the DOM. What keeps that bounded is
 `pagination` — the carousel holds a page and asks for the next one when the reader
 reaches the end, so the DOM follows how far they actually walked.
+
+**The end is reached by hand as often as by arrow.** A row of tiles that scrolls
+under the finger is a row people throw, so **dragging past the last tile** asks
+for the next page exactly as pressing Next does. Both are answered the same way:
+placeholder tiles go where that page will be, the row moves onto them, and they
+become the posts. Anything less and the gesture is a rubber band that springs
+back on a carousel that did nothing.
+
+A page pulled in **ahead** of the reader — the prefetch that fires on arriving at
+the last page — draws none of that. Most fetches here are that one, asked for by
+nobody, and work done ahead of the reader should pass unnoticed rather than invite
+them to wait for it.
 
 <Canvas of={Stories.WithImages} />
 
@@ -96,13 +109,21 @@ accessible names and their tooltips. Both stay in the row at the ends and go
 `disabled` rather than disappearing, so their position never shifts under the
 pointer. The dots come from `CarouselDots` unchanged.
 
-While `loading`, the carousel is `aria-busy` and its placeholder tiles are
-skeletons. Whether a placeholder keeps room for a cover depends on what is
-already known: on the **first** page nothing is loaded yet, so the seat is
-reserved — a card that starts short and grows moves everything under it. On a
-**later** page the loaded posts are asked, so a feed of text posts stops flashing
-an image-shaped hole every time it fetches.
+The row of tiles is `aria-busy` whenever any of it is a placeholder — while
+`loading`, and while a page the reader asked for is on its way. Whether a
+placeholder keeps room for a cover depends on what is already known: on the
+**first** page nothing is loaded yet, so the seat is reserved — a card that starts
+short and grows moves everything under it. On a **later** page the loaded posts
+are asked, so a feed of text posts stops flashing an image-shaped hole every time
+it fetches.
+
+Dragging is an addition to the arrows, never a replacement: both arrows stay in
+the row, named and reachable by keyboard, and `Left`/`Right` page through it. A
+gesture nobody can perform with a keyboard cannot be the only way to the rest of
+the feed.
 
 <Canvas of={Stories.Loading} />
 
 <Canvas of={Stories.PagedFromDataSource} />
+
+<Canvas of={Stories.LoadsMoreOnDrag} />

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
@@ -190,19 +190,23 @@ const FEED = Array.from({ length: 12 }, (_, index) => {
  */
 type PostRecord = CommunityPostSummary & Record<string, unknown>
 
+const FIRST_PAGE_MS = 700
+
 /**
  * A CURSOR-PAGED SOURCE, the shape a real one has: an offset in, a slice out,
- * `hasMore` saying whether the feed continues. The delay is there so the
- * loading tile and the arrow's spinner are actually visible.
+ * `hasMore` saying whether the feed continues. The delays are there so the
+ * loading tiles and the arrow's spinner are actually visible.
  */
-const pagedPosts = () =>
+const pagedPosts = (nextPageMs: number) =>
   createDataSourceDefinition<PostRecord>({
     dataAdapter: {
       paginationType: "infinite-scroll",
       perPage: POSTS_PER_PAGE,
       fetchData: async ({ pagination }) => {
         const from = Number(pagination?.cursor ?? 0)
-        await new Promise((resolve) => setTimeout(resolve, 700))
+        await new Promise((resolve) =>
+          setTimeout(resolve, from === 0 ? FIRST_PAGE_MS : nextPageMs)
+        )
         const records = FEED.slice(from, from + POSTS_PER_PAGE) as PostRecord[]
         const next = from + records.length
         return {
@@ -222,8 +226,10 @@ const pagedPosts = () =>
  * accumulated plus the three fields `pagination` wants, and the carousel does the
  * rest. The component never learns what a data source is.
  */
-const PagedCarousel = () => {
-  const source = useDataSource(useMemo(pagedPosts, []))
+const PagedCarousel = ({ nextPageMs = 700 }: { nextPageMs?: number }) => {
+  const source = useDataSource(
+    useMemo(() => pagedPosts(nextPageMs), [nextPageMs])
+  )
   const { data, isInitialLoading, isLoadingMore, paginationInfo, loadMore } =
     useData(source)
 
@@ -253,9 +259,11 @@ const PagedCarousel = () => {
  * The carousel holds only the pages that have been asked for, so what is in the
  * DOM is bounded by how far you actually walked rather than by how long the feed
  * is. Reaching the last tile asks for the next page BEFORE the arrow is pressed
- * there, so pressing it usually just scrolls; press it early and you get the
- * spinner on the arrow and a placeholder tile to scroll onto while the fetch is
- * in flight. Next only goes dead once the source says `hasMore: false`.
+ * there, so pressing it usually just scrolls; press it early — or throw the row
+ * past the end — and you get the spinner on the arrow and placeholder tiles to
+ * move onto while the fetch is in flight. Next only goes dead once the source
+ * says `hasMore: false`.
+
  *
  * There is no windowing: every page fetched stays mounted (embla measures its
  * own slides, so it cannot page them out). Paging is what keeps that bounded.
@@ -264,20 +272,6 @@ export const PagedFromDataSource: Story = {
   render: () => <PagedCarousel />,
 }
 
-/**
- * THROW THE ROW FORWARD past its last tile, as a hand does: press, drag left,
- * let go.
- *
- * MOUSE events, because that is what embla listens for, and the release goes to
- * the document because that is where it moves its own listeners once it knows
- * the gesture is a mouse.
- *
- * A STEP PER FRAME rather than one jump. Past the end there is nothing to scroll
- * to, so embla answers with a rubber band whose stretch is worked out on its own
- * animation frames — a pointer that teleports 300px is one frame of pull, not
- * twenty, and one frame of pull is not a gesture. 15px a frame for 20 frames is
- * about 300px of unhurried travel, comfortably past what the carousel asks for.
- */
 const throwRowPastTheEnd = async (tile: HTMLElement) => {
   const { left, top, width, height } = tile.getBoundingClientRect()
   const y = top + height / 2
@@ -293,24 +287,19 @@ const throwRowPastTheEnd = async (tile: HTMLElement) => {
   fireEvent.mouseUp(document, { clientX: from - steps * step, clientY: y })
 }
 
+const SLOW_NEXT_PAGE_MS = 2500
+
 /**
- * DRAGGING IS A WAY FORWARD, not just the arrow.
- *
- * The first page of this feed is exactly one screenful, so there is no next snap
- * to walk to and no arrival to prefetch on: the end of the row is the end of
- * everything the carousel has. Thrown past it, it asks the source for the next
- * page, puts placeholder tiles where that page will go, and moves onto them —
- * and they become the posts. Before this, the same gesture was answered by a
- * rubber band and nothing else.
+ * DRAGGING IS A WAY FORWARD, not just the arrow. Thrown past the last tile, the
+ * carousel asks for the next page, puts placeholder tiles where it will go and
+ * moves onto them. The next page takes 2.5s here, so that middle state is
+ * something you can watch.
  */
 export const LoadsMoreOnDrag: Story = {
-  render: () => <PagedCarousel />,
+  render: () => <PagedCarousel nextPageMs={SLOW_NEXT_PAGE_MS} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    // The first page, once it has landed. `findBy` with room to spare rather
-    // than `getBy`: the source is deliberately slow so that the waiting is
-    // visible, and its delay is most of the default timeout on its own.
     const firstTile = await canvas.findByText(
       `${POSTS[0].title} (#1)`,
       {},
@@ -321,11 +310,11 @@ export const LoadsMoreOnDrag: Story = {
 
     await throwRowPastTheEnd(firstTile.closest("[role='group']") as HTMLElement)
 
-    // A post from the SECOND page — the drag was the only thing that asked for
-    // it. `waitFor` spans the fetch and the row's own move onto it.
+    await waitFor(() => expect(canvas.getAllByRole("group")).toHaveLength(4))
+
     await waitFor(
       () => expect(canvas.getByText(`${POSTS[2].title} (#3)`)).toBeVisible(),
-      { timeout: 5000 }
+      { timeout: 15000 }
     )
   },
 }

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
@@ -2,7 +2,14 @@ import { useMemo } from "react"
 
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { expect, fn, userEvent, waitFor, within } from "storybook/test"
+import {
+  expect,
+  fireEvent,
+  fn,
+  userEvent,
+  waitFor,
+  within,
+} from "storybook/test"
 
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
@@ -255,6 +262,72 @@ const PagedCarousel = () => {
  */
 export const PagedFromDataSource: Story = {
   render: () => <PagedCarousel />,
+}
+
+/**
+ * THROW THE ROW FORWARD past its last tile, as a hand does: press, drag left,
+ * let go.
+ *
+ * MOUSE events, because that is what embla listens for, and the release goes to
+ * the document because that is where it moves its own listeners once it knows
+ * the gesture is a mouse.
+ *
+ * A STEP PER FRAME rather than one jump. Past the end there is nothing to scroll
+ * to, so embla answers with a rubber band whose stretch is worked out on its own
+ * animation frames — a pointer that teleports 300px is one frame of pull, not
+ * twenty, and one frame of pull is not a gesture. 15px a frame for 20 frames is
+ * about 300px of unhurried travel, comfortably past what the carousel asks for.
+ */
+const throwRowPastTheEnd = async (tile: HTMLElement) => {
+  const { left, top, width, height } = tile.getBoundingClientRect()
+  const y = top + height / 2
+  const from = left + width - 8
+  const steps = 20
+  const step = 15
+
+  fireEvent.mouseDown(tile, { clientX: from, clientY: y, button: 0 })
+  for (let index = 1; index <= steps; index++) {
+    fireEvent.mouseMove(document, { clientX: from - index * step, clientY: y })
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  fireEvent.mouseUp(document, { clientX: from - steps * step, clientY: y })
+}
+
+/**
+ * DRAGGING IS A WAY FORWARD, not just the arrow.
+ *
+ * The first page of this feed is exactly one screenful, so there is no next snap
+ * to walk to and no arrival to prefetch on: the end of the row is the end of
+ * everything the carousel has. Thrown past it, it asks the source for the next
+ * page, puts placeholder tiles where that page will go, and moves onto them —
+ * and they become the posts. Before this, the same gesture was answered by a
+ * rubber band and nothing else.
+ */
+export const LoadsMoreOnDrag: Story = {
+  render: () => <PagedCarousel />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // The first page, once it has landed. `findBy` with room to spare rather
+    // than `getBy`: the source is deliberately slow so that the waiting is
+    // visible, and its delay is most of the default timeout on its own.
+    const firstTile = await canvas.findByText(
+      `${POSTS[0].title} (#1)`,
+      {},
+      {
+        timeout: 5000,
+      }
+    )
+
+    await throwRowPastTheEnd(firstTile.closest("[role='group']") as HTMLElement)
+
+    // A post from the SECOND page — the drag was the only thing that asked for
+    // it. `waitFor` spans the fetch and the row's own move onto it.
+    await waitFor(
+      () => expect(canvas.getByText(`${POSTS[2].title} (#3)`)).toBeVisible(),
+      { timeout: 5000 }
+    )
+  },
 }
 
 /**

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.test.tsx
@@ -31,7 +31,6 @@ const render = (props = {}) =>
     <F0CommunityPostsCarousel posts={POSTS} labels={LABELS} {...props} />
   )
 
-/** The tiles in the row, placeholders included — one `role="group"` each. */
 const slides = () => screen.getAllByRole("group")
 
 describe("F0CommunityPostsCarousel", () => {
@@ -254,14 +253,8 @@ describe("F0CommunityPostsCarousel", () => {
       expect(screen.getByRole("button", { name: "More posts" })).toBeDisabled()
     })
 
-    /**
-     * THE DRAG ITSELF IS NOT HERE, and cannot be: embla only wires its drag
-     * handler up when `container.offsetParent` is set, and jsdom has no layout,
-     * so `offsetParent` is forever `null` and a carousel in this environment
-     * cannot be dragged at all. What a drag past the end leads to — the ask, the
-     * placeholder page, the row moving onto it — is what these cover; that the
-     * gesture reaches it is `LoadsMoreOnDrag`, in a real browser.
-     */
+    // The drag itself lives in the `LoadsMoreOnDrag` story: jsdom has no layout,
+    // so embla never wires its drag handler up here.
     test("a page the reader is waiting on gets tiles to land on", async () => {
       const onLoadMore = vi.fn()
       const { rerender } = render({
@@ -270,8 +263,6 @@ describe("F0CommunityPostsCarousel", () => {
       })
 
       await userEvent.click(screen.getByRole("button", { name: "More posts" }))
-      // The source answers the ask the way a real one does: a tick later, with
-      // `isLoading` on.
       rerender(
         <F0CommunityPostsCarousel
           posts={POSTS}
@@ -281,9 +272,6 @@ describe("F0CommunityPostsCarousel", () => {
         />
       )
 
-      // The posts already being read stay put, and the page that was asked for
-      // is there as placeholders — which is what the move lands on. Without them
-      // the carousel has nowhere to go and answers a gesture by not moving.
       expect(screen.getByText("Yusuf Adeyemi")).toBeInTheDocument()
       expect(slides()).toHaveLength(POSTS.length + 2)
     })
@@ -318,7 +306,6 @@ describe("F0CommunityPostsCarousel", () => {
       )
 
       expect(screen.getByText("A third post")).toBeInTheDocument()
-      // Not the posts PLUS the grey rectangles that stood in for them.
       expect(slides()).toHaveLength(arrived.length)
     })
 

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.test.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.test.tsx
@@ -31,6 +31,9 @@ const render = (props = {}) =>
     <F0CommunityPostsCarousel posts={POSTS} labels={LABELS} {...props} />
   )
 
+/** The tiles in the row, placeholders included — one `role="group"` each. */
+const slides = () => screen.getAllByRole("group")
+
 describe("F0CommunityPostsCarousel", () => {
   test("draws a tile per post: its title, its body, its author and its counters", () => {
     render()
@@ -249,6 +252,74 @@ describe("F0CommunityPostsCarousel", () => {
       })
 
       expect(screen.getByRole("button", { name: "More posts" })).toBeDisabled()
+    })
+
+    /**
+     * THE DRAG ITSELF IS NOT HERE, and cannot be: embla only wires its drag
+     * handler up when `container.offsetParent` is set, and jsdom has no layout,
+     * so `offsetParent` is forever `null` and a carousel in this environment
+     * cannot be dragged at all. What a drag past the end leads to — the ask, the
+     * placeholder page, the row moving onto it — is what these cover; that the
+     * gesture reaches it is `LoadsMoreOnDrag`, in a real browser.
+     */
+    test("a page the reader is waiting on gets tiles to land on", async () => {
+      const onLoadMore = vi.fn()
+      const { rerender } = render({
+        pagination: { hasMore: true, isLoading: false, onLoadMore },
+        expectedItemsCount: 2,
+      })
+
+      await userEvent.click(screen.getByRole("button", { name: "More posts" }))
+      // The source answers the ask the way a real one does: a tick later, with
+      // `isLoading` on.
+      rerender(
+        <F0CommunityPostsCarousel
+          posts={POSTS}
+          labels={LABELS}
+          expectedItemsCount={2}
+          pagination={{ hasMore: true, isLoading: true, onLoadMore }}
+        />
+      )
+
+      // The posts already being read stay put, and the page that was asked for
+      // is there as placeholders — which is what the move lands on. Without them
+      // the carousel has nowhere to go and answers a gesture by not moving.
+      expect(screen.getByText("Yusuf Adeyemi")).toBeInTheDocument()
+      expect(slides()).toHaveLength(POSTS.length + 2)
+    })
+
+    test("the placeholders give their places up when the posts arrive", async () => {
+      const onLoadMore = vi.fn()
+      const arrived = [
+        ...POSTS,
+        { ...POSTS[0], id: "third", title: "A third post" },
+      ]
+      const { rerender } = render({
+        pagination: { hasMore: true, isLoading: false, onLoadMore },
+        expectedItemsCount: 2,
+      })
+
+      await userEvent.click(screen.getByRole("button", { name: "More posts" }))
+      rerender(
+        <F0CommunityPostsCarousel
+          posts={POSTS}
+          labels={LABELS}
+          expectedItemsCount={2}
+          pagination={{ hasMore: true, isLoading: true, onLoadMore }}
+        />
+      )
+      rerender(
+        <F0CommunityPostsCarousel
+          posts={arrived}
+          labels={LABELS}
+          expectedItemsCount={2}
+          pagination={{ hasMore: true, isLoading: false, onLoadMore }}
+        />
+      )
+
+      expect(screen.getByText("A third post")).toBeInTheDocument()
+      // Not the posts PLUS the grey rectangles that stood in for them.
+      expect(slides()).toHaveLength(arrived.length)
     })
 
     test("only the pages fetched are in the DOM", () => {

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.tsx
@@ -11,6 +11,7 @@ import {
   CarouselContent,
   CarouselControls,
   CarouselItem,
+  useCarouselPaging,
   type CarouselPaging,
 } from "@/ui/carousel"
 import { Skeleton } from "@/ui/skeleton"
@@ -476,12 +477,18 @@ export interface F0CommunityPostsCarouselProps {
    * blank the tiles you are already reading.
    */
   loading?: boolean
-  /** How many placeholder tiles `loading` draws. Defaults to 2 — one screenful. */
+  /**
+   * How many placeholder tiles are drawn. Defaults to 2 — one screenful.
+   *
+   * It is the count for both kinds of wait: the whole row while `loading`, and
+   * the page at the end of the row that a reader asked for and is waiting on.
+   */
   expectedItemsCount?: number
   /**
-   * THE POSTS ARE A PAGE, not the whole feed. Pass this and the Next arrow stays
-   * live past the last mounted tile: reaching the end asks for the next page, and
-   * the new posts are appended to `posts` by whoever owns them.
+   * THE POSTS ARE A PAGE, not the whole feed. Pass this and the end of the row
+   * stops being the end of the feed: the Next arrow stays live past the last
+   * mounted tile, DRAGGING past it asks too, and the new posts are appended to
+   * `posts` by whoever owns them.
    *
    * It is `useData`'s infinite-scroll return, field for field — `hasMore` off
    * `paginationInfo`, `isLoadingMore`, `loadMore` — because that is where these
@@ -492,6 +499,69 @@ export interface F0CommunityPostsCarouselProps {
    * "latest five" is.
    */
   pagination?: CarouselPaging
+}
+
+/**
+ * THE WIDTH OF ONE TILE — the whole card under 480px of CARD (`@lg`), half of it
+ * above, which is the same width at which the `Widget` frame itself decides it is
+ * wide. Shared, because a placeholder tile that took a different width would
+ * change how many fit and move the page boundaries under the reader.
+ */
+const TILE_WIDTH = "basis-full @lg:basis-1/2"
+
+/**
+ * THE ROW ITSELF: a tile per post, and placeholders for whatever page has not
+ * arrived.
+ *
+ * Its own component because of the question in the middle of it — is a page THE
+ * READER IS STANDING ON in flight? That is the carousel's answer, not this
+ * widget's, and it can only be asked from inside one.
+ */
+const CommunityPostsSlides = ({
+  posts,
+  loading,
+  expectedItemsCount,
+}: {
+  posts: CommunityPostSummary[]
+  loading: boolean
+  expectedItemsCount: number
+}) => {
+  const { isPageInFlight } = useCarouselPaging()
+
+  /**
+   * PLACEHOLDER TILES, for two quite different waits:
+   *
+   * - `loading` — the FIRST posts. There is nothing else in the row, so these
+   *   ARE the row, and their job is to give the card the height it will have.
+   * - `isPageInFlight` — a LATER page, asked for by the reader: the Next arrow
+   *   at the end of the feed, or a drag thrown past it. The posts already in
+   *   hand stay exactly where they are and the placeholders go after them, which
+   *   is what the gesture then moves onto — a page in the shape of the posts
+   *   that are coming, rather than a rubber band that springs back and a row
+   *   that never went anywhere.
+   *
+   * A page pulled in AHEAD of the reader draws none of this. Most fetches here
+   * are that prefetch, asked for by nobody, and work done ahead of the reader
+   * should pass unnoticed instead of inviting them to wait for it.
+   */
+  const placeholders = loading || isPageInFlight ? expectedItemsCount : 0
+
+  return (
+    <CarouselContent aria-busy={loading || isPageInFlight || undefined}>
+      {loading
+        ? null
+        : posts.map((post) => (
+            <CarouselItem key={post.id} className={TILE_WIDTH}>
+              <CommunityPostCard post={post} />
+            </CarouselItem>
+          ))}
+      {Array.from({ length: placeholders }, (_, index) => (
+        <CarouselItem key={`placeholder-${index}`} className={TILE_WIDTH}>
+          <CommunityPostCardSkeleton withImage={reservesImageSeat(posts)} />
+        </CarouselItem>
+      ))}
+    </CarouselContent>
+  )
 }
 
 /**
@@ -524,6 +594,13 @@ export interface F0CommunityPostsCarouselProps {
  * a longer carousel, it is a carousel that holds a PAGE and asks for the next
  * one when you reach the end — so what is mounted is bounded by how far the
  * reader actually walked rather than by how much the server has.
+ *
+ * AND THE END IS REACHED BY HAND AS OFTEN AS BY ARROW. A row of tiles that
+ * scrolls under the finger is a row people throw, so a drag past the last tile
+ * asks for the next page exactly as the arrow does, and both are answered the
+ * same way: placeholder tiles at the end of the row, which the row then moves
+ * onto and which become the posts. Anything less and the gesture is a rubber
+ * band that springs back on a carousel that did nothing.
  */
 export const F0CommunityPostsCarousel = ({
   posts,
@@ -532,26 +609,6 @@ export const F0CommunityPostsCarousel = ({
   expectedItemsCount = 2,
   pagination,
 }: F0CommunityPostsCarouselProps) => {
-  const items = loading
-    ? Array.from({ length: expectedItemsCount }, (_, index) => (
-        <CommunityPostCardSkeleton
-          key={index}
-          withImage={reservesImageSeat(posts)}
-        />
-      ))
-    : // NO TILE FOR THE PAGE IN FLIGHT. There used to be one, to give the
-      // carousel somewhere to scroll to while a fetch ran — but most fetches
-      // here are PREFETCHES, pulled in when the reader reaches the last page and
-      // asked for by nobody. A placeholder tile made every one of them visible,
-      // which is the opposite of the point: work done ahead of the reader should
-      // pass unnoticed.
-      //
-      // A press that genuinely has to wait is answered instead by the arrow
-      // (`isAwaitingPage` puts the spinner there) and by the row moving on its
-      // own the moment the page lands, onto real posts rather than onto a grey
-      // rectangle that then becomes them.
-      posts.map((post) => <CommunityPostCard key={post.id} post={post} />)
-
   return (
     <Carousel
       opts={{
@@ -573,18 +630,17 @@ export const F0CommunityPostsCarousel = ({
       // not the window's: the same widget sits in a 712px main column and in a
       // 396px rail, and a viewport media query cannot tell those apart.
       className="@container"
-      {...(loading ? { "aria-busy": true } : {})}
+      // ON THE CAROUSEL, not on the paging row: the arrow is one of the ways to
+      // reach the next page and the drag is another, and the tiles have to know
+      // about the fetch either way to stand in for it.
+      paging={pagination}
     >
-      <CarouselContent>
-        {items.map((item, index) => (
-          // `basis-full` under 480px of CARD (`@lg`), half above it — the same
-          // width at which the `Widget` frame itself decides it is wide.
-          <CarouselItem key={index} className="basis-full @lg:basis-1/2">
-            {item}
-          </CarouselItem>
-        ))}
-      </CarouselContent>
-      <CarouselControls labels={labels} paging={pagination} />
+      <CommunityPostsSlides
+        posts={posts}
+        loading={loading}
+        expectedItemsCount={expectedItemsCount}
+      />
+      <CarouselControls labels={labels} />
     </Carousel>
   )
 }

--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.tsx
@@ -477,18 +477,13 @@ export interface F0CommunityPostsCarouselProps {
    * blank the tiles you are already reading.
    */
   loading?: boolean
-  /**
-   * How many placeholder tiles are drawn. Defaults to 2 — one screenful.
-   *
-   * It is the count for both kinds of wait: the whole row while `loading`, and
-   * the page at the end of the row that a reader asked for and is waiting on.
-   */
+  /** How many placeholder tiles are drawn. Defaults to 2 — one screenful. */
   expectedItemsCount?: number
   /**
-   * THE POSTS ARE A PAGE, not the whole feed. Pass this and the end of the row
-   * stops being the end of the feed: the Next arrow stays live past the last
-   * mounted tile, DRAGGING past it asks too, and the new posts are appended to
-   * `posts` by whoever owns them.
+   * THE POSTS ARE A PAGE, not the whole feed. Pass this and the Next arrow stays
+   * live past the last mounted tile — as does dragging past it: reaching the end
+   * asks for the next page, and the new posts are appended to `posts` by whoever
+   * owns them.
    *
    * It is `useData`'s infinite-scroll return, field for field — `hasMore` off
    * `paginationInfo`, `isLoadingMore`, `loadMore` — because that is where these
@@ -501,22 +496,10 @@ export interface F0CommunityPostsCarouselProps {
   pagination?: CarouselPaging
 }
 
-/**
- * THE WIDTH OF ONE TILE — the whole card under 480px of CARD (`@lg`), half of it
- * above, which is the same width at which the `Widget` frame itself decides it is
- * wide. Shared, because a placeholder tile that took a different width would
- * change how many fit and move the page boundaries under the reader.
- */
+// `basis-full` under 480px of CARD (`@lg`), half above it — the same width at
+// which the `Widget` frame itself decides it is wide.
 const TILE_WIDTH = "basis-full @lg:basis-1/2"
 
-/**
- * THE ROW ITSELF: a tile per post, and placeholders for whatever page has not
- * arrived.
- *
- * Its own component because of the question in the middle of it — is a page THE
- * READER IS STANDING ON in flight? That is the carousel's answer, not this
- * widget's, and it can only be asked from inside one.
- */
 const CommunityPostsSlides = ({
   posts,
   loading,
@@ -528,22 +511,6 @@ const CommunityPostsSlides = ({
 }) => {
   const { isPageInFlight } = useCarouselPaging()
 
-  /**
-   * PLACEHOLDER TILES, for two quite different waits:
-   *
-   * - `loading` — the FIRST posts. There is nothing else in the row, so these
-   *   ARE the row, and their job is to give the card the height it will have.
-   * - `isPageInFlight` — a LATER page, asked for by the reader: the Next arrow
-   *   at the end of the feed, or a drag thrown past it. The posts already in
-   *   hand stay exactly where they are and the placeholders go after them, which
-   *   is what the gesture then moves onto — a page in the shape of the posts
-   *   that are coming, rather than a rubber band that springs back and a row
-   *   that never went anywhere.
-   *
-   * A page pulled in AHEAD of the reader draws none of this. Most fetches here
-   * are that prefetch, asked for by nobody, and work done ahead of the reader
-   * should pass unnoticed instead of inviting them to wait for it.
-   */
   const placeholders = loading || isPageInFlight ? expectedItemsCount : 0
 
   return (
@@ -594,13 +561,6 @@ const CommunityPostsSlides = ({
  * a longer carousel, it is a carousel that holds a PAGE and asks for the next
  * one when you reach the end — so what is mounted is bounded by how far the
  * reader actually walked rather than by how much the server has.
- *
- * AND THE END IS REACHED BY HAND AS OFTEN AS BY ARROW. A row of tiles that
- * scrolls under the finger is a row people throw, so a drag past the last tile
- * asks for the next page exactly as the arrow does, and both are answered the
- * same way: placeholder tiles at the end of the row, which the row then moves
- * onto and which become the posts. Anything less and the gesture is a rubber
- * band that springs back on a carousel that did nothing.
  */
 export const F0CommunityPostsCarousel = ({
   posts,
@@ -630,9 +590,6 @@ export const F0CommunityPostsCarousel = ({
       // not the window's: the same widget sits in a 712px main column and in a
       // 396px rail, and a viewport media query cannot tell those apart.
       className="@container"
-      // ON THE CAROUSEL, not on the paging row: the arrow is one of the ways to
-      // reach the next page and the drag is another, and the tiles have to know
-      // about the fetch either way to stand in for it.
       paging={pagination}
     >
       <CommunityPostsSlides

--- a/packages/react/src/ui/carousel.tsx
+++ b/packages/react/src/ui/carousel.tsx
@@ -44,14 +44,6 @@ type CarouselProps = {
   plugins?: CarouselPlugin
   orientation?: "horizontal" | "vertical"
   setApi?: (api: CarouselApi) => void
-  /**
-   * THE SLIDES ARE ONE PAGE of a longer list — see {@link CarouselPaging}.
-   *
-   * It belongs to the carousel rather than to its controls because two different
-   * things need the answer: the arrow that fetches when it has nowhere left to
-   * scroll, and the CONTENT, which draws the placeholder page a reader-driven
-   * fetch is answered with (see {@link useCarouselPaging}).
-   */
   paging?: CarouselPaging
 }
 
@@ -62,7 +54,6 @@ type CarouselContextProps = {
   scrollNext: () => void
   canScrollPrev: boolean
   canScrollNext: boolean
-  /** What this carousel's paging is doing — {@link useCarouselPaging}. */
   pagingState: CarouselPagingState
 } & Omit<CarouselProps, "paging">
 
@@ -91,14 +82,7 @@ function useCarousel() {
 export type CarouselPaging = {
   /** Whether the source has records past the slides currently mounted. */
   hasMore: boolean
-  /**
-   * A fetch for the next page is in flight.
-   *
-   * It is also what puts a PLACEHOLDER PAGE at the end of the row: the carousel
-   * knows a page the reader is standing on is still coming only because of this
-   * field. A source that leaves it out still pages — the row simply has nothing
-   * to move onto until the records land.
-   */
+  /** A fetch for the next page is in flight. */
   isLoading?: boolean
   /** Fetch the next page and APPEND it to the slides. */
   onLoadMore: () => void
@@ -115,22 +99,10 @@ export type CarouselPaging = {
   total?: number
 }
 
-/** What the enclosing carousel's paging is doing — {@link useCarouselPaging}. */
 export type CarouselPagingState = {
-  /** Whether forward is possible at all: a next slide, or a next page. */
   canGoNext: boolean
-  /** Forward — scroll if there is room, fetch the next page if there isn't. */
   goNext: () => void
-  /**
-   * A MOVE THE READER ASKED FOR that has not happened yet. The Next arrow's
-   * spinner and nothing else: a page pulled in ahead of them is not a wait.
-   */
   isAwaitingPage: boolean
-  /**
-   * A page THE READER IS STANDING ON is in flight, so the content should draw
-   * placeholder slides for it at the end of the row — that is what the move
-   * they asked for lands on while the records are still coming.
-   */
   isPageInFlight: boolean
 }
 
@@ -141,37 +113,18 @@ export type CarouselPagingState = {
 const countSlides = (api: CarouselApi) =>
   api?.containerNode()?.childElementCount ?? 0
 
-/**
- * HOW FAR PAST THE LAST SLIDE a drag has to pull before it counts as asking for
- * the next page, as a percentage of the carousel's own width.
- *
- * There is nothing to scroll to at the end of the last page, so embla answers a
- * forward drag there with a rubber band: the track follows the finger against a
- * friction that grows with the distance, and springs back on release. That pull
- * is all there is to read the gesture from — the events say nothing about how
- * far the finger went, only where the row ended up.
- *
- * A PERCENTAGE, because the band itself is one: embla's resistance ramps up over
- * half the view, so the same pull costs proportionally the same effort on a
- * 752px card and on a phone. Measured on the real thing, 5% is around 80px of
- * finger travel at an unhurried speed and far less when thrown — while a wobble
- * of a tile or two under a click never leaves the first few pixels.
- */
 const DRAG_PAST_END_PERCENT = 5
 
 /**
- * Makes the Next arrow tell the truth when the slides are a page, and gives the
- * content a way to show the page that is coming.
+ * Makes the Next arrow tell the truth when the slides are a page.
  *
  * THREE WAYS THE NEXT PAGE IS ASKED FOR, and they cover each other:
  *
  * - PRESSING NEXT at the end of what is mounted. `goNext` scrolls if there is
  *   anywhere to scroll and fetches if there isn't, so the arrow always does
  *   something as long as the feed continues.
- * - DRAGGING PAST THE END. The row rubber-bands because there is no next slide
- *   yet, which is a reader saying "further" with the only gesture they have. A
- *   pull past {@link DRAG_PAST_END_PERCENT} fetches, exactly as the arrow does —
- *   an arrow is not the only way forward on a surface built to be thrown.
+ * - DRAGGING past the end, which rubber-bands because the next slide does not
+ *   exist yet. A pull past `DRAG_PAST_END_PERCENT` of the view fetches too.
  * - ARRIVING at the last snap, which fetches the page after it. So walking
  *   through a carousel stays smooth: the page you are about to need is usually
  *   already in flight by the time you ask for it.
@@ -194,25 +147,21 @@ const usePagingState = (
   const onLoadMore = paging?.onLoadMore
 
   /**
-   * THE MOVE THE READER ASKED FOR, still owed.
+   * THE MOVE THE READER ASKED FOR, still owed — and the only reason to show that
+   * anything is loading at all.
    *
-   * Pressing Next — or throwing the row — at the end of a page cannot scroll
-   * yet, because the slides do not exist. So the ask is remembered and finished
-   * the moment there is somewhere to go: without it the carousel fetches, fills,
-   * and then just sits there, having moved nothing in answer to a gesture.
+   * Pressing Next at the end of a page cannot scroll yet, because the slides do
+   * not exist. So the press is remembered and finished the moment there is
+   * somewhere to go: without it the carousel fetches, fills, and then just sits
+   * there, having moved nothing in answer to an arrow.
+   *
+   * It is STATE rather than a ref because it is also the answer to "is anybody
+   * waiting on this fetch". A page pulled in ahead of the reader — the prefetch
+   * on arriving at the last page — is work nobody asked about, and announcing it
+   * with a spinner invites them to wait for something that was never in their
+   * way. Only a fetch somebody is standing on says so.
    */
   const [owedNext, setOwedNext] = React.useState(false)
-  /**
-   * WHETHER ANYBODY IS STANDING ON THE FETCH — kept apart from `owedNext`
-   * because the two stop being true at different moments. The owed move is spent
-   * as soon as there is a slide to scroll to, which is the PLACEHOLDER page; the
-   * wait lasts until the records themselves land, and so does the placeholder.
-   *
-   * A page pulled in ahead of the reader — the prefetch on arriving at the last
-   * page — is work nobody asked about, and announcing it invites them to wait
-   * for something that was never in their way. Only a fetch somebody is standing
-   * on says so.
-   */
   const [awaitedPage, setAwaitedPage] = React.useState(false)
   // Whether the load in flight is the one that just finished, so an owed move
   // that turned out to have nowhere to go stops waiting instead of hanging.
@@ -226,17 +175,14 @@ const usePagingState = (
   const latest = React.useRef({ hasMore, isLoading, onLoadMore, owedNext })
   latest.current = { hasMore, isLoading, onLoadMore, owedNext }
 
-  /** The reader wants the next page — from the arrow or from the drag. */
   const askForNextPage = React.useCallback(() => {
     const { hasMore, isLoading, onLoadMore, owedNext } = latest.current
     if (!hasMore || !onLoadMore) return
-    // Already asked and still waiting: the move is on the books and the records
-    // are on their way. Asking again is not how they arrive sooner.
     if (owedNext) return
     slidesAtAsk.current = countSlides(api)
     setOwedNext(true)
     setAwaitedPage(true)
-    // Recorded whether or not we are the ones who ask: a gesture landing while a
+    // Recorded whether or not we are the ones who ask: a press landing while a
     // page is already in flight must still move the row when it lands, and
     // asking twice for the same records is not the way to make that happen.
     if (!isLoading) onLoadMore()
@@ -250,33 +196,16 @@ const usePagingState = (
       if (!hasMore || isLoading || !onLoadMore) return
       const snaps = api.scrollSnapList().length
       if (api.selectedScrollSnap() < snaps - 1) return
-      // THIS one is nobody's wait, whatever the last one was. A source that
-      // answers so fast it never reports `isLoading` leaves the previous ask
-      // with no settling to clear it, and the next page in flight would then
-      // draw a placeholder the reader never asked for. Reaching here says the
-      // carousel is idle and moving on, which is when that can be let go of.
       setAwaitedPage(false)
       onLoadMore()
     }
 
-    /**
-     * A pull past the end that has gone far enough to be an ask.
-     *
-     * ARMED HERE, SENT ON RELEASE. Appending slides makes embla re-measure
-     * itself, and re-measuring mid-gesture drops the drag the reader is still in
-     * the middle of — so a pull that clears the threshold is only remembered
-     * while the finger is down. Nothing else can arm it: embla constrains the
-     * momentum of a throw to a snap it already has, so track past the last slide
-     * only ever exists under a pointer.
-     */
     let pulledPastEnd = false
 
     const watchPull = () => {
       const { dragHandler, limit, location, percentOfView } =
         api.internalEngine()
       if (!dragHandler.pointerDown()) return
-      // Scroll positions run NEGATIVE as the row advances, so the far end is
-      // `limit.min` and anything below it is track the drag is holding open.
       const pull = limit.min - location.get()
       if (pull < percentOfView.measure(DRAG_PAST_END_PERCENT)) return
       pulledPastEnd = true
@@ -308,8 +237,6 @@ const usePagingState = (
   React.useEffect(() => {
     const settled = wasLoading.current && !isLoading
     wasLoading.current = isLoading
-    // The page somebody was standing on has arrived — or come back empty. Either
-    // way the wait is over, and with it the placeholder that stood in for it.
     if (settled) setAwaitedPage(false)
     if (!owedNext) return
     if (canScrollNext) {
@@ -339,6 +266,7 @@ const usePagingState = (
 
   return {
     canGoNext: canScrollNext || (hasMore && !isLoading),
+    /** A fetch the reader is actually standing on. */
     isAwaitingPage: owedNext,
     isPageInFlight: awaitedPage && isLoading,
     goNext: () => {
@@ -351,16 +279,6 @@ const usePagingState = (
   }
 }
 
-/**
- * THE PAGING STATE of the enclosing carousel, for content that has to draw
- * something while a page the reader asked for is on its way.
- *
- * A carousel whose slides are a page cannot answer a gesture past the last one
- * by scrolling — the slide is not there yet. What it does instead is fetch, and
- * `isPageInFlight` is the moment in between: append that many placeholder slides
- * and the move the reader asked for has somewhere to land, in the shape of the
- * records that are coming.
- */
 const useCarouselPaging = (): CarouselPagingState => useCarousel().pagingState
 
 const Carousel = React.forwardRef<
@@ -762,9 +680,6 @@ const CarouselControls = React.forwardRef<
   }
 >(({ className, labels, showDots = true, ...props }, ref) => {
   const { scrollPrev, canScrollPrev } = useCarousel()
-  // That the slides are a PAGE of a longer list is the CAROUSEL's `paging` prop
-  // rather than this row's: the content needs the same answer to draw the page
-  // in flight, and of two copies one is always the stale one.
   const { canGoNext, goNext, isAwaitingPage } = useCarouselPaging()
 
   return (

--- a/packages/react/src/ui/carousel.tsx
+++ b/packages/react/src/ui/carousel.tsx
@@ -44,6 +44,15 @@ type CarouselProps = {
   plugins?: CarouselPlugin
   orientation?: "horizontal" | "vertical"
   setApi?: (api: CarouselApi) => void
+  /**
+   * THE SLIDES ARE ONE PAGE of a longer list — see {@link CarouselPaging}.
+   *
+   * It belongs to the carousel rather than to its controls because two different
+   * things need the answer: the arrow that fetches when it has nowhere left to
+   * scroll, and the CONTENT, which draws the placeholder page a reader-driven
+   * fetch is answered with (see {@link useCarouselPaging}).
+   */
+  paging?: CarouselPaging
 }
 
 type CarouselContextProps = {
@@ -53,7 +62,9 @@ type CarouselContextProps = {
   scrollNext: () => void
   canScrollPrev: boolean
   canScrollNext: boolean
-} & CarouselProps
+  /** What this carousel's paging is doing — {@link useCarouselPaging}. */
+  pagingState: CarouselPagingState
+} & Omit<CarouselProps, "paging">
 
 const CarouselContext = React.createContext<CarouselContextProps | null>(null)
 
@@ -67,6 +78,291 @@ function useCarousel() {
   return context
 }
 
+/**
+ * A carousel whose slides are ONE PAGE of a longer list.
+ *
+ * A carousel can only reason about the slides it holds, so on its own it says
+ * "there is no next one" the moment it reaches the last one it was given — which
+ * is wrong when the list continues on the server. This is the missing half of
+ * that answer, and it is deliberately the shape `useData` already returns for an
+ * infinite-scroll source (`paginationInfo.hasMore`, `isLoadingMore`, `loadMore`),
+ * so wiring one to the other is passing three fields across.
+ */
+export type CarouselPaging = {
+  /** Whether the source has records past the slides currently mounted. */
+  hasMore: boolean
+  /**
+   * A fetch for the next page is in flight.
+   *
+   * It is also what puts a PLACEHOLDER PAGE at the end of the row: the carousel
+   * knows a page the reader is standing on is still coming only because of this
+   * field. A source that leaves it out still pages — the row simply has nothing
+   * to move onto until the records land.
+   */
+  isLoading?: boolean
+  /** Fetch the next page and APPEND it to the slides. */
+  onLoadMore: () => void
+  /**
+   * How many records the source holds ALTOGETHER, when it says — `useData`'s
+   * `totalItems`. For anything that reports a position out loud ("3 of 11"):
+   * without it the only number available is how many have been loaded, which
+   * moves every time another page arrives.
+   *
+   * The carousel itself ignores it. Its dots describe the slides that exist, and
+   * a dot for a page nobody has fetched would be a control that cannot be
+   * pressed.
+   */
+  total?: number
+}
+
+/** What the enclosing carousel's paging is doing — {@link useCarouselPaging}. */
+export type CarouselPagingState = {
+  /** Whether forward is possible at all: a next slide, or a next page. */
+  canGoNext: boolean
+  /** Forward — scroll if there is room, fetch the next page if there isn't. */
+  goNext: () => void
+  /**
+   * A MOVE THE READER ASKED FOR that has not happened yet. The Next arrow's
+   * spinner and nothing else: a page pulled in ahead of them is not a wait.
+   */
+  isAwaitingPage: boolean
+  /**
+   * A page THE READER IS STANDING ON is in flight, so the content should draw
+   * placeholder slides for it at the end of the row — that is what the move
+   * they asked for lands on while the records are still coming.
+   */
+  isPageInFlight: boolean
+}
+
+/**
+ * How many slides are IN THE DOM right now — React's view, not the carousel's
+ * cached one, which lags a re-measure behind.
+ */
+const countSlides = (api: CarouselApi) =>
+  api?.containerNode()?.childElementCount ?? 0
+
+/**
+ * HOW FAR PAST THE LAST SLIDE a drag has to pull before it counts as asking for
+ * the next page, as a percentage of the carousel's own width.
+ *
+ * There is nothing to scroll to at the end of the last page, so embla answers a
+ * forward drag there with a rubber band: the track follows the finger against a
+ * friction that grows with the distance, and springs back on release. That pull
+ * is all there is to read the gesture from — the events say nothing about how
+ * far the finger went, only where the row ended up.
+ *
+ * A PERCENTAGE, because the band itself is one: embla's resistance ramps up over
+ * half the view, so the same pull costs proportionally the same effort on a
+ * 752px card and on a phone. Measured on the real thing, 5% is around 80px of
+ * finger travel at an unhurried speed and far less when thrown — while a wobble
+ * of a tile or two under a click never leaves the first few pixels.
+ */
+const DRAG_PAST_END_PERCENT = 5
+
+/**
+ * Makes the Next arrow tell the truth when the slides are a page, and gives the
+ * content a way to show the page that is coming.
+ *
+ * THREE WAYS THE NEXT PAGE IS ASKED FOR, and they cover each other:
+ *
+ * - PRESSING NEXT at the end of what is mounted. `goNext` scrolls if there is
+ *   anywhere to scroll and fetches if there isn't, so the arrow always does
+ *   something as long as the feed continues.
+ * - DRAGGING PAST THE END. The row rubber-bands because there is no next slide
+ *   yet, which is a reader saying "further" with the only gesture they have. A
+ *   pull past {@link DRAG_PAST_END_PERCENT} fetches, exactly as the arrow does —
+ *   an arrow is not the only way forward on a surface built to be thrown.
+ * - ARRIVING at the last snap, which fetches the page after it. So walking
+ *   through a carousel stays smooth: the page you are about to need is usually
+ *   already in flight by the time you ask for it.
+ *
+ * ARRIVAL, not render. The prefetch is bound to embla's `select` — a real
+ * navigation — rather than run whenever the paging props change. That is what
+ * makes it loop-proof without a bookkeeping ref: a source that answers
+ * `hasMore: true` with no new records leaves you on the same snap, no `select`
+ * fires, and nothing asks again. It also means a carousel nobody touched fetches
+ * exactly the page it was given, which is the point of paging.
+ */
+const usePagingState = (
+  api: CarouselApi,
+  canScrollNext: boolean,
+  scrollNext: () => void,
+  paging?: CarouselPaging
+): CarouselPagingState => {
+  const hasMore = paging?.hasMore ?? false
+  const isLoading = paging?.isLoading ?? false
+  const onLoadMore = paging?.onLoadMore
+
+  /**
+   * THE MOVE THE READER ASKED FOR, still owed.
+   *
+   * Pressing Next — or throwing the row — at the end of a page cannot scroll
+   * yet, because the slides do not exist. So the ask is remembered and finished
+   * the moment there is somewhere to go: without it the carousel fetches, fills,
+   * and then just sits there, having moved nothing in answer to a gesture.
+   */
+  const [owedNext, setOwedNext] = React.useState(false)
+  /**
+   * WHETHER ANYBODY IS STANDING ON THE FETCH — kept apart from `owedNext`
+   * because the two stop being true at different moments. The owed move is spent
+   * as soon as there is a slide to scroll to, which is the PLACEHOLDER page; the
+   * wait lasts until the records themselves land, and so does the placeholder.
+   *
+   * A page pulled in ahead of the reader — the prefetch on arriving at the last
+   * page — is work nobody asked about, and announcing it invites them to wait
+   * for something that was never in their way. Only a fetch somebody is standing
+   * on says so.
+   */
+  const [awaitedPage, setAwaitedPage] = React.useState(false)
+  // Whether the load in flight is the one that just finished, so an owed move
+  // that turned out to have nowhere to go stops waiting instead of hanging.
+  const wasLoading = React.useRef(isLoading)
+  /** How many slides there were when the move was asked for. */
+  const slidesAtAsk = React.useRef(0)
+
+  // The listeners are bound ONCE per carousel and read the paging state through
+  // a ref: subscribing on every change of `hasMore`/`isLoading` would tear the
+  // handlers down and rebuild them in the middle of the very fetch they started.
+  const latest = React.useRef({ hasMore, isLoading, onLoadMore, owedNext })
+  latest.current = { hasMore, isLoading, onLoadMore, owedNext }
+
+  /** The reader wants the next page — from the arrow or from the drag. */
+  const askForNextPage = React.useCallback(() => {
+    const { hasMore, isLoading, onLoadMore, owedNext } = latest.current
+    if (!hasMore || !onLoadMore) return
+    // Already asked and still waiting: the move is on the books and the records
+    // are on their way. Asking again is not how they arrive sooner.
+    if (owedNext) return
+    slidesAtAsk.current = countSlides(api)
+    setOwedNext(true)
+    setAwaitedPage(true)
+    // Recorded whether or not we are the ones who ask: a gesture landing while a
+    // page is already in flight must still move the row when it lands, and
+    // asking twice for the same records is not the way to make that happen.
+    if (!isLoading) onLoadMore()
+  }, [api])
+
+  React.useEffect(() => {
+    if (!api) return
+
+    const prefetchIfAtEnd = () => {
+      const { hasMore, isLoading, onLoadMore } = latest.current
+      if (!hasMore || isLoading || !onLoadMore) return
+      const snaps = api.scrollSnapList().length
+      if (api.selectedScrollSnap() < snaps - 1) return
+      // THIS one is nobody's wait, whatever the last one was. A source that
+      // answers so fast it never reports `isLoading` leaves the previous ask
+      // with no settling to clear it, and the next page in flight would then
+      // draw a placeholder the reader never asked for. Reaching here says the
+      // carousel is idle and moving on, which is when that can be let go of.
+      setAwaitedPage(false)
+      onLoadMore()
+    }
+
+    /**
+     * A pull past the end that has gone far enough to be an ask.
+     *
+     * ARMED HERE, SENT ON RELEASE. Appending slides makes embla re-measure
+     * itself, and re-measuring mid-gesture drops the drag the reader is still in
+     * the middle of — so a pull that clears the threshold is only remembered
+     * while the finger is down. Nothing else can arm it: embla constrains the
+     * momentum of a throw to a snap it already has, so track past the last slide
+     * only ever exists under a pointer.
+     */
+    let pulledPastEnd = false
+
+    const watchPull = () => {
+      const { dragHandler, limit, location, percentOfView } =
+        api.internalEngine()
+      if (!dragHandler.pointerDown()) return
+      // Scroll positions run NEGATIVE as the row advances, so the far end is
+      // `limit.min` and anything below it is track the drag is holding open.
+      const pull = limit.min - location.get()
+      if (pull < percentOfView.measure(DRAG_PAST_END_PERCENT)) return
+      pulledPastEnd = true
+    }
+
+    const askIfPulledPastEnd = () => {
+      if (!pulledPastEnd) return
+      pulledPastEnd = false
+      askForNextPage()
+    }
+
+    const forgetPull = () => {
+      pulledPastEnd = false
+    }
+
+    api.on("select", prefetchIfAtEnd)
+    api.on("scroll", watchPull)
+    api.on("pointerDown", forgetPull)
+    api.on("pointerUp", askIfPulledPastEnd)
+
+    return () => {
+      api.off("select", prefetchIfAtEnd)
+      api.off("scroll", watchPull)
+      api.off("pointerDown", forgetPull)
+      api.off("pointerUp", askIfPulledPastEnd)
+    }
+  }, [api, askForNextPage])
+
+  React.useEffect(() => {
+    const settled = wasLoading.current && !isLoading
+    wasLoading.current = isLoading
+    // The page somebody was standing on has arrived — or come back empty. Either
+    // way the wait is over, and with it the placeholder that stood in for it.
+    if (settled) setAwaitedPage(false)
+    if (!owedNext) return
+    if (canScrollNext) {
+      setOwedNext(false)
+      scrollNext()
+      return
+    }
+    /**
+     * THE FETCH IS DONE, AND THE CAROUSEL HAS NOT CAUGHT UP.
+     *
+     * `isLoading` going false and the new slides arriving happen in one React
+     * commit, but `canScrollNext` does not: it comes from the carousel
+     * re-measuring itself, which is asynchronous. Clearing the owed move on
+     * `settled` alone therefore cancelled it a beat before there was anywhere to
+     * go — the page loaded, the arrow stopped spinning, and the row sat still.
+     *
+     * So the slide count decides. More slides than when we asked means the move
+     * is still coming and this is just the gap before the measurement; the same
+     * number means the fetch brought nothing and nobody should keep waiting.
+     *
+     * Counted off the DOM rather than asked of the carousel: at this exact
+     * moment the carousel's own list is the stale thing being worked around, so
+     * consulting it answers "still two" and cancels the move all over again.
+     */
+    if (settled && countSlides(api) <= slidesAtAsk.current) setOwedNext(false)
+  }, [owedNext, canScrollNext, isLoading, scrollNext, api])
+
+  return {
+    canGoNext: canScrollNext || (hasMore && !isLoading),
+    isAwaitingPage: owedNext,
+    isPageInFlight: awaitedPage && isLoading,
+    goNext: () => {
+      if (canScrollNext) {
+        scrollNext()
+        return
+      }
+      askForNextPage()
+    },
+  }
+}
+
+/**
+ * THE PAGING STATE of the enclosing carousel, for content that has to draw
+ * something while a page the reader asked for is on its way.
+ *
+ * A carousel whose slides are a page cannot answer a gesture past the last one
+ * by scrolling — the slide is not there yet. What it does instead is fetch, and
+ * `isPageInFlight` is the moment in between: append that many placeholder slides
+ * and the move the reader asked for has somewhere to land, in the shape of the
+ * records that are coming.
+ */
+const useCarouselPaging = (): CarouselPagingState => useCarousel().pagingState
+
 const Carousel = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement> & CarouselProps
@@ -77,6 +373,7 @@ const Carousel = React.forwardRef<
       opts,
       setApi,
       plugins,
+      paging,
       className,
       children,
       ...props
@@ -109,6 +406,8 @@ const Carousel = React.forwardRef<
     const scrollNext = React.useCallback(() => {
       api?.scrollNext()
     }, [api])
+
+    const pagingState = usePagingState(api, canScrollNext, scrollNext, paging)
 
     const handleKeyDown = React.useCallback(
       (event: React.KeyboardEvent<HTMLDivElement>) => {
@@ -157,6 +456,7 @@ const Carousel = React.forwardRef<
           scrollNext,
           canScrollPrev,
           canScrollNext,
+          pagingState,
         }}
       >
         <div
@@ -431,166 +731,6 @@ const CarouselDots = React.forwardRef<
 CarouselDots.displayName = "CarouselDots"
 
 /**
- * A carousel whose slides are ONE PAGE of a longer list.
- *
- * A carousel can only reason about the slides it holds, so on its own it says
- * "there is no next one" the moment it reaches the last one it was given — which
- * is wrong when the list continues on the server. This is the missing half of
- * that answer, and it is deliberately the shape `useData` already returns for an
- * infinite-scroll source (`paginationInfo.hasMore`, `isLoadingMore`, `loadMore`),
- * so wiring one to the other is passing three fields across.
- */
-export type CarouselPaging = {
-  /** Whether the source has records past the slides currently mounted. */
-  hasMore: boolean
-  /** A fetch for the next page is in flight. */
-  isLoading?: boolean
-  /** Fetch the next page and APPEND it to the slides. */
-  onLoadMore: () => void
-  /**
-   * How many records the source holds ALTOGETHER, when it says — `useData`'s
-   * `totalItems`. For anything that reports a position out loud ("3 of 11"):
-   * without it the only number available is how many have been loaded, which
-   * moves every time another page arrives.
-   *
-   * The carousel itself ignores it. Its dots describe the slides that exist, and
-   * a dot for a page nobody has fetched would be a control that cannot be
-   * pressed.
-   */
-  total?: number
-}
-
-/**
- * Makes the Next arrow tell the truth when the slides are a page.
- *
- * TWO WAYS THE NEXT PAGE IS ASKED FOR, and they cover each other:
- *
- * - PRESSING NEXT at the end of what is mounted. `goNext` scrolls if there is
- *   anywhere to scroll and fetches if there isn't, so the arrow always does
- *   something as long as the feed continues.
- * - ARRIVING at the last snap, which fetches the page after it. So walking
- *   through a carousel stays smooth: the page you are about to need is usually
- *   already in flight by the time you ask for it.
- *
- * ARRIVAL, not render. The prefetch is bound to embla's `select` — a real
- * navigation — rather than run whenever the paging props change. That is what
- * makes it loop-proof without a bookkeeping ref: a source that answers
- * `hasMore: true` with no new records leaves you on the same snap, no `select`
- * fires, and nothing asks again. It also means a carousel nobody touched fetches
- * exactly the page it was given, which is the point of paging.
- *
- * The trade is that a first page which fills the view exactly has no last snap to
- * arrive at, so its second page waits for the arrow. That is one press, and it
- * beats a fetch on mount that the reader never asked for.
- */
-/**
- * How many slides are IN THE DOM right now — React's view, not the carousel's
- * cached one, which lags a re-measure behind.
- */
-const countSlides = (api: CarouselApi) =>
-  api?.containerNode()?.childElementCount ?? 0
-
-const useCarouselPaging = (paging?: CarouselPaging) => {
-  const { api, canScrollNext, scrollNext } = useCarousel()
-  const hasMore = paging?.hasMore ?? false
-  const isLoading = paging?.isLoading ?? false
-  const onLoadMore = paging?.onLoadMore
-
-  // The listener is bound ONCE per carousel and reads the paging state through a
-  // ref: subscribing on every change of `hasMore`/`isLoading` would tear the
-  // handler down and rebuild it in the middle of the very fetch it started.
-  const latest = React.useRef({ hasMore, isLoading, onLoadMore })
-  latest.current = { hasMore, isLoading, onLoadMore }
-
-  React.useEffect(() => {
-    if (!api) return
-
-    const askIfAtEnd = () => {
-      const { hasMore, isLoading, onLoadMore } = latest.current
-      if (!hasMore || isLoading || !onLoadMore) return
-      const snaps = api.scrollSnapList().length
-      if (api.selectedScrollSnap() < snaps - 1) return
-      onLoadMore()
-    }
-
-    api.on("select", askIfAtEnd)
-    return () => {
-      api.off("select", askIfAtEnd)
-    }
-  }, [api])
-
-  /**
-   * THE MOVE THE READER ASKED FOR, still owed — and the only reason to show that
-   * anything is loading at all.
-   *
-   * Pressing Next at the end of a page cannot scroll yet, because the slides do
-   * not exist. So the press is remembered and finished the moment there is
-   * somewhere to go: without it the carousel fetches, fills, and then just sits
-   * there, having moved nothing in answer to an arrow.
-   *
-   * It is STATE rather than a ref because it is also the answer to "is anybody
-   * waiting on this fetch". A page pulled in ahead of the reader — the prefetch
-   * on arriving at the last page — is work nobody asked about, and announcing it
-   * with a spinner invites them to wait for something that was never in their
-   * way. Only a fetch somebody is standing on says so.
-   */
-  const [owedNext, setOwedNext] = React.useState(false)
-  // Whether the load in flight is the one that just finished, so an owed move
-  // that turned out to have nowhere to go stops waiting instead of hanging.
-  const wasLoading = React.useRef(isLoading)
-  /** How many slides there were when the move was asked for. */
-  const slidesAtAsk = React.useRef(0)
-
-  React.useEffect(() => {
-    const settled = wasLoading.current && !isLoading
-    wasLoading.current = isLoading
-    if (!owedNext) return
-    if (canScrollNext) {
-      setOwedNext(false)
-      scrollNext()
-      return
-    }
-    /**
-     * THE FETCH IS DONE, AND THE CAROUSEL HAS NOT CAUGHT UP.
-     *
-     * `isLoading` going false and the new slides arriving happen in one React
-     * commit, but `canScrollNext` does not: it comes from the carousel
-     * re-measuring itself, which is asynchronous. Clearing the owed move on
-     * `settled` alone therefore cancelled it a beat before there was anywhere to
-     * go — the page loaded, the arrow stopped spinning, and the row sat still.
-     *
-     * So the slide count decides. More slides than when we asked means the move
-     * is still coming and this is just the gap before the measurement; the same
-     * number means the fetch brought nothing and nobody should keep waiting.
-     *
-     * Counted off the DOM rather than asked of the carousel: at this exact
-     * moment the carousel's own list is the stale thing being worked around, so
-     * consulting it answers "still two" and cancels the move all over again.
-     */
-    if (settled && countSlides(api) <= slidesAtAsk.current) setOwedNext(false)
-  }, [owedNext, canScrollNext, isLoading, scrollNext, api])
-
-  return {
-    canGoNext: canScrollNext || (hasMore && !isLoading),
-    /** A fetch the reader is actually standing on. */
-    isAwaitingPage: owedNext,
-    goNext: () => {
-      if (canScrollNext) {
-        scrollNext()
-        return
-      }
-      if (!hasMore) return
-      // Recorded whether or not we are the ones who ask: a press landing while a
-      // page is already in flight must still move the row when it lands, and
-      // asking twice for the same records is not the way to make that happen.
-      slidesAtAsk.current = countSlides(api)
-      setOwedNext(true)
-      if (!isLoading) onLoadMore?.()
-    },
-  }
-}
-
-/**
  * THE PAGING ROW: an arrow on each end, the dots between them, under the slides.
  *
  * The alternative to `CarouselPrevious`/`CarouselNext`, which are absolutely
@@ -619,15 +759,13 @@ const CarouselControls = React.forwardRef<
     labels?: { previous?: string; next?: string }
     /** Whether the dots sit between the arrows. Defaults to true. */
     showDots?: boolean
-    /**
-     * The slides are a PAGE of a longer list: Next then stays live at the end and
-     * fetches the rest. See {@link CarouselPaging}.
-     */
-    paging?: CarouselPaging
   }
->(({ className, labels, showDots = true, paging, ...props }, ref) => {
+>(({ className, labels, showDots = true, ...props }, ref) => {
   const { scrollPrev, canScrollPrev } = useCarousel()
-  const { canGoNext, goNext, isAwaitingPage } = useCarouselPaging(paging)
+  // That the slides are a PAGE of a longer list is the CAROUSEL's `paging` prop
+  // rather than this row's: the content needs the same answer to draw the page
+  // in flight, and of two copies one is always the stale one.
+  const { canGoNext, goNext, isAwaitingPage } = useCarouselPaging()
 
   return (
     <div
@@ -678,5 +816,6 @@ export {
   CarouselItem,
   CarouselNext,
   CarouselPrevious,
+  useCarouselPaging,
   type CarouselApi,
 }


### PR DESCRIPTION
## Description

Only the Next arrow could reach the next page of the Communities feed. Dragging past the last tile had nowhere to scroll to, so embla answered the gesture with a rubber band and dropped it — on a row of tiles built to be thrown. A pull past the end now asks for the next page exactly as the arrow does, and both are answered with placeholder tiles that the row moves onto while the records are in flight.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

### Note for review

`DynamicCarousel` documented `paging` as `arrowsPlacement: "bottom"` only, because a hover-only overlay arrow that silently fetches is worse than none. Drag-to-load now works in either placement — a drag is the reader's own visible gesture, not a hidden control — so `paging` is passed to the carousel unconditionally and that prop's doc now says the restriction applies to the *arrow*. The overlay `CarouselNext` stays paging-unaware.

To see it: the `Loads More On Drag` story drags itself, or throw the row in `Paged From Data Source` under `Domain specific / Home / Communities / F0CommunityPostsCarousel`.

