### PR TITLE
fix(F0Checkbox): remove the border hover state

### DIFF
--- a/packages/react/src/components/F0Checkbox/__test__/F0Checkbox.test.tsx
+++ b/packages/react/src/components/F0Checkbox/__test__/F0Checkbox.test.tsx
@@ -140,6 +140,25 @@ describe("F0Checkbox", () => {
     expect(checkbox).not.toBeDisabled()
   })
 
+  // Regression: hovering the checkbox darkened its border. The box is not an
+  // interactive-looking control on its own, so it must have no hover state:
+  // no `hover:` utility may reach it in any of its states.
+  it.each([
+    { name: "unchecked", props: {} },
+    { name: "checked", props: { checked: true } },
+    { name: "indeterminate", props: { indeterminate: true, checked: true } },
+    { name: "disabled", props: { disabled: true } },
+    { name: "checked and disabled", props: { checked: true, disabled: true } },
+  ])("has no hover styles when $name", ({ props }) => {
+    render(<F0Checkbox title="No hover" {...props} />)
+
+    const hoverClasses = Array.from(
+      screen.getByRole("checkbox").classList
+    ).filter((className) => className.includes("hover:"))
+
+    expect(hoverClasses).toEqual([])
+  })
+
   it("generates unique id when not provided", () => {
     render(
       <>

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -33,8 +33,8 @@ const Checkbox = React.forwardRef<
           aria-label={props.title}
           className={cn(
             "relative h-6 w-6 shrink-0 rounded-sm text-f1-foreground-selected data-[state=checked]:text-f1-foreground-inverse",
-            "after:absolute after:left-0.5 after:top-0.5 after:z-[1] after:h-5 after:w-5 after:rounded-xs after:border after:border-solid after:border-f1-border after:transition-[background-color,border-color] after:content-[''] hover:after:border-f1-border-hover data-[state=checked]:after:bg-f1-background-selected-bold hover:data-[state=checked]:after:border-transparent",
-            disabled && "cursor-not-allowed opacity-50 hover:border-f1-border",
+            "after:absolute after:left-0.5 after:top-0.5 after:z-[1] after:h-5 after:w-5 after:rounded-xs after:border after:border-solid after:border-f1-border after:transition-[background-color] after:content-[''] data-[state=checked]:after:bg-f1-background-selected-bold",
+            disabled && "cursor-not-allowed opacity-50",
             indeterminate && "data-[state=checked]:text-f1-foreground-inverse",
             props.checked &&
               disabled &&


### PR DESCRIPTION
## What

The checkbox no longer changes on hover.

Two hover rules on the box (the `after:` layer that draws the 20x20 square) are gone:

- `hover:after:border-f1-border-hover` — darkened the border of an unchecked checkbox.
- `hover:data-[state=checked]:after:border-transparent` — dropped the border of a checked one.

The resting appearance is untouched in every state: unchecked keeps `f1-border`, checked keeps the `background-selected-bold` fill. Only the hover delta is removed, so a checkbox now looks the same hovered and not hovered.

Two pieces of dead weight went with them:

- `hover:border-f1-border` on the disabled branch, which never rendered anything — the root element has no border width, the border comes from the `after:` layer.
- the `border-color` entry in `after:transition-[…]`, now that no state transitions a border color.

Focus ring, label hover cursor, disabled and indeterminate states are unchanged.

## Regression test

`F0Checkbox.test.tsx` asserts the checkbox root carries no `hover:` utility, across unchecked / checked / indeterminate / disabled / checked+disabled. It fails on `main` (it reports the exact classes above) and passes here.

## Test plan

- `pnpm vitest --run src/components/F0Checkbox` — 18 passed
- `pnpm tsc` — clean
- `pnpm lint` / `pnpm format:check` on the touched files — clean
- Red half verified locally: stashing the `checkbox.tsx` change makes the 5 new cases fail


🤖 Generated with [Claude Code](https://claude.com/claude-code)
