### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.84.0",
+  "packages/react": "6.84.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.84.1](https://github.com/factorialco/f0/compare/f0-react-v6.84.0...f0-react-v6.84.1) (2026-09-03)
+
+
+### Bug Fixes
+
+* **OneEmptyState:** stack actions in a narrow container ([#5383](https://github.com/factorialco/f0/issues/5383)) ([46c0fae](https://github.com/factorialco/f0/commit/46c0faeef94a895085007e4c2f0a39c5747b55e2))
+
 ## [6.84.0](https://github.com/factorialco/f0/compare/f0-react-v6.83.3...f0-react-v6.84.0) (2026-09-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.84.0",
+  "version": "6.84.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.84.1</summary>

## [6.84.1](https://github.com/factorialco/f0/compare/f0-react-v6.84.0...f0-react-v6.84.1) (2026-09-03)


### Bug Fixes

* **OneEmptyState:** stack actions in a narrow container ([#5383](https://github.com/factorialco/f0/issues/5383)) ([46c0fae](https://github.com/factorialco/f0/commit/46c0faeef94a895085007e4c2f0a39c5747b55e2))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).