### PR TITLE
fix(EmojiPicker): stop its tests mounting every emoji

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/EmojiPicker/__tests__/EmojiPicker.test.tsx
@@ -11,7 +11,20 @@ import { screen, zeroRender as render, within } from "@/testing/test-utils"
 
 // jsdom has no layout, so Virtuoso would render zero rows and every assertion
 // here would pass against an empty grid. The official mock context gives it a
-// viewport tall enough to mount everything.
+// viewport to measure against.
+//
+// 320px is the panel's real one — what the grid gets once the search box and
+// the jump bar have taken theirs — and it is deliberately not a viewport tall
+// enough to mount all ~1,870 emoji at once. Mounting the whole set cost seconds
+// per render under CI's coverage instrumentation, this file re-renders the grid
+// on the first keystroke of every search, and that is what pushed these tests
+// past the 5s default timeout. Ten rows instead of ~210 is the same coverage
+// for a twentieth of the work.
+//
+// The catch: jsdom cannot scroll, so a cell below the fold is genuinely absent
+// from the DOM. Nothing here may assert an *absence* without holding a mounted
+// neighbour up against it, and nothing may reach for a cell far down the list —
+// see "clamps at the ends", which narrows the list with a search instead.
 vi.mock("react-virtuoso", async (importOriginal) => {
   const actual = await importOriginal<typeof import("react-virtuoso")>()
   const Mocked = forwardRef<
@@ -20,7 +33,7 @@ vi.mock("react-virtuoso", async (importOriginal) => {
   >(function MockedGroupedVirtuoso(props, ref): ReactNode {
     return createElement(
       actual.VirtuosoMockContext.Provider,
-      { value: { viewportHeight: 100_000, itemHeight: 32 } },
+      { value: { viewportHeight: 320, itemHeight: 32 } },
       createElement(actual.GroupedVirtuoso, { ...props, ref })
     )
   })
@@ -276,12 +289,22 @@ describe("EmojiPicker", () => {
     const user = userEvent.setup()
     renderPicker()
 
+    // Against a search rather than the whole set: clamping doesn't care how
+    // long the list is, and `{End}` on 1,870 emoji would land on a cell far
+    // outside the viewport — which in jsdom means not in the DOM at all, so
+    // both sides of the comparison would be null and it would pass on nothing.
+    // Four rows, the last of them partial, exercise every edge.
+    await user.type(searchBox(), "clock")
+
     const first = activeOption()
+    expect(first).not.toBeNull()
     await user.keyboard("{ArrowLeft}{ArrowUp}")
     expect(activeOption()).toBe(first)
 
     await user.keyboard("{End}")
     const last = activeOption()
+    expect(last).not.toBeNull()
+    expect(last).not.toBe(first)
     await user.keyboard("{ArrowRight}{ArrowDown}")
     expect(activeOption()).toBe(last)
   })
@@ -357,8 +380,13 @@ describe("EmojiPicker", () => {
     // Emoji 13 predates the melting face (14) and the shaking face (15).
     render(<EmojiPicker onSelect={() => {}} emojiVersion={13} />)
 
-    expect(screen.queryByLabelText("Melting Face")).not.toBeInTheDocument()
+    // Melting Face sits eleventh in Smileys, two rows into a viewport that
+    // mounts ten — and Winking Face, the entry right after it, is here to prove
+    // the window reaches that far. So the absence below is the filter, not
+    // virtualization.
     expect(screen.getByLabelText("Grinning Face")).toBeInTheDocument()
+    expect(screen.getByLabelText("Winking Face")).toBeInTheDocument()
+    expect(screen.queryByLabelText("Melting Face")).not.toBeInTheDocument()
   })
 
   it("offers a jump-to bar for every category", () => {
@@ -375,9 +403,17 @@ describe("EmojiPicker", () => {
     renderPicker()
 
     await user.type(searchBox(), "tada")
+    const whileSearching = searchBox().getAttribute("aria-activedescendant")
     await user.click(screen.getByRole("tab", { name: "Food & drink" }))
 
+    // Browsing again, with the selection moved into the section you asked for.
     expect(searchBox()).toHaveValue("")
-    expect(screen.getByText("Food & drink")).toBeInTheDocument()
+    expect(screen.getByText("Frequently used")).toBeInTheDocument()
+    expect(searchBox().getAttribute("aria-activedescendant")).not.toBe(
+      whileSearching
+    )
+    // Where the scroller lands is Storybook's to verify: jsdom has no
+    // scrolling, so asserting a mounted "Food & drink" header here would only
+    // prove the section exists — which it does whether the jump worked or not.
   })
 })


### PR DESCRIPTION
## Description

`EmojiPicker > hides emoji the platform cannot draw` has been red on main with `Test timed out in 5000ms`, blocking the ✅ Unit Tests gate for unrelated PRs. The test body is fully synchronous — nothing is un-awaited. The `react-virtuoso` mock in this suite handed Virtuoso a 100,000px viewport, which mounts the entire emoji set (1,878 buttons per render, measured locally), and the first keystroke of a search re-renders all of it. Under CI's coverage instrumentation on a loaded 2-core runner that tips past the 5s default `testTimeout`. This makes the render cheap instead of raising the timeout: the mocked viewport is now the panel's real 320px, so a render mounts ~8 rows rather than ~210.

## Type of change

- [x] Bug fix

## Implementation details

- fix: give the mocked Virtuoso the picker panel's real 320px viewport instead of 100,000px
- fix: rework the three assertions that were only true because the whole list happened to be mounted

  <details>
  <summary>Why each one had to change</summary>

  jsdom cannot scroll, so a cell below the fold is genuinely absent from the DOM. Three assertions would have silently stopped testing anything:

  - **`hides emoji the platform cannot draw`** — asserts Melting Face (Emoji 14) is absent at `emojiVersion={13}`, which is vacuous if it was never mounted. It sits 11th in Smileys, two rows into a viewport that mounts ~8, and Winking Face — the entry immediately after it — is now asserted present as the mounted control that proves the window reaches that far.
  - **`clamps at the ends instead of wrapping`** — `{End}` lands on the last of ~1,870 cells, far outside the viewport, so both sides of the comparison would have been `null` and it would have passed on nothing. It now narrows the list with a `clock` search first (30 results, 4 rows, the last one partial): clamping is length-independent, and every cell is mounted. Explicit non-null assertions guard the rest.
  - **`leaves a search when you jump to a category`** — asserted a mounted `Food & drink` header, which only proved the section exists; it did so whether or not the jump ran. It now checks the browse view returns and `aria-activedescendant` moves into the requested section. Where the scroller lands stays Storybook's to verify, consistent with the file's existing notes about jsdom having no scrolling.

  The mock's comment records the constraint so the next person doesn't reintroduce a tall viewport.
  </details>

### Verification

Reproduced CI conditions locally with `--coverage.enabled true` plus eight busy `node -e` loops starving the CPU:

| | before | after |
| --- | --- | --- |
| tests over the 5s default timeout | 8 | 0 |
| slowest test | timed out | 3.2s |
| the reported flaky test | 11.4s → timeout | 0.9s |

Uncontended, the file's test time drops from 106s to 8.4s. Lint, format and typecheck clean.

### `ChatEmojiPickerButton.test.tsx` is deliberately untouched

It carries the identical 100,000px mock and mounts the same picker, so it has the same exposure (slowest test 2.0s locally). I shrank it too at first, and CI caught why that is not safe: it makes `lets the composer keep the caret so you can carry on typing` racy — 2 failures in 6 local runs, against 0 in 6 with the tall viewport. That test pins the winner of a focus contest between the consumer's `requestAnimationFrame(() => textarea.focus())` and Radix's focus-restore-to-trigger on close. The ordering isn't actually guaranteed; the cost of unmounting 1,878 buttons was hiding that. Fixing it means making the handoff deterministic in the component rather than relying on render cost, which is a behaviour change and wants its own PR — so that file stays as it is here and keeps passing.

### Note on the Bugfix Red-Green gate

This needs the `skip-red-green` label. The bug is a timeout under CPU contention and coverage instrumentation, not a behavioural defect, so it cannot be captured as a test that is deterministically red on main — the component is unchanged and this test file passes against main's source. The regression guard is the mock comment plus the assertions above, which now fail loudly rather than vacuously if someone widens the viewport again.