### PR TITLE
feat(EditableTable): commit number/money cells on blur

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableCellRenderer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableCellRenderer.test.tsx
@@ -281,6 +281,39 @@ describe("EditableCellRenderer", () => {
       // This depends on how TextCell/Input displays errors
     })
 
+    it("does not debounce and only commits on blur for numberConfig.commitOn: 'blur'", async () => {
+      const user = userEvent.setup()
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+      const numericItem = { ...testItem, name: "100" }
+
+      render(
+        <EditableRowProvider item={numericItem} onCellChange={onCellChange}>
+          <EditableCellRenderer
+            column={createEditableColumn({
+              editType: () => "number",
+              numberConfig: { commitOn: "blur" },
+            })}
+            item={numericItem}
+            cellIndex={0}
+          >
+            <span>Fallback</span>
+          </EditableCellRenderer>
+        </EditableRowProvider>
+      )
+
+      const input = screen.getByRole("textbox")
+      await user.clear(input)
+      await user.type(input, "5")
+
+      // Typing does not trigger a save, even after the usual debounce delay
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      expect(onCellChange).not.toHaveBeenCalled()
+
+      await user.tab()
+
+      await waitFor(() => expect(onCellChange).toHaveBeenCalledTimes(1))
+    })
+
     it("applies right border except for last column", () => {
       const { container } = render(
         <EditableRowProvider item={testItem} onCellChange={vi.fn()}>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableRowContext.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableRowContext.test.tsx
@@ -66,6 +66,27 @@ function TestConsumer() {
       >
         Update Email
       </button>
+      <button
+        onClick={() =>
+          ctx.handleCellChange("name", "Blurred Name", { commitOn: "blur" })
+        }
+        data-testid="type-name-blur"
+      >
+        Type Name (commitOn blur)
+      </button>
+      <button
+        onClick={() =>
+          ctx.handleCellChange("email", "typed@example.com", {
+            debounce: true,
+          })
+        }
+        data-testid="type-email-debounced"
+      >
+        Type Email (debounced)
+      </button>
+      <button onClick={() => ctx.flushPendingChanges()} data-testid="flush">
+        Flush
+      </button>
     </div>
   )
 }
@@ -422,6 +443,113 @@ describe("EditableRowContext", () => {
       expect(onCellChange).toHaveBeenCalledWith({
         updatedItem: { ...reloadedItem, name: "Typed N" },
         changes: { name: ["John Doe", "Typed N"] },
+      })
+    })
+  })
+
+  describe("commit-on-blur cell changes", () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+    })
+
+    it("updates localItem immediately but never saves on its own", async () => {
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+
+      render(
+        <EditableRowProvider item={testItem} onCellChange={onCellChange}>
+          <TestConsumer />
+        </EditableRowProvider>
+      )
+
+      fireEvent.click(screen.getByTestId("type-name-blur"))
+
+      expect(screen.getByTestId("name")).toHaveTextContent("Blurred Name")
+      expect(onCellChange).not.toHaveBeenCalled()
+
+      await act(async () => {
+        vi.advanceTimersByTime(CELL_CHANGE_DEBOUNCE_MS * 10)
+      })
+
+      expect(onCellChange).not.toHaveBeenCalled()
+    })
+
+    it("saves the pending change when flushPendingChanges is called", () => {
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+
+      render(
+        <EditableRowProvider item={testItem} onCellChange={onCellChange}>
+          <TestConsumer />
+        </EditableRowProvider>
+      )
+
+      fireEvent.click(screen.getByTestId("type-name-blur"))
+      fireEvent.click(screen.getByTestId("flush"))
+
+      expect(onCellChange).toHaveBeenCalledTimes(1)
+      expect(onCellChange).toHaveBeenCalledWith({
+        updatedItem: { ...testItem, name: "Blurred Name" },
+        changes: { name: ["John Doe", "Blurred Name"] },
+      })
+    })
+
+    it("does not save a debounced change from another column in the same row until flushed", async () => {
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+
+      render(
+        <EditableRowProvider item={testItem} onCellChange={onCellChange}>
+          <TestConsumer />
+        </EditableRowProvider>
+      )
+
+      fireEvent.click(screen.getByTestId("type-name-blur"))
+      fireEvent.click(screen.getByTestId("type-email-debounced"))
+
+      // Without the deferred flag, the email column's debounce timer would
+      // save the whole row (including the still-unblurred name) early.
+      await act(async () => {
+        vi.advanceTimersByTime(CELL_CHANGE_DEBOUNCE_MS * 10)
+      })
+
+      expect(onCellChange).not.toHaveBeenCalled()
+
+      fireEvent.click(screen.getByTestId("flush"))
+
+      expect(onCellChange).toHaveBeenCalledTimes(1)
+      expect(onCellChange).toHaveBeenCalledWith({
+        updatedItem: {
+          ...testItem,
+          name: "Blurred Name",
+          email: "typed@example.com",
+        },
+        changes: {
+          name: ["John Doe", "Blurred Name"],
+          email: ["john@example.com", "typed@example.com"],
+        },
+      })
+    })
+
+    it("flushes the pending blur change on unmount", () => {
+      const onCellChange = vi.fn().mockResolvedValue(undefined)
+
+      const { unmount } = render(
+        <EditableRowProvider item={testItem} onCellChange={onCellChange}>
+          <TestConsumer />
+        </EditableRowProvider>
+      )
+
+      fireEvent.click(screen.getByTestId("type-name-blur"))
+      expect(onCellChange).not.toHaveBeenCalled()
+
+      unmount()
+
+      expect(onCellChange).toHaveBeenCalledTimes(1)
+      expect(onCellChange).toHaveBeenCalledWith({
+        updatedItem: { ...testItem, name: "Blurred Name" },
+        changes: { name: ["John Doe", "Blurred Name"] },
       })
     })
   })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NumberCell.test.tsx
@@ -160,6 +160,18 @@ describe("NumberCell", () => {
     expect(screen.getByText("€")).toBeInTheDocument()
   })
 
+  it("calls onBlur when the input loses focus", () => {
+    const onBlur = vi.fn()
+
+    render(<NumberCell {...defaultProps} onBlur={onBlur} />)
+
+    const input = screen.getByRole("textbox")
+    input.focus()
+    input.blur()
+
+    expect(onBlur).toHaveBeenCalledTimes(1)
+  })
+
   it("resolves units from a function based on the item", () => {
     render(
       <NumberCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/EditableCellRenderer.tsx
@@ -65,6 +65,7 @@ export function EditableCellRenderer<
     cellLoading,
     handleCellChange,
     batchCellChanges,
+    flushPendingChanges,
   } = editableCtx
   const editableColumn = column as EditableTableColumnDefinition<
     R,
@@ -76,10 +77,20 @@ export function EditableCellRenderer<
 
   const hasId = editableColumn.id !== undefined
 
+  // Number/money columns can opt into committing on blur instead of the
+  // default debounce (see numberConfig.commitOn).
+  const commitOn =
+    (cellEditType === "number" || cellEditType === "money") &&
+    editableColumn.numberConfig?.commitOn === "blur"
+      ? ("blur" as const)
+      : undefined
+
   // Typing cells debounce the parent notification so it fires once when the
   // user stops typing; discrete cells (select, date...) commit immediately.
   const debounce =
-    cellEditType !== undefined && typingEditTypes.has(cellEditType)
+    commitOn !== "blur" &&
+    cellEditType !== undefined &&
+    typingEditTypes.has(cellEditType)
 
   const onChange = (
     value: string | string[] | null,
@@ -105,10 +116,10 @@ export function EditableCellRenderer<
             [editableColumn.id]: value,
             ...formulaUpdates,
           },
-          { debounce }
+          { debounce, commitOn }
         )
       } else {
-        handleCellChange(editableColumn.id, value, { debounce })
+        handleCellChange(editableColumn.id, value, { debounce, commitOn })
       }
     }
   }
@@ -141,6 +152,9 @@ export function EditableCellRenderer<
             isLastColumn={isLastColumn}
             loading={loading}
             onChange={onChange}
+            onBlur={
+              commitOn === "blur" ? () => flushPendingChanges() : undefined
+            }
             hint={editableColumn.cellHint?.(localItem)}
           />
         </div>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -16,6 +16,7 @@ export function NumberCell<R extends RecordType>({
   error,
   loading,
   onChange,
+  onBlur,
   item,
   hint,
 }: EditableCellProps<R>) {
@@ -85,6 +86,7 @@ export function NumberCell<R extends RecordType>({
             value={numericValue}
             placeholder={inputPlaceholder ?? editableColumn.inputPlaceholder}
             onChange={handleChange}
+            onBlur={onBlur}
             loading={loading}
             transparent
             hint=""

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
@@ -24,6 +24,11 @@ export type EditableCellProps<R extends RecordType> = {
   ) => void
   item: R
   isLastColumn?: boolean
+  /**
+   * Called when the cell's input loses focus. Currently only wired for
+   * number/money cells with `numberConfig.commitOn: "blur"`.
+   */
+  onBlur?: () => void
   hint?: {
     icon: IconType
     message: string

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/consts.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/consts.ts
@@ -42,7 +42,9 @@ export const editableCellMap: Record<
  * Edit types backed by free-typing inputs. Changes coming from these cells
  * are debounced so onCellChange fires once when the user stops typing,
  * instead of on every keystroke. Discrete cells (select, date...) save
- * immediately.
+ * immediately. Number/money columns with `numberConfig.commitOn: "blur"`
+ * opt out of this debounce in favor of committing on blur instead (see
+ * EditableCellRenderer).
  */
 export const typingEditTypes: ReadonlySet<EditableTableCellEditType> = new Set([
   "text",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
@@ -21,11 +21,21 @@ export type CellChangeOptions = {
    * so a save is not triggered on every keystroke.
    */
   debounce?: boolean
+  /**
+   * Commit strategy for this update. When "blur", the value updates the
+   * local item immediately but the save to onCellChange waits until
+   * flushPendingChanges() is called explicitly (e.g. on input blur)
+   * instead of the CELL_CHANGE_DEBOUNCE_MS timer or an immediate save.
+   * Defaults to the behavior driven by `debounce`.
+   */
+  commitOn?: "change" | "blur"
 }
 
 /** A change already applied locally whose save is still waiting for the user to stop typing. */
 type PendingChange = {
-  timer: ReturnType<typeof setTimeout>
+  timer?: ReturnType<typeof setTimeout>
+  /** Whether this pending change waits for an explicit flushPendingChanges() call instead of a timer. */
+  deferred?: boolean
   /** Value of each column before the user started typing */
   previousValues: Record<string, unknown>
   /** Latest typed values, re-applied if the item prop reloads mid-typing */
@@ -50,6 +60,11 @@ type EditableRowContextValue<R extends RecordType> = {
     updates: Record<string, unknown>,
     options?: CellChangeOptions
   ) => void
+  /**
+   * Saves any pending change immediately, e.g. called on input blur when a
+   * column commits on blur instead of on debounce.
+   */
+  flushPendingChanges: () => void
 }
 
 // React's createContext does not support per-usage generics.
@@ -150,7 +165,7 @@ export function EditableRowProvider<R extends RecordType>({
     const pending = pendingRef.current
     if (!pending) return
 
-    clearTimeout(pending.timer)
+    if (pending.timer) clearTimeout(pending.timer)
     pendingRef.current = null
     save(pending.previousValues)
   }
@@ -178,7 +193,7 @@ export function EditableRowProvider<R extends RecordType>({
     setLocalItem(updatedItem)
     setErrors(columnIds, undefined)
 
-    if (!options?.debounce) {
+    if (!options?.debounce && options?.commitOn !== "blur") {
       // Save any pending typing first so changes reach the parent in order
       flushPending()
       save(previousValues)
@@ -189,15 +204,20 @@ export function EditableRowProvider<R extends RecordType>({
     // from before the first keystroke so the reported change covers the
     // whole typing session, not just the last keystroke.
     const pending = pendingRef.current
-    if (pending) clearTimeout(pending.timer)
+    if (pending?.timer) clearTimeout(pending.timer)
+
+    // Once any change in this row is waiting for an explicit flush (e.g. a
+    // commitOn: "blur" column), keep the whole row deferred so another
+    // column's debounce timer can't save it early.
+    const deferred = pending?.deferred || options?.commitOn === "blur"
 
     pendingRef.current = {
       previousValues: { ...previousValues, ...pending?.previousValues },
       updates: { ...pending?.updates, ...updates },
-      timer: setTimeout(
-        () => flushPendingRef.current(),
-        CELL_CHANGE_DEBOUNCE_MS
-      ),
+      deferred,
+      timer: deferred
+        ? undefined
+        : setTimeout(() => flushPendingRef.current(), CELL_CHANGE_DEBOUNCE_MS),
     }
   }
 
@@ -220,6 +240,7 @@ export function EditableRowProvider<R extends RecordType>({
         cellLoading,
         handleCellChange,
         batchCellChanges,
+        flushPendingChanges: flushPending,
       }}
     >
       {children}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -96,6 +96,14 @@ export type NumberCellConfig<R extends RecordType = RecordType> = {
    */
   units?: string | ((item: R) => string | undefined)
   unitsPosition?: "before" | "after"
+  /**
+   * When to notify onCellChange. Defaults to `"change"` (debounced ~250ms
+   * after the user stops typing). Set to `"blur"` to wait until the field
+   * loses focus instead — useful when partial values while typing (e.g.
+   * "12.") shouldn't trigger transient saves. Applies to money cells too,
+   * since they reuse this config.
+   */
+  commitOn?: "change" | "blur"
 }
 
 /**


### PR DESCRIPTION
## Description

`EditableTable` today commits every typing cell (text, number, money) with a fixed 250ms debounce, with no way for a single column to confirm its change at a different moment. This adds `numberConfig.commitOn: "change" | "blur"` so a `number`/`money` column can opt into confirming `onCellChange` on blur instead, without touching the default debounce for other columns or other consumers of the table.

Jira: https://factorialmakers.atlassian.net/browse/FCT-58518

## Implementation details

- feat: add `numberConfig.commitOn?: "change" | "blur"` (default `"change"`, no behavior change)
- feat: expose `flushPendingChanges()` from `EditableRowContext` so a cell can force-save its pending value
- feat: wire `EditableCellRenderer` to disable the debounce and call `flushPendingChanges()` on blur when `commitOn: "blur"`
- feat: pass `onBlur` through `NumberCell` to `F0NumberInput` (`MoneyCell` inherits it via prop spread, since it reuses `numberConfig`)
- fix: guard the row's shared pending-change timer so a `commitOn: "blur"` column isn't saved early by another column's debounce timer in the same row

  <details>
  <summary>Why?</summary>

  `EditableRowContext` batches all pending column changes for a row under a single timer. If a `blur` column and a normal debounced column are both edited in the same row before either commits, the debounced column's timer would otherwise flush the whole row — including the still-unblurred value. A `deferred` flag on the pending change keeps the whole row waiting for an explicit flush once any column in it is `commitOn: "blur"`.
  </details>

- test: cover commit-on-blur behavior in `EditableRowContext`, `EditableCellRenderer`, and `NumberCell` tests

## Manual testing
Before
https://github.com/user-attachments/assets/41d05449-dff3-4b08-a27f-771358d19ce4

After
https://github.com/user-attachments/assets/7779ebee-a649-482e-95b2-1ae85e88a76f

