### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.82.0",
+  "packages/react": "6.82.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.82.1](https://github.com/factorialco/f0/compare/f0-react-v6.82.0...f0-react-v6.82.1) (2026-09-02)
+
+
+### Bug Fixes
+
+* **ci:** count .spec.ts(x) files as unit tests ([#5364](https://github.com/factorialco/f0/issues/5364)) ([75a3cc3](https://github.com/factorialco/f0/commit/75a3cc326b5c07de89eb96a9d337bddf067c334f))
+
 ## [6.82.0](https://github.com/factorialco/f0/compare/f0-react-v6.81.3...f0-react-v6.82.0) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.82.0",
+  "version": "6.82.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.82.1</summary>

## [6.82.1](https://github.com/factorialco/f0/compare/f0-react-v6.82.0...f0-react-v6.82.1) (2026-09-02)


### Bug Fixes

* **ci:** count .spec.ts(x) files as unit tests ([#5364](https://github.com/factorialco/f0/issues/5364)) ([75a3cc3](https://github.com/factorialco/f0/commit/75a3cc326b5c07de89eb96a9d337bddf067c334f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).