### PR TITLE
fix(F0Button): tooltip behaviour on clipped labels

### DIFF
--- a/packages/react/src/components/F0Button/__tests__/F0Button.test.tsx
+++ b/packages/react/src/components/F0Button/__tests__/F0Button.test.tsx
@@ -1,9 +1,10 @@
 import { userEvent } from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { Add } from "@/icons/app"
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
+import { ButtonInternal } from "../internal"
 import { F0Button } from "../index"
 
 describe("F0Button", () => {
@@ -152,6 +153,93 @@ describe("F0Button", () => {
       expect(counterWrapper()?.className).not.toContain("dark")
       await userEvent.hover(screen.getByRole("button"))
       expect(counterWrapper()?.className).toContain("dark")
+    })
+  })
+
+  describe("clipped label tooltip", () => {
+    // jsdom lays nothing out, so both metrics read 0 and no text ever looks
+    // clipped. Stubbing them on the prototype is what makes truncation
+    // observable at all — the label span is the element OneEllipsis measures.
+    const setLabelWidths = (scrollWidth: number, clientWidth: number) => {
+      Object.defineProperty(HTMLElement.prototype, "scrollWidth", {
+        configurable: true,
+        value: scrollWidth,
+      })
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+        configurable: true,
+        value: clientWidth,
+      })
+    }
+
+    // The measured case: 75 characters needing 486px in a 253px slot.
+    const LONG_LABEL =
+      "Upload your first receipt and we will fill in the expense details for you"
+
+    // The tooltip is a Radix popper rendered into a portal, so the bubbles on
+    // screen are counted from the document rather than from the tree.
+    const openTooltips = () =>
+      Array.from(
+        document.querySelectorAll("[data-radix-popper-content-wrapper]")
+      ).map((node) => node.textContent ?? "")
+
+    // Past the label tooltip's 700ms open delay by a wide margin, so what is on
+    // screen by now is the resting state: one that was going to open has, and
+    // one that is absent is absent for good. These are real timers, and a
+    // tighter window flakes under a loaded run.
+    const settleAfterHover = () =>
+      new Promise((resolve) => setTimeout(resolve, 2500))
+
+    afterEach(() => {
+      delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth
+      delete (HTMLElement.prototype as { clientWidth?: number }).clientWidth
+    })
+
+    it("shows the full label when the visible one is clipped", async () => {
+      setLabelWidths(486, 253)
+      render(<F0Button label={LONG_LABEL} />)
+
+      await userEvent.hover(screen.getByText(LONG_LABEL))
+      await settleAfterHover()
+
+      expect(openTooltips().join("")).toContain(LONG_LABEL)
+    })
+
+    it("shows nothing when the label fits", async () => {
+      setLabelWidths(253, 253)
+      render(<F0Button label={LONG_LABEL} />)
+
+      await userEvent.hover(screen.getByText(LONG_LABEL))
+      await settleAfterHover()
+
+      expect(openTooltips()).toHaveLength(0)
+    })
+
+    it("stays silent under noAutoTooltip, which opts out of every automatic tooltip", async () => {
+      setLabelWidths(486, 253)
+      // `noAutoTooltip` is private, so the public F0Button strips it before it
+      // can reach the label — the internal is the only place it is observable.
+      render(<ButtonInternal label={LONG_LABEL} noAutoTooltip />)
+
+      await userEvent.hover(screen.getByText(LONG_LABEL))
+      await settleAfterHover()
+
+      expect(openTooltips()).toHaveLength(0)
+    })
+
+    it("adds no second tooltip when the button already has an explicit one", () => {
+      setLabelWidths(486, 253)
+      render(<F0Button label={LONG_LABEL} tooltip="Explicit tooltip" />)
+
+      // Asserted on the markup rather than by hovering: a hover over the label
+      // reaches the button's own trigger only intermittently under user-event,
+      // and the defect is structural anyway. Radix stamps `data-state` on
+      // whatever it makes a trigger, so a clipped label that stays unstamped is
+      // exactly the guarantee — two triggers stacked over one pointer used to
+      // open together and then close each other for good, leaving the hover
+      // showing nothing at all.
+      expect(screen.getByText(LONG_LABEL)).not.toHaveAttribute("data-state")
+      // ...while the explicit tooltip is still wired up to the button itself.
+      expect(screen.getByRole("button")).toHaveAttribute("data-state")
     })
   })
 })

--- a/packages/react/src/components/F0Button/__tests__/F0Button.test.tsx
+++ b/packages/react/src/components/F0Button/__tests__/F0Button.test.tsx
@@ -2,7 +2,7 @@ import { userEvent } from "@testing-library/user-event"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { Add } from "@/icons/app"
-import { zeroRender as render, screen } from "@/testing/test-utils"
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
 
 import { ButtonInternal } from "../internal"
 import { F0Button } from "../index"
@@ -182,12 +182,12 @@ describe("F0Button", () => {
         document.querySelectorAll("[data-radix-popper-content-wrapper]")
       ).map((node) => node.textContent ?? "")
 
-    // Past the label tooltip's 700ms open delay by a wide margin, so what is on
-    // screen by now is the resting state: one that was going to open has, and
-    // one that is absent is absent for good. These are real timers, and a
-    // tighter window flakes under a loaded run.
+    // Several times the label tooltip's open delay, so what is on screen by now
+    // is the resting state: one that was going to open has, and one that is
+    // absent is absent for good. These are real timers, and a tighter window
+    // flakes under a loaded run.
     const settleAfterHover = () =>
-      new Promise((resolve) => setTimeout(resolve, 2500))
+      new Promise((resolve) => setTimeout(resolve, 1500))
 
     afterEach(() => {
       delete (HTMLElement.prototype as { scrollWidth?: number }).scrollWidth
@@ -202,6 +202,22 @@ describe("F0Button", () => {
       await settleAfterHover()
 
       expect(openTooltips().join("")).toContain(LONG_LABEL)
+    })
+
+    it("reveals a clipped label sooner than the default tooltip delay", async () => {
+      setLabelWidths(486, 253)
+      render(<F0Button label={LONG_LABEL} />)
+
+      await userEvent.hover(screen.getByText(LONG_LABEL))
+
+      // Opens at ~300ms. The window matters as much as the assertion: it sits
+      // under Radix's 700ms default, so a tooltip still on the old delay fails
+      // here. A loaded machine can only push an open later, never earlier, so
+      // the failing direction stays honest.
+      await waitFor(() => expect(openTooltips()).toHaveLength(1), {
+        timeout: 550,
+        interval: 25,
+      })
     })
 
     it("shows nothing when the label fits", async () => {

--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -118,7 +118,9 @@ export type ButtonInternalProps = Pick<
     pressed?: boolean
     /**
      * @private
-     * If true, the button will not automatically add a tooltip based on the hideLabel and label properties.
+     * If true, the button adds no automatic tooltip — neither the one derived
+     * from `hideLabel` + `label`, nor the one the label shows when it is too
+     * long and gets clipped to an ellipsis.
      */
     noAutoTooltip?: boolean
     /**

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -185,6 +185,14 @@ const ButtonInternal = forwardRef<
               fontSizeVariants({ fontSize: buttonFontSize })
             )}
             tag="span"
+            // A clipped label's own ellipsis tooltip is the only way a sighted
+            // mouse user recovers the hidden text, so it stays on by default.
+            // It has to stand down in two cases: `noAutoTooltip` opts out of
+            // every automatic tooltip, and an explicit `tooltip` already wraps
+            // the whole button — two Radix tooltips over one pointer open
+            // together and then close each other for good, leaving the hover
+            // showing nothing at all.
+            noTooltip={noAutoTooltip || !!tooltip}
           >
             {buttonLabel}
           </OneEllipsis>

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -15,6 +15,12 @@ import { fontSizeVariants } from "./variants"
 const IconMotion = motion.create(F0Icon)
 
 /**
+ * Open delay for the tooltip that reveals a label too long to fit. Short on
+ * purpose — see where it is passed below.
+ */
+const CLIPPED_LABEL_TOOLTIP_DELAY_MS = 300
+
+/**
  * A button component internal that includes the private slots and props
  */
 const ButtonInternal = forwardRef<
@@ -193,6 +199,10 @@ const ButtonInternal = forwardRef<
             // together and then close each other for good, leaving the hover
             // showing nothing at all.
             noTooltip={noAutoTooltip || !!tooltip}
+            // Faster than the 700ms default: this tooltip is not a hint layered
+            // on top of a readable control, it is the only way to read a label
+            // the layout has cut off, so waiting on it reads as unresponsive.
+            delay={CLIPPED_LABEL_TOOLTIP_DELAY_MS}
           >
             {buttonLabel}
           </OneEllipsis>

--- a/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
+++ b/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
@@ -24,6 +24,13 @@ export const tags = [
 ] as const
 export type Tag = (typeof tags)[number]
 
+/**
+ * Radix's own default open delay. Named here so a caller passing `delay` is
+ * changing a value this component owns rather than silently diverging from an
+ * upstream default.
+ */
+const DEFAULT_TOOLTIP_DELAY_MS = 700
+
 const checkForEllipsis = (element: HTMLElement | null, lines: number) => {
   if (!element) return false
   if (lines > 1) {
@@ -176,6 +183,13 @@ type OneEllipsisProps = {
    * @default false
    */
   markdown?: boolean
+  /**
+   * How long the pointer has to rest on the clipped text before the tooltip
+   * opens, in milliseconds. Lower it where the tooltip is the only way to read
+   * text the layout has cut off, so recovering it does not feel like a wait.
+   * @default 700
+   */
+  delay?: number
 }
 
 const OneEllipsis = forwardRef<HTMLElement, OneEllipsisProps>(
@@ -188,6 +202,7 @@ const OneEllipsis = forwardRef<HTMLElement, OneEllipsisProps>(
       disabled = false,
       markdown = false,
       tag = "span",
+      delay = DEFAULT_TOOLTIP_DELAY_MS,
       ...props
     },
     forwardedRef
@@ -222,7 +237,7 @@ const OneEllipsis = forwardRef<HTMLElement, OneEllipsisProps>(
     }, [children, markdown])
 
     return hasEllipsis && !noTooltip ? (
-      <TooltipProvider>
+      <TooltipProvider delayDuration={delay}>
         <Tooltip>
           {/*
            * `pointer-events-auto` on the trigger, not just via the wrapper's own


### PR DESCRIPTION
## Description

A `F0Button` whose label is too long clips it to an ellipsis and already shows the full text in a tooltip — the label renders through `OneEllipsis`, which measures `scrollWidth > clientWidth` and wraps itself in one. That tooltip ignored both of the opt-outs around it, so `noAutoTooltip` did not silence it and an explicit `tooltip` collided with it, leaving the clipped text hoverable but showing nothing at all. This makes the automatic tooltip stand down in exactly those two cases, and shortens its open delay, since it is the only way to read text the layout has cut off.

## Implementation details

- fix: suppress the clipped-label tooltip when `noAutoTooltip` is set — it previously gated only the `hideLabel` tooltip, not this one

- fix: suppress it when an explicit `tooltip` is passed, so the two no longer race

  <details>
  <summary>Why?</summary>

  `ui/Action` wraps the whole button in a Radix tooltip when `tooltip` is set, and `OneEllipsis` wraps the label in another when the text is clipped. Two triggers stacked over one pointer both open at their own delay and then close each other via Radix's document-level `tooltip.open` event — and because the pointer never re-enters, neither reopens. Timeline on `main`, hovering the clipped label:

  ```
  @400ms  poppers=[]
  @800ms  poppers=[]
  @1200ms poppers=["Upload your first re…", "Explicit text…"]   ← both
  @1600ms poppers=[]                                            ← both gone, for good
  ```

  The user-visible result was a hover dead zone. Verified fixed in Storybook: hovering a clipped label on a button with an explicit tooltip now shows exactly that one bubble.
  </details>

- feat: open the clipped-label tooltip after 300ms instead of 700ms

  <details>
  <summary>Why 300ms, and why only here?</summary>

  This tooltip is not a hint layered on top of a readable control — it is the only way to read a label the layout has cut off, so the default delay reads as unresponsive. 300ms is fast enough to feel immediate without firing on a pointer that is only crossing the button.

  `OneEllipsis` gains an optional `delay` and keeps its 700ms default (Radix's own), so none of the other 64 files that import it change behaviour. Measured in jsdom, the tooltip now opens at ~310ms.
  </details>

- test: add a `clipped label tooltip` suite — three regression tests that fail on `main`, plus two that characterise the existing behaviour (clipped shows the full text, fitting shows nothing)

  <details>
  <summary>Three notes on how these are written</summary>

  jsdom reports `0` for both `scrollWidth` and `clientWidth`, so nothing ever looks clipped; the tests stub both on `HTMLElement.prototype`.

  The `noAutoTooltip` test renders `ButtonInternal` rather than `F0Button`, because `noAutoTooltip` is private and the public component strips it — a test through `F0Button` would be vacuous.

  The explicit-tooltip test asserts on markup (`data-state`, which Radix stamps on every trigger it owns) rather than by hovering: a `user-event` hover over a descendant reaches an ancestor's `onPointerEnter` only intermittently, roughly 1 run in 6, and a first behavioural version of that test flaked. The delay test does hover — the trigger is the hovered element there, which is reliable — and asserts the tooltip opens inside a 550ms window, under the old 700ms default. A loaded machine can only push an open later, never earlier, so that window fails in the honest direction.
  </details>

- docs: correct the `noAutoTooltip` JSDoc, which described only the `hideLabel` tooltip