### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.84.2",
+  "packages/react": "6.84.3",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.84.3](https://github.com/factorialco/f0/compare/f0-react-v6.84.2...f0-react-v6.84.3) (2026-09-04)
+
+
+### Bug Fixes
+
+* **OneDataCollection:** keep collapsed groups collapsed across data changes ([#5391](https://github.com/factorialco/f0/issues/5391)) ([c53c0d5](https://github.com/factorialco/f0/commit/c53c0d54b4da9f8547bdc38ff3ae712988fd2dac))
+
 ## [6.84.2](https://github.com/factorialco/f0/compare/f0-react-v6.84.1...f0-react-v6.84.2) (2026-09-03)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.84.2",
+  "version": "6.84.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.84.3</summary>

## [6.84.3](https://github.com/factorialco/f0/compare/f0-react-v6.84.2...f0-react-v6.84.3) (2026-09-04)


### Bug Fixes

* **OneDataCollection:** keep collapsed groups collapsed across data changes ([#5391](https://github.com/factorialco/f0/issues/5391)) ([c53c0d5](https://github.com/factorialco/f0/commit/c53c0d54b4da9f8547bdc38ff3ae712988fd2dac))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).