### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.83.0",
+  "packages/react": "6.83.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [6.83.1](https://github.com/factorialco/f0/compare/f0-react-v6.83.0...f0-react-v6.83.1) (2026-09-02)
+
+
+### Bug Fixes
+
+* **carousel:** stop the shadow bleed eating pointer events ([#5370](https://github.com/factorialco/f0/issues/5370)) ([59ba711](https://github.com/factorialco/f0/commit/59ba7115e948f7dcfc23ba8e04e864b1a07902d5))
+* **F0Chat:** de-flake the composer hotkeys play test ([#5371](https://github.com/factorialco/f0/issues/5371)) ([9844caa](https://github.com/factorialco/f0/commit/9844caafcc4a75ade8cbdfd3609bddb9b9af9812))
+
 ## [6.83.0](https://github.com/factorialco/f0/compare/f0-react-v6.82.1...f0-react-v6.83.0) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.83.0",
+  "version": "6.83.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.83.1</summary>

## [6.83.1](https://github.com/factorialco/f0/compare/f0-react-v6.83.0...f0-react-v6.83.1) (2026-09-02)


### Bug Fixes

* **carousel:** stop the shadow bleed eating pointer events ([#5370](https://github.com/factorialco/f0/issues/5370)) ([59ba711](https://github.com/factorialco/f0/commit/59ba7115e948f7dcfc23ba8e04e864b1a07902d5))
* **F0Chat:** de-flake the composer hotkeys play test ([#5371](https://github.com/factorialco/f0/issues/5371)) ([9844caa](https://github.com/factorialco/f0/commit/9844caafcc4a75ade8cbdfd3609bddb9b9af9812))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).