### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.83.1",
+  "packages/react": "6.83.2",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.83.2](https://github.com/factorialco/f0/compare/f0-react-v6.83.1...f0-react-v6.83.2) (2026-09-02)
+
+
+### Bug Fixes
+
+* **EmojiPicker:** stop its tests mounting every emoji ([#5372](https://github.com/factorialco/f0/issues/5372)) ([640f521](https://github.com/factorialco/f0/commit/640f5218114953b43044de097fa92c9c777daf99))
+
 ## [6.83.1](https://github.com/factorialco/f0/compare/f0-react-v6.83.0...f0-react-v6.83.1) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.83.1",
+  "version": "6.83.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.83.2</summary>

## [6.83.2](https://github.com/factorialco/f0/compare/f0-react-v6.83.1...f0-react-v6.83.2) (2026-09-02)


### Bug Fixes

* **EmojiPicker:** stop its tests mounting every emoji ([#5372](https://github.com/factorialco/f0/issues/5372)) ([640f521](https://github.com/factorialco/f0/commit/640f5218114953b43044de097fa92c9c777daf99))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).