### PR TITLE
fix(F0Chat): keep the emoji autocomplete recoverable after a blur

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1067,8 +1067,11 @@ export const Snapshot: Story = {
       })
       await userEvent.clear(composer)
       await userEvent.type(composer, ":smil")
+      // Same rule as the dedicated autocomplete story: the list follows the
+      // composer's value, so wait for the value and then for the list.
+      await waitFor(() => expect(composer).toHaveValue(":smil"))
       await expect(
-        defaultChat.getByRole("listbox", { name: "Add emoji" })
+        await defaultChat.findByRole("listbox", { name: "Add emoji" })
       ).toBeVisible()
     })
 
@@ -1156,46 +1159,64 @@ export const EmojiAutocomplete: Story = {
   render: () => <Conversation initialCount={8} />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
-    const composer = canvas.getByRole("combobox", {
-      name: /write something here/i,
-    })
+    // Re-queried per use rather than captured once: the composer is a live
+    // node, and a story that holds the first reference types into a detached
+    // textarea if anything re-mounts the panel mid-play.
+    const composer = () =>
+      canvas.getByRole("combobox", { name: /write something here/i })
+    const emojiList = () => canvas.findByRole("listbox", { name: "Add emoji" })
+
+    /** Type a `:` trigger and wait for the state the list is *derived* from.
+     *
+     * The list is not a timed popover — it renders from the composer's own
+     * `value` + caret, so `expected` (the value once shortcode replacement has
+     * run) is the real precondition. Waiting on it also keeps the failure
+     * honest: a keystroke that never landed now reports the value it got
+     * instead of "the listbox is missing", which is how this story used to
+     * flake in CI. */
+    const typeTrigger = async (text: string, expected: string) => {
+      const field = composer()
+      await userEvent.click(field)
+      await waitFor(() => expect(field).toHaveFocus())
+      await userEvent.type(field, text, { skipClick: true })
+      await waitFor(() => expect(field).toHaveValue(expected))
+    }
 
     await step("Search and select with the keyboard", async () => {
-      await userEvent.type(composer, ":smil")
-      const listbox = canvas.getByRole("listbox", { name: "Add emoji" })
-      const selectedOption = within(listbox).getByRole("option", {
+      await typeTrigger(":smil", ":smil")
+      const listbox = await emojiList()
+      const selectedOption = await within(listbox).findByRole("option", {
         name: /:smile:.*Grinning Face with Smiling Eyes/,
       })
 
       await expect(listbox).toBeVisible()
-      await expect(composer).toHaveAttribute("aria-expanded", "true")
-      await expect(composer).toHaveAttribute("aria-controls", listbox.id)
-      await expect(composer).toHaveAttribute(
+      await expect(composer()).toHaveAttribute("aria-expanded", "true")
+      await expect(composer()).toHaveAttribute("aria-controls", listbox.id)
+      await expect(composer()).toHaveAttribute(
         "aria-activedescendant",
         selectedOption.id
       )
       await expect(selectedOption).toHaveAttribute("aria-selected", "true")
 
       await userEvent.keyboard("{Enter}")
-      await expect(composer).toHaveValue("😄 ")
-      await expect(
-        canvas.queryByRole("listbox", { name: "Add emoji" })
-      ).not.toBeInTheDocument()
-      await expect(composer).toHaveAttribute("aria-expanded", "false")
-      await expect(composer).toHaveFocus()
+      await waitFor(() => expect(composer()).toHaveValue("😄 "))
+      await waitFor(() =>
+        expect(
+          canvas.queryByRole("listbox", { name: "Add emoji" })
+        ).not.toBeInTheDocument()
+      )
+      await expect(composer()).toHaveAttribute("aria-expanded", "false")
+      await expect(composer()).toHaveFocus()
     })
 
     await step("Convert a complete alias", async () => {
-      await userEvent.clear(composer)
-      await userEvent.type(composer, ":thumbsup:")
-      await expect(composer).toHaveValue("👍")
+      await userEvent.clear(composer())
+      await typeTrigger(":thumbsup:", "👍")
     })
 
     await step("Leave the visual example open", async () => {
-      await userEvent.type(composer, " :joy")
-      await expect(
-        canvas.getByRole("listbox", { name: "Add emoji" })
-      ).toBeVisible()
+      await typeTrigger(" :joy", "👍 :joy")
+      await expect(await emojiList()).toBeVisible()
     })
   },
 }

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatComposer.emojiAutocomplete.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatComposer.emojiAutocomplete.test.tsx
@@ -1,0 +1,119 @@
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import {
+  zeroRender as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+
+import { F0Chat } from "../F0Chat"
+import { F0ChatProvider } from "../providers/F0ChatProvider"
+import { type F0ChatRuntime } from "../types"
+
+// jsdom has no layout — wrap Virtuoso in its official mock context so every
+// row renders (see mocks/virtuoso-jsdom).
+vi.mock("react-virtuoso", async (importOriginal) => {
+  const { mockVirtuosoModule } = await import("../mocks/virtuoso-jsdom")
+  return mockVirtuosoModule(
+    await importOriginal<typeof import("react-virtuoso")>()
+  )
+})
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const runtime: F0ChatRuntime = {
+  currentUserId: "me",
+  channel: {
+    id: "c1",
+    type: "dm",
+    title: "María José",
+    avatar: { type: "person", firstName: "María", lastName: "José" },
+  },
+  status: "ready",
+  messages: [],
+  typingUsers: [],
+  hasMoreOlder: false,
+  loadingOlder: false,
+  unreadCount: 0,
+  firstUnreadId: null,
+  sendMessage: vi.fn(),
+  retryMessage: vi.fn(),
+  loadOlder: vi.fn(),
+  toggleReaction: vi.fn(),
+  deleteMessage: vi.fn(),
+  onInputActivity: vi.fn(),
+  markRead: vi.fn(),
+}
+
+const renderChat = () =>
+  render(
+    <F0ChatProvider runtime={runtime}>
+      <F0Chat />
+    </F0ChatProvider>
+  )
+
+const composer = () =>
+  screen.getByRole("combobox", { name: /write something here/i })
+
+describe("ChatComposer emoji autocomplete", () => {
+  it("comes back when the composer is focused again mid-token", async () => {
+    const user = userEvent.setup()
+    renderChat()
+
+    await user.type(composer(), ":")
+    expect(
+      await screen.findByRole("listbox", { name: "Add emoji" })
+    ).toBeVisible()
+
+    // Anything can take focus away mid-token — clicking a header action, the
+    // window going to the background, a re-render that recreates the textarea.
+    // The token under the caret survives it, so the list has to as well.
+    await user.click(screen.getByRole("button", { name: "Add emoji" }))
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("listbox", { name: "Add emoji" })
+      ).not.toBeInTheDocument()
+    )
+
+    await user.type(composer(), "smil")
+    expect(composer()).toHaveValue(":smil")
+    expect(
+      await screen.findByRole("listbox", { name: "Add emoji" })
+    ).toBeVisible()
+    expect(composer()).toHaveAttribute("aria-expanded", "true")
+  })
+
+  it("keeps Escape's dismissal sticky for the token it dismissed", async () => {
+    const user = userEvent.setup()
+    renderChat()
+
+    await user.type(composer(), ":smil")
+    expect(
+      await screen.findByRole("listbox", { name: "Add emoji" })
+    ).toBeVisible()
+
+    // Escape is a deliberate "not now": unlike a blur it must not come back
+    // for this token, however much more of it you type.
+    await user.keyboard("{Escape}")
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("listbox", { name: "Add emoji" })
+      ).not.toBeInTheDocument()
+    )
+
+    await user.type(composer(), "e")
+    expect(composer()).toHaveValue(":smile")
+    expect(
+      screen.queryByRole("listbox", { name: "Add emoji" })
+    ).not.toBeInTheDocument()
+
+    // A new token is a new question — that one opens.
+    await user.type(composer(), " :joy")
+    expect(
+      await screen.findByRole("listbox", { name: "Add emoji" })
+    ).toBeVisible()
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -160,6 +160,8 @@ export const ChatComposer = (): ReactNode => {
   })
   const closeEmojiAutocomplete = emojiAutocomplete.close
   const handleEmojiAutocompleteKeyDown = emojiAutocomplete.handleKeyDown
+  const handleEmojiAutocompleteFocus = emojiAutocomplete.handleFocus
+  const handleEmojiAutocompleteBlur = emojiAutocomplete.handleBlur
   const mentionReactId = useId()
   const mentionListboxId = `chat-mention-autocomplete-${mentionReactId.replace(/:/g, "")}`
   const activeMentionCandidate =
@@ -998,7 +1000,11 @@ export const ChatComposer = (): ReactNode => {
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
-            onBlur={closeEmojiAutocomplete}
+            // Focus, not dismissal: the list belongs to the focused
+            // composer, but the `:token` under the caret stays live while you
+            // are away, so coming back shows it again.
+            onFocus={handleEmojiAutocompleteFocus}
+            onBlur={handleEmojiAutocompleteBlur}
             onCursorUpdate={updateCursorPosition}
             onScroll={syncHighlightScroll}
             highlightSegments={highlightSegments}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -13,6 +13,7 @@ type ChatTextareaFieldProps = {
   onChange: (value: string, cursorPos: number) => void
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
   onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
+  onFocus?: (event: React.FocusEvent<HTMLTextAreaElement>) => void
   onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => void
   onCursorUpdate: () => void
   onScroll: () => void
@@ -53,6 +54,7 @@ export const ChatTextareaField = ({
   onChange,
   onKeyDown,
   onPaste,
+  onFocus,
   onBlur,
   onCursorUpdate,
   onScroll,
@@ -136,6 +138,7 @@ export const ChatTextareaField = ({
         onChange={(e) => onChange(e.target.value, e.target.selectionStart ?? 0)}
         onKeyDown={onKeyDown}
         onPaste={onPaste}
+        onFocus={onFocus}
         onBlur={onBlur}
         onKeyUp={onCursorUpdate}
         onClick={onCursorUpdate}

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
@@ -47,6 +47,8 @@ export type UseEmojiAutocompleteReturn = {
   handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => boolean
   selectCandidate: (candidate: EmojiAutocompleteCandidate) => void
   setSelectedIndex: (index: number) => void
+  handleFocus: () => void
+  handleBlur: () => void
   close: () => void
 }
 
@@ -130,6 +132,13 @@ export function useEmojiAutocomplete({
   const listboxId = `chat-emoji-autocomplete-${reactId.replace(/:/g, "")}`
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [dismissedTrigger, setDismissedTrigger] = useState<number | null>(null)
+  // Leaving the composer HIDES the list; it does not dismiss the token under
+  // the caret. Blur used to route through `close()`, which parks the trigger in
+  // `dismissedTrigger` — and that is only released once the trigger disappears
+  // entirely, so a single focusout in the middle of `:smil` left the list
+  // unable to reopen however much more you typed. Escape and picking a
+  // candidate still dismiss the token for real.
+  const [isBlurred, setIsBlurred] = useState(false)
 
   // The same localized layer the picker uses, so `:` and the picker's search
   // box agree in every language, not just in English.
@@ -145,6 +154,7 @@ export function useEmojiAutocomplete({
   )
   const isOpen =
     trigger !== null &&
+    !isBlurred &&
     trigger.colonIndex !== dismissedTrigger &&
     results.length > 0
   const effectiveSelectedIndex = results[selectedIndex] ? selectedIndex : 0
@@ -158,6 +168,9 @@ export function useEmojiAutocomplete({
     setDismissedTrigger(trigger?.colonIndex ?? null)
     setSelectedIndex(0)
   }, [trigger?.colonIndex])
+
+  const handleFocus = useCallback(() => setIsBlurred(false), [])
+  const handleBlur = useCallback(() => setIsBlurred(true), [])
 
   const selectCandidate = useCallback(
     (candidate: EmojiAutocompleteCandidate) => {
@@ -279,6 +292,8 @@ export function useEmojiAutocomplete({
     handleKeyDown,
     selectCandidate,
     setSelectedIndex,
+    handleFocus,
+    handleBlur,
     close,
   }
 }


### PR DESCRIPTION
## Description

Losing focus in the middle of a `:token` left the composer's emoji autocomplete unable to reopen: blur routed through the same `close()` that Escape uses, which parks the trigger in `dismissedTrigger`, and that flag is only released once the trigger disappears entirely — so typing the rest of `:smil`, or clicking back into the composer, got you nothing. Blur now hides the list without dismissing the token, while Escape and picking a candidate still dismiss for real. That sticky state is also what made the `Composer emoji autocomplete` play test flaky in CI (`Unable to find an accessible element with the role "listbox" and name "Add emoji"`, e.g. runs 33617813101 and 33525609288 on main), since one stray focusout during `userEvent.type` puts the composer somewhere no amount of waiting recovers from.
