### PR TITLE
fix(OneDataCollection): keep collapsed groups collapsed across data changes

### DIFF
--- a/packages/react/src/hooks/datasource/__test__/useGroups.test.ts
+++ b/packages/react/src/hooks/datasource/__test__/useGroups.test.ts
@@ -6,12 +6,15 @@ import { useGroups } from "../useGroups"
 
 type TestRecord = { id: number; name: string }
 
-const buildGroups = (keys: string[]): GroupRecord<TestRecord>[] =>
+const buildGroups = (
+  keys: string[],
+  records: TestRecord[] = []
+): GroupRecord<TestRecord>[] =>
   keys.map((key) => ({
     key,
     label: key,
-    itemCount: 0,
-    records: [],
+    itemCount: records.length,
+    records,
   }))
 
 describe("useGroups", () => {
@@ -84,6 +87,42 @@ describe("useGroups", () => {
       rerender({ groups: buildGroups(["x", "y"]) })
 
       expect(result.current.openGroups).toEqual({ x: true, y: true })
+    })
+  })
+
+  describe("when the records of the same groups change", () => {
+    it("keeps the groups the user toggled", () => {
+      const { result, rerender } = renderHook(
+        ({ groups }) => useGroups(groups, false),
+        {
+          initialProps: {
+            groups: buildGroups(["a", "b"], [{ id: 1, name: "one" }]),
+          },
+        }
+      )
+
+      act(() => {
+        result.current.setGroupOpen("a", true)
+      })
+
+      rerender({ groups: buildGroups(["a", "b"], [{ id: 2, name: "two" }]) })
+
+      expect(result.current.openGroups).toEqual({ a: true, b: false })
+    })
+
+    it("seeds only the groups that were not known before", () => {
+      const { result, rerender } = renderHook(
+        ({ groups }) => useGroups(groups, false),
+        { initialProps: { groups: buildGroups(["a"]) } }
+      )
+
+      act(() => {
+        result.current.setGroupOpen("a", true)
+      })
+
+      rerender({ groups: buildGroups(["a", "b"]) })
+
+      expect(result.current.openGroups).toEqual({ a: true, b: false })
     })
   })
 })

--- a/packages/react/src/hooks/datasource/useGroups.ts
+++ b/packages/react/src/hooks/datasource/useGroups.ts
@@ -26,13 +26,22 @@ export const useGroups = <R extends RecordType>(
     computeDefaultOpenGroups(groups, defaultOpenGroups)
   )
 
+  const groupKeys = groups.map((group) => group.key).join("|")
+
   useEffect(() => {
     const defaultValue = computeDefaultOpenGroups(groups, defaultOpenGroups)
-    if (Object.values(defaultValue).length > 0) {
-      setOpenGroups(defaultValue)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- only run on deep changes
-  }, [JSON.stringify(groups), JSON.stringify(defaultOpenGroups)])
+    if (Object.values(defaultValue).length === 0) return
+
+    setOpenGroups((prev) =>
+      Object.fromEntries(
+        Object.entries(defaultValue).map(([key, isOpen]) => [
+          key,
+          prev[key] ?? isOpen,
+        ])
+      )
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupKeys, JSON.stringify(defaultOpenGroups)])
 
   const setGroupOpen = (key: string, open: boolean) => {
     setOpenGroups((prev) => ({ ...prev, [key]: open }))


### PR DESCRIPTION
## Problem

In a grouped collection, expanding or collapsing a group is lost as soon as the data changes — paginating to the next page, refetching, or re-sorting all reset every group back to `defaultOpenGroups`.

Reported from Factorial's IT Inventory: with `defaultOpenGroups: false`, the user opens a group, moves to the next page, and finds it collapsed again.

## Cause

`useGroups` re-seeded the whole open-state map from the defaults on an effect keyed by `JSON.stringify(groups)`. `GroupRecord` carries `records`, so any data change re-ran the effect and overwrote every manual toggle.

## Fix

- Seed only the group keys that were not known yet; keep whatever the user set for the ones already tracked.
- Key the effect on the group keys rather than the full group records, so changing rows within the same groups is not a re-seed at all.

Defaults on first render, on groups arriving asynchronously, and on a brand-new group appearing are unchanged.

## Testing

Collapsed last model:

<img width="1282" height="705" alt="image" src="https://github.com/user-attachments/assets/0499721b-6e31-4e83-acfb-e8b7e11ab664" />

Paginate:

Now is collapsed
<img width="1289" height="439" alt="image" src="https://github.com/user-attachments/assets/6c49189f-235d-4f24-b1ac-efb4bfaab1b4" />

By default:

<img width="1316" height="215" alt="image" src="https://github.com/user-attachments/assets/05c904f1-3344-481b-a70e-d5cd0ae100fd" />
<img width="1279" height="657" alt="image" src="https://github.com/user-attachments/assets/3b89c10b-39b4-43e5-a483-580312786268" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)
