### PR TITLE
feat(SlotWidget): let a row's second line go critical

### DIFF
--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -47,6 +47,50 @@ describe("HomeListItem", () => {
     )
   })
 
+  test("says a description carrying bad news in the critical colour — muted by default", () => {
+    const { rerender } = zeroRender(
+      <HomeListItem title="Expenses report" description="Rejected by Finance" />
+    )
+
+    const description = () => screen.getByText("Rejected by Finance")
+
+    expect(description()).toHaveClass("text-f1-foreground-secondary")
+    expect(description()).not.toHaveClass("text-f1-foreground-critical")
+
+    rerender(
+      <HomeListItem
+        title="Expenses report"
+        description="Rejected by Finance"
+        descriptionCritical
+      />
+    )
+
+    expect(description()).toHaveClass("text-f1-foreground-critical")
+    expect(description()).not.toHaveClass("text-f1-foreground-secondary")
+    // The title is untouched: it says what the row IS, not what's wrong with it.
+    expect(screen.getByText("Expenses report")).toHaveClass(
+      "text-f1-foreground"
+    )
+  })
+
+  test("colours the two murmuring lines independently — one can go critical without the other", () => {
+    zeroRender(
+      <HomeListItem
+        title="Expenses report"
+        subtitle="Travel"
+        description="Rejected by Finance"
+        descriptionCritical
+      />
+    )
+
+    expect(screen.getByText("Rejected by Finance")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+    expect(screen.getByText("· Travel")).toHaveClass(
+      "text-f1-foreground-secondary"
+    )
+  })
+
   test("draws a left slot when given an avatar, none otherwise", () => {
     const { container, rerender } = zeroRender(
       <HomeListItem

--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -73,6 +73,92 @@ describe("HomeListItem", () => {
     )
   })
 
+  test("draws a list of description parts dot-separated, each with its own tone", () => {
+    zeroRender(
+      <HomeListItem
+        title="Expenses report"
+        description={[
+          { text: "2 days overdue", critical: true },
+          { text: "€340" },
+          { text: "12 receipts" },
+        ]}
+      />
+    )
+
+    expect(screen.getByText("2 days overdue")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+    expect(screen.getByText("€340")).toHaveClass("text-f1-foreground-secondary")
+    expect(screen.getByText("12 receipts")).toHaveClass(
+      "text-f1-foreground-secondary"
+    )
+  })
+
+  test("keeps the separator muted between parts of any tone — it belongs to neither", () => {
+    const { container } = zeroRender(
+      <HomeListItem
+        title="Expenses report"
+        description={[
+          { text: "2 days overdue", critical: true },
+          { text: "€340" },
+        ]}
+      />
+    )
+
+    const separators = [...container.querySelectorAll("span")].filter(
+      (node) => node.textContent === " · "
+    )
+
+    // One separator for two parts — not a leading or trailing one.
+    expect(separators).toHaveLength(1)
+    expect(separators[0]).toHaveClass("text-f1-foreground-secondary")
+    // The whole line still reads as one sentence.
+    expect(screen.getByText("2 days overdue").parentElement).toHaveTextContent(
+      "2 days overdue · €340"
+    )
+  })
+
+  test("says nothing for an EMPTY parts list — [] is as silent as no description", () => {
+    const { container, rerender } = zeroRender(
+      <HomeListItem title="Onboarding" description={[]} />
+    )
+
+    expect(container.textContent).toBe("Onboarding")
+
+    // And a part with no text is dropped rather than drawn as a stray dot.
+    rerender(
+      <HomeListItem
+        title="Onboarding"
+        description={[{ text: "" }, { text: "Due Friday" }]}
+      />
+    )
+
+    expect(
+      container.querySelector("span[class*='secondary']")
+    ).toHaveTextContent("Due Friday")
+    expect(container.textContent).not.toContain("·")
+  })
+
+  test("a plain string still takes the whole-line flag — the two forms agree", () => {
+    const { rerender } = zeroRender(
+      <HomeListItem title="x" description="Rejected" descriptionCritical />
+    )
+    expect(screen.getByText("Rejected")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+
+    // The same thing said the other way round renders identically.
+    rerender(
+      <HomeListItem
+        title="x"
+        description={[{ text: "Rejected", critical: true }]}
+      />
+    )
+    expect(screen.getByText("Rejected")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+  })
+
   test("colours the two murmuring lines independently — one can go critical without the other", () => {
     zeroRender(
       <HomeListItem

--- a/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.spec.tsx
@@ -118,6 +118,50 @@ describe("HomeListItem", () => {
     )
   })
 
+  test("gives the truncating line its OWN tone — the ellipsis is painted in the container's colour, not the last part's", () => {
+    // Left to inherit, a link row's second line ends in a browser-blue "…":
+    // the row is an anchor, and `truncate` paints its ellipsis in the colour of
+    // the element the class sits on.
+    const line = (container: HTMLElement) =>
+      container.querySelector("div.truncate:not([class*='font-medium'])")
+
+    const { container, rerender } = zeroRender(
+      <HomeListItem
+        title="Conference"
+        href="/expenses"
+        description={[
+          { text: "Submitted Monday" },
+          { text: "2 days overdue", critical: true },
+        ]}
+      />
+    )
+
+    // Several parts: muted, like the separators — the ellipsis stands for the
+    // line, not for whichever part it happened to cut.
+    expect(line(container)).toHaveClass("text-f1-foreground-secondary")
+
+    // A wholly critical line truncates in critical instead.
+    rerender(
+      <HomeListItem
+        title="Conference"
+        href="/expenses"
+        description={[{ text: "2 days overdue", critical: true }]}
+      />
+    )
+    expect(line(container)).toHaveClass("text-f1-foreground-critical")
+
+    // Same for the string form, which is the same line said another way.
+    rerender(
+      <HomeListItem
+        title="Conference"
+        href="/expenses"
+        description="2 days overdue"
+        descriptionCritical
+      />
+    )
+    expect(line(container)).toHaveClass("text-f1-foreground-critical")
+  })
+
   test("says nothing for an EMPTY parts list — [] is as silent as no description", () => {
     const { container, rerender } = zeroRender(
       <HomeListItem title="Onboarding" description={[]} />

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -100,9 +100,10 @@ const ACTIONS_PINNED_CLASS = "pointer-events-auto opacity-100"
  * module glyph, an alert).
  *
  * The text stack is three optional voices: `title` leads, `subtitle` murmurs on
- * the same line after a dot, `description` takes the second line. A subtitle
- * carrying BAD NEWS about the row — overdue, rejected, over budget — stops
- * murmuring and says so (`subtitleCritical`).
+ * the same line after a dot, `description` takes the second line. Either
+ * murmuring voice, when what it carries is BAD NEWS about the row — overdue,
+ * rejected, over budget — stops murmuring and says so (`subtitleCritical`,
+ * `descriptionCritical`).
  *
  * A row can also carry `actions` — what you can DO to it without leaving the
  * widget (snooze it, dismiss it). They stay out of the way until the row is
@@ -132,6 +133,15 @@ export interface HomeListItemProps {
   subtitleCritical?: boolean
   /** The second line. */
   description?: string
+  /**
+   * Draws the `description` CRITICAL rather than muted — the row is overdue,
+   * rejected, over budget. Per row, because it is a state of THAT row's data:
+   * one list holds rows whose second line is bad news and rows whose isn't.
+   *
+   * The title reads the same either way — it says what the row IS, and the
+   * description is what has gone wrong with it. Inert without a `description`.
+   */
+  descriptionCritical?: boolean
   /** Trailing slot: a tag, a counter, people. */
   right?: ReactNode
   /**
@@ -165,6 +175,7 @@ export function HomeListItem({
   subtitle,
   subtitleCritical = false,
   description,
+  descriptionCritical = false,
   right,
   actions,
   unread = false,
@@ -214,7 +225,14 @@ export function HomeListItem({
           ) : null}
         </div>
         {description ? (
-          <div className="truncate text-f1-foreground-secondary">
+          <div
+            className={cn(
+              "truncate",
+              descriptionCritical
+                ? "text-f1-foreground-critical"
+                : "text-f1-foreground-secondary"
+            )}
+          >
             {description}
           </div>
         ) : null}

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -283,7 +283,23 @@ export function HomeListItem({
           ) : null}
         </div>
         {parts.length > 0 ? (
-          <div className="truncate">
+          // The ellipsis `truncate` adds is painted in THIS element's colour,
+          // not the last part's — so the container has to carry a tone of its
+          // own. Left to inherit, a link row's second line ends in a browser-
+          // blue "…" hanging off the end of the sentence.
+          //
+          // One part lends its own tone, so a wholly critical line truncates
+          // in critical. Several fall back to muted, like the separators: the
+          // ellipsis stands for the line rather than for whichever part it
+          // happened to cut.
+          <div
+            className={cn(
+              "truncate",
+              parts.length === 1 && parts[0].critical
+                ? "text-f1-foreground-critical"
+                : "text-f1-foreground-secondary"
+            )}
+          >
             {parts.map((part, i) => (
               <Fragment key={i}>
                 {/* The separator belongs to NEITHER neighbour, so it stays

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -89,6 +89,56 @@ const ACTIONS_CLASS = cn(
 const ACTIONS_PINNED_CLASS = "pointer-events-auto opacity-100"
 
 /**
+ * ONE FACT on a row's second line — the unit a `description` is made of when
+ * the row has more than one thing to say ("€340", "12 receipts", "2 days
+ * overdue"). Parts draw dot-separated, each carrying its OWN tone, so the one
+ * fact that has gone wrong goes red while the rest keep murmuring.
+ *
+ * Put the critical part FIRST. The second line is a single truncating line —
+ * about 306px at the rail's 24rem width, some 40 characters — and it is cut
+ * from the RIGHT, so a part marked critical in third place is the part most
+ * likely to vanish into the ellipsis. Marking a part critical claims it is the
+ * most important thing on the line; leading with it makes that claim true.
+ */
+export type DescriptionPart = {
+  text: string
+  /** Draws THIS part critical rather than muted. */
+  critical?: boolean
+}
+
+/** A row's second line, in either of the forms it may be given. */
+export type Description = string | DescriptionPart[]
+
+/**
+ * A `description` as the row draws it: a list of parts, whatever form it
+ * arrived in, with the empty ones dropped. Empty means there is no second line
+ * at all — an `[]` is as silent as an absent `description`, which a bare
+ * truthiness check would get wrong.
+ */
+export function descriptionParts(
+  description: Description | undefined,
+  descriptionCritical = false
+): DescriptionPart[] {
+  if (typeof description === "string") {
+    return description
+      ? [{ text: description, critical: descriptionCritical }]
+      : []
+  }
+  return (description ?? []).filter((part) => part.text)
+}
+
+/**
+ * A `description` flattened to PLAIN TEXT. What a compact row's tooltip can
+ * carry — `Tooltip`'s `label` takes a string — so a segmented second line
+ * arrives there dot-joined and untinted.
+ */
+export function descriptionText(description: Description | undefined): string {
+  return descriptionParts(description)
+    .map((part) => part.text)
+    .join(" · ")
+}
+
+/**
  * The BASE row every Home list draws: a LEFT slot, a text stack and a RIGHT
  * slot. A row that goes somewhere says so by being a link — hover state and
  * all — not with a trailing chevron: a column of arrows repeating "clickable"
@@ -131,15 +181,22 @@ export interface HomeListItemProps {
    * subtitle is what has gone wrong with it. Inert without a `subtitle`.
    */
   subtitleCritical?: boolean
-  /** The second line. */
-  description?: string
   /**
-   * Draws the `description` CRITICAL rather than muted — the row is overdue,
-   * rejected, over budget. Per row, because it is a state of THAT row's data:
-   * one list holds rows whose second line is bad news and rows whose isn't.
+   * The second line — one string, or {@link DescriptionPart}s when the row has
+   * several facts to state and only some of them are bad news. Parts draw
+   * dot-separated and each carries its own tone.
+   */
+  description?: Description
+  /**
+   * Draws the whole `description` CRITICAL rather than muted — the row is
+   * overdue, rejected, over budget. Per row, because it is a state of THAT
+   * row's data: one list holds rows whose second line is bad news and rows
+   * whose isn't.
    *
    * The title reads the same either way — it says what the row IS, and the
-   * description is what has gone wrong with it. Inert without a `description`.
+   * description is what has gone wrong with it. Inert without a
+   * `description`, and IGNORED when the description is already a list of
+   * parts: those carry their own `critical`.
    */
   descriptionCritical?: boolean
   /** Trailing slot: a tag, a counter, people. */
@@ -190,6 +247,7 @@ export function HomeListItem({
   const [openMenu, setOpenMenu] = useState<string | null>(null)
   const leading =
     left ?? (avatar ? <F0Avatar avatar={avatar} size={avatarSize} /> : null)
+  const parts = descriptionParts(description, descriptionCritical)
 
   const content = (
     <>
@@ -224,16 +282,29 @@ export function HomeListItem({
             </span>
           ) : null}
         </div>
-        {description ? (
-          <div
-            className={cn(
-              "truncate",
-              descriptionCritical
-                ? "text-f1-foreground-critical"
-                : "text-f1-foreground-secondary"
-            )}
-          >
-            {description}
+        {parts.length > 0 ? (
+          <div className="truncate">
+            {parts.map((part, i) => (
+              <Fragment key={i}>
+                {/* The separator belongs to NEITHER neighbour, so it stays
+                    muted between two parts of any tone — unlike the subtitle's
+                    leading dot, which is that subtitle's own punctuation and
+                    takes its colour. A red separator would read as a third,
+                    wordless piece of bad news. */}
+                {i > 0 ? (
+                  <span className="text-f1-foreground-secondary">{" · "}</span>
+                ) : null}
+                <span
+                  className={
+                    part.critical
+                      ? "text-f1-foreground-critical"
+                      : "text-f1-foreground-secondary"
+                  }
+                >
+                  {part.text}
+                </span>
+              </Fragment>
+            ))}
           </div>
         ) : null}
       </div>

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -429,12 +429,63 @@ line, or neither. Reddening both is almost always wrong — it is a red row, and
 red row has no emphasis left to place. Colour the line that names the problem
 and leave the other one murmuring.
 
-One limit: in a **compact** list the second line has folded into the row's
-tooltip, so there is nothing left to colour and `descriptionCritical` goes
-silent. If the news matters at every density, put it in the subtitle, which
-shares the title's line and always shows.
-
 <Canvas of={SlotWidgetStories.CriticalDescriptions} />
+
+### Several facts on one line
+
+When the second line states more than one thing and only some of it is bad news,
+`description` takes a list of **parts** instead of a string. Each carries its own
+`critical`, and they draw dot-separated:
+
+```tsx
+{
+  id: "travel",
+  title: "Q3 travel",
+  description: [
+    { text: "2 days overdue", critical: true }, // ← in critical red
+    { text: "€340" },
+    { text: "12 receipts" },
+  ],
+}
+```
+
+The separator between parts stays **muted** whatever its neighbours do. It
+belongs to neither of them — unlike the subtitle's leading dot, which is that
+subtitle's own punctuation and takes its colour — and a red separator would read
+as a third, wordless piece of bad news.
+
+Parts and the whole-line `descriptionCritical` are mutually exclusive, and the
+types enforce it: parts already carry their own tone, so a row passing both is
+saying the same thing twice and meaning different things by it. A plain string
+with `descriptionCritical` is still the right way to say the simple case, and
+the two forms can sit side by side in one list.
+
+#### Put the critical part first
+
+The second line is a single **truncating** line — about **306px** at the rail's
+24rem width, some 40 characters — and it is cut from the **right**:
+
+| Second line                                                 | Width | Fits |
+| ----------------------------------------------------------- | ----- | ---- |
+| `Rejected by Finance`                                       | 134px | ✅   |
+| `Submitted Monday · Rejected by Finance`                    | 271px | ✅   |
+| `€340 · 12 receipts · 2 days overdue`                       | 233px | ✅   |
+| `Submitted Monday · Rejected by Finance · €340 over budget` | 403px | ❌   |
+
+So two facts fit comfortably and three fit only if they are short. A part marked
+critical in third place is the part most likely to vanish into the ellipsis —
+which defeats the marking. Marking a part critical claims it is the most
+important thing on the line; leading with it makes that claim true.
+
+Past three facts the row is trying to be a detail view, and should link to one
+instead.
+
+<Canvas of={SlotWidgetStories.SegmentedDescriptions} />
+
+One limit shared with the whole-line flag: a **compact** list folds the second
+line into the row's tooltip, and `Tooltip`'s `label` takes a string — so parts
+arrive there dot-joined and untinted. If the news matters at every density, put
+it in the subtitle, which shares the title's line and always shows.
 
 ### Even rows, and rows that aren't
 

--- a/packages/react/src/sds/Home/SlotWidget/index.mdx
+++ b/packages/react/src/sds/Home/SlotWidget/index.mdx
@@ -387,6 +387,55 @@ said nothing: red is only loud while the row beside it is quiet.
 
 <Canvas of={SlotWidgetStories.CriticalSubtitles} />
 
+### …and a second line that does
+
+`descriptionCritical` is the same flag one line down. A `description` also
+murmurs by default; when the second line is what has gone **wrong** with the row
+rather than more about it, the row sets `descriptionCritical` and it draws in
+`text-f1-foreground-critical`:
+
+```tsx
+listSlot(
+  {
+    left: "icon",
+    subtitleOptional: true,
+    descriptionOptional: true,
+    clickBehavior: "link",
+  },
+  [
+    {
+      id: "expenses",
+      title: "Expenses report",
+      subtitle: "Travel", // ← still muted: the trip isn't what went wrong
+      description: "Rejected by Finance", // ← in critical red
+      descriptionCritical: true,
+      avatar: { icon: Receipt, color: "viridian" },
+      href: "/expenses",
+    },
+    {
+      id: "review",
+      title: "Performance review",
+      subtitle: "Q3",
+      description: "Due Friday", // ← still muted
+      avatar: { icon: Clock, color: "purple" },
+      href: "/reviews",
+    },
+  ]
+)
+```
+
+The two flags are **independent**: a row may redden its subtitle, its second
+line, or neither. Reddening both is almost always wrong — it is a red row, and a
+red row has no emphasis left to place. Colour the line that names the problem
+and leave the other one murmuring.
+
+One limit: in a **compact** list the second line has folded into the row's
+tooltip, so there is nothing left to colour and `descriptionCritical` goes
+silent. If the news matters at every density, put it in the subtitle, which
+shares the title's line and always shows.
+
+<Canvas of={SlotWidgetStories.CriticalDescriptions} />
+
 ### Even rows, and rows that aren't
 
 The schema's default is **evenness**: declaring `right: "person"` means every

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -411,6 +411,67 @@ describe("list slot schema", () => {
     )
   })
 
+  test("a second line may be a list of facts, only the bad one red", () => {
+    zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ descriptionRequired: true }, [
+            {
+              id: "1",
+              title: "Expenses report",
+              description: [
+                { text: "2 days overdue", critical: true },
+                { text: "€340" },
+                { text: "12 receipts" },
+              ],
+            },
+            { id: "2", title: "Onboarding", description: "Due Friday" },
+          ]),
+        ]}
+      />
+    )
+
+    expect(screen.getByText("2 days overdue")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+    expect(screen.getByText("€340")).toHaveClass("text-f1-foreground-secondary")
+    // The plain-string form still works in the same list.
+    expect(screen.getByText("Due Friday")).toHaveClass(
+      "text-f1-foreground-secondary"
+    )
+  })
+
+  test("a COMPACT row flattens its parts into the tooltip — dot-joined and untinted, all a label can carry", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ descriptionRequired: true, compact: true }, [
+            {
+              id: "1",
+              title: "Expenses report",
+              description: [
+                { text: "2 days overdue", critical: true },
+                { text: "€340" },
+              ],
+            },
+          ]),
+        ]}
+      />
+    )
+
+    // Folded away: no part is drawn on the row itself.
+    expect(screen.queryByText("2 days overdue")).not.toBeInTheDocument()
+    expect(screen.queryByText("€340")).not.toBeInTheDocument()
+
+    await user.hover(screen.getByText("Expenses report"))
+
+    // The whole line arrives as ONE string, its separators intact.
+    expect(await screen.findByRole("tooltip")).toHaveTextContent(
+      "2 days overdue · €340"
+    )
+  })
+
   test("a mixed list does NOT auto-compact — folding its few second lines away would hide the only thing telling those rows apart", () => {
     const many = Array.from({ length: LIST_COMPACT_AFTER + 1 }, (_, i) => ({
       id: String(i),

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -374,6 +374,43 @@ describe("list slot schema", () => {
     )
   })
 
+  test("a row's second line goes critical on its own, without touching its neighbours or its own subtitle", () => {
+    zeroRender(
+      <SlotWidget
+        slots={[
+          listSlot({ subtitleRequired: true, descriptionOptional: true }, [
+            {
+              id: "1",
+              title: "Expenses report",
+              subtitle: "Travel",
+              description: "Rejected by Finance",
+              descriptionCritical: true,
+            },
+            {
+              id: "2",
+              title: "Performance review",
+              subtitle: "Q3",
+              description: "Due Friday",
+            },
+            { id: "3", title: "Onboarding", subtitle: "Checklist" },
+          ]),
+        ]}
+      />
+    )
+
+    // The rejected row alone is critical; its neighbour still murmurs.
+    expect(screen.getByText("Rejected by Finance")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+    expect(screen.getByText("Due Friday")).toHaveClass(
+      "text-f1-foreground-secondary"
+    )
+    // The two lines are coloured independently — the subtitle stays muted.
+    expect(screen.getByText("· Travel")).toHaveClass(
+      "text-f1-foreground-secondary"
+    )
+  })
+
   test("a mixed list does NOT auto-compact — folding its few second lines away would hide the only thing telling those rows apart", () => {
     const many = Array.from({ length: LIST_COMPACT_AFTER + 1 }, (_, i) => ({
       id: String(i),

--- a/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
@@ -622,6 +622,67 @@ export const CriticalDescriptions: Story = {
   },
 }
 
+/**
+ * SEVERAL FACTS ON ONE LINE, one of them bad. When a row's second line states
+ * more than one thing, `description` takes a list of parts instead of a string
+ * and each carries its own `critical`. They draw dot-separated, and the
+ * separator stays muted whatever its neighbours do — it belongs to neither, and
+ * a red one would read as a third, wordless piece of bad news.
+ *
+ * THE CRITICAL PART GOES FIRST. The second line is a single truncating line —
+ * about 306px at this 24rem rail width, some 40 characters — and it is cut from
+ * the RIGHT. The last row here is what that costs: its overdue notice sits
+ * third and the ellipsis eats it, which is why the first row leads with the
+ * same news instead. Marking a part critical claims it is the most important
+ * thing on the line; putting it first makes the claim true.
+ *
+ * Two facts fit comfortably; three fit only if they are short. Past that the
+ * row is trying to be a detail view, and should link to one.
+ */
+export const SegmentedDescriptions: Story = {
+  args: {
+    header: { title: "Your expenses", count: 3 },
+    action: { label: "See all", onClick: () => {} },
+    slots: [
+      listSlot(
+        { left: "icon", descriptionRequired: true, clickBehavior: "link" },
+        [
+          {
+            id: "overdue",
+            title: "Q3 travel",
+            description: [
+              { text: "2 days overdue", critical: true },
+              { text: "€340" },
+              { text: "12 receipts" },
+            ],
+            avatar: { icon: Receipt, color: "viridian" },
+            href: "/expenses/1",
+          },
+          {
+            id: "fine",
+            title: "Client dinner",
+            description: [{ text: "€82" }, { text: "3 receipts" }],
+            avatar: { icon: Receipt, color: "purple" },
+            href: "/expenses/2",
+          },
+          {
+            // What NOT to do: the news is third, so the ellipsis takes it.
+            id: "buried",
+            title: "Conference",
+            description: [
+              { text: "Submitted Monday" },
+              { text: "€1,240 for flights" },
+              { text: "2 days overdue", critical: true },
+            ],
+            avatar: { icon: Receipt, color: "army" },
+            href: "/expenses/3",
+          },
+        ]
+      ),
+    ],
+  },
+}
+
 /** The pool `ItemChurn` adds from, cycled so the button never runs out. */
 const CHURN_ITEMS = [
   { title: "You never clocked out yesterday", icon: Clock, color: "purple" },

--- a/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.stories.tsx
@@ -561,6 +561,67 @@ export const CriticalSubtitles: Story = {
   },
 }
 
+/**
+ * A SECOND LINE THAT CARRIES BAD NEWS. Same story as `subtitleCritical`, one
+ * line down: the description is normally the muted second line of a row, and a
+ * row whose second line is what has gone WRONG with it — rejected, overdue,
+ * over budget — sets `descriptionCritical` and says it in red.
+ *
+ * Per row, like `unread`: rejection is a state of that row's data, so the first
+ * row here reports it while the second one, with the same schema, still murmurs
+ * "Due Friday". The titles are the same colour in both — a title says what the
+ * row IS, not what's wrong with it.
+ *
+ * The two murmuring lines are coloured INDEPENDENTLY: the first row's subtitle
+ * ("Travel") stays muted under a critical second line, because what has gone
+ * wrong is the rejection and not the trip. Reddening both would just be a red
+ * row.
+ *
+ * Keep the red for what the reader has to act on: a list where every second
+ * line is critical has said nothing.
+ */
+export const CriticalDescriptions: Story = {
+  args: {
+    header: { title: "Your expenses", count: 3 },
+    action: { label: "See all", onClick: () => {} },
+    slots: [
+      listSlot(
+        {
+          left: "icon",
+          subtitleOptional: true,
+          descriptionOptional: true,
+          clickBehavior: "link",
+        },
+        [
+          {
+            id: "expenses",
+            title: "Expenses report",
+            subtitle: "Travel",
+            description: "Rejected by Finance",
+            descriptionCritical: true,
+            avatar: { icon: Receipt, color: "viridian" },
+            href: "/expenses",
+          },
+          {
+            id: "review",
+            title: "Performance review",
+            subtitle: "Q3",
+            description: "Due Friday",
+            avatar: { icon: Clock, color: "purple" },
+            href: "/reviews",
+          },
+          {
+            id: "onboarding",
+            title: "Onboarding checklist",
+            avatar: { icon: PersonPlus, color: "army" },
+            href: "/onboarding",
+          },
+        ]
+      ),
+    ],
+  },
+}
+
 /** The pool `ItemChurn` adds from, cycled so the button never runs out. */
 const CHURN_ITEMS = [
   { title: "You never clocked out yesterday", icon: Clock, color: "purple" },

--- a/packages/react/src/sds/Home/slotRenderers.test-d.ts
+++ b/packages/react/src/sds/Home/slotRenderers.test-d.ts
@@ -171,6 +171,51 @@ test("a row's subtitle may be critical — wherever a subtitle is declared at al
   ])
 })
 
+test("a row's second line may be critical — wherever a description is declared at all", () => {
+  listSlot({ descriptionRequired: true }, [
+    {
+      id: 1,
+      title: "x",
+      description: "Rejected by Finance",
+      descriptionCritical: true,
+    },
+    { id: 2, title: "y", description: "Due Friday" },
+  ])
+  listSlot({ descriptionOptional: true }, [
+    {
+      id: 1,
+      title: "x",
+      description: "Rejected by Finance",
+      descriptionCritical: true,
+    },
+    { id: 2, title: "y" },
+  ])
+
+  listSlot({}, [
+    // @ts-expect-error nothing to colour: this schema declares no description
+    { id: 1, title: "x", descriptionCritical: true },
+  ])
+})
+
+test("the two murmuring lines carry their tone independently", () => {
+  listSlot({ subtitleRequired: true, descriptionRequired: true }, [
+    {
+      id: 1,
+      title: "x",
+      subtitle: "Travel",
+      description: "Rejected by Finance",
+      descriptionCritical: true,
+    },
+    {
+      id: 2,
+      title: "y",
+      subtitle: "2 days overdue",
+      subtitleCritical: true,
+      description: "Submitted Monday",
+    },
+  ])
+})
+
 test("an icon row may be tinted, and only with a colour from the palette", () => {
   listSlot({ left: "icon" }, [
     { id: 1, title: "Row", avatar: { icon: PalmTree, color: "purple" } },

--- a/packages/react/src/sds/Home/slotRenderers.test-d.ts
+++ b/packages/react/src/sds/Home/slotRenderers.test-d.ts
@@ -197,6 +197,51 @@ test("a row's second line may be critical — wherever a description is declared
   ])
 })
 
+test("a second line may be a LIST of facts, each with its own tone", () => {
+  listSlot({ descriptionRequired: true }, [
+    {
+      id: 1,
+      title: "Expenses",
+      description: [
+        { text: "2 days overdue", critical: true },
+        { text: "€340" },
+        { text: "12 receipts" },
+      ],
+    },
+    // The plain string form still works beside it, in the same list.
+    { id: 2, title: "Onboarding", description: "Due Friday" },
+  ])
+
+  listSlot({ descriptionOptional: true }, [
+    { id: 1, title: "x", description: [{ text: "Rejected", critical: true }] },
+    { id: 2, title: "y" },
+  ])
+
+  listSlot({ descriptionRequired: true }, [
+    {
+      id: 1,
+      title: "x",
+      // @ts-expect-error a part's tone is `critical`, not `descriptionCritical`
+      description: [{ text: "Rejected", descriptionCritical: true }],
+    },
+  ])
+
+  listSlot({ descriptionRequired: true }, [
+    // @ts-expect-error parts carry their own tone — the whole-line flag is not also allowed
+    {
+      id: 1,
+      title: "x",
+      description: [{ text: "Rejected", critical: true }],
+      descriptionCritical: true,
+    },
+  ])
+
+  listSlot({}, [
+    // @ts-expect-error nothing to say: this schema declares no description
+    { id: 1, title: "x", description: [{ text: "Rejected" }] },
+  ])
+})
+
 test("the two murmuring lines carry their tone independently", () => {
   listSlot({ subtitleRequired: true, descriptionRequired: true }, [
     {

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -31,7 +31,12 @@ import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { useWidgetIsWide, WidgetProps } from "@/experimental/Widgets/Widget"
 import { type F0FormSchema } from "@/patterns/F0Form"
 
-import { HomeListItem, type HomeListItemAction } from "./HomeListItem"
+import {
+  descriptionText,
+  HomeListItem,
+  type DescriptionPart,
+  type HomeListItemAction,
+} from "./HomeListItem"
 import { HomeSlotItem, HomeSlotItems, useIsBulkChange } from "./home-motion"
 
 /**
@@ -404,23 +409,26 @@ type SubtitleTone = {
 }
 
 /**
- * What a row may say ABOUT its second line — offered by every schema that
- * declares a `description` at all, required by none of them.
+ * A row's SECOND LINE, in either of the two forms it may take.
+ *
+ * One string with `descriptionCritical` colours the whole line; a list of
+ * {@link DescriptionPart}s colours each fact on it separately. The two are
+ * mutually exclusive on purpose — parts already carry their own `critical`, so
+ * a row that passes both is saying the same thing twice and meaning different
+ * things by it.
+ *
+ * Whichever form, the tone is per ROW rather than per schema, for the same
+ * reason `subtitleCritical` is: what has gone wrong is a state of the row's
+ * own data, so one list holds rows that say so beside rows that have nothing
+ * to report.
+ *
+ * Both forms go untinted in a COMPACT list, where the second line has folded
+ * into the row's tooltip and there is nothing left to colour — see
+ * {@link listCompacts}.
  */
-type DescriptionTone = {
-  /**
-   * Draws THIS row's second line critical instead of muted — the row is
-   * overdue, rejected, over budget.
-   *
-   * Per ROW rather than per schema, for the same reason `subtitleCritical` is:
-   * what has gone wrong is a state of the row's own data, so one list holds
-   * rows that say so beside rows that have nothing to report.
-   *
-   * Silent in a COMPACT list, where the second line has folded into the row's
-   * tooltip and there is nothing left to colour — see {@link listCompacts}.
-   */
-  descriptionCritical?: boolean
-}
+type DescribedRow =
+  | { description: string; descriptionCritical?: boolean }
+  | { description: DescriptionPart[]; descriptionCritical?: never }
 
 type ListTextData<S extends ListSchema> = {
   title: string
@@ -430,9 +438,9 @@ type ListTextData<S extends ListSchema> = {
     ? { subtitle?: string } & SubtitleTone
     : { subtitle?: never; subtitleCritical?: never }) &
   (S["descriptionRequired"] extends true
-    ? { description: string } & DescriptionTone
+    ? DescribedRow
     : S["descriptionOptional"] extends true
-      ? { description?: string } & DescriptionTone
+      ? DescribedRow | { description?: undefined; descriptionCritical?: never }
       : { description?: never; descriptionCritical?: never })
 
 /**
@@ -941,7 +949,7 @@ type ListRow = {
   title: string
   subtitle?: string
   subtitleCritical?: boolean
-  description?: string
+  description?: string | DescriptionPart[]
   descriptionCritical?: boolean
   unread?: boolean
   avatar?: object & { icon?: IconType; color?: ListIconColor }
@@ -1079,6 +1087,12 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
           animates out and the rest close the gap. */}
       <HomeSlotItems>
         {rows.map(({ href, description, ...row }) => {
+          // A compact row hides its second line and offers it on hover
+          // instead — as PLAIN TEXT, all `Tooltip`'s `label` can carry, so a
+          // segmented description arrives dot-joined and untinted. Computed
+          // rather than checking `description` for truthiness: an empty parts
+          // list is a row with nothing to say, and `[]` is truthy.
+          const tooltip = compact ? descriptionText(description) : ""
           const node = (
             <HomeListItem
               title={row.title}
@@ -1095,10 +1109,10 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
           )
           return (
             <HomeSlotItem key={row.id} animated={!isBulkChange}>
-              {compact && description ? (
+              {tooltip ? (
                 // The hidden second line surfaces on hover. The span is the
                 // tooltip's trigger — HomeListItem doesn't forward trigger props.
-                <Tooltip label={description}>
+                <Tooltip label={tooltip}>
                   <span className="block">{node}</span>
                 </Tooltip>
               ) : (

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -403,6 +403,25 @@ type SubtitleTone = {
   subtitleCritical?: boolean
 }
 
+/**
+ * What a row may say ABOUT its second line — offered by every schema that
+ * declares a `description` at all, required by none of them.
+ */
+type DescriptionTone = {
+  /**
+   * Draws THIS row's second line critical instead of muted — the row is
+   * overdue, rejected, over budget.
+   *
+   * Per ROW rather than per schema, for the same reason `subtitleCritical` is:
+   * what has gone wrong is a state of the row's own data, so one list holds
+   * rows that say so beside rows that have nothing to report.
+   *
+   * Silent in a COMPACT list, where the second line has folded into the row's
+   * tooltip and there is nothing left to colour — see {@link listCompacts}.
+   */
+  descriptionCritical?: boolean
+}
+
 type ListTextData<S extends ListSchema> = {
   title: string
 } & (S["subtitleRequired"] extends true
@@ -411,10 +430,10 @@ type ListTextData<S extends ListSchema> = {
     ? { subtitle?: string } & SubtitleTone
     : { subtitle?: never; subtitleCritical?: never }) &
   (S["descriptionRequired"] extends true
-    ? { description: string }
+    ? { description: string } & DescriptionTone
     : S["descriptionOptional"] extends true
-      ? { description?: string }
-      : { description?: never })
+      ? { description?: string } & DescriptionTone
+      : { description?: never; descriptionCritical?: never })
 
 /**
  * One HOVER ACTION on a `list` row: an icon button over the row's right edge
@@ -923,6 +942,7 @@ type ListRow = {
   subtitle?: string
   subtitleCritical?: boolean
   description?: string
+  descriptionCritical?: boolean
   unread?: boolean
   avatar?: object & { icon?: IconType; color?: ListIconColor }
   module?: ModuleId
@@ -1065,6 +1085,7 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
               subtitle={row.subtitle}
               subtitleCritical={row.subtitleCritical}
               description={compact ? undefined : description}
+              descriptionCritical={row.descriptionCritical}
               unread={row.unread}
               {...listLeft(schema.left, row, avatarSize)}
               right={listRight(schema.right, row, rightAvatarSize)}


### PR DESCRIPTION
## Description

A Home `list` row can now say that its second line is what has gone **wrong** with it — rejected, overdue, over budget — rather than more about it. Two forms: `descriptionCritical` reddens the whole line, and a list of `DescriptionPart`s reddens individual facts on it. This is [#5341](https://github.com/factorialco/f0/pull/5341)'s `subtitleCritical` one line down; the two tones are independent, so an expense whose description reads "Rejected by Finance" keeps a muted "Travel" subtitle, because the trip is not what went wrong.

```tsx
description: [
  { text: "2 days overdue", critical: true },
  { text: "€340" },
  { text: "12 receipts" },
]
```
