### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.78.2",
+  "packages/react": "6.78.3",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.78.3](https://github.com/factorialco/f0/compare/f0-react-v6.78.2...f0-react-v6.78.3) (2026-09-01)
+
+
+### Bug Fixes
+
+* **NewHomeLayout:** stop clipping the composer's glow ([#5350](https://github.com/factorialco/f0/issues/5350)) ([2472c36](https://github.com/factorialco/f0/commit/2472c3610f265ec3face3a6f60c911d32f6d379c))
+
 ## [6.78.2](https://github.com/factorialco/f0/compare/f0-react-v6.78.1...f0-react-v6.78.2) (2026-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.78.2",
+  "version": "6.78.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.78.3</summary>

## [6.78.3](https://github.com/factorialco/f0/compare/f0-react-v6.78.2...f0-react-v6.78.3) (2026-09-01)


### Bug Fixes

* **NewHomeLayout:** stop clipping the composer's glow ([#5350](https://github.com/factorialco/f0/issues/5350)) ([2472c36](https://github.com/factorialco/f0/commit/2472c3610f265ec3face3a6f60c911d32f6d379c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).