### PR TITLE
feat(F0AnalyticsDashboard): comparison props for period-over-period dashboards

### DIFF
--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -180,7 +180,10 @@ const defaultFetchDataAndUpdateOptions = <
   options: O
 ): O => options
 
-const defaultIdProvider = (item: RecordType, index?: number): string | number =>
+export const defaultIdProvider = (
+  item: RecordType,
+  index?: number
+): string | number =>
   "id" in item ? `${item.id}` : index || JSON.stringify(item)
 
 /**

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -2363,3 +2363,89 @@ describe("BarChart — target progress row", () => {
     expect(html).not.toContain("Infinity")
   })
 })
+
+// ---------------------------------------------------------------------------
+// Category comparison — a consumer-computed line under the hovered value.
+// ---------------------------------------------------------------------------
+
+describe("BarChart — category comparison", () => {
+  function hover(params: unknown) {
+    const call = setOptionMock.mock.calls.at(-1)
+    if (!call) throw new Error("setOption was never called")
+    const formatter = (
+      call[0] as { tooltip?: { formatter?: (p: unknown) => string } }
+    ).tooltip?.formatter
+    if (!formatter) throw new Error("the chart built no tooltip formatter")
+    return formatter(params)
+  }
+
+  const chart = (withComparison: boolean) => (
+    <F0DataChart
+      type="bar"
+      categories={["Engineering", "Sales"]}
+      series={[
+        { name: "This period", data: [96, 58] },
+        { name: "Previous period", data: [84, 57], muted: true },
+      ]}
+      categoryComparison={
+        withComparison
+          ? {
+              Engineering: {
+                label: "+12 (+14.3%)",
+                description: "Previous: 84",
+                tone: "positive",
+              },
+            }
+          : undefined
+      }
+    />
+  )
+
+  it("adds the category's comparison line under the value", () => {
+    render(chart(true))
+
+    const html = hover({
+      seriesName: "This period",
+      name: "Engineering",
+      value: 96,
+      dataIndex: 0,
+    })
+    expect(html).toContain("+12 (+14.3%)")
+    expect(html).toContain("Previous: 84")
+    expect(html).toContain(resolveChartTheme().colors.positive)
+  })
+
+  it("adds no line for a category without an entry, nor on a muted baseline bar", () => {
+    render(chart(true))
+
+    expect(
+      hover({
+        seriesName: "This period",
+        name: "Sales",
+        value: 58,
+        dataIndex: 1,
+      })
+    ).not.toContain("Previous")
+    expect(
+      hover({
+        seriesName: "Previous period",
+        name: "Engineering",
+        value: 84,
+        dataIndex: 0,
+      })
+    ).not.toContain("+12 (+14.3%)")
+  })
+
+  it("changes nothing without the prop", () => {
+    render(chart(false))
+
+    const html = hover({
+      seriesName: "This period",
+      name: "Engineering",
+      value: 96,
+      dataIndex: 0,
+    })
+    expect(html).toContain("96")
+    expect(html).not.toContain("Previous")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
@@ -235,3 +235,22 @@ describe("FunnelChart — tooltip", () => {
     expect(html).not.toContain("undefined")
   })
 })
+
+describe("FunnelChart — category comparison", () => {
+  it("adds the stage's comparison line after its conversion rows", () => {
+    render(
+      <F0DataChart
+        {...funnelProps}
+        showConversion
+        categoryComparison={{
+          Screened: { label: "−40 (−7.7%)", tone: "negative" },
+        }}
+      />
+    )
+
+    const html = hover({ name: "Screened", value: 480 })
+    expect(html).toContain("of total")
+    expect(html.indexOf("of total")).toBeLessThan(html.indexOf("−40 (−7.7%)"))
+    expect(hover({ name: "Applied", value: 1200 })).not.toContain("−40")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -280,3 +280,49 @@ describe("LineChart — tooltip value formatting", () => {
     expect(hoverFirstPoint()).toContain("107,505 €")
   })
 })
+
+describe("LineChart — muted series", () => {
+  const optionSeries = () =>
+    getLatestOption().series as Array<{
+      lineStyle?: { opacity?: number; type?: string }
+      itemStyle?: { opacity?: number }
+    }>
+
+  it("fades a muted series and leaves the others at full strength", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["Jan", "Feb"]}
+        series={[
+          { name: "This period", data: [1, 2] },
+          { name: "Previous period", data: [3, 4], muted: true, dashed: true },
+        ]}
+      />
+    )
+
+    const [current, previous] = optionSeries()
+    expect(current.lineStyle?.opacity).toBeUndefined()
+    expect(current.itemStyle?.opacity).toBeUndefined()
+    expect(previous.lineStyle?.opacity).toBe(0.45)
+    expect(previous.itemStyle?.opacity).toBe(0.45)
+    expect(previous.lineStyle?.type).toBe("dashed")
+  })
+
+  it("keeps the legend entry at full strength", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["Jan", "Feb"]}
+        series={[
+          { name: "This period", data: [1, 2] },
+          { name: "Previous period", data: [3, 4], muted: true },
+        ]}
+      />
+    )
+
+    const legend = getLatestOption().legend as {
+      itemStyle?: { opacity?: number }
+    }
+    expect(legend.itemStyle?.opacity).toBe(1)
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -284,45 +284,35 @@ describe("LineChart — tooltip value formatting", () => {
 describe("LineChart — muted series", () => {
   const optionSeries = () =>
     getLatestOption().series as Array<{
+      itemStyle?: { color?: string; opacity?: number }
       lineStyle?: { opacity?: number; type?: string }
-      itemStyle?: { opacity?: number }
     }>
 
-  it("fades a muted series and leaves the others at full strength", () => {
-    render(
-      <F0DataChart
-        type="line"
-        categories={["Jan", "Feb"]}
-        series={[
-          { name: "This period", data: [1, 2] },
-          { name: "Previous period", data: [3, 4], muted: true, dashed: true },
-        ]}
-      />
-    )
+  const chart = (muted: boolean) => (
+    <F0DataChart
+      type="line"
+      categories={["Jan", "Feb"]}
+      series={[
+        { name: "This period", data: [1, 2] },
+        { name: "Previous period", data: [3, 4], muted, dashed: muted },
+      ]}
+    />
+  )
 
+  it("fades the muted series' colour and leaves its sibling identical", () => {
+    const { unmount } = render(chart(false))
+    const plain = optionSeries()
+    unmount()
+
+    render(chart(true))
     const [current, previous] = optionSeries()
-    expect(current.lineStyle?.opacity).toBeUndefined()
-    expect(current.itemStyle?.opacity).toBeUndefined()
-    expect(previous.lineStyle?.opacity).toBe(0.45)
-    expect(previous.itemStyle?.opacity).toBe(0.45)
+
+    expect(current).toEqual(plain[0])
+    // Same colour at 45% alpha (`73`), so the line, its dots, its area fill
+    // and its legend swatch all fade together without an opacity key.
+    expect(previous.itemStyle?.color).toBe(`${plain[1].itemStyle?.color}73`)
+    expect(previous.itemStyle).not.toHaveProperty("opacity")
+    expect(previous.lineStyle).not.toHaveProperty("opacity")
     expect(previous.lineStyle?.type).toBe("dashed")
-  })
-
-  it("keeps the legend entry at full strength", () => {
-    render(
-      <F0DataChart
-        type="line"
-        categories={["Jan", "Feb"]}
-        series={[
-          { name: "This period", data: [1, 2] },
-          { name: "Previous period", data: [3, 4], muted: true },
-        ]}
-      />
-    )
-
-    const legend = getLatestOption().legend as {
-      itemStyle?: { opacity?: number }
-    }
-    expect(legend.itemStyle?.opacity).toBe(1)
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
@@ -161,3 +161,35 @@ describe("PieChart — tooltip", () => {
     expect(html).not.toContain("NaN")
   })
 })
+
+describe("PieChart — category comparison", () => {
+  it("adds the slice's comparison line, and none for a slice without one", () => {
+    render(
+      <F0DataChart
+        {...pieProps}
+        categoryComparison={{
+          Engineering: { label: "+14.3%", tone: "positive" },
+          Design: { label: "New this period" },
+        }}
+      />
+    )
+
+    expect(hover({ name: "Engineering", value: 45, percent: 53.6 })).toContain(
+      "+14.3%"
+    )
+    expect(hover({ name: "Design", value: 18, percent: 21.2 })).toContain(
+      "New this period"
+    )
+    expect(hover({ name: "Product", value: 22, percent: 25.2 })).not.toContain(
+      "+14.3%"
+    )
+  })
+
+  it("reads the same without the prop", () => {
+    render(<F0DataChart {...pieProps} />)
+
+    expect(
+      hover({ name: "Engineering", value: 45, percent: 53.6 })
+    ).not.toContain("+14.3%")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import {
+  comparisonRow,
   buildValueAxis,
   computeCategoryAxisLayout,
   computeLabelInterval,
@@ -267,5 +268,41 @@ describe("tooltipValueFormat", () => {
     expect(tooltipValueFormat(undefined, undefined)(0)).toBe(
       (0).toLocaleString()
     )
+  })
+})
+
+describe("comparisonRow", () => {
+  const theme = resolveChartTheme()
+
+  it("puts the consumer's label first, in the colour of its tone", () => {
+    expect(
+      comparisonRow(
+        {
+          label: "+12 (+14.3%)",
+          description: "Previous: 84",
+          tone: "positive",
+        },
+        theme
+      )
+    ).toEqual({
+      value: "+12 (+14.3%)",
+      label: "Previous: 84",
+      color: theme.colors.positive,
+    })
+    expect(comparisonRow({ label: "−3", tone: "negative" }, theme)?.color).toBe(
+      theme.colors.critical
+    )
+    expect(comparisonRow({ label: "0", tone: "neutral" }, theme)?.color).toBe(
+      theme.colors.foregroundSecondary
+    )
+  })
+
+  it("leaves an untoned note in the default colour and draws nothing for no entry", () => {
+    expect(comparisonRow({ label: "New this period" }, theme)).toEqual({
+      value: "New this period",
+      label: "",
+      color: undefined,
+    })
+    expect(comparisonRow(undefined, theme)).toBeUndefined()
   })
 })

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -12,6 +12,8 @@ import type {
 
 import {
   darkenChartColor,
+  fadeChartColor,
+  mutedChartColor,
   paletteColor,
   resolveChartColorToken,
 } from "../../utils/colors"
@@ -19,7 +21,6 @@ import {
   buildBaseChartOptions,
   buildItemTooltip,
   labelWidthCap,
-  MUTED_SERIES_OPACITY,
   renderMarker,
   renderValueTooltip,
   tooltipValueFormat,
@@ -211,9 +212,11 @@ function getPointColor(point: F0DataChartBarDataPoint): string | undefined {
 
 /** Resolve the color for a series to hex, falling back to the shared palette */
 function resolveColor(series: F0DataChartBarSeries, index: number): string {
-  return series.color
+  const color = series.color
     ? resolveChartColorToken(series.color)
     : paletteColor(index)
+  // Muting by colour, so bars, target ghosts and legend swatch fade alike.
+  return series.muted ? mutedChartColor(color) : color
 }
 
 /**
@@ -594,7 +597,6 @@ function buildSeriesEntries(
     itemStyle: {
       color,
       borderRadius,
-      ...(series.muted && { opacity: MUTED_SERIES_OPACITY }),
       // ECharts has no native gap between stacked segments — a border in the
       // container's background color is the standard way to separate them.
       ...(stacked && {
@@ -695,9 +697,9 @@ function buildSeriesEntries(
           : ([1, 0, 0, 0] as [number, number, number, number])),
         [
           // offset 0 = far end from the solid bar → more opaque (darker)
-          { offset: 0, color: `${color}33` },
+          { offset: 0, color: fadeChartColor(color, 0.2) },
           // offset 1 = near the solid bar → transparent
-          { offset: 1, color: `${color}00` },
+          { offset: 1, color: fadeChartColor(color, 0) },
         ]
       ),
       // Only round the far end (away from the solid bar)

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -20,6 +20,7 @@ import {
 import {
   buildBaseChartOptions,
   buildItemTooltip,
+  comparisonRow,
   labelWidthCap,
   renderMarker,
   renderValueTooltip,
@@ -936,6 +937,7 @@ export function useBarChartOptions(
     categoryFormatter,
     labelFontSize,
     valueAxisSplitNumber = 2,
+    categoryComparison,
     echartsOptions,
   }: F0DataChartBarProps,
   size: BarChartSize,
@@ -1342,6 +1344,9 @@ export function useBarChartOptions(
             categoryValues.some((v) => v < 0)
           const total = categoryValues.reduce((sum, v) => sum + v, 0)
           const showTotal = stackHasTotal && !hasMixedSigns
+          // A muted series is itself the baseline, so the comparison line
+          // would only restate the bar beside it.
+          const isBaseline = series.find((s) => s.name === seriesName)?.muted
 
           // No "from previous" row here: bar categories are not necessarily a
           // sequence (locations, departments), so comparing a bar with the one
@@ -1374,6 +1379,8 @@ export function useBarChartOptions(
                     value: `${((value / target) * 100).toFixed(1)}%`,
                     label: i18n.dataChart.tooltip.ofTarget,
                   },
+                !isBaseline &&
+                  comparisonRow(categoryComparison?.[String(p.name)], theme),
               ],
             },
             theme
@@ -1477,6 +1484,7 @@ export function useBarChartOptions(
     categoryFormatter,
     labelFontSize,
     valueAxisSplitNumber,
+    categoryComparison,
     echartsOptions,
     theme,
     i18n,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -19,6 +19,7 @@ import {
   buildBaseChartOptions,
   buildItemTooltip,
   labelWidthCap,
+  MUTED_SERIES_OPACITY,
   renderMarker,
   renderValueTooltip,
   tooltipValueFormat,
@@ -593,6 +594,7 @@ function buildSeriesEntries(
     itemStyle: {
       color,
       borderRadius,
+      ...(series.muted && { opacity: MUTED_SERIES_OPACITY }),
       // ECharts has no native gap between stacked segments — a border in the
       // container's background color is the standard way to separate them.
       ...(stacked && {

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
@@ -14,6 +14,7 @@ import { formatPercent } from "../../utils/formatters"
 import {
   buildGrid,
   buildItemTooltip,
+  comparisonRow,
   renderValueTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
@@ -35,6 +36,7 @@ export function useFunnelChartOptions(
     colorScale = true,
     valueFormatter,
     tooltipValueFormatter,
+    categoryComparison,
     echartsOptions,
   }: F0DataChartFunnelProps
 ): echarts.EChartsOption {
@@ -173,7 +175,10 @@ export function useFunnelChartOptions(
             marker: p.marker,
             title: name,
             value: formattedValue,
-            rows: conversionRows,
+            rows: [
+              ...conversionRows,
+              comparisonRow(categoryComparison?.[name], theme),
+            ],
           },
           theme
         )
@@ -216,6 +221,7 @@ export function useFunnelChartOptions(
     colorScale,
     valueFormatter,
     tooltipValueFormatter,
+    categoryComparison,
     echartsOptions,
     theme,
     i18n,

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -10,11 +10,15 @@ import type {
   F0DataChartLineType,
 } from "../../types"
 
-import { paletteColor, resolveChartColorToken } from "../../utils/colors"
+import {
+  fadeChartColor,
+  mutedChartColor,
+  paletteColor,
+  resolveChartColorToken,
+} from "../../utils/colors"
 import {
   buildBaseChartOptions,
   deltaRow,
-  MUTED_SERIES_OPACITY,
   renderValueTooltip,
   tooltipValueFormat,
 } from "../../utils/options"
@@ -29,9 +33,11 @@ function getValue(point: F0DataChartLineDataPoint): number {
 
 /** Resolve the color for a series to hex, falling back to the shared palette */
 function resolveColor(series: F0DataChartLineSeries, index: number): string {
-  return series.color
+  const color = series.color
     ? resolveChartColorToken(series.color)
     : paletteColor(index)
+  // Muting by colour, so line, dots, area fill and legend swatch fade alike.
+  return series.muted ? mutedChartColor(color) : color
 }
 
 /**
@@ -64,8 +70,8 @@ function resolveLineStyle(lineType: F0DataChartLineType): {
 function buildAreaStyle(color: string): echarts.LineSeriesOption["areaStyle"] {
   return {
     color: new echarts.graphic.LinearGradient(0, 0, 0, 1, [
-      { offset: 0, color: `${color}59` },
-      { offset: 1, color: `${color}00` },
+      { offset: 0, color: fadeChartColor(color, 0.35) },
+      { offset: 1, color: fadeChartColor(color, 0) },
     ]),
   }
 }
@@ -86,7 +92,6 @@ function buildSeriesEntry(
   const lineType = series.lineType ?? globalLineType
   const showArea = series.showArea ?? globalShowArea
   const { smooth, step } = resolveLineStyle(lineType)
-  const opacity = series.muted ? MUTED_SERIES_OPACITY : undefined
 
   return {
     name: series.name,
@@ -96,12 +101,10 @@ function buildSeriesEntry(
     step,
     itemStyle: {
       color,
-      opacity,
     },
     lineStyle: {
       width: 2,
       type: series.dashed ? "dashed" : "solid",
-      opacity,
     },
     areaStyle: showArea ? buildAreaStyle(color) : undefined,
     showSymbol: showDots,

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -14,6 +14,7 @@ import { paletteColor, resolveChartColorToken } from "../../utils/colors"
 import {
   buildBaseChartOptions,
   deltaRow,
+  MUTED_SERIES_OPACITY,
   renderValueTooltip,
   tooltipValueFormat,
 } from "../../utils/options"
@@ -85,6 +86,7 @@ function buildSeriesEntry(
   const lineType = series.lineType ?? globalLineType
   const showArea = series.showArea ?? globalShowArea
   const { smooth, step } = resolveLineStyle(lineType)
+  const opacity = series.muted ? MUTED_SERIES_OPACITY : undefined
 
   return {
     name: series.name,
@@ -94,10 +96,12 @@ function buildSeriesEntry(
     step,
     itemStyle: {
       color,
+      opacity,
     },
     lineStyle: {
       width: 2,
       type: series.dashed ? "dashed" : "solid",
+      opacity,
     },
     areaStyle: showArea ? buildAreaStyle(color) : undefined,
     showSymbol: showDots,

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -12,6 +12,7 @@ import {
 } from "../../utils/colors"
 import {
   buildItemTooltip,
+  comparisonRow,
   buildLegend,
   DEFAULT_EMPHASIS,
   renderValueTooltip,
@@ -49,6 +50,7 @@ export function usePieChartOptions(
     showPercentage = false,
     valueFormatter,
     tooltipValueFormatter,
+    categoryComparison,
     echartsOptions,
   }: F0DataChartPieProps,
   size: PieChartSize
@@ -191,6 +193,7 @@ export function usePieChartOptions(
                   value: formatTooltipValue(total),
                   label: i18n.dataChart.tooltip.total,
                 },
+                comparisonRow(categoryComparison?.[String(p.name)], theme),
               ],
             },
             theme
@@ -213,6 +216,7 @@ export function usePieChartOptions(
     showPercentage,
     valueFormatter,
     tooltipValueFormatter,
+    categoryComparison,
     echartsOptions,
     theme,
     i18n,

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -6,6 +6,7 @@ export type {
   F0DataChartBarDataPoint,
   F0DataChartBarProps,
   F0DataChartBarSeries,
+  F0DataChartCategoryComparison,
   F0DataChartEmptyStateProps,
   F0DataChartFunnelDataPoint,
   F0DataChartFunnelProps,

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -155,6 +155,12 @@ export interface F0DataChartBarSeries {
   data: F0DataChartBarDataPoint[]
   /** Override color for this series. Must be an F0 design token name. Falls back to the theme palette. */
   color?: ChartColorToken
+  /**
+   * Draw this series faded, keeping its colour and its legend entry. For a
+   * secondary reading of the same measure — the previous period beside the
+   * current one — so the primary series stays the one being read.
+   */
+  muted?: boolean
 }
 
 // ---------------------------------------------------------------------------
@@ -190,6 +196,12 @@ export interface F0DataChartLineSeries {
   lineType?: F0DataChartLineType
   /** Override area fill for this series */
   showArea?: boolean
+  /**
+   * Draw this series faded, keeping its colour and its legend entry. For a
+   * secondary reading of the same measure — the previous period beside the
+   * current one — so the primary series stays the one being read.
+   */
+  muted?: boolean
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -155,11 +155,7 @@ export interface F0DataChartBarSeries {
   data: F0DataChartBarDataPoint[]
   /** Override color for this series. Must be an F0 design token name. Falls back to the theme palette. */
   color?: ChartColorToken
-  /**
-   * Draw this series faded, keeping its colour and its legend entry. For a
-   * secondary reading of the same measure — the previous period beside the
-   * current one — so the primary series stays the one being read.
-   */
+  /** Draw faded (keeps colour and legend entry) for a secondary reading of the same measure. */
   muted?: boolean
 }
 
@@ -196,11 +192,7 @@ export interface F0DataChartLineSeries {
   lineType?: F0DataChartLineType
   /** Override area fill for this series */
   showArea?: boolean
-  /**
-   * Draw this series faded, keeping its colour and its legend entry. For a
-   * secondary reading of the same measure — the previous period beside the
-   * current one — so the primary series stays the one being read.
-   */
+  /** Draw faded (keeps colour and legend entry) for a secondary reading of the same measure. */
   muted?: boolean
 }
 

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -117,6 +117,29 @@ interface F0DataChartCommonProps {
   onPointClick?: (point: F0DataChartPointClick) => void
 }
 
+/**
+ * How one category compares to a baseline the consumer computed. The tooltip
+ * adds a line for it under the value; nothing drawn on the chart changes.
+ */
+export interface F0DataChartCategoryComparison {
+  /** The change as the consumer wrote it — "+12 (+14.3%)", or a note such as "New". */
+  label: string
+  /** Trailing context for the label, e.g. the baseline it compares against. */
+  description?: string
+  /** Colours the label; omitted, it takes the plain foreground. */
+  tone?: "positive" | "negative" | "neutral"
+}
+
+/** Props shared by the variants whose marks are categories rather than moments. */
+interface F0DataChartCategoryComparisonProps {
+  /**
+   * Per-category comparison, keyed the way the chart names its marks: the
+   * category label for bars, the point `name` for pie slices and funnel stages.
+   * Categories without an entry get no line.
+   */
+  categoryComparison?: Record<string, F0DataChartCategoryComparison>
+}
+
 /** Props shared only by variants with an interactive legend. */
 interface F0DataChartLegendInteractionProps {
   /**
@@ -228,7 +251,8 @@ interface F0DataChartBaseProps
 /**
  * Bar chart variant props.
  */
-export interface F0DataChartBarProps extends F0DataChartBaseProps {
+export interface F0DataChartBarProps
+  extends F0DataChartBaseProps, F0DataChartCategoryComparisonProps {
   /** Chart type */
   type: "bar"
   /** One or more data series to render as bars */
@@ -412,7 +436,10 @@ export interface F0DataChartFunnelSeries {
  * points themselves. This interface is separate from `F0DataChartBaseProps`.
  */
 export interface F0DataChartFunnelProps
-  extends F0DataChartCommonProps, F0DataChartLegendInteractionProps {
+  extends
+    F0DataChartCommonProps,
+    F0DataChartLegendInteractionProps,
+    F0DataChartCategoryComparisonProps {
   /** Chart type */
   type: "funnel"
   /** The funnel series to render */
@@ -491,7 +518,10 @@ export interface F0DataChartPieSeries {
  * points themselves. This interface is separate from `F0DataChartBaseProps`.
  */
 export interface F0DataChartPieProps
-  extends F0DataChartCommonProps, F0DataChartLegendInteractionProps {
+  extends
+    F0DataChartCommonProps,
+    F0DataChartLegendInteractionProps,
+    F0DataChartCategoryComparisonProps {
   /** Chart type */
   type: "pie"
   /** The pie series to render */

--- a/packages/react/src/kits/F0DataChart/utils/colors.ts
+++ b/packages/react/src/kits/F0DataChart/utils/colors.ts
@@ -132,6 +132,19 @@ export function darkenChartColor(color: string): string {
   return colord(color).darken(DARKEN_AMOUNT).toHex()
 }
 
+/** `color` at `alpha`, scaled by the alpha it already carries. */
+export function fadeChartColor(color: string, alpha: number): string {
+  const base = colord(color)
+  return base.alpha(base.alpha() * alpha).toHex()
+}
+
+const MUTED_SERIES_ALPHA = 0.45
+
+/** Color for a `muted` series: faded enough to recede, solid enough to read. */
+export function mutedChartColor(color: string): string {
+  return fadeChartColor(color, MUTED_SERIES_ALPHA)
+}
+
 /** Linearly interpolate between two hex colors */
 export function lerpColor(from: string, to: string, t: number): string {
   const f = colord(from).toRgb()

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -2,12 +2,6 @@ import type * as echarts from "echarts"
 
 import type { ChartTheme } from "./theme"
 
-/**
- * Opacity of a series drawn as a secondary reading (`series.muted`). Faded
- * enough to recede behind the primary series, solid enough to still be read.
- */
-export const MUTED_SERIES_OPACITY = 0.45
-
 // ---------------------------------------------------------------------------
 // Category axis
 // ---------------------------------------------------------------------------
@@ -399,10 +393,6 @@ export function buildLegend({
     icon: "circle",
     itemWidth: 10,
     itemHeight: 10,
-    // The legend is a list of what the chart contains, not a preview of how
-    // each series is drawn: a muted series still gets a solid dot, so its
-    // entry stays as clickable and as legible as every other.
-    itemStyle: { opacity: 1 },
     selectedMode: true,
     textStyle: {
       fontWeight: theme.textStyle.fontWeight,

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -1,5 +1,7 @@
 import type * as echarts from "echarts"
 
+import type { F0DataChartCategoryComparison } from "../types"
+
 import type { ChartTheme } from "./theme"
 
 // ---------------------------------------------------------------------------
@@ -602,6 +604,27 @@ export function deltaRow(
     value: `${change >= 0 ? "+" : ""}${change.toFixed(1)}%`,
     label,
     color: change >= 0 ? theme.colors.positive : theme.colors.critical,
+  }
+}
+
+/** The tooltip line for a consumer-computed comparison, in the tone it asked for. */
+export function comparisonRow(
+  comparison: F0DataChartCategoryComparison | undefined,
+  theme: ChartTheme
+): ValueTooltipRow | undefined {
+  if (!comparison) return undefined
+  const { tone } = comparison
+  return {
+    value: comparison.label,
+    label: comparison.description ?? "",
+    color:
+      tone === "positive"
+        ? theme.colors.positive
+        : tone === "negative"
+          ? theme.colors.critical
+          : tone === "neutral"
+            ? theme.colors.foregroundSecondary
+            : undefined,
   }
 }
 

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -2,6 +2,12 @@ import type * as echarts from "echarts"
 
 import type { ChartTheme } from "./theme"
 
+/**
+ * Opacity of a series drawn as a secondary reading (`series.muted`). Faded
+ * enough to recede behind the primary series, solid enough to still be read.
+ */
+export const MUTED_SERIES_OPACITY = 0.45
+
 // ---------------------------------------------------------------------------
 // Category axis
 // ---------------------------------------------------------------------------
@@ -393,6 +399,10 @@ export function buildLegend({
     icon: "circle",
     itemWidth: 10,
     itemHeight: 10,
+    // The legend is a list of what the chart contains, not a preview of how
+    // each series is drawn: a muted series still gets a solid dot, so its
+    // entry stays as clickable and as legible as every other.
+    itemStyle: { opacity: 1 },
     selectedMode: true,
     textStyle: {
       fontWeight: theme.textStyle.fontWeight,

--- a/packages/react/src/kits/ai/canvas/types.ts
+++ b/packages/react/src/kits/ai/canvas/types.ts
@@ -530,20 +530,14 @@ export interface ChatDashboardConfig {
   items: ChatDashboardItem[]
   /** Fetch specs for server-side data retrieval, keyed by datasetId */
   fetchSpecs: Record<string, DashboardFetchSpec>
-  /**
-   * What every item in this dashboard is compared against, as the user picked
-   * it. Dashboard-level: one comparison target, applied to the whole canvas.
-   *
-   * The host decides how to honour it — it owns the fetch, so it is the one
-   * that can resolve "previous period" against the dashboard's current date
-   * window and return the baseline figures. `"none"` and an absent value both
-   * mean no comparison.
-   */
+  /** Dashboard-wide comparison target; the host owns resolving the shifted window. */
   compareTo?:
     | "none"
     | "previous_period"
+    | "previous_week"
     | "previous_month"
     | "previous_quarter"
+    | "previous_half_year"
     | "previous_year"
 }
 

--- a/packages/react/src/kits/ai/canvas/types.ts
+++ b/packages/react/src/kits/ai/canvas/types.ts
@@ -530,6 +530,21 @@ export interface ChatDashboardConfig {
   items: ChatDashboardItem[]
   /** Fetch specs for server-side data retrieval, keyed by datasetId */
   fetchSpecs: Record<string, DashboardFetchSpec>
+  /**
+   * What every item in this dashboard is compared against, as the user picked
+   * it. Dashboard-level: one comparison target, applied to the whole canvas.
+   *
+   * The host decides how to honour it — it owns the fetch, so it is the one
+   * that can resolve "previous period" against the dashboard's current date
+   * window and return the baseline figures. `"none"` and an absent value both
+   * mean no comparison.
+   */
+  compareTo?:
+    | "none"
+    | "previous_period"
+    | "previous_month"
+    | "previous_quarter"
+    | "previous_year"
 }
 
 /**

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -475,6 +475,11 @@ export const defaultTranslations = {
       errorTitle: "Error loading data",
       retry: "Retry",
       dataExplanation: "Where does this data come from?",
+      comparison: {
+        change: "Change",
+        newCategory: "New",
+        notPresent: "Not present this period: {{categories}}",
+      },
     },
     pong: {
       title: "Pong",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -478,7 +478,16 @@ export const defaultTranslations = {
       comparison: {
         change: "Change",
         newCategory: "New",
-        notPresent: "Not present this period: {{categories}}",
+        goneCategory: "Gone",
+        newThisPeriod: "New this period",
+        previous: "Previous: {{value}}",
+        countUp: "{{count}} up",
+        countDown: "{{count}} down",
+        countNew: "{{count}} new",
+        countGone: "{{count}} gone",
+        showChange: "Show change",
+        showValues: "Show values",
+        more: "+{{count}} more",
       },
     },
     pong: {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
@@ -53,7 +53,9 @@ export const F0AnalyticsDashboard = <
   onAskAi,
   onAskAiTarget,
   navigationFilters,
+  navigationActions,
   filtersLoading,
+  dataKey,
 }: F0AnalyticsDashboardProps<Filters>) => {
   const i18n = useI18n()
 
@@ -127,7 +129,11 @@ export const F0AnalyticsDashboard = <
     <div
       className={cn("flex flex-col gap-5 pb-10", fillHeight && "h-full pb-0")}
     >
-      {(filters || filtersLoading || enableExport || navigationFilters) && (
+      {(filters ||
+        filtersLoading ||
+        enableExport ||
+        navigationFilters ||
+        navigationActions) && (
         <div className="flex items-center justify-between gap-4 px-5">
           <div className="w-full">
             {filters ? (
@@ -142,6 +148,7 @@ export const F0AnalyticsDashboard = <
             ) : null}
           </div>
           <div className="flex shrink-0 items-center gap-2">
+            {navigationActions}
             {navigationFilters && (
               <NavigationFilters
                 navigationFilters={navigationFilters}
@@ -179,6 +186,7 @@ export const F0AnalyticsDashboard = <
           onAskAi={onAskAi}
           onAskAiTarget={onAskAiTarget}
           resetKey={resetKey}
+          dataKey={dataKey}
           onFullscreenChange={setIsItemFullscreen}
         />
       </div>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -1187,6 +1187,26 @@ const comparisonItems = (compareTo: CompareTarget): DashboardItem[] => {
             : [{ name: "This period", data: CURRENT_HEADCOUNT }],
         }),
     },
+    {
+      id: "headcount-by-department",
+      type: "chart",
+      title: "Headcount by department",
+      chart: {
+        type: "bar",
+        showLegend: true,
+        comparisonSeriesNames: ["Previous period"],
+      },
+      fetchData: () =>
+        withLatency<DashboardChartData>({
+          categories: ["Engineering", "Sales", "Operations", "People"],
+          series: comparing
+            ? [
+                { name: "This period", data: [96, 58, 61, 33] },
+                { name: "Previous period", data: [84, 57, 55, 28] },
+              ]
+            : [{ name: "This period", data: [96, 58, 61, 33] }],
+        }),
+    },
   ]
 }
 
@@ -1235,7 +1255,10 @@ export const PeriodComparison: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
 
-    await expect(await canvas.findByText("+10.7%")).toBeInTheDocument()
+    // Fake latency plus the grid's size measurement outlast the default wait.
+    await expect(
+      await canvas.findByText("+10.7%", undefined, { timeout: 5000 })
+    ).toBeInTheDocument()
     await expect(canvas.getByText("No change")).toBeInTheDocument()
     // The trend badge announces its own baseline, not just the change.
     await expect(

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -1144,11 +1144,37 @@ const comparisonItems = (compareTo: CompareTarget): DashboardItem[] => {
             ? {
                 value: 4.2,
                 // Percentage points, not a percentage of a percentage — the
-                // reason a host formats the label itself.
-                trend: { direction: "down", label: "−1.2 pp" },
+                // reason a host formats the label itself. Attrition falling is
+                // good news, so the down arrow reads positive.
+                trend: {
+                  direction: "down",
+                  label: "−1.2 pp",
+                  sentiment: "positive",
+                },
                 comparisonLabel,
               }
             : { value: 4.2 }
+        ),
+    },
+    {
+      id: "absenteeism",
+      type: "metric",
+      title: "Absenteeism",
+      format: { type: "percent" },
+      decimals: 1,
+      fetchData: () =>
+        withLatency<DashboardMetricData>(
+          comparing
+            ? {
+                value: 3.1,
+                trend: {
+                  direction: "up",
+                  label: "+0.8 pp",
+                  sentiment: "negative",
+                },
+                comparisonLabel,
+              }
+            : { value: 3.1 }
         ),
     },
     {
@@ -1247,8 +1273,11 @@ const ComparisonDashboard = () => {
  *
  * The metrics render a server-computed `trend` verbatim — a percentage, a
  * difference in percentage points, and a neutral "No change" — each with the
- * `comparisonLabel` in a tooltip. The chart draws the previous period faded
- * and dashed via `comparisonSeriesNames`, still listed in the legend.
+ * `comparisonLabel` in a tooltip. Attrition and absenteeism also carry a
+ * `sentiment`, which colours the change against its sign: falling attrition is
+ * a green down arrow, rising absenteeism a red up one. The chart draws the
+ * previous period faded and dashed via `comparisonSeriesNames`, still listed
+ * in the legend.
  */
 export const PeriodComparison: Story = {
   tags: ["no-sidebar"],
@@ -1267,6 +1296,23 @@ export const PeriodComparison: Story = {
         selector: ".sr-only",
       })
     ).toBeInTheDocument()
+
+    // A sentiment overrides the colour the sign would have picked.
+    const change = async (text: string) =>
+      await canvas.findByText(
+        text,
+        { selector: "[aria-hidden='true']" },
+        {
+          timeout: 5000,
+        }
+      )
+
+    await expect(await change("−1.2 pp")).toHaveClass(
+      "text-f1-foreground-positive"
+    )
+    await expect(await change("+0.8 pp")).toHaveClass(
+      "text-f1-foreground-critical"
+    )
   },
 }
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -1,16 +1,21 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { useId, useState } from "react"
+import { useId, useMemo, useState } from "react"
 import { expect, fn, userEvent, waitFor, within } from "storybook/test"
 
+import type { F0SelectItemProps } from "@/components/F0Select"
 import type { FiltersState } from "@/patterns/OneFilterPicker/types"
+
+import { F0Select } from "@/components/F0Select"
 
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import type {
+  DashboardChartData,
   DashboardItem,
   DashboardItemFiltersConfig,
   DashboardItemFiltersState,
+  DashboardMetricData,
 } from "../types"
 
 import { F0AnalyticsDashboard } from "../index"
@@ -1070,5 +1075,160 @@ export const HoverItemFilterSignal: Story = {
       await expect(trigger).toHaveFocus()
       await waitFor(() => expect(trigger).toBeVisible())
     })
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Period comparison
+// ---------------------------------------------------------------------------
+
+type CompareTarget = "none" | "previous_period" | "previous_year"
+
+const comparisonOptions: F0SelectItemProps<CompareTarget>[] = [
+  { value: "none", label: "No comparison" },
+  { value: "previous_period", label: "Previous period" },
+  { value: "previous_year", label: "Previous year" },
+]
+
+const COMPARISON_MONTHS = ["Apr", "May", "Jun", "Jul", "Aug", "Sep"]
+
+const CURRENT_HEADCOUNT = [231, 236, 240, 243, 246, 248]
+const PREVIOUS_HEADCOUNT = [204, 209, 214, 219, 221, 224]
+
+/** Stands in for the host's comparison endpoint. */
+const withLatency = <T,>(value: T): Promise<T> =>
+  new Promise((resolve) => setTimeout(() => resolve(value), 400))
+
+const comparisonItems = (compareTo: CompareTarget): DashboardItem[] => {
+  const comparing = compareTo !== "none"
+  const comparisonLabel =
+    compareTo === "previous_year" ? "vs same period last year" : "vs Oct–Mar"
+
+  return [
+    {
+      id: "headcount",
+      type: "metric",
+      title: "Headcount",
+      fetchData: () =>
+        withLatency<DashboardMetricData>(
+          comparing
+            ? {
+                value: 248,
+                trend: { direction: "up", label: "+10.7%" },
+                comparisonLabel,
+              }
+            : { value: 248 }
+        ),
+    },
+    {
+      id: "voluntary-attrition",
+      type: "metric",
+      title: "Voluntary attrition",
+      format: { type: "percent" },
+      decimals: 1,
+      fetchData: () =>
+        withLatency<DashboardMetricData>(
+          comparing
+            ? {
+                value: 4.2,
+                // Percentage points, not a percentage of a percentage — the
+                // reason a host formats the label itself.
+                trend: { direction: "down", label: "−1.2 pp" },
+                comparisonLabel,
+              }
+            : { value: 4.2 }
+        ),
+    },
+    {
+      id: "offer-acceptance",
+      type: "metric",
+      title: "Offer acceptance",
+      format: { type: "percent" },
+      decimals: 0,
+      fetchData: () =>
+        withLatency<DashboardMetricData>(
+          comparing
+            ? {
+                value: 87,
+                trend: { direction: "flat", label: "No change" },
+                comparisonLabel,
+              }
+            : { value: 87 }
+        ),
+    },
+    {
+      id: "headcount-trend",
+      type: "chart",
+      title: "Headcount over time",
+      chart: {
+        type: "line",
+        showDots: true,
+        comparisonSeriesNames: ["Previous period"],
+      },
+      fetchData: () =>
+        withLatency<DashboardChartData>({
+          categories: COMPARISON_MONTHS,
+          series: comparing
+            ? [
+                { name: "This period", data: CURRENT_HEADCOUNT },
+                { name: "Previous period", data: PREVIOUS_HEADCOUNT },
+              ]
+            : [{ name: "This period", data: CURRENT_HEADCOUNT }],
+        }),
+    },
+  ]
+}
+
+const ComparisonDashboard = () => {
+  const [compareTo, setCompareTo] = useState<CompareTarget>("previous_period")
+  const items = useMemo(() => comparisonItems(compareTo), [compareTo])
+
+  return (
+    <F0AnalyticsDashboard
+      items={items}
+      dataKey={compareTo}
+      navigationActions={
+        <F0Select
+          variant="inline"
+          label="Compare to"
+          placeholder="No comparison"
+          options={comparisonOptions}
+          value={compareTo}
+          onChange={setCompareTo}
+        />
+      }
+      navigationFilters={{
+        date: {
+          type: "date-navigator",
+          defaultValue: new Date(),
+          granularity: ["month", "range"],
+        },
+      }}
+    />
+  )
+}
+
+/**
+ * A host-owned comparison picker beside the date navigator (`navigationActions`),
+ * driving every widget through `dataKey`: the grid is not remounted and the
+ * figures already on screen stay readable, dimmed, until the comparison arrives.
+ *
+ * The metrics render a server-computed `trend` verbatim — a percentage, a
+ * difference in percentage points, and a neutral "No change" — each with the
+ * `comparisonLabel` in a tooltip. The chart draws the previous period muted
+ * and dashed via `comparisonSeriesNames`, with its legend entry untouched.
+ */
+export const PeriodComparison: Story = {
+  tags: ["no-sidebar"],
+  render: () => <ComparisonDashboard />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(await canvas.findByText("+10.7%")).toBeInTheDocument()
+    await expect(canvas.getByText("No change")).toBeInTheDocument()
+    // The trend badge announces its own baseline, not just the change.
+    await expect(
+      canvas.getByText("−1.2 pp vs Oct–Mar", { selector: ".sr-only" })
+    ).toBeInTheDocument()
   },
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -11,6 +11,7 @@ import { F0Select } from "@/components/F0Select"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import type {
+  DashboardCategoryComparison,
   DashboardChartData,
   DashboardItem,
   DashboardItemFiltersConfig,
@@ -1266,5 +1267,138 @@ export const PeriodComparison: Story = {
         selector: ".sr-only",
       })
     ).toBeInTheDocument()
+  },
+}
+
+const DEPARTMENT_COMPARISON: DashboardCategoryComparison = {
+  byCategory: {
+    Engineering: { direction: "up", label: "+14.3%" },
+    Sales: { direction: "up", label: "+1.8%" },
+    Operations: { direction: "down", label: "−4.6%" },
+    People: { direction: "flat", label: "0%" },
+  },
+  added: ["Legal"],
+  removed: ["Support"],
+}
+
+const DEPARTMENT_ROWS = [
+  { id: "engineering", name: "Engineering", headcount: 96 },
+  { id: "sales", name: "Sales", headcount: 58 },
+  { id: "operations", name: "Operations", headcount: 61 },
+  { id: "legal", name: "Legal", headcount: 4 },
+]
+
+const deltaItems: DashboardItem[] = [
+  {
+    id: "headcount-by-department",
+    type: "chart",
+    title: "Headcount by department",
+    chart: { type: "bar", orientation: "horizontal" },
+    fetchData: () =>
+      withLatency<DashboardChartData>({
+        categories: ["Engineering", "Sales", "Operations", "People", "Legal"],
+        series: [{ name: "This period", data: [96, 58, 61, 33, 4] }],
+        trend: { direction: "up", label: "+10.7%" },
+        comparisonLabel: "vs previous month",
+        categoryComparison: DEPARTMENT_COMPARISON,
+      }),
+  },
+  {
+    id: "headcount-share",
+    type: "chart",
+    title: "Headcount share",
+    chart: { type: "pie", innerRadius: 60 },
+    fetchData: () =>
+      withLatency<DashboardChartData>({
+        series: {
+          name: "Headcount",
+          data: [
+            { name: "Engineering", value: 96 },
+            { name: "Sales", value: 58 },
+            { name: "Operations", value: 61 },
+            { name: "Legal", value: 4 },
+          ],
+        },
+        trend: { direction: "up", label: "+3.1 pp" },
+        comparisonLabel: "vs previous month",
+        categoryComparison: {
+          byCategory: DEPARTMENT_COMPARISON.byCategory,
+          added: DEPARTMENT_COMPARISON.added,
+        },
+      }),
+  },
+  {
+    id: "departments",
+    type: "collection",
+    title: "Departments",
+    itemHeight: 336,
+    createSource: () => ({
+      dataAdapter: {
+        fetchData: () =>
+          withLatency({
+            records: DEPARTMENT_ROWS,
+            rowTrends: {
+              engineering: { direction: "up", label: "+12" },
+              sales: { direction: "up", label: "+1" },
+              operations: { direction: "down", label: "−3" },
+              legal: { direction: "flat", label: "0" },
+            },
+          }),
+      },
+    }),
+    visualizations: [
+      {
+        type: "table" as const,
+        options: {
+          columns: [
+            {
+              id: "name",
+              label: "Department",
+              render: (row: (typeof DEPARTMENT_ROWS)[number]) => row.name,
+            },
+            {
+              id: "headcount",
+              label: "Headcount",
+              render: (row: (typeof DEPARTMENT_ROWS)[number]) =>
+                String(row.headcount),
+            },
+          ],
+        },
+      },
+    ],
+  },
+]
+
+/**
+ * The same host-computed trend on the widgets that have no single number to
+ * put it beside.
+ *
+ * Both charts show their own `trend` as a badge in the header. The bar chart
+ * also carries a `categoryComparison`: each department's change is drawn into
+ * its label, the department the compared period lacked is marked as new, and
+ * the one it had but this period does not — nothing draws it — is named in the
+ * caption under the chart. The collection's fetch returns `rowTrends`, which
+ * become a "Change" column.
+ */
+export const PeriodComparisonDeltas: Story = {
+  tags: ["no-sidebar"],
+  render: () => <F0AnalyticsDashboard items={deltaItems} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Every widget fetches with the same fake latency, so each affordance is
+    // awaited on its own rather than assumed to have landed with the first.
+    const find = (text: string) =>
+      canvas.findByText(text, undefined, { timeout: 5000 })
+
+    await expect(await find("+10.7%")).toBeInTheDocument()
+    await expect(await find("+3.1 pp")).toBeInTheDocument()
+    await expect(
+      await find("Not present this period: Support")
+    ).toBeInTheDocument()
+    // The category marks themselves are drawn on the chart canvas; the column
+    // the collection gains is the one that lands in the DOM.
+    await expect(await find("Change")).toBeInTheDocument()
+    await expect(await find("+12")).toBeInTheDocument()
   },
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -1334,18 +1334,15 @@ const deltaItems: DashboardItem[] = [
     itemHeight: 336,
     createSource: () => ({
       dataAdapter: {
-        fetchData: () =>
-          withLatency({
-            records: DEPARTMENT_ROWS,
-            rowTrends: {
-              engineering: { direction: "up", label: "+12" },
-              sales: { direction: "up", label: "+1" },
-              operations: { direction: "down", label: "−3" },
-              legal: { direction: "flat", label: "0" },
-            },
-          }),
+        fetchData: () => withLatency({ records: DEPARTMENT_ROWS }),
       },
     }),
+    rowTrends: {
+      engineering: { direction: "up", label: "+12" },
+      sales: { direction: "up", label: "+1" },
+      operations: { direction: "down", label: "−3" },
+      legal: { direction: "flat", label: "0" },
+    },
     visualizations: [
       {
         type: "table" as const,
@@ -1377,7 +1374,7 @@ const deltaItems: DashboardItem[] = [
  * also carries a `categoryComparison`: each department's change is drawn into
  * its label, the department the compared period lacked is marked as new, and
  * the one it had but this period does not — nothing draws it — is named in the
- * caption under the chart. The collection's fetch returns `rowTrends`, which
+ * caption under the chart. The collection item carries `rowTrends`, which
  * become a "Change" column.
  */
 export const PeriodComparisonDeltas: Story = {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -17,6 +17,7 @@ import type {
   DashboardItemFiltersConfig,
   DashboardItemFiltersState,
   DashboardMetricData,
+  DashboardMetricTrend,
 } from "../types"
 
 import { F0AnalyticsDashboard } from "../index"
@@ -1316,35 +1317,120 @@ export const PeriodComparison: Story = {
   },
 }
 
-const DEPARTMENT_COMPARISON: DashboardCategoryComparison = {
-  byCategory: {
-    Engineering: { direction: "up", label: "+14.3%" },
-    Sales: { direction: "up", label: "+1.8%" },
-    Operations: { direction: "down", label: "−4.6%" },
-    People: { direction: "flat", label: "0%" },
-  },
-  added: ["Legal"],
-  removed: ["Support"],
+/** The host's own change text, as a metric trend carries it. */
+const change = (
+  value: number,
+  delta: number,
+  sentiment?: DashboardMetricTrend["sentiment"]
+): DashboardMetricTrend => {
+  const previous = value - delta
+  const percent = previous === 0 ? 0 : (delta / previous) * 100
+  const sign = delta > 0 ? "+" : delta < 0 ? "−" : ""
+  return {
+    direction: delta > 0 ? "up" : delta < 0 ? "down" : "flat",
+    label:
+      delta === 0
+        ? "0"
+        : `${sign}${Math.abs(delta)} (${sign}${Math.abs(percent).toFixed(1)}%)`,
+    delta,
+    sentiment,
+  }
 }
 
-const DEPARTMENT_ROWS = [
-  { id: "engineering", name: "Engineering", headcount: 96 },
-  { id: "sales", name: "Sales", headcount: 58 },
-  { id: "operations", name: "Operations", headcount: 61 },
-  { id: "legal", name: "Legal", headcount: 4 },
+/** Real-shaped departments: long names, a wide spread, two new and one gone. */
+const DEPARTMENTS: {
+  id: string
+  name: string
+  headcount: number
+  delta: number
+}[] = [
+  {
+    id: "eng-platform",
+    name: "Engineering — Platform",
+    headcount: 96,
+    delta: 12,
+  },
+  { id: "eng-product", name: "Engineering — Product", headcount: 74, delta: 6 },
+  { id: "cs-emea", name: "Customer Success — EMEA", headcount: 58, delta: 9 },
+  {
+    id: "cs-americas",
+    name: "Customer Success — Americas",
+    headcount: 41,
+    delta: -3,
+  },
+  { id: "sales-ent", name: "Sales — Enterprise", headcount: 37, delta: 4 },
+  { id: "sales-mm", name: "Sales — Mid-market", headcount: 29, delta: -5 },
+  {
+    id: "mkt-brand",
+    name: "Marketing — Brand & Content",
+    headcount: 18,
+    delta: 2,
+  },
+  { id: "mkt-growth", name: "Marketing — Growth", headcount: 14, delta: 0 },
+  { id: "people", name: "People & Talent", headcount: 22, delta: 1 },
+  { id: "finance", name: "Finance & Legal", headcount: 16, delta: 0 },
+  {
+    id: "ops-facilities",
+    name: "Operations — Facilities",
+    headcount: 12,
+    delta: -2,
+  },
+  { id: "ops-it", name: "Operations — IT & Security", headcount: 15, delta: 3 },
+  { id: "data", name: "Data & Analytics", headcount: 11, delta: 5 },
+  { id: "design", name: "Design — Product & Brand", headcount: 13, delta: -1 },
+  { id: "research", name: "Research — Applied AI", headcount: 6, delta: 6 },
+  {
+    id: "partnerships",
+    name: "Partnerships — Channel",
+    headcount: 4,
+    delta: 4,
+  },
 ]
+const NEW_DEPARTMENTS = ["Research — Applied AI", "Partnerships — Channel"]
+const GONE_DEPARTMENT = "Support — Tier 1"
+
+const DEPARTMENT_COMPARISON: DashboardCategoryComparison = {
+  byCategory: Object.fromEntries([
+    ...DEPARTMENTS.filter((d) => !NEW_DEPARTMENTS.includes(d.name)).map((d) => [
+      d.name,
+      change(d.headcount, d.delta),
+    ]),
+    [GONE_DEPARTMENT, change(0, -9)],
+  ]),
+  added: NEW_DEPARTMENTS,
+  removed: [GONE_DEPARTMENT],
+}
+
+/** Share of headcount in percentage points: no `delta` in the measure's unit, so no baseline. */
+const SHARE_COMPARISON: DashboardCategoryComparison = {
+  byCategory: {
+    Engineering: { direction: "up", label: "+0.9 pp" },
+    "Customer Success": { direction: "up", label: "+0.6 pp" },
+    Sales: { direction: "down", label: "−0.7 pp", sentiment: "neutral" },
+    Marketing: { direction: "down", label: "−0.3 pp", sentiment: "neutral" },
+    "People & Talent": { direction: "flat", label: "0.0 pp" },
+    "Finance & Legal": { direction: "down", label: "−0.1 pp" },
+    Operations: { direction: "down", label: "−0.2 pp" },
+    Other: { direction: "up", label: "+1.4 pp" },
+  },
+}
+
+const DEPARTMENT_ROWS = DEPARTMENTS.slice(0, 12)
 
 const deltaItems: DashboardItem[] = [
   {
     id: "headcount-by-department",
     type: "chart",
     title: "Headcount by department",
+    itemHeight: 520,
     chart: { type: "bar", orientation: "horizontal" },
     fetchData: () =>
       withLatency<DashboardChartData>({
-        categories: ["Engineering", "Sales", "Operations", "People", "Legal"],
-        series: [{ name: "This period", data: [96, 58, 61, 33, 4] }],
-        trend: { direction: "up", label: "+10.7%" },
+        categories: DEPARTMENTS.map((d) => d.name),
+        series: [
+          { name: "This period", data: DEPARTMENTS.map((d) => d.headcount) },
+        ],
+        trend: { direction: "up", label: "+32 (+7.4%)" },
         comparisonLabel: "vs previous month",
         categoryComparison: DEPARTMENT_COMPARISON,
       }),
@@ -1353,42 +1439,41 @@ const deltaItems: DashboardItem[] = [
     id: "headcount-share",
     type: "chart",
     title: "Headcount share",
+    itemHeight: 520,
     chart: { type: "pie", innerRadius: 60 },
     fetchData: () =>
       withLatency<DashboardChartData>({
         series: {
           name: "Headcount",
           data: [
-            { name: "Engineering", value: 96 },
-            { name: "Sales", value: 58 },
-            { name: "Operations", value: 61 },
-            { name: "Legal", value: 4 },
+            { name: "Engineering", value: 170 },
+            { name: "Customer Success", value: 99 },
+            { name: "Sales", value: 66 },
+            { name: "Other", value: 34 },
+            { name: "Marketing", value: 32 },
+            { name: "Operations", value: 27 },
+            { name: "People & Talent", value: 22 },
+            { name: "Finance & Legal", value: 16 },
           ],
         },
-        trend: { direction: "up", label: "+3.1 pp" },
+        trend: { direction: "up", label: "+0.9 pp" },
         comparisonLabel: "vs previous month",
-        categoryComparison: {
-          byCategory: DEPARTMENT_COMPARISON.byCategory,
-          added: DEPARTMENT_COMPARISON.added,
-        },
+        categoryComparison: SHARE_COMPARISON,
       }),
   },
   {
     id: "departments",
     type: "collection",
     title: "Departments",
-    itemHeight: 336,
+    itemHeight: 560,
     createSource: () => ({
       dataAdapter: {
         fetchData: () => withLatency({ records: DEPARTMENT_ROWS }),
       },
     }),
-    rowTrends: {
-      engineering: { direction: "up", label: "+12" },
-      sales: { direction: "up", label: "+1" },
-      operations: { direction: "down", label: "−3" },
-      legal: { direction: "flat", label: "0" },
-    },
+    rowTrends: Object.fromEntries(
+      DEPARTMENT_ROWS.map((d) => [d.id, change(d.headcount, d.delta)])
+    ),
     visualizations: [
       {
         type: "table" as const,
@@ -1414,34 +1499,56 @@ const deltaItems: DashboardItem[] = [
 
 /**
  * The same host-computed trend on the widgets that have no single number to
- * put it beside.
+ * put it beside, at a realistic size: sixteen departments with long names,
+ * eight pie slices, twelve table rows.
  *
- * Both charts show their own `trend` as a badge in the header. The bar chart
- * also carries a `categoryComparison`: each department's change is drawn into
- * its label, the department the compared period lacked is marked as new, and
- * the one it had but this period does not — nothing draws it — is named in the
- * caption under the chart. The collection item carries `rowTrends`, which
- * become a "Change" column.
+ * Every widget shows its own `trend` as a badge in the header, and beside it
+ * a chip summing the per-category outcome — how many rose, fell, appeared or
+ * vanished, with the names on hover. Category labels stay clean: each
+ * category's change is a line in its tooltip, with the baseline value where
+ * the trend carries a numeric `delta`. The widget menu offers "Show change",
+ * which redraws the chart as diverging bars of those deltas — new departments
+ * first, the vanished one last, the rest by size of move, folded past ten
+ * rows. The share pie has no deltas in its unit, so its change view lists the
+ * labels instead. The collection carries `rowTrends`, which become a compact
+ * "Change" column right after the name.
  */
 export const PeriodComparisonDeltas: Story = {
   tags: ["no-sidebar"],
   render: () => <F0AnalyticsDashboard items={deltaItems} />,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
+    // Menus open in a portal, outside the story's own element.
+    const page = within(document.body)
 
     // Every widget fetches with the same fake latency, so each affordance is
     // awaited on its own rather than assumed to have landed with the first.
     const find = (text: string) =>
       canvas.findByText(text, undefined, { timeout: 5000 })
 
-    await expect(await find("+10.7%")).toBeInTheDocument()
-    await expect(await find("+3.1 pp")).toBeInTheDocument()
+    // Header trend badges.
+    await expect(await find("+32 (+7.4%)")).toBeInTheDocument()
+    await expect(await find("+0.9 pp")).toBeInTheDocument()
+    // Header chips: chart, pie (no added/removed parts), table (up/down only).
     await expect(
-      await find("Not present this period: Support")
+      await find("8 up · 4 down · 2 new · 1 gone")
     ).toBeInTheDocument()
-    // The category marks themselves are drawn on the chart canvas; the column
-    // the collection gains is the one that lands in the DOM.
+    await expect(await find("3 up · 4 down")).toBeInTheDocument()
+    await expect(await find("7 up · 3 down")).toBeInTheDocument()
+    // The Change column, right after the department name.
     await expect(await find("Change")).toBeInTheDocument()
-    await expect(await find("+12")).toBeInTheDocument()
+    await expect(await find("+12 (+14.3%)")).toBeInTheDocument()
+
+    // The change view toggles from the widget menu and offers the way back.
+    const widget = within(
+      (await find("Headcount by department")).closest<HTMLElement>(
+        "[class*='dashitem']"
+      )!
+    )
+    await userEvent.click(widget.getByLabelText("Other actions"))
+    await userEvent.click(await page.findByText("Show change"))
+    await userEvent.click(widget.getByLabelText("Other actions"))
+    await expect(await page.findByText("Show values")).toBeInTheDocument()
+    await userEvent.keyboard("{Escape}")
   },
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -1082,12 +1082,22 @@ export const HoverItemFilterSignal: Story = {
 // Period comparison
 // ---------------------------------------------------------------------------
 
-type CompareTarget = "none" | "previous_period" | "previous_year"
+const COMPARISON_PERIODS = {
+  previous_week: "week",
+  previous_month: "month",
+  previous_quarter: "quarter",
+  previous_half_year: "half year",
+  previous_year: "year",
+} as const
+
+type CompareTarget = "none" | keyof typeof COMPARISON_PERIODS
 
 const comparisonOptions: F0SelectItemProps<CompareTarget>[] = [
   { value: "none", label: "No comparison" },
-  { value: "previous_period", label: "Previous period" },
-  { value: "previous_year", label: "Previous year" },
+  ...Object.entries(COMPARISON_PERIODS).map(([value, period]) => ({
+    value: value as CompareTarget,
+    label: `Previous ${period}`,
+  })),
 ]
 
 const COMPARISON_MONTHS = ["Apr", "May", "Jun", "Jul", "Aug", "Sep"]
@@ -1101,8 +1111,9 @@ const withLatency = <T,>(value: T): Promise<T> =>
 
 const comparisonItems = (compareTo: CompareTarget): DashboardItem[] => {
   const comparing = compareTo !== "none"
-  const comparisonLabel =
-    compareTo === "previous_year" ? "vs same period last year" : "vs Oct–Mar"
+  const comparisonLabel = comparing
+    ? `vs previous ${COMPARISON_PERIODS[compareTo]}`
+    : ""
 
   return [
     {
@@ -1180,7 +1191,7 @@ const comparisonItems = (compareTo: CompareTarget): DashboardItem[] => {
 }
 
 const ComparisonDashboard = () => {
-  const [compareTo, setCompareTo] = useState<CompareTarget>("previous_period")
+  const [compareTo, setCompareTo] = useState<CompareTarget>("previous_month")
   const items = useMemo(() => comparisonItems(compareTo), [compareTo])
 
   return (
@@ -1215,8 +1226,8 @@ const ComparisonDashboard = () => {
  *
  * The metrics render a server-computed `trend` verbatim — a percentage, a
  * difference in percentage points, and a neutral "No change" — each with the
- * `comparisonLabel` in a tooltip. The chart draws the previous period muted
- * and dashed via `comparisonSeriesNames`, with its legend entry untouched.
+ * `comparisonLabel` in a tooltip. The chart draws the previous period faded
+ * and dashed via `comparisonSeriesNames`, still listed in the legend.
  */
 export const PeriodComparison: Story = {
   tags: ["no-sidebar"],
@@ -1228,7 +1239,9 @@ export const PeriodComparison: Story = {
     await expect(canvas.getByText("No change")).toBeInTheDocument()
     // The trend badge announces its own baseline, not just the change.
     await expect(
-      canvas.getByText("−1.2 pp vs Oct–Mar", { selector: ".sr-only" })
+      canvas.getByText("−1.2 pp vs previous month", {
+        selector: ".sr-only",
+      })
     ).toBeInTheDocument()
   },
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -23,10 +23,10 @@ import type { F0AnalyticsDashboardPointClick } from "../types"
 import {
   buildPointQuoteText,
   buildAccessibleChartPoints,
-  buildChartProps,
   ChartItem,
   hasAccessibleChartPoint,
 } from "../components/ChartItem/ChartItem"
+import { buildChartProps } from "../components/ChartItem/chartProps"
 
 /** The mark a click lands on, as `usePointClick` would report it. */
 const POINT: F0DataChartPointClick = {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -197,6 +197,39 @@ describe("ChartItem — asking about a mark", () => {
     )
   })
 
+  it("quotes a marked category by its plain label", async () => {
+    const compared: DashboardChartItem = {
+      ...item,
+      fetchData: () =>
+        Promise.resolve({
+          categories: ["Barcelona office"],
+          series: [{ name: "Male", data: [18] }],
+          categoryComparison: {
+            byCategory: {
+              "Barcelona office": { direction: "up", label: "+4.2%" },
+            },
+          },
+        }),
+    }
+    render(
+      <AiChatStateProvider enabled>
+        <ChatProbe />
+        <ChartItem item={compared} filters={filters} />
+      </AiChatStateProvider>
+    )
+
+    await pickAMark()
+
+    // The category mark is drawn on the chart. What the reader asked about is
+    // the category, so that is what the quote says.
+    await waitFor(() =>
+      expect(screen.getByTestId("probe")).toHaveAttribute(
+        "data-quote",
+        "Headcount by workplace — Barcelona office\nMale: 18"
+      )
+    )
+  })
+
   it("offers the click with no chat mounted, once the host answers it", async () => {
     const onAskAi = vi.fn()
     render(<ChartItem item={item} filters={{}} onAskAi={onAskAi} />)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.changeView.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.changeView.test.tsx
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
+
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import type { DashboardChartData, DashboardChartItem } from "../types"
+
+import { ChartItem } from "../components/ChartItem/ChartItem"
+
+// jsdom has no canvas; what the chart was asked to draw is what matters here.
+vi.mock("@/kits/F0DataChart", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/kits/F0DataChart")>()
+  return {
+    ...actual,
+    F0DataChart: (props: F0DataChartProps) => (
+      <div role="img" aria-label="Chart">
+        {props.type === "bar" ? props.categories.join(" | ") : props.type}
+      </div>
+    ),
+  }
+})
+
+const data: DashboardChartData = {
+  categories: ["Sales", "Operations", "Legal"],
+  series: [{ name: "This period", data: [58, 61, 4] }],
+}
+
+const comparison: DashboardChartData["categoryComparison"] = {
+  byCategory: {
+    Sales: { direction: "up", label: "+4", delta: 4 },
+    Operations: { direction: "down", label: "−9", delta: 9 },
+  },
+  added: ["Legal"],
+  removed: ["Support"],
+}
+
+const item = (chartData: DashboardChartData): DashboardChartItem => ({
+  id: "headcount",
+  title: "Headcount by department",
+  type: "chart",
+  chart: { type: "bar" },
+  fetchData: () => Promise.resolve(chartData),
+})
+
+const openMenu = () => userEvent.click(screen.getByLabelText("Other actions"))
+
+describe("ChartItem — change view", () => {
+  it("offers no change view without a comparison", async () => {
+    render(<ChartItem item={item(data)} filters={{}} />)
+
+    await screen.findByLabelText("Chart")
+    await openMenu()
+    expect(screen.queryByText("Show change")).toBeNull()
+  })
+
+  it("swaps the values for ranked deltas and back from the menu", async () => {
+    render(
+      <ChartItem
+        item={item({ ...data, categoryComparison: comparison })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByLabelText("Chart")).toHaveTextContent(
+      "Sales | Operations | Legal"
+    )
+    expect(
+      screen.getByText("1 up · 1 down · 1 new · 1 gone")
+    ).toBeInTheDocument()
+
+    await openMenu()
+    await userEvent.click(screen.getByText("Show change"))
+    expect(screen.getByLabelText("Chart")).toHaveTextContent(
+      "Legal (New) | Operations | Sales | Support (Gone)"
+    )
+
+    await openMenu()
+    await userEvent.click(screen.getByText("Show values"))
+    expect(screen.getByLabelText("Chart")).toHaveTextContent(
+      "Sales | Operations | Legal"
+    )
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -128,6 +128,40 @@ describe("CollectionItem", () => {
     expect(column.render({ id: "unknown" })).toBeUndefined()
   })
 
+  it("colours a Change cell by its sentiment and keeps the arrow on its direction", () => {
+    const collection = item(() => ({ id: "source" }), tableViz, {
+      "1": { direction: "down", label: "−1.2 pp", sentiment: "positive" },
+      "2": { direction: "up", label: "+0.8 pp", sentiment: "negative" },
+      "3": { direction: "flat", label: "0", sentiment: "neutral" },
+    })
+
+    render(<CollectionItem item={collection} filters={{}} />)
+
+    const column = changeColumnOf()
+    expect(column.render({ id: "1" })).toEqual({
+      type: "delta",
+      value: { label: "−1.2 pp", deltaStatus: "positive", arrow: "down" },
+    })
+    expect(column.render({ id: "2" })).toEqual({
+      type: "delta",
+      value: { label: "+0.8 pp", deltaStatus: "negative", arrow: "up" },
+    })
+    expect(column.render({ id: "3" })).toEqual({
+      type: "delta",
+      value: { label: "0", deltaStatus: "neutral", arrow: "none" },
+    })
+  })
+
+  it("renders a flat trend as plain text when no sentiment is given", () => {
+    const collection = item(() => ({ id: "source" }), tableViz, {
+      "1": { direction: "flat", label: "0" },
+    })
+
+    render(<CollectionItem item={collection} filters={{}} />)
+
+    expect(changeColumnOf().render({ id: "1" })).toBe("0")
+  })
+
   it("leaves the visualizations untouched when the item carries no rowTrends", () => {
     const collection = item(() => ({ id: "source" }), tableViz)
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -79,22 +79,19 @@ describe("CollectionItem", () => {
     ])
   })
 
-  it("recreates the source when the dataKey changes", () => {
+  it("re-creates its source on a dataKey change instead of refetching in place", () => {
     const createSource = vi.fn(() => ({ id: "source" }))
+    const collection = item(createSource)
 
     const { rerender } = render(
-      <CollectionItem
-        item={item(createSource) as never}
-        filters={{}}
-        dataKey="none"
-      />
+      <CollectionItem item={collection} filters={{}} dataKey="none" />
     )
 
     expect(createSource).toHaveBeenCalledOnce()
 
     rerender(
       <CollectionItem
-        item={item(createSource) as never}
+        item={collection}
         filters={{}}
         dataKey="previous_period"
       />

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { act, zeroRender as render } from "@/testing/test-utils"
+import { zeroRender as render } from "@/testing/test-utils"
 
 import type { DashboardCollectionItem } from "../types"
 
@@ -35,28 +35,20 @@ vi.mock("../hooks/useCollectionDownloadActions", () => ({
 
 const item = (
   createSource: DashboardCollectionItem["createSource"],
-  visualizations: DashboardCollectionItem["visualizations"] = []
+  visualizations: DashboardCollectionItem["visualizations"] = [],
+  rowTrends?: DashboardCollectionItem["rowTrends"]
 ): DashboardCollectionItem => ({
   id: "employees",
   type: "collection",
   title: "Employees",
   visualizations,
   createSource,
+  rowTrends,
 })
 
 const tableViz = [
   { type: "table", options: { columns: [{ label: "Name", id: "name" }] } },
 ]
-
-/** Runs the source's own fetch, which is what carries `rowTrends` back. */
-async function fetchOnce() {
-  const definition = useDataCollectionSource.mock.lastCall?.[0] as {
-    dataAdapter: { fetchData: (options: unknown) => Promise<unknown> }
-  }
-  await act(async () => {
-    await definition.dataAdapter.fetchData({})
-  })
-}
 
 function changeColumnOf() {
   const [viz] = rendered.visualizations as [
@@ -120,45 +112,53 @@ describe("CollectionItem", () => {
     ])
   })
 
-  it("appends a Change column for the rowTrends its own fetch returns", async () => {
-    const records = [{ id: "1", name: "Ada" }]
-    const collection = item(
-      () => ({
-        dataAdapter: {
-          fetchData: () =>
-            Promise.resolve({
-              records,
-              rowTrends: { "1": { direction: "up", label: "+2" } },
-            }),
-        },
-      }),
-      tableViz
-    )
+  it("appends a Change column for the rowTrends the item carries", () => {
+    const collection = item(() => ({ id: "source" }), tableViz, {
+      "1": { direction: "up", label: "+2" },
+    })
 
     render(<CollectionItem item={collection} filters={{}} />)
-    await fetchOnce()
 
     const column = changeColumnOf()
     expect(column.label).toBe("Change")
-    expect(column.render(records[0])).toEqual({
+    expect(column.render({ id: "1", name: "Ada" })).toEqual({
       type: "delta",
       value: { label: "+2", deltaStatus: "positive" },
     })
     expect(column.render({ id: "unknown" })).toBeUndefined()
   })
 
-  it("leaves the visualizations untouched when the fetch carries no rowTrends", async () => {
-    const collection = item(
-      () => ({
-        dataAdapter: { fetchData: () => Promise.resolve({ records: [] }) },
-      }),
-      tableViz
-    )
+  it("leaves the visualizations untouched when the item carries no rowTrends", () => {
+    const collection = item(() => ({ id: "source" }), tableViz)
 
     render(<CollectionItem item={collection} filters={{}} />)
-    await fetchOnce()
 
     expect(rendered.visualizations).toBe(collection.visualizations)
+  })
+
+  it("keys trends by the source's idProvider, else by the record id", () => {
+    const trends = { "emp-7": { direction: "up" as const, label: "+2" } }
+    const withProvider = item(
+      () => ({ idProvider: (row: { code: number }) => `emp-${row.code}` }),
+      tableViz,
+      trends
+    )
+
+    render(<CollectionItem item={withProvider} filters={{}} />)
+    expect(changeColumnOf().render({ code: 7 })).toEqual({
+      type: "delta",
+      value: { label: "+2", deltaStatus: "positive" },
+    })
+
+    // No idProvider: the same lookup the datasource itself falls back to.
+    const withoutProvider = item(() => ({ id: "source" }), tableViz, trends)
+
+    render(<CollectionItem item={withoutProvider} filters={{}} />)
+    expect(changeColumnOf().render({ code: 7 })).toBeUndefined()
+    expect(changeColumnOf().render({ id: "emp-7" })).toEqual({
+      type: "delta",
+      value: { label: "+2", deltaStatus: "positive" },
+    })
   })
 
   it("re-creates its source on a dataKey change instead of refetching in place", () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { zeroRender as render } from "@/testing/test-utils"
+import { screen, zeroRender as render } from "@/testing/test-utils"
 
 import type { DashboardCollectionItem } from "../types"
 
@@ -60,12 +60,20 @@ function changeColumnOf() {
           id?: string
           label: string
           sorting?: string
+          width?: number
           render: (row: Record<string, unknown>) => unknown
         }[]
       }
     },
   ]
-  return viz.options.columns.at(-1)!
+  return viz.options.columns.find((c) => c.id === "dashboard-row-change")!
+}
+
+function columnIdsOf() {
+  const [viz] = rendered.visualizations as [
+    { options: { columns: { id?: string }[] } },
+  ]
+  return viz.options.columns.map((c) => c.id)
 }
 
 describe("CollectionItem", () => {
@@ -129,6 +137,36 @@ describe("CollectionItem", () => {
       value: { label: "+2", deltaStatus: "positive" },
     })
     expect(column.render({ id: "unknown" })).toBeUndefined()
+  })
+
+  it("places the Change column right after the first and keeps it narrow", () => {
+    const columns = [
+      { label: "Name", id: "name" },
+      { label: "Headcount", id: "headcount" },
+    ]
+    const collection = item(
+      () => ({ id: "source" }),
+      [{ type: "table", options: { columns } }],
+      { "1": { direction: "up", label: "+2" } }
+    )
+
+    render(<CollectionItem item={collection} filters={{}} />)
+
+    expect(columnIdsOf()).toEqual(["name", "dashboard-row-change", "headcount"])
+    expect(changeColumnOf().width).toBe(144)
+  })
+
+  it("counts the rows that rose and fell in a chip beside the title", () => {
+    const collection = item(() => ({ id: "source" }), tableViz, {
+      "1": { direction: "up", label: "+2" },
+      "2": { direction: "up", label: "+1" },
+      "3": { direction: "down", label: "−4" },
+      "4": { direction: "flat", label: "0" },
+    })
+
+    render(<CollectionItem item={collection} filters={{}} />)
+
+    expect(screen.getByText("2 up · 1 down")).toBeInTheDocument()
   })
 
   it("sorts the Change column only through a sorting the source declares", () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -36,7 +36,8 @@ vi.mock("../hooks/useCollectionDownloadActions", () => ({
 const item = (
   createSource: DashboardCollectionItem["createSource"],
   visualizations: DashboardCollectionItem["visualizations"] = [],
-  rowTrends?: DashboardCollectionItem["rowTrends"]
+  rowTrends?: DashboardCollectionItem["rowTrends"],
+  rowTrendsSorting?: string
 ): DashboardCollectionItem => ({
   id: "employees",
   type: "collection",
@@ -44,6 +45,7 @@ const item = (
   visualizations,
   createSource,
   rowTrends,
+  rowTrendsSorting,
 })
 
 const tableViz = [
@@ -57,6 +59,7 @@ function changeColumnOf() {
         columns: {
           id?: string
           label: string
+          sorting?: string
           render: (row: Record<string, unknown>) => unknown
         }[]
       }
@@ -126,6 +129,26 @@ describe("CollectionItem", () => {
       value: { label: "+2", deltaStatus: "positive" },
     })
     expect(column.render({ id: "unknown" })).toBeUndefined()
+  })
+
+  it("sorts the Change column only through a sorting the source declares", () => {
+    const trends = { "1": { direction: "up" as const, label: "+2" } }
+
+    render(
+      <CollectionItem
+        item={item(() => ({ id: "source" }), tableViz, trends)}
+        filters={{}}
+      />
+    )
+    expect(changeColumnOf().sorting).toBeUndefined()
+
+    render(
+      <CollectionItem
+        item={item(() => ({ id: "source" }), tableViz, trends, "change")}
+        filters={{}}
+      />
+    )
+    expect(changeColumnOf().sorting).toBe("change")
   })
 
   it("colours a Change cell by its sentiment and keeps the arrow on its direction", () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -56,6 +56,7 @@ describe("CollectionItem", () => {
     expect(useDataCollectionSource).toHaveBeenLastCalledWith(firstDefinition, [
       "{}",
       "{}",
+      undefined,
     ])
 
     rerender(
@@ -74,6 +75,36 @@ describe("CollectionItem", () => {
     expect(useDataCollectionSource).toHaveBeenLastCalledWith(secondDefinition, [
       "{}",
       '{"employee":"Ada"}',
+      undefined,
+    ])
+  })
+
+  it("recreates the source when the dataKey changes", () => {
+    const createSource = vi.fn(() => ({ id: "source" }))
+
+    const { rerender } = render(
+      <CollectionItem
+        item={item(createSource) as never}
+        filters={{}}
+        dataKey="none"
+      />
+    )
+
+    expect(createSource).toHaveBeenCalledOnce()
+
+    rerender(
+      <CollectionItem
+        item={item(createSource) as never}
+        filters={{}}
+        dataKey="previous_period"
+      />
+    )
+
+    expect(createSource).toHaveBeenCalledTimes(2)
+    expect(useDataCollectionSource).toHaveBeenLastCalledWith({ id: "source" }, [
+      "{}",
+      "{}",
+      "previous_period",
     ])
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { zeroRender as render } from "@/testing/test-utils"
+import { act, zeroRender as render } from "@/testing/test-utils"
 
 import type { DashboardCollectionItem } from "../types"
 
@@ -14,8 +14,19 @@ vi.mock("@/patterns/OneDataCollection/hooks/useDataCollectionSource", () => ({
   useDataCollectionSource,
 }))
 
+const rendered = vi.hoisted(() => ({
+  visualizations: undefined as ReadonlyArray<unknown> | undefined,
+}))
+
 vi.mock("@/patterns/OneDataCollection", () => ({
-  OneDataCollection: () => <div>Collection</div>,
+  OneDataCollection: ({
+    visualizations,
+  }: {
+    visualizations: ReadonlyArray<unknown>
+  }) => {
+    rendered.visualizations = visualizations
+    return <div>Collection</div>
+  },
 }))
 
 vi.mock("../hooks/useCollectionDownloadActions", () => ({
@@ -23,14 +34,44 @@ vi.mock("../hooks/useCollectionDownloadActions", () => ({
 }))
 
 const item = (
-  createSource: DashboardCollectionItem["createSource"]
+  createSource: DashboardCollectionItem["createSource"],
+  visualizations: DashboardCollectionItem["visualizations"] = []
 ): DashboardCollectionItem => ({
   id: "employees",
   type: "collection",
   title: "Employees",
-  visualizations: [],
+  visualizations,
   createSource,
 })
+
+const tableViz = [
+  { type: "table", options: { columns: [{ label: "Name", id: "name" }] } },
+]
+
+/** Runs the source's own fetch, which is what carries `rowTrends` back. */
+async function fetchOnce() {
+  const definition = useDataCollectionSource.mock.lastCall?.[0] as {
+    dataAdapter: { fetchData: (options: unknown) => Promise<unknown> }
+  }
+  await act(async () => {
+    await definition.dataAdapter.fetchData({})
+  })
+}
+
+function changeColumnOf() {
+  const [viz] = rendered.visualizations as [
+    {
+      options: {
+        columns: {
+          id?: string
+          label: string
+          render: (row: Record<string, unknown>) => unknown
+        }[]
+      }
+    },
+  ]
+  return viz.options.columns.at(-1)!
+}
 
 describe("CollectionItem", () => {
   it("recreates the source with the latest item closure when widget filters change", () => {
@@ -77,6 +118,47 @@ describe("CollectionItem", () => {
       '{"employee":"Ada"}',
       undefined,
     ])
+  })
+
+  it("appends a Change column for the rowTrends its own fetch returns", async () => {
+    const records = [{ id: "1", name: "Ada" }]
+    const collection = item(
+      () => ({
+        dataAdapter: {
+          fetchData: () =>
+            Promise.resolve({
+              records,
+              rowTrends: { "1": { direction: "up", label: "+2" } },
+            }),
+        },
+      }),
+      tableViz
+    )
+
+    render(<CollectionItem item={collection} filters={{}} />)
+    await fetchOnce()
+
+    const column = changeColumnOf()
+    expect(column.label).toBe("Change")
+    expect(column.render(records[0])).toEqual({
+      type: "delta",
+      value: { label: "+2", deltaStatus: "positive" },
+    })
+    expect(column.render({ id: "unknown" })).toBeUndefined()
+  })
+
+  it("leaves the visualizations untouched when the fetch carries no rowTrends", async () => {
+    const collection = item(
+      () => ({
+        dataAdapter: { fetchData: () => Promise.resolve({ records: [] }) },
+      }),
+      tableViz
+    )
+
+    render(<CollectionItem item={collection} filters={{}} />)
+    await fetchOnce()
+
+    expect(rendered.visualizations).toBe(collection.visualizations)
   })
 
   it("re-creates its source on a dataKey change instead of refetching in place", () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ComparisonChip.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ComparisonChip.test.tsx
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+
+import { screen, zeroRender as render } from "@/testing/test-utils"
+
+import {
+  ComparisonChip,
+  comparisonSummary,
+} from "../components/ComparisonChip/ComparisonChip"
+
+describe("comparisonSummary", () => {
+  it("groups categories by outcome, counting each once and never a flat one", () => {
+    expect(
+      comparisonSummary({
+        byCategory: {
+          Sales: { direction: "up", label: "+4" },
+          Operations: { direction: "down", label: "−3" },
+          People: { direction: "flat", label: "0" },
+          Legal: { direction: "up", label: "+4" },
+          Support: { direction: "down", label: "−5" },
+        },
+        added: ["Legal"],
+        removed: ["Support"],
+      })
+    ).toEqual({
+      up: ["Sales"],
+      down: ["Operations"],
+      added: ["Legal"],
+      removed: ["Support"],
+    })
+  })
+
+  it("is nothing when there is nothing to count", () => {
+    expect(comparisonSummary(undefined)).toBeUndefined()
+    expect(
+      comparisonSummary({
+        byCategory: { People: { direction: "flat", label: "0" } },
+      })
+    ).toBeUndefined()
+  })
+})
+
+describe("ComparisonChip", () => {
+  it("writes the counts that are there and leaves out the ones that are zero", () => {
+    render(
+      <ComparisonChip
+        summary={{
+          up: ["Sales", "Legal"],
+          down: [],
+          added: ["Ops"],
+          removed: [],
+        }}
+      />
+    )
+
+    expect(screen.getByText("2 up · 1 new")).toBeInTheDocument()
+    expect(screen.queryByText(/down|gone/)).toBeNull()
+  })
+
+  it("renders nothing without a summary", () => {
+    const { container } = render(<ComparisonChip />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
@@ -2,15 +2,19 @@ import { describe, expect, it, vi } from "vitest"
 
 import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
 
-import type { DashboardMetricData, DashboardMetricItem } from "../types"
+import type {
+  DashboardChartItem,
+  DashboardMetricData,
+  DashboardMetricItem,
+} from "../types"
 
 import { F0AnalyticsDashboard } from "../F0AnalyticsDashboard"
 
-const containerSize = vi.hoisted(() => ({ width: 320, height: 0 }))
-
-vi.mock("@/kits/F0DataChart/utils/useContainerSize", () => ({
-  useContainerSize: () => containerSize,
-}))
+// jsdom has no canvas context; the refetch this pins is ordinary React state.
+vi.mock("@/kits/F0DataChart", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/kits/F0DataChart")>()
+  return { ...actual, F0DataChart: () => <div aria-label="Chart" role="img" /> }
+})
 
 function metricItem(
   fetchData: DashboardMetricItem["fetchData"]
@@ -120,5 +124,31 @@ describe("F0AnalyticsDashboard comparison props", () => {
 
     await screen.findByText("10")
     expect(screen.queryByRole("button", { name: "Compare to" })).toBeNull()
+  })
+
+  it("refetches a chart item on a dataKey change", async () => {
+    const fetchData = vi
+      .fn<DashboardChartItem["fetchData"]>()
+      .mockResolvedValue({
+        categories: ["Jan", "Feb"],
+        series: [{ name: "This period", data: [1, 2] }],
+      })
+    const chart: DashboardChartItem = {
+      id: "headcount-trend",
+      title: "Headcount over time",
+      type: "chart",
+      chart: { type: "line", comparisonSeriesNames: ["Previous period"] },
+      fetchData,
+    }
+
+    const { rerender } = render(
+      <F0AnalyticsDashboard items={[chart]} dataKey="none" />
+    )
+
+    await waitFor(() => expect(fetchData).toHaveBeenCalledTimes(1))
+
+    rerender(<F0AnalyticsDashboard items={[chart]} dataKey="previous_month" />)
+
+    await waitFor(() => expect(fetchData).toHaveBeenCalledTimes(2))
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
@@ -1,0 +1,124 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import type { DashboardMetricData, DashboardMetricItem } from "../types"
+
+import { F0AnalyticsDashboard } from "../F0AnalyticsDashboard"
+
+const containerSize = vi.hoisted(() => ({ width: 320, height: 0 }))
+
+vi.mock("@/kits/F0DataChart/utils/useContainerSize", () => ({
+  useContainerSize: () => containerSize,
+}))
+
+function metricItem(
+  fetchData: DashboardMetricItem["fetchData"]
+): DashboardMetricItem {
+  return { id: "headcount", title: "Headcount", type: "metric", fetchData }
+}
+
+/** The widget card, which must survive a `dataKey` change untouched. */
+function widgetCard(): HTMLElement {
+  return screen.getByText("Headcount").closest("[class*='dashitem']")!
+}
+
+describe("F0AnalyticsDashboard comparison props", () => {
+  it("refetches every item on a dataKey change without remounting the grid", async () => {
+    const fetchData = vi
+      .fn<DashboardMetricItem["fetchData"]>()
+      .mockResolvedValueOnce({ value: 10 })
+      .mockResolvedValueOnce({ value: 20 })
+
+    const { rerender } = render(
+      <F0AnalyticsDashboard items={[metricItem(fetchData)]} dataKey="none" />
+    )
+
+    await screen.findByText("10")
+    const card = widgetCard()
+
+    rerender(
+      <F0AnalyticsDashboard
+        items={[metricItem(fetchData)]}
+        dataKey="previous_period"
+      />
+    )
+
+    await waitFor(() => expect(fetchData).toHaveBeenCalledTimes(2))
+    await screen.findByText("20")
+    expect(widgetCard()).toBe(card)
+  })
+
+  it("keeps the previous value on screen, marked busy, until the new one arrives", async () => {
+    let resolveSecond: ((data: DashboardMetricData) => void) | undefined
+    const fetchData = vi
+      .fn<DashboardMetricItem["fetchData"]>()
+      .mockResolvedValueOnce({ value: 10 })
+      .mockImplementationOnce(
+        () =>
+          new Promise<DashboardMetricData>((resolve) => {
+            resolveSecond = resolve
+          })
+      )
+
+    const { rerender } = render(
+      <F0AnalyticsDashboard items={[metricItem(fetchData)]} dataKey="none" />
+    )
+
+    await screen.findByText("10")
+
+    rerender(
+      <F0AnalyticsDashboard
+        items={[metricItem(fetchData)]}
+        dataKey="previous_period"
+      />
+    )
+
+    await waitFor(() =>
+      expect(widgetCard()).toHaveAttribute("aria-busy", "true")
+    )
+    expect(screen.getByText("10")).toBeInTheDocument()
+
+    resolveSecond?.({ value: 20 })
+
+    await screen.findByText("20")
+    expect(widgetCard()).not.toHaveAttribute("aria-busy")
+  })
+
+  it("does not refetch when dataKey is absent", async () => {
+    const fetchData = vi.fn().mockResolvedValue({ value: 10 })
+
+    const { rerender } = render(
+      <F0AnalyticsDashboard items={[metricItem(fetchData)]} />
+    )
+
+    await screen.findByText("10")
+    rerender(<F0AnalyticsDashboard items={[metricItem(fetchData)]} />)
+
+    await waitFor(() => expect(fetchData).toHaveBeenCalledTimes(1))
+  })
+
+  it("renders navigationActions in the header row", async () => {
+    render(
+      <F0AnalyticsDashboard
+        items={[metricItem(() => Promise.resolve({ value: 10 }))]}
+        navigationActions={<button type="button">Compare to</button>}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Compare to" })
+    ).toBeInTheDocument()
+  })
+
+  it("renders no header row when navigationActions is absent", async () => {
+    render(
+      <F0AnalyticsDashboard
+        items={[metricItem(() => Promise.resolve({ value: 10 }))]}
+      />
+    )
+
+    await screen.findByText("10")
+    expect(screen.queryByRole("button", { name: "Compare to" })).toBeNull()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest"
 import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
 
 import type {
+  DashboardChartData,
   DashboardChartItem,
   DashboardMetricData,
   DashboardMetricItem,
@@ -20,6 +21,16 @@ function metricItem(
   fetchData: DashboardMetricItem["fetchData"]
 ): DashboardMetricItem {
   return { id: "headcount", title: "Headcount", type: "metric", fetchData }
+}
+
+function chartItem(data: DashboardChartData): DashboardChartItem {
+  return {
+    id: "headcount-by-department",
+    title: "Headcount by department",
+    type: "chart",
+    chart: { type: "bar" },
+    fetchData: () => Promise.resolve(data),
+  }
 }
 
 /** The widget card, which must survive a `dataKey` change untouched. */
@@ -124,6 +135,63 @@ describe("F0AnalyticsDashboard comparison props", () => {
 
     await screen.findByText("10")
     expect(screen.queryByRole("button", { name: "Compare to" })).toBeNull()
+  })
+
+  it("shows a chart's own trend as a badge in its header", async () => {
+    render(
+      <F0AnalyticsDashboard
+        items={[
+          chartItem({
+            categories: ["Jan"],
+            series: [{ name: "This period", data: [1] }],
+            trend: { direction: "up", label: "+10.7%" },
+            comparisonLabel: "vs previous month",
+          }),
+        ]}
+      />
+    )
+
+    expect(await screen.findByText("+10.7%")).toBeInTheDocument()
+    expect(
+      screen.getByText("+10.7% vs previous month", { selector: ".sr-only" })
+    ).toBeInTheDocument()
+  })
+
+  it("shows no header badge when the chart data carries no trend", async () => {
+    render(
+      <F0AnalyticsDashboard
+        items={[
+          chartItem({
+            categories: ["Jan"],
+            series: [{ name: "This period", data: [1] }],
+          }),
+        ]}
+      />
+    )
+
+    await screen.findByLabelText("Chart")
+    expect(screen.queryByText(/%/)).toBeNull()
+  })
+
+  it("names the categories the compared period had and this one does not", async () => {
+    render(
+      <F0AnalyticsDashboard
+        items={[
+          chartItem({
+            categories: ["Sales"],
+            series: [{ name: "This period", data: [1] }],
+            categoryComparison: {
+              byCategory: {},
+              removed: ["Legal", "Support"],
+            },
+          }),
+        ]}
+      />
+    )
+
+    expect(
+      await screen.findByText("Not present this period: Legal, Support")
+    ).toBeInTheDocument()
   })
 
   it("refetches a chart item on a dataKey change", async () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/F0AnalyticsDashboard.comparison.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
+import {
+  screen,
+  userEvent,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
 
 import type {
   DashboardChartData,
@@ -173,16 +178,21 @@ describe("F0AnalyticsDashboard comparison props", () => {
     expect(screen.queryByText(/%/)).toBeNull()
   })
 
-  it("names the categories the compared period had and this one does not", async () => {
+  it("sums the per-category comparison into a chip beside the title", async () => {
     render(
       <F0AnalyticsDashboard
         items={[
           chartItem({
-            categories: ["Sales"],
-            series: [{ name: "This period", data: [1] }],
+            categories: ["Sales", "Operations", "Legal"],
+            series: [{ name: "This period", data: [58, 61, 4] }],
             categoryComparison: {
-              byCategory: {},
-              removed: ["Legal", "Support"],
+              byCategory: {
+                Sales: { direction: "up", label: "+4.2%" },
+                Operations: { direction: "down", label: "−3.0%" },
+                People: { direction: "flat", label: "0%" },
+              },
+              added: ["Legal"],
+              removed: ["Support"],
             },
           }),
         ]}
@@ -190,8 +200,27 @@ describe("F0AnalyticsDashboard comparison props", () => {
     )
 
     expect(
-      await screen.findByText("Not present this period: Legal, Support")
+      await screen.findByText("1 up · 1 down · 1 new · 1 gone")
     ).toBeInTheDocument()
+    expect(screen.queryByText(/Not present/)).toBeNull()
+  })
+
+  it("adds neither chip nor change view when the data carries no comparison", async () => {
+    render(
+      <F0AnalyticsDashboard
+        items={[
+          chartItem({
+            categories: ["Sales"],
+            series: [{ name: "This period", data: [1] }],
+          }),
+        ]}
+      />
+    )
+
+    await screen.findByLabelText("Chart")
+    expect(screen.queryByText(/\d+ (up|down|new|gone)/)).toBeNull()
+    await userEvent.click(screen.getByLabelText("Other actions"))
+    expect(screen.queryByText("Show change")).toBeNull()
   })
 
   it("refetches a chart item on a dataKey change", async () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
@@ -1,9 +1,10 @@
 import { waitFor } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
-import type { DashboardMetricItem } from "../types"
+import type { DashboardMetricData, DashboardMetricItem } from "../types"
 
 import { MetricItem, MetricValue } from "../components/MetricItem/MetricItem"
 
@@ -191,5 +192,96 @@ describe("MetricItem", () => {
     containerSize.width = 600
     rerender(<MetricValue value="100" />)
     await waitFor(() => expect(container).not.toHaveAttribute("tabindex"))
+  })
+
+  describe("comparison trend", () => {
+    const withTrend = (data: Partial<DashboardMetricData>) =>
+      metricItem({
+        fetchData: () =>
+          Promise.resolve({ value: 123, previousValue: 100, ...data }),
+      })
+
+    /** The visible half of the trend; its screen-reader twin repeats the text. */
+    const findTrendText = (text: string) =>
+      screen.findByText(text, { selector: "[aria-hidden='true']" })
+
+    it("prefers the trend from data over the one derived from previousValue", async () => {
+      render(
+        <MetricItem
+          item={withTrend({ trend: { direction: "down", label: "-1.2 pp" } })}
+          filters={{}}
+        />
+      )
+
+      expect(await findTrendText("-1.2 pp")).toBeInTheDocument()
+      expect(screen.queryByText("23.0%")).toBeNull()
+    })
+
+    it("renders a flat trend without an arrow, in muted text", async () => {
+      render(
+        <MetricItem
+          item={withTrend({ trend: { direction: "flat", label: "No change" } })}
+          filters={{}}
+        />
+      )
+
+      const label = await findTrendText("No change")
+      expect(label).toHaveClass("text-f1-foreground-secondary")
+      expect(label.parentElement?.querySelector("svg")).toBeNull()
+    })
+
+    it("keeps a computed flat trend hidden", async () => {
+      render(
+        <MetricItem
+          item={metricItem({
+            fetchData: () =>
+              Promise.resolve({ value: 100, previousValue: 100 }),
+          })}
+          filters={{}}
+        />
+      )
+
+      await screen.findByText("100")
+      expect(screen.queryByText("0.0%")).toBeNull()
+    })
+
+    it("announces the comparison label with the trend", async () => {
+      render(
+        <MetricItem
+          item={withTrend({
+            trend: { direction: "up", label: "+10.7%" },
+            comparisonLabel: "vs previous month",
+          })}
+          filters={{}}
+        />
+      )
+
+      expect(
+        await screen.findByText("+10.7% vs previous month")
+      ).toBeInTheDocument()
+    })
+
+    it("shows the comparison label in a tooltip on the trend", async () => {
+      const user = userEvent.setup()
+      render(
+        <MetricItem
+          item={withTrend({
+            trend: { direction: "up", label: "+10.7%" },
+            comparisonLabel: "vs previous month",
+          })}
+          filters={{}}
+        />
+      )
+
+      await user.hover(await findTrendText("+10.7%"))
+
+      await waitFor(
+        () =>
+          expect(screen.getByRole("tooltip")).toHaveTextContent(
+            "vs previous month"
+          ),
+        { timeout: 3000 }
+      )
+    })
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
@@ -161,7 +161,10 @@ describe("MetricItem", () => {
     expect(container).not.toHaveAttribute("tabindex")
 
     rerender(
-      <MetricValue value="100" trend={{ percent: 100, direction: "up" }} />
+      <MetricValue
+        value="100"
+        trend={{ direction: "up", text: "100.0%", srText: "+100.0%" }}
+      />
     )
 
     await screen.findByText("+100.0%")

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/TrendBadge.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/TrendBadge.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+import { F0Icon } from "@/components/F0Icon"
+import { ArrowDown, ArrowUp } from "@/icons/app"
+
+import type { DashboardMetricTrend } from "../types"
+
+import { TrendBadge, toTrendBadge } from "../components/TrendBadge/TrendBadge"
+
+type Direction = DashboardMetricTrend["direction"]
+type Sentiment = DashboardMetricTrend["sentiment"]
+
+/** The arrows are bare SVG paths, so the drawn one is named by its own markup. */
+function arrowMarkup(icon: typeof ArrowUp) {
+  const { container, unmount } = render(<F0Icon icon={icon} size="sm" />)
+  const markup = container.querySelector("svg")!.innerHTML
+  unmount()
+  return markup
+}
+
+function renderBadge(direction: Direction, sentiment: Sentiment) {
+  const { container } = render(
+    <TrendBadge
+      trend={toTrendBadge({ direction, label: "1.2 pp", sentiment })}
+    />
+  )
+  return {
+    label: container.querySelector("span[aria-hidden='true']")!,
+    arrow: container.querySelector("svg"),
+  }
+}
+
+describe("TrendBadge", () => {
+  // Sentiment absent: exactly what the badge showed before it existed.
+  const cases: [Direction, Sentiment, string, string | null][] = [
+    ["up", undefined, "text-f1-foreground-positive", "text-f1-icon-positive"],
+    ["down", undefined, "text-f1-foreground-critical", "text-f1-icon-critical"],
+    ["flat", undefined, "text-f1-foreground-secondary", null],
+    ["up", "positive", "text-f1-foreground-positive", "text-f1-icon-positive"],
+    ["up", "negative", "text-f1-foreground-critical", "text-f1-icon-critical"],
+    ["up", "neutral", "text-f1-foreground-secondary", "text-f1-icon-secondary"],
+    [
+      "down",
+      "positive",
+      "text-f1-foreground-positive",
+      "text-f1-icon-positive",
+    ],
+    [
+      "down",
+      "negative",
+      "text-f1-foreground-critical",
+      "text-f1-icon-critical",
+    ],
+    [
+      "down",
+      "neutral",
+      "text-f1-foreground-secondary",
+      "text-f1-icon-secondary",
+    ],
+    ["flat", "positive", "text-f1-foreground-positive", null],
+    ["flat", "negative", "text-f1-foreground-critical", null],
+    ["flat", "neutral", "text-f1-foreground-secondary", null],
+  ]
+
+  it.each(cases)(
+    "colours a %s / %s trend with %s",
+    (direction, sentiment, labelClass, iconClass) => {
+      const { arrow, label } = renderBadge(direction, sentiment)
+
+      expect(label).toHaveClass(labelClass)
+      if (iconClass === null) {
+        expect(arrow).toBeNull()
+      } else {
+        expect(arrow).toHaveClass(iconClass)
+      }
+    }
+  )
+
+  it("keeps the arrow on the direction when the sentiment disagrees", () => {
+    expect(renderBadge("down", "positive").arrow!.innerHTML).toBe(
+      arrowMarkup(ArrowDown)
+    )
+    expect(renderBadge("up", "negative").arrow!.innerHTML).toBe(
+      arrowMarkup(ArrowUp)
+    )
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/categoryComparison.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/categoryComparison.test.ts
@@ -1,16 +1,35 @@
 import { describe, expect, it } from "vitest"
 
 import type { F0DataChartProps } from "@/kits/F0DataChart"
+import type { I18nContextType } from "@/lib/providers/i18n/i18n-provider"
+
+import { defaultTranslations } from "@/lib/providers/i18n/i18n-provider-defaults"
 
 import type { DashboardCategoryComparison } from "../types"
 
-import { markCategoryComparison } from "../components/ChartItem/categoryComparison"
+import {
+  categoryValues,
+  withTooltipComparison,
+} from "../components/ChartItem/categoryComparison"
+
+/** The default dictionary with the one interpolating key the module reads. */
+const i18n: I18nContextType = {
+  ...defaultTranslations,
+  t: (key, args = {}) =>
+    Object.entries(args).reduce(
+      (text, [name, value]) => text.replace(`{{${name}}}`, String(value)),
+      key === "ai.dashboardItem.comparison.previous"
+        ? defaultTranslations.ai.dashboardItem.comparison.previous
+        : key
+    ),
+}
 
 const comparison: DashboardCategoryComparison = {
   byCategory: {
-    Sales: { direction: "up", label: "+4.2%" },
-    Operations: { direction: "down", label: "−3.0%" },
+    Sales: { direction: "up", label: "+4.2%", delta: 4 },
+    Operations: { direction: "down", label: "−3.0%", sentiment: "positive" },
     People: { direction: "flat", label: "0%" },
+    Quiet: { direction: "up", label: "" },
   },
   added: ["Legal"],
   removed: ["Support"],
@@ -19,106 +38,74 @@ const comparison: DashboardCategoryComparison = {
 const barProps: F0DataChartProps = {
   type: "bar",
   categories: ["Sales", "Operations", "People", "Legal", "Engineering"],
-  series: [{ name: "This period", data: [58, 61, 33, 4, 96] }],
+  series: [
+    { name: "Previous period", data: [54, 63, 33, 0, 96], muted: true },
+    { name: "This period", data: [58, 61, 33, 4, 96] },
+  ],
 }
 
+const points = [
+  { name: "Sales", value: 58 },
+  { name: "Legal", value: 4 },
+  { name: "Engineering", value: 96 },
+]
 const pieProps: F0DataChartProps = {
   type: "pie",
-  series: {
-    name: "Headcount",
-    data: [
-      { name: "Sales", value: 58 },
-      { name: "Legal", value: 4 },
-      { name: "Engineering", value: 96 },
-    ],
-  },
+  series: { name: "Headcount", data: points },
 }
-
 const funnelProps: F0DataChartProps = {
   type: "funnel",
-  series: {
-    name: "Pipeline",
-    data: [
-      { name: "Sales", value: 58 },
-      { name: "Legal", value: 4 },
-      { name: "Engineering", value: 96 },
-    ],
-  },
+  series: { name: "Pipeline", data: points },
 }
 
-/** The label a bar chart draws for `category`, formatter and all. */
-function barLabel(props: F0DataChartProps, category: string): string {
-  if (props.type !== "bar") throw new Error("not a bar chart")
-  return props.categoryFormatter?.(category) ?? category
+function comparisonOf(props: F0DataChartProps) {
+  if (!("categoryComparison" in props)) throw new Error("not a category chart")
+  return props.categoryComparison
 }
 
-describe("markCategoryComparison", () => {
-  it("appends the direction and label to a compared bar category", () => {
-    const props = markCategoryComparison(barProps, comparison, "New")
+describe("withTooltipComparison", () => {
+  it("hands a bar chart one tooltip line per compared category, labels untouched", () => {
+    const props = withTooltipComparison(barProps, comparison, i18n)
 
-    expect(barLabel(props, "Sales")).toBe("Sales ▲ +4.2%")
-    expect(barLabel(props, "Operations")).toBe("Operations ▼ −3.0%")
+    expect(comparisonOf(props)).toEqual({
+      Sales: { label: "+4.2%", tone: "positive", description: "Previous: 54" },
+      Operations: { label: "−3.0%", tone: "positive" },
+      People: { label: "0%", tone: "neutral" },
+      Legal: { label: "New this period" },
+    })
+    if (props.type !== "bar") throw new Error("not a bar chart")
+    expect(props.categories).toBe(barProps.categories)
+    expect(props.series).toBe(barProps.series)
+    expect(props.categoryFormatter).toBeUndefined()
   })
 
-  it("gives a flat category its change with no glyph", () => {
-    const props = markCategoryComparison(barProps, comparison, "New")
-
-    expect(barLabel(props, "People")).toBe("People 0%")
-  })
-
-  it("marks an added category as new and leaves an uncompared one plain", () => {
-    const props = markCategoryComparison(barProps, comparison, "New")
-
-    expect(barLabel(props, "Legal")).toBe("Legal (New)")
-    expect(barLabel(props, "Engineering")).toBe("Engineering")
-  })
-
-  it("marks a new category with the caller's own label", () => {
-    const props = markCategoryComparison(barProps, comparison, "Nuevo")
-
-    expect(barLabel(props, "Legal")).toBe("Legal (Nuevo)")
-  })
-
-  it("marks on top of the host's own category formatter", () => {
-    const props = markCategoryComparison(
-      { ...barProps, categoryFormatter: (value) => value.toUpperCase() },
+  it("states the baseline in the chart's own value format", () => {
+    const props = withTooltipComparison(
+      { ...barProps, valueFormatter: (value) => `${value} FTE` },
       comparison,
-      "New"
+      i18n
     )
 
-    expect(barLabel(props, "Sales")).toBe("SALES ▲ +4.2%")
+    expect(comparisonOf(props)?.Sales.description).toBe("Previous: 54 FTE")
   })
 
-  it("marks a pie chart through its point names", () => {
-    const props = markCategoryComparison(pieProps, comparison, "New")
+  it("reads pie and funnel values off their points", () => {
+    for (const chart of [pieProps, funnelProps]) {
+      const props = withTooltipComparison(chart, comparison, i18n)
 
-    if (props.type !== "pie") throw new Error("not a pie chart")
-    expect(props.series.data.map((point) => point.name)).toEqual([
-      "Sales ▲ +4.2%",
-      "Legal (New)",
-      "Engineering",
-    ])
-    expect(props.series.data.map((point) => point.value)).toEqual([58, 4, 96])
-  })
-
-  it("marks a funnel chart through its stage names", () => {
-    const props = markCategoryComparison(funnelProps, comparison, "New")
-
-    if (props.type !== "funnel") throw new Error("not a funnel chart")
-    expect(props.series.data.map((point) => point.name)).toEqual([
-      "Sales ▲ +4.2%",
-      "Legal (New)",
-      "Engineering",
-    ])
-    expect(props.series.data.map((point) => point.value)).toEqual([58, 4, 96])
+      expect(comparisonOf(props)?.Sales).toEqual({
+        label: "+4.2%",
+        tone: "positive",
+        description: "Previous: 54",
+      })
+      expect(comparisonOf(props)?.Legal).toEqual({ label: "New this period" })
+      expect(comparisonOf(props)?.Engineering).toBeUndefined()
+    }
   })
 
   it("returns the very same props when no comparison is given", () => {
-    expect(markCategoryComparison(barProps, undefined, "New")).toBe(barProps)
-    expect(markCategoryComparison(pieProps, undefined, "New")).toBe(pieProps)
-    expect(markCategoryComparison(funnelProps, undefined, "New")).toBe(
-      funnelProps
-    )
+    expect(withTooltipComparison(barProps, undefined, i18n)).toBe(barProps)
+    expect(withTooltipComparison(pieProps, undefined, i18n)).toBe(pieProps)
   })
 
   it("leaves a time series alone — its baseline is a faded series", () => {
@@ -128,6 +115,19 @@ describe("markCategoryComparison", () => {
       series: [{ name: "This period", data: [1] }],
     }
 
-    expect(markCategoryComparison(lineProps, comparison, "New")).toBe(lineProps)
+    expect(withTooltipComparison(lineProps, comparison, i18n)).toBe(lineProps)
+  })
+})
+
+describe("categoryValues", () => {
+  it("reads the first drawn series of a bar chart, skipping the muted baseline", () => {
+    if (barProps.type !== "bar") throw new Error("not a bar chart")
+    expect(categoryValues(barProps).get("Sales")).toBe(58)
+    expect(
+      categoryValues({
+        ...barProps,
+        series: [{ name: "Only", data: [{ value: 7, target: 9 }] }],
+      }).get("Sales")
+    ).toBe(7)
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/categoryComparison.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/categoryComparison.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest"
+
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import type { DashboardCategoryComparison } from "../types"
+
+import { markCategoryComparison } from "../components/ChartItem/categoryComparison"
+
+const comparison: DashboardCategoryComparison = {
+  byCategory: {
+    Sales: { direction: "up", label: "+4.2%" },
+    Operations: { direction: "down", label: "−3.0%" },
+    People: { direction: "flat", label: "0%" },
+  },
+  added: ["Legal"],
+  removed: ["Support"],
+}
+
+const barProps: F0DataChartProps = {
+  type: "bar",
+  categories: ["Sales", "Operations", "People", "Legal", "Engineering"],
+  series: [{ name: "This period", data: [58, 61, 33, 4, 96] }],
+}
+
+const pieProps: F0DataChartProps = {
+  type: "pie",
+  series: {
+    name: "Headcount",
+    data: [
+      { name: "Sales", value: 58 },
+      { name: "Legal", value: 4 },
+      { name: "Engineering", value: 96 },
+    ],
+  },
+}
+
+/** The label a bar chart draws for `category`, formatter and all. */
+function barLabel(props: F0DataChartProps, category: string): string {
+  if (props.type !== "bar") throw new Error("not a bar chart")
+  return props.categoryFormatter?.(category) ?? category
+}
+
+describe("markCategoryComparison", () => {
+  it("appends the direction and label to a compared bar category", () => {
+    const props = markCategoryComparison(barProps, comparison, "New")
+
+    expect(barLabel(props, "Sales")).toBe("Sales ▲ +4.2%")
+    expect(barLabel(props, "Operations")).toBe("Operations ▼ −3.0%")
+    expect(barLabel(props, "People")).toBe("People = 0%")
+  })
+
+  it("marks an added category as new and leaves an uncompared one plain", () => {
+    const props = markCategoryComparison(barProps, comparison, "New")
+
+    expect(barLabel(props, "Legal")).toBe("Legal (New)")
+    expect(barLabel(props, "Engineering")).toBe("Engineering")
+  })
+
+  it("marks on top of the host's own category formatter", () => {
+    const props = markCategoryComparison(
+      { ...barProps, categoryFormatter: (value) => value.toUpperCase() },
+      comparison,
+      "New"
+    )
+
+    expect(barLabel(props, "Sales")).toBe("SALES ▲ +4.2%")
+  })
+
+  it("marks a pie chart through its point names", () => {
+    const props = markCategoryComparison(pieProps, comparison, "New")
+
+    if (props.type !== "pie") throw new Error("not a pie chart")
+    expect(props.series.data.map((point) => point.name)).toEqual([
+      "Sales ▲ +4.2%",
+      "Legal (New)",
+      "Engineering",
+    ])
+    expect(props.series.data.map((point) => point.value)).toEqual([58, 4, 96])
+  })
+
+  it("returns the very same props when no comparison is given", () => {
+    expect(markCategoryComparison(barProps, undefined, "New")).toBe(barProps)
+    expect(markCategoryComparison(pieProps, undefined, "New")).toBe(pieProps)
+  })
+
+  it("leaves a time series alone — its baseline is a faded series", () => {
+    const lineProps: F0DataChartProps = {
+      type: "line",
+      categories: ["Sales"],
+      series: [{ name: "This period", data: [1] }],
+    }
+
+    expect(markCategoryComparison(lineProps, comparison, "New")).toBe(lineProps)
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/categoryComparison.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/categoryComparison.test.ts
@@ -34,6 +34,18 @@ const pieProps: F0DataChartProps = {
   },
 }
 
+const funnelProps: F0DataChartProps = {
+  type: "funnel",
+  series: {
+    name: "Pipeline",
+    data: [
+      { name: "Sales", value: 58 },
+      { name: "Legal", value: 4 },
+      { name: "Engineering", value: 96 },
+    ],
+  },
+}
+
 /** The label a bar chart draws for `category`, formatter and all. */
 function barLabel(props: F0DataChartProps, category: string): string {
   if (props.type !== "bar") throw new Error("not a bar chart")
@@ -46,7 +58,12 @@ describe("markCategoryComparison", () => {
 
     expect(barLabel(props, "Sales")).toBe("Sales ▲ +4.2%")
     expect(barLabel(props, "Operations")).toBe("Operations ▼ −3.0%")
-    expect(barLabel(props, "People")).toBe("People = 0%")
+  })
+
+  it("gives a flat category its change with no glyph", () => {
+    const props = markCategoryComparison(barProps, comparison, "New")
+
+    expect(barLabel(props, "People")).toBe("People 0%")
   })
 
   it("marks an added category as new and leaves an uncompared one plain", () => {
@@ -54,6 +71,12 @@ describe("markCategoryComparison", () => {
 
     expect(barLabel(props, "Legal")).toBe("Legal (New)")
     expect(barLabel(props, "Engineering")).toBe("Engineering")
+  })
+
+  it("marks a new category with the caller's own label", () => {
+    const props = markCategoryComparison(barProps, comparison, "Nuevo")
+
+    expect(barLabel(props, "Legal")).toBe("Legal (Nuevo)")
   })
 
   it("marks on top of the host's own category formatter", () => {
@@ -78,9 +101,24 @@ describe("markCategoryComparison", () => {
     expect(props.series.data.map((point) => point.value)).toEqual([58, 4, 96])
   })
 
+  it("marks a funnel chart through its stage names", () => {
+    const props = markCategoryComparison(funnelProps, comparison, "New")
+
+    if (props.type !== "funnel") throw new Error("not a funnel chart")
+    expect(props.series.data.map((point) => point.name)).toEqual([
+      "Sales ▲ +4.2%",
+      "Legal (New)",
+      "Engineering",
+    ])
+    expect(props.series.data.map((point) => point.value)).toEqual([58, 4, 96])
+  })
+
   it("returns the very same props when no comparison is given", () => {
     expect(markCategoryComparison(barProps, undefined, "New")).toBe(barProps)
     expect(markCategoryComparison(pieProps, undefined, "New")).toBe(pieProps)
+    expect(markCategoryComparison(funnelProps, undefined, "New")).toBe(
+      funnelProps
+    )
   })
 
   it("leaves a time series alone — its baseline is a faded series", () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/changeRows.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/changeRows.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest"
+
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import type { DashboardCategoryComparison } from "../types"
+
+import {
+  CHANGE_VIEW_ROWS,
+  changeChartProps,
+  changeRows,
+  type ChangeViewCopy,
+} from "../components/ChartItem/changeRows"
+
+const copy: ChangeViewCopy = {
+  change: "Change",
+  newCategory: "New",
+  goneCategory: "Gone",
+  more: (count) => `+${count} more`,
+}
+const format = (value: number) => String(value)
+
+const chart: F0DataChartProps = {
+  type: "bar",
+  categories: ["Sales", "Operations", "People", "Attrition", "Legal"],
+  series: [{ name: "This period", data: [58, 61, 33, 12, 4] }],
+}
+
+const comparison: DashboardCategoryComparison = {
+  byCategory: {
+    Sales: { direction: "up", label: "+4", delta: 4 },
+    Operations: { direction: "down", label: "−3", delta: 3 },
+    People: { direction: "flat", label: "0", delta: 0 },
+    Attrition: {
+      direction: "down",
+      label: "−9",
+      delta: -9,
+      sentiment: "positive",
+    },
+    Support: { direction: "down", label: "−5", delta: -5 },
+  },
+  added: ["Legal"],
+  removed: ["Support"],
+}
+
+describe("changeRows", () => {
+  it("pins new first at full value, ranks moves by size, pins gone last, drops flat", () => {
+    const { rows, more } = changeRows(chart, comparison, format)
+
+    expect(rows.map((row) => [row.name, row.kind, row.delta])).toEqual([
+      ["Legal", "added", 4],
+      ["Attrition", "changed", -9],
+      ["Sales", "changed", 4],
+      ["Operations", "changed", -3],
+      ["Support", "removed", -5],
+    ])
+    expect(more).toBe(0)
+  })
+
+  it("takes the side from the direction, whatever sign the delta carries", () => {
+    const { rows } = changeRows(chart, comparison, format)
+
+    expect(rows.find((row) => row.name === "Operations")?.delta).toBe(-3)
+    expect(rows.find((row) => row.name === "Attrition")?.delta).toBe(-9)
+  })
+
+  it("folds everything past the cap into a count", () => {
+    const byCategory = Object.fromEntries(
+      Array.from({ length: 14 }, (_, i) => [
+        `C${i}`,
+        { direction: "up" as const, label: `+${i}`, delta: i + 1 },
+      ])
+    )
+
+    const { rows, more } = changeRows(chart, { byCategory }, format)
+
+    expect(rows).toHaveLength(CHANGE_VIEW_ROWS)
+    expect(rows[0].name).toBe("C13")
+    expect(more).toBe(4)
+  })
+
+  it("orders by label when no trend carries a number", () => {
+    const { rows } = changeRows(
+      chart,
+      {
+        byCategory: {
+          Sales: { direction: "up", label: "+4.2%" },
+          Operations: { direction: "down", label: "−3.0%" },
+          People: { direction: "up", label: "+1.8%" },
+        },
+      },
+      format
+    )
+
+    expect(rows.map((row) => row.label)).toEqual(["+1.8%", "+4.2%", "−3.0%"])
+    expect(rows.every((row) => row.delta === undefined)).toBe(true)
+  })
+})
+
+describe("changeChartProps", () => {
+  it("draws one diverging bar per row, coloured by sentiment, gone and folded rows barless", () => {
+    const { rows } = changeRows(chart, comparison, format)
+    const props = changeChartProps(rows, 3, copy, format)
+
+    expect(props.orientation).toBe("horizontal")
+    expect(props.categories).toEqual([
+      "Legal (New)",
+      "Attrition",
+      "Sales",
+      "Operations",
+      "Support (Gone)",
+      "+3 more",
+    ])
+    expect(props.series[0].data).toEqual([
+      { value: 4, color: "grass" },
+      // Down, but good news: the bar goes left in the positive colour.
+      { value: -9, color: "grass" },
+      { value: 4, color: "grass" },
+      { value: -3, color: "red" },
+      { value: -5, color: "red" },
+      { value: 0, color: "smoke" },
+    ])
+    expect(props.valueFormatter?.(4)).toBe("+4")
+    expect(props.valueFormatter?.(-3)).toBe("-3")
+    expect(props.valueFormatter?.(0)).toBe("")
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { buildChartProps } from "../components/ChartItem/ChartItem"
+import { buildChartProps } from "../components/ChartItem/chartProps"
 import type {
   DashboardChartConfig,
   DashboardChartData,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/comparisonSeries.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/comparisonSeries.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import type {
-  F0DataChartBarProps,
-  F0DataChartLineProps,
-} from "@/kits/F0DataChart"
+import type { F0DataChartProps } from "@/kits/F0DataChart"
 
 import type {
   DashboardChartConfig,
@@ -11,7 +8,7 @@ import type {
   DashboardChartItem,
 } from "../types"
 
-import { buildChartProps } from "../components/ChartItem/ChartItem"
+import { buildChartProps } from "../components/ChartItem/chartProps"
 
 const seriesData: DashboardChartData = {
   categories: ["Jan", "Feb"],
@@ -31,6 +28,15 @@ function chartItem(chart: DashboardChartConfig): DashboardChartItem {
   }
 }
 
+function assertChartType<T extends F0DataChartProps["type"]>(
+  props: F0DataChartProps,
+  type: T
+): asserts props is Extract<F0DataChartProps, { type: T }> {
+  if (props.type !== type) {
+    throw new Error(`Expected a ${type} chart, got ${props.type}`)
+  }
+}
+
 describe("comparisonSeriesNames", () => {
   it("mutes and dashes the named series on a line chart", () => {
     const props = buildChartProps(
@@ -39,7 +45,8 @@ describe("comparisonSeriesNames", () => {
         comparisonSeriesNames: ["Previous period"],
       }),
       seriesData
-    ) as F0DataChartLineProps
+    )
+    assertChartType(props, "line")
 
     expect(props.series).toEqual([
       { name: "This period", data: [10, 12] },
@@ -51,7 +58,8 @@ describe("comparisonSeriesNames", () => {
     const props = buildChartProps(
       chartItem({ type: "bar", comparisonSeriesNames: ["Previous period"] }),
       seriesData
-    ) as F0DataChartBarProps
+    )
+    assertChartType(props, "bar")
 
     expect(props.series).toEqual([
       { name: "This period", data: [10, 12] },
@@ -59,11 +67,18 @@ describe("comparisonSeriesNames", () => {
     ])
   })
 
-  it("leaves series untouched when the config names none", () => {
+  it("keeps the names out of the chart props", () => {
     const props = buildChartProps(
-      chartItem({ type: "line" }),
+      chartItem({ type: "line", comparisonSeriesNames: ["Previous period"] }),
       seriesData
-    ) as F0DataChartLineProps
+    )
+
+    expect(props).not.toHaveProperty("comparisonSeriesNames")
+  })
+
+  it("leaves series untouched when the config names none", () => {
+    const props = buildChartProps(chartItem({ type: "line" }), seriesData)
+    assertChartType(props, "line")
 
     expect(props.series).toEqual(seriesData.series)
   })
@@ -72,7 +87,8 @@ describe("comparisonSeriesNames", () => {
     const props = buildChartProps(
       chartItem({ type: "line", comparisonSeriesNames: ["Last year"] }),
       seriesData
-    ) as F0DataChartLineProps
+    )
+    assertChartType(props, "line")
 
     expect(props.series).toEqual(seriesData.series)
   })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/comparisonSeries.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/comparisonSeries.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest"
+
+import type {
+  F0DataChartBarProps,
+  F0DataChartLineProps,
+} from "@/kits/F0DataChart"
+
+import type {
+  DashboardChartConfig,
+  DashboardChartData,
+  DashboardChartItem,
+} from "../types"
+
+import { buildChartProps } from "../components/ChartItem/ChartItem"
+
+const seriesData: DashboardChartData = {
+  categories: ["Jan", "Feb"],
+  series: [
+    { name: "This period", data: [10, 12] },
+    { name: "Previous period", data: [8, 9] },
+  ],
+}
+
+function chartItem(chart: DashboardChartConfig): DashboardChartItem {
+  return {
+    id: "item",
+    title: "Item",
+    type: "chart",
+    chart,
+    fetchData: () => Promise.resolve(seriesData),
+  }
+}
+
+describe("comparisonSeriesNames", () => {
+  it("mutes and dashes the named series on a line chart", () => {
+    const props = buildChartProps(
+      chartItem({
+        type: "line",
+        comparisonSeriesNames: ["Previous period"],
+      }),
+      seriesData
+    ) as F0DataChartLineProps
+
+    expect(props.series).toEqual([
+      { name: "This period", data: [10, 12] },
+      { name: "Previous period", data: [8, 9], muted: true, dashed: true },
+    ])
+  })
+
+  it("mutes the named series on a bar chart without dashing it", () => {
+    const props = buildChartProps(
+      chartItem({ type: "bar", comparisonSeriesNames: ["Previous period"] }),
+      seriesData
+    ) as F0DataChartBarProps
+
+    expect(props.series).toEqual([
+      { name: "This period", data: [10, 12] },
+      { name: "Previous period", data: [8, 9], muted: true },
+    ])
+  })
+
+  it("leaves series untouched when the config names none", () => {
+    const props = buildChartProps(
+      chartItem({ type: "line" }),
+      seriesData
+    ) as F0DataChartLineProps
+
+    expect(props.series).toEqual(seriesData.series)
+  })
+
+  it("ignores a name that matches no series", () => {
+    const props = buildChartProps(
+      chartItem({ type: "line", comparisonSeriesNames: ["Last year"] }),
+      seriesData
+    ) as F0DataChartLineProps
+
+    expect(props.series).toEqual(seriesData.series)
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
@@ -144,4 +144,45 @@ describe("useDashboardExport", () => {
     expect(filteredCreateSource).toHaveBeenCalledWith(activeFilters)
     expect(unfilteredCreateSource).toHaveBeenCalledWith({})
   })
+
+  it("adds a Change column carrying the trend label the widget renders", async () => {
+    await runExport([
+      {
+        id: "headcount",
+        title: "Headcount",
+        type: "metric",
+        fetchData: () =>
+          Promise.resolve({
+            value: 248,
+            previousValue: 224,
+            trend: { direction: "up", label: "+10.7%" },
+          }),
+      },
+    ])
+
+    const [sheets] = vi.mocked(downloadHelpers.downloadMultiSheetExcel).mock
+      .calls[0]
+    expect(sheets[0].columns).toEqual([
+      "Metric",
+      "Value",
+      "Previous Value",
+      "Change",
+    ])
+    expect(sheets[0].rows[0]).toMatchObject({ Change: "+10.7%" })
+  })
+
+  it("leaves the Change column out when no metric reports a trend", async () => {
+    await runExport([
+      {
+        id: "headcount",
+        title: "Headcount",
+        type: "metric",
+        fetchData: () => Promise.resolve({ value: 248, previousValue: 224 }),
+      },
+    ])
+
+    const [sheets] = vi.mocked(downloadHelpers.downloadMultiSheetExcel).mock
+      .calls[0]
+    expect(sheets[0].columns).toEqual(["Metric", "Value", "Previous Value"])
+  })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
@@ -171,7 +171,7 @@ describe("useDashboardExport", () => {
     expect(sheets[0].rows[0]).toMatchObject({ Change: "+10.7%" })
   })
 
-  it("carries a chart's own trend into its sheet, once", async () => {
+  it("keeps a chart's own trend out of its sheet — it describes no row", async () => {
     await runExport([
       {
         id: "headcount-by-department",
@@ -189,43 +189,21 @@ describe("useDashboardExport", () => {
 
     const [sheets] = vi.mocked(downloadHelpers.downloadMultiSheetExcel).mock
       .calls[0]
-    expect(sheets[0].columns).toEqual(["Category", "This period", "Change"])
+    expect(sheets[0].columns).toEqual(["Category", "This period"])
     expect(sheets[0].rows).toEqual([
-      { Category: "Engineering", "This period": 96, Change: "+10.7%" },
+      { Category: "Engineering", "This period": 96 },
       { Category: "Sales", "This period": 58 },
     ])
   })
 
-  it("leaves a chart sheet exactly as it was without a trend", async () => {
-    await runExport([
-      {
-        id: "headcount-by-department",
-        title: "Headcount by department",
-        type: "chart",
-        chart: { type: "bar" },
-        fetchData: () =>
-          Promise.resolve({
-            categories: ["Engineering"],
-            series: [{ name: "This period", data: [96] }],
-          }),
-      },
-    ])
-
-    const [sheets] = vi.mocked(downloadHelpers.downloadMultiSheetExcel).mock
-      .calls[0]
-    expect(sheets[0].columns).toEqual(["Category", "This period"])
-    expect(sheets[0].rows).toEqual([
-      { Category: "Engineering", "This period": 96 },
-    ])
-  })
-
-  it("exports a collection's rowTrends as a Change column", async () => {
+  it("exports a collection item's rowTrends as a Change column", async () => {
     await runExport([
       {
         id: "employees",
         title: "Employees",
         type: "collection",
         visualizations: [],
+        rowTrends: { "1": { direction: "up", label: "+2" } },
         createSource: () => ({
           dataAdapter: {
             fetchData: () =>
@@ -234,7 +212,6 @@ describe("useDashboardExport", () => {
                   { id: "1", name: "Ada" },
                   { id: "2", name: "Grace" },
                 ],
-                rowTrends: { "1": { direction: "up", label: "+2" } },
               }),
           },
         }),

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardExport.test.ts
@@ -171,6 +171,85 @@ describe("useDashboardExport", () => {
     expect(sheets[0].rows[0]).toMatchObject({ Change: "+10.7%" })
   })
 
+  it("carries a chart's own trend into its sheet, once", async () => {
+    await runExport([
+      {
+        id: "headcount-by-department",
+        title: "Headcount by department",
+        type: "chart",
+        chart: { type: "bar" },
+        fetchData: () =>
+          Promise.resolve({
+            categories: ["Engineering", "Sales"],
+            series: [{ name: "This period", data: [96, 58] }],
+            trend: { direction: "up", label: "+10.7%" },
+          }),
+      },
+    ])
+
+    const [sheets] = vi.mocked(downloadHelpers.downloadMultiSheetExcel).mock
+      .calls[0]
+    expect(sheets[0].columns).toEqual(["Category", "This period", "Change"])
+    expect(sheets[0].rows).toEqual([
+      { Category: "Engineering", "This period": 96, Change: "+10.7%" },
+      { Category: "Sales", "This period": 58 },
+    ])
+  })
+
+  it("leaves a chart sheet exactly as it was without a trend", async () => {
+    await runExport([
+      {
+        id: "headcount-by-department",
+        title: "Headcount by department",
+        type: "chart",
+        chart: { type: "bar" },
+        fetchData: () =>
+          Promise.resolve({
+            categories: ["Engineering"],
+            series: [{ name: "This period", data: [96] }],
+          }),
+      },
+    ])
+
+    const [sheets] = vi.mocked(downloadHelpers.downloadMultiSheetExcel).mock
+      .calls[0]
+    expect(sheets[0].columns).toEqual(["Category", "This period"])
+    expect(sheets[0].rows).toEqual([
+      { Category: "Engineering", "This period": 96 },
+    ])
+  })
+
+  it("exports a collection's rowTrends as a Change column", async () => {
+    await runExport([
+      {
+        id: "employees",
+        title: "Employees",
+        type: "collection",
+        visualizations: [],
+        createSource: () => ({
+          dataAdapter: {
+            fetchData: () =>
+              Promise.resolve({
+                records: [
+                  { id: "1", name: "Ada" },
+                  { id: "2", name: "Grace" },
+                ],
+                rowTrends: { "1": { direction: "up", label: "+2" } },
+              }),
+          },
+        }),
+      },
+    ])
+
+    const [sheets] = vi.mocked(downloadHelpers.downloadMultiSheetExcel).mock
+      .calls[0]
+    expect(sheets[0].columns).toEqual(["id", "name", "Change"])
+    expect(sheets[0].rows).toEqual([
+      { id: "1", name: "Ada", Change: "+2" },
+      { id: "2", name: "Grace", Change: undefined },
+    ])
+  })
+
   it("leaves the Change column out when no metric reports a trend", async () => {
     await runExport([
       {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardItemData.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/useDashboardItemData.test.tsx
@@ -1,6 +1,11 @@
 import { act, waitFor } from "@testing-library/react"
 import { describe, expect, it, vi } from "vitest"
 
+import type {
+  FiltersDefinition,
+  FiltersState,
+} from "@/patterns/OneFilterPicker/types"
+
 import { zeroRenderHook as renderHook } from "@/testing/test-utils"
 
 import { useDashboardItemData } from "../hooks/useDashboardItemData"
@@ -82,5 +87,25 @@ describe("useDashboardItemData", () => {
     await act(async () => resolveFirst?.({ value: 10 }))
 
     expect(result.current.data).toEqual({ value: 20 })
+  })
+
+  it("goes back to the skeleton on a filters change, dimming only for a dataKey", async () => {
+    const fetchData = vi
+      .fn()
+      .mockResolvedValueOnce({ value: 10 })
+      .mockImplementationOnce(() => new Promise(() => {}))
+    const { result, rerender } = renderHook(
+      ({ filters }) =>
+        useDashboardItemData(fetchData, filters, true, "{}", "none"),
+      { initialProps: { filters: {} as FiltersState<FiltersDefinition> } }
+    )
+
+    await waitFor(() => expect(result.current.data).toEqual({ value: 10 }))
+
+    rerender({ filters: { country: { operator: "equals", values: ["ES"] } } })
+
+    await waitFor(() => expect(fetchData).toHaveBeenCalledTimes(2))
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.isRefreshing).toBe(false)
   })
 })

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChangeView.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChangeView.tsx
@@ -1,0 +1,70 @@
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import { F0DataChart } from "@/kits/F0DataChart"
+import { tooltipValueFormat } from "@/kits/F0DataChart/utils/options"
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { DashboardCategoryComparison } from "../../types"
+
+import { TrendBadge } from "../TrendBadge/TrendBadge"
+import {
+  changeChartProps,
+  changeRowLabel,
+  changeRows,
+  type ChangeViewCopy,
+} from "./changeRows"
+
+/**
+ * The widget's "Show change" reading: the same categories ranked by how much
+ * they moved. With numeric deltas that is a diverging bar chart; without any,
+ * there is nothing to size a bar by, so it is a list of the labels instead.
+ */
+export function ChangeView({
+  chart,
+  comparison,
+}: {
+  chart: F0DataChartProps
+  comparison: DashboardCategoryComparison
+}) {
+  const translations = useI18n()
+  const copy: ChangeViewCopy = {
+    change: translations.ai.dashboardItem.comparison.change,
+    newCategory: translations.ai.dashboardItem.comparison.newCategory,
+    goneCategory: translations.ai.dashboardItem.comparison.goneCategory,
+    more: (count) =>
+      translations.t("ai.dashboardItem.comparison.more", { count }),
+  }
+  const format =
+    "valueFormatter" in chart
+      ? tooltipValueFormat(chart.tooltipValueFormatter, chart.valueFormatter)
+      : tooltipValueFormat()
+
+  const { rows, more } = changeRows(chart, comparison, format)
+
+  if (rows.some((row) => row.delta !== undefined)) {
+    return <F0DataChart {...changeChartProps(rows, more, copy, format)} />
+  }
+
+  return (
+    <ol className="m-0 flex list-none flex-col gap-1 p-0 text-base">
+      {rows.map((row) => (
+        <li key={row.name} className="flex items-center justify-between gap-2">
+          <span className="truncate text-f1-foreground">
+            {changeRowLabel(row, copy)}
+          </span>
+          <TrendBadge
+            trend={{
+              direction: row.direction,
+              sentiment: row.sentiment,
+              text: row.label,
+              srText: row.label,
+            }}
+          />
+        </li>
+      ))}
+      {more > 0 && (
+        <li className="text-f1-foreground-secondary">{copy.more(more)}</li>
+      )}
+    </ol>
+  )
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -514,6 +514,60 @@ export function buildChartProps(
   overrideType?: DashboardChartConfig["type"],
   overrideOrientation?: "vertical" | "horizontal"
 ): F0DataChartProps {
+  return muteComparisonSeries(
+    buildBaseChartProps(item, data, overrideType, overrideOrientation),
+    "comparisonSeriesNames" in item.chart
+      ? item.chart.comparisonSeriesNames
+      : undefined
+  )
+}
+
+/**
+ * Draw the series the item named as comparison baselines muted, so the current
+ * period stays the figure being read: reduced opacity on both, plus a dashed
+ * stroke on a line, where two solid lines in the same colour family are the
+ * hardest pair to tell apart. Legend entries are untouched — switching a
+ * comparison series off works like any other.
+ *
+ * Only bar and line carry named series that can pair up this way; the other
+ * types pass through.
+ */
+function muteComparisonSeries(
+  props: F0DataChartProps,
+  comparisonSeriesNames?: string[]
+): F0DataChartProps {
+  if (!comparisonSeriesNames?.length) return props
+  const names = new Set(comparisonSeriesNames)
+
+  if (props.type === "line") {
+    return {
+      ...props,
+      series: props.series.map((series) =>
+        names.has(series.name)
+          ? { ...series, muted: true, dashed: true }
+          : series
+      ),
+    }
+  }
+
+  if (props.type === "bar") {
+    return {
+      ...props,
+      series: props.series.map((series) =>
+        names.has(series.name) ? { ...series, muted: true } : series
+      ),
+    }
+  }
+
+  return props
+}
+
+function buildBaseChartProps(
+  item: DashboardChartItem,
+  data: DashboardChartData,
+  overrideType?: DashboardChartConfig["type"],
+  overrideOrientation?: "vertical" | "horizontal"
+): F0DataChartProps {
   const targetType = overrideType ?? item.chart.type
   // Detect actual data shape — after a transform, item.chart.type may have
   // changed but the data from fetchData still has its original shape.
@@ -800,6 +854,8 @@ export function chartItemFitsContent<Filters extends FiltersDefinition>(
 interface ChartItemProps<Filters extends FiltersDefinition> {
   item: DashboardChartItem<Filters>
   filters: FiltersState<Filters>
+  /** Refetch signal. See `F0AnalyticsDashboardProps.dataKey`. */
+  dataKey?: string
   actions?: DropdownItem[]
   itemFilters?: DashboardItemFiltersConfig
   editMode?: boolean
@@ -818,6 +874,7 @@ interface ChartItemProps<Filters extends FiltersDefinition> {
 export function ChartItem<Filters extends FiltersDefinition>({
   item,
   filters,
+  dataKey,
   actions,
   itemFilters,
   editMode,
@@ -858,10 +915,10 @@ export function ChartItem<Filters extends FiltersDefinition>({
   >()
   const enabled = item.useDashboardFilters !== false
   const itemFiltersKey = JSON.stringify(itemFilters?.value ?? {})
-  const { data, isLoading, error, retry } = useDashboardItemData<
+  const { data, isLoading, isRefreshing, error, retry } = useDashboardItemData<
     Filters,
     DashboardChartData
-  >(item.fetchData, filters, enabled, itemFiltersKey)
+  >(item.fetchData, filters, enabled, itemFiltersKey, dataKey)
   const chartContainerRef = useRef<HTMLDivElement>(null)
   const keyboardPointTriggerRef = useRef<HTMLButtonElement | null>(null)
 
@@ -1137,6 +1194,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       {...(descriptionAction ? { descriptionAction } : {})}
       explanation={item.explanation}
       isLoading={isLoading}
+      isRefreshing={isRefreshing}
       error={
         error ??
         // Deliberately message-less: the shared "Error loading data" title

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -670,13 +670,24 @@ export function ChartItem<Filters extends FiltersDefinition>({
   const chartProps = useMemo(
     () =>
       data && !unrenderableChart
-        ? markCategoryComparison(
-            buildChartProps(item as DashboardChartItem, data),
-            data.categoryComparison,
-            translations.ai.dashboardItem.comparison.newCategory
-          )
+        ? buildChartProps(item as DashboardChartItem, data)
         : undefined,
-    [item, data, unrenderableChart, translations]
+    [item, data, unrenderableChart]
+  )
+
+  // A category mark is decoration on the drawn label, so it is applied last,
+  // to the rendered props alone: `chartProps` above is what quotes, keyboard
+  // labels and downloads read, and none of them should say "Sales ▲ +4.2%".
+  const newCategoryLabel = translations.ai.dashboardItem.comparison.newCategory
+  const markedChartProps = useMemo(
+    () =>
+      chartProps &&
+      markCategoryComparison(
+        chartProps,
+        data?.categoryComparison,
+        newCategoryLabel
+      ),
+    [chartProps, data?.categoryComparison, newCategoryLabel]
   )
 
   // A point belongs to one exact data render. A filter/type/refetch transition
@@ -969,7 +980,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       fitContent={fitContent}
       onFullscreenChange={onFullscreenChange}
     >
-      {data && chartProps ? (
+      {data && markedChartProps ? (
         viewMode === "table" ? (
           <ChartTableView config={safeChart} data={data} />
         ) : (
@@ -984,8 +995,9 @@ export function ChartItem<Filters extends FiltersDefinition>({
             )}
           >
             <F0DataChart
-              {...chartProps}
-              {...(chartProps.type !== "gauge" && chartProps.type !== "heatmap"
+              {...markedChartProps}
+              {...(markedChartProps.type !== "gauge" &&
+              markedChartProps.type !== "heatmap"
                 ? { onLegendSelectionChange: setLegendSelection }
                 : {})}
               // Something has to be able to answer the click: the host, or
@@ -1012,8 +1024,6 @@ export function ChartItem<Filters extends FiltersDefinition>({
               {...(fitContent ? { showAllCategories: true } : {})}
             />
             {removedCategories.length > 0 && (
-              // The categories the comparison dropped: nothing draws them, so
-              // the widget says so rather than letting them vanish.
               <p className="absolute bottom-2 left-4 right-4 m-0 truncate text-base text-f1-foreground-secondary">
                 {translations.t("ai.dashboardItem.comparison.notPresent", {
                   categories: removedCategories.join(", "),

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -31,6 +31,7 @@ import {
 } from "@/kits/F0DataChart"
 import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
 
@@ -53,10 +54,12 @@ import {
 } from "../../utils/chartDataAdapter"
 import { chartDataToTabular } from "../../utils/chartDataToTabular"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
+import { toTrendBadge } from "../TrendBadge/TrendBadge"
 import {
   AccessiblePointActions,
   type AccessiblePointAction,
 } from "./AccessiblePointActions"
+import { markCategoryComparison } from "./categoryComparison"
 import { buildChartProps } from "./chartProps"
 import { PointActionPopover } from "./PointActionPopover"
 
@@ -667,9 +670,13 @@ export function ChartItem<Filters extends FiltersDefinition>({
   const chartProps = useMemo(
     () =>
       data && !unrenderableChart
-        ? buildChartProps(item as DashboardChartItem, data)
+        ? markCategoryComparison(
+            buildChartProps(item as DashboardChartItem, data),
+            data.categoryComparison,
+            translations.ai.dashboardItem.comparison.newCategory
+          )
         : undefined,
-    [item, data, unrenderableChart]
+    [item, data, unrenderableChart, translations]
   )
 
   // A point belongs to one exact data render. A filter/type/refetch transition
@@ -893,6 +900,8 @@ export function ChartItem<Filters extends FiltersDefinition>({
   // it duplicates the header's collapse button rather than inventing anything.
   const canCollapseCategories = canRevealCategories && !!isFullscreen
 
+  const removedCategories = data?.categoryComparison?.removed ?? []
+
   // While rows are windowed, the item's own description is replaced by what the
   // reader is actually looking at: a subset. Both counts come from the data and
   // the chart's reported hidden count, so they track resizes without a second
@@ -930,6 +939,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       title={item.title}
       description={windowedDescription ?? item.description}
       info={item.info}
+      trend={toTrendBadge(data?.trend, data?.comparisonLabel)}
       {...(descriptionAction ? { descriptionAction } : {})}
       explanation={item.explanation}
       isLoading={isLoading}
@@ -965,7 +975,13 @@ export function ChartItem<Filters extends FiltersDefinition>({
         ) : (
           <div
             ref={chartContainerRef}
-            className="relative h-full w-full px-4 py-3"
+            className={cn(
+              "relative h-full w-full px-4 py-3",
+              // The caption sits in reserved padding rather than in the flow:
+              // an expanded chart takes its own intrinsic height, which a flex
+              // row above the caption would fight.
+              removedCategories.length > 0 && "pb-8"
+            )}
           >
             <F0DataChart
               {...chartProps}
@@ -995,6 +1011,15 @@ export function ChartItem<Filters extends FiltersDefinition>({
               // category at a fixed row height, growing the widget.
               {...(fitContent ? { showAllCategories: true } : {})}
             />
+            {removedCategories.length > 0 && (
+              // The categories the comparison dropped: nothing draws them, so
+              // the widget says so rather than letting them vanish.
+              <p className="absolute bottom-2 left-4 right-4 m-0 truncate text-base text-f1-foreground-secondary">
+                {translations.t("ai.dashboardItem.comparison.notPresent", {
+                  categories: removedCategories.join(", "),
+                })}
+              </p>
+            )}
             <AccessiblePointActions
               hasActions={hasAccessiblePointActions}
               getActions={getAccessiblePointActions}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -15,6 +15,7 @@ import {
   ChartLine,
   ChartPie,
   ChartVerticalBars,
+  Swap,
   Table as TableIcon,
 } from "@/icons/app"
 import { DataChartEmptyStateView, F0DataChart } from "@/kits/F0DataChart"
@@ -31,7 +32,6 @@ import {
 } from "@/kits/F0DataChart"
 import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn } from "@/lib/utils"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
 
@@ -53,13 +53,18 @@ import {
   compatibleTargetTypes,
 } from "../../utils/chartDataAdapter"
 import { chartDataToTabular } from "../../utils/chartDataToTabular"
+import {
+  ComparisonChip,
+  comparisonSummary,
+} from "../ComparisonChip/ComparisonChip"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
 import { toTrendBadge } from "../TrendBadge/TrendBadge"
 import {
   AccessiblePointActions,
   type AccessiblePointAction,
 } from "./AccessiblePointActions"
-import { markCategoryComparison } from "./categoryComparison"
+import { withTooltipComparison } from "./categoryComparison"
+import { ChangeView } from "./ChangeView"
 import { buildChartProps } from "./chartProps"
 import { PointActionPopover } from "./PointActionPopover"
 
@@ -629,6 +634,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
 }: ChartItemProps<Filters>) {
   const translations = useI18n()
   const [viewMode, setViewMode] = useState<"chart" | "table">("chart")
+  const [showChange, setShowChange] = useState(false)
   const {
     enabled: aiEnabled,
     setPendingQuote,
@@ -675,19 +681,12 @@ export function ChartItem<Filters extends FiltersDefinition>({
     [item, data, unrenderableChart]
   )
 
-  // A category mark is decoration on the drawn label, so it is applied last,
-  // to the rendered props alone: `chartProps` above is what quotes, keyboard
-  // labels and downloads read, and none of them should say "Sales ▲ +4.2%".
-  const newCategoryLabel = translations.ai.dashboardItem.comparison.newCategory
-  const markedChartProps = useMemo(
+  // Hover copy on the rendered props alone: quotes, keyboard labels and downloads read `chartProps`.
+  const comparison = data?.categoryComparison
+  const renderedChartProps = useMemo(
     () =>
-      chartProps &&
-      markCategoryComparison(
-        chartProps,
-        data?.categoryComparison,
-        newCategoryLabel
-      ),
-    [chartProps, data?.categoryComparison, newCategoryLabel]
+      chartProps && withTooltipComparison(chartProps, comparison, translations),
+    [chartProps, comparison, translations]
   )
 
   // A point belongs to one exact data render. A filter/type/refetch transition
@@ -775,6 +774,16 @@ export function ChartItem<Filters extends FiltersDefinition>({
     () => [...(actions ?? []), ...downloadActions],
     [actions, downloadActions]
   )
+
+  const viewActions = comparison && [
+    {
+      label: showChange
+        ? translations.ai.dashboardItem.comparison.showValues
+        : translations.ai.dashboardItem.comparison.showChange,
+      icon: Swap,
+      onClick: () => setShowChange((on) => !on),
+    },
+  ]
 
   const hasAccessiblePointActions = useMemo(
     () =>
@@ -911,8 +920,6 @@ export function ChartItem<Filters extends FiltersDefinition>({
   // it duplicates the header's collapse button rather than inventing anything.
   const canCollapseCategories = canRevealCategories && !!isFullscreen
 
-  const removedCategories = data?.categoryComparison?.removed ?? []
-
   // While rows are windowed, the item's own description is replaced by what the
   // reader is actually looking at: a subset. Both counts come from the data and
   // the chart's reported hidden count, so they track resizes without a second
@@ -951,6 +958,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       description={windowedDescription ?? item.description}
       info={item.info}
       trend={toTrendBadge(data?.trend, data?.comparisonLabel)}
+      comparison={<ComparisonChip summary={comparisonSummary(comparison)} />}
       {...(descriptionAction ? { descriptionAction } : {})}
       explanation={item.explanation}
       isLoading={isLoading}
@@ -969,6 +977,7 @@ export function ChartItem<Filters extends FiltersDefinition>({
       onRetry={unrenderableChart ? undefined : retry}
       skeleton={chartSkeleton(safeChart)}
       actions={allActions}
+      viewActions={viewActions}
       itemFilters={itemFilters}
       editMode={editMode}
       handleDelete={handleDelete}
@@ -980,24 +989,22 @@ export function ChartItem<Filters extends FiltersDefinition>({
       fitContent={fitContent}
       onFullscreenChange={onFullscreenChange}
     >
-      {data && markedChartProps ? (
+      {data && chartProps && renderedChartProps ? (
         viewMode === "table" ? (
           <ChartTableView config={safeChart} data={data} />
+        ) : showChange && comparison ? (
+          <div ref={chartContainerRef} className="h-full w-full px-4 py-3">
+            <ChangeView chart={chartProps} comparison={comparison} />
+          </div>
         ) : (
           <div
             ref={chartContainerRef}
-            className={cn(
-              "relative h-full w-full px-4 py-3",
-              // The caption sits in reserved padding rather than in the flow:
-              // an expanded chart takes its own intrinsic height, which a flex
-              // row above the caption would fight.
-              removedCategories.length > 0 && "pb-8"
-            )}
+            className="relative h-full w-full px-4 py-3"
           >
             <F0DataChart
-              {...markedChartProps}
-              {...(markedChartProps.type !== "gauge" &&
-              markedChartProps.type !== "heatmap"
+              {...renderedChartProps}
+              {...(renderedChartProps.type !== "gauge" &&
+              renderedChartProps.type !== "heatmap"
                 ? { onLegendSelectionChange: setLegendSelection }
                 : {})}
               // Something has to be able to answer the click: the host, or
@@ -1023,13 +1030,6 @@ export function ChartItem<Filters extends FiltersDefinition>({
               // category at a fixed row height, growing the widget.
               {...(fitContent ? { showAllCategories: true } : {})}
             />
-            {removedCategories.length > 0 && (
-              <p className="absolute bottom-2 left-4 right-4 m-0 truncate text-base text-f1-foreground-secondary">
-                {translations.t("ai.dashboardItem.comparison.notPresent", {
-                  categories: removedCategories.join(", "),
-                })}
-              </p>
-            )}
             <AccessiblePointActions
               hasActions={hasAccessiblePointActions}
               getActions={getAccessiblePointActions}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -47,12 +47,9 @@ import type {
 import { useChartDownloadActions } from "../../hooks/useChartDownloadActions"
 import { useDashboardItemData } from "../../hooks/useDashboardItemData"
 import {
-  defaultChartConfig,
   detectDataShape,
   isRenderableChart,
-  fromCanonical,
   compatibleTargetTypes,
-  toCanonical,
 } from "../../utils/chartDataAdapter"
 import { chartDataToTabular } from "../../utils/chartDataToTabular"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
@@ -60,6 +57,7 @@ import {
   AccessiblePointActions,
   type AccessiblePointAction,
 } from "./AccessiblePointActions"
+import { buildChartProps } from "./chartProps"
 import { PointActionPopover } from "./PointActionPopover"
 
 // ---------------------------------------------------------------------------
@@ -499,264 +497,6 @@ function chartSkeleton(config: DashboardChartConfig) {
 }
 
 // ---------------------------------------------------------------------------
-// Build chart props using the centralized adapter
-// ---------------------------------------------------------------------------
-
-/**
- * Build F0DataChart props. When `overrideType` differs from the item's
- * original chart type, the data is converted via the canonical adapter.
- *
- * @internal Exported for unit tests — not part of the package's public API.
- */
-export function buildChartProps(
-  item: DashboardChartItem,
-  data: DashboardChartData,
-  overrideType?: DashboardChartConfig["type"],
-  overrideOrientation?: "vertical" | "horizontal"
-): F0DataChartProps {
-  return muteComparisonSeries(
-    buildBaseChartProps(item, data, overrideType, overrideOrientation),
-    "comparisonSeriesNames" in item.chart
-      ? item.chart.comparisonSeriesNames
-      : undefined
-  )
-}
-
-/**
- * Draw the series the item named as comparison baselines muted, so the current
- * period stays the figure being read: reduced opacity on both, plus a dashed
- * stroke on a line, where two solid lines in the same colour family are the
- * hardest pair to tell apart. Legend entries are untouched — switching a
- * comparison series off works like any other.
- *
- * Only bar and line carry named series that can pair up this way; the other
- * types pass through.
- */
-function muteComparisonSeries(
-  props: F0DataChartProps,
-  comparisonSeriesNames?: string[]
-): F0DataChartProps {
-  if (!comparisonSeriesNames?.length) return props
-  const names = new Set(comparisonSeriesNames)
-
-  if (props.type === "line") {
-    return {
-      ...props,
-      series: props.series.map((series) =>
-        names.has(series.name)
-          ? { ...series, muted: true, dashed: true }
-          : series
-      ),
-    }
-  }
-
-  if (props.type === "bar") {
-    return {
-      ...props,
-      series: props.series.map((series) =>
-        names.has(series.name) ? { ...series, muted: true } : series
-      ),
-    }
-  }
-
-  return props
-}
-
-function buildBaseChartProps(
-  item: DashboardChartItem,
-  data: DashboardChartData,
-  overrideType?: DashboardChartConfig["type"],
-  overrideOrientation?: "vertical" | "horizontal"
-): F0DataChartProps {
-  const targetType = overrideType ?? item.chart.type
-  // Detect actual data shape — after a transform, item.chart.type may have
-  // changed but the data from fetchData still has its original shape.
-  const dataShape = detectDataShape(data, targetType)
-
-  // When the data shape matches the target and chart type, pass through
-  // directly to preserve type-specific features (targets, color overrides).
-  if (
-    targetType === dataShape &&
-    targetType === item.chart.type &&
-    !overrideOrientation
-  ) {
-    return buildNativeChartProps(item, data)
-  }
-
-  // Cross-type transform: auto-detect source shape → canonical → target
-  const canonical = toCanonical(data)
-  const adapted = fromCanonical(canonical, targetType)
-  const config = defaultChartConfig(targetType)
-
-  // Preserve shared props from the original config
-  const shared: Record<string, unknown> = {}
-  if ("valueFormatter" in item.chart && item.chart.valueFormatter) {
-    shared.valueFormatter = item.chart.valueFormatter
-  }
-  if (
-    "tooltipValueFormatter" in item.chart &&
-    item.chart.tooltipValueFormatter
-  ) {
-    shared.tooltipValueFormatter = item.chart.tooltipValueFormatter
-  }
-  if ("showLegend" in item.chart) {
-    shared.showLegend = item.chart.showLegend
-  }
-  // Only bar targets inherit the source config's `showLabels`. Other types keep
-  // their own default, so transforming a pie (labels on by default) into a line
-  // doesn't drag labels along. `undefined` is not an explicit value — letting it
-  // through would clobber the target's default with "unset".
-  if (
-    targetType === "bar" &&
-    "showLabels" in item.chart &&
-    item.chart.showLabels !== undefined
-  ) {
-    shared.showLabels = item.chart.showLabels
-  }
-
-  // Build the final props by merging config + adapted data
-  switch (targetType) {
-    case "bar": {
-      // Resolve orientation: explicit override > item config > default config
-      const orientation =
-        overrideOrientation ??
-        ("orientation" in item.chart
-          ? (item.chart as { orientation?: string }).orientation
-          : undefined) ??
-        (config as { orientation?: string }).orientation
-      return {
-        ...config,
-        ...shared,
-        ...(orientation ? { orientation } : {}),
-        categories: adapted.categories ?? [],
-        series: adapted.series,
-      } as F0DataChartProps
-    }
-    case "line":
-      return {
-        ...config,
-        ...shared,
-        categories: adapted.categories ?? [],
-        series: adapted.series,
-      } as F0DataChartProps
-    case "funnel":
-      return {
-        ...config,
-        ...shared,
-        series: adapted.series,
-      } as F0DataChartProps
-    case "pie":
-      return {
-        ...config,
-        ...shared,
-        series: adapted.series,
-      } as F0DataChartProps
-    case "radar":
-      return {
-        ...config,
-        ...shared,
-        indicators: adapted.indicators ?? [],
-        series: adapted.series,
-      } as F0DataChartProps
-    case "gauge":
-      return {
-        ...config,
-        ...shared,
-        ...(adapted.series as { value: number; name?: string }),
-      } as F0DataChartProps
-    case "heatmap":
-      return {
-        ...config,
-        ...shared,
-        xCategories: adapted.xCategories ?? [],
-        yCategories: adapted.yCategories ?? [],
-        data: adapted.data ?? [],
-      } as F0DataChartProps
-    case "scatter":
-      // Reached only when the data doesn't look like a scatter: `detectDataShape`
-      // falls through to "bar" for an empty or errored result, which sends a
-      // scatter-configured item down the conversion path. Renders the empty
-      // state, so losing the axis names and pointSize that `shared` drops
-      // doesn't matter here.
-      return {
-        ...config,
-        ...shared,
-        series: adapted.scatterSeries ?? [],
-      } as F0DataChartProps
-  }
-}
-
-/**
- * Build props for the native (non-transformed) chart type.
- * This is the original buildChartProps logic that passes data through
- * as-is, preserving type-specific features.
- */
-function buildNativeChartProps(
-  item: DashboardChartItem,
-  data: DashboardChartData
-): F0DataChartProps {
-  const { chart } = item
-
-  switch (chart.type) {
-    case "funnel": {
-      let funnelSeries = data.series
-      if (Array.isArray(data.series)) {
-        const canonical = toCanonical(data, "bar")
-        funnelSeries = fromCanonical(canonical, "funnel").series
-      }
-      return { ...chart, series: funnelSeries } as F0DataChartProps
-    }
-    case "pie":
-      return { ...chart, series: data.series } as F0DataChartProps
-    case "radar":
-      return {
-        ...chart,
-        indicators: data.indicators ?? [],
-        series: data.series,
-      } as F0DataChartProps
-    case "gauge":
-      return {
-        ...chart,
-        ...(data.series as { value: number; name?: string }),
-      } as F0DataChartProps
-    case "heatmap":
-      return {
-        ...chart,
-        xCategories: data.xCategories ?? [],
-        yCategories: data.yCategories ?? [],
-        data: data.data ?? [],
-      } as F0DataChartProps
-    case "scatter":
-      return {
-        ...chart,
-        series: data.scatterSeries ?? [],
-      } as F0DataChartProps
-    case "bar":
-    case "line": {
-      let { series } = data
-      let categories = data.categories ?? []
-      if (series && !Array.isArray(series)) {
-        const canonical = toCanonical(data, "funnel")
-        const adapted = fromCanonical(canonical, chart.type)
-        series = adapted.series
-        categories = adapted.categories ?? []
-      }
-      return {
-        ...chart,
-        // Dashboard bar charts show value labels by default. Resolved after the
-        // spread rather than before it: `...chart` carries `showLabels` even
-        // when it is explicitly `undefined`, which would overwrite the default.
-        ...(chart.type === "bar"
-          ? { showLabels: chart.showLabels ?? true }
-          : {}),
-        categories,
-        series,
-      } as F0DataChartProps
-    }
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Table view — renders chart data as a OneDataCollection table
 // ---------------------------------------------------------------------------
 
@@ -854,7 +594,6 @@ export function chartItemFitsContent<Filters extends FiltersDefinition>(
 interface ChartItemProps<Filters extends FiltersDefinition> {
   item: DashboardChartItem<Filters>
   filters: FiltersState<Filters>
-  /** Refetch signal. See `F0AnalyticsDashboardProps.dataKey`. */
   dataKey?: string
   actions?: DropdownItem[]
   itemFilters?: DashboardItemFiltersConfig

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/categoryComparison.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/categoryComparison.ts
@@ -1,93 +1,85 @@
 import type {
-  F0DataChartPieDataPoint,
+  F0DataChartCategoryComparison,
   F0DataChartProps,
 } from "@/kits/F0DataChart"
+import type { I18nContextType } from "@/lib/providers/i18n/i18n-provider"
+
+import { tooltipValueFormat } from "@/kits/F0DataChart/utils/options"
 
 import type { DashboardCategoryComparison } from "../../types"
 
-/**
- * Glyphs, not copy: the arrow is the mark, the label beside it is the host's.
- * Flat gets none, matching the trend badge, which draws no arrow for it.
- */
-const DIRECTION_GLYPH = { up: "▲", down: "▼", flat: "" } as const
+import { trendSentiment } from "../TrendBadge/TrendBadge"
 
-function markCategory(
-  category: string,
-  label: string,
-  comparison: DashboardCategoryComparison,
-  newLabel: string
-): string {
-  const trend = comparison.byCategory[category]
-  if (trend?.label) {
-    return [label, DIRECTION_GLYPH[trend.direction], trend.label]
-      .filter(Boolean)
-      .join(" ")
-  }
-  return comparison.added?.includes(category) ? `${label} (${newLabel})` : label
-}
+type CategoryChart = Extract<
+  F0DataChartProps,
+  { type: "bar" | "pie" | "funnel" }
+>
 
-/** Pie and funnel differ only in their discriminant: both name their points. */
-function markSeriesNames<S extends { data: F0DataChartPieDataPoint[] }>(
-  series: S,
-  comparison: DashboardCategoryComparison,
-  newLabel: string
-): S {
-  return {
-    ...series,
-    data: series.data.map((point) => ({
-      ...point,
-      name: markCategory(point.name, point.name, comparison, newLabel),
-    })),
-  }
+/** The chart types whose marks are categories, which is what a comparison is keyed by. */
+export function isCategoryChart(
+  chart: F0DataChartProps
+): chart is CategoryChart {
+  return chart.type === "bar" || chart.type === "pie" || chart.type === "funnel"
 }
 
 /**
- * Draw a per-category comparison into the labels a chart renders.
- *
- * A bar chart gets it through its `categoryFormatter` — the seam every drawn
- * category label and axis tick goes through — composed on top of the host's
- * own formatter so a formatted category stays formatted. Pie and funnel have
- * no such formatter: their labels, legend and tooltip all read a data point's
- * `name`, so the mark goes there instead.
- *
- * Every other type passes through untouched, as the same object: line and its
- * kin are time series, where the faded baseline series carries the comparison
- * and a mark per bucket would only crowd the axis.
+ * The value each category currently shows. A bar chart reads its first drawn
+ * series — a muted one is the baseline, not the reading — and pie and funnel
+ * read their points.
  */
-export function markCategoryComparison(
-  props: F0DataChartProps,
+export function categoryValues(chart: CategoryChart): Map<string, number> {
+  if (chart.type !== "bar") {
+    return new Map(chart.series.data.map((point) => [point.name, point.value]))
+  }
+  const series = chart.series.find((s) => !s.muted) ?? chart.series[0]
+  return new Map(
+    chart.categories.flatMap((category, index) => {
+      const point = series?.data[index]
+      const value = typeof point === "number" ? point : point?.value
+      return value === undefined ? [] : [[category, value]]
+    })
+  )
+}
+
+/**
+ * Hand the chart its comparison as a tooltip line per category: the host's
+ * label in the trend's tone, with the baseline value when the trend carries a
+ * numeric delta. Added categories say they are new. Any other chart type is
+ * returned as the same object.
+ */
+export function withTooltipComparison(
+  chart: F0DataChartProps,
   comparison: DashboardCategoryComparison | undefined,
-  newLabel: string
+  i18n: I18nContextType
 ): F0DataChartProps {
-  if (!comparison) return props
+  if (!comparison || !isCategoryChart(chart)) return chart
 
-  if (props.type === "bar") {
-    const { categoryFormatter } = props
-    return {
-      ...props,
-      categoryFormatter: (value) =>
-        markCategory(
-          value,
-          categoryFormatter ? categoryFormatter(value) : value,
-          comparison,
-          newLabel
-        ),
+  const values = categoryValues(chart)
+  const format = tooltipValueFormat(
+    chart.tooltipValueFormatter,
+    chart.valueFormatter
+  )
+  const categoryComparison: Record<string, F0DataChartCategoryComparison> = {}
+
+  for (const [name, trend] of Object.entries(comparison.byCategory)) {
+    if (!trend.label) continue
+    const entry: F0DataChartCategoryComparison = {
+      label: trend.label,
+      tone: trendSentiment(trend),
+    }
+    const value = values.get(name)
+    if (trend.delta !== undefined && value !== undefined) {
+      entry.description = i18n.t("ai.dashboardItem.comparison.previous", {
+        value: format(value - trend.delta),
+      })
+    }
+    categoryComparison[name] = entry
+  }
+  for (const name of comparison.added ?? []) {
+    categoryComparison[name] ??= {
+      label: i18n.ai.dashboardItem.comparison.newThisPeriod,
     }
   }
 
-  if (props.type === "pie") {
-    return {
-      ...props,
-      series: markSeriesNames(props.series, comparison, newLabel),
-    }
-  }
-
-  if (props.type === "funnel") {
-    return {
-      ...props,
-      series: markSeriesNames(props.series, comparison, newLabel),
-    }
-  }
-
-  return props
+  return { ...chart, categoryComparison }
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/categoryComparison.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/categoryComparison.ts
@@ -1,15 +1,16 @@
-import type { F0DataChartProps } from "@/kits/F0DataChart"
+import type {
+  F0DataChartPieDataPoint,
+  F0DataChartProps,
+} from "@/kits/F0DataChart"
 
 import type { DashboardCategoryComparison } from "../../types"
 
-/** Glyphs, not copy: the arrow is the mark, the label beside it is the host's. */
-const DIRECTION_GLYPH = { up: "▲", down: "▼", flat: "=" } as const
-
 /**
- * The category label with its comparison appended — "Sales ▲ +4.2%", or the
- * `newLabel` for a category the compared period did not have. Returns the
- * label untouched for a category the comparison says nothing about.
+ * Glyphs, not copy: the arrow is the mark, the label beside it is the host's.
+ * Flat gets none, matching the trend badge, which draws no arrow for it.
  */
+const DIRECTION_GLYPH = { up: "▲", down: "▼", flat: "" } as const
+
 function markCategory(
   category: string,
   label: string,
@@ -18,19 +19,36 @@ function markCategory(
 ): string {
   const trend = comparison.byCategory[category]
   if (trend?.label) {
-    return `${label} ${DIRECTION_GLYPH[trend.direction]} ${trend.label}`
+    return [label, DIRECTION_GLYPH[trend.direction], trend.label]
+      .filter(Boolean)
+      .join(" ")
   }
   return comparison.added?.includes(category) ? `${label} (${newLabel})` : label
 }
 
+/** Pie and funnel differ only in their discriminant: both name their points. */
+function markSeriesNames<S extends { data: F0DataChartPieDataPoint[] }>(
+  series: S,
+  comparison: DashboardCategoryComparison,
+  newLabel: string
+): S {
+  return {
+    ...series,
+    data: series.data.map((point) => ({
+      ...point,
+      name: markCategory(point.name, point.name, comparison, newLabel),
+    })),
+  }
+}
+
 /**
- * Draw a per-category comparison into the labels a chart already renders.
+ * Draw a per-category comparison into the labels a chart renders.
  *
- * A bar chart gets it through its `categoryFormatter` — the seam every category
- * label, axis tick and quoted point already goes through — composed on top of
- * the host's own formatter so a formatted category stays formatted. Pie and
- * funnel have no such formatter: their labels, legend and tooltip all read a
- * data point's `name`, so the mark goes there instead.
+ * A bar chart gets it through its `categoryFormatter` — the seam every drawn
+ * category label and axis tick goes through — composed on top of the host's
+ * own formatter so a formatted category stays formatted. Pie and funnel have
+ * no such formatter: their labels, legend and tooltip all read a data point's
+ * `name`, so the mark goes there instead.
  *
  * Every other type passes through untouched, as the same object: line and its
  * kin are time series, where the faded baseline series carries the comparison
@@ -60,26 +78,14 @@ export function markCategoryComparison(
   if (props.type === "pie") {
     return {
       ...props,
-      series: {
-        ...props.series,
-        data: props.series.data.map((point) => ({
-          ...point,
-          name: markCategory(point.name, point.name, comparison, newLabel),
-        })),
-      },
+      series: markSeriesNames(props.series, comparison, newLabel),
     }
   }
 
   if (props.type === "funnel") {
     return {
       ...props,
-      series: {
-        ...props.series,
-        data: props.series.data.map((point) => ({
-          ...point,
-          name: markCategory(point.name, point.name, comparison, newLabel),
-        })),
-      },
+      series: markSeriesNames(props.series, comparison, newLabel),
     }
   }
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/categoryComparison.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/categoryComparison.ts
@@ -1,0 +1,87 @@
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import type { DashboardCategoryComparison } from "../../types"
+
+/** Glyphs, not copy: the arrow is the mark, the label beside it is the host's. */
+const DIRECTION_GLYPH = { up: "▲", down: "▼", flat: "=" } as const
+
+/**
+ * The category label with its comparison appended — "Sales ▲ +4.2%", or the
+ * `newLabel` for a category the compared period did not have. Returns the
+ * label untouched for a category the comparison says nothing about.
+ */
+function markCategory(
+  category: string,
+  label: string,
+  comparison: DashboardCategoryComparison,
+  newLabel: string
+): string {
+  const trend = comparison.byCategory[category]
+  if (trend?.label) {
+    return `${label} ${DIRECTION_GLYPH[trend.direction]} ${trend.label}`
+  }
+  return comparison.added?.includes(category) ? `${label} (${newLabel})` : label
+}
+
+/**
+ * Draw a per-category comparison into the labels a chart already renders.
+ *
+ * A bar chart gets it through its `categoryFormatter` — the seam every category
+ * label, axis tick and quoted point already goes through — composed on top of
+ * the host's own formatter so a formatted category stays formatted. Pie and
+ * funnel have no such formatter: their labels, legend and tooltip all read a
+ * data point's `name`, so the mark goes there instead.
+ *
+ * Every other type passes through untouched, as the same object: line and its
+ * kin are time series, where the faded baseline series carries the comparison
+ * and a mark per bucket would only crowd the axis.
+ */
+export function markCategoryComparison(
+  props: F0DataChartProps,
+  comparison: DashboardCategoryComparison | undefined,
+  newLabel: string
+): F0DataChartProps {
+  if (!comparison) return props
+
+  if (props.type === "bar") {
+    const { categoryFormatter } = props
+    return {
+      ...props,
+      categoryFormatter: (value) =>
+        markCategory(
+          value,
+          categoryFormatter ? categoryFormatter(value) : value,
+          comparison,
+          newLabel
+        ),
+    }
+  }
+
+  if (props.type === "pie") {
+    return {
+      ...props,
+      series: {
+        ...props.series,
+        data: props.series.data.map((point) => ({
+          ...point,
+          name: markCategory(point.name, point.name, comparison, newLabel),
+        })),
+      },
+    }
+  }
+
+  if (props.type === "funnel") {
+    return {
+      ...props,
+      series: {
+        ...props.series,
+        data: props.series.data.map((point) => ({
+          ...point,
+          name: markCategory(point.name, point.name, comparison, newLabel),
+        })),
+      },
+    }
+  }
+
+  return props
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/changeRows.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/changeRows.ts
@@ -1,0 +1,161 @@
+import type {
+  ChartColorToken,
+  F0DataChartBarProps,
+  F0DataChartProps,
+} from "@/kits/F0DataChart"
+
+import type {
+  DashboardCategoryComparison,
+  DashboardMetricTrend,
+} from "../../types"
+
+import { trendSentiment } from "../TrendBadge/TrendBadge"
+import { categoryValues, isCategoryChart } from "./categoryComparison"
+
+/** Rows the change view draws before folding the rest into "+N more". */
+export const CHANGE_VIEW_ROWS = 10
+
+export interface ChangeRow {
+  name: string
+  kind: "changed" | "added" | "removed"
+  label: string
+  direction: DashboardMetricTrend["direction"]
+  sentiment?: DashboardMetricTrend["sentiment"]
+  /** Signed by direction, so a "down" trend draws to the left whatever sign its delta carries. */
+  delta?: number
+}
+
+const TONE_COLOR: Record<ReturnType<typeof trendSentiment>, ChartColorToken> = {
+  positive: "grass",
+  negative: "red",
+  neutral: "smoke",
+}
+
+function signedDelta(trend: DashboardMetricTrend): number | undefined {
+  if (trend.delta === undefined) return undefined
+  return trend.direction === "down"
+    ? -Math.abs(trend.delta)
+    : Math.abs(trend.delta)
+}
+
+/** Largest change first; rows without a number after them, in label order. */
+function byMagnitude(a: ChangeRow, b: ChangeRow): number {
+  const size = (row: ChangeRow) =>
+    row.delta === undefined ? -1 : Math.abs(row.delta)
+  return size(b) - size(a) || a.label.localeCompare(b.label)
+}
+
+/**
+ * The rows of the change view: new categories first at their full value,
+ * then every category that moved, largest move first, then the ones that
+ * vanished. Flat categories are not a change, so they are left out.
+ */
+export function changeRows(
+  chart: F0DataChartProps,
+  comparison: DashboardCategoryComparison,
+  format: (value: number) => string
+): { rows: ChangeRow[]; more: number } {
+  const { byCategory } = comparison
+  const added = comparison.added ?? []
+  const removed = comparison.removed ?? []
+  const values = isCategoryChart(chart) ? categoryValues(chart) : new Map()
+
+  const changed = Object.entries(byCategory)
+    .filter(
+      ([name, trend]) =>
+        trend.direction !== "flat" &&
+        !added.includes(name) &&
+        !removed.includes(name)
+    )
+    .map(
+      ([name, trend]): ChangeRow => ({
+        name,
+        kind: "changed",
+        label: trend.label,
+        direction: trend.direction,
+        sentiment: trend.sentiment,
+        delta: signedDelta(trend),
+      })
+    )
+    .sort(byMagnitude)
+
+  const first = added.map((name): ChangeRow => {
+    const value = values.get(name)
+    const trend = byCategory[name]
+    return {
+      name,
+      kind: "added",
+      label: trend?.label ?? (value === undefined ? "" : format(value)),
+      direction: trend?.direction ?? "up",
+      sentiment: trend?.sentiment,
+      delta: value,
+    }
+  })
+
+  const last = removed.map((name): ChangeRow => {
+    const trend = byCategory[name]
+    return {
+      name,
+      kind: "removed",
+      label: trend?.label ?? "",
+      direction: trend?.direction ?? "down",
+      sentiment: trend?.sentiment,
+      delta: trend && signedDelta(trend),
+    }
+  })
+
+  const all = [...first, ...changed, ...last]
+  return {
+    rows: all.slice(0, CHANGE_VIEW_ROWS),
+    more: Math.max(0, all.length - CHANGE_VIEW_ROWS),
+  }
+}
+
+export interface ChangeViewCopy {
+  change: string
+  newCategory: string
+  goneCategory: string
+  more: (count: number) => string
+}
+
+/** The row's name, with what kind of row it is where that is not a plain change. */
+export function changeRowLabel(row: ChangeRow, copy: ChangeViewCopy): string {
+  if (row.kind === "added") return `${row.name} (${copy.newCategory})`
+  if (row.kind === "removed") return `${row.name} (${copy.goneCategory})`
+  return row.name
+}
+
+/**
+ * A diverging horizontal bar chart of the rows: gains to the right, losses to
+ * the left, each in its trend's tone. A row without a number — a vanished
+ * category the host gave no delta, the "+N more" fold — keeps its label and
+ * draws no bar.
+ */
+export function changeChartProps(
+  rows: ChangeRow[],
+  more: number,
+  copy: ChangeViewCopy,
+  format: (value: number) => string
+): F0DataChartBarProps {
+  const categories = rows.map((row) => changeRowLabel(row, copy))
+  const data = rows.map((row) => ({
+    value: row.delta ?? 0,
+    color: TONE_COLOR[trendSentiment(row)],
+  }))
+  if (more > 0) {
+    categories.push(copy.more(more))
+    data.push({ value: 0, color: TONE_COLOR.neutral })
+  }
+  const signed = (value: number) =>
+    value === 0 ? "" : value > 0 ? `+${format(value)}` : format(value)
+
+  return {
+    type: "bar",
+    orientation: "horizontal",
+    categories,
+    series: [{ name: copy.change, data }],
+    showLegend: false,
+    showLabels: true,
+    valueFormatter: signed,
+  }
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/chartProps.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/chartProps.ts
@@ -1,0 +1,264 @@
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import type {
+  DashboardChartConfig,
+  DashboardChartData,
+  DashboardChartItem,
+} from "../../types"
+
+import {
+  defaultChartConfig,
+  detectDataShape,
+  fromCanonical,
+  toCanonical,
+} from "../../utils/chartDataAdapter"
+
+/**
+ * Build F0DataChart props. When `overrideType` differs from the item's
+ * original chart type, the data is converted via the canonical adapter.
+ *
+ * @internal Exported for unit tests — not part of the package's public API.
+ */
+export function buildChartProps(
+  item: DashboardChartItem,
+  data: DashboardChartData,
+  overrideType?: DashboardChartConfig["type"],
+  overrideOrientation?: "vertical" | "horizontal"
+): F0DataChartProps {
+  return muteComparisonSeries(
+    buildBaseChartProps(item, data, overrideType, overrideOrientation),
+    item.chart
+  )
+}
+
+/** Only bar and line carry the named series that can pair up; the rest pass through. */
+function muteComparisonSeries(
+  props: F0DataChartProps,
+  chart: DashboardChartConfig
+): F0DataChartProps {
+  const names =
+    "comparisonSeriesNames" in chart ? chart.comparisonSeriesNames : undefined
+  if (!names?.length) return props
+
+  if (props.type === "line") {
+    return {
+      ...props,
+      series: props.series.map((series) =>
+        // Two solid lines in the same colour family are the hardest pair to
+        // tell apart, hence dashed as well as faded.
+        names.includes(series.name)
+          ? { ...series, muted: true, dashed: true }
+          : series
+      ),
+    }
+  }
+
+  if (props.type === "bar") {
+    return {
+      ...props,
+      series: props.series.map((series) =>
+        names.includes(series.name) ? { ...series, muted: true } : series
+      ),
+    }
+  }
+
+  return props
+}
+
+function buildBaseChartProps(
+  item: DashboardChartItem,
+  data: DashboardChartData,
+  overrideType?: DashboardChartConfig["type"],
+  overrideOrientation?: "vertical" | "horizontal"
+): F0DataChartProps {
+  const targetType = overrideType ?? item.chart.type
+  // Detect actual data shape — after a transform, item.chart.type may have
+  // changed but the data from fetchData still has its original shape.
+  const dataShape = detectDataShape(data, targetType)
+
+  // When the data shape matches the target and chart type, pass through
+  // directly to preserve type-specific features (targets, color overrides).
+  if (
+    targetType === dataShape &&
+    targetType === item.chart.type &&
+    !overrideOrientation
+  ) {
+    return buildNativeChartProps(item, data)
+  }
+
+  // Cross-type transform: auto-detect source shape → canonical → target
+  const canonical = toCanonical(data)
+  const adapted = fromCanonical(canonical, targetType)
+  const config = defaultChartConfig(targetType)
+
+  // Preserve shared props from the original config
+  const shared: Record<string, unknown> = {}
+  if ("valueFormatter" in item.chart && item.chart.valueFormatter) {
+    shared.valueFormatter = item.chart.valueFormatter
+  }
+  if (
+    "tooltipValueFormatter" in item.chart &&
+    item.chart.tooltipValueFormatter
+  ) {
+    shared.tooltipValueFormatter = item.chart.tooltipValueFormatter
+  }
+  if ("showLegend" in item.chart) {
+    shared.showLegend = item.chart.showLegend
+  }
+  // Only bar targets inherit the source config's `showLabels`. Other types keep
+  // their own default, so transforming a pie (labels on by default) into a line
+  // doesn't drag labels along. `undefined` is not an explicit value — letting it
+  // through would clobber the target's default with "unset".
+  if (
+    targetType === "bar" &&
+    "showLabels" in item.chart &&
+    item.chart.showLabels !== undefined
+  ) {
+    shared.showLabels = item.chart.showLabels
+  }
+
+  // Build the final props by merging config + adapted data
+  switch (targetType) {
+    case "bar": {
+      // Resolve orientation: explicit override > item config > default config
+      const orientation =
+        overrideOrientation ??
+        ("orientation" in item.chart
+          ? (item.chart as { orientation?: string }).orientation
+          : undefined) ??
+        (config as { orientation?: string }).orientation
+      return {
+        ...config,
+        ...shared,
+        ...(orientation ? { orientation } : {}),
+        categories: adapted.categories ?? [],
+        series: adapted.series,
+      } as F0DataChartProps
+    }
+    case "line":
+      return {
+        ...config,
+        ...shared,
+        categories: adapted.categories ?? [],
+        series: adapted.series,
+      } as F0DataChartProps
+    case "funnel":
+      return {
+        ...config,
+        ...shared,
+        series: adapted.series,
+      } as F0DataChartProps
+    case "pie":
+      return {
+        ...config,
+        ...shared,
+        series: adapted.series,
+      } as F0DataChartProps
+    case "radar":
+      return {
+        ...config,
+        ...shared,
+        indicators: adapted.indicators ?? [],
+        series: adapted.series,
+      } as F0DataChartProps
+    case "gauge":
+      return {
+        ...config,
+        ...shared,
+        ...(adapted.series as { value: number; name?: string }),
+      } as F0DataChartProps
+    case "heatmap":
+      return {
+        ...config,
+        ...shared,
+        xCategories: adapted.xCategories ?? [],
+        yCategories: adapted.yCategories ?? [],
+        data: adapted.data ?? [],
+      } as F0DataChartProps
+    case "scatter":
+      // Reached only when the data doesn't look like a scatter: `detectDataShape`
+      // falls through to "bar" for an empty or errored result, which sends a
+      // scatter-configured item down the conversion path. Renders the empty
+      // state, so losing the axis names and pointSize that `shared` drops
+      // doesn't matter here.
+      return {
+        ...config,
+        ...shared,
+        series: adapted.scatterSeries ?? [],
+      } as F0DataChartProps
+  }
+}
+
+/**
+ * Build props for the native (non-transformed) chart type.
+ * This is the original buildChartProps logic that passes data through
+ * as-is, preserving type-specific features.
+ */
+function buildNativeChartProps(
+  item: DashboardChartItem,
+  data: DashboardChartData
+): F0DataChartProps {
+  const { chart } = item
+
+  switch (chart.type) {
+    case "funnel": {
+      let funnelSeries = data.series
+      if (Array.isArray(data.series)) {
+        const canonical = toCanonical(data, "bar")
+        funnelSeries = fromCanonical(canonical, "funnel").series
+      }
+      return { ...chart, series: funnelSeries } as F0DataChartProps
+    }
+    case "pie":
+      return { ...chart, series: data.series } as F0DataChartProps
+    case "radar":
+      return {
+        ...chart,
+        indicators: data.indicators ?? [],
+        series: data.series,
+      } as F0DataChartProps
+    case "gauge":
+      return {
+        ...chart,
+        ...(data.series as { value: number; name?: string }),
+      } as F0DataChartProps
+    case "heatmap":
+      return {
+        ...chart,
+        xCategories: data.xCategories ?? [],
+        yCategories: data.yCategories ?? [],
+        data: data.data ?? [],
+      } as F0DataChartProps
+    case "scatter":
+      return {
+        ...chart,
+        series: data.scatterSeries ?? [],
+      } as F0DataChartProps
+    case "bar":
+    case "line": {
+      let { series } = data
+      let categories = data.categories ?? []
+      if (series && !Array.isArray(series)) {
+        const canonical = toCanonical(data, "funnel")
+        const adapted = fromCanonical(canonical, chart.type)
+        series = adapted.series
+        categories = adapted.categories ?? []
+      }
+      // Dropped from the spread: the chart kit is told which series are
+      // baselines through `series.muted`, not by name.
+      const { comparisonSeriesNames: _comparisonSeriesNames, ...chartProps } =
+        chart
+      return {
+        ...chartProps,
+        // Dashboard bar charts show value labels by default. Resolved after the
+        // spread rather than before it: `...chart` carries `showLabels` even
+        // when it is explicitly `undefined`, which would overwrite the default.
+        ...(chart.type === "bar"
+          ? { showLabels: chart.showLabels ?? true }
+          : {}),
+        categories,
+        series,
+      } as F0DataChartProps
+    }
+  }
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -7,18 +7,21 @@ import type {
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import type { RecordType } from "@/hooks/datasource"
 
+import { useI18n } from "@/lib/providers/i18n"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
 
 import type {
   DashboardCollectionItem,
   DashboardItemFiltersConfig,
+  DashboardRowTrends,
   F0AnalyticsDashboardAskAiTarget,
   F0AnalyticsDashboardAskAiTargetWithQuote,
 } from "../../types"
 
 import { useCollectionDownloadActions } from "../../hooks/useCollectionDownloadActions"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
+import { changeColumn, tapRowTrends } from "./rowTrends"
 
 interface CollectionItemProps<Filters extends FiltersDefinition> {
   item: DashboardCollectionItem<Filters>
@@ -59,14 +62,27 @@ export function CollectionItem<Filters extends FiltersDefinition>({
   const enabled = item.useDashboardFilters !== false
   const effectiveFilters = enabled ? filters : ({} as FiltersState<Filters>)
 
+  const translations = useI18n()
+  const [rowTrends, setRowTrends] = useState<DashboardRowTrends>()
+
   // Memoize the source definition to avoid re-creating on every render.
   const filtersKey = JSON.stringify(effectiveFilters)
   const itemFiltersKey = JSON.stringify(itemFilters?.value ?? {})
-  const sourceDefinition = useMemo(
-    () => item.createSource(effectiveFilters),
+  const sourceDefinition = useMemo(() => {
+    const definition = item.createSource(effectiveFilters)
+    const fetchData = definition?.dataAdapter?.fetchData
+    if (typeof fetchData !== "function") return definition
+
+    return {
+      ...definition,
+      dataAdapter: {
+        ...definition.dataAdapter,
+        fetchData: (options: unknown) =>
+          tapRowTrends(fetchData(options), setRowTrends),
+      },
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filtersKey, itemFiltersKey, dataKey]
-  )
+  }, [filtersKey, itemFiltersKey, dataKey])
   const source = useDataCollectionSource<RecordType>(sourceDefinition, [
     filtersKey,
     itemFiltersKey,
@@ -129,6 +145,29 @@ export function CollectionItem<Filters extends FiltersDefinition>({
     [actions, downloadActions]
   )
 
+  // The table viz is the only one with columns to append to; the others show
+  // whatever fields their own layout declares.
+  const visualizations = useMemo(() => {
+    if (!rowTrends) return item.visualizations
+    const column = changeColumn(
+      translations.ai.dashboardItem.comparison.change,
+      rowTrends,
+      sourceDefinition?.idProvider
+    )
+
+    return item.visualizations.map((visualization) =>
+      visualization?.type === "table"
+        ? {
+            ...visualization,
+            options: {
+              ...visualization.options,
+              columns: [...(visualization.options?.columns ?? []), column],
+            },
+          }
+        : visualization
+    )
+  }, [item.visualizations, rowTrends, sourceDefinition, translations])
+
   return (
     <DashboardItem
       title={item.title}
@@ -149,7 +188,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
       <OneDataCollection
         fullHeight
         source={source}
-        visualizations={item.visualizations}
+        visualizations={visualizations}
         // We deliberately do NOT enable `csvExport` here — the dashboard
         // surface already exposes Excel + CSV downloads from the
         // DashboardItem 3-dot menu (`downloadActions` above) and both

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -23,6 +23,8 @@ import { DashboardItem } from "../DashboardItem/DashboardItem"
 interface CollectionItemProps<Filters extends FiltersDefinition> {
   item: DashboardCollectionItem<Filters>
   filters: FiltersState<Filters>
+  /** Refetch signal. See `F0AnalyticsDashboardProps.dataKey`. */
+  dataKey?: string
   actions?: DropdownItem[]
   itemFilters?: DashboardItemFiltersConfig
   editMode?: boolean
@@ -45,6 +47,7 @@ interface CollectionItemProps<Filters extends FiltersDefinition> {
 export function CollectionItem<Filters extends FiltersDefinition>({
   item,
   filters,
+  dataKey,
   actions,
   itemFilters,
   editMode,
@@ -63,11 +66,12 @@ export function CollectionItem<Filters extends FiltersDefinition>({
   const sourceDefinition = useMemo(
     () => item.createSource(effectiveFilters),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filtersKey, itemFiltersKey]
+    [filtersKey, itemFiltersKey, dataKey]
   )
   const source = useDataCollectionSource<RecordType>(sourceDefinition, [
     filtersKey,
     itemFiltersKey,
+    dataKey,
   ])
 
   // We capture the current table visualization settings (hidden columns +

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -19,6 +19,10 @@ import type {
 } from "../../types"
 
 import { useCollectionDownloadActions } from "../../hooks/useCollectionDownloadActions"
+import {
+  ComparisonChip,
+  comparisonSummary,
+} from "../ComparisonChip/ComparisonChip"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
 import { changeColumn } from "./rowTrends"
 
@@ -135,8 +139,10 @@ export function CollectionItem<Filters extends FiltersDefinition>({
 
   const changeLabel = translations.ai.dashboardItem.comparison.change
 
-  // The table viz is the only one with columns to append to; the others show
-  // whatever fields their own layout declares.
+  // The table viz is the only one with columns to add to; the others show
+  // whatever fields their own layout declares. The change sits right after
+  // the row's name, where the eye reads it against the row rather than after
+  // every other figure.
   const visualizations = useMemo(() => {
     if (!item.rowTrends) return item.visualizations
     const column = changeColumn(
@@ -146,17 +152,17 @@ export function CollectionItem<Filters extends FiltersDefinition>({
       item.rowTrendsSorting
     )
 
-    return item.visualizations.map((visualization) =>
-      visualization?.type === "table"
-        ? {
-            ...visualization,
-            options: {
-              ...visualization.options,
-              columns: [...(visualization.options?.columns ?? []), column],
-            },
-          }
-        : visualization
-    )
+    return item.visualizations.map((visualization) => {
+      if (visualization?.type !== "table") return visualization
+      const [first, ...rest] = visualization.options?.columns ?? []
+      return {
+        ...visualization,
+        options: {
+          ...visualization.options,
+          columns: first ? [first, column, ...rest] : [column],
+        },
+      }
+    })
   }, [
     item.visualizations,
     item.rowTrends,
@@ -170,6 +176,14 @@ export function CollectionItem<Filters extends FiltersDefinition>({
       title={item.title}
       description={item.description}
       info={item.info}
+      comparison={
+        <ComparisonChip
+          summary={comparisonSummary(
+            item.rowTrends && { byCategory: item.rowTrends }
+          )}
+          names={false}
+        />
+      }
       explanation={item.explanation}
       isLoading={false}
       actions={allActions}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -142,7 +142,8 @@ export function CollectionItem<Filters extends FiltersDefinition>({
     const column = changeColumn(
       changeLabel,
       item.rowTrends,
-      sourceDefinition?.idProvider
+      sourceDefinition?.idProvider,
+      item.rowTrendsSorting
     )
 
     return item.visualizations.map((visualization) =>
@@ -156,7 +157,13 @@ export function CollectionItem<Filters extends FiltersDefinition>({
           }
         : visualization
     )
-  }, [item.visualizations, item.rowTrends, sourceDefinition, changeLabel])
+  }, [
+    item.visualizations,
+    item.rowTrends,
+    item.rowTrendsSorting,
+    sourceDefinition,
+    changeLabel,
+  ])
 
   return (
     <DashboardItem

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -14,14 +14,13 @@ import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useD
 import type {
   DashboardCollectionItem,
   DashboardItemFiltersConfig,
-  DashboardRowTrends,
   F0AnalyticsDashboardAskAiTarget,
   F0AnalyticsDashboardAskAiTargetWithQuote,
 } from "../../types"
 
 import { useCollectionDownloadActions } from "../../hooks/useCollectionDownloadActions"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
-import { changeColumn, tapRowTrends } from "./rowTrends"
+import { changeColumn } from "./rowTrends"
 
 interface CollectionItemProps<Filters extends FiltersDefinition> {
   item: DashboardCollectionItem<Filters>
@@ -63,26 +62,15 @@ export function CollectionItem<Filters extends FiltersDefinition>({
   const effectiveFilters = enabled ? filters : ({} as FiltersState<Filters>)
 
   const translations = useI18n()
-  const [rowTrends, setRowTrends] = useState<DashboardRowTrends>()
 
   // Memoize the source definition to avoid re-creating on every render.
   const filtersKey = JSON.stringify(effectiveFilters)
   const itemFiltersKey = JSON.stringify(itemFilters?.value ?? {})
-  const sourceDefinition = useMemo(() => {
-    const definition = item.createSource(effectiveFilters)
-    const fetchData = definition?.dataAdapter?.fetchData
-    if (typeof fetchData !== "function") return definition
-
-    return {
-      ...definition,
-      dataAdapter: {
-        ...definition.dataAdapter,
-        fetchData: (options: unknown) =>
-          tapRowTrends(fetchData(options), setRowTrends),
-      },
-    }
+  const sourceDefinition = useMemo(
+    () => item.createSource(effectiveFilters),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filtersKey, itemFiltersKey, dataKey])
+    [filtersKey, itemFiltersKey, dataKey]
+  )
   const source = useDataCollectionSource<RecordType>(sourceDefinition, [
     filtersKey,
     itemFiltersKey,
@@ -145,13 +133,15 @@ export function CollectionItem<Filters extends FiltersDefinition>({
     [actions, downloadActions]
   )
 
+  const changeLabel = translations.ai.dashboardItem.comparison.change
+
   // The table viz is the only one with columns to append to; the others show
   // whatever fields their own layout declares.
   const visualizations = useMemo(() => {
-    if (!rowTrends) return item.visualizations
+    if (!item.rowTrends) return item.visualizations
     const column = changeColumn(
-      translations.ai.dashboardItem.comparison.change,
-      rowTrends,
+      changeLabel,
+      item.rowTrends,
       sourceDefinition?.idProvider
     )
 
@@ -166,7 +156,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
           }
         : visualization
     )
-  }, [item.visualizations, rowTrends, sourceDefinition, translations])
+  }, [item.visualizations, item.rowTrends, sourceDefinition, changeLabel])
 
   return (
     <DashboardItem

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -23,7 +23,6 @@ import { DashboardItem } from "../DashboardItem/DashboardItem"
 interface CollectionItemProps<Filters extends FiltersDefinition> {
   item: DashboardCollectionItem<Filters>
   filters: FiltersState<Filters>
-  /** Refetch signal. See `F0AnalyticsDashboardProps.dataKey`. */
   dataKey?: string
   actions?: DropdownItem[]
   itemFilters?: DashboardItemFiltersConfig

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
@@ -23,7 +23,7 @@ export function rowTrendOf(
 /**
  * Rendered through the table's own `delta` cell rather than the widget's
  * `TrendBadge` — a column renders a value-display definition, not arbitrary
- * nodes. `delta` has no neutral state, so a flat trend renders as plain text.
+ * nodes.
  */
 export function changeColumn(
   label: string,
@@ -42,13 +42,26 @@ function renderTrend(
   trend: DashboardMetricTrend | undefined
 ): RendererDefinition | string | undefined {
   if (!trend?.label) return undefined
-  if (trend.direction === "flat") return trend.label
+
+  // No sentiment: the arrow follows the direction and carries its own colour,
+  // and a flat trend has neither, so it stays the plain text it always was.
+  if (!trend.sentiment) {
+    if (trend.direction === "flat") return trend.label
+    return {
+      type: "delta",
+      value: {
+        label: trend.label,
+        deltaStatus: trend.direction === "up" ? "positive" : "negative",
+      },
+    }
+  }
 
   return {
     type: "delta",
     value: {
       label: trend.label,
-      deltaStatus: trend.direction === "up" ? "positive" : "negative",
+      deltaStatus: trend.sentiment,
+      arrow: trend.direction === "flat" ? "none" : trend.direction,
     },
   }
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
@@ -1,7 +1,8 @@
 import type { RecordType } from "@/hooks/datasource"
 import type { RendererDefinition } from "@/patterns/OneDataCollection/property-render"
+import type { TableColumnDefinition } from "@/patterns/OneDataCollection/visualizations/collection/Table/types"
 
-import { isObservableLike, isPromiseLike } from "@/lib/promise-to-observable"
+import { defaultIdProvider } from "@/hooks/datasource/useData"
 
 import type { DashboardMetricTrend, DashboardRowTrends } from "../../types"
 
@@ -11,58 +12,15 @@ type RowIdProvider = (
   index?: number
 ) => string | number | symbol
 
-/** The trends a collection's fetch result carries, if it carries any. */
-export function readRowTrends(result: unknown): DashboardRowTrends | undefined {
-  if (typeof result !== "object" || result === null || !("rowTrends" in result))
-    return undefined
-  return (result as { rowTrends?: DashboardRowTrends }).rowTrends
-}
-
-/**
- * Report the `rowTrends` a source's own `fetchData` returns.
- *
- * The datasource keeps only `records`, so the trends have to be read off the
- * response on its way through — as a plain value, a promise or an observable,
- * whichever the host's adapter returns.
- */
-export function tapRowTrends(
-  result: unknown,
-  onTrends: (trends: DashboardRowTrends | undefined) => void
-): unknown {
-  if (isObservableLike<unknown>(result)) {
-    return result.map((state) => {
-      if (!state.loading) onTrends(readRowTrends(state.data))
-      return state
-    })
-  }
-
-  if (isPromiseLike<unknown>(result)) {
-    return result.then((value) => {
-      onTrends(readRowTrends(value))
-      return value
-    })
-  }
-
-  onTrends(readRowTrends(result))
-  return result
-}
-
-/**
- * A row's trend, looked up by the id the collection identifies rows by: the
- * source's `idProvider` when it has one, else the record's own `id`.
- */
 export function rowTrendOf(
   row: RecordType,
   rowTrends: DashboardRowTrends,
-  idProvider?: RowIdProvider
+  idProvider: RowIdProvider = defaultIdProvider
 ): DashboardMetricTrend | undefined {
-  return rowTrends[String(idProvider ? idProvider(row) : row.id)]
+  return rowTrends[String(idProvider(row))]
 }
 
 /**
- * The "Change" column: each row's trend, looked up by the id the collection
- * identifies rows by.
- *
  * Rendered through the table's own `delta` cell rather than the widget's
  * `TrendBadge` — a column renders a value-display definition, not arbitrary
  * nodes. `delta` has no neutral state, so a flat trend renders as plain text.
@@ -71,7 +29,7 @@ export function changeColumn(
   label: string,
   rowTrends: DashboardRowTrends,
   idProvider?: RowIdProvider
-) {
+): TableColumnDefinition<RecordType, never, never> {
   return {
     id: "dashboard-row-change",
     label,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
@@ -35,6 +35,8 @@ export function changeColumn(
     id: "dashboard-row-change",
     label,
     sorting,
+    // Sized for its arrow and a short figure, so it never takes a data column's share.
+    width: 144,
     render: (row: RecordType): RendererDefinition | string | undefined =>
       renderTrend(rowTrendOf(row, rowTrends, idProvider)),
   }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
@@ -1,0 +1,96 @@
+import type { RecordType } from "@/hooks/datasource"
+import type { RendererDefinition } from "@/patterns/OneDataCollection/property-render"
+
+import { isObservableLike, isPromiseLike } from "@/lib/promise-to-observable"
+
+import type { DashboardMetricTrend, DashboardRowTrends } from "../../types"
+
+/** As `DataSourceDefinition.idProvider`, which is what keys `rowTrends`. */
+type RowIdProvider = (
+  item: RecordType,
+  index?: number
+) => string | number | symbol
+
+/** The trends a collection's fetch result carries, if it carries any. */
+export function readRowTrends(result: unknown): DashboardRowTrends | undefined {
+  if (typeof result !== "object" || result === null || !("rowTrends" in result))
+    return undefined
+  return (result as { rowTrends?: DashboardRowTrends }).rowTrends
+}
+
+/**
+ * Report the `rowTrends` a source's own `fetchData` returns.
+ *
+ * The datasource keeps only `records`, so the trends have to be read off the
+ * response on its way through — as a plain value, a promise or an observable,
+ * whichever the host's adapter returns.
+ */
+export function tapRowTrends(
+  result: unknown,
+  onTrends: (trends: DashboardRowTrends | undefined) => void
+): unknown {
+  if (isObservableLike<unknown>(result)) {
+    return result.map((state) => {
+      if (!state.loading) onTrends(readRowTrends(state.data))
+      return state
+    })
+  }
+
+  if (isPromiseLike<unknown>(result)) {
+    return result.then((value) => {
+      onTrends(readRowTrends(value))
+      return value
+    })
+  }
+
+  onTrends(readRowTrends(result))
+  return result
+}
+
+/**
+ * A row's trend, looked up by the id the collection identifies rows by: the
+ * source's `idProvider` when it has one, else the record's own `id`.
+ */
+export function rowTrendOf(
+  row: RecordType,
+  rowTrends: DashboardRowTrends,
+  idProvider?: RowIdProvider
+): DashboardMetricTrend | undefined {
+  return rowTrends[String(idProvider ? idProvider(row) : row.id)]
+}
+
+/**
+ * The "Change" column: each row's trend, looked up by the id the collection
+ * identifies rows by.
+ *
+ * Rendered through the table's own `delta` cell rather than the widget's
+ * `TrendBadge` — a column renders a value-display definition, not arbitrary
+ * nodes. `delta` has no neutral state, so a flat trend renders as plain text.
+ */
+export function changeColumn(
+  label: string,
+  rowTrends: DashboardRowTrends,
+  idProvider?: RowIdProvider
+) {
+  return {
+    id: "dashboard-row-change",
+    label,
+    render: (row: RecordType): RendererDefinition | string | undefined =>
+      renderTrend(rowTrendOf(row, rowTrends, idProvider)),
+  }
+}
+
+function renderTrend(
+  trend: DashboardMetricTrend | undefined
+): RendererDefinition | string | undefined {
+  if (!trend?.label) return undefined
+  if (trend.direction === "flat") return trend.label
+
+  return {
+    type: "delta",
+    value: {
+      label: trend.label,
+      deltaStatus: trend.direction === "up" ? "positive" : "negative",
+    },
+  }
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/rowTrends.ts
@@ -1,4 +1,4 @@
-import type { RecordType } from "@/hooks/datasource"
+import type { RecordType, SortingsDefinition } from "@/hooks/datasource"
 import type { RendererDefinition } from "@/patterns/OneDataCollection/property-render"
 import type { TableColumnDefinition } from "@/patterns/OneDataCollection/visualizations/collection/Table/types"
 
@@ -28,11 +28,13 @@ export function rowTrendOf(
 export function changeColumn(
   label: string,
   rowTrends: DashboardRowTrends,
-  idProvider?: RowIdProvider
-): TableColumnDefinition<RecordType, never, never> {
+  idProvider?: RowIdProvider,
+  sorting?: string
+): TableColumnDefinition<RecordType, SortingsDefinition, never> {
   return {
     id: "dashboard-row-change",
     label,
+    sorting,
     render: (row: RecordType): RendererDefinition | string | undefined =>
       renderTrend(rowTrendOf(row, rowTrends, idProvider)),
   }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ComparisonChip/ComparisonChip.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ComparisonChip/ComparisonChip.tsx
@@ -1,0 +1,72 @@
+import type { TranslationKey } from "@/lib/providers/i18n/i18n-provider-defaults"
+
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { DashboardCategoryComparison } from "../../types"
+
+/** Category names by what happened to them; a category counts once. */
+export interface ComparisonSummary {
+  up: string[]
+  down: string[]
+  added: string[]
+  removed: string[]
+}
+
+const GROUPS: (keyof ComparisonSummary)[] = ["up", "down", "added", "removed"]
+
+const COUNT_KEYS: Record<keyof ComparisonSummary, TranslationKey> = {
+  up: "ai.dashboardItem.comparison.countUp",
+  down: "ai.dashboardItem.comparison.countDown",
+  added: "ai.dashboardItem.comparison.countNew",
+  removed: "ai.dashboardItem.comparison.countGone",
+}
+
+export function comparisonSummary(
+  comparison: DashboardCategoryComparison | undefined
+): ComparisonSummary | undefined {
+  if (!comparison) return undefined
+  const added = comparison.added ?? []
+  const removed = comparison.removed ?? []
+  const moved = Object.entries(comparison.byCategory).filter(
+    ([name]) => !added.includes(name) && !removed.includes(name)
+  )
+  const summary = {
+    up: moved.filter(([, t]) => t.direction === "up").map(([name]) => name),
+    down: moved.filter(([, t]) => t.direction === "down").map(([name]) => name),
+    added,
+    removed,
+  }
+  return Object.values(summary).some((names) => names.length > 0)
+    ? summary
+    : undefined
+}
+
+/**
+ * "3 up · 1 down · 2 new · 1 gone", the empty parts left out, with the names
+ * behind each count on hover. A collection's rows are keyed by id rather than
+ * name, so it turns the hover off and shows the counts alone.
+ */
+export function ComparisonChip({
+  summary,
+  names = true,
+}: {
+  summary?: ComparisonSummary
+  names?: boolean
+}) {
+  const translations = useI18n()
+  if (!summary) return null
+
+  const parts = GROUPS.filter((key) => summary[key].length > 0).map((key) => ({
+    title: translations.t(COUNT_KEYS[key], { count: summary[key].length }),
+    description: summary[key].join(", "),
+  }))
+
+  const chip = (
+    <span className="shrink-0 whitespace-nowrap rounded-xs bg-f1-background-secondary px-1.5 py-0.5 text-sm font-medium text-f1-foreground-secondary">
+      {parts.map((part) => part.title).join(" · ")}
+    </span>
+  )
+
+  return names ? <Tooltip items={parts}>{chip}</Tooltip> : chip
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -62,7 +62,6 @@ interface DashboardGridProps<Filters extends FiltersDefinition> {
   onLayoutChange?: (layout: DashboardItemLayout[]) => void
   /** Incrementing counter that forces the grid to reset rows to initial layout. */
   resetKey?: number
-  /** Refetch signal forwarded to every item. See `F0AnalyticsDashboardProps.dataKey`. */
   dataKey?: string
   /** Called when a chart item's type is changed */
   onTransformChart?: (

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -62,6 +62,8 @@ interface DashboardGridProps<Filters extends FiltersDefinition> {
   onLayoutChange?: (layout: DashboardItemLayout[]) => void
   /** Incrementing counter that forces the grid to reset rows to initial layout. */
   resetKey?: number
+  /** Refetch signal forwarded to every item. See `F0AnalyticsDashboardProps.dataKey`. */
+  dataKey?: string
   /** Called when a chart item's type is changed */
   onTransformChart?: (
     itemId: string,
@@ -98,6 +100,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
   editMode,
   onLayoutChange,
   resetKey,
+  dataKey,
   onTransformChart,
   onAskAi,
   onAskAiTarget,
@@ -549,6 +552,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           item={soleItem}
           itemFilters={itemFilters?.(soleItem)}
           filters={filters}
+          dataKey={dataKey}
           editMode={editMode}
           onDelete={handleDelete}
           onTransformChart={onTransformChart}
@@ -590,6 +594,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
             item={fullscreenItem}
             itemFilters={itemFilters?.(fullscreenItem)}
             filters={filters}
+            dataKey={dataKey}
             editMode={editMode}
             onDelete={handleDelete}
             onTransformChart={onTransformChart}
@@ -679,6 +684,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
                       item={item}
                       itemFilters={itemFilters?.(item)}
                       filters={filters}
+                      dataKey={dataKey}
                       editMode={editMode}
                       onDelete={handleDelete}
                       onTransformChart={onTransformChart}
@@ -1098,11 +1104,13 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
   onAskAiTarget,
   isFullscreen,
   onFullscreenChange,
+  dataKey,
 }: {
   item: DashboardItemType<Filters>
   filters: FiltersState<Filters>
   actions?: DropdownItemType[]
   itemFilters?: DashboardItemFiltersConfig
+  dataKey?: string
   editMode?: boolean
   onDelete?: (id: string) => void
   onTransformChart?: (
@@ -1121,6 +1129,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
         <ChartItem
           item={item}
           filters={filters}
+          dataKey={dataKey}
           actions={actions}
           itemFilters={itemFilters}
           editMode={editMode}
@@ -1137,6 +1146,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
         <MetricItem
           item={item}
           filters={filters}
+          dataKey={dataKey}
           actions={actions}
           itemFilters={itemFilters}
           editMode={editMode}
@@ -1152,6 +1162,7 @@ function DashboardGridItem<Filters extends FiltersDefinition>({
         <CollectionItem
           item={item}
           filters={filters}
+          dataKey={dataKey}
           actions={actions}
           itemFilters={itemFilters}
           editMode={editMode}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -42,6 +42,7 @@ import {
 
 import type { DashboardItemFiltersConfig } from "../../types"
 
+import { TrendBadge, type TrendBadgeTrend } from "../TrendBadge/TrendBadge"
 import { DashboardItemFilters } from "./DashboardItemFilters"
 
 interface DashboardItemProps {
@@ -53,6 +54,12 @@ interface DashboardItemProps {
    * and `explanation`.
    */
   info?: string | InfoHintContent
+  /**
+   * How this widget compares to the compared period, rendered as a badge
+   * beside the title. Where a metric puts the same badge next to its number,
+   * every other widget type has no single figure to sit beside.
+   */
+  trend?: TrendBadgeTrend
   isLoading: boolean
   /** A refetch is in flight: dim the previous data instead of collapsing to the skeleton. */
   isRefreshing?: boolean
@@ -130,6 +137,7 @@ export function DashboardItem({
   title,
   description,
   info,
+  trend,
   isLoading,
   isRefreshing = false,
   error,
@@ -358,6 +366,7 @@ export function DashboardItem({
                 <InfoHint info={info} />
               </div>
             )}
+            <TrendBadge trend={trend} />
           </div>
           {(description || descriptionAction) && (
             // Baseline-aligned row so the link sits on the description's own

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -60,6 +60,8 @@ interface DashboardItemProps {
    * every other widget type has no single figure to sit beside.
    */
   trend?: TrendBadgeTrend
+  /** Rendered after the trend badge: the per-category outcome, as a chip. */
+  comparison?: ReactNode
   isLoading: boolean
   /** A refetch is in flight: dim the previous data instead of collapsing to the skeleton. */
   isRefreshing?: boolean
@@ -70,6 +72,8 @@ interface DashboardItemProps {
   children: ReactNode
   /** Download actions shown inside a "Download" submenu */
   actions?: DropdownItemType[]
+  /** Other readings of the same data — "Show change" — listed under the chart types. */
+  viewActions?: DropdownItemObject[]
   /**
    * Per-widget filter configuration. When set, a filter icon appears with the
    * other header actions on hover or keyboard focus (and remains available on
@@ -138,6 +142,7 @@ export function DashboardItem({
   description,
   info,
   trend,
+  comparison,
   isLoading,
   isRefreshing = false,
   error,
@@ -145,6 +150,7 @@ export function DashboardItem({
   skeleton,
   children,
   actions = [],
+  viewActions = [],
   itemFilters,
   editMode,
   handleDelete,
@@ -189,6 +195,7 @@ export function DashboardItem({
       !("type" in a) || a.type === "item" || a.type === undefined
   )
   const hasDownloads = downloadActions.length > 0
+  const hasViewActions = viewActions.length > 0
   const hasDelete = editMode && handleDelete && itemId
   const hasChartTypes = chartTypeOptions && chartTypeOptions.length > 0
   const hasExplanation = !!explanation && explanation.trim().length > 0
@@ -199,7 +206,12 @@ export function DashboardItem({
   // whose setters are no-ops, so offering the action would do nothing.
   const hasAskOne = title.trim().length > 0 && (onAskAi ? !!itemId : aiEnabled)
   const showMenu =
-    hasAskOne || hasDownloads || hasDelete || hasChartTypes || hasExplanation
+    hasAskOne ||
+    hasDownloads ||
+    hasViewActions ||
+    hasDelete ||
+    hasChartTypes ||
+    hasExplanation
   const actionsClassName = cn(
     "flex flex-shrink-0 gap-0.5",
     !isFullscreen &&
@@ -235,6 +247,15 @@ export function DashboardItem({
     // mounting. The buffered request moves focus once registration completes.
     if (focusChatInput()) event.preventDefault()
   }
+
+  const menuEntry = (action: DropdownItemObject) => (
+    <DropdownMenuItem key={action.label} onClick={action.onClick}>
+      <div className="flex w-full flex-row items-center gap-2">
+        {action.icon && <F0Icon icon={action.icon} />}
+        <span className="flex-1">{action.label}</span>
+      </div>
+    </DropdownMenuItem>
+  )
 
   const askOneMenuItem = hasAskOne ? (
     <DropdownMenuGroup>
@@ -367,6 +388,7 @@ export function DashboardItem({
               </div>
             )}
             <TrendBadge trend={trend} />
+            {comparison}
           </div>
           {(description || descriptionAction) && (
             // Baseline-aligned row so the link sits on the description's own
@@ -481,6 +503,11 @@ export function DashboardItem({
                         />
                       </div>
                     )}
+                    {hasViewActions && (
+                      <DropdownMenuGroup>
+                        {viewActions.map(menuEntry)}
+                      </DropdownMenuGroup>
+                    )}
                     {hasExplanation && (
                       <DropdownMenuGroup>
                         <DropdownMenuItem
@@ -514,21 +541,7 @@ export function DashboardItem({
                           </DropdownMenuSubTrigger>
                           <DropdownMenuPortal>
                             <DropdownMenuSubContent>
-                              {downloadActions.map((action) => (
-                                <DropdownMenuItem
-                                  key={action.label}
-                                  onClick={action.onClick}
-                                >
-                                  <div className="flex w-full flex-row items-center gap-2">
-                                    {action.icon && (
-                                      <F0Icon icon={action.icon} />
-                                    )}
-                                    <span className="flex-1">
-                                      {action.label}
-                                    </span>
-                                  </div>
-                                </DropdownMenuItem>
-                              ))}
+                              {downloadActions.map(menuEntry)}
                             </DropdownMenuSubContent>
                           </DropdownMenuPortal>
                         </DropdownMenuSub>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -54,11 +54,7 @@ interface DashboardItemProps {
    */
   info?: string | InfoHintContent
   isLoading: boolean
-  /**
-   * A refetch is in flight while the previous data is still rendered. The
-   * content dims instead of collapsing to the skeleton, and the card reports
-   * itself busy.
-   */
+  /** A refetch is in flight: dim the previous data instead of collapsing to the skeleton. */
   isRefreshing?: boolean
   error?: Error
   onRetry?: () => void
@@ -558,8 +554,6 @@ export function DashboardItem({
         className={cn(
           "flex-1",
           !fitContent && "min-h-0",
-          // Still readable, visibly not the final answer. The card's aria-busy
-          // is what says so to a screen reader.
           isRefreshing && "opacity-60 transition-opacity duration-150"
         )}
       >

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -54,6 +54,12 @@ interface DashboardItemProps {
    */
   info?: string | InfoHintContent
   isLoading: boolean
+  /**
+   * A refetch is in flight while the previous data is still rendered. The
+   * content dims instead of collapsing to the skeleton, and the card reports
+   * itself busy.
+   */
+  isRefreshing?: boolean
   error?: Error
   onRetry?: () => void
   /** Content-area skeleton shown while loading. Each item type provides its own. */
@@ -129,6 +135,7 @@ export function DashboardItem({
   description,
   info,
   isLoading,
+  isRefreshing = false,
   error,
   onRetry,
   skeleton,
@@ -336,8 +343,8 @@ export function DashboardItem({
         // border stops at the fold while the chart keeps drawing below it.
         fitContent ? "min-h-full shrink-0" : "h-full"
       )}
-      aria-busy={isLoading ? "true" : undefined}
-      aria-live={isLoading ? "polite" : undefined}
+      aria-busy={isLoading || isRefreshing ? "true" : undefined}
+      aria-live={isLoading || isRefreshing ? "polite" : undefined}
     >
       <div className="flex items-start px-4 py-3">
         <div className="flex min-w-0 flex-1 flex-col">
@@ -547,7 +554,15 @@ export function DashboardItem({
           )}
         </div>
       </div>
-      <div className={cn("flex-1", !fitContent && "min-h-0")}>
+      <div
+        className={cn(
+          "flex-1",
+          !fitContent && "min-h-0",
+          // Still readable, visibly not the final answer. The card's aria-busy
+          // is what says so to a screen reader.
+          isRefreshing && "opacity-60 transition-opacity duration-150"
+        )}
+      >
         {isLoading ? skeleton : children}
       </div>
     </div>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -5,9 +5,6 @@ import type {
   FiltersState,
 } from "@/patterns/OneFilterPicker/types"
 
-import { F0Icon } from "@/components/F0Icon"
-import { Tooltip } from "@/experimental/Overlays/Tooltip"
-import { ArrowUp, ArrowDown } from "@/icons/app"
 import { useContainerSize } from "@/kits/F0DataChart/utils/useContainerSize"
 import { cn, focusRing } from "@/lib/utils"
 
@@ -23,6 +20,11 @@ import type {
 import { useDashboardItemData } from "../../hooks/useDashboardItemData"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
 import { MetricSkeleton } from "../DashboardItem/DashboardItemSkeleton"
+import {
+  toTrendBadge,
+  TrendBadge,
+  type TrendBadgeTrend,
+} from "../TrendBadge/TrendBadge"
 
 interface MetricItemProps<Filters extends FiltersDefinition> {
   item: DashboardMetricItem<Filters>
@@ -75,14 +77,6 @@ function formatValue(
   }
 }
 
-type MetricTrend = {
-  direction: "up" | "down" | "flat"
-  text: string
-  /** The same change signed: the arrow that carries the sign is aria-hidden. */
-  srText: string
-  comparisonLabel?: string
-}
-
 function computeTrend(value: number, previousValue?: number) {
   if (previousValue === undefined || previousValue === 0) return undefined
 
@@ -92,18 +86,9 @@ function computeTrend(value: number, previousValue?: number) {
   return { percent: Math.abs(percent), direction } as const
 }
 
-function resolveTrend(data: DashboardMetricData): MetricTrend | undefined {
-  const comparisonLabel = data.comparisonLabel || undefined
-  // An empty label leaves nothing to draw, so it counts as no host trend.
-  const label = data.trend?.label
-  if (data.trend && label) {
-    return {
-      direction: data.trend.direction,
-      text: label,
-      srText: label,
-      comparisonLabel,
-    }
-  }
+function resolveTrend(data: DashboardMetricData): TrendBadgeTrend | undefined {
+  const hostTrend = toTrendBadge(data.trend, data.comparisonLabel)
+  if (hostTrend) return hostTrend
 
   const computed = computeTrend(data.value, data.previousValue)
   // A computed flat trend stays hidden — drawing it would change what existing
@@ -115,50 +100,8 @@ function resolveTrend(data: DashboardMetricData): MetricTrend | undefined {
     direction: computed.direction,
     text: change,
     srText: `${computed.direction === "up" ? "+" : "−"}${change}`,
-    comparisonLabel,
+    comparisonLabel: data.comparisonLabel || undefined,
   }
-}
-
-function MetricTrendBadge({ trend }: { trend?: MetricTrend }) {
-  if (!trend) return null
-
-  const { comparisonLabel, direction, srText, text } = trend
-
-  const badge = (
-    <div className="flex shrink-0 items-center">
-      {direction === "up" && (
-        <F0Icon icon={ArrowUp} color="positive" size="sm" aria-hidden="true" />
-      )}
-      {direction === "down" && (
-        <F0Icon
-          icon={ArrowDown}
-          color="critical"
-          size="sm"
-          aria-hidden="true"
-        />
-      )}
-      <span className="sr-only">
-        {comparisonLabel ? `${srText} ${comparisonLabel}` : srText}
-      </span>
-      <span
-        aria-hidden="true"
-        className={cn(
-          "whitespace-nowrap text-base font-medium",
-          direction === "up" && "text-f1-foreground-positive",
-          direction === "down" && "text-f1-foreground-critical",
-          direction === "flat" && "text-f1-foreground-secondary"
-        )}
-      >
-        {text}
-      </span>
-    </div>
-  )
-
-  return comparisonLabel ? (
-    <Tooltip label={comparisonLabel}>{badge}</Tooltip>
-  ) : (
-    badge
-  )
 }
 
 /**
@@ -174,7 +117,7 @@ export function MetricValue({
   trend,
 }: {
   value: string
-  trend?: MetricTrend
+  trend?: TrendBadgeTrend
 }) {
   const ref = useRef<HTMLDivElement>(null)
   const { height, width } = useContainerSize(ref)
@@ -216,7 +159,7 @@ export function MetricValue({
         <span className="whitespace-nowrap text-3xl font-semibold leading-none tracking-tight text-f1-foreground">
           {value}
         </span>
-        <MetricTrendBadge trend={trend} />
+        <TrendBadge trend={trend} />
       </div>
     </div>
   )

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -27,7 +27,6 @@ import { MetricSkeleton } from "../DashboardItem/DashboardItemSkeleton"
 interface MetricItemProps<Filters extends FiltersDefinition> {
   item: DashboardMetricItem<Filters>
   filters: FiltersState<Filters>
-  /** Refetch signal. See `F0AnalyticsDashboardProps.dataKey`. */
   dataKey?: string
   actions?: import("@/experimental/Navigation/Dropdown").DropdownItem[]
   itemFilters?: DashboardItemFiltersConfig
@@ -78,71 +77,52 @@ function formatValue(
 
 type MetricTrend = {
   direction: "up" | "down" | "flat"
-  /** Percentage change derived from `previousValue`. */
-  percent?: number
-  /**
-   * Host-supplied text, rendered verbatim in place of `percent` — the host
-   * owns sign, unit, locale and rounding.
-   */
-  label?: string
-  /** What the trend compares against, e.g. "vs previous month". */
+  text: string
+  /** The same change signed: the arrow that carries the sign is aria-hidden. */
+  srText: string
   comparisonLabel?: string
 }
 
-function computeTrend(
-  value: number,
-  previousValue?: number
-): MetricTrend | undefined {
+function computeTrend(value: number, previousValue?: number) {
   if (previousValue === undefined || previousValue === 0) return undefined
 
   const percent = ((value - previousValue) / Math.abs(previousValue)) * 100
   const direction = percent > 0.5 ? "up" : percent < -0.5 ? "down" : "flat"
 
-  return { percent: Math.abs(percent), direction }
+  return { percent: Math.abs(percent), direction } as const
 }
 
-/**
- * The trend to render: the host's when it sent one, otherwise the percentage
- * change against `previousValue`.
- */
 function resolveTrend(data: DashboardMetricData): MetricTrend | undefined {
-  const trend = data.trend
-    ? { direction: data.trend.direction, label: data.trend.label }
-    : computeTrend(data.value, data.previousValue)
+  const comparisonLabel = data.comparisonLabel || undefined
+  // An empty label leaves nothing to draw, so it counts as no host trend.
+  const label = data.trend?.label
+  if (data.trend && label) {
+    return {
+      direction: data.trend.direction,
+      text: label,
+      srText: label,
+      comparisonLabel,
+    }
+  }
 
-  if (!trend) return undefined
-  return data.comparisonLabel
-    ? { ...trend, comparisonLabel: data.comparisonLabel }
-    : trend
+  const computed = computeTrend(data.value, data.previousValue)
+  // A computed flat trend stays hidden — drawing it would change what existing
+  // dashboards show.
+  if (!computed || computed.direction === "flat") return undefined
+
+  const change = `${computed.percent.toFixed(1)}%`
+  return {
+    direction: computed.direction,
+    text: change,
+    srText: `${computed.direction === "up" ? "+" : "−"}${change}`,
+    comparisonLabel,
+  }
 }
 
-/**
- * The arrow + change beside the value, and the tooltip naming what it is
- * compared against.
- *
- * A `flat` trend is only drawn when the host sent the copy for it: a computed
- * one has nothing to say beyond "no meaningful change", which the absent badge
- * already says, and drawing it would change what existing dashboards show.
- */
 function MetricTrendBadge({ trend }: { trend?: MetricTrend }) {
   if (!trend) return null
 
-  const { comparisonLabel, direction, label, percent } = trend
-
-  // The sign only reaches a screen reader through the text: the arrow that
-  // carries it visually is hidden from the accessibility tree.
-  const computed =
-    percent === undefined || direction === "flat"
-      ? undefined
-      : {
-          change: `${percent.toFixed(1)}%`,
-          signedChange: `${direction === "up" ? "+" : "−"}${percent.toFixed(1)}%`,
-        }
-  const text =
-    label === undefined ? computed : { change: label, signedChange: label }
-
-  if (!text) return null
-  const { change, signedChange } = text
+  const { comparisonLabel, direction, srText, text } = trend
 
   const badge = (
     <div className="flex shrink-0 items-center">
@@ -158,7 +138,7 @@ function MetricTrendBadge({ trend }: { trend?: MetricTrend }) {
         />
       )}
       <span className="sr-only">
-        {comparisonLabel ? `${signedChange} ${comparisonLabel}` : signedChange}
+        {comparisonLabel ? `${srText} ${comparisonLabel}` : srText}
       </span>
       <span
         aria-hidden="true"
@@ -169,7 +149,7 @@ function MetricTrendBadge({ trend }: { trend?: MetricTrend }) {
           direction === "flat" && "text-f1-foreground-secondary"
         )}
       >
-        {change}
+        {text}
       </span>
     </div>
   )
@@ -208,7 +188,7 @@ export function MetricValue({
         (element.scrollWidth > element.clientWidth ||
           element.scrollHeight > element.clientHeight)
     )
-  }, [height, trend?.direction, trend?.label, trend?.percent, value, width])
+  }, [height, trend?.direction, trend?.text, value, width])
 
   return (
     <div

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -6,6 +6,7 @@ import type {
 } from "@/patterns/OneFilterPicker/types"
 
 import { F0Icon } from "@/components/F0Icon"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { ArrowUp, ArrowDown } from "@/icons/app"
 import { useContainerSize } from "@/kits/F0DataChart/utils/useContainerSize"
 import { cn, focusRing } from "@/lib/utils"
@@ -26,6 +27,8 @@ import { MetricSkeleton } from "../DashboardItem/DashboardItemSkeleton"
 interface MetricItemProps<Filters extends FiltersDefinition> {
   item: DashboardMetricItem<Filters>
   filters: FiltersState<Filters>
+  /** Refetch signal. See `F0AnalyticsDashboardProps.dataKey`. */
+  dataKey?: string
   actions?: import("@/experimental/Navigation/Dropdown").DropdownItem[]
   itemFilters?: DashboardItemFiltersConfig
   editMode?: boolean
@@ -73,7 +76,18 @@ function formatValue(
   }
 }
 
-type MetricTrend = { percent: number; direction: "up" | "down" | "flat" }
+type MetricTrend = {
+  direction: "up" | "down" | "flat"
+  /** Percentage change derived from `previousValue`. */
+  percent?: number
+  /**
+   * Host-supplied text, rendered verbatim in place of `percent` — the host
+   * owns sign, unit, locale and rounding.
+   */
+  label?: string
+  /** What the trend compares against, e.g. "vs previous month". */
+  comparisonLabel?: string
+}
 
 function computeTrend(
   value: number,
@@ -85,6 +99,86 @@ function computeTrend(
   const direction = percent > 0.5 ? "up" : percent < -0.5 ? "down" : "flat"
 
   return { percent: Math.abs(percent), direction }
+}
+
+/**
+ * The trend to render: the host's when it sent one, otherwise the percentage
+ * change against `previousValue`.
+ */
+function resolveTrend(data: DashboardMetricData): MetricTrend | undefined {
+  const trend = data.trend
+    ? { direction: data.trend.direction, label: data.trend.label }
+    : computeTrend(data.value, data.previousValue)
+
+  if (!trend) return undefined
+  return data.comparisonLabel
+    ? { ...trend, comparisonLabel: data.comparisonLabel }
+    : trend
+}
+
+/**
+ * The arrow + change beside the value, and the tooltip naming what it is
+ * compared against.
+ *
+ * A `flat` trend is only drawn when the host sent the copy for it: a computed
+ * one has nothing to say beyond "no meaningful change", which the absent badge
+ * already says, and drawing it would change what existing dashboards show.
+ */
+function MetricTrendBadge({ trend }: { trend?: MetricTrend }) {
+  if (!trend) return null
+
+  const { comparisonLabel, direction, label, percent } = trend
+
+  // The sign only reaches a screen reader through the text: the arrow that
+  // carries it visually is hidden from the accessibility tree.
+  const computed =
+    percent === undefined || direction === "flat"
+      ? undefined
+      : {
+          change: `${percent.toFixed(1)}%`,
+          signedChange: `${direction === "up" ? "+" : "−"}${percent.toFixed(1)}%`,
+        }
+  const text =
+    label === undefined ? computed : { change: label, signedChange: label }
+
+  if (!text) return null
+  const { change, signedChange } = text
+
+  const badge = (
+    <div className="flex shrink-0 items-center">
+      {direction === "up" && (
+        <F0Icon icon={ArrowUp} color="positive" size="sm" aria-hidden="true" />
+      )}
+      {direction === "down" && (
+        <F0Icon
+          icon={ArrowDown}
+          color="critical"
+          size="sm"
+          aria-hidden="true"
+        />
+      )}
+      <span className="sr-only">
+        {comparisonLabel ? `${signedChange} ${comparisonLabel}` : signedChange}
+      </span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "whitespace-nowrap text-base font-medium",
+          direction === "up" && "text-f1-foreground-positive",
+          direction === "down" && "text-f1-foreground-critical",
+          direction === "flat" && "text-f1-foreground-secondary"
+        )}
+      >
+        {change}
+      </span>
+    </div>
+  )
+
+  return comparisonLabel ? (
+    <Tooltip label={comparisonLabel}>{badge}</Tooltip>
+  ) : (
+    badge
+  )
 }
 
 /**
@@ -114,7 +208,7 @@ export function MetricValue({
         (element.scrollWidth > element.clientWidth ||
           element.scrollHeight > element.clientHeight)
     )
-  }, [height, trend?.direction, trend?.percent, value, width])
+  }, [height, trend?.direction, trend?.label, trend?.percent, value, width])
 
   return (
     <div
@@ -142,40 +236,7 @@ export function MetricValue({
         <span className="whitespace-nowrap text-3xl font-semibold leading-none tracking-tight text-f1-foreground">
           {value}
         </span>
-        {trend && trend.direction !== "flat" && (
-          <div className="flex shrink-0 items-center">
-            {trend.direction === "up" ? (
-              <F0Icon
-                icon={ArrowUp}
-                color="positive"
-                size="sm"
-                aria-hidden="true"
-              />
-            ) : (
-              <F0Icon
-                icon={ArrowDown}
-                color="critical"
-                size="sm"
-                aria-hidden="true"
-              />
-            )}
-            <span className="sr-only">
-              {trend.direction === "up" ? "+" : "−"}
-              {trend.percent.toFixed(1)}%
-            </span>
-            <span
-              aria-hidden="true"
-              className={cn(
-                "whitespace-nowrap text-base font-medium",
-                trend.direction === "up"
-                  ? "text-f1-foreground-positive"
-                  : "text-f1-foreground-critical"
-              )}
-            >
-              {trend.percent.toFixed(1)}%
-            </span>
-          </div>
-        )}
+        <MetricTrendBadge trend={trend} />
       </div>
     </div>
   )
@@ -190,6 +251,7 @@ export function MetricValue({
 export function MetricItem<Filters extends FiltersDefinition>({
   item,
   filters,
+  dataKey,
   actions,
   itemFilters,
   editMode,
@@ -199,12 +261,12 @@ export function MetricItem<Filters extends FiltersDefinition>({
 }: MetricItemProps<Filters>) {
   const enabled = item.useDashboardFilters !== false
   const itemFiltersKey = JSON.stringify(itemFilters?.value ?? {})
-  const { data, isLoading, error, retry } = useDashboardItemData<
+  const { data, isLoading, isRefreshing, error, retry } = useDashboardItemData<
     Filters,
     DashboardMetricData
-  >(item.fetchData, filters, enabled, itemFiltersKey)
+  >(item.fetchData, filters, enabled, itemFiltersKey, dataKey)
 
-  const trend = data ? computeTrend(data.value, data.previousValue) : undefined
+  const trend = data ? resolveTrend(data) : undefined
 
   return (
     <DashboardItem
@@ -213,6 +275,7 @@ export function MetricItem<Filters extends FiltersDefinition>({
       info={item.info}
       explanation={item.explanation}
       isLoading={isLoading}
+      isRefreshing={isRefreshing}
       error={error}
       onRetry={retry}
       skeleton={<MetricSkeleton />}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/TrendBadge/TrendBadge.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/TrendBadge/TrendBadge.tsx
@@ -7,10 +7,33 @@ import type { DashboardMetricTrend } from "../../types"
 
 export type TrendBadgeTrend = {
   direction: DashboardMetricTrend["direction"]
+  sentiment?: DashboardMetricTrend["sentiment"]
   text: string
   /** The same change signed: the arrow that carries the sign is aria-hidden. */
   srText: string
   comparisonLabel?: string
+}
+
+/**
+ * The colour is the sentiment's when the host set one; otherwise the direction
+ * is read as its own sentiment, which is what every trend showed before.
+ */
+const TONES = {
+  positive: { icon: "positive", text: "text-f1-foreground-positive" },
+  negative: { icon: "critical", text: "text-f1-foreground-critical" },
+  neutral: { icon: "secondary", text: "text-f1-foreground-secondary" },
+} as const
+
+function trendTone({
+  direction,
+  sentiment,
+}: Pick<TrendBadgeTrend, "direction" | "sentiment">) {
+  if (sentiment) return TONES[sentiment]
+  return direction === "up"
+    ? TONES.positive
+    : direction === "down"
+      ? TONES.negative
+      : TONES.neutral
 }
 
 /**
@@ -25,6 +48,7 @@ export function toTrendBadge(
   if (!trend?.label) return undefined
   return {
     direction: trend.direction,
+    sentiment: trend.sentiment,
     text: trend.label,
     srText: trend.label,
     comparisonLabel: comparisonLabel || undefined,
@@ -36,16 +60,17 @@ export function TrendBadge({ trend }: { trend?: TrendBadgeTrend }) {
   if (!trend) return null
 
   const { comparisonLabel, direction, srText, text } = trend
+  const tone = trendTone(trend)
 
   const badge = (
     <div className="flex shrink-0 items-center">
       {direction === "up" && (
-        <F0Icon icon={ArrowUp} color="positive" size="sm" aria-hidden="true" />
+        <F0Icon icon={ArrowUp} color={tone.icon} size="sm" aria-hidden="true" />
       )}
       {direction === "down" && (
         <F0Icon
           icon={ArrowDown}
-          color="critical"
+          color={tone.icon}
           size="sm"
           aria-hidden="true"
         />
@@ -55,12 +80,7 @@ export function TrendBadge({ trend }: { trend?: TrendBadgeTrend }) {
       </span>
       <span
         aria-hidden="true"
-        className={cn(
-          "whitespace-nowrap text-base font-medium",
-          direction === "up" && "text-f1-foreground-positive",
-          direction === "down" && "text-f1-foreground-critical",
-          direction === "flat" && "text-f1-foreground-secondary"
-        )}
+        className={cn("whitespace-nowrap text-base font-medium", tone.text)}
       >
         {text}
       </span>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/TrendBadge/TrendBadge.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/TrendBadge/TrendBadge.tsx
@@ -24,16 +24,17 @@ const TONES = {
   neutral: { icon: "secondary", text: "text-f1-foreground-secondary" },
 } as const
 
-function trendTone({
+/** The tone a trend reads in: its sentiment, else its direction read as one. */
+export function trendSentiment({
   direction,
   sentiment,
-}: Pick<TrendBadgeTrend, "direction" | "sentiment">) {
-  if (sentiment) return TONES[sentiment]
+}: Pick<DashboardMetricTrend, "direction" | "sentiment">): keyof typeof TONES {
+  if (sentiment) return sentiment
   return direction === "up"
-    ? TONES.positive
+    ? "positive"
     : direction === "down"
-      ? TONES.negative
-      : TONES.neutral
+      ? "negative"
+      : "neutral"
 }
 
 /**
@@ -60,7 +61,7 @@ export function TrendBadge({ trend }: { trend?: TrendBadgeTrend }) {
   if (!trend) return null
 
   const { comparisonLabel, direction, srText, text } = trend
-  const tone = trendTone(trend)
+  const tone = TONES[trendSentiment(trend)]
 
   const badge = (
     <div className="flex shrink-0 items-center">

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/TrendBadge/TrendBadge.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/TrendBadge/TrendBadge.tsx
@@ -1,0 +1,75 @@
+import { F0Icon } from "@/components/F0Icon"
+import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { ArrowDown, ArrowUp } from "@/icons/app"
+import { cn } from "@/lib/utils"
+
+import type { DashboardMetricTrend } from "../../types"
+
+export type TrendBadgeTrend = {
+  direction: DashboardMetricTrend["direction"]
+  text: string
+  /** The same change signed: the arrow that carries the sign is aria-hidden. */
+  srText: string
+  comparisonLabel?: string
+}
+
+/**
+ * A host-computed trend as the badge takes it — the label is already the whole
+ * change, sign included. An empty label leaves nothing to draw, so it counts
+ * as no trend at all.
+ */
+export function toTrendBadge(
+  trend: DashboardMetricTrend | undefined,
+  comparisonLabel?: string
+): TrendBadgeTrend | undefined {
+  if (!trend?.label) return undefined
+  return {
+    direction: trend.direction,
+    text: trend.label,
+    srText: trend.label,
+    comparisonLabel: comparisonLabel || undefined,
+  }
+}
+
+/** Arrow + change, with the baseline it compares against on hover and to a reader. */
+export function TrendBadge({ trend }: { trend?: TrendBadgeTrend }) {
+  if (!trend) return null
+
+  const { comparisonLabel, direction, srText, text } = trend
+
+  const badge = (
+    <div className="flex shrink-0 items-center">
+      {direction === "up" && (
+        <F0Icon icon={ArrowUp} color="positive" size="sm" aria-hidden="true" />
+      )}
+      {direction === "down" && (
+        <F0Icon
+          icon={ArrowDown}
+          color="critical"
+          size="sm"
+          aria-hidden="true"
+        />
+      )}
+      <span className="sr-only">
+        {comparisonLabel ? `${srText} ${comparisonLabel}` : srText}
+      </span>
+      <span
+        aria-hidden="true"
+        className={cn(
+          "whitespace-nowrap text-base font-medium",
+          direction === "up" && "text-f1-foreground-positive",
+          direction === "down" && "text-f1-foreground-critical",
+          direction === "flat" && "text-f1-foreground-secondary"
+        )}
+      >
+        {text}
+      </span>
+    </div>
+  )
+
+  return comparisonLabel ? (
+    <Tooltip label={comparisonLabel}>{badge}</Tooltip>
+  ) : (
+    badge
+  )
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
@@ -53,6 +53,7 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
 
   const rows: Record<string, unknown>[] = []
   let hasPrevious = false
+  let hasChange = false
 
   for (const item of metricItems) {
     try {
@@ -67,6 +68,13 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
         row["Previous Value"] = data.previousValue
         hasPrevious = true
       }
+      // The label as the widget renders it — the host already formatted the
+      // sign, unit and rounding, and the sheet should not disagree with the
+      // screen about what the change was.
+      if (data.trend?.label !== undefined) {
+        row.Change = data.trend.label
+        hasChange = true
+      }
       rows.push(row)
     } catch (err) {
       console.warn(
@@ -78,9 +86,12 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
 
   if (rows.length === 0) return null
 
-  const columns = hasPrevious
-    ? ["Metric", "Value", "Previous Value"]
-    : ["Metric", "Value"]
+  const columns = [
+    "Metric",
+    "Value",
+    ...(hasPrevious ? ["Previous Value"] : []),
+    ...(hasChange ? ["Change"] : []),
+  ]
 
   return { name: "Metrics", columns, rows }
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
@@ -12,10 +12,7 @@ import type {
   DashboardMetricItem,
 } from "../types"
 
-import {
-  readRowTrends,
-  rowTrendOf,
-} from "../components/CollectionItem/rowTrends"
+import { rowTrendOf } from "../components/CollectionItem/rowTrends"
 import { isRenderableChart } from "../utils/chartDataAdapter"
 import { chartDataToTabular } from "../utils/chartDataToTabular"
 import { downloadMultiSheetExcel } from "../utils/downloadHelpers"
@@ -42,25 +39,6 @@ interface UseDashboardExportResult {
 
 /** Header the metrics sheet already uses for a trend, shared by the other sheets. */
 const CHANGE_COLUMN = "Change"
-
-/**
- * The chart's own trend as a sheet cell. It describes the whole chart rather
- * than any one row, so it lands once, on the first.
- */
-function withChartChange(
-  sheet: SheetData,
-  change: string | undefined
-): SheetData {
-  const [first, ...rest] = sheet.rows
-  if (!change || !first) return sheet
-
-  return {
-    ...sheet,
-    columns: [...sheet.columns, CHANGE_COLUMN],
-    keys: sheet.keys && [...sheet.keys, CHANGE_COLUMN],
-    rows: [{ ...first, [CHANGE_COLUMN]: change }, ...rest],
-  }
-}
 
 function getItemFilters<Filters extends FiltersDefinition>(
   item: { useDashboardFilters?: boolean },
@@ -97,7 +75,7 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
       // The sheet must not disagree with the screen about the change: an empty
       // label falls back to `previousValue` there too.
       if (data.trend?.label) {
-        row.Change = data.trend.label
+        row[CHANGE_COLUMN] = data.trend.label
         hasChange = true
       }
       rows.push(row)
@@ -115,7 +93,7 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
     "Metric",
     "Value",
     ...(hasPrevious ? ["Previous Value"] : []),
-    ...(hasChange ? ["Change"] : []),
+    ...(hasChange ? [CHANGE_COLUMN] : []),
   ]
 
   return { name: "Metrics", columns, rows }
@@ -153,16 +131,16 @@ async function buildAllSheets<Filters extends FiltersDefinition>(
             )
             return null
           }
+          // The chart's own trend describes the sheet, not any row in it, so
+          // it stays on screen: parked on row 0 it would follow that row the
+          // first time the reader sorts.
           const tabular = chartDataToTabular(item.chart, data)
-          return withChartChange(
-            {
-              name: item.title,
-              columns: tabular.columns,
-              rows: tabular.rows,
-              keys: tabular.keys,
-            },
-            data.trend?.label
-          )
+          return {
+            name: item.title,
+            columns: tabular.columns,
+            rows: tabular.rows,
+            keys: tabular.keys,
+          }
         } catch (err) {
           console.warn(
             `[useDashboardExport] Failed to export chart "${item.title}":`,
@@ -186,7 +164,7 @@ async function buildAllSheets<Filters extends FiltersDefinition>(
               : (result as Record<string, unknown>[])
           if (records.length === 0) return null
           const columns = extractColumns(records)
-          const rowTrends = readRowTrends(result)
+          const rowTrends = item.rowTrends
           if (!rowTrends) {
             return { name: item.title, columns, rows: records }
           }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
@@ -68,10 +68,9 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
         row["Previous Value"] = data.previousValue
         hasPrevious = true
       }
-      // The label as the widget renders it — the host already formatted the
-      // sign, unit and rounding, and the sheet should not disagree with the
-      // screen about what the change was.
-      if (data.trend?.label !== undefined) {
+      // The sheet must not disagree with the screen about the change: an empty
+      // label falls back to `previousValue` there too.
+      if (data.trend?.label) {
         row.Change = data.trend.label
         hasChange = true
       }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
@@ -12,6 +12,10 @@ import type {
   DashboardMetricItem,
 } from "../types"
 
+import {
+  readRowTrends,
+  rowTrendOf,
+} from "../components/CollectionItem/rowTrends"
 import { isRenderableChart } from "../utils/chartDataAdapter"
 import { chartDataToTabular } from "../utils/chartDataToTabular"
 import { downloadMultiSheetExcel } from "../utils/downloadHelpers"
@@ -34,6 +38,28 @@ interface UseDashboardExportOptions<Filters extends FiltersDefinition> {
 interface UseDashboardExportResult {
   exportAsExcel: () => Promise<void>
   isExporting: boolean
+}
+
+/** Header the metrics sheet already uses for a trend, shared by the other sheets. */
+const CHANGE_COLUMN = "Change"
+
+/**
+ * The chart's own trend as a sheet cell. It describes the whole chart rather
+ * than any one row, so it lands once, on the first.
+ */
+function withChartChange(
+  sheet: SheetData,
+  change: string | undefined
+): SheetData {
+  const [first, ...rest] = sheet.rows
+  if (!change || !first) return sheet
+
+  return {
+    ...sheet,
+    columns: [...sheet.columns, CHANGE_COLUMN],
+    keys: sheet.keys && [...sheet.keys, CHANGE_COLUMN],
+    rows: [{ ...first, [CHANGE_COLUMN]: change }, ...rest],
+  }
 }
 
 function getItemFilters<Filters extends FiltersDefinition>(
@@ -128,12 +154,15 @@ async function buildAllSheets<Filters extends FiltersDefinition>(
             return null
           }
           const tabular = chartDataToTabular(item.chart, data)
-          return {
-            name: item.title,
-            columns: tabular.columns,
-            rows: tabular.rows,
-            keys: tabular.keys,
-          }
+          return withChartChange(
+            {
+              name: item.title,
+              columns: tabular.columns,
+              rows: tabular.rows,
+              keys: tabular.keys,
+            },
+            data.trend?.label
+          )
         } catch (err) {
           console.warn(
             `[useDashboardExport] Failed to export chart "${item.title}":`,
@@ -157,7 +186,23 @@ async function buildAllSheets<Filters extends FiltersDefinition>(
               : (result as Record<string, unknown>[])
           if (records.length === 0) return null
           const columns = extractColumns(records)
-          return { name: item.title, columns, rows: records }
+          const rowTrends = readRowTrends(result)
+          if (!rowTrends) {
+            return { name: item.title, columns, rows: records }
+          }
+
+          return {
+            name: item.title,
+            columns: [...columns, CHANGE_COLUMN],
+            rows: records.map((record) => ({
+              ...record,
+              [CHANGE_COLUMN]: rowTrendOf(
+                record,
+                rowTrends,
+                sourceDef.idProvider
+              )?.label,
+            })),
+          }
         } catch (err) {
           console.warn(
             `[useDashboardExport] Failed to export collection "${item.title}":`,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardItemData.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardItemData.ts
@@ -13,11 +13,7 @@ export interface DashboardItemDataState<T> {
   data: T | undefined
   /** Whether a fetch is in progress with nothing to show meanwhile */
   isLoading: boolean
-  /**
-   * Whether a fetch is in progress while the previous result stays on screen.
-   * Only a `dataKey` change fetches this way; everything else keeps showing
-   * the skeleton.
-   */
+  /** Whether a fetch is in progress while the previous result stays on screen */
   isRefreshing: boolean
   /** The most recent error, if any */
   error: Error | undefined
@@ -30,10 +26,8 @@ export interface DashboardItemDataState<T> {
  *
  * Calls `fetchData(filters)` whenever the filters change, managing
  * loading / error / data states and protecting against stale responses
- * via an incrementing request counter.
- *
- * `dataKey` refetches the same question — the previous result stays on screen
- * as `isRefreshing` instead of being replaced by a skeleton.
+ * via an incrementing request counter. A `dataKey` change refetches the same
+ * question, keeping the previous result on screen as `isRefreshing`.
  */
 export function useDashboardItemData<Filters extends FiltersDefinition, T>(
   fetchData: (filters: FiltersState<Filters>) => Promise<T>,
@@ -50,8 +44,6 @@ export function useDashboardItemData<Filters extends FiltersDefinition, T>(
   // Incrementing counter to discard stale responses
   const requestIdRef = useRef(0)
 
-  // Read inside `doFetch` to decide whether there is anything worth keeping on
-  // screen during a soft refetch, without making the callback depend on it.
   const dataRef = useRef(data)
   dataRef.current = data
 
@@ -66,10 +58,7 @@ export function useDashboardItemData<Filters extends FiltersDefinition, T>(
   const doFetch = useCallback(
     (soft = false) => {
       const id = ++requestIdRef.current
-      // A soft refetch answers the same question with a different comparison
-      // target, so the answer already on screen is still worth reading while the
-      // next one loads. With nothing fetched yet there is nothing to keep, and
-      // the skeleton is the honest state.
+      // Nothing fetched yet means nothing to keep.
       const keepPrevious = soft && dataRef.current !== undefined
       setIsLoading(!keepPrevious)
       setIsRefreshing(keepPrevious)
@@ -109,14 +98,11 @@ export function useDashboardItemData<Filters extends FiltersDefinition, T>(
   // When disabled, use a static key so dashboard filter changes don't refetch.
   const filtersKey = enabled ? JSON.stringify(filters) : "disabled"
 
-  // What the widget is asking about. A change here means the answer on screen
-  // is about to be replaced by a different one, so it goes back to a skeleton.
   const questionKey = `${filtersKey}|${refreshKey}`
   const previousQuestionKeyRef = useRef<string | null>(null)
 
   useEffect(() => {
-    // Same question, new `dataKey`: the only case that keeps the previous
-    // result visible. Mount included, since the ref starts unset.
+    // Mount included, since the ref starts unset.
     const soft = previousQuestionKeyRef.current === questionKey
     previousQuestionKeyRef.current = questionKey
     doFetch(soft)

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardItemData.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardItemData.ts
@@ -11,8 +11,14 @@ import type {
 export interface DashboardItemDataState<T> {
   /** Resolved data, undefined while loading or on error */
   data: T | undefined
-  /** Whether a fetch is in progress */
+  /** Whether a fetch is in progress with nothing to show meanwhile */
   isLoading: boolean
+  /**
+   * Whether a fetch is in progress while the previous result stays on screen.
+   * Only a `dataKey` change fetches this way; everything else keeps showing
+   * the skeleton.
+   */
+  isRefreshing: boolean
   /** The most recent error, if any */
   error: Error | undefined
   /** Re-trigger the fetch with the current filters */
@@ -25,19 +31,29 @@ export interface DashboardItemDataState<T> {
  * Calls `fetchData(filters)` whenever the filters change, managing
  * loading / error / data states and protecting against stale responses
  * via an incrementing request counter.
+ *
+ * `dataKey` refetches the same question — the previous result stays on screen
+ * as `isRefreshing` instead of being replaced by a skeleton.
  */
 export function useDashboardItemData<Filters extends FiltersDefinition, T>(
   fetchData: (filters: FiltersState<Filters>) => Promise<T>,
   filters: FiltersState<Filters>,
   enabled: boolean,
-  refreshKey = ""
+  refreshKey = "",
+  dataKey = ""
 ): DashboardItemDataState<T> {
   const [data, setData] = useState<T | undefined>(undefined)
   const [isLoading, setIsLoading] = useState(true)
+  const [isRefreshing, setIsRefreshing] = useState(false)
   const [error, setError] = useState<Error | undefined>(undefined)
 
   // Incrementing counter to discard stale responses
   const requestIdRef = useRef(0)
+
+  // Read inside `doFetch` to decide whether there is anything worth keeping on
+  // screen during a soft refetch, without making the callback depend on it.
+  const dataRef = useRef(data)
+  dataRef.current = data
 
   // Stable reference to the latest fetchData function
   const fetchDataRef = useRef(fetchData)
@@ -47,31 +63,42 @@ export function useDashboardItemData<Filters extends FiltersDefinition, T>(
   const filtersRef = useRef(filters)
   filtersRef.current = filters
 
-  const doFetch = useCallback(() => {
-    const id = ++requestIdRef.current
-    setIsLoading(true)
-    setError(undefined)
+  const doFetch = useCallback(
+    (soft = false) => {
+      const id = ++requestIdRef.current
+      // A soft refetch answers the same question with a different comparison
+      // target, so the answer already on screen is still worth reading while the
+      // next one loads. With nothing fetched yet there is nothing to keep, and
+      // the skeleton is the honest state.
+      const keepPrevious = soft && dataRef.current !== undefined
+      setIsLoading(!keepPrevious)
+      setIsRefreshing(keepPrevious)
+      setError(undefined)
 
-    const effectiveFilters = enabled
-      ? filtersRef.current
-      : ({} as FiltersState<Filters>)
+      const effectiveFilters = enabled
+        ? filtersRef.current
+        : ({} as FiltersState<Filters>)
 
-    fetchDataRef
-      .current(effectiveFilters)
-      .then((result) => {
-        // Only apply if this is still the latest request
-        if (id === requestIdRef.current) {
-          setData(result)
-          setIsLoading(false)
-        }
-      })
-      .catch((err: unknown) => {
-        if (id === requestIdRef.current) {
-          setError(err instanceof Error ? err : new Error(String(err)))
-          setIsLoading(false)
-        }
-      })
-  }, [enabled])
+      fetchDataRef
+        .current(effectiveFilters)
+        .then((result) => {
+          // Only apply if this is still the latest request
+          if (id === requestIdRef.current) {
+            setData(result)
+            setIsLoading(false)
+            setIsRefreshing(false)
+          }
+        })
+        .catch((err: unknown) => {
+          if (id === requestIdRef.current) {
+            setError(err instanceof Error ? err : new Error(String(err)))
+            setIsLoading(false)
+            setIsRefreshing(false)
+          }
+        })
+    },
+    [enabled]
+  )
 
   // Re-fetch whenever effective dashboard filters or the caller's semantic
   // dependency changes. `fetchData` itself intentionally stays behind a ref:
@@ -82,14 +109,23 @@ export function useDashboardItemData<Filters extends FiltersDefinition, T>(
   // When disabled, use a static key so dashboard filter changes don't refetch.
   const filtersKey = enabled ? JSON.stringify(filters) : "disabled"
 
+  // What the widget is asking about. A change here means the answer on screen
+  // is about to be replaced by a different one, so it goes back to a skeleton.
+  const questionKey = `${filtersKey}|${refreshKey}`
+  const previousQuestionKeyRef = useRef<string | null>(null)
+
   useEffect(() => {
-    doFetch()
+    // Same question, new `dataKey`: the only case that keeps the previous
+    // result visible. Mount included, since the ref starts unset.
+    const soft = previousQuestionKeyRef.current === questionKey
+    previousQuestionKeyRef.current = questionKey
+    doFetch(soft)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filtersKey, refreshKey, doFetch])
+  }, [questionKey, dataKey, doFetch])
 
   const retry = useCallback(() => {
     doFetch()
   }, [doFetch])
 
-  return { data, isLoading, error, retry }
+  return { data, isLoading, isRefreshing, error, retry }
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
@@ -4,6 +4,7 @@ import { F0AnalyticsDashboard as _F0AnalyticsDashboard } from "./F0AnalyticsDash
 
 export type {
   BarChartConfig,
+  DashboardCategoryComparison,
   DashboardChartConfig,
   DashboardChartData,
   DashboardChartItem,
@@ -16,6 +17,7 @@ export type {
   DashboardMetricData,
   DashboardMetricItem,
   DashboardMetricTrend,
+  DashboardRowTrends,
   F0AnalyticsDashboardAskAiTarget,
   F0AnalyticsDashboardAskAiTargetWithQuote,
   F0AnalyticsDashboardPointClick,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/index.ts
@@ -15,6 +15,7 @@ export type {
   DashboardItemFiltersState,
   DashboardMetricData,
   DashboardMetricItem,
+  DashboardMetricTrend,
   F0AnalyticsDashboardAskAiTarget,
   F0AnalyticsDashboardAskAiTargetWithQuote,
   F0AnalyticsDashboardPointClick,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -475,6 +475,8 @@ export interface DashboardCollectionItem<
    * ride here because its source owns its rows.
    */
   rowTrends?: DashboardRowTrends
+  /** Sorting key of `createSource` that orders rows by their change; the column sorts only when the source can. */
+  rowTrendsSorting?: string
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -233,11 +233,17 @@ export interface DashboardMetricTrend {
   /** Rendered verbatim ("+1.2 pp"); empty falls back to `previousValue`. */
   label: string
   /**
+   * The change as a number in the measure's own unit, for what draws or ranks
+   * it: a chart's change view sizes its bars by it, and the tooltip states the
+   * baseline (value − delta) beside the label. Without it the change view can
+   * only list categories by their label text, ordered by that text.
+   */
+  delta?: number
+  /**
    * Whether the change is good news, for the measures where that does not
    * follow its sign — attrition falling is positive. It decides the colour,
    * `direction` still decides the arrow. Omitted, the colour follows the
-   * direction as before. Only read where there is a colour to set: a category
-   * mark is plain text in a chart label, so it takes the glyph and no tone.
+   * direction as before.
    */
   sentiment?: "positive" | "negative" | "neutral"
 }
@@ -251,12 +257,12 @@ export interface DashboardMetricTrend {
 export interface DashboardCategoryComparison {
   /** Keyed by the category label, as it appears in `categories` or a point's `name`. */
   byCategory: Record<string, DashboardMetricTrend>
-  /** Categories the compared period did not have. Marked as new. */
+  /** Categories the compared period did not have. Their tooltip says so; the change view pins them first. */
   added?: string[]
   /**
-   * Categories the compared period had and this one does not. They have no
-   * mark to carry — nothing draws them — so the widget names them in a caption
-   * under the chart.
+   * Categories the compared period had and this one does not. Nothing draws
+   * them, so they show only as a count in the header chip and as the last
+   * rows of the change view.
    */
   removed?: string[]
 }
@@ -304,7 +310,11 @@ export interface DashboardChartData {
   trend?: DashboardMetricTrend
   /** What `trend` compares against, e.g. "vs previous month". Tooltip + screen reader. */
   comparisonLabel?: string
-  /** Per-category comparison, drawn into the category labels of bar/pie/funnel charts. */
+  /**
+   * Per-category comparison for bar/pie/funnel charts: a line in each
+   * category's tooltip, a summary chip beside `trend`, and a "Show change"
+   * view in the widget menu. Labels stay as they are.
+   */
   categoryComparison?: DashboardCategoryComparison
 }
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react"
+
 import type {
   ChartColorToken,
   F0DataChartBarSeries,
@@ -47,6 +49,14 @@ interface ChartConfigBase {
   tooltipValueFormatter?: (value: number) => string
   /** Format category axis tick labels */
   categoryFormatter?: (value: string) => string
+  /**
+   * Names of series that carry a comparison baseline (e.g. the same measure
+   * over the previous period). They are drawn muted — reduced opacity, and
+   * dashed on a line chart — so the current period stays the figure being
+   * read. Their legend entries are untouched, so switching one off works the
+   * same way as for any other series.
+   */
+  comparisonSeriesNames?: string[]
 }
 
 export interface BarChartConfig extends ChartConfigBase {
@@ -336,12 +346,40 @@ export type MetricFormat =
   | { type: "percent" }
   | { type: "custom"; suffix?: string; prefix?: string }
 
+/**
+ * A trend the host computed itself, shown beside the metric value.
+ *
+ * Use it when the change is not a percentage of `previousValue` — a difference
+ * in percentage points, a server-side comparison against a target, a figure
+ * whose rounding must match a report elsewhere.
+ */
+export interface DashboardMetricTrend {
+  /** Which way the change points. `flat` renders neutrally, without an arrow. */
+  direction: "up" | "down" | "flat"
+  /**
+   * Rendered verbatim next to the arrow, so the host owns sign, unit, locale
+   * and rounding — "+1.2 pp", "−12.5%", "sin cambios".
+   */
+  label: string
+}
+
 /** Data returned by a metric item's fetchData */
 export interface DashboardMetricData {
   /** The main numeric value displayed in large text */
   value: number
   /** Optional previous value — used to compute a trend indicator */
   previousValue?: number
+  /**
+   * A ready-made trend. Takes precedence over the one derived from
+   * `previousValue`, which stays the default when this is absent.
+   */
+  trend?: DashboardMetricTrend
+  /**
+   * What the trend compares against, e.g. "vs previous month". Shown in a
+   * tooltip on the trend and announced with it, so the figure states its own
+   * baseline instead of relying on the widget title.
+   */
+  comparisonLabel?: string
 }
 
 /**
@@ -643,4 +681,19 @@ export interface F0AnalyticsDashboardProps<
    * Rendered above the grid alongside the regular filter bar.
    */
   navigationFilters?: NavigationFiltersDefinition
+  /**
+   * Host controls rendered in the header row, immediately left of the
+   * navigation filters — a comparison picker beside the date navigator.
+   * Nothing is rendered, and no row appears, when omitted.
+   */
+  navigationActions?: ReactNode
+  /**
+   * Changes when the host wants widgets to refetch with the same filters
+   * (e.g. a comparison target changed).
+   *
+   * Every item re-runs its `fetchData` in place: the grid is not remounted and
+   * the data already on screen stays visible, dimmed, until the new result
+   * arrives. A widget with nothing to keep shows its skeleton as usual.
+   */
+  dataKey?: string
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -256,7 +256,7 @@ export interface DashboardCategoryComparison {
 /**
  * Per-row trends for a collection item, keyed the way the collection itself
  * identifies rows: its source's `idProvider` when it has one, otherwise the
- * record's `id`. Returned by the source's `fetchData` alongside `records`.
+ * record's `id`.
  */
 export type DashboardRowTrends = Record<string, DashboardMetricTrend>
 
@@ -452,10 +452,6 @@ export interface DashboardCollectionItem<
    * Called whenever dashboard filters change.
    * The returned definition should NOT include its own filters/presets
    * (the dashboard provides those globally).
-   *
-   * Its `dataAdapter.fetchData` may return {@link DashboardRowTrends} as
-   * `rowTrends` alongside `records`; the widget then appends a "Change" column
-   * rendering each row's trend.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createSource: (filters: FiltersState<Filters>) => any
@@ -465,6 +461,12 @@ export interface DashboardCollectionItem<
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   visualizations: ReadonlyArray<any>
+  /**
+   * Per-row comparison, appended as a "Change" column. A chart's trends ride
+   * in its `fetchData` result because that fetch owns its data; a collection's
+   * ride here because its source owns its rows.
+   */
+  rowTrends?: DashboardRowTrends
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -232,6 +232,14 @@ export interface DashboardMetricTrend {
   direction: "up" | "down" | "flat"
   /** Rendered verbatim ("+1.2 pp"); empty falls back to `previousValue`. */
   label: string
+  /**
+   * Whether the change is good news, for the measures where that does not
+   * follow its sign — attrition falling is positive. It decides the colour,
+   * `direction` still decides the arrow. Omitted, the colour follows the
+   * direction as before. Only read where there is a colour to set: a category
+   * mark is plain text in a chart label, so it takes the glyph and no tone.
+   */
+  sentiment?: "positive" | "negative" | "neutral"
 }
 
 /**

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -50,11 +50,9 @@ interface ChartConfigBase {
   /** Format category axis tick labels */
   categoryFormatter?: (value: string) => string
   /**
-   * Names of series that carry a comparison baseline (e.g. the same measure
-   * over the previous period). They are drawn muted — reduced opacity, and
-   * dashed on a line chart — so the current period stays the figure being
-   * read. Their legend entries are untouched, so switching one off works the
-   * same way as for any other series.
+   * Names of the series carrying a comparison baseline — drawn faded, and
+   * dashed on a line chart. Matched after any chart-type transform, so a
+   * series the transform renamed or collapsed is not muted.
    */
   comparisonSeriesNames?: string[]
 }
@@ -347,19 +345,13 @@ export type MetricFormat =
   | { type: "custom"; suffix?: string; prefix?: string }
 
 /**
- * A trend the host computed itself, shown beside the metric value.
- *
- * Use it when the change is not a percentage of `previousValue` — a difference
- * in percentage points, a server-side comparison against a target, a figure
- * whose rounding must match a report elsewhere.
+ * A trend the host computed itself, for a change that is not a percentage of
+ * `previousValue` — percentage points, a target comparison, a rounding.
  */
 export interface DashboardMetricTrend {
-  /** Which way the change points. `flat` renders neutrally, without an arrow. */
+  /** `flat` renders neutrally, without an arrow. */
   direction: "up" | "down" | "flat"
-  /**
-   * Rendered verbatim next to the arrow, so the host owns sign, unit, locale
-   * and rounding — "+1.2 pp", "−12.5%", "sin cambios".
-   */
+  /** Rendered verbatim ("+1.2 pp"); empty falls back to `previousValue`. */
   label: string
 }
 
@@ -369,16 +361,9 @@ export interface DashboardMetricData {
   value: number
   /** Optional previous value — used to compute a trend indicator */
   previousValue?: number
-  /**
-   * A ready-made trend. Takes precedence over the one derived from
-   * `previousValue`, which stays the default when this is absent.
-   */
+  /** Takes precedence over the trend derived from `previousValue`. */
   trend?: DashboardMetricTrend
-  /**
-   * What the trend compares against, e.g. "vs previous month". Shown in a
-   * tooltip on the trend and announced with it, so the figure states its own
-   * baseline instead of relying on the widget title.
-   */
+  /** What the trend compares against, e.g. "vs previous month". Tooltip + screen reader. */
   comparisonLabel?: string
 }
 
@@ -681,19 +666,14 @@ export interface F0AnalyticsDashboardProps<
    * Rendered above the grid alongside the regular filter bar.
    */
   navigationFilters?: NavigationFiltersDefinition
-  /**
-   * Host controls rendered in the header row, immediately left of the
-   * navigation filters — a comparison picker beside the date navigator.
-   * Nothing is rendered, and no row appears, when omitted.
-   */
+  /** Host controls in the header row, left of the navigation filters. */
   navigationActions?: ReactNode
   /**
-   * Changes when the host wants widgets to refetch with the same filters
-   * (e.g. a comparison target changed).
-   *
-   * Every item re-runs its `fetchData` in place: the grid is not remounted and
-   * the data already on screen stays visible, dimmed, until the new result
-   * arrives. A widget with nothing to keep shows its skeleton as usual.
+   * Changes when the host wants widgets to refetch with the same filters. The
+   * grid is not remounted: metric and chart items re-run `fetchData` in place,
+   * keeping what is on screen visible but dimmed until the result arrives. A
+   * collection item instead re-creates its data source, which owns the fetch,
+   * so its page, sort and selection reset.
    */
   dataKey?: string
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -220,6 +220,47 @@ export type DashboardChartConfig =
   | ScatterChartConfig
 
 // ---------------------------------------------------------------------------
+// Trends — a comparison the host computed, rendered verbatim by every widget
+// ---------------------------------------------------------------------------
+
+/**
+ * A trend the host computed itself, for a change that is not a percentage of
+ * `previousValue` — percentage points, a target comparison, a rounding.
+ */
+export interface DashboardMetricTrend {
+  /** `flat` renders neutrally, without an arrow. */
+  direction: "up" | "down" | "flat"
+  /** Rendered verbatim ("+1.2 pp"); empty falls back to `previousValue`. */
+  label: string
+}
+
+/**
+ * Per-category comparison for a chart whose categories are things rather than
+ * moments — bar, pie, funnel. Time series show their baseline as a faded
+ * series instead (see {@link BarChartConfig.comparisonSeriesNames}) and read
+ * their overall direction off {@link DashboardChartData.trend}.
+ */
+export interface DashboardCategoryComparison {
+  /** Keyed by the category label, as it appears in `categories` or a point's `name`. */
+  byCategory: Record<string, DashboardMetricTrend>
+  /** Categories the compared period did not have. Marked as new. */
+  added?: string[]
+  /**
+   * Categories the compared period had and this one does not. They have no
+   * mark to carry — nothing draws them — so the widget names them in a caption
+   * under the chart.
+   */
+  removed?: string[]
+}
+
+/**
+ * Per-row trends for a collection item, keyed the way the collection itself
+ * identifies rows: its source's `idProvider` when it has one, otherwise the
+ * record's `id`. Returned by the source's `fetchData` alongside `records`.
+ */
+export type DashboardRowTrends = Record<string, DashboardMetricTrend>
+
+// ---------------------------------------------------------------------------
 // Chart data — the shape returned by a chart item's fetchData
 // ---------------------------------------------------------------------------
 
@@ -248,6 +289,15 @@ export interface DashboardChartData {
    * can never confuse it with a bar/line series array or the heatmap grid.
    */
   scatterSeries?: F0DataChartScatterSeries[]
+  /**
+   * How the chart as a whole compares to the compared period. Rendered as a
+   * badge beside the widget title, the same one a metric shows.
+   */
+  trend?: DashboardMetricTrend
+  /** What `trend` compares against, e.g. "vs previous month". Tooltip + screen reader. */
+  comparisonLabel?: string
+  /** Per-category comparison, drawn into the category labels of bar/pie/funnel charts. */
+  categoryComparison?: DashboardCategoryComparison
 }
 
 // ---------------------------------------------------------------------------
@@ -344,17 +394,6 @@ export type MetricFormat =
   | { type: "percent" }
   | { type: "custom"; suffix?: string; prefix?: string }
 
-/**
- * A trend the host computed itself, for a change that is not a percentage of
- * `previousValue` — percentage points, a target comparison, a rounding.
- */
-export interface DashboardMetricTrend {
-  /** `flat` renders neutrally, without an arrow. */
-  direction: "up" | "down" | "flat"
-  /** Rendered verbatim ("+1.2 pp"); empty falls back to `previousValue`. */
-  label: string
-}
-
 /** Data returned by a metric item's fetchData */
 export interface DashboardMetricData {
   /** The main numeric value displayed in large text */
@@ -413,6 +452,10 @@ export interface DashboardCollectionItem<
    * Called whenever dashboard filters change.
    * The returned definition should NOT include its own filters/presets
    * (the dashboard provides those globally).
+   *
+   * Its `dataAdapter.fetchData` may return {@link DashboardRowTrends} as
+   * `rowTrends` alongside `records`; the widget then appends a "Change" column
+   * rendering each row's trend.
    */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   createSource: (filters: FiltersState<Filters>) => any

--- a/packages/react/src/ui/value-display/types/delta/delta.test.tsx
+++ b/packages/react/src/ui/value-display/types/delta/delta.test.tsx
@@ -1,0 +1,44 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { DeltaCell, type DeltaCellValue } from "./delta"
+
+const cell = (value: DeltaCellValue) => render(DeltaCell(value)).container
+
+describe("DeltaCell", () => {
+  it("takes its arrow from the status", () => {
+    expect(
+      cell({ label: "10%", deltaStatus: "positive" }).querySelector("svg")
+    ).toHaveClass("text-f1-icon-positive")
+    expect(
+      cell({ label: "10%", deltaStatus: "negative" }).querySelector("svg")
+    ).toHaveClass("text-f1-icon-critical")
+  })
+
+  it("keeps the colour on the status when an arrow overrides it", () => {
+    const positive = cell({
+      label: "−1.2 pp",
+      deltaStatus: "positive",
+      arrow: "down",
+    })
+    const down = cell({ label: "10%", deltaStatus: "negative" })
+
+    expect(positive.querySelector("svg")).toHaveClass("text-f1-icon-positive")
+    expect(positive.querySelector("svg")!.innerHTML).toBe(
+      down.querySelector("svg")!.innerHTML
+    )
+  })
+
+  it("draws no arrow for a neutral status, nor for an explicit none", () => {
+    expect(
+      cell({ label: "0", deltaStatus: "neutral" }).querySelector("svg")
+    ).toBeNull()
+    expect(
+      cell({
+        label: "0",
+        deltaStatus: "positive",
+        arrow: "none",
+      }).querySelector("svg")
+    ).toBeNull()
+  })
+})

--- a/packages/react/src/ui/value-display/types/delta/delta.tsx
+++ b/packages/react/src/ui/value-display/types/delta/delta.tsx
@@ -3,31 +3,47 @@
  * Used for displaying changes or differences in data collections.
  */
 import { ArrowDown, ArrowUp } from "@/icons/app"
-import { F0Icon, type IconType } from "@/components/F0Icon"
+import { F0Icon } from "@/components/F0Icon"
 
-type DeltaStatus = "positive" | "negative"
+type DeltaStatus = "positive" | "negative" | "neutral"
 
 interface DeltaValue {
   label: string
   deltaStatus: DeltaStatus
+  /**
+   * The arrow to draw. Defaults to the one the status implies; pass it when
+   * the sign of the change and how it reads disagree — a falling number that
+   * is good news is a down arrow in positive green.
+   */
+  arrow?: "up" | "down" | "none"
 }
 export type DeltaCellValue = DeltaValue
 
-const iconMap: Record<DeltaStatus, IconType> = {
-  positive: ArrowUp,
-  negative: ArrowDown,
-}
+const arrowByStatus = {
+  positive: "up",
+  negative: "down",
+  neutral: "none",
+} as const
+
+const iconByArrow = {
+  up: ArrowUp,
+  down: ArrowDown,
+  none: undefined,
+} as const
+
+const colorByStatus = {
+  positive: "positive",
+  negative: "critical",
+  neutral: "secondary",
+} as const
 
 export const DeltaCell = (args: DeltaCellValue) => {
   const { deltaStatus: status } = args
-  const icon = iconMap[status]
+  const icon = iconByArrow[args.arrow ?? arrowByStatus[status]]
 
   return (
     <div className="flex items-center gap-1 pt-0.5">
-      <F0Icon
-        icon={icon}
-        color={status == "positive" ? "positive" : "critical"}
-      />
+      {icon && <F0Icon icon={icon} color={colorByStatus[status]} />}
       <span className="text-f1-foreground font-normal">{args.label}</span>
     </div>
   )


### PR DESCRIPTION
## What

Additive props on `F0AnalyticsDashboard` so a host can show period-over-period comparisons without remounting the grid. Consumer: Factorial's semantic dashboards (factorialco/factorial#112487). Every prop is optional and inert when absent.

## Props

- **`dataKey?: string`** on `F0AnalyticsDashboardProps`. When it changes, metric and chart items re-run `fetchData` with the same filters, in place: the previous result stays on screen at reduced opacity with `aria-busy`, and the new data swaps in. A filter change still shows the skeleton exactly as before; a first fetch with nothing to keep also shows the skeleton. Collection items re-create their data source instead, because the source owns the fetch, so their table state resets. Threaded as a prop, never as a React `key`, so no subtree identity changes. `useDashboardItemData` exposes the new `isRefreshing` state next to `isLoading`.
- **`navigationActions?: ReactNode`** rendered left of the navigation filters in the header row (a comparison picker beside the date pill).
- **`DashboardMetricData.trend?: { direction: 'up' | 'down' | 'flat'; label: string }`** and **`comparisonLabel?: string`**. `MetricItem` prefers a host-computed trend over its `previousValue` arithmetic and renders the label verbatim ("+1.2 pp", "−12.5%"); `flat` renders a neutral indicator; `comparisonLabel` becomes a tooltip on the badge and part of the `sr-only` text. Existing `previousValue` behaviour is unchanged when `trend` is absent.
- **`comparisonSeriesNames?: string[]`** on bar and line chart configs: named series render muted (colour at ~45% alpha, dashed for lines), so bars, dots, area fill and the legend dot fade together with no opacity plumbing and no change to the shared legend builder. Implemented as a post-process over the built chart props so the canonical-conversion path cannot drop it; the F0DataChart series types gain `muted?: boolean`. Names are matched after transforms, so a renamed or collapsed series is simply not muted.
- **Higher / lower / equal on every widget, not only metrics.** The same host-computed trend contract extends to charts and collections, rendered by one shared `TrendBadge`:
  - `DashboardChartData.trend` + `comparisonLabel` → a badge beside the chart title (the chart's overall direction; for time series this is what the faded previous series cannot say at a glance).
  - `DashboardChartData.categoryComparison { byCategory, added?, removed? }` on bar, pie and funnel charts. Labels stay clean; the per-category change lives in three places that scale to template-sized data: the tooltip (a coloured "+12 (+14.3%) · Previous: 84" row, "New this period" for added categories), a header chip beside the badge ("8 up · 4 down · 2 new · 1 gone", hover lists the names), and a "Show change" entry in the widget menu that swaps the chart for a diverging delta view sorted by magnitude, gains right and losses left, sentiment-coloured, new categories pinned first and gone ones last, ten rows plus "+N more". The change view needs `DashboardMetricTrend.delta?: number`; without it, it degrades to a ranked list of badges. The tooltip row is a typed kit prop, `F0DataChart*Props.categoryComparison`, so any consumer of the chart kit can use it.
  - Collections: `DashboardCollectionItem.rowTrends` (host-provided, keyed the way the collection's source identifies rows) → a "Change" column with the same badge per row, joined at render. Absent `rowTrends`, no column. Charts carry trends in their data because `fetchData` owns it; collections carry them on the item because the source owns theirs.
  - Marks are presentational only: the labels handed to Ask-AI quotes and export stay plain.
  - `DashboardCollectionItem.rowTrendsSorting` names a sorting the item's source declares; the Change column becomes sortable only then, so a client-joined column never pretends to sort server pages.
- **Sentiment, not sign, decides the colour.** `DashboardMetricTrend.sentiment?: 'positive' | 'negative' | 'neutral'`: when present it colours the badge (and the collection delta cell) while `direction` keeps the arrow, so attrition falling is a green down-arrow. Absent, colour follows direction exactly as before. The shared `delta` value display gains a `neutral` status and an optional `arrow` override with the old defaults.
- **Export**: a "Change" column from `trend.label`, after "Previous Value", for metrics that report one, and the collection Change column like any other column.
- **`ChatDashboardConfig.compareTo?`** (`'none' | 'previous_period' | 'previous_week' | 'previous_month' | 'previous_quarter' | 'previous_half_year' | 'previous_year'`) so agent-authored dashboards can express a comparison; the host decides how to honour it.

## Story

`AnalyticsDashboard / Period Comparison`: a comparison picker as `navigationActions` driving `dataKey`, three metrics with trend labels and comparison tooltips (including a flat one), a line chart and a bar chart with a muted "Previous period" series, 400 ms fake latency so the in-place refresh is visible.

`AnalyticsDashboard / Period Comparison Deltas`: template-sized data on purpose. A bar chart of sixteen long-named departments with two new and one gone, an eight-slice pie, and a twelve-row table; header badges and chips everywhere, tooltip comparison rows, the Change column, and the "Show change" toggle exercised by the play function.

## Verification

```
pnpm tsc            # clean
pnpm lint           # 0 warnings, 0 errors
pnpm format:check   # clean
pnpm vitest:ci      # 602 files passed, 7575 tests passed
pnpm build          # ok
pnpm check:untranslated-copy   # no new untranslated copy (133, baseline 133)
```
New tests: grid node identity preserved and `fetchData` called twice on a `dataKey` change; previous value kept with `aria-busy` until resolve; no refetch without `dataKey`; a filter change still goes back to the skeleton; chart item refetches on `dataKey`; `navigationActions` render; trend precedence, flat rendering, computed-flat hidden, empty label falls back, sr-only text, tooltip; muted series faded colour + dash with the unmuted sibling asserted unchanged; `comparisonSeriesNames` never reaches `F0DataChartProps`; export Change column; collection item re-creates its source.

`kits/F0DataChart/utils/options.ts` is byte-identical to main: nothing shared changes for consumers who pass none of the new props. The chart-prop builders moved out of the 1.3k-line `ChartItem.tsx` into `chartProps.ts` as pure functions.

Pre-PR review gates: thermo-nuclear review (blockers on the opacity plumbing, the `dataKey` contract for collections and the trend shape fixed before opening), ponytail cuts applied, anti-slop clean.

Storybook interaction tests were not run locally (needs a built Storybook + Playwright); the new story's `play` asserts only text covered by unit tests.

## Status

Parked for design review. The engine side (factorialco/factorial#112486) and the Factorial dashboard wiring (#112487) ship independently of this PR and run against the pinned f0; the picker is hidden behind the `dev_one_analytics_comparison` flag until the presentation here is settled with design. Nothing in Factorial depends on this branch today. The two stories (`AnalyticsDashboard / Period Comparison` and `/ Period Comparison Deltas`) are the reference for that conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
