### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.83.2",
+  "packages/react": "6.83.3",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.83.3](https://github.com/factorialco/f0/compare/f0-react-v6.83.2...f0-react-v6.83.3) (2026-09-02)
+
+
+### Bug Fixes
+
+* **F0Chat:** keep the emoji autocomplete recoverable after a blur ([#5368](https://github.com/factorialco/f0/issues/5368)) ([cdf6f56](https://github.com/factorialco/f0/commit/cdf6f5673730abf6d19b3aed62b4e09e3081f5d0))
+
 ## [6.83.2](https://github.com/factorialco/f0/compare/f0-react-v6.83.1...f0-react-v6.83.2) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.83.2",
+  "version": "6.83.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.83.3</summary>

## [6.83.3](https://github.com/factorialco/f0/compare/f0-react-v6.83.2...f0-react-v6.83.3) (2026-09-02)


### Bug Fixes

* **F0Chat:** keep the emoji autocomplete recoverable after a blur ([#5368](https://github.com/factorialco/f0/issues/5368)) ([cdf6f56](https://github.com/factorialco/f0/commit/cdf6f5673730abf6d19b3aed62b4e09e3081f5d0))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).