### PR TITLE
fix(carousel): stop the shadow bleed eating pointer events

### DIFF
--- a/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/F0CommunityPostsCarousel/index.stories.tsx
@@ -370,4 +370,29 @@ export const InsideAWidget: Story = {
       }}
     />
   ),
+  /**
+   * The linked title is clickable all the way down. The carousel's shadow bleed
+   * (`CAROUSEL_SHADOW_BLEED`) overhangs 28px upward into the header, and while
+   * that band took pointer events it covered the bottom 16px of the title.
+   * Sampled down the whole title, since one point at its centre would pass
+   * again the moment the type scale moved.
+   */
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const title = canvas.getByRole("link", { name: "Go to Communities" })
+
+    await waitFor(() => {
+      const box = title.getBoundingClientRect()
+      expect(box.height).toBeGreaterThan(0)
+
+      const covered = []
+      for (let y = box.top + 1; y < box.bottom - 1; y += 2) {
+        const onTop = document.elementFromPoint(box.left + box.width / 2, y)
+        if (!title.contains(onTop)) {
+          covered.push(`${Math.round(y - box.top)}px: ${onTop?.className}`)
+        }
+      }
+      expect(covered).toEqual([])
+    })
+  },
 }

--- a/packages/react/src/ui/carousel.test.tsx
+++ b/packages/react/src/ui/carousel.test.tsx
@@ -46,4 +46,8 @@ describe("the carousel's shadow bleed", () => {
       expect(rule).toContain(`transparent_calc(100%_-_${bleed / 2}px)`)
     }
   })
+
+  test("takes no pointer events, so the band cannot cover its neighbours", () => {
+    expect(CAROUSEL_SHADOW_BLEED).toContain("pointer-events-none")
+  })
 })

--- a/packages/react/src/ui/carousel.tsx
+++ b/packages/react/src/ui/carousel.tsx
@@ -26,10 +26,16 @@ import { cn } from "@/lib/utils"
  * `carousel.test.tsx` fails if these drift from it: 28px is `-m-7` / `p-7`, 56px
  * is the pair, 14px is the half.
  *
+ * The borrowed band paints nothing but still hit-tests, so it takes no pointer
+ * events; the track turns them back on for the slides in {@link CarouselContent}.
+ * Embla's drag survives it — its listeners are on the viewport, but a drag
+ * starts on a slide and the events reach it by bubbling.
+ *
  * Exported for that test alone — nothing else should need it.
  */
 export const CAROUSEL_SHADOW_BLEED = cn(
   "-m-7 h-[calc(100%_+_56px)] w-[calc(100%_+_56px)] p-7",
+  "pointer-events-none",
   "[mask-image:linear-gradient(to_right,transparent_0px,transparent_14px,black_28px,black_calc(100%_-_28px),transparent_calc(100%_-_14px),transparent_100%)]",
   "[-webkit-mask-image:linear-gradient(to_right,transparent_0px,transparent_14px,black_28px,black_calc(100%_-_28px),transparent_calc(100%_-_14px),transparent_100%)]"
 )
@@ -415,6 +421,9 @@ const CarouselContent = React.forwardRef<
         ref={ref}
         className={cn(
           "flex",
+          // The slides take the pointer; the bleed band around them does not
+          // (see `CAROUSEL_SHADOW_BLEED`).
+          "pointer-events-auto",
           orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
           className
         )}


### PR DESCRIPTION
## Description

A carousel inside a `Widget` made the widget's linked header title only partly clickable: hovering the top of the title gave the pointer cursor and the hover tint, hovering the rest gave neither and a click there did nothing. The cause is the carousel viewport's shadow bleed — it borrows 28px on every side so its slides' shadows have somewhere to land inside the clip, and although that band paints nothing it still hit-tests, so its top edge sat over the header and took the bottom 16px of the 28px title. Reproduced in `Home/NewHomeLayout` → `Default`, where the Communities widget sits in the main area with `link: { title: "Go to Communities", url: "/communities" }`.
