### PR TITLE
feat(F0DataChart): a target for a whole stacked bar

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -214,6 +214,60 @@ export const WithOverachievement: Story = {
   },
 }
 
+/**
+ * A goal measured by its sub-goals: each series is one sub-goal's contribution
+ * to the quarter, and `targets` is what the parent goal is measured against —
+ * one number per category, for the stack as a whole rather than any one series.
+ *
+ * The target is drawn as a column behind the bars and a little wider than them,
+ * so it stays readable once a stack has grown past it: Q2 clears the line, and
+ * where the line was is still there in the margin either side of the bar.
+ *
+ * Each sub-goal also has a target of its own, and `highlightOverachievement`
+ * marks a segment against that one: Expansion beat its 100k in both Q2 and Q3,
+ * so the part of it past that number is darker in each — including Q3, where
+ * the quarter as a whole is nowhere near the 300k the parent is measured by.
+ * Q4 has not started, and hovering its column reports the target it is
+ * measured against.
+ */
+export const StackedWithTargets: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Q1", "Q2", "Q3", "Q4"],
+    stacked: true,
+    series: [
+      {
+        name: "New logos",
+        data: [120_000, 130_000, 90_000, 0].map((value) => ({
+          value,
+          target: 150_000,
+        })),
+      },
+      {
+        name: "Expansion",
+        // Q2 and Q3 beat this sub-goal's own number even where the parent's is
+        // still out of reach.
+        data: [80_000, 140_000, 120_000, 0].map((value) => ({
+          value,
+          target: 100_000,
+        })),
+      },
+      {
+        name: "Renewals",
+        data: [40_000, 90_000, 45_000, 0].map((value) => ({
+          value,
+          target: 50_000,
+        })),
+      },
+    ],
+    targets: [300_000, 300_000, 300_000, 300_000],
+    highlightOverachievement: true,
+    showTargetProgress: true,
+    valueFormatter: (v) => `${v / 1000}k €`,
+  },
+}
+
 /** Multiple series stacked into a single bar per category. */
 export const Stacked: Story = {
   render: (args) => <F0DataChart {...args} />,

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -92,6 +92,12 @@ Renders a gradient fade from the bar top up to the target value. Hovering that g
 
 <Canvas of={BarStories.WithTargets} />
 
+### Stacked With Targets
+
+`targets` sets one target per category for the bar as a whole — the counterpart of a point's own `target` when the bar is a stack. The gap up to it is drawn over the whole stack in a neutral gradient, and with `highlightOverachievement` the part of the stack beyond the target is darkened, splitting whichever segment the target falls inside.
+
+<Canvas of={BarStories.StackedWithTargets} />
+
 ### Overachievement
 
 `highlightOverachievement` draws the stretch of a bar that passed its target in a darker shade of its own color, split at the target — otherwise a bar that beat its target looks like one that landed exactly on it. `showTargetProgress` adds `value / target` to the tooltip, under the target row.

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -2363,3 +2363,140 @@ describe("BarChart — target progress row", () => {
     expect(html).not.toContain("Infinity")
   })
 })
+
+describe("BarChart — a target for the whole stack", () => {
+  const base = {
+    type: "bar" as const,
+    stacked: true,
+    categories: ["Q1", "Q2"],
+    series: [
+      { name: "A", data: [60, 180] },
+      { name: "B", data: [40, 120] },
+    ],
+    // Q1 falls short of 200, Q2 reaches 300 against it.
+    targets: [200, 200],
+  }
+
+  function series() {
+    const call = setOptionMock.mock.calls.at(-1)
+    if (!call) throw new Error("setOption was never called")
+    return (
+      call[0] as {
+        series: {
+          name?: string
+          stack?: string
+          type?: string
+          z?: number
+          data: unknown[]
+        }[]
+      }
+    ).series
+  }
+
+  it("keeps every series in one stack and marks the target behind them", () => {
+    render(<F0DataChart {...base} />)
+
+    const drawn = series()
+    // Per-point targets split a stacked chart into a stack per series; a target
+    // for the stack must not — the parts still add up into one bar.
+    expect(drawn.slice(0, 2).map((s) => s.stack)).toEqual([
+      "stacked",
+      "stacked",
+    ])
+
+    // The column is drawn by hand, under the bars, at the full height of the
+    // target: what stays visible once a stack passes it is the margin around it.
+    const column = drawn.at(-1)
+    expect(column?.type).toBe("custom")
+    expect(column?.z).toBe(1)
+    expect(column?.data).toEqual([
+      [0, 200],
+      [1, 200],
+    ])
+    expect(drawn.slice(0, 2).every((s) => s.z === 3)).toBe(true)
+  })
+
+  it("leaves a category without a target alone", () => {
+    render(<F0DataChart {...base} targets={[200, null]} />)
+
+    // A zero draws nothing: `renderItem` returns no shape for it.
+    expect(series().at(-1)?.data).toEqual([
+      [0, 200],
+      [1, 0],
+    ])
+  })
+
+  it("says so and ignores them when the bars are not stacked", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    render(<F0DataChart {...base} stacked={false} />)
+
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("stacked"))
+    // No column: the last series drawn is still the last one configured.
+    expect(series().at(-1)?.name).toBe("B")
+    warn.mockRestore()
+  })
+
+  it("marks a segment against its own target, not the stack's", () => {
+    render(
+      <F0DataChart
+        {...base}
+        highlightOverachievement
+        series={[
+          // Short of its own 100, so nothing to mark.
+          { name: "A", data: [{ value: 60, target: 100 }, 180] },
+          // Past its own 100 by 20, in a stack that never reaches 200.
+          { name: "B", data: [{ value: 120, target: 100 }, 120] },
+        ]}
+        targets={[200, 200]}
+      />
+    )
+
+    const [first, second] = series()
+    const short = first?.data?.[0] as { itemStyle: { color?: unknown } }
+    const beat = second?.data?.[0] as { itemStyle: { color?: unknown } }
+    expect(short.itemStyle.color).toBeUndefined()
+    expect(beat.itemStyle.color).toBeDefined()
+
+    // 20 of its 120 sit past its target, so the gradient breaks at 1/6.
+    const split = linearGradientMock.mock.calls.find(
+      (args) => (args[4] as unknown[]).length === 4
+    )
+    const stops = split?.[4] as { offset: number }[]
+    expect(stops.map((s) => s.offset)).toEqual([0, 20 / 120, 20 / 120, 1])
+  })
+
+  it("leaves the stack alone when only the stack has a target", () => {
+    render(<F0DataChart {...base} highlightOverachievement />)
+
+    // Q2 stacks 180 + 120 well past the stack's 200, but no segment was given a
+    // number of its own to beat, so nothing is marked: the bar rising past the
+    // column already says the stack cleared it.
+    const [first, second] = series()
+    const a = first?.data?.[1] as { itemStyle: { color?: unknown } }
+    const b = second?.data?.[1] as { itemStyle: { color?: unknown } }
+    expect(a.itemStyle.color).toBeUndefined()
+    expect(b.itemStyle.color).toBeUndefined()
+  })
+
+  it("reports the stack against its target when the gradient is hovered", () => {
+    render(<F0DataChart {...base} showTargetProgress />)
+
+    const call = setOptionMock.mock.calls.at(-1)
+    if (!call) throw new Error("setOption was never called")
+    const formatter = (
+      call[0] as { tooltip?: { formatter?: (p: unknown) => string } }
+    ).tooltip?.formatter
+    const html = formatter?.({
+      seriesName: "__stack__ (target)",
+      name: "Q1",
+      value: 100,
+      dataIndex: 0,
+    })
+
+    // The card is the bar's, so it carries what the stack stands at — not the
+    // height of the gap ECharts reports for that item.
+    expect(html).toContain("100")
+    expect(html).toContain("200")
+    expect(html).toContain("50.0%")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -2478,6 +2478,41 @@ describe("BarChart — a target for the whole stack", () => {
     expect(b.itemStyle.color).toBeUndefined()
   })
 
+  it("puts the segment's own numbers before the stack's, and rules between", () => {
+    render(
+      <F0DataChart
+        {...base}
+        showTargetProgress
+        series={[
+          { name: "A", data: [{ value: 60, target: 50 }, 180] },
+          { name: "B", data: [{ value: 40, target: 50 }, 120] },
+        ]}
+      />
+    )
+
+    const call = setOptionMock.mock.calls.at(-1)
+    if (!call) throw new Error("setOption was never called")
+    const formatter = (
+      call[0] as { tooltip?: { formatter?: (p: unknown) => string } }
+    ).tooltip?.formatter
+    const html =
+      formatter?.({ seriesName: "A", name: "Q1", value: 60, dataIndex: 0 }) ??
+      ""
+
+    // How this segment did against its own target, then what it comes to inside
+    // the bar: reading them the other way round invites taking one subject's
+    // percentage for the other's.
+    const order = ["50", "120.0%", "100", "60.0%"].map((text) =>
+      html.indexOf(text)
+    )
+    expect(order.every((i) => i >= 0)).toBe(true)
+    expect([...order].sort((a, b) => a - b)).toEqual(order)
+
+    // The rule sits on the first row of the second group, not anywhere else.
+    expect(html.match(/border-top/g)).toHaveLength(1)
+    expect(html.indexOf("border-top")).toBeGreaterThan(html.indexOf("120.0%"))
+  })
+
   it("reports the stack against its target when the gradient is hovered", () => {
     render(<F0DataChart {...base} showTargetProgress />)
 

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -1564,18 +1564,11 @@ export function useBarChartOptions(
               title: seriesName,
               subtitle: String(p.name ?? ""),
               value: formatTooltipValue(value),
+              // Two subjects, in this order: how the hovered mark did against
+              // the target it was set, then what it amounts to inside the bar
+              // it sits in. The rule between them keeps the reader from taking
+              // a percentage for the other subject's.
               rows: [
-                showTotal &&
-                  total !== 0 && {
-                    // Same sign on both sides, so the ratio is positive even
-                    // when the whole category is negative.
-                    value: `${((value / total) * 100).toFixed(1)}%`,
-                    label: i18n.dataChart.tooltip.ofTotal,
-                  },
-                showTotal && {
-                  value: formatTooltipValue(total),
-                  label: i18n.dataChart.tooltip.total,
-                },
                 target !== undefined && {
                   value: formatTooltipValue(target),
                   label: i18n.dataChart.tooltip.target,
@@ -1587,6 +1580,18 @@ export function useBarChartOptions(
                     // against the stack's, what counts is the whole stack.
                     value: `${(((ownTarget !== undefined ? value : (heights?.[dataIndex] ?? value)) / target) * 100).toFixed(1)}%`,
                     label: i18n.dataChart.tooltip.ofTarget,
+                  },
+                showTotal && {
+                  value: formatTooltipValue(total),
+                  label: i18n.dataChart.tooltip.total,
+                  separator: target !== undefined,
+                },
+                showTotal &&
+                  total !== 0 && {
+                    // Same sign on both sides, so the ratio is positive even
+                    // when the whole category is negative.
+                    value: `${((value / total) * 100).toFixed(1)}%`,
+                    label: i18n.dataChart.tooltip.ofTotal,
                   },
               ],
             },

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../types"
 
 import {
+  chartColorAlpha,
   darkenChartColor,
   paletteColor,
   resolveChartColorToken,
@@ -86,6 +87,9 @@ const STACK_GAP_BORDER_WIDTH = 0.5
  * and the tooltip resolves it back to the bar it belongs to.
  */
 const TARGET_SERIES_SUFFIX = " (target)"
+
+/** Opacity the target gradient starts from, at its far end from the bar. */
+const GHOST_ALPHA = 0.2
 
 /** Opacity of the series that are *not* hovered, while one series has focus. */
 const BLUR_OPACITY = 0.4
@@ -225,13 +229,11 @@ function resolveColor(series: F0DataChartBarSeries, index: number): string {
  */
 function overachievementFill(
   color: string,
-  value: number,
-  target: number,
+  darkShare: number,
   isVertical: boolean
 ): echarts.graphic.LinearGradient {
   // Offset 0 is the far end from the axis (top of a column, right of a row),
   // so the darker stretch runs from there down to the target.
-  const split = (value - target) / value
   const darker = darkenChartColor(color)
   return new echarts.graphic.LinearGradient(
     ...(isVertical
@@ -239,8 +241,8 @@ function overachievementFill(
       : ([1, 0, 0, 0] as [number, number, number, number])),
     [
       { offset: 0, color: darker },
-      { offset: split, color: darker },
-      { offset: split, color },
+      { offset: darkShare, color: darker },
+      { offset: darkShare, color },
       { offset: 1, color },
     ]
   )
@@ -260,6 +262,74 @@ function overachievesTarget(
   return target
 }
 
+/**
+ * How much of a category band a bar occupies — ECharts' default, its 20%
+ * `barCategoryGap` taken off. Read here to size the target column against the
+ * bars it frames.
+ */
+const DEFAULT_BAR_SHARE = 0.8
+
+/**
+ * Margin (px) the target column keeps either side of the bar it frames.
+ *
+ * The column is what says where the target was, so it has to survive the stack
+ * growing past it: drawn at the bar's own width it would be covered exactly,
+ * and a target once cleared would leave no trace of where it had been.
+ */
+const STACK_TARGET_MARGIN = 4
+
+/** Name of the internal series marking a stack's target. */
+const STACK_TARGET_SERIES = `__stack__${TARGET_SERIES_SUFFIX}`
+
+/**
+ * Per-category targets for the bar as a whole, or `undefined` when the chart
+ * has none to draw. Only stacked charts have a single bar per category to
+ * measure, so a grouped one is told rather than guessed at.
+ */
+function resolveStackTargets(
+  targets: (number | null)[] | undefined,
+  stacked: boolean,
+  categoryCount: number
+): (number | undefined)[] | undefined {
+  if (!targets?.some((t) => t !== null && t !== undefined)) return undefined
+  if (!stacked) {
+    console.warn(
+      "F0DataChart: `targets` measures a whole stacked bar and is ignored on a grouped chart. Set `stacked`, or give each point its own `target`."
+    )
+    return undefined
+  }
+  return Array.from({ length: categoryCount }, (_, i) => {
+    const target = targets[i]
+    return target === null || target === undefined ? undefined : target
+  })
+}
+
+/**
+ * The positive height of each stack, category by category — what a stack target
+ * is measured against. Negatives grow the other way and are left out, matching
+ * how the value axis sizes the bar.
+ */
+function stackHeights(
+  series: F0DataChartBarSeries[],
+  categoryCount: number
+): number[] {
+  return Array.from({ length: categoryCount }, (_, dataIndex) =>
+    series.reduce((height, s) => {
+      const point = s.data[dataIndex]
+      const value = point === undefined ? 0 : getValue(point)
+      return value > 0 ? height + value : height
+    }, 0)
+  )
+}
+
+/**
+ * Fill for a segment of a stack that has run past the stack's target: the part
+ * of it above the target in a darker shade, split where the target falls.
+ *
+ * A stack crosses its target inside whichever segment happens to span it, so
+ * this walks the stack from the axis outwards and hands each segment the share
+ * of itself that sits beyond the line — none, part, or all of it.
+ */
 /** Check whether a series contains any target values */
 function hasTargets(series: F0DataChartBarSeries): boolean {
   return series.data.some(
@@ -522,6 +592,7 @@ function buildSeriesEntries(
   showLabels: boolean,
   stacked: boolean,
   highlightOverachievement: boolean,
+  stackTargeted: boolean,
   labelColor: string,
   stackGapColor: string,
   labelFontSize: number,
@@ -530,9 +601,11 @@ function buildSeriesEntries(
   valueFormatter?: (value: number) => string
 ): echarts.BarSeriesOption[] {
   const color = resolveColor(series, index)
-  const hasTargetData = hasTargets(series)
-  // When stacked, all series share "stacked"; when using targets, each series
-  // gets its own stack so the ghost bar stacks on its own solid bar only
+  // A target that belongs to the whole stack is drawn once, over the top of it,
+  // so the series keep sharing one stack and none of them grows a ghost of its
+  // own. Per-point targets are the other way round: each needs its own stack for
+  // its ghost to sit on its own bar.
+  const hasTargetData = !stackTargeted && hasTargets(series)
   const stackId = stacked
     ? hasTargetData
       ? `stacked-${index}`
@@ -547,18 +620,20 @@ function buildSeriesEntries(
     const value = getValue(point)
     const pointColor = getPointColor(point)
     const pointBorderRadius = resolveBorderRadius?.(index, dataIndex, value)
+    // A segment carries its own target inside a stack: the sub-goal that beat
+    // its number is marked whether or not the stack has reached the one it is
+    // all adding up to.
     const passedTarget = highlightOverachievement
       ? overachievesTarget(point)
       : undefined
+    const darkShare =
+      passedTarget === undefined ? undefined : (value - passedTarget) / value
     const fill =
-      passedTarget === undefined
+      darkShare === undefined
         ? pointColor
-        : overachievementFill(
-            pointColor ?? color,
-            value,
-            passedTarget,
-            isVertical
-          )
+        : darkShare >= 1
+          ? darkenChartColor(pointColor ?? color)
+          : overachievementFill(pointColor ?? color, darkShare, isVertical)
     if (fill === undefined && pointBorderRadius === undefined) {
       return value
     }
@@ -663,8 +738,8 @@ function buildSeriesEntries(
               ? ([0, 0, 0, 1] as [number, number, number, number])
               : ([1, 0, 0, 0] as [number, number, number, number])),
             [
-              { offset: 0, color: `${pointColor}33` },
-              { offset: 1, color: `${pointColor}00` },
+              { offset: 0, color: chartColorAlpha(pointColor, GHOST_ALPHA) },
+              { offset: 1, color: chartColorAlpha(pointColor, 0) },
             ]
           ),
           borderRadius,
@@ -693,9 +768,9 @@ function buildSeriesEntries(
           : ([1, 0, 0, 0] as [number, number, number, number])),
         [
           // offset 0 = far end from the solid bar → more opaque (darker)
-          { offset: 0, color: `${color}33` },
+          { offset: 0, color: chartColorAlpha(color, GHOST_ALPHA) },
           // offset 1 = near the solid bar → transparent
-          { offset: 1, color: `${color}00` },
+          { offset: 1, color: chartColorAlpha(color, 0) },
         ]
       ),
       // Only round the far end (away from the solid bar)
@@ -721,6 +796,79 @@ function buildSeriesEntries(
 }
 
 /**
+ * The gradient topping each stack up to its target, drawn as one internal
+ * series over the whole stack rather than one per series: the target belongs to
+ * the category, and only the outermost segment has an edge to fade from.
+ *
+ * Neutral rather than a series colour. On a single bar the gap continues the bar
+ * it tops, so wearing its colour reads as "the rest of this"; a stack is several
+ * things at once, and borrowing the topmost one's colour would credit the gap to
+ * whichever series happened to be last — a quarter with nothing attained would
+ * be a column in one sub-goal's colour.
+ */
+function buildStackTargetSeries(
+  stackTargets: (number | undefined)[],
+  color: string,
+  isVertical: boolean
+): echarts.CustomSeriesOption {
+  const fill = new echarts.graphic.LinearGradient(
+    ...(isVertical
+      ? ([0, 0, 0, 1] as [number, number, number, number])
+      : ([1, 0, 0, 0] as [number, number, number, number])),
+    [
+      { offset: 0, color: chartColorAlpha(color, GHOST_ALPHA) },
+      { offset: 1, color: chartColorAlpha(color, 0) },
+    ]
+  )
+  const radius = BAR_CORNER_RADIUS
+
+  return {
+    name: STACK_TARGET_SERIES,
+    type: "custom",
+    // Under the bars, and out of the legend: it marks the line they are measured
+    // against rather than adding a quantity of its own.
+    z: 1,
+    legendHoverLink: false,
+    data: stackTargets.map((target, dataIndex) => [dataIndex, target ?? 0]),
+    renderItem: (_params, api) => {
+      const dataIndex = Number(api.value(0))
+      const target = Number(api.value(1))
+      if (!Number.isFinite(target) || target <= 0) return
+      const [x, y] = api.coord([dataIndex, target])
+      const [zeroX, zeroY] = api.coord([dataIndex, 0])
+      // A category step in pixels: the bars take 80% of it (ECharts' default
+      // category gap), and the target column takes that plus its margin.
+      const band = api.size?.([1, 0]) as number[] | undefined
+      const step = isVertical ? (band?.[0] ?? 0) : (band?.[1] ?? 0)
+      const thickness = step * DEFAULT_BAR_SHARE + STACK_TARGET_MARGIN * 2
+      return isVertical
+        ? {
+            type: "rect",
+            shape: {
+              x: x - thickness / 2,
+              y,
+              width: thickness,
+              height: zeroY - y,
+              r: [radius, radius, 0, 0],
+            },
+            style: { fill },
+          }
+        : {
+            type: "rect",
+            shape: {
+              x: zeroX,
+              y: y - thickness / 2,
+              width: x - zeroX,
+              height: thickness,
+              r: [0, radius, radius, 0],
+            },
+            style: { fill },
+          }
+    },
+  }
+}
+
+/**
  * Slack left beyond the longest bar when the value axis maximum comes from the
  * data. Enough that the bar doesn't read as jammed against its own label; small
  * enough that the plot isn't paying for empty space.
@@ -737,9 +885,10 @@ const VALUE_AXIS_HEADROOM = 1.05
  * end, so their extent is the sum — but only of the parts pointing the same way:
  * ECharts stacks each sign away from zero independently, so a category of +100,
  * +100, -150 reaches +200 and a signed sum would pin the axis at 52.5 and clip
- * most of the positive stack. (A stacked chart that also carries targets splits
- * into one stack per series, which makes the sum an over-estimate — the safe
- * direction, since it only leaves slack rather than clipping a bar.)
+ * most of the positive stack. (Per-point targets split a stacked chart into one
+ * stack per series, which makes the sum an over-estimate — the safe direction,
+ * since it only leaves slack rather than clipping a bar. A target for the whole
+ * stack is drawn on top of it, so it enters the running maximum directly.)
  *
  * Negative-only data returns `undefined`: the maximum is not the far end of
  * anything there, and pinning it would squash the axis against zero. The
@@ -748,7 +897,8 @@ const VALUE_AXIS_HEADROOM = 1.05
 function dataValueAxisMax(
   series: F0DataChartBarSeries[],
   stacked: boolean,
-  categoryCount: number
+  categoryCount: number,
+  stackTargets?: (number | undefined)[]
 ): number | undefined {
   const pointExtent = (point: F0DataChartBarDataPoint): number => {
     const value = getValue(point)
@@ -758,6 +908,8 @@ function dataValueAxisMax(
 
   let widest = 0
   for (let dataIndex = 0; dataIndex < categoryCount; dataIndex++) {
+    const stackTarget = stackTargets?.[dataIndex]
+    if (stackTarget !== undefined) widest = Math.max(widest, stackTarget)
     // Positive and negative parts of a stack grow away from zero in opposite
     // directions rather than cancelling, so they accumulate separately: a
     // category of +100, +100, -150 reaches +200 on the axis, not the +50 a
@@ -917,6 +1069,7 @@ export function useBarChartOptions(
     series,
     orientation = "vertical",
     stacked = false,
+    targets,
     highlightOverachievement = false,
     showTargetProgress = false,
     showLegend = true,
@@ -986,12 +1139,27 @@ export function useBarChartOptions(
     const labelsReplaceValueAxis = !isVertical && showLabels
     const showValueAxis = responsive.showValueAxis && !labelsReplaceValueAxis
 
+    // A target for the whole stack: resolved once, then read by the fill, the
+    // ghost on top, the value axis and the tooltip.
+    const stackTargets = resolveStackTargets(
+      targets,
+      stacked,
+      categories.length
+    )
+    const heights = stackTargets
+      ? stackHeights(visibleSeries, categories.length)
+      : undefined
     // The same call, applied to the axis extent: ECharts rounds its maximum up to
     // a nice number, which is worth the whitespace only while someone can read
     // the ticks it lands on. With them hidden, a 106 max rounded to 150 spends a
     // third of the plot labelling nothing, so take the extent from the data.
     const valueAxisMax = labelsReplaceValueAxis
-      ? dataValueAxisMax(visibleSeries, stacked, categories.length)
+      ? dataValueAxisMax(
+          visibleSeries,
+          stacked,
+          categories.length,
+          stackTargets
+        )
       : undefined
 
     // Horizontal rows carry their category names along the side, where the axis
@@ -1083,7 +1251,10 @@ export function useBarChartOptions(
     }
 
     // Build all ECharts series (including target ghost bars)
-    const echartsSeries = series.flatMap((s, i) =>
+    const echartsSeries: (
+      | echarts.BarSeriesOption
+      | echarts.CustomSeriesOption
+    )[] = series.flatMap((s, i) =>
       buildSeriesEntries(
         s,
         i,
@@ -1091,6 +1262,7 @@ export function useBarChartOptions(
         showLabels,
         stacked,
         highlightOverachievement,
+        stackTargets !== undefined,
         theme.colors.foregroundSecondary,
         theme.colors.containerBackground ?? theme.colors.background,
         resolvedLabelFontSize,
@@ -1133,6 +1305,21 @@ export function useBarChartOptions(
       for (const entry of echartsSeries) {
         Object.assign(entry, gaps)
       }
+    }
+
+    // The target column is drawn by hand rather than as another bar: ECharts
+    // lays bar series out side by side within the category band, and a column
+    // that has to be wider than the bars it frames — and behind them — is not a
+    // position in that row.
+    if (stackTargets) {
+      for (const entry of echartsSeries) entry.z = 3
+      echartsSeries.push(
+        buildStackTargetSeries(
+          stackTargets,
+          theme.colors.foregroundTertiary,
+          isVertical
+        )
+      )
     }
 
     // Legend should only show the main series (not the target ghost bars)
@@ -1291,6 +1478,31 @@ export function useBarChartOptions(
           const dataIndex = p.dataIndex ?? 0
           // Hovering the gradient reads as hovering the bar it tops, so the card
           // is the bar's: its own name, its own value — not the gap's height.
+          const overStackTarget = hovered === STACK_TARGET_SERIES
+          if (overStackTarget) {
+            const stackTarget = stackTargets?.[dataIndex]
+            const height = heights?.[dataIndex] ?? 0
+            if (stackTarget === undefined) return ""
+            return renderValueTooltip(
+              {
+                subtitle: String(p.name ?? ""),
+                value: formatTooltipValue(height),
+                rows: [
+                  {
+                    value: formatTooltipValue(stackTarget),
+                    label: i18n.dataChart.tooltip.target,
+                  },
+                  showTargetProgress &&
+                    stackTarget !== 0 && {
+                      value: `${((height / stackTarget) * 100).toFixed(1)}%`,
+                      label: i18n.dataChart.tooltip.ofTarget,
+                    },
+                ],
+              },
+              theme
+            )
+          }
+
           const overTarget = hovered.endsWith(TARGET_SERIES_SUFFIX)
           const seriesName = overTarget
             ? hovered.slice(0, -TARGET_SERIES_SUFFIX.length)
@@ -1304,7 +1516,11 @@ export function useBarChartOptions(
           const marker = overTarget
             ? renderMarker(seriesColors.get(seriesName) ?? "")
             : p.marker
-          const target = targetMap.get(seriesName)?.[dataIndex]
+          // A segment with a target of its own is measured against it; one
+          // without falls back to the target the whole stack is working towards.
+          const ownTarget = targetMap.get(seriesName)?.[dataIndex]
+          const stackTarget = stackTargets?.[dataIndex]
+          const target = ownTarget ?? stackTarget
           // Only a stack has a total this component can be sure of: its
           // segments are parts of the very bar being hovered. Grouped bars
           // sometimes add up to something real — male and female headcount
@@ -1367,7 +1583,9 @@ export function useBarChartOptions(
                 showTargetProgress &&
                   target !== undefined &&
                   target !== 0 && {
-                    value: `${((value / target) * 100).toFixed(1)}%`,
+                    // Against its own target the segment answers for itself;
+                    // against the stack's, what counts is the whole stack.
+                    value: `${(((ownTarget !== undefined ? value : (heights?.[dataIndex] ?? value)) / target) * 100).toFixed(1)}%`,
                     label: i18n.dataChart.tooltip.ofTarget,
                   },
               ],
@@ -1458,6 +1676,7 @@ export function useBarChartOptions(
     series,
     orientation,
     stacked,
+    targets,
     highlightOverachievement,
     showTargetProgress,
     showLegend,

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -234,6 +234,24 @@ export interface F0DataChartBarProps extends F0DataChartBaseProps {
   /** Stack all series into a single bar per category. @default false */
   stacked?: boolean
   /**
+   * One target per category, for the bar as a whole — the counterpart of a data
+   * point's own `target` when the bar is a stack of several series.
+   *
+   * A stacked bar answers "how much did all of this add up to", and a target
+   * for it belongs to the category, not to any one series: the parts of a goal
+   * measured by its sub-goals are each a series, and the number they are all
+   * working towards is one.
+   *
+   * Drawn as a faded column behind the bars and a little wider than them, so a
+   * stack that has grown past its target still shows where the target was — in
+   * the margin either side of it.
+   *
+   * Only read on a stacked chart — a grouped category has several bars and no
+   * single one to measure. `null` leaves a category without a target.
+   * @default undefined
+   */
+  targets?: (number | null)[]
+  /**
    * Draw the stretch of a bar that ran past its `target` in a darker shade of
    * the bar's own colour, split at the target.
    *
@@ -242,6 +260,12 @@ export interface F0DataChartBarProps extends F0DataChartBaseProps {
    * it — the reader has to eye its height against the ghosts beside it. Turn it
    * on wherever passing the target is itself the news: attainment against a
    * quota, a goal, a budget.
+   *
+   * On a stacked chart this marks each segment against the target on its own
+   * data point, not against {@link F0DataChartBarProps.targets}: a sub-goal that
+   * beat its own number is worth seeing whether or not the stack it belongs to
+   * has reached the one they all add up to. That the stack cleared its own
+   * target is already visible without colour, in the bar rising past the column.
    *
    * Ignored by points with no target, and by negative values — "past the
    * target" has no single reading when the bar grows downwards.

--- a/packages/react/src/kits/F0DataChart/utils/colors.ts
+++ b/packages/react/src/kits/F0DataChart/utils/colors.ts
@@ -127,6 +127,17 @@ export function paletteColor(index: number): string {
  */
 const DARKEN_AMOUNT = 0.12
 
+/**
+ * The same color at a given alpha, as hex ECharts can parse.
+ *
+ * Concatenating `"33"` onto a color string only works while every color is a
+ * 6-digit hex; theme colors are not — several already carry an alpha channel,
+ * and `#011b4b73` + `33` is not a color at all.
+ */
+export function chartColorAlpha(color: string, alpha: number): string {
+  return colord(color).alpha(alpha).toHex()
+}
+
 /** Darker variant of a hex color, for the part of a mark that passed its target */
 export function darkenChartColor(color: string): string {
   return colord(color).darken(DARKEN_AMOUNT).toHex()

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -489,6 +489,14 @@ export interface ValueTooltipRow {
    * point is two coordinates, neither subordinate to the other.
    */
   size?: "large"
+  /**
+   * Draw a rule above this row, splitting the list where it changes subject.
+   *
+   * A stacked segment's card answers two questions at once — how this part did
+   * against its own target, and what it contributes to the bar it sits in — and
+   * read as one run of numbers the two blur into each other.
+   */
+  separator?: boolean
 }
 
 export interface ValueTooltipContent {
@@ -524,14 +532,17 @@ export function renderValueTooltip(
   const renderRow = (row: ValueTooltipRow): string => {
     const color = row.color ?? theme.colors.foreground
     const marker = String(row.marker ?? "")
+    const rule = row.separator
+      ? `border-top: 1px solid ${theme.colors.borderSecondary}; margin-top: 6px; padding-top: 6px`
+      : ""
 
     if (row.size === "large") {
       // Label sits under its value rather than beside it: with two stacked
       // large rows, trailing labels would leave the numbers ragged.
-      return `<div style="margin-top: 6px">${marker}<div style="${headline}; color: ${color}">${escapeTooltipText(row.value)}</div><div style="${secondary}">${escapeTooltipText(row.label)}</div></div>`
+      return `<div style="margin-top: 6px; ${rule}">${marker}<div style="${headline}; color: ${color}">${escapeTooltipText(row.value)}</div><div style="${secondary}">${escapeTooltipText(row.label)}</div></div>`
     }
 
-    return `<div style="${secondary}">${marker}<strong style="color: ${color}">${escapeTooltipText(row.value)}</strong> ${escapeTooltipText(row.label)}</div>`
+    return `<div style="${secondary}; ${rule}">${marker}<strong style="color: ${color}">${escapeTooltipText(row.value)}</strong> ${escapeTooltipText(row.label)}</div>`
   }
 
   const html = [


### PR DESCRIPTION
## Description

A stacked bar answers "how much did all of this add up to", and the number it is working towards belongs to the category rather than to any one series. In our use case, a goal measured by its sub-goals is exactly that shape: each sub-goal is a series, and the quarter has one target they are all adding up to.

There was no way to say so. Setting a per-point `target` on a stacked chart silently split the stack into one column per series — misleading rather than merely missing:

| Before | After |
| --- | --- |
| `stacked` + a per-point `target` breaks the category into two columns, one carrying the ghost | one stack, with a target column behind it |

`targets` takes one number per category, read only when `stacked` (otherwise it warns and is ignored — a grouped category has several bars and no single one to measure). `null` leaves a category without one.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots 

<img width="632" height="393" alt="image" src="https://github.com/user-attachments/assets/9ed6ce69-bec4-4044-b305-87775177014b" />
<img width="628" height="370" alt="image" src="https://github.com/user-attachments/assets/d3239ef4-9c9f-40ba-965f-c5816c63bf58" />


New story: **F0DataChart/Bar → Stacked With Targets** (`kits-f0datachart-bar--stacked-with-targets`) — a goal by quarters with three sub-goals, a 300k parent target, and a target on each sub-goal.

- **The target stays readable once cleared.** The column is a little wider than the bars (4px each side), so a stack that has grown past it still shows where the line was, in the margin either side. Q2 totals 360k against 300k and the line is still there.
- **Overachievement is per sub-goal.** In Q3 the stack reaches 255k — nowhere near the parent's 300k — yet Expansion carries its darker band, because it did 120k against its own 100k. That is the case the whole thing is for.
- **Q4 has not started**: only the column, and hovering it reports the target.

**The card is grouped by subject.** A segment with a target answers two questions at once, and read as one run of five numbers the two blur into each other — a percentage is easily taken for the other subject's. It now leads with the mark's own numbers, rules, then gives the stack's:

```
Expansion
Q3
120k €
100k € target
120.0% of target
────────────────
255k € total
47.1% of total
```

Hovering the column instead answers for the stack alone (`Q3 / 255k € / 300k € target / 85.0% of target`).

## Implementation details

**The column is drawn by hand**, as a `custom` series under the bars (`z: 1` against their `z: 3`). ECharts lays bar series out side by side within the category band and takes the layout from the first series on the axis, so a column that has to be *wider* than the bars it frames — and behind them — is not a position in that row. `renderItem` sizes it from the band: the bars' 80% share plus a 4px margin either side.

**`highlightOverachievement` now reads a stacked segment against the target on its own data point**, not against `targets`. One meaning for the darker shade — this mark passed the number it was given — instead of two in the same bar. That the stack cleared its own target needs no colour: the bar rises past the column.

**`renderValueTooltip` grows a `separator` flag** on a row, drawing a rule above the row that opens a new subject. Kept on the shared renderer rather than assembled in the bar chart, so any card that comes to mix two subjects can say so the same way.

Within each block the absolute now comes before the share, which flips the existing `of total` / `total` pair — the same two numbers, in the order the block above them reads. That reaches stacked charts with no target at all, `F0AnalyticsDashboard` included: order only, no change to what is reported.

**`chartColorAlpha`** replaces `` `${color}33` `` for the target gradients. Theme colors already carry an alpha channel, so the old string concat produced `#011b4b7333`, which is not a color, and the chart threw on the first render with a neutral column.

## Checks

`pnpm tsc`, `pnpm lint` and `pnpm format:check` clean. 349 tests in the kit, 7 new: one stack rather than one per series, the column's data and depth, a category left without a target, the warning when not stacked, a segment marked against its own target (with the gradient breaking at the right fraction), the stack's own target marking nothing on its own, and the card's two blocks in order with the rule on the first row of the second — and only there.
