### PR TITLE
fix(F0RichTextDisplay): prevent props spread bypassing sanitizer

### DIFF
--- a/packages/react/.oxlint-plugins/README.md
+++ b/packages/react/.oxlint-plugins/README.md
@@ -1,0 +1,56 @@
+# Local lint plugins
+
+ESLint-format rules loaded by oxlint through its `jsPlugins` option (see
+`.oxlintrc.json`). They run under the same `pnpm lint` that CI runs.
+
+## Why rules here, and a ratchet script in `.scripts/`
+
+f0 has two enforcement mechanisms and they are not interchangeable. Pick by
+**how much existing debt the rule has**:
+
+|                                  | Violations today | Mechanism                                                           |
+| -------------------------------- | ---------------- | ------------------------------------------------------------------- |
+| Inline styles                    | 244              | `.scripts/check-inline-styles.ts` — AST scan + shrink-only baseline |
+| `dangerouslySetInnerHTML` misuse | 1–2              | a rule in here, shipped as `error`                                  |
+
+A lint rule has no baseline mechanism: it is on or off for the whole codebase.
+With hundreds of pre-existing violations that leaves only "ship it as `off`" or
+"add hundreds of suppressions", which is why the inline-styles gate is a script.
+With one or two violations you just fix them and turn the rule on, and a rule is
+the better tool — it runs on every file, needs no debt file, and cannot drift.
+
+So: **a handful of violations → write a rule here. Hundreds → write a ratchet
+script.** If a rule you want lands in between, that is the signal to fix the
+code first.
+
+## Caveat
+
+oxc marks JS plugins experimental and does not support them in the language
+server, so **these rules do not surface in editors** — only in `pnpm lint` and
+CI. Keep the messages self-contained enough to act on from a CI log.
+
+## Adding a rule
+
+1. Write it in `f0-security/rules/<name>.js` using the standard ESLint shape
+   (`meta`, `create(context)`). Visitor keys are ESTree node types.
+2. Register it in `f0-security/index.js`.
+3. Turn it on in `.oxlintrc.json`.
+4. Add cases to `__tests__/f0-security.test.ts`. Those tests shell out to the
+   real oxlint binary rather than using ESLint's `RuleTester`: the rules only
+   matter insofar as `pnpm lint` enforces them, and oxlint's JS-plugin AST is
+   what they actually see.
+
+## Rules
+
+- **`no-spread-after-inner-html`** — a props spread after
+  `dangerouslySetInnerHTML` overwrites it, so a caller can replace sanitized
+  HTML with their own. Pure attribute-ordering check, no data flow.
+- **`require-sanitized-inner-html`** — `__html` must come from a sanitizer.
+  A _shallow, same-file_ check: it resolves direct calls, local bindings
+  (through `useMemo` and ternaries) and reassignments, but not values routed
+  through another module. A tripwire for the accidental case, not a proof.
+  Extend the `sanitizers` option when a new helper sanitizes.
+- **`require-style-nonce`** — an inline `<style>` without a `nonce` is dropped
+  silently by a strict CSP. The two elements that predate the rule are listed in
+  the `allow` option rather than suppressed inline, so the debt stays in one
+  readable place and the rule still blocks new ones.

--- a/packages/react/.oxlint-plugins/__tests__/f0-security.test.ts
+++ b/packages/react/.oxlint-plugins/__tests__/f0-security.test.ts
@@ -1,0 +1,235 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+/**
+ * These run the real oxlint binary against the real plugin, rather than
+ * re-implementing the rules against a stand-in AST. The rules only matter
+ * insofar as `pnpm lint` enforces them, and oxlint's JS-plugin AST is the thing
+ * they actually see — a parallel ESLint RuleTester would prove something else.
+ */
+const PLUGIN_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const PKG_DIR = resolve(PLUGIN_DIR, "..")
+// Resolved explicitly rather than trusting PATH: this has to work the same
+// under `pnpm test`, a bare vitest run and CI.
+const OXLINT = resolve(PKG_DIR, "node_modules/.bin/oxlint")
+
+let workspace: string
+let configPath: string
+
+beforeAll(() => {
+  workspace = mkdtempSync(join(tmpdir(), "f0-security-"))
+  configPath = join(workspace, ".oxlintrc.json")
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      jsPlugins: [join(PLUGIN_DIR, "f0-security", "index.js")],
+      rules: {
+        "f0-security/no-spread-after-inner-html": "error",
+        "f0-security/require-sanitized-inner-html": "error",
+        "f0-security/require-style-nonce": [
+          "error",
+          { allow: ["allowed.tsx"] },
+        ],
+      },
+    })
+  )
+})
+
+afterAll(() => rmSync(workspace, { recursive: true, force: true }))
+
+/** Lint one snippet and return the f0-security rule names it triggered. */
+const lint = (source: string, filename = "probe.tsx"): string[] => {
+  const file = join(workspace, filename)
+  writeFileSync(file, source)
+  let output = ""
+  try {
+    output = execFileSync(
+      OXLINT,
+      ["--config", configPath, "--format", "default", file],
+      { cwd: PKG_DIR, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }
+    )
+  } catch (error) {
+    // oxlint exits non-zero when it reports something; the diagnostics are still
+    // on stdout.
+    output = (error as { stdout?: string }).stdout ?? ""
+  }
+  return [...output.matchAll(/f0-security\(([a-z-]+)\)/g)].map((m) => m[1])
+}
+
+describe("no-spread-after-inner-html", () => {
+  it("flags a spread that lands after dangerouslySetInnerHTML", () => {
+    expect(
+      lint(
+        `export const A = (props) => <div dangerouslySetInnerHTML={{ __html: "x" }} {...props} />`
+      )
+    ).toContain("no-spread-after-inner-html")
+  })
+
+  it("accepts a spread that lands before it", () => {
+    expect(
+      lint(
+        `export const A = (props) => <div {...props} dangerouslySetInnerHTML={{ __html: "x" }} />`
+      )
+    ).not.toContain("no-spread-after-inner-html")
+  })
+
+  it("flags the same mistake in a createElement props object", () => {
+    expect(
+      lint(
+        `export const A = (props) => createElement("div", { dangerouslySetInnerHTML: { __html: "x" }, ...props })`
+      )
+    ).toContain("no-spread-after-inner-html")
+  })
+
+  it("accepts the props object when the spread comes first", () => {
+    expect(
+      lint(
+        `export const A = (props) => createElement("div", { ...props, dangerouslySetInnerHTML: { __html: "x" } })`
+      )
+    ).not.toContain("no-spread-after-inner-html")
+  })
+
+  it("says which spread is at fault", () => {
+    const file = join(workspace, "named.tsx")
+    writeFileSync(
+      file,
+      `export const A = (rest) => <div dangerouslySetInnerHTML={{ __html: "x" }} {...rest} />`
+    )
+    let output = ""
+    try {
+      output = execFileSync(OXLINT, ["--config", configPath, file], {
+        cwd: PKG_DIR,
+        encoding: "utf-8",
+        stdio: ["ignore", "pipe", "pipe"],
+      })
+    } catch (error) {
+      output = (error as { stdout?: string }).stdout ?? ""
+    }
+    expect(output).toContain("`...rest`")
+  })
+})
+
+describe("require-sanitized-inner-html", () => {
+  const RULE = "require-sanitized-inner-html"
+
+  it("flags a raw value", () => {
+    expect(
+      lint(
+        `export const A = ({ h }) => <div dangerouslySetInnerHTML={{ __html: h }} />`
+      )
+    ).toContain(RULE)
+  })
+
+  it("accepts a direct sanitizer call", () => {
+    expect(
+      lint(
+        `export const A = ({ h }) => <div dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(h) }} />`
+      )
+    ).not.toContain(RULE)
+  })
+
+  it("accepts a local const bound to a sanitizer", () => {
+    expect(
+      lint(
+        `export const A = ({ h }) => { const html = parseMarkdown(h); return <div dangerouslySetInnerHTML={{ __html: html }} /> }`
+      )
+    ).not.toContain(RULE)
+  })
+
+  it("accepts a sanitizer memoized with useMemo", () => {
+    expect(
+      lint(
+        `export const A = ({ h }) => { const html = useMemo(() => DOMPurify.sanitize(h), [h]); return <div dangerouslySetInnerHTML={{ __html: html }} /> }`
+      )
+    ).not.toContain(RULE)
+  })
+
+  it("accepts a ternary whose arms are all safe", () => {
+    expect(
+      lint(
+        `export const A = ({ h, md }) => { const html = md ? parseMarkdown(h) : undefined; return <div dangerouslySetInnerHTML={{ __html: html }} /> }`
+      )
+    ).not.toContain(RULE)
+  })
+
+  it("flags a ternary with one unsafe arm", () => {
+    expect(
+      lint(
+        `export const A = ({ h, md }) => { const html = md ? parseMarkdown(h) : h; return <div dangerouslySetInnerHTML={{ __html: html }} /> }`
+      )
+    ).toContain(RULE)
+  })
+
+  it("accepts a static template literal", () => {
+    expect(
+      lint(
+        "export const A = () => <div dangerouslySetInnerHTML={{ __html: `.a{color:red}` }} />"
+      )
+    ).not.toContain(RULE)
+  })
+
+  // The bug this rule was written against: a `let` that looks safe from its
+  // initializer and is reassigned to something unsanitized further down.
+  it("flags a let whose later assignment is unsanitized", () => {
+    expect(
+      lint(
+        `export const A = ({ el }) => { let html = ""; if (el) html = clone(el); return <div dangerouslySetInnerHTML={{ __html: html }} /> }`
+      )
+    ).toContain(RULE)
+  })
+
+  it("accepts a let whose later assignment is sanitized", () => {
+    expect(
+      lint(
+        `export const A = ({ el }) => { let html = ""; if (el) html = DOMPurify.sanitize(clone(el)); return <div dangerouslySetInnerHTML={{ __html: html }} /> }`
+      )
+    ).not.toContain(RULE)
+  })
+})
+
+describe("require-style-nonce", () => {
+  const RULE = "require-style-nonce"
+
+  it("flags an inline style element with no nonce", () => {
+    expect(
+      lint(
+        "export const A = () => <style dangerouslySetInnerHTML={{ __html: `.a{color:red}` }} />"
+      )
+    ).toContain(RULE)
+  })
+
+  it("accepts one that carries a nonce", () => {
+    expect(
+      lint(
+        "export const A = ({ nonce }) => <style nonce={nonce} dangerouslySetInnerHTML={{ __html: `.a{color:red}` }} />"
+      )
+    ).not.toContain(RULE)
+  })
+
+  it("does not guess against a spread that might carry the nonce", () => {
+    expect(
+      lint(
+        "export const A = (props) => <style {...props} dangerouslySetInnerHTML={{ __html: `.a{color:red}` }} />"
+      )
+    ).not.toContain(RULE)
+  })
+
+  it("leaves a file on the allow list alone", () => {
+    expect(
+      lint(
+        "export const A = () => <style dangerouslySetInnerHTML={{ __html: `.a{color:red}` }} />",
+        "allowed.tsx"
+      )
+    ).not.toContain(RULE)
+  })
+
+  it("leaves non-style elements alone", () => {
+    expect(lint(`export const A = () => <div className="x" />`)).not.toContain(
+      RULE
+    )
+  })
+})

--- a/packages/react/.oxlint-plugins/f0-security/index.js
+++ b/packages/react/.oxlint-plugins/f0-security/index.js
@@ -1,0 +1,25 @@
+/**
+ * f0-security — local oxlint JS plugin.
+ *
+ * These are ESLint-format rules. The repo lints with oxlint, whose `jsPlugins`
+ * option loads ESLint plugins from a path, so the rules below run under the
+ * same `pnpm lint` that CI runs. They are NOT visible in editors: oxc marks JS
+ * plugins experimental and does not support them in the language server yet.
+ *
+ * Each rule guards one way `dangerouslySetInnerHTML` goes wrong. See
+ * .scripts/README-f0-security.md for why these are rules rather than a ratchet
+ * script: unlike the inline-styles gate, the codebase has ~1 violation each, so
+ * they can ship as `error` with no baseline.
+ */
+import noSpreadAfterInnerHtml from "./rules/no-spread-after-inner-html.js"
+import requireSanitizedInnerHtml from "./rules/require-sanitized-inner-html.js"
+import requireStyleNonce from "./rules/require-style-nonce.js"
+
+export default {
+  meta: { name: "f0-security" },
+  rules: {
+    "no-spread-after-inner-html": noSpreadAfterInnerHtml,
+    "require-sanitized-inner-html": requireSanitizedInnerHtml,
+    "require-style-nonce": requireStyleNonce,
+  },
+}

--- a/packages/react/.oxlint-plugins/f0-security/rules/no-spread-after-inner-html.js
+++ b/packages/react/.oxlint-plugins/f0-security/rules/no-spread-after-inner-html.js
@@ -1,0 +1,80 @@
+/**
+ * A props spread that lands AFTER `dangerouslySetInnerHTML` overwrites it.
+ *
+ * When the element's props type extends `HTMLAttributes`, `dangerouslySetInnerHTML`
+ * is a legal prop, so a caller can pass their own and silently replace whatever
+ * the component sanitized. The component's sanitization contract stops holding
+ * without anything in the component looking wrong.
+ *
+ * Ordering is the whole fix: spread first, then set `dangerouslySetInnerHTML`,
+ * and the sanitized value always wins.
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow a props spread after `dangerouslySetInnerHTML`, which lets a caller override sanitized HTML.",
+    },
+    messages: {
+      spreadAfter:
+        "`{{spread}}` is spread after `dangerouslySetInnerHTML`, so a caller can override the sanitized HTML. Move the spread above `dangerouslySetInnerHTML`, or omit the key from it.",
+    },
+    schema: [],
+  },
+  create(context) {
+    /** Report every spread that sits after the first `dangerouslySetInnerHTML`. */
+    const checkAttributes = (attributes) => {
+      const dangerIndex = attributes.findIndex(
+        (attribute) =>
+          attribute.type === "JSXAttribute" &&
+          attribute.name?.name === "dangerouslySetInnerHTML"
+      )
+      if (dangerIndex === -1) return
+
+      for (const attribute of attributes.slice(dangerIndex + 1)) {
+        if (attribute.type !== "JSXSpreadAttribute") continue
+        const { argument } = attribute
+        context.report({
+          node: attribute,
+          messageId: "spreadAfter",
+          data: {
+            spread: argument?.name ? `...${argument.name}` : "...spread",
+          },
+        })
+      }
+    }
+
+    return {
+      JSXOpeningElement(node) {
+        checkAttributes(node.attributes)
+      },
+
+      // `createElement(tag, { ...props, dangerouslySetInnerHTML })` has the same
+      // hazard, and Text.tsx / OneEllipsis build their props exactly this way.
+      ObjectExpression(node) {
+        const dangerIndex = node.properties.findIndex(
+          (property) =>
+            property.type === "Property" &&
+            !property.computed &&
+            (property.key?.name === "dangerouslySetInnerHTML" ||
+              property.key?.value === "dangerouslySetInnerHTML")
+        )
+        if (dangerIndex === -1) return
+
+        for (const property of node.properties.slice(dangerIndex + 1)) {
+          if (property.type !== "SpreadElement") continue
+          context.report({
+            node: property,
+            messageId: "spreadAfter",
+            data: {
+              spread: property.argument?.name
+                ? `...${property.argument.name}`
+                : "...spread",
+            },
+          })
+        }
+      },
+    }
+  },
+}

--- a/packages/react/.oxlint-plugins/f0-security/rules/require-sanitized-inner-html.js
+++ b/packages/react/.oxlint-plugins/f0-security/rules/require-sanitized-inner-html.js
@@ -1,0 +1,143 @@
+/**
+ * The `__html` handed to `dangerouslySetInnerHTML` must come from a sanitizer.
+ *
+ * This is a SHALLOW, same-file check, and it is worth being honest about that:
+ * it resolves a direct sanitizer call, a local `const` bound to one (including
+ * through `useMemo` and a ternary), and static literals. Route the HTML through
+ * a helper in another module and this rule sees nothing.
+ *
+ * So it is a tripwire, not a proof. It catches the accidental case — someone
+ * pasting a value straight into `__html` — which is the case that actually
+ * happens. A determined bypass was never in scope for a lint rule.
+ */
+const DEFAULT_SANITIZERS = [
+  "sanitize",
+  "parseMarkdown",
+  "parseMarkdownDocument",
+]
+
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require the `__html` passed to `dangerouslySetInnerHTML` to come from a sanitizer.",
+    },
+    messages: {
+      unsanitized:
+        "`__html` here is not visibly sanitized. Pass it through {{sanitizers}} (or a static literal). If it is safe by construction, say why in a comment and add the helper to the rule's `sanitizers` option.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          sanitizers: { type: "array", items: { type: "string" } },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const sanitizers = new Set(
+      context.options?.[0]?.sanitizers ?? DEFAULT_SANITIZERS
+    )
+
+    const isSanitizerCall = (node) => {
+      if (node?.type !== "CallExpression") return false
+      const callee = node.callee
+      const name =
+        callee?.type === "MemberExpression"
+          ? callee.property?.name
+          : callee?.name
+      return sanitizers.has(name)
+    }
+
+    const isStaticString = (node) =>
+      node?.type === "Literal" ||
+      (node?.type === "TemplateLiteral" && node.expressions.length === 0)
+
+    /** `useMemo(() => X, deps)` → X, so the memoized sanitizer is still visible. */
+    const unwrapMemo = (node) => {
+      if (
+        node?.type === "CallExpression" &&
+        node.callee?.name === "useMemo" &&
+        (node.arguments[0]?.type === "ArrowFunctionExpression" ||
+          node.arguments[0]?.type === "FunctionExpression") &&
+        node.arguments[0].body?.type !== "BlockStatement"
+      ) {
+        return node.arguments[0].body
+      }
+      return node
+    }
+
+    const isSafe = (node) => {
+      const value = unwrapMemo(node)
+      if (!value) return true // `undefined` renders nothing.
+      if (isSanitizerCall(value) || isStaticString(value)) return true
+      // `markdown ? parseMarkdown(x) : undefined` — safe only if both arms are.
+      if (value.type === "ConditionalExpression") {
+        return isSafe(value.consequent) && isSafe(value.alternate)
+      }
+      if (value.type === "Identifier") {
+        if (value.name === "undefined") return true
+        const binding = context.sourceCode
+          ?.getScope(value)
+          ?.references?.find(
+            (reference) => reference.identifier === value
+          )?.resolved
+        if (!binding) return false
+        // A `let` that is reassigned later is only as safe as its narrowest
+        // write: `let html = ""` followed by `html = clone(el)` must not pass
+        // on the strength of its initializer.
+        const writes = (binding.references ?? []).filter((r) => r.writeExpr)
+        if (writes.length > 0) {
+          return writes.every((r) => isSafe(r.writeExpr))
+        }
+        const declarator = binding.defs?.[0]?.node
+        if (declarator?.type === "VariableDeclarator" && declarator.init) {
+          return isSafe(declarator.init)
+        }
+        return false
+      }
+      return false
+    }
+
+    const check = (node, htmlValue) => {
+      if (isSafe(htmlValue)) return
+      context.report({
+        node,
+        messageId: "unsanitized",
+        data: {
+          sanitizers: [...sanitizers].map((s) => `\`${s}()\``).join(", "),
+        },
+      })
+    }
+
+    /** Pull the `__html` value out of a `{ __html: ... }` object. */
+    const htmlValueOf = (objectExpression) =>
+      objectExpression?.type === "ObjectExpression"
+        ? objectExpression.properties.find(
+            (property) =>
+              property.type === "Property" && property.key?.name === "__html"
+          )?.value
+        : undefined
+
+    return {
+      JSXAttribute(node) {
+        if (node.name?.name !== "dangerouslySetInnerHTML") return
+        const expression =
+          node.value?.type === "JSXExpressionContainer"
+            ? node.value.expression
+            : undefined
+        check(node, htmlValueOf(expression))
+      },
+
+      Property(node) {
+        if (node.computed) return
+        const key = node.key?.name ?? node.key?.value
+        if (key !== "dangerouslySetInnerHTML") return
+        check(node, htmlValueOf(node.value))
+      },
+    }
+  },
+}

--- a/packages/react/.oxlint-plugins/f0-security/rules/require-style-nonce.js
+++ b/packages/react/.oxlint-plugins/f0-security/rules/require-style-nonce.js
@@ -1,0 +1,64 @@
+/**
+ * An inline `<style>` element needs a `nonce` to survive a strict CSP.
+ *
+ * Under a `style-src` without `'unsafe-inline'`, an inline stylesheet with no
+ * nonce is dropped by the browser — silently. The component still renders, it
+ * just loses whatever the stylesheet was doing (chart colours, scrollbar
+ * hiding). Nothing throws, so this fails in a consumer's hardened deployment
+ * and nowhere else.
+ *
+ * f0 has no nonce plumbing yet, so the two elements that predate this rule are
+ * listed in `allow` rather than suppressed inline. Keeping them in one place
+ * makes the debt legible and keeps the rule live for anything new — which is
+ * the point: this rule exists to stop the third one from being added.
+ */
+export default {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Require a `nonce` on inline `<style>` elements so they survive a strict CSP.",
+    },
+    messages: {
+      missingNonce:
+        "`<style>` has no `nonce`, so a strict CSP (`style-src` without `'unsafe-inline'`) drops it silently. Pass a `nonce`, or move the rules into a Tailwind layer.",
+    },
+    schema: [
+      {
+        type: "object",
+        properties: {
+          allow: { type: "array", items: { type: "string" } },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+  create(context) {
+    const allow = context.options?.[0]?.allow ?? []
+    const filename = (
+      context.filename ??
+      context.getFilename?.() ??
+      ""
+    ).replace(/\\/g, "/")
+    if (allow.some((suffix) => filename.endsWith(suffix))) return {}
+
+    return {
+      JSXOpeningElement(node) {
+        if (node.name?.type !== "JSXIdentifier" || node.name.name !== "style") {
+          return
+        }
+        const hasNonce = node.attributes.some(
+          (attribute) =>
+            attribute.type === "JSXAttribute" &&
+            attribute.name?.name === "nonce"
+        )
+        // A spread could carry the nonce; do not guess against it.
+        const hasSpread = node.attributes.some(
+          (attribute) => attribute.type === "JSXSpreadAttribute"
+        )
+        if (hasNonce || hasSpread) return
+        context.report({ node, messageId: "missingNonce" })
+      },
+    }
+  },
+}

--- a/packages/react/.oxlintrc.json
+++ b/packages/react/.oxlintrc.json
@@ -5,13 +5,24 @@
     "correctness": "error"
   },
   "rules": {
-    "react-hooks/exhaustive-deps": "off"
+    "react-hooks/exhaustive-deps": "off",
+    "f0-security/no-spread-after-inner-html": "error",
+    "f0-security/require-sanitized-inner-html": "error",
+    "f0-security/require-style-nonce": [
+      "error",
+      {
+        "allow": ["src/ui/chart.tsx", "src/kits/ai/F0AiPong/F0AiPong.tsx"]
+      }
+    ]
   },
   "env": {
     "builtin": true,
     "browser": true
   },
-  "jsPlugins": ["eslint-plugin-react-refresh"],
+  "jsPlugins": [
+    "eslint-plugin-react-refresh",
+    "./.oxlint-plugins/f0-security/index.js"
+  ],
   "overrides": [
     {
       "files": ["**/*.{js,jsx,ts,tsx}"],

--- a/packages/react/AGENTS.md
+++ b/packages/react/AGENTS.md
@@ -183,6 +183,19 @@ See `f0-component-patterns` skill for code examples.
 - Export component prop interfaces
 - No circular imports
 
+## Injecting HTML
+
+- `dangerouslySetInnerHTML` needs a sanitizer — `parseMarkdown()` /
+  `parseMarkdownDocument()` from `@/lib/markdown`, or `DOMPurify.sanitize()`
+- Put the props spread **before** `dangerouslySetInnerHTML`, never after: it is a
+  legal DOM prop, so spreading after it lets a caller replace the sanitized HTML
+- A component that sanitizes should `Omit<..., "dangerouslySetInnerHTML">` from
+  its props type, so the mistake is a type error rather than a silent bypass
+- Inline `<style>` needs a `nonce` or a strict CSP drops it silently
+
+Enforced by the `f0-security` rules in `.oxlint-plugins/` (they run in
+`pnpm lint`, but oxc does not surface JS plugins in editors yet).
+
 ## Testing
 
 - Test files: `.test.tsx` / `.test.ts` — never `.spec.ts`

--- a/packages/react/src/components/RichText/F0RichTextDisplay/F0RichTextDisplay.test.tsx
+++ b/packages/react/src/components/RichText/F0RichTextDisplay/F0RichTextDisplay.test.tsx
@@ -1,0 +1,41 @@
+import { render } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { F0RichTextDisplay } from "./F0RichTextDisplay"
+
+describe("F0RichTextDisplay sanitization", () => {
+  it("strips event handlers from content", () => {
+    const { container } = render(
+      <F0RichTextDisplay content={`<img src="x" onerror="alert(1)">`} />
+    )
+
+    expect(container.innerHTML).not.toContain("onerror")
+  })
+
+  it("strips javascript: URLs from content", () => {
+    const { container } = render(
+      <F0RichTextDisplay content={`<a href="javascript:alert(1)">go</a>`} />
+    )
+
+    expect(container.innerHTML).not.toContain("javascript:")
+  })
+
+  // Regression: `{...props}` used to be spread AFTER `dangerouslySetInnerHTML`,
+  // so a caller could hand over raw HTML and silently replace the sanitized
+  // output. The prop type now omits the key, but a JS consumer (or a `{...rest}`
+  // forwarded from a wider prop bag) can still reach the runtime path — so the
+  // attribute ordering has to hold on its own.
+  it("ignores a caller-supplied dangerouslySetInnerHTML instead of rendering it", () => {
+    const { container } = render(
+      <F0RichTextDisplay
+        content="safe content"
+        // @ts-expect-error -- omitted from the prop type on purpose; this
+        // asserts the runtime is safe even when the type check is bypassed.
+        dangerouslySetInnerHTML={{ __html: `<img src="x" onerror="alert(1)">` }}
+      />
+    )
+
+    expect(container.innerHTML).not.toContain("onerror")
+    expect(container.textContent).toContain("safe content")
+  })
+})

--- a/packages/react/src/components/RichText/F0RichTextDisplay/F0RichTextDisplay.tsx
+++ b/packages/react/src/components/RichText/F0RichTextDisplay/F0RichTextDisplay.tsx
@@ -13,7 +13,11 @@ import "../index.css"
 
 // Declared next to the component (not in a sibling types.ts) so api-extractor
 // rolls them into the bundled d.ts instead of emitting a broken './types' import.
-export interface F0RichTextDisplayProps extends HTMLAttributes<HTMLDivElement> {
+export interface F0RichTextDisplayProps
+  // `dangerouslySetInnerHTML` is omitted on purpose: this component exists to
+  // sanitize `content`, so accepting raw HTML alongside it would hand callers a
+  // way to skip that. Omitting the key turns the mistake into a type error.
+  extends Omit<HTMLAttributes<HTMLDivElement>, "dangerouslySetInnerHTML"> {
   content: string
   className?: string
   format?: "html" | "markdown"
@@ -56,6 +60,12 @@ const F0RichTextDisplayBase = forwardRef<
 
   return (
     <div
+      // The spread goes FIRST. `dangerouslySetInnerHTML` is a legal DOM prop,
+      // so spreading after it would let a caller replace the sanitized HTML
+      // with their own — silently defeating the only thing this component is
+      // for. The prop type omits the key as well; this ordering is the runtime
+      // half of that guarantee.
+      {...props}
       ref={ref}
       className={cn(
         "rich-text-display-container",
@@ -65,7 +75,6 @@ const F0RichTextDisplayBase = forwardRef<
       dangerouslySetInnerHTML={{
         __html: sanitized,
       }}
-      {...props}
     />
   )
 })

--- a/packages/react/src/lib/F0GridStack/components/grid-stack-provider.tsx
+++ b/packages/react/src/lib/F0GridStack/components/grid-stack-provider.tsx
@@ -6,6 +6,7 @@ import type {
 } from "gridstack"
 
 import { useDeepCompareEffect } from "@reactuses/core"
+import DOMPurify from "dompurify"
 import { motion } from "motion/react"
 import React, {
   type PropsWithChildren,
@@ -334,8 +335,15 @@ export function GridStackProvider({
             // Capture the static HTML and dimensions from the DOM before wrapping
             let staticHTML = ""
             if (widgetElement) {
-              // Clone the element with canvas content preserved
-              staticHTML = cloneElementWithCanvas(widgetElement)
+              // Clone the element with canvas content preserved, then sanitize:
+              // this markup came out of already-rendered DOM, so it is only as
+              // trustworthy as whatever the widget rendered, and it is about to
+              // go back through dangerouslySetInnerHTML. DOMPurify keeps
+              // everything the snapshot needs — data: URI images, inline
+              // styles, classes, SVG — and drops handlers.
+              staticHTML = DOMPurify.sanitize(
+                cloneElementWithCanvas(widgetElement)
+              )
             }
 
             next.set(


### PR DESCRIPTION
## Description

`F0RichTextDisplay` spread `{...props}` **after** `dangerouslySetInnerHTML`. Because its props type extends `HTMLAttributes<HTMLDivElement>`, `dangerouslySetInnerHTML` is a legal prop — so a caller could pass their own and silently replace the sanitized HTML. The `content` path sanitized correctly; the props path did not. This fixes that, and adds three lint rules so the whole family of `dangerouslySetInnerHTML` mistakes is caught mechanically rather than by review.

## Why it matters

Not attacker-reachable on its own — a consumer has to pass the prop. The realistic route is forwarding `{...rest}` from a wider component API into `<F0RichTextDisplay {...rest} />` without realizing you have handed callers a way to skip sanitization.

It matters *here* because of what sits on top: `PostDescription` renders Communities posts — genuinely user-generated content — through this component, and its 16-test XSS suite asserts the sanitizer holds. That suite only exercises `content`, so the bypass was invisible to it.

## Implementation details

- fix: put the props spread before `dangerouslySetInnerHTML` in `F0RichTextDisplay`
- fix: omit `dangerouslySetInnerHTML` from `F0RichTextDisplayProps`

  <details>
  <summary>Why both?</summary>

  The reorder fixes the runtime. The `Omit` turns the mistake into a type error so it never reaches runtime in the first place. The regression test deliberately uses `@ts-expect-error` to bypass the type and assert the runtime holds anyway — a JS consumer, or a `{...rest}` typed loosely upstream, can still reach that path.

  This will trip the api-surface job's **"breaking changes"** label. That is expected and correct: removing this prop is the point, and `F0RichTextDisplay` is `@experimental`.
  </details>

- test: add a regression test that fails without the reorder

- feat: add an `f0-security` oxlint plugin with three ESLint-format rules

  <details>
  <summary>Rules, and why rules rather than a ratchet script</summary>

  Loaded through oxlint's `jsPlugins`, which accepts a local path — so these are plain ESLint-shaped rules running inside the `pnpm lint` CI already runs.

  - **`no-spread-after-inner-html`** — the defect above, as a pure attribute-ordering check. No data flow, nothing to maintain. Also covers the `createElement({ ...props })` form, which is how `Text.tsx` and `OneEllipsis` build their props.
  - **`require-sanitized-inner-html`** — `__html` must come from a sanitizer. Shallow and same-file by design: it resolves direct calls, local bindings through `useMemo` and ternaries, and reassignments, but not values routed through another module. A tripwire for the accidental case, not a proof.
  - **`require-style-nonce`** — an inline `<style>` with no `nonce` is dropped silently by a strict CSP; the component renders but loses its styling, and only in a consumer's hardened deployment.

  These are rules and not a ratchet script — the mechanism [#5318](https://github.com/factorialco/f0/pull/5318) uses for inline styles — precisely because there were only **two** violations in the whole codebase. A lint rule has no baseline mechanism, so it is the right tool exactly when you can fix the violations and turn it on. `.oxlint-plugins/README.md` records that trade-off so the next rule picks the right mechanism.
  </details>

- fix: sanitize the re-injected DOM snapshot in `grid-stack-provider`

  <details>
  <summary>Found by the new rule</summary>

  It re-injected HTML it had just serialized out of rendered DOM, unsanitized — so it is only as trustworthy as whatever the widget rendered. Now goes through DOMPurify. I verified sanitization preserves everything the exit-animation snapshot needs: `data:` URI images (the canvas→img conversion), inline styles, classes and SVG. The existing 75-test F0GridStack suite still passes.
  </details>

- chore: list the two pre-existing nonce-less `<style>` elements in the rule's `allow` option

  <details>
  <summary>Why an option and not disable comments</summary>

  f0 has no nonce plumbing — adding one means threading a nonce through `F0Provider` and the public chart API, which is a feature, not a lint-rule PR. The codebase also has zero `oxlint-disable` comments today and I would rather not start that precedent for two known cases.

  Keeping them in the rule's `allow` list puts the debt in one readable place and keeps the rule live for anything new — which is the actual value: stopping the third one from being added. **Follow-up:** add nonce support so `src/ui/chart.tsx` and `src/kits/ai/F0AiPong/F0AiPong.tsx` can come off the list.
  </details>

- docs: add `.oxlint-plugins/README.md` and an "Injecting HTML" section to `AGENTS.md`

## Verification

- Red-green confirmed by hand: reverting only the attribute order makes the new test fail and the new lint rule fire; restoring it makes both pass
- The rules run against all 3,450 files with **zero false positives** — they flagged exactly the two real defects and left the other six `dangerouslySetInnerHTML` sites alone
- 19 rule tests, which shell out to the real oxlint binary rather than using ESLint's `RuleTester` — the rules only matter insofar as `pnpm lint` enforces them, and oxlint's JS-plugin AST is what they actually see
- `pnpm lint` clean (100 rules, up from 97), `pnpm tsc` clean, `oxfmt --check` clean, 113 tests pass across the rules and everything the fixes touch

## Caveat worth knowing

oxc marks JS plugins experimental and **does not support them in the language server**, so these three rules fire in `pnpm lint` and CI but not in your editor. Rule messages are written to be actionable from a CI log alone.

## Costs

The rule test file shells out to oxlint 19 times, adding roughly 3–10s to the unit suite depending on parallel load. Worth it for testing the real integration rather than a parallel ESLint universe, but it is not free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)