### PR TITLE
fix(SlotWidget): give View more the same gap below it as beside it

### DIFF
--- a/packages/react/src/sds/Home/SlotWidget/index.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.tsx
@@ -315,8 +315,14 @@ export function SlotWidget({
     >
       <SlotWidgetContent
         // The selection goes DOWN, so a slot that owns its data fetches for
-        // whatever the header is showing.
-        ctx={selection === undefined ? ctx : { ...ctx, selection }}
+        // whatever the header is showing. So does whether this frame draws a
+        // FOOTER: the last slot's bottom bleed is the card's bottom edge only
+        // when nothing follows it (see `listMoreButtonClass`).
+        ctx={{
+          ...ctx,
+          hasFooter: Boolean(action),
+          ...(selection === undefined ? {} : { selection }),
+        }}
         loading={loading}
         slotRenderers={slotRenderers}
         slots={slots}

--- a/packages/react/src/sds/Home/SlotWidget/viewMoreAlignment.test.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/viewMoreAlignment.test.tsx
@@ -13,9 +13,15 @@ import { SlotWidget } from "./index"
  * title. It belongs on the frame's footer-button edge instead: that is the same
  * button one slot lower.
  *
- * jsdom computes no layout, so the assertion is on the offset CLASS. The 6px is
- * the bleed cancelled (8px) minus the 2px nudge `SlotWidget`'s footer takes —
- * change either and this is the test that says so.
+ * The BOTTOM is the same story on the other axis: the last slot keeps its
+ * bottom bleed so ROWS reach the card's bottom edge, and a button left in it
+ * sits 8px from the border while measuring 14px from the left. It takes the
+ * left edge's treatment too — unless a footer follows, where the bleed is
+ * already what the footer's own `mt-2` buys back.
+ *
+ * jsdom computes no layout, so the assertions are on the offset CLASSES. The
+ * 6px is the bleed cancelled (8px) minus the 2px nudge `SlotWidget`'s footer
+ * takes — change either and this is the test that says so.
  */
 describe("the list slot's View more button", () => {
   const rows = Array.from({ length: 5 }, (_, i) => ({
@@ -25,17 +31,18 @@ describe("the list slot's View more button", () => {
     avatar: { firstName: `Person${i}`, lastName: "Doe" },
   }))
 
+  const cappedList = () =>
+    listSlot(
+      { left: "person", descriptionRequired: true, maxVisibleItems: 2 },
+      rows
+    )
+
   const renderCappedList = () =>
     zeroRender(
       <SlotWidget
         header={{ title: "Needs you" }}
         action={{ label: "See all", onClick: () => {} }}
-        slots={[
-          listSlot(
-            { left: "person", descriptionRequired: true, maxVisibleItems: 2 },
-            rows
-          ),
-        ]}
+        slots={[cappedList()]}
       />
     )
 
@@ -50,5 +57,33 @@ describe("the list slot's View more button", () => {
     // Expanded, the same button carries the same edge.
     await userEvent.click(screen.getByRole("button", { name: /View more/ }))
     expect(wrapperOf("View less")).toHaveClass("ml-1.5")
+  })
+
+  test("takes the same edge below it when it is the last thing on the card", async () => {
+    zeroRender(
+      <SlotWidget header={{ title: "Needs you" }} slots={[cappedList()]} />
+    )
+
+    expect(wrapperOf(/View more/)).toHaveClass("mb-1.5")
+
+    await userEvent.click(screen.getByRole("button", { name: /View more/ }))
+    expect(wrapperOf("View less")).toHaveClass("mb-1.5")
+  })
+
+  test("keeps the bleed when a footer follows it — that is the footer's own gap", () => {
+    renderCappedList()
+
+    expect(wrapperOf(/View more/)).not.toHaveClass("mb-1.5")
+  })
+
+  test("keeps the bleed when another slot follows it", () => {
+    zeroRender(
+      <SlotWidget
+        header={{ title: "Needs you" }}
+        slots={[cappedList(), listSlot({ left: "person" }, rows.slice(0, 2))]}
+      />
+    )
+
+    expect(wrapperOf(/View more/)).not.toHaveClass("mb-1.5")
   })
 })

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -63,6 +63,14 @@ export interface HomeRenderCtx {
    */
   isLastSlot?: boolean
   /**
+   * Whether the widget draws a FOOTER under its slots (the frame's `action`).
+   * The last slot's bottom bleed is spent differently either way: with a footer
+   * it is what the footer's own `mt-2` buys back; without one, the slot's
+   * bottom IS the card's bottom edge — which is what a "View more" button
+   * sitting there needs to know (see {@link listMoreButtonClass}).
+   */
+  hasFooter?: boolean
+  /**
    * WHAT THE CARD IS SHOWING, when its header carries a `headerSelect`: the
    * option the reader is on. A slot renderer that owns its own data reads this
    * to fetch for it — the switcher is in the header, the fetching is here, and
@@ -913,6 +921,21 @@ export const slotRowBleed = (ctx: HomeRenderCtx) =>
  */
 export const LIST_MORE_BUTTON_CLASS = "ml-1.5 mt-1 self-start"
 
+/**
+ * The same edge on the OTHER axis, for when the button is the last thing on the
+ * card. The bleed a row-based slot keeps at its bottom is there so ROWS reach
+ * the card's bottom edge; the button is not a row, so left in that bleed it
+ * ends up 8px from the card's border while measuring 14px from its left — the
+ * corner reads as cropped. `mb-1.5` gives it the left edge's exact treatment
+ * (bleed cancelled, 2px nudge kept), so the gap below it equals the gap beside.
+ *
+ * Only when there is nothing after it: with a footer under the slots the bleed
+ * is already what the footer's own `mt-2` buys back, and padding here would
+ * push that footer 6px further down instead.
+ */
+export const listMoreButtonClass = (ctx: HomeRenderCtx) =>
+  cn(LIST_MORE_BUTTON_CLASS, ctx.isLastSlot && !ctx.hasFooter && "mb-1.5")
+
 /** The gap between rows of the `event-list` slot. */
 export const EVENT_LIST_GAP = "gap-2"
 
@@ -1088,7 +1111,7 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
         })}
       </HomeSlotItems>
       {overflows ? (
-        <div className={LIST_MORE_BUTTON_CLASS}>
+        <div className={listMoreButtonClass(ctx)}>
           {/* `neutral`, the same button a widget's own call to action is (the
               frame's `action`): "View more" is something you press, and a ghost
               button under a dense list of rows reads as another row. Past the
@@ -1255,7 +1278,7 @@ const ListSlotSkeleton = ({
         </div>
       ))}
       {overflows ? (
-        <div className={LIST_MORE_BUTTON_CLASS}>
+        <div className={listMoreButtonClass(ctx)}>
           {/* An `sm` neutral button — what "View more (n)" will be. */}
           <Skeleton className="h-6 w-24 rounded-sm" />
         </div>


### PR DESCRIPTION
## Description

A `list` slot's "View more (n)" button sat 8px from the card's bottom border while measuring 14px from its left, so the card's bottom-left corner read as cropped. The button's wrapper cancelled the slot's row bleed only horizontally; vertically it was left out in the bleed that the last slot deliberately keeps so its ROWS reach the card's edge. It now takes the same treatment on both axes.

## Type of change

- [x] Bug fix
