### PR TITLE
fix(ci): count .spec.ts(x) files as unit tests

### DIFF
--- a/packages/react/.scripts/__tests__/check-bugfix-red-green.test.ts
+++ b/packages/react/.scripts/__tests__/check-bugfix-red-green.test.ts
@@ -46,6 +46,48 @@ describe("overlayFilesFrom", () => {
     })
   })
 
+  it("collects .spec.ts(x) files too — the repo uses both conventions", () => {
+    const diff = [
+      "M\tpackages/react/src/sds/Home/HomeListItem/index.spec.tsx",
+      "A\tpackages/react/src/lib/__tests__/parse.spec.ts",
+      "M\tpackages/react/src/sds/Home/HomeListItem/index.tsx",
+    ].join("\n")
+
+    expect(overlayFilesFrom(diff)).toEqual({
+      testFiles: [
+        "packages/react/src/sds/Home/HomeListItem/index.spec.tsx",
+        "packages/react/src/lib/__tests__/parse.spec.ts",
+      ],
+      supportFiles: [],
+    })
+  })
+
+  it("collects .test. and .spec. files from the same diff", () => {
+    const diff = [
+      "A\tpackages/react/src/components/F0Tag/__tests__/F0Tag.test.tsx",
+      "A\tpackages/react/src/components/F0Tag/F0Tag.spec.ts",
+    ].join("\n")
+
+    expect(overlayFilesFrom(diff).testFiles).toEqual([
+      "packages/react/src/components/F0Tag/__tests__/F0Tag.test.tsx",
+      "packages/react/src/components/F0Tag/F0Tag.spec.ts",
+    ])
+  })
+
+  it("does not mistake a .spec. helper name for a test file", () => {
+    const diff = [
+      "A\tpackages/react/src/components/F0Tag/__tests__/spec.fixtures.ts",
+      "A\tpackages/react/src/components/F0Tag/specimen.ts",
+    ].join("\n")
+
+    expect(overlayFilesFrom(diff)).toEqual({
+      testFiles: [],
+      supportFiles: [
+        "packages/react/src/components/F0Tag/__tests__/spec.fixtures.ts",
+      ],
+    })
+  })
+
   it("collects tests for the repo's own scripts", () => {
     const diff = [
       "M\tpackages/react/.scripts/__tests__/check-api-surface.test.ts",

--- a/packages/react/.scripts/check-bugfix-red-green.ts
+++ b/packages/react/.scripts/check-bugfix-red-green.ts
@@ -7,8 +7,9 @@
  * applied (green: the fix works).
  *
  * How CI verifies that:
- *   1. Collect the unit-test files this PR adds or modifies (vs the base ref),
- *      plus any changed `__tests__/` helpers they may import.
+ *   1. Collect the unit-test files this PR adds or modifies (vs the base ref)
+ *      — `.test.ts(x)` and `.spec.ts(x)` alike — plus any changed
+ *      `__tests__/` helpers they may import.
  *   2. RED — build a throwaway git worktree of the base ref (latest main),
  *      overlay ONLY those files on top of it, and run the tests there: at
  *      least one must fail, proving the test reproduces the bug without the fix.
@@ -49,7 +50,8 @@ export function isBugfixTitle(title: string): boolean {
 }
 
 export interface OverlayFiles {
-  /** Unit-test files (.test.ts / .test.tsx) added or modified by the PR. */
+  /** Unit-test files added or modified by the PR — both the `.test.` and
+   * `.spec.` conventions (.ts and .tsx), since Vitest runs both. */
   testFiles: string[]
   /** Changed non-test files under `__tests__/` (helpers, fixtures, factories)
    * that the tests may import — overlaid alongside them. */
@@ -73,7 +75,7 @@ export function overlayFilesFrom(nameStatusOutput: string): OverlayFiles {
     const file = parts[parts.length - 1]
     if (!TESTED_ROOTS.some((root) => file.startsWith(`${PKG_PREFIX}${root}`)))
       continue
-    if (/\.test\.(ts|tsx)$/.test(file)) {
+    if (/\.(test|spec)\.(ts|tsx)$/.test(file)) {
       testFiles.push(file)
     } else if (file.includes("/__tests__/")) {
       supportFiles.push(file)

--- a/packages/react/scripts/component-status-build.mjs
+++ b/packages/react/scripts/component-status-build.mjs
@@ -13,7 +13,8 @@
  * - name (from the story `title` or the filename)
  * - zone (components, patterns, sds, kits, experimental, layouts, deprecated…)
  * - API status tag (stable / experimental / deprecated / internal — from tags)
- * - hasUnitTests  (a __tests__ folder or *.test.ts(x) near the story)
+ * - hasUnitTests  (a __tests__ folder, or a *.test.ts(x) / *.spec.ts(x) file,
+ *                  near the story)
  * - hasSnapshot   (a Chromatic snapshot story — `withSnapshot(...)`)
  * - hasMdxDocs    (an *.mdx file alongside the story)
  * - docQuality    (heuristic tier from the MDX structure)
@@ -266,9 +267,7 @@ export function a11yTierOf(content) {
 export function computeComponentStatusData(srcDir = SRC_DIR) {
   const allFiles = walk(srcDir)
   const storyFiles = allFiles.filter((f) => f.endsWith(".stories.tsx"))
-  const testFiles = allFiles.filter(
-    (f) => f.endsWith(".test.tsx") || f.endsWith(".test.ts")
-  )
+  const testFiles = allFiles.filter((f) => /\.(test|spec)\.(ts|tsx)$/.test(f))
   const mdxByDir = new Map()
   for (const f of allFiles) {
     if (!f.endsWith(".mdx")) continue

--- a/packages/react/scripts/component-status-build.test.ts
+++ b/packages/react/scripts/component-status-build.test.ts
@@ -127,6 +127,21 @@ beforeAll(() => {
     story("Alert", ["stable"], "\n" + PLAY_STORY)
   )
 
+  // 10a) Component whose only unit test uses the `.spec.` convention. The repo
+  // uses both `.test.` and `.spec.`, and Vitest runs both.
+  write(
+    "sds/Home/HomeListItem/index.stories.tsx",
+    story("HomeListItem", ["experimental"])
+  )
+  write("sds/Home/HomeListItem/index.spec.tsx", "test('x', () => {})")
+
+  // 10b) Same, with a `.spec.ts` inside `__tests__/`.
+  write(
+    "sds/Home/ClockIn/index.stories.tsx",
+    story("ClockIn", ["experimental"])
+  )
+  write("sds/Home/ClockIn/__tests__/clock.spec.ts", "test('x', () => {})")
+
   // 10) The meta title must win over a `title:` in a sample-data/args object
   // that appears before the meta (e.g. AI cards).
   write(
@@ -195,6 +210,13 @@ describe("computeComponentStatusData (extraction)", () => {
       hasMdxDocs: true,
       docQuality: "stub",
     })
+  })
+
+  test("counts .spec.ts(x) files as unit tests, like Vitest does", () => {
+    // The repo uses both conventions; a component tested only via `.spec.`
+    // must not read as untested.
+    expect(byName("HomeListItem")?.hasUnitTests).toBe(true)
+    expect(byName("ClockIn")?.hasUnitTests).toBe(true)
   })
 
   test("unit-test detection is scoped to the component, not the zone", () => {


### PR DESCRIPTION
## Description

Two file-collection filters only recognised the `.test.` convention, but Vitest runs both `.test.` and `.spec.` and 37 files under `packages/react/src` use `.spec.`. The visible symptom was the red-green gate reporting "adds or modifies no unit test" for a bugfix whose regression test lived in a `.spec.` file — blocking the push and failing the CI job, with `SKIP_RED_GREEN=1` or the `skip-red-green` label as the only outs, both of which disable a check that should have passed. The same blind spot in `component-status-build`'s `hasUnitTests` was mislabelling 11 components as untested.
