### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.78.4",
+  "packages/react": "6.79.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.79.0](https://github.com/factorialco/f0/compare/f0-react-v6.78.4...f0-react-v6.79.0) (2026-09-01)
+
+
+### Features
+
+* **F0CommunityPostsCarousel:** load the next page on a drag ([#5351](https://github.com/factorialco/f0/issues/5351)) ([859e160](https://github.com/factorialco/f0/commit/859e1604650bc9db729157fafb6e85e43ab9fb5a))
+
 ## [6.78.4](https://github.com/factorialco/f0/compare/f0-react-v6.78.3...f0-react-v6.78.4) (2026-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.78.4",
+  "version": "6.79.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.79.0</summary>

## [6.79.0](https://github.com/factorialco/f0/compare/f0-react-v6.78.4...f0-react-v6.79.0) (2026-09-01)


### Features

* **F0CommunityPostsCarousel:** load the next page on a drag ([#5351](https://github.com/factorialco/f0/issues/5351)) ([859e160](https://github.com/factorialco/f0/commit/859e1604650bc9db729157fafb6e85e43ab9fb5a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).