### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.83.3",
+  "packages/react": "6.84.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.84.0](https://github.com/factorialco/f0/compare/f0-react-v6.83.3...f0-react-v6.84.0) (2026-09-03)
+
+
+### Features
+
+* **charts:** connect line series that continue another ([#5331](https://github.com/factorialco/f0/issues/5331)) ([9656265](https://github.com/factorialco/f0/commit/96562659cd63bbfd73ffc5c0d219015eff38daf4))
+
 ## [6.83.3](https://github.com/factorialco/f0/compare/f0-react-v6.83.2...f0-react-v6.83.3) (2026-09-02)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.83.3",
+  "version": "6.84.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.84.0</summary>

## [6.84.0](https://github.com/factorialco/f0/compare/f0-react-v6.83.3...f0-react-v6.84.0) (2026-09-03)


### Features

* **charts:** connect line series that continue another ([#5331](https://github.com/factorialco/f0/issues/5331)) ([9656265](https://github.com/factorialco/f0/commit/96562659cd63bbfd73ffc5c0d219015eff38daf4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).