### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.84.1",
+  "packages/react": "6.84.2",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.84.2](https://github.com/factorialco/f0/compare/f0-react-v6.84.1...f0-react-v6.84.2) (2026-09-03)
+
+
+### Bug Fixes
+
+* **F0Button:** tooltip behaviour on clipped labels ([#5386](https://github.com/factorialco/f0/issues/5386)) ([d5fa5e0](https://github.com/factorialco/f0/commit/d5fa5e0d111434b32e9047ca2f20dc2177279ba8))
+
 ## [6.84.1](https://github.com/factorialco/f0/compare/f0-react-v6.84.0...f0-react-v6.84.1) (2026-09-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.84.1",
+  "version": "6.84.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.84.2</summary>

## [6.84.2](https://github.com/factorialco/f0/compare/f0-react-v6.84.1...f0-react-v6.84.2) (2026-09-03)


### Bug Fixes

* **F0Button:** tooltip behaviour on clipped labels ([#5386](https://github.com/factorialco/f0/issues/5386)) ([d5fa5e0](https://github.com/factorialco/f0/commit/d5fa5e0d111434b32e9047ca2f20dc2177279ba8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).