### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.82.1",
+  "packages/react": "6.83.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.83.0](https://github.com/factorialco/f0/compare/f0-react-v6.82.1...f0-react-v6.83.0) (2026-09-02)
+
+
+### Features
+
+* **CommunityPost:** show the body whole where the post is the destination ([#5263](https://github.com/factorialco/f0/issues/5263)) ([51df876](https://github.com/factorialco/f0/commit/51df87608f7d992971a19b2e4e2fcbb60d585ccf))
+
 ## [6.82.1](https://github.com/factorialco/f0/compare/f0-react-v6.82.0...f0-react-v6.82.1) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.82.1",
+  "version": "6.83.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.83.0</summary>

## [6.83.0](https://github.com/factorialco/f0/compare/f0-react-v6.82.1...f0-react-v6.83.0) (2026-09-02)


### Features

* **CommunityPost:** show the body whole where the post is the destination ([#5263](https://github.com/factorialco/f0/issues/5263)) ([51df876](https://github.com/factorialco/f0/commit/51df87608f7d992971a19b2e4e2fcbb60d585ccf))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).