### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.81.3",
+  "packages/react": "6.82.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.82.0](https://github.com/factorialco/f0/compare/f0-react-v6.81.3...f0-react-v6.82.0) (2026-09-02)
+
+
+### Features
+
+* **SlotWidget:** let a row's second line go critical ([#5360](https://github.com/factorialco/f0/issues/5360)) ([17f908f](https://github.com/factorialco/f0/commit/17f908fc91187fae0e6020fe74ee9358a7107cf7))
+
 ## [6.81.3](https://github.com/factorialco/f0/compare/f0-react-v6.81.2...f0-react-v6.81.3) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.81.3",
+  "version": "6.82.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.82.0</summary>

## [6.82.0](https://github.com/factorialco/f0/compare/f0-react-v6.81.3...f0-react-v6.82.0) (2026-09-02)


### Features

* **SlotWidget:** let a row's second line go critical ([#5360](https://github.com/factorialco/f0/issues/5360)) ([17f908f](https://github.com/factorialco/f0/commit/17f908fc91187fae0e6020fe74ee9358a7107cf7))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).