### PR TITLE
chore(ownership): restore AI and surveys CODEOWNERS rules

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,8 +5,18 @@
 
 # Global rules, maintained by hand. Module-level ownership (sds/)
 # is declared in each module's package.yml — do not add those paths here.
+#
+# These paths are plain strings: moving or renaming a directory does NOT
+# update them, it silently hands the files back to the global fallback.
+# `pnpm ownership:check` fails on any rule whose path no longer exists, so
+# a move has to update this file in the same PR.
 * @factorialco/f0-devs
 /packages/react-native/ @factorialco/mobile
+
+# Team-owned areas outside sds/ (kits/ and the deprecated re-export barrels)
+/packages/react/src/ai/ @factorialco/platform-ai-building-blocks
+/packages/react/src/kits/ai/ @factorialco/platform-ai-building-blocks
+/packages/react/src/kits/surveys/ @factorialco/talent-engagement
 
 # --- Module ownership (generated from package.yml manifests) ---
 /packages/react/src/sds/chat/ @factorialco/platform-ai-building-blocks

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -39,6 +39,8 @@ pre-commit:
       glob: "packages/react/src/**/*.tsx"
       run: pnpm exec tsx packages/react/.scripts/check-animated-css-variables.ts --staged
 
+    # Globs cover every path CODEOWNERS points at, so moving or renaming an
+    # owned directory fails here instead of silently losing its owner team.
     ownership:
-      glob: "{CODEOWNERS,ownership/*,packages/react/src/sds/**}"
+      glob: "{CODEOWNERS,ownership/*,packages/react/src/sds/**,packages/react/src/kits/**,packages/react/src/ai/**}"
       run: pnpm --filter @factorialco/f0-ownership run check

--- a/ownership/CODEOWNERS.base
+++ b/ownership/CODEOWNERS.base
@@ -1,4 +1,14 @@
 # Global rules, maintained by hand. Module-level ownership (sds/)
 # is declared in each module's package.yml — do not add those paths here.
+#
+# These paths are plain strings: moving or renaming a directory does NOT
+# update them, it silently hands the files back to the global fallback.
+# `pnpm ownership:check` fails on any rule whose path no longer exists, so
+# a move has to update this file in the same PR.
 * @factorialco/f0-devs
 /packages/react-native/ @factorialco/mobile
+
+# Team-owned areas outside sds/ (kits/ and the deprecated re-export barrels)
+/packages/react/src/ai/ @factorialco/platform-ai-building-blocks
+/packages/react/src/kits/ai/ @factorialco/platform-ai-building-blocks
+/packages/react/src/kits/surveys/ @factorialco/talent-engagement

--- a/ownership/README.md
+++ b/ownership/README.md
@@ -3,8 +3,10 @@
 This folder contains the data and tooling that assign a **mandatory owner team**
 to every module in `packages/react/src/sds/`, generate the root `CODEOWNERS`
 file from those declarations, and enforce the **PR review policy** (which teams
-must approve each kind of PR). Everything else — including `kits/` — follows
-the regular component rules (no manifest).
+must approve each kind of PR). Everything else follows the regular component
+rules (no manifest) — except a handful of team-owned areas outside `sds/`
+(`kits/ai`, `kits/surveys`, `src/ai`), whose owners are declared by hand in
+[`CODEOWNERS.base`](CODEOWNERS.base).
 
 It is inspired by the `ownership/` system in `factorialco/factorial`.
 
@@ -55,6 +57,15 @@ membership. Keep it in sync with the GitHub org teams.
   rules override the global fallback: the owner team is the only required
   reviewer for its module.
 
+- Team-owned areas **outside** `sds/` (today `kits/ai`, `kits/surveys` and the
+  deprecated `src/ai` barrel) are declared by hand in
+  [`CODEOWNERS.base`](CODEOWNERS.base). Those paths are plain strings: GitHub
+  never validates them, so a rule pointing at a moved or renamed directory
+  keeps parsing while owning nothing, and its files quietly fall back to the
+  global owner. `pnpm ownership:check` fails on any such rule — **if you move
+  an owned directory, update the rule in the same PR**. Ownership declared
+  through a `package.yml` is immune: the manifest travels with the folder.
+
 - Nested manifests are supported: a deeper `package.yml` refines ownership of
   its subtree. Scoped reviewers (`reviewers[].include`) add extra teams for
   specific paths inside a module.
@@ -67,12 +78,17 @@ membership. Keep it in sync with the GitHub org teams.
 From the repo root:
 
 - `pnpm ownership` — regenerate `CODEOWNERS` from the manifests.
-- `pnpm ownership:check` — validate everything (run in CI on every PR):
+- `pnpm ownership:check` — validate everything (run in CI on every PR by the
+  `Ownership checks` workflow, and pre-commit by lefthook):
   1. every sds module has a manifest
   2. every manifest declares a valid `metadata.owner` (mandatory)
   3. all teams are in `teams.yml`
   4. reviewer `include` paths exist
-  5. `CODEOWNERS` is up to date with the manifests
+  5. every `CODEOWNERS` rule still matches a real path (catches moves and
+     renames that would otherwise drop a team's ownership silently)
+  6. every `CODEOWNERS` rule owner is a team from `teams.yml` (checks the
+     hand-maintained base rules too)
+  7. `CODEOWNERS` is up to date with the manifests
 
 ## Adding a new module
 
@@ -83,4 +99,14 @@ From the repo root:
 
 ## Changing ownership
 
-Edit the module's `package.yml`, run `pnpm ownership`, commit both files.
+Edit the module's `package.yml`, run `pnpm ownership`, commit both files. For a
+team-owned area outside `sds/`, edit [`CODEOWNERS.base`](CODEOWNERS.base)
+instead and regenerate the same way.
+
+## Moving an owned directory
+
+Move the folder, then update the rule that points at it — the module's
+`package.yml` moves with it, but a `CODEOWNERS.base` path does not — and run
+`pnpm ownership`. Check 5 fails while any rule points at a path that no longer
+exists, which is what stops a move from silently handing the files back to
+`@factorialco/f0-devs`.

--- a/ownership/check.ts
+++ b/ownership/check.ts
@@ -1,15 +1,18 @@
 import fs from "node:fs"
 import path from "node:path"
+import type { PatternProblem } from "./lib.ts"
 import {
   CODEOWNERS_FILE,
   MANIFEST_TEMPLATE,
   REPO_ROOT,
   TEAM_PATTERN,
+  checkCodeownersPattern,
   generateCodeowners,
   getManifestFiles,
   getModuleFolders,
   getValidTeams,
   loadManifest,
+  parseCodeowners,
 } from "./lib.ts"
 
 interface CheckResult {
@@ -110,6 +113,66 @@ function validateReviewerPaths(): CheckResult {
   ])
 }
 
+/**
+ * A rule whose path no longer exists is how ownership gets lost silently:
+ * GitHub keeps accepting the file, the rule just stops matching and the files
+ * fall back to the global owner. Moving or renaming a directory must update
+ * (or remove) the rule that points at it in the same PR.
+ */
+function validateCodeownersPaths(): CheckResult {
+  const problems = parseCodeowners(generateCodeowners()).flatMap((rule) => {
+    const problem = checkCodeownersPattern(rule.pattern)
+    return problem ? [{ rule, problem }] : []
+  })
+  if (problems.length === 0) return pass()
+
+  const explain: Record<PatternProblem, string> = {
+    missing: "path does not exist — was it moved, renamed or deleted?",
+    "not-a-directory": "pattern ends with / but the path is a file",
+    unanchored: 'must start with "/" so it is anchored to the repo root',
+  }
+  return fail([
+    "These CODEOWNERS rules don't match anything in the repo, so the files they",
+    "should own fall back to the global owner:",
+    ...problems.map(
+      ({ rule, problem }) =>
+        `  >> ${rule.pattern} ${rule.teams.join(" ")} — ${explain[problem]}`
+    ),
+    "",
+    "Fix the path in ownership/CODEOWNERS.base (or the module's package.yml,",
+    "for reviewer include paths) and run:",
+    "",
+    "  pnpm ownership",
+  ])
+}
+
+/**
+ * CODEOWNERS.base is hand-maintained, so its teams get no validation from the
+ * manifest checks. A team that doesn't exist (or lost write access, hence the
+ * teams.yml allowlist) is ignored by GitHub — same silent loss of ownership.
+ */
+function validateCodeownersTeams(): CheckResult {
+  const validTeams = getValidTeams()
+  const errors: string[] = []
+  for (const { pattern, teams } of parseCodeowners(generateCodeowners())) {
+    if (teams.length === 0) {
+      errors.push(`  >> ${pattern}: rule has no owner`)
+      continue
+    }
+    for (const team of teams.filter((team) => !validTeams.includes(team))) {
+      errors.push(`  >> ${pattern}: unknown team "${team}"`)
+    }
+  }
+  if (errors.length === 0) return pass()
+  return fail([
+    "The following CODEOWNERS rules reference teams that are not in",
+    "ownership/teams.yml:",
+    ...errors,
+    "If the team exists in the GitHub org and has write access to this repo,",
+    "add it to ownership/teams.yml.",
+  ])
+}
+
 function validateCodeownersUpToDate(): CheckResult {
   const current = fs.existsSync(CODEOWNERS_FILE)
     ? fs.readFileSync(CODEOWNERS_FILE, "utf8")
@@ -132,6 +195,8 @@ const checks = [
   { name: "Every manifest declares a valid owner", run: validateManifestSchema },
   { name: "All teams exist in ownership/teams.yml", run: validateTeams },
   { name: "All reviewer include paths point to real files", run: validateReviewerPaths },
+  { name: "Every CODEOWNERS rule matches a real path", run: validateCodeownersPaths },
+  { name: "Every CODEOWNERS rule owner is a known team", run: validateCodeownersTeams },
   { name: "CODEOWNERS is up to date", run: validateCodeownersUpToDate },
 ]
 

--- a/ownership/lib.ts
+++ b/ownership/lib.ts
@@ -69,6 +69,63 @@ export function getManifestFiles(): string[] {
   })
 }
 
+export interface CodeownersRule {
+  /** Path pattern, exactly as written in the CODEOWNERS file */
+  pattern: string
+  teams: string[]
+}
+
+/** Ownership rules of a CODEOWNERS body, with comments and blank lines dropped */
+export function parseCodeowners(contents: string): CodeownersRule[] {
+  return contents
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"))
+    .map((line) => {
+      const [pattern, ...teams] = line.split(/\s+/)
+      return { pattern, teams }
+    })
+}
+
+/** Leading segments of a pattern, up to the first one holding a glob */
+function concretePrefix(pattern: string): string {
+  const segments: string[] = []
+  for (const segment of pattern.split("/")) {
+    if (/[*?[\]]/.test(segment)) break
+    segments.push(segment)
+  }
+  return segments.join("/")
+}
+
+export type PatternProblem = "unanchored" | "missing" | "not-a-directory"
+
+/**
+ * Why a CODEOWNERS path pattern can no longer own anything, or undefined when
+ * it is fine. Patterns are plain strings that GitHub never validates: when a
+ * directory is moved or renamed the rule keeps parsing but stops matching, and
+ * its files silently fall back to the global owner.
+ */
+export function checkCodeownersPattern(pattern: string): PatternProblem | undefined {
+  if (pattern === "*") return undefined // global fallback
+  if (!pattern.startsWith("/")) return "unanchored"
+
+  const relative = pattern.slice(1)
+  const expectsDirectory = relative.endsWith("/")
+  const target = expectsDirectory ? relative.slice(0, -1) : relative
+
+  // A glob can't be resolved to a single path, so validate its fixed prefix —
+  // enough to catch the directory it points into being moved away.
+  const probe = concretePrefix(target)
+  if (probe === "") return undefined
+
+  const absolute = path.join(REPO_ROOT, probe)
+  if (!fs.existsSync(absolute)) return "missing"
+  if (probe === target && expectsDirectory && !fs.statSync(absolute).isDirectory()) {
+    return "not-a-directory"
+  }
+  return undefined
+}
+
 export function loadManifest(manifestFile: string): Manifest {
   return parse(fs.readFileSync(path.join(REPO_ROOT, manifestFile), "utf8"))
 }


### PR DESCRIPTION
## Description

The AI and Surveys teams silently lost code ownership of their kits. [#4823](https://github.com/factorialco/f0/pull/4823) moved both kits out of `sds/` and updated `CODEOWNERS` correctly, but [#4797](https://github.com/factorialco/f0/pull/4797) landed a few hours later, regenerated the file from the `sds/`-only manifests and dropped every rule outside `sds/` — so `kits/ai`, `kits/surveys` and the deprecated `src/ai` barrel have been falling through to the global `@factorialco/f0-devs` fallback ever since. This restores the three rules and adds two ownership checks so a rule that stops matching anything fails CI instead of quietly handing its files back to the fallback owner.
