### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.79.0",
+  "packages/react": "6.80.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.80.0](https://github.com/factorialco/f0/compare/f0-react-v6.79.0...f0-react-v6.80.0) (2026-09-02)
+
+
+### Features
+
+* **ChatSpinner:** exact One mark at rest, non-pixelated edge, reworked motion ([#5335](https://github.com/factorialco/f0/issues/5335)) ([842a689](https://github.com/factorialco/f0/commit/842a689a524bd7d12d6080015f37ed0d78acb90d))
+
 ## [6.79.0](https://github.com/factorialco/f0/compare/f0-react-v6.78.4...f0-react-v6.79.0) (2026-09-01)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.79.0",
+  "version": "6.80.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.80.0</summary>

## [6.80.0](https://github.com/factorialco/f0/compare/f0-react-v6.79.0...f0-react-v6.80.0) (2026-09-02)


### Features

* **ChatSpinner:** exact One mark at rest, non-pixelated edge, reworked motion ([#5335](https://github.com/factorialco/f0/issues/5335)) ([842a689](https://github.com/factorialco/f0/commit/842a689a524bd7d12d6080015f37ed0d78acb90d))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).