### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.78.3",
+  "packages/react": "6.78.4",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.78.4](https://github.com/factorialco/f0/compare/f0-react-v6.78.3...f0-react-v6.78.4) (2026-09-01)
+
+
+### Bug Fixes
+
+* **Tooltip:** even out content padding to 8px ([#4992](https://github.com/factorialco/f0/issues/4992)) ([917c2fc](https://github.com/factorialco/f0/commit/917c2fcc516b1ec7e3a67680bcef148ed3cf6f63))
+
 ## [6.78.3](https://github.com/factorialco/f0/compare/f0-react-v6.78.2...f0-react-v6.78.3) (2026-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.78.3",
+  "version": "6.78.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.78.4</summary>

## [6.78.4](https://github.com/factorialco/f0/compare/f0-react-v6.78.3...f0-react-v6.78.4) (2026-09-01)


### Bug Fixes

* **Tooltip:** even out content padding to 8px ([#4992](https://github.com/factorialco/f0/issues/4992)) ([917c2fc](https://github.com/factorialco/f0/commit/917c2fcc516b1ec7e3a67680bcef148ed3cf6f63))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).