### PR TITLE
fix(OneEmptyState): stack actions in a narrow container

### DIFF
--- a/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
+++ b/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
@@ -16,7 +16,7 @@ function _OneEmptyState({
 }: Types.OneEmptyStateProps) {
   return (
     <div
-      className="flex flex-col items-center justify-center gap-5 p-8"
+      className="@container flex flex-col items-center justify-center gap-5 p-8"
       {...rest}
     >
       {variant === "default" && <F0AvatarEmoji emoji={emoji!} size="lg" />}
@@ -32,7 +32,7 @@ function _OneEmptyState({
         )}
       </div>
       {actions && (
-        <div className="flex w-full flex-col items-center justify-center gap-2 sm:w-fit sm:flex-row sm:gap-3 [&>div]:w-full">
+        <div className="flex w-full max-w-full flex-col items-center justify-center gap-2 @sm:w-fit @sm:flex-row @sm:flex-wrap @sm:gap-3 [&>div]:w-full">
           {actions.map((action) => {
             if (action.type === "upsell") {
               return (

--- a/packages/react/src/components/OneEmptyState/__tests__/OneEmptyState.actions.test.tsx
+++ b/packages/react/src/components/OneEmptyState/__tests__/OneEmptyState.actions.test.tsx
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { OneEmptyState } from "../OneEmptyState"
+
+const actionsRow = () =>
+  screen.getByText("No expenses yet").closest("div")?.parentElement
+    ?.lastElementChild as HTMLElement
+
+const twoActions = [
+  { label: "Upload your first receipt", onClick: () => {} },
+  { label: "Learn how expenses work", onClick: () => {} },
+] as const
+
+describe("OneEmptyState's actions", () => {
+  it("takes its direction from the container's width, not the viewport's", () => {
+    render(
+      <OneEmptyState
+        emoji="🧾"
+        title="No expenses yet"
+        actions={[...twoActions]}
+      />
+    )
+
+    const row = actionsRow()
+
+    expect(row).toHaveClass("flex-col", "@sm:flex-row")
+    expect(row.className).not.toMatch(/(^|\s)sm:/)
+  })
+
+  it("can never be wider than the box it is in", () => {
+    render(
+      <OneEmptyState
+        emoji="🧾"
+        title="No expenses yet"
+        actions={[...twoActions]}
+      />
+    )
+
+    expect(actionsRow()).toHaveClass("@sm:flex-wrap", "max-w-full")
+  })
+
+  it("is a container, so the query above has something to query", () => {
+    render(
+      <OneEmptyState
+        emoji="🧾"
+        title="No expenses yet"
+        actions={[...twoActions]}
+      />
+    )
+
+    expect(actionsRow().parentElement).toHaveClass("@container")
+  })
+})

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState, type ReactNode } from "react"
+import {
+  type ComponentProps,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react"
 
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { z } from "zod"
@@ -12,6 +18,7 @@ import { F0Button } from "@/components/F0Button"
 import { F0Card } from "@/components/F0Card"
 import { F0Heading } from "@/components/F0Heading"
 import { F0Icon, type IconType } from "@/components/F0Icon"
+import { OneEmptyState } from "@/components/OneEmptyState/OneEmptyState"
 import { F0TagStatus } from "@/components/tags/F0TagStatus"
 import { One } from "@/icons/ai"
 import {
@@ -826,6 +833,39 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
   // carries "Edit params" — and its title, its info and the events it lists all
   // follow what you set there.
   eventsWidget(EVENTS_DEFAULTS),
+  {
+    id: "expenses",
+    icon: Receipt,
+    header: {
+      title: "Expenses",
+      info: "Receipts you submitted and what each one is waiting on.",
+      link: { title: "Go to Expenses", url: "/expenses" },
+    },
+    slots: [
+      {
+        visualization: "empty-state",
+        params: {
+          emoji: "🧾",
+          title: "No expenses yet",
+          description:
+            "Submit a receipt and it shows up here with whatever it is waiting on.",
+          actions: [
+            {
+              label: "Upload your first receipt",
+              icon: Plus,
+              onClick: () => {},
+            },
+            {
+              label: "Learn how expenses work",
+              variant: "outline",
+              icon: ExternalLink,
+              onClick: () => {},
+            },
+          ],
+        } satisfies EmptyStateParams,
+      },
+    ],
+  },
   // ANOTHER HOST, both flavors: the widget's link and every row's `href` point
   // off this site. These are the only links that open a new tab — the widgets
   // above navigate in place, fragment and all.
@@ -882,6 +922,9 @@ const RIGHT_WIDGETS: HomeWidgetItem[] = [
  * two are the SAME component, told whether its data has landed.
  */
 const SLOT_RENDERERS: SlotRenderers = {
+  "empty-state": (params) => (
+    <OneEmptyState {...(params as EmptyStateParams)} />
+  ),
   "clock-in": {
     render: () => <ClockInTile />,
     skeleton: () => <ClockInTile loading />,
@@ -923,9 +966,10 @@ const LOADING_RIGHT_WIDGETS: HomeWidgetItem[] = RIGHT_WIDGETS.map((widget) => ({
   slots: widget.slots.map((slot) => {
     const params = slot.params as { items?: unknown[]; events?: unknown[] }
     const items = params.items ?? params.events
+    if (!items) return slot
     return {
       ...slot,
-      expectedItemsCount: items?.length,
+      expectedItemsCount: items.length,
       params: params.events
         ? { ...params, events: [] }
         : { ...params, items: [] },
@@ -1151,6 +1195,17 @@ const communitiesWidget = ({
       },
     ],
   })
+
+interface EmptyStateParams {
+  emoji: string
+  title: string
+  description: string
+  actions: [OneEmptyStateAction, OneEmptyStateAction]
+}
+
+type OneEmptyStateAction = NonNullable<
+  ComponentProps<typeof OneEmptyState>["actions"]
+>[number]
 
 /** What the bespoke `community-posts` slot carries — which posts is `ctx`'s. */
 interface CommunityPostsParams {

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1384,7 +1384,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             // cards instead of letting them go into the glyphs.
             hidden={railInPanel && rail.panelHidden}
             className={cn(
-              "min-h-0 overflow-y-auto",
+              "min-h-0 overflow-y-auto overflow-x-hidden",
               SCROLLBAR_HIDDEN,
               railInPanel &&
                 "absolute z-10 rounded-xl bg-f1-background dark:bg-f1-background-secondary dark:backdrop-blur-[100px] dark:backdrop-saturate-150",

--- a/packages/react/src/sds/Home/NewHomeLayout/railOverflow.test.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/railOverflow.test.tsx
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, test, vi } from "vitest"
+
+import { Calendar, Clock } from "@/icons/app"
+import { act, zeroRender } from "@/testing/test-utils"
+
+import { type HomeWidgetItem } from "../slotRenderers"
+import { NewHomeLayout } from "./index"
+
+let layoutWidth = 1400
+
+let resizeCallbacks: Array<(entries: ResizeObserverEntry[]) => void> = []
+
+const widget = (id: string): HomeWidgetItem => ({
+  id,
+  icon: id === "clock" ? Clock : Calendar,
+  header: { title: id },
+  slots: [],
+})
+
+const renderLayout = (width: number) => {
+  layoutWidth = width
+  return zeroRender(
+    <NewHomeLayout rightWidgets={[widget("clock"), widget("events")]}>
+      <p>feed</p>
+    </NewHomeLayout>
+  )
+}
+
+const railBody = (container: HTMLElement) =>
+  [...container.querySelectorAll<HTMLElement>("aside")].find(
+    (el) =>
+      el.style.gridColumn === "2" &&
+      !el.className.includes("pointer-events-none")
+  ) as HTMLElement
+
+beforeEach(() => {
+  Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+    configurable: true,
+    get: () => layoutWidth,
+  })
+  resizeCallbacks = []
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      constructor(callback: (entries: ResizeObserverEntry[]) => void) {
+        resizeCallbacks.push(callback)
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  )
+  act(() => resizeCallbacks.forEach((notify) => notify([])))
+})
+
+describe("the rail's overflow", () => {
+  test("scrolls down but never sideways", () => {
+    const { container } = renderLayout(1400)
+
+    expect(railBody(container)).toHaveClass(
+      "overflow-y-auto",
+      "overflow-x-hidden"
+    )
+  })
+
+  test("clips instead, so an oversized widget cannot widen the page", () => {
+    const { container } = renderLayout(1600)
+    const rail = railBody(container)
+
+    expect(rail.className).not.toMatch(/overflow-x-(auto|scroll|visible)/)
+    expect(rail).toHaveClass("overflow-x-hidden")
+  })
+})


### PR DESCRIPTION
## Description

Adding an empty-state widget to `NewHomeLayout`'s rail story turned up two overflow bugs, both of which this PR fixes at the source: an empty state's actions laid themselves out from the *viewport's* width rather than their own container's, so two full-sentence buttons in Home's 396px rail sat side by side and hung past the card's edge on both sides; and the rail, being a `overflow-y-auto` scrollport, computed its x axis to `auto` as well, so that overflow turned a fixed-width column into a sideways scroller with nothing to scroll to.
