### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.81.2",
+  "packages/react": "6.81.3",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.81.3](https://github.com/factorialco/f0/compare/f0-react-v6.81.2...f0-react-v6.81.3) (2026-09-02)
+
+
+### Bug Fixes
+
+* **SlotWidget:** give View more the same gap below it as beside it ([#5363](https://github.com/factorialco/f0/issues/5363)) ([c35aa9b](https://github.com/factorialco/f0/commit/c35aa9b91d7c0dd2ff12eec190097dd94fee4652))
+
 ## [6.81.2](https://github.com/factorialco/f0/compare/f0-react-v6.81.1...f0-react-v6.81.2) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.81.2",
+  "version": "6.81.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.81.3</summary>

## [6.81.3](https://github.com/factorialco/f0/compare/f0-react-v6.81.2...f0-react-v6.81.3) (2026-09-02)


### Bug Fixes

* **SlotWidget:** give View more the same gap below it as beside it ([#5363](https://github.com/factorialco/f0/issues/5363)) ([c35aa9b](https://github.com/factorialco/f0/commit/c35aa9b91d7c0dd2ff12eec190097dd94fee4652))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).