### PR TITLE
fix(F0Chat): de-flake the composer hotkeys play test

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1243,8 +1243,10 @@ export const ComposerHotkeys: Story = {
           canvas.getByRole("button", { name: /remove quote/i })
         ).toBeVisible()
       )
-      await expect(composer).toHaveValue("")
-      await expect(composer).toHaveFocus()
+      // Dropping the edit draft and handing focus over are the quote's own
+      // follow-up effects, not part of the render that shows its chip.
+      await waitFor(() => expect(composer).toHaveValue(""))
+      await waitFor(() => expect(composer).toHaveFocus())
     })
 
     await step("The menu's Reply hands focus to the composer", async () => {
@@ -1255,11 +1257,25 @@ export const ComposerHotkeys: Story = {
       // The row defers its real popover until interaction intent — hover first,
       // or the click lands on the placeholder trigger instead.
       await userEvent.hover(row)
-      const menu = await waitFor(
-        () => canvas.getAllByRole("button", { name: /message actions/i })[0]
-      )
+      // Hovering only *starts* the swap: the row waits out any in-flight click
+      // before replacing the placeholder. Waiting for the button alone
+      // resolves on the placeholder still in place, and a click that lands
+      // mid-swap is lost — the detached node no longer reaches the React root.
+      // Only the armed trigger is a Radix PopoverTrigger, so `aria-expanded`
+      // is the swap's own signal.
+      const menu = await waitFor(() => {
+        const [trigger] = canvas.getAllByRole("button", {
+          name: /message actions/i,
+        })
+        expect(trigger).toHaveAttribute("aria-expanded", "false")
+        return trigger
+      })
       await userEvent.click(menu)
-      await userEvent.click(overlay.getByRole("button", { name: /^Reply$/i }))
+      // Radix portals the content on a later tick, so the menu's rows are
+      // never in the document on the click's own tick — find, don't get.
+      await userEvent.click(
+        await overlay.findByRole("button", { name: /^Reply$/i })
+      )
       // Radix keeps the popover mounted for its exit animation and only then
       // decides about focus — assert after that window, not before.
       await waitFor(() => expect(composer).toHaveFocus(), { timeout: 3000 })


### PR DESCRIPTION
## Description

`ComposerHotkeys` had two zero-tolerance reads in its last step, and under CPU load either one could lose: it took the first `message actions` button it found — which is the placeholder trigger the row swaps out 150ms after hover, so a click landing mid-swap hit a detached node — and then read the menu's Reply row with `getByRole` on the same tick as the click that opens it, before Radix had portalled the content. Both surfaced as the same failure, `Unable to find an accessible element with the role "button" and name /^Reply$/i`. Each read now waits on the real condition, the same way [#5368](https://github.com/factorialco/f0/pull/5368) fixed the emoji autocomplete story.

## Testing

Run against a built Storybook with six busy `node -e` CPU hogs on a 12-core machine, no `--testNamePattern`:

| build | result |
| --- | --- |
| with this change | **20/20 passed** |
| same build, change reverted | **8/15 passed** — 7 failures, all `ComposerHotkeys › play-test`, all the `/^Reply$/i` lookup |

No other story in the file failed in either set.

Story-only change, so it carries `skip-red-green`: there is no product-code change to write a failing-on-main unit test against — the flake lives entirely in the play function's timing.
