### PR TITLE
perf(OneDataCollection): stop a page append re-rendering every row already on screen

### DIFF
--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -90,6 +90,42 @@ export type WithGroupId<RecordType> = RecordType & {
   [GROUP_ID_SYMBOL]: unknown | undefined
 }
 
+type GroupIdCache<R extends RecordType> = {
+  field: string | undefined
+  entries: WeakMap<R, WithGroupId<R>>
+}
+
+/**
+ * Decorates records with their group id, reusing the object built for a record
+ * the last time it was seen. A page append rebuilds the array but keeps the
+ * objects of the records already loaded, and the table's row memo compares on
+ * those objects: decorating each record afresh would re-render every row
+ * already on screen.
+ */
+const decorateWithGroupId = <R extends RecordType>(
+  records: R[],
+  field: string,
+  cacheRef: { current: GroupIdCache<R> }
+): WithGroupId<R>[] => {
+  const cache = cacheRef.current
+  if (cache.field !== field) {
+    cache.field = field
+    cache.entries = new WeakMap()
+  }
+
+  return records.map((record) => {
+    const cached = cache.entries.get(record)
+    if (cached) return cached
+
+    const decorated = {
+      ...record,
+      [GROUP_ID_SYMBOL]: getValueByPath(record, field) || undefined,
+    }
+    cache.entries.set(record, decorated)
+    return decorated
+  })
+}
+
 /**
  * Hook return type for useData
  */
@@ -497,30 +533,25 @@ export function useData<
     ]
   )
 
+  const groupIdCacheRef = useRef<GroupIdCache<R>>({
+    field: undefined,
+    entries: new WeakMap(),
+  })
+
   const data = useMemo(() => {
-    // if (hasLanes) return { type: "flat" as const, records: [] }
-    // Add the groupId to the data if grouping is enabled
-    const data: WithGroupId<R>[] = rawData.map((record) => ({
-      ...record,
-      [GROUP_ID_SYMBOL]:
-        (currentGrouping?.field &&
-          getValueByPath(record, currentGrouping.field as string)) ||
-        undefined,
-    }))
+    const groupingField = currentGrouping?.field as string | undefined
+    const isGrouped =
+      !!groupingField &&
+      !!grouping &&
+      !!(grouping.groupBy as Record<string, unknown>)[groupingField]
 
     /**
      * Grouped data
      */
-    if (
-      currentGrouping &&
-      currentGrouping.field &&
-      grouping &&
-      (grouping.groupBy as Record<string, unknown>)[
-        currentGrouping.field as string
-      ]
-    ) {
+    if (isGrouped) {
+      const data = decorateWithGroupId(rawData, groupingField, groupIdCacheRef)
       const groupedData = groupBy(data, GROUP_ID_SYMBOL)
-      const fieldName = currentGrouping.field as string
+      const fieldName = groupingField
       const groupConfig = (grouping.groupBy as Record<string, unknown>)[
         fieldName
       ] as {
@@ -554,6 +585,12 @@ export function useData<
     /**
      * Flat data
      */
+    // The group id is only ever read from a grouped result, so ungrouped
+    // records are handed through untouched. Decorating them would give every
+    // record a new identity on each run of this memo, which is what the row
+    // memo downstream compares on.
+    const data = rawData as WithGroupId<R>[]
+
     return {
       type: "flat" as const,
       records: data,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -344,6 +344,30 @@ export const TableCollection = <
     getRenderedSelectableEntries: selectionRegistry.getEntries,
     renderedSelectableCount: selectionRegistry.ids.length,
   })
+
+  // `handleSelectItemChange` is rebuilt whenever the consumer's `selectable`
+  // changes identity, which for an inline definition is every render. Rows get a
+  // stable wrapper instead, so the latest handler still runs.
+  const latestSelectItemChangeRef = useRef(handleSelectItemChange)
+  latestSelectItemChangeRef.current = handleSelectItemChange
+  const stableSelectItemChange = useMemo(
+    () => (item: R, checked: boolean) =>
+      latestSelectItemChangeRef.current(item, checked),
+    []
+  )
+
+  // Selection is handed to each row as its own boolean. Passing the whole Map made
+  // every row's props differ on any selection change (measured: 25 mismatches for
+  // 25 rows), so one checkbox re-rendered the entire table.
+  const isItemSelected = (record: R): boolean => {
+    const id = stableSource.selectable?.(record)
+    return id !== undefined && selectedItems.has(id)
+  }
+
+  // Only rows that render nested children need the Map, to derive their own
+  // children's state. Flat rows get `undefined`, which is stable.
+  const nestedSelectedItems = (record: R): typeof selectedItems | undefined =>
+    stableSource.itemsWithChildren?.(record) ? selectedItems : undefined
   const summaryData = useMemo(() => {
     // Early return if no summaries configuration or summaries data is available
 
@@ -886,11 +910,9 @@ export const TableCollection = <
                                 item={item}
                                 index={index}
                                 groupIndex={groupIndex}
-                                onItemCheckedChange={handleSelectItemChange}
-                                onCheckedChange={(checked) =>
-                                  handleSelectItemChange(item, checked)
-                                }
-                                selectedItems={selectedItems}
+                                onItemCheckedChange={stableSelectItemChange}
+                                isSelected={isItemSelected(item)}
+                                selectedItems={nestedSelectedItems(item)}
                                 columns={columns}
                                 frozenColumnsLeft={frozenColumnsLeft}
                                 checkColumnWidth={checkColumnWidth}
@@ -951,11 +973,9 @@ export const TableCollection = <
                       source={stableSource}
                       item={item}
                       index={index}
-                      onItemCheckedChange={handleSelectItemChange}
-                      onCheckedChange={(checked) =>
-                        handleSelectItemChange(item, checked)
-                      }
-                      selectedItems={selectedItems}
+                      onItemCheckedChange={stableSelectItemChange}
+                      isSelected={isItemSelected(item)}
+                      selectedItems={nestedSelectedItems(item)}
                       columns={columns}
                       frozenColumnsLeft={frozenColumnsLeft}
                       checkColumnWidth={checkColumnWidth}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
-import { Fragment, useEffect, useMemo, useRef, useState } from "react"
+import { Fragment, memo, useEffect, useMemo, useRef, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
@@ -137,18 +137,30 @@ export const TableCollection = <
   TableCustomizationProps<R, Sortings, Summaries>) => {
   const { t, ...i18n } = useI18n()
   const addRow = useAddRow()
-  // Created a motion component for the row
+  // Created a motion component for the row.
+  //
+  // Memoized on the OUTSIDE of `motion.create`, not on `Row`: rows carry framer's
+  // `layout` prop, so the wrapper measures each row's box on every commit. A memo
+  // inside would skip React's render of the row but still pay that measurement,
+  // which is a large part of what makes a full-table commit expensive.
+  //
+  // Default shallow comparison on purpose. A hand-written comparator is faster but
+  // fails unsafely — omit a prop and a row silently shows stale data. Shallow only
+  // skips when every prop is identical, so a prop we have not stabilized costs a
+  // render rather than correctness.
   const [MotionRow] = useState(() =>
-    motion.create(
-      Row<
-        R,
-        Filters,
-        Sortings,
-        Summaries,
-        ItemActions,
-        NavigationFilters,
-        Grouping
-      >
+    memo(
+      motion.create(
+        Row<
+          R,
+          Filters,
+          Sortings,
+          Summaries,
+          ItemActions,
+          NavigationFilters,
+          Grouping
+        >
+      )
     )
   )
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -236,6 +236,11 @@ export const TableCollection = <
     [source, showItemActionsProp]
   )
 
+  // Called with no arguments at every use site, so the result is always the same
+  // object by value. Building it once stops every row receiving a fresh
+  // `variants` prop on each render.
+  const rowAnimationVariants = useMemo(() => getAnimationVariants(), [])
+
   // Infinite scroll pagination
   const { loadingIndicatorRef } = useInfiniteScrollPagination(
     paginationInfo,
@@ -824,7 +829,7 @@ export const TableCollection = <
                             const rowKey = `row-${groupIndex}-${getRowKey(item, index)}`
                             const motionRow = (
                               <MotionRow
-                                variants={getAnimationVariants()}
+                                variants={rowAnimationVariants}
                                 initial={collapsible ? "hidden" : "visible"}
                                 animate="visible"
                                 exit="hidden"
@@ -886,7 +891,7 @@ export const TableCollection = <
                   const isNew = addedRowKeys.has(rowKey)
                   const motionRow = (
                     <MotionRow
-                      variants={getAnimationVariants()}
+                      variants={rowAnimationVariants}
                       // Only a genuinely-inserted row plays the enter
                       // animation; rows arriving via pagination or the initial
                       // load appear in place, without movement.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -241,6 +241,40 @@ export const TableCollection = <
   // `variants` prop on each render.
   const rowAnimationVariants = useMemo(() => getAnimationVariants(), [])
 
+  // Rows receive the source, and it gets a fresh identity on every render of the
+  // consumer: `useDataCollectionSource` returns an object literal whose spread
+  // members come from the consumer's inline definition, so it cannot be memoized
+  // at the origin. While that identity churns, no memo boundary on a row can ever
+  // hit — the comparison fails on this prop alone, every time.
+  //
+  // This hands rows a stable object that forwards every read to the latest
+  // source, so values are never stale; only the identity is pinned. A proxy
+  // rather than a hand-picked copy of the fields rows use, because the subtree
+  // both reads individual fields AND spreads the whole object (`RowLoading`
+  // rebuilds it to override one), so an explicit list would silently go out of
+  // date the next time a field is added.
+  const latestSourceRef = useRef(effectiveSource)
+  latestSourceRef.current = effectiveSource
+  const stableSource = useMemo(
+    () =>
+      new Proxy({} as typeof effectiveSource, {
+        get: (_target, prop) =>
+          latestSourceRef.current[prop as keyof typeof effectiveSource],
+        has: (_target, prop) => prop in latestSourceRef.current,
+        ownKeys: () => Reflect.ownKeys(latestSourceRef.current),
+        // The proxy target is empty, so a descriptor for a key it does not own
+        // must be reported configurable or the proxy invariant throws.
+        getOwnPropertyDescriptor: (_target, prop) => {
+          const descriptor = Reflect.getOwnPropertyDescriptor(
+            latestSourceRef.current,
+            prop
+          )
+          return descriptor && { ...descriptor, configurable: true }
+        },
+      }),
+    []
+  )
+
   // Infinite scroll pagination
   const { loadingIndicatorRef } = useInfiniteScrollPagination(
     paginationInfo,
@@ -836,7 +870,7 @@ export const TableCollection = <
                                 custom={index}
                                 key={rowKey}
                                 layout
-                                source={effectiveSource}
+                                source={stableSource}
                                 item={item}
                                 index={index}
                                 groupIndex={groupIndex}
@@ -902,7 +936,7 @@ export const TableCollection = <
                       layout
                       isNew={isNew}
                       groupIndex={0}
-                      source={effectiveSource}
+                      source={stableSource}
                       item={item}
                       index={index}
                       onItemCheckedChange={handleSelectItemChange}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -253,40 +253,6 @@ export const TableCollection = <
   // `variants` prop on each render.
   const rowAnimationVariants = useMemo(() => getAnimationVariants(), [])
 
-  // Rows receive the source, and it gets a fresh identity on every render of the
-  // consumer: `useDataCollectionSource` returns an object literal whose spread
-  // members come from the consumer's inline definition, so it cannot be memoized
-  // at the origin. While that identity churns, no memo boundary on a row can ever
-  // hit — the comparison fails on this prop alone, every time.
-  //
-  // This hands rows a stable object that forwards every read to the latest
-  // source, so values are never stale; only the identity is pinned. A proxy
-  // rather than a hand-picked copy of the fields rows use, because the subtree
-  // both reads individual fields AND spreads the whole object (`RowLoading`
-  // rebuilds it to override one), so an explicit list would silently go out of
-  // date the next time a field is added.
-  const latestSourceRef = useRef(effectiveSource)
-  latestSourceRef.current = effectiveSource
-  const stableSource = useMemo(
-    () =>
-      new Proxy({} as typeof effectiveSource, {
-        get: (_target, prop) =>
-          latestSourceRef.current[prop as keyof typeof effectiveSource],
-        has: (_target, prop) => prop in latestSourceRef.current,
-        ownKeys: () => Reflect.ownKeys(latestSourceRef.current),
-        // The proxy target is empty, so a descriptor for a key it does not own
-        // must be reported configurable or the proxy invariant throws.
-        getOwnPropertyDescriptor: (_target, prop) => {
-          const descriptor = Reflect.getOwnPropertyDescriptor(
-            latestSourceRef.current,
-            prop
-          )
-          return descriptor && { ...descriptor, configurable: true }
-        },
-      }),
-    []
-  )
-
   // Infinite scroll pagination
   const { loadingIndicatorRef } = useInfiniteScrollPagination(
     paginationInfo,
@@ -360,14 +326,14 @@ export const TableCollection = <
   // every row's props differ on any selection change (measured: 25 mismatches for
   // 25 rows), so one checkbox re-rendered the entire table.
   const isItemSelected = (record: R): boolean => {
-    const id = stableSource.selectable?.(record)
+    const id = effectiveSource.selectable?.(record)
     return id !== undefined && selectedItems.has(id)
   }
 
   // Only rows that render nested children need the Map, to derive their own
   // children's state. Flat rows get `undefined`, which is stable.
   const nestedSelectedItems = (record: R): typeof selectedItems | undefined =>
-    stableSource.itemsWithChildren?.(record) ? selectedItems : undefined
+    effectiveSource.itemsWithChildren?.(record) ? selectedItems : undefined
   const summaryData = useMemo(() => {
     // Early return if no summaries configuration or summaries data is available
 
@@ -906,7 +872,7 @@ export const TableCollection = <
                                 custom={index}
                                 key={rowKey}
                                 layout
-                                source={stableSource}
+                                source={effectiveSource}
                                 item={item}
                                 index={index}
                                 groupIndex={groupIndex}
@@ -970,7 +936,7 @@ export const TableCollection = <
                       layout
                       isNew={isNew}
                       groupIndex={0}
-                      source={stableSource}
+                      source={effectiveSource}
                       item={item}
                       index={index}
                       onItemCheckedChange={stableSelectItemChange}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/InfiniteScrollRowCommits.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/InfiniteScrollRowCommits.integration.test.tsx
@@ -1,0 +1,175 @@
+import { screen, waitFor } from "@testing-library/react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  FiltersDefinition,
+  GroupingDefinition,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+
+import { TextCell } from "@/ui/value-display/types/text"
+import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { SummariesDefinition } from "../../../../summary"
+import { TableCollection } from "../index"
+
+vi.mock("../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+type Person = { id: number; name: string }
+
+const PER_PAGE = 3
+const people: Person[] = Array.from({ length: 9 }, (_, index) => ({
+  id: index + 1,
+  name: `Person ${index + 1}`,
+}))
+
+/**
+ * Renders per row, counted where the row's own body runs. A row that skips its
+ * render does not call its columns' renderers.
+ */
+const renderCounts = new Map<number, number>()
+
+const columns = [
+  {
+    label: "name",
+    render: (item: Person) => {
+      renderCounts.set(item.id, (renderCounts.get(item.id) ?? 0) + 1)
+      return item.name
+    },
+  },
+]
+
+// The real observer never fires in jsdom, and the global stub in the test setup
+// only records the call. This one keeps the callback so the test can bring the
+// sentinel into view on demand — the only way to reach `loadMore`, which the
+// table owns internally.
+let intersect: (() => void) | undefined
+
+beforeEach(() => {
+  renderCounts.clear()
+  intersect = undefined
+  vi.stubGlobal(
+    "IntersectionObserver",
+    class {
+      constructor(private readonly callback: IntersectionObserverCallback) {}
+      observe(target: Element) {
+        intersect = () =>
+          this.callback(
+            [{ isIntersecting: true, target } as IntersectionObserverEntry],
+            this as unknown as IntersectionObserver
+          )
+      }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() {
+        return []
+      }
+    }
+  )
+})
+
+const Harness = () => {
+  const source = useDataCollectionSource<
+    Person,
+    FiltersDefinition,
+    SortingsDefinition,
+    SummariesDefinition,
+    ItemActionsDefinition<Person>,
+    NavigationFiltersDefinition,
+    GroupingDefinition<Person>
+  >(
+    {
+      selectable: (item: Person) => item.id,
+      dataAdapter: {
+        paginationType: "infinite-scroll",
+        fetchData: async ({
+          pagination,
+        }: {
+          pagination?: { cursor?: string | null }
+        }) => {
+          const offset = Number(pagination?.cursor ?? 0) || 0
+          const nextCursor = offset + PER_PAGE
+          return {
+            records: people.slice(offset, nextCursor),
+            total: people.length,
+            perPage: PER_PAGE,
+            cursor: String(nextCursor),
+            hasMore: nextCursor < people.length,
+          }
+        },
+      },
+    },
+    []
+  )
+
+  return (
+    <TableCollection<
+      Person,
+      FiltersDefinition,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<Person>
+    >
+      columns={columns}
+      source={source}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+    />
+  )
+}
+
+const loadNextPage = async (lastRowOfNextPage: string) => {
+  await waitFor(() => expect(intersect).toBeDefined())
+  intersect?.()
+  await waitFor(() =>
+    expect(screen.getByText(lastRowOfNextPage)).toBeInTheDocument()
+  )
+}
+
+describe("infinite scroll — rows already on screen", () => {
+  it("does not re-render them when the next page is appended", async () => {
+    render(<Harness />)
+
+    await waitFor(() =>
+      expect(screen.getByText("Person 3")).toBeInTheDocument()
+    )
+    const before = new Map(renderCounts)
+
+    await loadNextPage("Person 6")
+
+    for (const id of [1, 2, 3]) {
+      expect(renderCounts.get(id)).toBe(before.get(id))
+    }
+  })
+
+  it("keeps the cost of a page flat as pages accumulate", async () => {
+    render(<Harness />)
+
+    await waitFor(() =>
+      expect(screen.getByText("Person 3")).toBeInTheDocument()
+    )
+
+    const beforeSecond = [...renderCounts.values()].reduce((a, b) => a + b, 0)
+    await loadNextPage("Person 6")
+    const afterSecond = [...renderCounts.values()].reduce((a, b) => a + b, 0)
+
+    await loadNextPage("Person 9")
+    const afterThird = [...renderCounts.values()].reduce((a, b) => a + b, 0)
+
+    // The third page costs no more renders than the second, even though there
+    // are twice as many rows on screen by then.
+    expect(afterThird - afterSecond).toBeLessThanOrEqual(
+      afterSecond - beforeSecond
+    )
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SourceStaleness.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SourceStaleness.integration.test.tsx
@@ -1,0 +1,113 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  FiltersDefinition,
+  GroupingDefinition,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+
+import { TextCell } from "@/ui/value-display/types/text"
+import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { SummariesDefinition } from "../../../../summary"
+import { TableCollection } from "../index"
+
+vi.mock("../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+type Person = { id: number; name: string }
+
+const people: Person[] = [
+  { id: 1, name: "Ana" },
+  { id: 2, name: "Bruno" },
+]
+
+// Hoisted, so a consumer re-render changes no column identity — the case where
+// the row's memo has nothing else to compare on.
+const columns = [{ label: "name", render: (item: Person) => item.name }]
+
+/**
+ * The consumer owns a piece of state that `selectionDisabled` closes over.
+ * `Row` calls `source.selectionDisabled(item)` during render, so flipping it
+ * has to reach the rendered checkbox.
+ */
+const Harness = () => {
+  const [canEdit, setCanEdit] = useState(false)
+
+  const source = useDataCollectionSource<
+    Person,
+    FiltersDefinition,
+    SortingsDefinition,
+    SummariesDefinition,
+    ItemActionsDefinition<Person>,
+    NavigationFiltersDefinition,
+    GroupingDefinition<Person>
+  >(
+    {
+      selectable: (item: Person) => item.id,
+      selectionDisabled: () => !canEdit,
+      dataAdapter: {
+        fetchData: async () => people,
+      },
+    },
+    [canEdit]
+  )
+
+  return (
+    <>
+      <button onClick={() => setCanEdit(true)}>grant edit</button>
+      <TableCollection<
+        Person,
+        FiltersDefinition,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        NavigationFiltersDefinition,
+        GroupingDefinition<Person>
+      >
+        columns={columns}
+        source={source}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    </>
+  )
+}
+
+const rowCheckboxes = () =>
+  Array.from(
+    document.querySelectorAll<HTMLElement>(
+      'tbody [role="checkbox"], tbody input[type="checkbox"]'
+    )
+  )
+
+describe("a source callback read during render", () => {
+  it("reaches the rows when the consumer's state behind it changes", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await waitFor(() => expect(screen.getByText("Ana")).toBeInTheDocument())
+    await waitFor(() => expect(rowCheckboxes()).toHaveLength(2))
+    expect(rowCheckboxes().every((box) => box.hasAttribute("disabled"))).toBe(
+      true
+    )
+
+    await user.click(screen.getByText("grant edit"))
+
+    await waitFor(() =>
+      expect(rowCheckboxes().some((box) => box.hasAttribute("disabled"))).toBe(
+        false
+      )
+    )
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -84,9 +84,11 @@ export type RowProps<
   item: R
   index: number
   groupIndex: number
-  onCheckedChange: (checked: boolean) => void
   onItemCheckedChange?: (item: R, checked: boolean) => void
-  selectedItems: Map<string | number, R>
+  /** This row's own selected state, so a selection change only alters the prop
+   * of the row that changed. */
+  isSelected?: boolean
+  selectedItems?: Map<string | number, R>
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>
   frozenColumnsLeft: number
   checkColumnWidth: number
@@ -132,6 +134,14 @@ const NestedRowContent = <
     | null
 ) => {
   const internalRowRef = useRef<HTMLTableRowElement | null>(null)
+
+  // Each child gets its own boolean, for the same reason the parent does:
+  // handing down the Map made every sibling's props differ whenever any one of
+  // them changed, so selecting one row re-rendered them all.
+  const isChildSelected = (record: R): boolean => {
+    const childId = props.source.selectable?.(record)
+    return childId !== undefined && !!props.selectedItems?.has(childId)
+  }
   const sentinelRef = useRef<HTMLTableCellElement | null>(null)
   const addRow = useAddRow()
 
@@ -339,9 +349,7 @@ const NestedRowContent = <
                 key={`nested-row-${props.groupIndex}-${child.id}-${props.index}-${childIndex}`}
                 index={childIndex}
                 item={childItem}
-                onCheckedChange={(checked) => {
-                  props.onItemCheckedChange?.(childItem, checked)
-                }}
+                isSelected={isChildSelected(childItem)}
                 tableWithChildren={props.tableWithChildren}
                 ref={getChildRef()}
                 nestedRowProps={{
@@ -379,9 +387,7 @@ const NestedRowContent = <
                 key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
                 index={childIndex}
                 item={childItem}
-                onCheckedChange={(checked) => {
-                  props.onItemCheckedChange?.(childItem, checked)
-                }}
+                isSelected={isChildSelected(childItem)}
                 noBorder={leafShouldHideBorder}
                 ref={getChildRef()}
                 nestedRowProps={{

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -1,5 +1,5 @@
 import { useIsPresent } from "motion/react"
-import { forwardRef, useEffect, useState } from "react"
+import { forwardRef, useCallback, useEffect, useState } from "react"
 
 import type { IconType } from "@/components/F0Icon"
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
@@ -61,9 +61,14 @@ export type RowProps<
   item: R
   index: number
   groupIndex: number
-  onCheckedChange: (checked: boolean) => void
   onItemCheckedChange?: (item: R, checked: boolean) => void
-  selectedItems: Map<string | number, R>
+  /** This row's own selected state. Passed as a scalar so a selection change
+   * only alters the prop of the row that changed, not of every row. */
+  isSelected?: boolean
+  /** Only supplied for rows that render nested children, which need it to derive
+   * their own children's state. Absent for flat rows, so their props stay
+   * identical across a selection change. */
+  selectedItems?: Map<string | number, R>
   columns: ReadonlyArray<TableColumnDefinition<R, Sortings, Summaries>>
   frozenColumnsLeft: number
   checkColumnWidth: number
@@ -144,8 +149,8 @@ const RowComponentInner = <
   {
     source,
     item,
-    onCheckedChange,
     onItemCheckedChange,
+    isSelected: isSelectedProp,
     selectedItems,
     columns,
     frozenColumnsLeft,
@@ -189,6 +194,14 @@ const RowComponentInner = <
     id !== undefined &&
     (selectionInherited || source.selectionDisabled?.(item) === true)
   const rowWithChildren = !!source.itemsWithChildren?.(item)
+
+  // Derived here rather than passed in: as a prop it was an inline arrow built
+  // per row per render, which alone made the row's memo comparison fail every
+  // time (measured: 50 mismatches for 25 rows across two commits).
+  const onCheckedChange = useCallback(
+    (checked: boolean) => onItemCheckedChange?.(item, checked),
+    [onItemCheckedChange, item]
+  )
 
   const i18n = useI18n()
 
@@ -272,7 +285,6 @@ const RowComponentInner = <
       <NestedRow
         source={source}
         item={item}
-        onCheckedChange={onCheckedChange}
         onItemCheckedChange={onItemCheckedChange}
         selectedItems={selectedItems}
         columns={columns}
@@ -296,7 +308,7 @@ const RowComponentInner = <
     )
   }
 
-  const isSelected = id !== undefined && selectedItems.has(id)
+  const isSelected = isSelectedProp ?? false
   const referenceRowType = referenceRowTypeFn?.(item) ?? "none"
 
   const cellRenderedClass = CellRenderer
@@ -350,7 +362,7 @@ const RowComponentInner = <
               )}
             >
               <Checkbox
-                checked={selectionInherited || selectedItems.has(id)}
+                checked={selectionInherited || isSelected}
                 indeterminate={selectionInherited}
                 onCheckedChange={onCheckedChange}
                 disabled={selectionDisabled}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -1,5 +1,5 @@
 import { useIsPresent } from "motion/react"
-import { forwardRef, useCallback, useEffect, useState } from "react"
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
 
 import type { IconType } from "@/components/F0Icon"
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
@@ -259,26 +259,30 @@ const RowComponentInner = <
   // Only the row that owns the rendered checkbox registers (not the one
   // delegating to NestedRow), so each selectable id is registered once.
   const willRenderOwnRow = !(rowWithChildren && hasChildrenLoaded)
+  const isRegistered =
+    id !== undefined && !selectionDisabled && willRenderOwnRow && isPresent
+
+  const itemRef = useRef(item)
+  itemRef.current = item
+
+  // Deliberately not keyed on `item`: a page append rebuilds the record of
+  // every row, and re-running this effect for that would take each row out of
+  // the registry and put it straight back in — a membership change per rendered
+  // row, on every page.
   useEffect(() => {
-    if (
-      id === undefined ||
-      selectionDisabled ||
-      !willRenderOwnRow ||
-      !registerSelectable ||
-      !isPresent
-    )
-      return
-    registerSelectable(id, item)
+    if (id === undefined || !isRegistered || !registerSelectable) return
+    registerSelectable(id, itemRef.current)
     return () => unregisterSelectable?.(id)
-  }, [
-    id,
-    item,
-    selectionDisabled,
-    willRenderOwnRow,
-    registerSelectable,
-    unregisterSelectable,
-    isPresent,
-  ])
+  }, [id, isRegistered, registerSelectable, unregisterSelectable])
+
+  // "Select all" is served the items the registry holds, so a row whose record
+  // is replaced has to refresh its entry. Re-registering an id already present
+  // only overwrites the item; membership, and the id list built from it, are
+  // untouched.
+  useEffect(() => {
+    if (id === undefined || !isRegistered || !registerSelectable) return
+    registerSelectable(id, item)
+  }, [id, item, isRegistered, registerSelectable])
 
   if (rowWithChildren && hasChildrenLoaded) {
     return (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
@@ -36,7 +36,6 @@ const SingleLoadingRowInner = <
     frozenColumnsLeft,
     nestedRowProps,
     groupIndex,
-    onCheckedChange,
     selectedItems,
     checkColumnWidth,
     tableWithChildren,
@@ -95,7 +94,6 @@ const SingleLoadingRowInner = <
       columns={columns}
       noBorder={shouldHideBorder ?? false}
       groupIndex={groupIndex}
-      onCheckedChange={onCheckedChange}
       selectedItems={selectedItems}
       checkColumnWidth={checkColumnWidth}
       loading

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/SelectionRegistryProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/SelectionRegistryProvider.tsx
@@ -18,26 +18,27 @@ export const useCreateSelectionRegistry = <
   R extends RecordType,
 >(): SelectionRegistryValue<R> => {
   const entriesRef = useRef<Map<SelectionId, R>>(new Map())
-  const [ids, setIds] = useState<SelectionId[]>([])
 
-  const syncIds = useCallback(() => {
-    setIds(Array.from(entriesRef.current.keys()))
+  // A membership counter rather than the id array itself: every rendered row
+  // registers, so materializing the array inside each mutation made a render
+  // cost one pass over the whole registry per row. The array is built once per
+  // render that changed membership instead.
+  const [membership, setMembership] = useState(0)
+
+  const register = useCallback((id: SelectionId, item: R) => {
+    const isNew = !entriesRef.current.has(id)
+    entriesRef.current.set(id, item)
+    if (isNew) setMembership((current) => current + 1)
   }, [])
 
-  const register = useCallback(
-    (id: SelectionId, item: R) => {
-      const isNew = !entriesRef.current.has(id)
-      entriesRef.current.set(id, item)
-      if (isNew) syncIds()
-    },
-    [syncIds]
-  )
+  const unregister = useCallback((id: SelectionId) => {
+    if (entriesRef.current.delete(id)) setMembership((current) => current + 1)
+  }, [])
 
-  const unregister = useCallback(
-    (id: SelectionId) => {
-      if (entriesRef.current.delete(id)) syncIds()
-    },
-    [syncIds]
+  const ids = useMemo(
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- the counter is the signal that the map changed
+    () => Array.from(entriesRef.current.keys()),
+    [membership]
   )
 
   const getEntries = useCallback(


### PR DESCRIPTION
## Why

A collection on infinite scroll gets heavier the further you scroll. The row count is not what makes it heavy: loading a page re-renders every row already on screen, and re-does bookkeeping once per row on top, so each page costs more than the last.

Nothing here changes what the collection looks like or how it behaves. Whether anything further is needed is [FCT-62647](https://factorialmakers.atlassian.net/browse/FCT-62647), which starts by measuring what is left.

## What was making a page append cost more than the page

**The record of every row was rebuilt on each fetch.** `useData` decorated every record with a group id through a spread — including when the collection is not grouped, which is when nothing ever reads it. `mergeItems` keeps the object of a record that is already loaded, so the only thing giving already-rendered rows a new identity was that decoration. Now ungrouped records pass through untouched, and a grouped collection reuses the object it built for a record the last time it saw it.

**Rows had no memo boundary, and three props that would have defeated one.** The animation variants were rebuilt per row per render, `onCheckedChange` was an inline arrow per row, and the whole selection `Map` was handed to every row so any selection change altered every row's props. Rows now take their own `isSelected` boolean, and the memo sits outside `motion.create` so a skipped row also skips framer's layout measurement.

**The selection registry was rebuilt once per rendered row.** Registration was keyed on the row's record, so a page append took every already-rendered row out of the registry and put it straight back in — and each of those membership changes re-materialized the entire id list. Rows now register on their id, refresh their entry separately, and the registry counts membership changes instead of rebuilding the list inside each one.

## Behaviour

Unchanged. The set of registered rows is still the selectable rows on screen; the group id is still attached wherever anything reads it; rows still flash, animate and select as before.

## Testing

`InfiniteScrollRowCommits.integration.test.tsx` drives the real source with an infinite-scroll adapter and fires the sentinel's `IntersectionObserver` to load each page, counting renders per row.

Red on `main` (source reverted, test kept):

```
× does not re-render them when the next page is appended
  AssertionError: expected 3 to be 2

× keeps the cost of a page flat as pages accumulate
  AssertionError: expected 18 to be less than or equal to 12
```

The second number is the shape of the problem: the third page cost 18 row renders where the second cost 12, with nothing added but rows already on screen.

Green here, and the full unit suite passes (7552 tests).

`SourceStaleness.integration.test.tsx` guards the other side of a memo boundary: `Row` calls six of the source's callbacks during its own render, so a consumer flipping state behind one of them — `selectionDisabled`, with hoisted columns, nothing else to compare on — has to reach the rendered checkbox. A row that skips its render never reads a new value, so any future attempt to make the source's identity stable has to answer this test.

Also validated by hand against the product: the alpha installed in a local slot, with the employees list switched from `pages` to `infinite-scroll` so rows accumulate.

## Not in this PR

- Windowing the rows. Considered and dropped: the collection renders a real `<table>`, so rows outside the DOM stop being reachable by the browser's find-in-page, and it would put the accessibility skip ratchet under pressure. FCT-62647 measures the linear remainder first; capping accumulation is the cheaper answer if it turns out to matter.
- The `layout` prop on every row: it still puts a framer projection node on each one. Scoping it changes reorder animations, so it wants design input.
- **A consumer render still re-renders every row.** `useDataCollectionSource` returns a new object each render — it carries the live filter, search and sorting state — and rows take it as a prop. This PR only fixes the append path, where the consumer never renders at all. #5411, stacked on this one, splits the definition out and hands rows that instead.
- Deriving the selection registry from the loaded data instead of from the rendered rows. Its docstring says it exists to reach loaded rows absent from `data.records`, so "loaded" was always the intent — but today the two sets coincide, so this is a design cleanup rather than a bug.


[FCT-62647]: https://factorialmakers.atlassian.net/browse/FCT-62647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


