### PR TITLE
feat(F0Coachmark): walk a page step by step, with a spotlight

### DIFF
--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
@@ -1,9 +1,27 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from "react"
 
+import { useReducedMotion } from "@/lib/a11y"
+
 import { F0Coachmark } from "./F0Coachmark"
 import { coachmarkStore } from "./store"
 import type { CoachmarkItem } from "./types"
 import { useTargetElement } from "./useTargetElement"
+
+/**
+ * HOW MANY PRESSES ON THE DIM PAGE END THE WALKTHROUGH. Five is well past a
+ * mis-click and well short of a user who is simply reading with the mouse in
+ * hand: by the fifth the wiggle has answered four times and the answer has
+ * stopped being information.
+ */
+const DEFAULT_SKIP_AFTER_OUTSIDE_CLICKS = 5
+
+/**
+ * HOW LONG THE OUTGOING STEP TAKES TO GO, and how long after the action the next
+ * one is committed. Matches the panel's own `duration-150` fade-out (the
+ * fade-IN it comes back with is longer): leaving should feel like a dismissal
+ * and arriving like an arrival, and the reader is only waiting on the second.
+ */
+const STEP_FADE_OUT_MS = 150
 
 type CoachmarkProviderProps = {
   children: React.ReactNode
@@ -34,6 +52,11 @@ const ActiveCoachmark = ({
   container: HTMLElement | null
 }) => {
   const [index, setIndex] = useState(0)
+  // THE HANDOVER BETWEEN TWO STEPS. `true` for the fade-out that runs before the
+  // next step is committed — see `advanceTo`.
+  const [leaving, setLeaving] = useState(false)
+  const handover = useRef<ReturnType<typeof setTimeout>>()
+  const reducedMotion = useReducedMotion()
 
   // Clamped rather than indexed directly: `coachmarks.open({ id })` can replace
   // this coachmark with a shorter sequence while it is on screen.
@@ -41,7 +64,41 @@ const ActiveCoachmark = ({
   const step = item.steps[stepIndex]
   const isLastStep = stepIndex === item.steps.length - 1
 
+  useEffect(() => () => clearTimeout(handover.current), [])
+
+  /**
+   * Moves to the next step THROUGH A FADE, and commits it while the panel is
+   * invisible: everything about a step changes at once — its copy, the element
+   * it is anchored to, the page's scroll — and committing all of that on a
+   * visible panel reads as a glitch rather than as a step. Faded out, the
+   * reposition happens where nobody can see it, and the new step fades up
+   * already in place.
+   *
+   * The step index is the ONLY thing the timer defers. Nothing here can leave
+   * the coachmark stuck mid-fade: the close button and the shield's own ending
+   * remove the item outright, and the timeout is cleared on unmount.
+   */
+  const advanceTo = (nextIndex: number) => {
+    if (reducedMotion) {
+      setIndex(nextIndex)
+      return
+    }
+    setLeaving(true)
+    handover.current = setTimeout(() => {
+      setIndex(nextIndex)
+      setLeaving(false)
+    }, STEP_FADE_OUT_MS)
+  }
+
   const target = useTargetElement(step.targetElement)
+
+  // Presses on the shield, counted ACROSS THE WHOLE COACHMARK rather than per
+  // step: someone pressing past the panel on every step is the exact user this
+  // is for, and a per-step count would never reach the threshold. A ref, not
+  // state — the panel owns the wiggle, so nothing here re-renders on a press.
+  const outsidePresses = useRef(0)
+  const skipAfter =
+    item.skipAfterOutsideClicks ?? DEFAULT_SKIP_AFTER_OUTSIDE_CLICKS
 
   const close = () => coachmarkStore.removeItem(item.id)
 
@@ -70,10 +127,20 @@ const ActiveCoachmark = ({
           item.onComplete?.()
           close()
         } else {
-          setIndex(stepIndex + 1)
+          advanceTo(stepIndex + 1)
         }
       }}
       onClose={() => {
+        item.onDismiss?.()
+        close()
+      }}
+      overlay={item.overlay}
+      leaving={leaving}
+      onOutsideInteraction={() => {
+        outsidePresses.current += 1
+        if (skipAfter <= 0 || outsidePresses.current < skipAfter) return
+        // The same ending as the close button: the user asked to be out of the
+        // way of the page, which is what dismissing is.
         item.onDismiss?.()
         close()
       }}

--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
@@ -136,6 +136,7 @@ const ActiveCoachmark = ({
       }}
       overlay={item.overlay}
       leaving={leaving}
+      focusTarget={step.focusTarget}
       onOutsideInteraction={() => {
         outsidePresses.current += 1
         if (skipAfter <= 0 || outsidePresses.current < skipAfter) return

--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
@@ -4,7 +4,7 @@ import { useReducedMotion } from "@/lib/a11y"
 
 import { F0Coachmark } from "./F0Coachmark"
 import { coachmarkStore } from "./store"
-import type { CoachmarkItem } from "./types"
+import type { CoachmarkEndReason, CoachmarkItem } from "./types"
 import { useTargetElement } from "./useTargetElement"
 
 /**
@@ -102,6 +102,26 @@ const ActiveCoachmark = ({
 
   const close = () => coachmarkStore.removeItem(item.id)
 
+  /**
+   * ENDS THE COACHMARK AND SAYS HOW. The one place all three endings go through,
+   * so `onEnd` cannot get out of step with what actually happened — and so the
+   * step the reader got to is read at the moment they left rather than
+   * reconstructed afterwards.
+   *
+   * `coachmarkStore.removeItem` from anywhere else (a `coachmarks.close`, a
+   * guidance's `stop()`) deliberately does NOT come through here: nobody ended
+   * it, so there is no outcome.
+   */
+  const endWith = (reason: CoachmarkEndReason) => {
+    item.onEnd?.({
+      reason,
+      step: stepIndex + 1,
+      totalSteps: item.steps.length,
+      outsidePresses: outsidePresses.current,
+    })
+    close()
+  }
+
   // `null` while the step's target is not in the DOM — see useTargetElement.
   if (!target) return null
 
@@ -125,14 +145,14 @@ const ActiveCoachmark = ({
         step.action?.onClick?.()
         if (isLastStep) {
           item.onComplete?.()
-          close()
+          endWith("completed")
         } else {
           advanceTo(stepIndex + 1)
         }
       }}
       onClose={() => {
         item.onDismiss?.()
-        close()
+        endWith("dismissed")
       }}
       overlay={item.overlay}
       leaving={leaving}
@@ -140,10 +160,11 @@ const ActiveCoachmark = ({
       onOutsideInteraction={() => {
         outsidePresses.current += 1
         if (skipAfter <= 0 || outsidePresses.current < skipAfter) return
-        // The same ending as the close button: the user asked to be out of the
-        // way of the page, which is what dismissing is.
+        // A dismissal to the app's bookkeeping — the reader asked to be out of
+        // the way of the page — and its own `reason` to whoever is tracking,
+        // because "pressed past it until it went away" is not "closed it".
         item.onDismiss?.()
-        close()
+        endWith("skipped")
       }}
     />
   )

--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
@@ -179,11 +179,19 @@ export const CoachmarkSpotlight = ({
           in `foreground-tertiary` — the emphasis the design asks for on a
           spotlighted card's border, drawn on the light's own edge rather than
           written onto an element this component does not own (and which may not
-          have a border to recolour in the first place). */}
+          have a border to recolour in the first place).
+
+          TWO SHADOWS, GLOW FIRST. The glow is the page's own surface colour
+          (`--neutral-0`: white in light, the dark ground in dark) blurred
+          outward over the dim, so the lit element reads as GLOWING rather than
+          as a hole cut in a sheet — the same thing a focused field does, for an
+          element that may not have a focus state to lend us. It has to come
+          first in the list: shadows paint first over last, and the 100vmax dim
+          would otherwise bury it. */}
       <div
         className={cn(
           "absolute rounded-xl border border-solid border-f1-foreground-tertiary",
-          "shadow-[0_0_0_100vmax_hsl(var(--neutral-40))]",
+          "shadow-[0_0_24px_6px_hsl(var(--neutral-0)/0.7),0_0_0_100vmax_hsl(var(--neutral-40))]",
           // Only while it has somewhere to go — see `useTravelling`. The dim
           // itself never fades: the light travels to the next step's element,
           // rather than the page coming up to full brightness in between.

--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
@@ -182,22 +182,22 @@ export const CoachmarkSpotlight = ({
       // focus glow with it, on the reader's first press anywhere on the page.
       onMouseDown={(event) => event.preventDefault()}
     >
-      {/* The lit region: clear box, dim cast outwards, and a hairline around it
-          in `foreground-tertiary` — the emphasis the design asks for on a
-          spotlighted card's border, drawn on the light's own edge rather than
-          written onto an element this component does not own (and which may not
-          have a border to recolour in the first place).
+      {/* The lit region: a clear box with no edge of its own. NO BORDER — the
+          element inside already has whatever border it has, and a second line
+          around it drew a box around a box: two rounded rectangles a few pixels
+          apart, neither of them the card.
 
           TWO SHADOWS, GLOW FIRST. The glow is the page's own surface colour
           (`--neutral-0`: white in light, the dark ground in dark) blurred
           outward over the dim, so the lit element reads as GLOWING rather than
           as a hole cut in a sheet — the same thing a focused field does, for an
-          element that may not have a focus state to lend us. It has to come
-          first in the list: shadows paint first over last, and the 100vmax dim
-          would otherwise bury it. */}
+          element that may not have a focus state to lend us. It is also the only
+          thing separating the light from the dim now, which is why it is soft
+          rather than tight. It has to come first in the list: shadows paint
+          first over last, and the 100vmax dim would otherwise bury it. */}
       <div
         className={cn(
-          "absolute rounded-xl border border-solid border-f1-foreground-tertiary",
+          "absolute rounded-xl",
           "shadow-[0_0_24px_6px_hsl(var(--neutral-0)/0.7),0_0_0_100vmax_hsl(var(--neutral-40))]",
           // Only while it has somewhere to go — see `useTravelling`. The dim
           // itself never fades: the light travels to the next step's element,

--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
@@ -1,0 +1,198 @@
+import { useEffect, useRef, useState } from "react"
+import { createPortal } from "react-dom"
+
+import { useReducedMotion } from "@/lib/a11y"
+import { cn } from "@/lib/utils"
+
+/** Air between the target's own box and the edge of the lit area. */
+const HIGHLIGHT_PADDING = 8
+
+type Rect = { top: number; left: number; width: number; height: number }
+
+const rectOf = (element: HTMLElement): Rect => {
+  const box = element.getBoundingClientRect()
+  return {
+    top: box.top - HIGHLIGHT_PADDING,
+    left: box.left - HIGHLIGHT_PADDING,
+    width: box.width + HIGHLIGHT_PADDING * 2,
+    height: box.height + HIGHLIGHT_PADDING * 2,
+  }
+}
+
+const isSameRect = (a: Rect, b: Rect) =>
+  a.top === b.top &&
+  a.left === b.left &&
+  a.width === b.width &&
+  a.height === b.height
+
+/**
+ * The target's box in viewport coordinates, kept current FRAME BY FRAME.
+ *
+ * Scroll and resize listeners plus a `ResizeObserver` would cover a static
+ * page, and would still leave the hole behind every target that moves for any
+ * other reason — a rail that expands, a widget that arrives, a card that
+ * animates in. A coachmark is on screen for seconds and measures one element,
+ * so it reads that element every frame and re-renders only when the box
+ * actually moved.
+ */
+const useTargetRect = (target: HTMLElement): Rect => {
+  const [rect, setRect] = useState<Rect>(() => rectOf(target))
+  // Mirrors the state so a frame that measured the same box costs nothing.
+  const measured = useRef(rect)
+
+  useEffect(() => {
+    const sync = () => {
+      const next = rectOf(target)
+      if (isSameRect(measured.current, next)) return
+      measured.current = next
+      setRect(next)
+    }
+
+    sync()
+
+    // A target handed to us in an environment with no frames (jsdom without
+    // `pretendToBeVisual`, SSR hydration) is measured once and left alone.
+    if (typeof requestAnimationFrame !== "function") return
+
+    let frame = requestAnimationFrame(function measure() {
+      sync()
+      frame = requestAnimationFrame(measure)
+    })
+    return () => cancelAnimationFrame(frame)
+  }, [target])
+
+  return rect
+}
+
+/** How long the light takes to travel from one step's element to the next's. */
+const MOVE_MS = 300
+
+/**
+ * `true` for as long as the light is TRAVELLING — the window after a step change
+ * in which the hole's geometry is transitioned rather than written.
+ *
+ * The transition cannot simply be left on: the hole is rewritten every frame to
+ * follow its target (see `useTargetRect`), and a transition on those writes
+ * makes the light lag half a second behind a scroll instead of sticking to what
+ * it is lighting. It belongs to the step change alone, which is the one time the
+ * hole has somewhere to go.
+ */
+const useTravelling = (target: HTMLElement, enabled: boolean) => {
+  const [travelling, setTravelling] = useState(false)
+  const previous = useRef(target)
+
+  useEffect(() => {
+    // Mount is not a move: the first step's light comes up where it comes up.
+    if (previous.current === target) return
+    previous.current = target
+    if (!enabled) return
+
+    setTravelling(true)
+    const timer = setTimeout(() => setTravelling(false), MOVE_MS)
+    return () => clearTimeout(timer)
+  }, [target, enabled])
+
+  return travelling
+}
+
+type CoachmarkSpotlightProps = {
+  /** The element that stays lit. */
+  target: HTMLElement
+  /** Portal target, the panel's own. Defaults to `document.body`. */
+  container?: HTMLElement | null
+  /** A pointer landing anywhere on the page while the coachmark is up. */
+  onOutsideInteraction: () => void
+}
+
+/**
+ * THE PAGE, DIMMED EXCEPT FOR ONE ELEMENT — and unclickable while it is.
+ *
+ * One `fixed` shield over the viewport (`data-f0-coachmark-blocker`) with the
+ * dim painted as a huge spread SHADOW cast by a box the size of the target: the
+ * box itself stays clear, so the hole shows the real element underneath at full
+ * strength and can have rounded corners. Four rects around the target would
+ * need no shadow trick but cannot round the corner where two of them meet.
+ *
+ * The shield swallows every pointer press, the lit area included: the highlight
+ * says WHERE to look, and a coachmark that let you act on the thing it is still
+ * explaining would be read as done with. The press is reported instead — that is
+ * what the panel wiggles at, and what eventually skips the walkthrough.
+ */
+export const CoachmarkSpotlight = ({
+  target,
+  container,
+  onOutsideInteraction,
+}: CoachmarkSpotlightProps) => {
+  const rect = useTargetRect(target)
+  const reducedMotion = useReducedMotion()
+  const travelling = useTravelling(target, !reducedMotion)
+
+  // BRINGS THE READER TO THE STEP. The shield covers every scroll region on the
+  // page, so a wheel over it scrolls nothing: while the overlay is up, a target
+  // below the fold is a target the reader cannot get to. Whoever lights an
+  // element has to put it on screen first — and again on every step, since the
+  // next one is regularly somewhere else entirely.
+  //
+  // INSTANTLY, not smoothly. A smooth scroll is an animation the browser
+  // abandons the moment anything else touches that scroller — and a column that
+  // renders only the widgets in view (`WidgetContainer`'s virtualization) does
+  // exactly that as the scroll passes over it. The rail's own add control ended
+  // up 6px from where it started, off screen, with the panel anchored to it.
+  useEffect(() => {
+    // jsdom has no scrolling to do.
+    if (typeof target.scrollIntoView !== "function") return
+    const bring = () =>
+      target.scrollIntoView({ block: "center", inline: "nearest" })
+
+    bring()
+
+    // AND AGAIN NEXT FRAME. A virtualized column mounts the widgets the scroll
+    // just brought into view, which changes its own height underneath the
+    // scroll that was aiming at the old one — the target lands short of centre,
+    // sometimes at the very edge of the scrollport. The second pass measures the
+    // column it actually became.
+    if (typeof requestAnimationFrame !== "function") return
+    const frame = requestAnimationFrame(bring)
+    return () => cancelAnimationFrame(frame)
+  }, [target])
+
+  if (typeof document === "undefined") return null
+
+  return createPortal(
+    <div
+      // Decoration and a shield, never content: the coachmark it belongs to
+      // says everything there is to read here.
+      aria-hidden
+      data-f0-coachmark-blocker
+      // `z-[1249]`: just under the panel's own `z-50` (1250 in the f0 scale,
+      // see core's tailwind config), so the shield covers the app and nothing
+      // else — the panel it belongs to still paints over it.
+      className="fixed inset-0 z-[1249] cursor-default"
+      // Pointer DOWN rather than click: it is the press that has to be
+      // swallowed, before the page under it can take focus or start a drag.
+      onPointerDown={(event) => {
+        event.preventDefault()
+        onOutsideInteraction()
+      }}
+    >
+      {/* The lit region: clear box, dim cast outwards, and a hairline around it
+          in `foreground-tertiary` — the emphasis the design asks for on a
+          spotlighted card's border, drawn on the light's own edge rather than
+          written onto an element this component does not own (and which may not
+          have a border to recolour in the first place). */}
+      <div
+        className={cn(
+          "absolute rounded-xl border border-solid border-f1-foreground-tertiary",
+          "shadow-[0_0_0_100vmax_hsl(var(--neutral-40))]",
+          // Only while it has somewhere to go — see `useTravelling`. The dim
+          // itself never fades: the light travels to the next step's element,
+          // rather than the page coming up to full brightness in between.
+          travelling &&
+            "transition-[top,left,width,height] duration-300 ease-out"
+        )}
+        style={rect}
+      />
+    </div>,
+    container ?? document.body
+  )
+}

--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
@@ -174,6 +174,13 @@ export const CoachmarkSpotlight = ({
         event.preventDefault()
         onOutsideInteraction()
       }}
+      // AND MOUSE DOWN, which is the one that moves focus. Preventing the
+      // pointer event does not stop the mouse event that follows it, and its
+      // default action is "focus what was pressed" — which, on a shield, means
+      // blurring whatever held focus and leaving it on the body. A step that
+      // focused its own field (`focusTarget`) lost that field's focus, and its
+      // focus glow with it, on the reader's first press anywhere on the page.
+      onMouseDown={(event) => event.preventDefault()}
     >
       {/* The lit region: clear box, dim cast outwards, and a hairline around it
           in `foreground-tertiary` — the emphasis the design asks for on a

--- a/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
@@ -1,7 +1,15 @@
-import { useEffect, useId, useMemo, useRef } from "react"
+import {
+  type RefObject,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+} from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { Cross } from "@/icons/app"
+import { useReducedMotion } from "@/lib/a11y"
 import { experimentalComponent } from "@/lib/experimental"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -12,10 +20,41 @@ import {
   PopoverContent,
 } from "@/ui/popover"
 
+import { CoachmarkSpotlight } from "./CoachmarkSpotlight"
 import type { F0CoachmarkProps } from "./types"
 
 const ARROW_WIDTH = 12
 const ARROW_HEIGHT = 6
+
+/**
+ * THE PANEL SAYING "OVER HERE": a press that the shield swallowed produces
+ * nothing on the page, so the panel is what has to answer for it — a short jump
+ * back and forth, the gesture a modal makes when you click its scrim.
+ *
+ * `translate` rather than `transform`: Radix positions the panel by writing a
+ * `transform` on its wrapper, and the tailwindcss-animate classes on the panel
+ * itself animate the same property when it opens. `translate` is its own
+ * property, so this composes with both instead of fighting them.
+ */
+const WIGGLE_OFFSETS = ["0px", "-6px", "6px", "-4px", "4px", "0px"]
+const WIGGLE_MS = 320
+
+const useWiggle = (ref: RefObject<HTMLElement>) => {
+  const reducedMotion = useReducedMotion()
+
+  return useCallback(() => {
+    const element = ref.current
+    // No `Element.animate` in jsdom, and nothing to say to someone who asked
+    // for less motion — the press is still counted either way.
+    if (!element || reducedMotion || typeof element.animate !== "function") {
+      return
+    }
+    element.animate(
+      WIGGLE_OFFSETS.map((translate) => ({ translate })),
+      { duration: WIGGLE_MS, easing: "ease-in-out" }
+    )
+  }, [ref, reducedMotion])
+}
 
 /**
  * The coachmark panel. Rendered by `CoachmarkProvider` for whichever coachmark
@@ -36,10 +75,14 @@ const CoachmarkPanel = ({
   align = "center",
   sideOffset = arrow ? ARROW_HEIGHT + 2 : 4,
   container,
+  overlay = false,
+  onOutsideInteraction,
+  leaving = false,
 }: F0CoachmarkProps) => {
   const i18n = useI18n()
   const contentRef = useRef<HTMLDivElement>(null)
   const previouslyFocused = useRef<HTMLElement | null>(null)
+  const wiggle = useWiggle(contentRef)
 
   const id = useId()
   const titleId = `${id}-title`
@@ -78,6 +121,19 @@ const CoachmarkPanel = ({
       }}
     >
       <PopoverAnchor virtualRef={anchorRef} />
+      {/* Under the panel and over everything else. Rendered from here rather
+          than by the provider so the two always agree on which element is lit:
+          the panel points at `target`, and so does the hole. */}
+      {overlay && (
+        <CoachmarkSpotlight
+          target={target}
+          container={container}
+          onOutsideInteraction={() => {
+            wiggle()
+            onOutsideInteraction?.()
+          }}
+        />
+      )}
       <PopoverContent
         ref={contentRef}
         container={container}
@@ -135,11 +191,26 @@ const CoachmarkPanel = ({
         // block for absolutely-positioned descendants — which pulls the arrow
         // inside that scroll box and clips it away entirely. A coachmark is a
         // few lines tall and never needs to scroll, so the clip buys nothing.
+        // THE STEP-TO-STEP CROSSFADE. `leaving` is the outgoing half: the panel
+        // fades down and the provider commits the next step while it is
+        // invisible, so the copy swapping and the panel jumping to another
+        // element both happen unseen — then the same element fades back up,
+        // already in its new place. Two durations rather than one, matched to
+        // the provider's own fade-out: going takes less time than arriving.
+        //
+        // A transition rather than an animation: it has to be interruptible
+        // (a second step can start while this one is still fading), and it must
+        // not compete with the entrance animation PopoverContent brings, which
+        // owns `animation` on this same element. `duration-150` is the provider's
+        // own `STEP_FADE_OUT_MS`, so the commit lands on a panel that has just
+        // finished going.
         className={cn(
           "w-72 overflow-visible rounded-lg border-none p-4",
           "shadow-lg backdrop-blur-sm",
           "bg-f1-background-inverse text-f1-foreground-inverse",
-          "dark:bg-f1-background-tertiary"
+          "dark:bg-f1-background-tertiary",
+          "transition-opacity",
+          leaving ? "opacity-0 duration-150" : "opacity-100 duration-200"
         )}
       >
         {/* `dark` so every control inside resolves the tokens that suit a dark

--- a/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
@@ -39,6 +39,30 @@ const ARROW_HEIGHT = 6
 const WIGGLE_OFFSETS = ["0px", "-6px", "6px", "-4px", "4px", "0px"]
 const WIGGLE_MS = 320
 
+/**
+ * WHAT A READER WOULD HAVE CLICKED INTO. Fields first and every other focusable
+ * second, in two passes rather than one selector list: a composer is a text area
+ * with a row of buttons under it, and in document order one of those buttons can
+ * come first — a step that says "ask One for it" and lands the caret on a
+ * toolbar chip has focused the wrong thing while looking like it worked.
+ */
+const FIELDS = "textarea, input:not([type='hidden']), [contenteditable='true']"
+const FOCUSABLE = `${FIELDS}, select, button, a[href], [tabindex]:not([tabindex='-1'])`
+
+/**
+ * The element a `focusTarget` step should focus: the target itself when it is
+ * focusable, otherwise the field (or failing that, the control) inside it —
+ * a step points at the box it is describing, and the box is regularly a wrapper
+ * around the thing you actually type into.
+ */
+const fieldIn = (target: HTMLElement): HTMLElement | null => {
+  if (target.matches(FOCUSABLE)) return target
+  return (
+    target.querySelector<HTMLElement>(FIELDS) ??
+    target.querySelector<HTMLElement>(FOCUSABLE)
+  )
+}
+
 const useWiggle = (ref: RefObject<HTMLElement>) => {
   const reducedMotion = useReducedMotion()
 
@@ -78,11 +102,25 @@ const CoachmarkPanel = ({
   overlay = false,
   onOutsideInteraction,
   leaving = false,
+  focusTarget = false,
 }: F0CoachmarkProps) => {
   const i18n = useI18n()
   const contentRef = useRef<HTMLDivElement>(null)
   const previouslyFocused = useRef<HTMLElement | null>(null)
   const wiggle = useWiggle(contentRef)
+
+  /**
+   * WHERE FOCUS BELONGS FOR THIS STEP. The panel, so the step is announced and
+   * Enter cannot fire the action unread — unless the step asked for its own
+   * element (`focusTarget`), in which case the field it is pointing at, which is
+   * how a composer gets its cursor and its own focus glow. Falls back to the
+   * panel when the target holds nothing focusable at all, so a step that asked
+   * for something impossible still behaves like every other step.
+   */
+  const focusForStep = () => {
+    const field = focusTarget ? fieldIn(target) : null
+    ;(field ?? contentRef.current)?.focus()
+  }
 
   const id = useId()
   const titleId = `${id}-title`
@@ -96,13 +134,14 @@ const CoachmarkPanel = ({
 
   // Advancing keeps the panel mounted, so focus would stay on the action button
   // — where a second Enter fires the NEXT step's action before the user has read
-  // it, and where the new copy is never announced. Pulling focus back to the
-  // panel on each step is what makes a step read like a new message.
+  // it, and where the new copy is never announced. Moving focus on each step is
+  // what makes a step read like a new message; `focusForStep` decides whether
+  // that is the panel or the element the new step points at.
   const announcedStep = useRef(step?.current)
   useEffect(() => {
     if (announcedStep.current === step?.current) return
     announcedStep.current = step?.current
-    contentRef.current?.focus()
+    focusForStep()
   }, [step?.current])
 
   // On the last step (or a single-step coachmark) the action ends the coachmark,
@@ -152,7 +191,7 @@ const CoachmarkPanel = ({
           event.preventDefault()
           previouslyFocused.current =
             document.activeElement as HTMLElement | null
-          contentRef.current?.focus()
+          focusForStep()
         }}
         // Radix restores focus to the Trigger on close, but a coachmark
         // anchors instead of triggering, so nothing owns the restore.

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.mdx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.mdx
@@ -137,6 +137,26 @@ coachmarks.open({
       </tr>
       <tr>
         <td>
+          <code>onEnd</code>
+        </td>
+        <td>
+          <code>{"(end: CoachmarkEnd) => void"}</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          How it ended, in one place:{" "}
+          <code>
+            {
+              '{ reason: "completed" | "dismissed" | "skipped" | "unavailable", step, totalSteps, outsidePresses }'
+            }
+          </code>
+          . Fires exactly once per ending — the callback to track a walkthrough
+          with. See Tracking.
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>onDismiss</code>
         </td>
         <td>
@@ -281,6 +301,72 @@ coachmarks.open({
 
 \* `title` and a `targetElement` are required for a single coachmark. With `steps`, each step brings its own `title` and either its own `targetElement` or the shared one.
 
+### Tracking
+
+`onEnd` fires **once per ending**, with the whole outcome — so a funnel is one event carrying a `reason` rather than two callbacks to join up afterwards:
+
+```tsx
+coachmarks.open({
+  steps: [...],
+  onEnd: ({ reason, step, totalSteps, outsidePresses }) =>
+    track("home-tour-ended", { reason, step, totalSteps, outsidePresses }),
+})
+```
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">reason</th>
+        <th className="text-left">What the reader did</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>completed</code>
+        </td>
+        <td>Pressed the action on the last step. They saw the whole thing</td>
+      </tr>
+      <tr>
+        <td>
+          <code>dismissed</code>
+        </td>
+        <td>
+          Closed it or pressed <kbd>Escape</kbd> part-way through —{" "}
+          <code>step</code> is where they dropped out
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>skipped</code>
+        </td>
+        <td>
+          Pressed past it on the dimmed page until it gave up (
+          <code>skipAfterOutsideClicks</code>). They never used the way out they
+          were offered
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>unavailable</code>
+        </td>
+        <td>
+          It never opened — nothing it points at was on the page. Only a
+          guidance reports this, and it is what separates "nobody finished the
+          tour" from "the tour never ran"
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+`step` / `totalSteps` say how far they got out of what they were actually offered (a guidance leaves out steps whose element was absent, so `totalSteps` is what the panel's own counter showed). `outsidePresses` is how many times they pressed the dimmed page and got a wiggle back: a tour that completed with six of those was fought with, one that completed with none was followed.
+
+Nothing fires when the app itself closes the coachmark (`coachmarks.close`, a guidance's `stop()`, the page unmounting) — nobody ended it, and counting a navigation as a drop-off blames the reader for it.
+
+`onDismiss` and `onComplete` still exist as the narrow pair, and still fire; `onEnd` is the one to reach for when you want the whole picture.
+
 ### Naming the element
 
 `targetElement` is handed straight to `querySelector`, so anything the DOM understands works — the question is only what the page can promise to keep stable:
@@ -315,7 +401,8 @@ const tour = defineStepByStepCoachmarkGuidance({
     // Something a component further down renders: point at it directly.
     { targetElement: '[data-add-widget="right"]', title: "Make the rail yours" },
   ],
-  onComplete: () => track("home-tour-finished"),
+  onEnd: ({ reason, step, totalSteps, outsidePresses }) =>
+    track("home-tour-ended", { reason, step, totalSteps, outsidePresses }),
 })
 
 // In the page — only the names the steps declared type-check
@@ -338,7 +425,9 @@ A guidance also arrives with the manners a walkthrough needs, because those belo
 - **The page is dimmed except the step's element** (`overlay` defaults to `true` here). The lit area is the real element at full strength, not a copy of it.
 - **A shield swallows every press on the page**, the lit element included: the highlight says where to look, and a walkthrough that let you act on the thing it is still explaining would read as done with. The shield is `[data-f0-coachmark-blocker]` if you need to find it in a test.
 - **A press that went nowhere makes the panel wiggle** — the panel answering for a press the page could not.
-- **Five of those end it** (`skipAfterOutsideClicks`), reported as a dismissal. Someone pressing past the panel five times is asking to be out, and the way out cannot be the button they are ignoring.
+- **Five of those end it** (`skipAfterOutsideClicks`), reported as a dismissal — and to `onEnd` as its own `skipped`, which is not the same thing as closing it. Someone pressing past the panel five times is asking to be out, and the way out cannot be the button they are ignoring.
+
+Whatever happens, `onEnd` says so once: finished, dropped out at step N, pressed past it, or never opened at all (see Tracking).
 
 `start()` opens the walkthrough under the guidance's own id, so starting it twice — an effect that runs twice, a re-render — shows one walkthrough rather than queueing a copy behind it. `stop()` ends it wherever it is and reports nothing: nobody dismissed it.
 
@@ -448,7 +537,7 @@ Reach for a coachmark when a feature is already on screen but users are walking 
     description: "Show at most one coachmark on a screen.",
     guidelines: [
       "Anchor it to the control it describes, so the arrow points somewhere meaningful",
-      "Give it an id and persist the dismissal from onDismiss / onComplete",
+      "Give it an id and persist the outcome from onEnd, so it is not shown twice",
       "Open it at a natural pause, not in the middle of a task",
     ],
   }}
@@ -490,7 +579,7 @@ Reach for a coachmark when a feature is already on screen but users are walking 
 
 ### Behavior
 
-- **It closes itself.** The close button and Escape always close it, whether or not `onDismiss` is passed. There is no `open` prop, so there is no state for a consumer to get out of sync. `onDismiss` and `onComplete` are told what happened after the fact — persist the decision there, since nothing is remembered between sessions.
+- **It closes itself.** The close button and Escape always close it, whether or not a callback is passed. There is no `open` prop, so there is no state for a consumer to get out of sync. `onEnd` (and the narrower `onDismiss` / `onComplete`) is told what happened after the fact — persist the decision there, since nothing is remembered between sessions.
 - **The action ends or advances.** Pressing it runs `action.onClick`, then moves to the next step, or closes on the last one. It never leaves the panel sitting open.
 - **Steps hand over through a fade.** Advancing fades the panel down, commits the next step while it is invisible — its copy, the element it is anchored to, the scroll that brings that element into view — and fades the same panel back up already in place. Nothing swaps under the reader's eyes, and the spotlight travels to the next element rather than the page coming up to full brightness in between. Under `prefers-reduced-motion` the step simply changes.
 - **One at a time.** A second `coachmarks.open` queues behind the first and appears once it is closed. Two panels competing for the same attention is worse than a wait.
@@ -520,8 +609,9 @@ coachmarks.open({
     { targetElement: "#filters-button", title: "Start with a filter" },
     { targetElement: "#save-view", title: "Then save it as a view" },
   ],
-  onComplete: () => track("filters-tour-finished"),
-  onDismiss: () => track("filters-tour-abandoned"),
+  // One event, whichever way it ends — see Tracking.
+  onEnd: ({ reason, step, totalSteps }) =>
+    track("filters-tour-ended", { reason, step, totalSteps }),
 })
 ```
 

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.mdx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.mdx
@@ -55,9 +55,12 @@ coachmarks.open({
         <td>—</td>
         <td>Yes*</td>
         <td>
-          What the panel points at: a CSS selector matching exactly one element,
-          or the element itself. With <code>steps</code> it is the fallback for
-          steps that do not name their own.
+          What the panel points at: ANY CSS selector — an id (
+          <code>#filters-button</code>), a class (<code>.js-filters</code>), an
+          attribute (<code>{'[data-add-widget="right"]'}</code>) — or the
+          element itself. It must match exactly one element. With{" "}
+          <code>steps</code> it is the fallback for steps that do not name their
+          own.
         </td>
       </tr>
       <tr>
@@ -180,6 +183,25 @@ coachmarks.open({
       </tr>
       <tr>
         <td>
+          <code>focusTarget</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>
+          Puts the caret in the element the step points at — or in the first
+          field inside it — instead of on the panel, so a composer starts with
+          its cursor in it and its own focus glow. Per step. Trades the step's
+          announcement for the caret, so use it only where the field <em>is</em>{" "}
+          the step (see Accessibility).
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>skipAfterOutsideClicks</code>
         </td>
         <td>
@@ -258,6 +280,21 @@ coachmarks.open({
 </Unstyled>
 
 \* `title` and a `targetElement` are required for a single coachmark. With `steps`, each step brings its own `title` and either its own `targetElement` or the shared one.
+
+### Naming the element
+
+`targetElement` is handed straight to `querySelector`, so anything the DOM understands works — the question is only what the page can promise to keep stable:
+
+```tsx
+targetElement: "#filters-button" // an id
+targetElement: ".js-onboarding-filters" // a class
+targetElement: '[data-add-widget="right"]' // an attribute (f0's own handles)
+targetElement: buttonRef.current // the element itself
+```
+
+It must match **exactly one** element. A selector that matches several anchors to the first and warns in development — a coachmark pointing at "one of these six cards" is pointing at nothing in particular. A selector is re-resolved while the coachmark is queued, so it can name something that mounts a moment later; an element cannot be re-resolved, so one that unmounts takes its coachmark off screen with it.
+
+For a walkthrough, prefer `defineStepByStepCoachmarkGuidance`'s `anchor()` over hand-written selectors: it marks the elements for you and the compiler holds the two sides together.
 
 `coachmarks.close(id)` removes a coachmark whether it is on screen or still queued, and `coachmarks.closeAll()` clears the lot. Both are for the app's own bookkeeping — the user never needs them, because the panel closes itself.
 
@@ -462,6 +499,7 @@ Reach for a coachmark when a feature is already on screen but users are walking 
 - **Outside clicks do not dismiss.** A coachmark stays until it is acknowledged. By default the page behind stays interactive; the panel is not modal and does not trap focus.
 - **`overlay` makes the page unpressable, not the coachmark modal.** The dim and its shield stop presses reaching the page and wiggle the panel instead, and give up after `skipAfterOutsideClicks` of them. Focus is still not trapped, and <kbd>Escape</kbd> still closes — the shield is about the pointer.
 - **Focus moves to the panel on open,** not to the close button, so a screen reader announces the message and Enter does not immediately discard it. On close, focus returns to whatever had it before.
+- **`focusTarget` moves it to the step's own element instead.** For a step whose subject is a field: the caret lands in it, so it wears its own focus state rather than being described from outside, and the reader can start typing the thing the panel is describing. The panel stays one Tab away and Escape still closes from anywhere — but the step is no longer announced, so this is per step and off by default.
 - **The target is an anchor, not a trigger.** It is never made clickable and never wrapped — clicking it does whatever it already did.
 
 ### Usage examples
@@ -557,5 +595,6 @@ The panel is a non-modal `dialog`, named by `title` and described by `descriptio
 - Opening moves focus to the panel itself, so the title and description are announced as a unit. The dismiss button is reached by tabbing, which keeps <kbd>Enter</kbd> from discarding the message the moment it appears.
 - Because focus is moved, only open a coachmark in response to something the user did or at a natural pause. One appearing mid-task pulls focus away from what they were doing.
 - Advancing a sequence pulls focus back to the panel, so the new step is announced as a message of its own and a second <kbd>Enter</kbd> cannot fire the next action before it has been read.
+- A step with `focusTarget` moves focus to its own element rather than to the panel, so THAT step is not announced — a screen reader reads the field the reader just landed in instead of the coachmark. It is a real trade, and it is the page's to make: take it where the field IS the step (a composer the reader is being invited to type into), and leave every other step to the panel. The panel is still one Tab away and Escape still closes, so the way on is never lost.
 - The close button is icon-only and carries a translated `Close` label for screen readers.
 - The arrow is decorative and conveys no information beyond the anchoring already implied by focus order.

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.mdx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.mdx
@@ -162,6 +162,41 @@ coachmarks.open({
       </tr>
       <tr>
         <td>
+          <code>overlay</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>
+          Dims the whole page except the element this step points at, and
+          swallows every press on the page while the coachmark is up. For a
+          walkthrough that has to be followed in order — one coachmark pointing
+          something out should not take the page hostage.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>skipAfterOutsideClicks</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>
+          <code>5</code>
+        </td>
+        <td>—</td>
+        <td>
+          How many presses on the dimmed page end the coachmark, reported to{" "}
+          <code>onDismiss</code>. The panel wiggles at each one; <code>0</code>{" "}
+          never gives up. Only has an effect alongside <code>overlay</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>arrow</code>
         </td>
         <td>
@@ -225,6 +260,54 @@ coachmarks.open({
 \* `title` and a `targetElement` are required for a single coachmark. With `steps`, each step brings its own `title` and either its own `targetElement` or the shared one.
 
 `coachmarks.close(id)` removes a coachmark whether it is on screen or still queued, and `coachmarks.closeAll()` clears the lot. Both are for the app's own bookkeeping — the user never needs them, because the panel closes itself.
+
+## Walking a page step by step
+
+`coachmarks.open({ steps })` takes a CSS selector per step, which means every walkthrough invents its own convention for marking the elements it walks — and a selector written against someone else's markup breaks the next time that markup is refactored, with no type error to say so.
+
+`defineStepByStepCoachmarkGuidance` closes that loop. The steps **name** their targets, `anchor()` marks them, and the names are a union the compiler holds both sides to:
+
+```tsx
+import { defineStepByStepCoachmarkGuidance } from "@factorialco/f0-react/experimental"
+
+const tour = defineStepByStepCoachmarkGuidance({
+  id: "home-tour",
+  steps: [
+    { element: "composer", title: "Let One do it for you", side: "bottom" },
+    { element: "needs-you", title: "Everything that needs you", side: "right" },
+    // Something a component further down renders: point at it directly.
+    { targetElement: '[data-add-widget="right"]', title: "Make the rail yours" },
+  ],
+  onComplete: () => track("home-tour-finished"),
+})
+
+// In the page — only the names the steps declared type-check
+<div {...tour.anchor("composer")}>…</div>
+<section {...tour.anchor("needs-you")}>…</section>
+
+// Whenever it should run
+useEffect(() => {
+  tour.start()
+  return () => tour.stop()
+}, [])
+```
+
+**Steps whose element is not there are left out.** A walkthrough is written once and runs on pages that differ: a control the reader has no permission for, a widget they removed, a block behind a flag. `start()` looks for every step's element, keeps looking for `lookForTargetsMs` (2000ms by default) while the page settles, then opens with the ones that turned up — the reader cannot tell there was ever another step, and the count is honest, because a walkthrough that says `1/3` has three steps to give. If none of them are there it does not open at all, and reports nothing: there was no walkthrough to dismiss.
+
+That waiting is not incidental. A walkthrough started on mount runs before the things it walks have arrived — a rail still measuring itself, a widget waiting on data — and opening on the first frame would drop those steps.
+
+A guidance also arrives with the manners a walkthrough needs, because those belong to walking someone through a page rather than to one coachmark:
+
+- **The page is dimmed except the step's element** (`overlay` defaults to `true` here). The lit area is the real element at full strength, not a copy of it.
+- **A shield swallows every press on the page**, the lit element included: the highlight says where to look, and a walkthrough that let you act on the thing it is still explaining would read as done with. The shield is `[data-f0-coachmark-blocker]` if you need to find it in a test.
+- **A press that went nowhere makes the panel wiggle** — the panel answering for a press the page could not.
+- **Five of those end it** (`skipAfterOutsideClicks`), reported as a dismissal. Someone pressing past the panel five times is asking to be out, and the way out cannot be the button they are ignoring.
+
+`start()` opens the walkthrough under the guidance's own id, so starting it twice — an effect that runs twice, a re-render — shows one walkthrough rather than queueing a copy behind it. `stop()` ends it wherever it is and reports nothing: nobody dismissed it.
+
+<Canvas of={Stories.Guidance} />
+
+Press the dimmed page to see the wiggle, and keep pressing to see it give up.
 
 ## Guidelines
 
@@ -372,10 +455,12 @@ Reach for a coachmark when a feature is already on screen but users are walking 
 
 - **It closes itself.** The close button and Escape always close it, whether or not `onDismiss` is passed. There is no `open` prop, so there is no state for a consumer to get out of sync. `onDismiss` and `onComplete` are told what happened after the fact — persist the decision there, since nothing is remembered between sessions.
 - **The action ends or advances.** Pressing it runs `action.onClick`, then moves to the next step, or closes on the last one. It never leaves the panel sitting open.
+- **Steps hand over through a fade.** Advancing fades the panel down, commits the next step while it is invisible — its copy, the element it is anchored to, the scroll that brings that element into view — and fades the same panel back up already in place. Nothing swaps under the reader's eyes, and the spotlight travels to the next element rather than the page coming up to full brightness in between. Under `prefers-reduced-motion` the step simply changes.
 - **One at a time.** A second `coachmarks.open` queues behind the first and appears once it is closed. Two panels competing for the same attention is worse than a wait.
 - **The target is re-resolved, not resolved once.** A selector is matched against the live DOM, so a coachmark opened during start-up shows as soon as its element mounts, and hides again if the element goes away — instead of pointing at nothing. A coachmark whose target never appears simply never shows; `coachmarks.close(id)` drops it.
 - **`side` is a preference.** The panel flips to the opposite side and shifts along the target when it would overflow the viewport, so the side you pass is not guaranteed.
-- **Outside clicks do not dismiss.** A coachmark stays until it is acknowledged. The page behind stays interactive; the panel is not modal and does not trap focus.
+- **Outside clicks do not dismiss.** A coachmark stays until it is acknowledged. By default the page behind stays interactive; the panel is not modal and does not trap focus.
+- **`overlay` makes the page unpressable, not the coachmark modal.** The dim and its shield stop presses reaching the page and wiggle the panel instead, and give up after `skipAfterOutsideClicks` of them. Focus is still not trapped, and <kbd>Escape</kbd> still closes — the shield is about the pointer.
 - **Focus moves to the panel on open,** not to the close button, so a screen reader announces the message and Enter does not immediately discard it. On close, focus returns to whatever had it before.
 - **The target is an anchor, not a trigger.** It is never made clickable and never wrapped — clicking it does whatever it already did.
 

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.stories.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { useEffect, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { expect, screen, userEvent, waitFor, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0Coachmark } from "../F0Coachmark"
+import { defineStepByStepCoachmarkGuidance } from "../guidance"
 import { coachmarks } from "../imperative"
 import type { F0CoachmarkProps } from "../types"
 
@@ -254,6 +255,86 @@ export const Imperative: Story = {
               })
             }}
           />
+        </div>
+      </div>
+    )
+  },
+}
+
+/**
+ * A WALKTHROUGH DECLARED IN ONE PLACE. The steps name the elements they point
+ * at, `anchor()` marks them, and the names are a union the compiler holds both
+ * sides to — no selectors written against someone else's markup.
+ *
+ * It also brings what walking someone through a page needs: the page dimmed
+ * except the step's element, a shield over it (`data-f0-coachmark-blocker`) that
+ * swallows presses, a wiggle when one lands, and a way out for the reader who
+ * keeps pressing — five of them and the walkthrough gives up.
+ */
+export const Guidance: Story = {
+  // Same reason as `Imperative`: it fires real coachmarks into the shared
+  // document-level overlay. A playground, not a visit target.
+  tags: ["!test", "no-sidebar"],
+  parameters: {
+    layout: "fullscreen",
+    docs: { story: { inline: false, height: "520px" } },
+  },
+  decorators: [(Story) => <>{Story()}</>],
+  render: function Guidance() {
+    const tour = useMemo(
+      () =>
+        defineStepByStepCoachmarkGuidance({
+          id: "story-guidance",
+          steps: [
+            {
+              element: "filters",
+              title: "Start with a filter",
+              description: "Narrow the list down to what you care about.",
+            },
+            {
+              element: "views",
+              title: "Then save it as a view",
+              description: "Your whole team can reuse it.",
+            },
+            {
+              element: "list",
+              title: "That is the list you get",
+              description: "Filtered, saved, and shared — in that order.",
+              side: "top",
+            },
+          ],
+        }),
+      []
+    )
+
+    // Leave nothing behind for the next story on the docs page.
+    useEffect(() => () => tour.stop(), [tour])
+
+    return (
+      <div className="flex flex-col items-start gap-6 p-8">
+        <F0Button
+          variant="outline"
+          label="Start the walkthrough"
+          onClick={() => {
+            tour.start()
+          }}
+        />
+        <div className="flex flex-row gap-2">
+          <span {...tour.anchor("filters")} className="inline-flex">
+            <F0Button variant="outline" label="Filters" />
+          </span>
+          <span {...tour.anchor("views")} className="inline-flex">
+            <F0Button variant="outline" label="Views" />
+          </span>
+        </div>
+        <div
+          {...tour.anchor("list")}
+          className="flex w-80 flex-col gap-2 rounded-md border border-solid border-f1-border bg-f1-background p-4"
+        >
+          <p className="m-0 font-medium">Candidates</p>
+          <p className="m-0 text-f1-foreground-secondary">
+            Three rows, one of them yours.
+          </p>
         </div>
       </div>
     )

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/coachmarks.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/coachmarks.test.tsx
@@ -60,6 +60,29 @@ describe("coachmarks API", () => {
       )
     })
 
+    it("takes any CSS selector — an id, a class, an attribute", async () => {
+      render(
+        <CoachmarkProvider>
+          <button className="js-filters">Filters</button>
+          <button data-add-widget="right">Add widget</button>
+        </CoachmarkProvider>
+      )
+
+      open({ targetElement: ".js-filters", title: "By class" })
+      await waitFor(() =>
+        expect(screen.getByRole("dialog")).toHaveAccessibleName("By class")
+      )
+
+      coachmarks.closeAll()
+      open({
+        targetElement: '[data-add-widget="right"]',
+        title: "By attribute",
+      })
+      await waitFor(() =>
+        expect(screen.getByRole("dialog")).toHaveAccessibleName("By attribute")
+      )
+    })
+
     it("accepts an element instead of a selector", async () => {
       renderApp()
 

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/guidance.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/guidance.test.tsx
@@ -1,0 +1,301 @@
+import { userEvent } from "@testing-library/user-event"
+import { useEffect, useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  act,
+  screen,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { CoachmarkProvider } from "../CoachmarkProvider"
+import { defineStepByStepCoachmarkGuidance } from "../guidance"
+import { coachmarks } from "../imperative"
+
+const walkthrough = () =>
+  defineStepByStepCoachmarkGuidance({
+    id: "tour",
+    steps: [
+      { element: "composer", title: "Ask for it" },
+      { element: "feed", title: "What needs you" },
+    ],
+  })
+
+/** A page whose two blocks are marked with the walkthrough's own anchors. */
+const renderPage = (
+  guidance: ReturnType<typeof walkthrough>,
+  extra?: React.ReactNode
+) =>
+  render(
+    <CoachmarkProvider>
+      <div {...guidance.anchor("composer")}>composer</div>
+      <div {...guidance.anchor("feed")}>feed</div>
+      {extra}
+    </CoachmarkProvider>
+  )
+
+const next = async () =>
+  await userEvent.click(screen.getByRole("button", { name: "Next" }))
+
+describe("defineStepByStepCoachmarkGuidance", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("marks an element with the attribute its own selector finds", () => {
+    const guidance = walkthrough()
+    renderPage(guidance)
+
+    expect(
+      document.querySelectorAll(guidance.selector("composer"))
+    ).toHaveLength(1)
+    expect(document.querySelector(guidance.selector("feed"))).toHaveTextContent(
+      "feed"
+    )
+  })
+
+  it("walks the anchored elements in order and completes on the last step", async () => {
+    const onComplete = vi.fn()
+    const guidance = defineStepByStepCoachmarkGuidance({
+      steps: [
+        { element: "composer", title: "Ask for it" },
+        { element: "feed", title: "What needs you" },
+      ],
+      onComplete,
+    })
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveAccessibleName("Ask for it")
+    expect(screen.getByText("1/2")).toBeInTheDocument()
+
+    await next()
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("What needs you")
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Got it" }))
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    expect(onComplete).toHaveBeenCalledOnce()
+  })
+
+  it("takes a step that names a target of its own", async () => {
+    const guidance = defineStepByStepCoachmarkGuidance({
+      steps: [
+        { element: "composer", title: "Ask for it" },
+        { targetElement: "#add", title: "Add a widget" },
+      ],
+    })
+    renderPage(guidance, <button id="add">Add</button>)
+
+    act(() => {
+      guidance.start()
+    })
+    await screen.findByRole("dialog")
+    await next()
+
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("Add a widget")
+    )
+  })
+
+  it("shows ONE walkthrough however many times it is started", async () => {
+    const guidance = walkthrough()
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+      guidance.start()
+    })
+
+    await screen.findByRole("dialog")
+    expect(screen.getAllByRole("dialog")).toHaveLength(1)
+
+    // And the second start did not queue a copy waiting behind the first.
+    await next()
+    await userEvent.click(await screen.findByRole("button", { name: "Got it" }))
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+  })
+
+  it("stops without reporting a dismissal — nobody dismissed it", async () => {
+    const onDismiss = vi.fn()
+    const guidance = defineStepByStepCoachmarkGuidance({
+      steps: [{ element: "composer", title: "Ask for it" }],
+      onDismiss,
+    })
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+    await screen.findByRole("dialog")
+
+    act(() => {
+      guidance.stop()
+    })
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it("spotlights and shields by default, and lets a page opt out", async () => {
+    const guidance = walkthrough()
+    const { unmount } = renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+    await screen.findByRole("dialog")
+    expect(document.querySelector("[data-f0-coachmark-blocker]")).not.toBeNull()
+
+    unmount()
+    coachmarks.closeAll()
+
+    const bare = defineStepByStepCoachmarkGuidance({
+      steps: [{ element: "composer", title: "Ask for it" }],
+      overlay: false,
+    })
+    renderPage(bare)
+    act(() => {
+      bare.start()
+    })
+    await screen.findByRole("dialog")
+    expect(document.querySelector("[data-f0-coachmark-blocker]")).toBeNull()
+  })
+})
+
+/**
+ * A step can name something that is not on the page: a control this user has no
+ * permission for, a widget they removed, a block behind a flag. None of that is
+ * a mistake to report — it is a walkthrough with less to say, and the reader
+ * should never be able to tell there was ever another step.
+ */
+describe("steps whose element is not there", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("leaves the missing step out, and counts only the ones it kept", async () => {
+    const guidance = defineStepByStepCoachmarkGuidance({
+      // Nothing waits on an element that is genuinely absent in a test.
+      lookForTargetsMs: 0,
+      steps: [
+        { element: "composer", title: "Ask for it" },
+        { targetElement: "#nowhere", title: "Never mounted" },
+        { element: "feed", title: "What needs you" },
+      ],
+    })
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveAccessibleName("Ask for it")
+    // 1/2, not 1/3: the count describes the walkthrough the reader is getting.
+    expect(screen.getByText("1/2")).toBeInTheDocument()
+
+    await next()
+
+    // Straight to the third step's copy — the second one never existed.
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("What needs you")
+    )
+    expect(screen.getByText("2/2")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Got it" })).toBeInTheDocument()
+  })
+
+  it("does not open at all when none of them are there", async () => {
+    const onDismiss = vi.fn()
+    const guidance = defineStepByStepCoachmarkGuidance({
+      lookForTargetsMs: 0,
+      steps: [
+        { targetElement: "#nowhere", title: "Never mounted" },
+        { targetElement: "#also-nowhere", title: "Nor this one" },
+      ],
+      onDismiss,
+    })
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+
+    // Nothing on screen, and nothing reported: there was no walkthrough to
+    // dismiss, so the page carries on as if none had been asked for.
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    expect(document.querySelector("[data-f0-coachmark-blocker]")).toBeNull()
+    expect(onDismiss).not.toHaveBeenCalled()
+  })
+
+  it("waits for an element that is still on its way, then keeps its step", async () => {
+    const guidance = walkthrough()
+
+    const LateFeed = () => {
+      const [mounted, setMounted] = useState(false)
+      useEffect(() => {
+        const timer = setTimeout(() => setMounted(true), 120)
+        return () => clearTimeout(timer)
+      }, [])
+      return mounted ? <div {...guidance.anchor("feed")}>feed</div> : null
+    }
+
+    render(
+      <CoachmarkProvider>
+        <div {...guidance.anchor("composer")}>composer</div>
+        <LateFeed />
+      </CoachmarkProvider>
+    )
+
+    act(() => {
+      guidance.start()
+    })
+
+    // It held off rather than opening a one-step walkthrough about the composer.
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    const dialog = await screen.findByRole("dialog")
+    expect(dialog).toHaveAccessibleName("Ask for it")
+    expect(screen.getByText("1/2")).toBeInTheDocument()
+  })
+
+  it("calls off a walkthrough that is still looking when the page goes", async () => {
+    const guidance = defineStepByStepCoachmarkGuidance({
+      lookForTargetsMs: 5000,
+      steps: [
+        { element: "composer", title: "Ask for it" },
+        { targetElement: "#nowhere", title: "Never mounted" },
+      ],
+    })
+    const { unmount } = renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+
+    act(() => {
+      guidance.stop()
+    })
+    unmount()
+
+    // The poll is off: nothing opens into the page that replaced this one.
+    renderPage(guidance)
+    await new Promise((resolve) => setTimeout(resolve, 150))
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/guidance.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/guidance.test.tsx
@@ -299,3 +299,90 @@ describe("steps whose element is not there", () => {
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
   })
 })
+
+describe("what a guidance's onEnd reports", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("says the walkthrough never ran when it had nothing to point at", async () => {
+    const onEnd = vi.fn()
+    const guidance = defineStepByStepCoachmarkGuidance({
+      lookForTargetsMs: 0,
+      steps: [{ targetElement: "#nowhere", title: "Never mounted" }],
+      onEnd,
+    })
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+
+    // Silence on screen is not silence to whoever is counting: "nobody finished
+    // the tour" and "the tour never ran" want opposite fixes.
+    await waitFor(() =>
+      expect(onEnd).toHaveBeenCalledWith({
+        reason: "unavailable",
+        step: 0,
+        totalSteps: 0,
+        outsidePresses: 0,
+      })
+    )
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+  })
+
+  it("counts only the steps the reader was offered", async () => {
+    const onEnd = vi.fn()
+    const guidance = defineStepByStepCoachmarkGuidance({
+      lookForTargetsMs: 0,
+      steps: [
+        { element: "composer", title: "Ask for it" },
+        { targetElement: "#nowhere", title: "Never mounted" },
+        { element: "feed", title: "What needs you" },
+      ],
+      onEnd,
+    })
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+    await screen.findByRole("dialog")
+    await next()
+    await userEvent.click(await screen.findByRole("button", { name: "Got it" }))
+
+    // 2 of 2, not 3: the dropped step was never part of what was walked, so it
+    // cannot be part of what is measured.
+    await waitFor(() =>
+      expect(onEnd).toHaveBeenCalledWith({
+        reason: "completed",
+        step: 2,
+        totalSteps: 2,
+        outsidePresses: 0,
+      })
+    )
+  })
+
+  it("says nothing when the page stops the walkthrough", async () => {
+    const onEnd = vi.fn()
+    const guidance = defineStepByStepCoachmarkGuidance({
+      steps: [{ element: "composer", title: "Ask for it" }],
+      onEnd,
+    })
+    renderPage(guidance)
+
+    act(() => {
+      guidance.start()
+    })
+    await screen.findByRole("dialog")
+
+    act(() => {
+      guidance.stop()
+    })
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    expect(onEnd).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
@@ -352,3 +352,41 @@ describe("a step that focuses what it points at", () => {
     await waitFor(() => expect(before).toHaveFocus())
   })
 })
+
+describe("what the shield does to focus", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  /**
+   * A press on the shield must not take focus off the page.
+   *
+   * Preventing the POINTER event is not enough: the mouse event that follows it
+   * has its own default action — "focus what was pressed" — and on a shield that
+   * means blurring whatever held focus and leaving it on the body. A step that
+   * focused its own field lost that field's focus glow on the reader's first
+   * press anywhere on the page.
+   *
+   * `defaultPrevented` is the observable here rather than `document.activeElement`:
+   * jsdom does not move focus on a mouse press at all, so only the real browser
+   * can show the blur — and only the prevention can be asserted here.
+   */
+  it("swallows the press without moving focus", async () => {
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+    })
+    await screen.findByRole("dialog")
+
+    const shield = blocker()
+    const press = new MouseEvent("mousedown", {
+      bubbles: true,
+      cancelable: true,
+    })
+    shield?.dispatchEvent(press)
+
+    expect(press.defaultPrevented).toBe(true)
+  })
+})

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
@@ -10,7 +10,7 @@ import {
 
 import { CoachmarkProvider } from "../CoachmarkProvider"
 import { coachmarks } from "../imperative"
-import type { CoachmarkOptions } from "../types"
+import type { CoachmarkEnd, CoachmarkOptions } from "../types"
 
 const renderApp = () =>
   render(
@@ -388,5 +388,121 @@ describe("what the shield does to focus", () => {
     shield?.dispatchEvent(press)
 
     expect(press.defaultPrevented).toBe(true)
+  })
+})
+
+/**
+ * ONE CALLBACK FOR THE WHOLE OUTCOME. Every ending arrives at `onEnd` exactly
+ * once, carrying which way out the reader took and how far they got — the shape
+ * a funnel is read off, rather than two callbacks to join up afterwards.
+ */
+describe("what onEnd reports", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  const twoSteps = (onEnd: (end: CoachmarkEnd) => void): CoachmarkOptions => ({
+    steps: [
+      { targetElement: "#filters", title: "First" },
+      { targetElement: "#outside", title: "Second" },
+    ],
+    overlay: true,
+    onEnd,
+  })
+
+  it("reports reaching the end, on the last step", async () => {
+    const onEnd = vi.fn()
+    renderApp()
+    open(twoSteps(onEnd))
+    await screen.findByRole("dialog")
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }))
+    await userEvent.click(await screen.findByRole("button", { name: "Got it" }))
+
+    await waitFor(() => expect(onEnd).toHaveBeenCalledOnce())
+    expect(onEnd).toHaveBeenCalledWith({
+      reason: "completed",
+      step: 2,
+      totalSteps: 2,
+      outsidePresses: 0,
+    })
+  })
+
+  it("reports where the reader dropped out", async () => {
+    const onEnd = vi.fn()
+    renderApp()
+    open(twoSteps(onEnd))
+    await screen.findByRole("dialog")
+
+    // Left on the FIRST step, which is the part a funnel cannot infer.
+    await userEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    await waitFor(() => expect(onEnd).toHaveBeenCalledOnce())
+    expect(onEnd).toHaveBeenCalledWith({
+      reason: "dismissed",
+      step: 1,
+      totalSteps: 2,
+      outsidePresses: 0,
+    })
+  })
+
+  it("tells a skip apart from a dismissal, and counts the presses", async () => {
+    const onEnd = vi.fn()
+    const onDismiss = vi.fn()
+    renderApp()
+    open({ ...twoSteps(onEnd), onDismiss })
+    await screen.findByRole("dialog")
+
+    for (let press = 0; press < 5; press++) await pressOutside()
+
+    await waitFor(() => expect(onEnd).toHaveBeenCalledOnce())
+    expect(onEnd).toHaveBeenCalledWith({
+      reason: "skipped",
+      step: 1,
+      totalSteps: 2,
+      outsidePresses: 5,
+    })
+    // The narrow pair still fires: a skip is an abandonment to the app's own
+    // bookkeeping, and `onEnd` is what says which kind it was.
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it("counts presses the reader made and then carried on past", async () => {
+    const onEnd = vi.fn()
+    renderApp()
+    open(twoSteps(onEnd))
+    await screen.findByRole("dialog")
+
+    await pressOutside()
+    await pressOutside()
+    await userEvent.click(screen.getByRole("button", { name: "Next" }))
+    await userEvent.click(await screen.findByRole("button", { name: "Got it" }))
+
+    await waitFor(() =>
+      expect(onEnd).toHaveBeenCalledWith({
+        reason: "completed",
+        step: 2,
+        totalSteps: 2,
+        outsidePresses: 2,
+      })
+    )
+  })
+
+  it("says nothing when the app closes the coachmark itself", async () => {
+    const onEnd = vi.fn()
+    renderApp()
+    open({ ...twoSteps(onEnd), id: "tour" })
+    await screen.findByRole("dialog")
+
+    act(() => {
+      coachmarks.close("tour")
+    })
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    // Nobody ended it, so there is no outcome — counting this as a drop-off
+    // would blame the reader for a navigation.
+    expect(onEnd).not.toHaveBeenCalled()
   })
 })

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
@@ -1,0 +1,247 @@
+import { userEvent } from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  act,
+  screen,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import { CoachmarkProvider } from "../CoachmarkProvider"
+import { coachmarks } from "../imperative"
+import type { CoachmarkOptions } from "../types"
+
+const renderApp = () =>
+  render(
+    <CoachmarkProvider>
+      <button id="filters">Filters</button>
+      <button id="outside">Outside</button>
+    </CoachmarkProvider>
+  )
+
+const open = (options: CoachmarkOptions) => {
+  act(() => {
+    coachmarks.open(options)
+  })
+}
+
+const blocker = () =>
+  document.querySelector<HTMLElement>("[data-f0-coachmark-blocker]")
+
+/** One press on the dimmed page. */
+const pressOutside = async () => {
+  const shield = blocker()
+  if (!shield) throw new Error("no blocker on screen")
+  await userEvent.click(shield)
+}
+
+describe("coachmark overlay", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("is off unless the coachmark asks for it", async () => {
+    renderApp()
+    open({ targetElement: "#filters", title: "Filters got smarter" })
+
+    await screen.findByRole("dialog")
+    expect(blocker()).toBeNull()
+  })
+
+  it("shields the page and keeps the coachmark open when it is pressed", async () => {
+    const onDismiss = vi.fn()
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+      onDismiss,
+    })
+    await screen.findByRole("dialog")
+
+    await pressOutside()
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(onDismiss).not.toHaveBeenCalled()
+    // Hidden from the accessibility tree: it is a shield, not content.
+    expect(blocker()).toHaveAttribute("aria-hidden", "true")
+  })
+
+  it("wiggles the panel at a press that went nowhere", async () => {
+    // jsdom has no `Element.animate`, so the wiggle is stubbed in: what is
+    // being tested is that a swallowed press is answered ON THE PANEL, since
+    // the page it landed on cannot answer for it.
+    const animate = vi.fn()
+    Object.defineProperty(Element.prototype, "animate", {
+      value: animate,
+      configurable: true,
+      writable: true,
+    })
+
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+    })
+    const dialog = await screen.findByRole("dialog")
+
+    await pressOutside()
+
+    expect(animate).toHaveBeenCalledOnce()
+    expect(animate.mock.instances[0]).toBe(dialog)
+
+    Reflect.deleteProperty(Element.prototype, "animate")
+  })
+
+  it("gives up after five presses, and reports the abandonment", async () => {
+    const onDismiss = vi.fn()
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+      onDismiss,
+    })
+    await screen.findByRole("dialog")
+
+    for (let press = 0; press < 4; press++) await pressOutside()
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+    expect(onDismiss).not.toHaveBeenCalled()
+
+    await pressOutside()
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it("counts presses across the whole walkthrough, not per step", async () => {
+    const onDismiss = vi.fn()
+    renderApp()
+    open({
+      steps: [
+        { targetElement: "#filters", title: "First" },
+        { targetElement: "#outside", title: "Second" },
+      ],
+      overlay: true,
+      skipAfterOutsideClicks: 2,
+      onDismiss,
+    })
+    await screen.findByRole("dialog")
+
+    await pressOutside()
+    await userEvent.click(screen.getByRole("button", { name: "Next" }))
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("Second")
+    )
+
+    await pressOutside()
+
+    await waitFor(() =>
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    )
+    expect(onDismiss).toHaveBeenCalledOnce()
+  })
+
+  it("never gives up when the threshold is 0", async () => {
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+      skipAfterOutsideClicks: 0,
+    })
+    await screen.findByRole("dialog")
+
+    for (let press = 0; press < 8; press++) await pressOutside()
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument()
+  })
+
+  it("goes away with the coachmark", async () => {
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+    })
+    await screen.findByRole("dialog")
+    expect(blocker()).not.toBeNull()
+
+    await userEvent.click(screen.getByRole("button", { name: "Got it" }))
+
+    await waitFor(() => expect(blocker()).toBeNull())
+  })
+})
+
+/** `prefers-reduced-motion: reduce`, for as long as the returned undo is not called. */
+const preferReducedMotion = () => {
+  const original = window.matchMedia
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes("prefers-reduced-motion"),
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia
+  return () => {
+    window.matchMedia = original
+  }
+}
+
+describe("the handover between two steps", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("holds the step it is leaving until the fade is over, on the same panel", async () => {
+    renderApp()
+    open({
+      steps: [
+        { targetElement: "#filters", title: "First" },
+        { targetElement: "#outside", title: "Second" },
+      ],
+    })
+    const dialog = await screen.findByRole("dialog")
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }))
+
+    // NOT SWAPPED IN PLACE. The action has been taken and the copy is still the
+    // one the reader was reading: the next step is committed further on, while
+    // the panel is invisible, so the words never change under their eyes.
+    expect(dialog).toHaveAccessibleName("First")
+
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("Second")
+    )
+    // The same panel throughout — it fades, it does not close and reopen.
+    expect(screen.getByRole("dialog")).toBe(dialog)
+  })
+
+  it("changes step outright for a reader who asked for less motion", async () => {
+    const restore = preferReducedMotion()
+    try {
+      renderApp()
+      open({
+        steps: [
+          { targetElement: "#filters", title: "First" },
+          { targetElement: "#outside", title: "Second" },
+        ],
+      })
+      await screen.findByRole("dialog")
+
+      await userEvent.click(screen.getByRole("button", { name: "Next" }))
+
+      // No fade to wait for, so no gap: the copy is already the next step's.
+      expect(screen.getByRole("dialog")).toHaveAccessibleName("Second")
+    } finally {
+      restore()
+    }
+  })
+})

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
@@ -245,3 +245,110 @@ describe("the handover between two steps", () => {
     }
   })
 })
+
+/**
+ * `focusTarget` on a step whose whole point is a field: the caret starts in it,
+ * so it wears its own focus state instead of being described from outside.
+ */
+describe("a step that focuses what it points at", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  /** A composer: a field with a row of controls under it, inside one box. */
+  const renderComposer = () =>
+    render(
+      <CoachmarkProvider>
+        <div id="composer">
+          <textarea aria-label="Ask One" />
+          <button>Analyse</button>
+        </div>
+        <button id="views">Views</button>
+      </CoachmarkProvider>
+    )
+
+  it("puts the caret in the field inside the target, not on the panel", async () => {
+    renderComposer()
+    open({
+      targetElement: "#composer",
+      title: "Let One do it for you",
+      focusTarget: true,
+    })
+
+    await screen.findByRole("dialog")
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Ask One" })).toHaveFocus()
+    )
+    // And the way on is still one Tab away, not lost with the focus.
+    expect(screen.getByRole("button", { name: "Got it" })).toBeInTheDocument()
+  })
+
+  it("keeps focus on the panel for a step that did not ask", async () => {
+    renderComposer()
+    open({ targetElement: "#composer", title: "Let One do it for you" })
+
+    const dialog = await screen.findByRole("dialog")
+    await waitFor(() => expect(dialog).toHaveFocus())
+  })
+
+  it("hands focus over per step, not once for the walkthrough", async () => {
+    renderComposer()
+    open({
+      steps: [
+        {
+          targetElement: "#composer",
+          title: "Ask One",
+          focusTarget: true,
+        },
+        { targetElement: "#views", title: "Then save a view" },
+      ],
+    })
+    await screen.findByRole("dialog")
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Ask One" })).toHaveFocus()
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Next" }))
+
+    // The second step never asked for its element, so the panel takes focus
+    // back and the step is announced like any other.
+    await waitFor(() =>
+      expect(screen.getByRole("dialog")).toHaveAccessibleName(
+        "Then save a view"
+      )
+    )
+    await waitFor(() => expect(screen.getByRole("dialog")).toHaveFocus())
+  })
+
+  it("falls back to the panel when the target holds nothing to focus", async () => {
+    render(
+      <CoachmarkProvider>
+        <p id="prose">Nothing focusable in here.</p>
+      </CoachmarkProvider>
+    )
+    open({ targetElement: "#prose", title: "Read this", focusTarget: true })
+
+    const dialog = await screen.findByRole("dialog")
+    await waitFor(() => expect(dialog).toHaveFocus())
+  })
+
+  it("restores focus to what had it, the way any other coachmark does", async () => {
+    renderComposer()
+    const before = screen.getByRole("button", { name: "Views" })
+    before.focus()
+
+    open({
+      targetElement: "#composer",
+      title: "Let One do it for you",
+      focusTarget: true,
+    })
+    await screen.findByRole("dialog")
+    await waitFor(() =>
+      expect(screen.getByRole("textbox", { name: "Ask One" })).toHaveFocus()
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Got it" }))
+
+    await waitFor(() => expect(before).toHaveFocus())
+  })
+})

--- a/packages/react/src/experimental/Overlays/F0Coachmark/guidance.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/guidance.ts
@@ -1,0 +1,244 @@
+import { nanoid } from "nanoid"
+
+import { coachmarks } from "./imperative"
+import type { CoachmarkId, CoachmarkStep, CoachmarkTarget } from "./types"
+
+/**
+ * The attribute a guidance's `anchor()` writes, and the one its steps are
+ * resolved through. A data attribute rather than the `id` attribute: an id is
+ * the page's own namespace — one per document, handed out by whatever renders
+ * the element — and a walkthrough that claimed ids would collide with the app's
+ * own the first time two of them named the same thing.
+ */
+const ANCHOR_ATTRIBUTE = "data-f0-coachmark"
+
+/** How long `start()` keeps looking for targets that are not on the page yet. */
+const DEFAULT_LOOK_FOR_TARGETS_MS = 2000
+/**
+ * How often it looks. Coarse on purpose: nothing here is animating, and a
+ * walkthrough that opens 50ms after its last element arrived is indistinguishable
+ * from one that opened on the frame it did.
+ */
+const LOOK_FOR_TARGETS_INTERVAL_MS = 50
+
+/**
+ * Whether a step has something to point at RIGHT NOW. The same resolution
+ * `useTargetElement` does when the coachmark is on screen, asked early — the
+ * difference being what the answer is for: there, `null` means "wait for it";
+ * here it means "leave this step out".
+ */
+const isOnPage = (step: CoachmarkStep): boolean => {
+  const target = step.targetElement
+  if (target === undefined) return false
+  if (typeof target !== "string") return target.isConnected
+  return document.querySelector(target) !== null
+}
+
+/**
+ * One step of a walkthrough. It points either at a NAME the guidance knows —
+ * marked on the element with `anchor()` — or, for an element you cannot put
+ * props on (something a library renders), straight at a selector or an element.
+ */
+export type CoachmarkGuidanceStep<TElement extends string> = Omit<
+  CoachmarkStep,
+  "targetElement"
+> &
+  (
+    | { element: TElement; targetElement?: never }
+    | { element?: never; targetElement: CoachmarkTarget }
+  )
+
+export type CoachmarkGuidanceOptions<TElement extends string> = {
+  /**
+   * Stable identity, so starting the same guidance twice shows ONE walkthrough.
+   * Defaults to a generated id.
+   */
+  id?: CoachmarkId
+  /** The walkthrough, in order. */
+  steps: readonly CoachmarkGuidanceStep<TElement>[]
+  /**
+   * Spotlight each step's element and shield the page from the pointer.
+   * Defaults to `true` — a walkthrough is a sequence, and a page you can act on
+   * mid-sequence is a sequence the user has already left.
+   */
+  overlay?: boolean
+  /** Presses on the dimmed page that end the walkthrough. Defaults to 5. */
+  skipAfterOutsideClicks?: number
+  /**
+   * HOW LONG `start()` KEEPS LOOKING for the steps whose elements are not on the
+   * page yet, before running the walkthrough without them. Defaults to 2000ms.
+   *
+   * A walkthrough is started on mount, and the things it walks arrive over the
+   * next few hundred milliseconds — a rail that is still measuring itself, a
+   * widget waiting on its data. Opening on the first frame would drop those
+   * steps; waiting forever on one that is genuinely absent (a control this user
+   * has no permission for) would mean no walkthrough at all.
+   */
+  lookForTargetsMs?: number
+  /** Abandoned: closed, escaped, or skipped by pressing past it. */
+  onDismiss?: () => void
+  /** Finished: the action on the last step. */
+  onComplete?: () => void
+}
+
+export type CoachmarkGuidance<TElement extends string> = {
+  /** The id every `start()` opens under, and the one `stop()` closes. */
+  id: CoachmarkId
+  /**
+   * MARKS AN ELEMENT AS A STEP'S TARGET. Spread onto the element (or onto any
+   * component that forwards unknown props to its DOM node):
+   *
+   * `<section {...guidance.anchor("needs-you")}>`
+   *
+   * Only names declared by a step type-check, so a renamed step breaks at the
+   * anchor rather than at run time — where a missing target is a coachmark that
+   * silently waits for an element that is never coming.
+   */
+  anchor: (element: TElement) => Record<typeof ANCHOR_ATTRIBUTE, TElement>
+  /** The selector `anchor(element)` is found by. For tests and edge cases. */
+  selector: (element: TElement) => string
+  /**
+   * Start the walkthrough — once the elements it points at are actually on the
+   * page (see `lookForTargetsMs`). Steps whose element never turns up are left
+   * out, and a walkthrough with nothing left to point at never opens at all.
+   * Returns the id it will open under, whether it has opened yet or not.
+   */
+  start: () => CoachmarkId
+  /** End it wherever it is. Reports nothing: nobody dismissed it. */
+  stop: () => void
+}
+
+/**
+ * A STEP-BY-STEP WALKTHROUGH OF A PAGE, declared in one place.
+ *
+ * `coachmarks.open({ steps })` already shows steps one at a time; what it takes
+ * is a CSS selector per step, which means every walkthrough invents its own
+ * convention for marking the elements it walks — and a selector written against
+ * someone else's markup breaks the next time that markup is refactored, without
+ * a single type error to say so.
+ *
+ * This closes that loop: the steps name their targets, `anchor()` marks them,
+ * and the names are a union the compiler holds both sides to. The walkthrough
+ * also arrives with the manners a walkthrough needs — the page dimmed to the
+ * step's element, the pointer shielded, and a way out for the user who keeps
+ * pressing past it — because those are properties of walking someone through a
+ * page rather than of one coachmark.
+ *
+ * @example
+ * const tour = defineStepByStepCoachmarkGuidance({
+ *   id: "home-tour",
+ *   steps: [
+ *     { element: "composer", title: "Let One do it for you", side: "bottom" },
+ *     { element: "needs-you", title: "What needs you", side: "right" },
+ *     // Something f0 renders: point at it directly.
+ *     { targetElement: '[data-add-widget="right"]', title: "Add a widget" },
+ *   ],
+ *   onComplete: () => track("home-tour-finished"),
+ * })
+ *
+ * // In the page
+ * <div {...tour.anchor("composer")}>…</div>
+ * <section {...tour.anchor("needs-you")}>…</section>
+ *
+ * // Whenever it should run
+ * useEffect(() => {
+ *   tour.start()
+ *   return () => tour.stop()
+ * }, [tour])
+ */
+export const defineStepByStepCoachmarkGuidance = <
+  const TElement extends string,
+>(
+  options: CoachmarkGuidanceOptions<TElement>
+): CoachmarkGuidance<TElement> => {
+  // Resolved ONCE, at definition: `start()` is called from an effect that can
+  // run twice, and a fresh id each time would queue the walkthrough again
+  // behind itself instead of replacing it.
+  const id = options.id ?? nanoid()
+
+  const selector = (element: TElement) => `[${ANCHOR_ATTRIBUTE}="${element}"]`
+
+  const anchor = (element: TElement) =>
+    ({ [ANCHOR_ATTRIBUTE]: element }) as Record<
+      typeof ANCHOR_ATTRIBUTE,
+      TElement
+    >
+
+  // Every step ends up with a target: a named one becomes the anchor's own
+  // selector, and a step that brought its own is passed through as it is.
+  const resolved: CoachmarkStep[] = options.steps.map(
+    ({ element, targetElement, ...step }) => ({
+      ...step,
+      targetElement: targetElement ?? selector(element as TElement),
+    })
+  )
+
+  const lookFor = options.lookForTargetsMs ?? DEFAULT_LOOK_FOR_TARGETS_MS
+
+  /**
+   * The pending look-for-targets poll, so `stop()` can call off a walkthrough
+   * that has not opened yet — a page unmounted mid-poll must not open one into
+   * the page that replaced it.
+   */
+  let polling: ReturnType<typeof setTimeout> | undefined
+
+  const openWithWhatIsThere = () => {
+    const present = resolved.filter(isOnPage)
+
+    // NOT A WALKTHROUGH AT ALL. Nothing this one wanted to point at is on the
+    // page: it is describing a screen the reader is not looking at, and three
+    // steps about elements that are not there is worse than silence. No warning
+    // either — an absent element is a legitimate state (a control this user has
+    // no permission for), not a mistake to report.
+    if (present.length === 0) return
+
+    coachmarks.open({
+      id,
+      // WITHOUT THE STEPS THAT NEVER TURNED UP. Dropped rather than shown
+      // waiting: `useTargetElement` would hold a coachmark open pointing at
+      // nothing until its element arrived, and the reader would be looking at a
+      // walkthrough that stopped halfway with no way on but the close button.
+      // Dropping them before opening is also what makes the count honest — a
+      // walkthrough that says 1/3 has three steps to give.
+      steps: present,
+      overlay: options.overlay ?? true,
+      skipAfterOutsideClicks: options.skipAfterOutsideClicks,
+      onDismiss: options.onDismiss,
+      onComplete: options.onComplete,
+    })
+  }
+
+  const start = () => {
+    clearTimeout(polling)
+    polling = undefined
+
+    if (typeof document === "undefined") return id
+
+    const deadline = Date.now() + lookFor
+    const openWhenReady = () => {
+      polling = undefined
+      // Every step accounted for, or out of time — either way, open with the
+      // steps that are on the page.
+      if (resolved.every(isOnPage) || Date.now() >= deadline) {
+        openWithWhatIsThere()
+        return
+      }
+      polling = setTimeout(openWhenReady, LOOK_FOR_TARGETS_INTERVAL_MS)
+    }
+    openWhenReady()
+
+    return id
+  }
+
+  return {
+    id,
+    anchor,
+    selector,
+    start,
+    stop: () => {
+      clearTimeout(polling)
+      polling = undefined
+      coachmarks.close(id)
+    },
+  }
+}

--- a/packages/react/src/experimental/Overlays/F0Coachmark/guidance.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/guidance.ts
@@ -1,7 +1,12 @@
 import { nanoid } from "nanoid"
 
 import { coachmarks } from "./imperative"
-import type { CoachmarkId, CoachmarkStep, CoachmarkTarget } from "./types"
+import type {
+  CoachmarkEnd,
+  CoachmarkId,
+  CoachmarkStep,
+  CoachmarkTarget,
+} from "./types"
 
 /**
  * The attribute a guidance's `anchor()` writes, and the one its steps are
@@ -75,6 +80,12 @@ export type CoachmarkGuidanceOptions<TElement extends string> = {
    * has no permission for) would mean no walkthrough at all.
    */
   lookForTargetsMs?: number
+  /**
+   * HOW IT ENDED, IN ONE PLACE: finished, left part-way through, pressed past
+   * until it gave up — or never opened at all, because nothing it points at was
+   * on the page. One event with a `reason`, which is what a funnel wants.
+   */
+  onEnd?: (end: CoachmarkEnd) => void
   /** Abandoned: closed, escaped, or skipped by pressing past it. */
   onDismiss?: () => void
   /** Finished: the action on the last step. */
@@ -133,7 +144,9 @@ export type CoachmarkGuidance<TElement extends string> = {
  *     // Something f0 renders: point at it directly.
  *     { targetElement: '[data-add-widget="right"]', title: "Add a widget" },
  *   ],
- *   onComplete: () => track("home-tour-finished"),
+ *   // Finished, dropped out at step N, pressed past it, or never shown.
+ *   onEnd: ({ reason, step, totalSteps }) =>
+ *     track("home-tour-ended", { reason, step, totalSteps }),
  * })
  *
  * // In the page
@@ -190,7 +203,19 @@ export const defineStepByStepCoachmarkGuidance = <
     // steps about elements that are not there is worse than silence. No warning
     // either — an absent element is a legitimate state (a control this user has
     // no permission for), not a mistake to report.
-    if (present.length === 0) return
+    //
+    // REPORTED, THOUGH. Silence on screen is not silence to whoever is counting:
+    // without this a funnel cannot tell "nobody finished the tour" from "the
+    // tour never ran", and those want opposite fixes.
+    if (present.length === 0) {
+      options.onEnd?.({
+        reason: "unavailable",
+        step: 0,
+        totalSteps: 0,
+        outsidePresses: 0,
+      })
+      return
+    }
 
     coachmarks.open({
       id,
@@ -203,6 +228,7 @@ export const defineStepByStepCoachmarkGuidance = <
       steps: present,
       overlay: options.overlay ?? true,
       skipAfterOutsideClicks: options.skipAfterOutsideClicks,
+      onEnd: options.onEnd,
       onDismiss: options.onDismiss,
       onComplete: options.onComplete,
     })

--- a/packages/react/src/experimental/Overlays/F0Coachmark/imperative.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/imperative.ts
@@ -92,6 +92,8 @@ const open = (options: CoachmarkOptions): CoachmarkId => {
     steps,
     onDismiss: options.onDismiss,
     onComplete: options.onComplete,
+    overlay: options.overlay,
+    skipAfterOutsideClicks: options.skipAfterOutsideClicks,
   })
 
   return id

--- a/packages/react/src/experimental/Overlays/F0Coachmark/imperative.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/imperative.ts
@@ -66,6 +66,7 @@ export const resolveSteps = (options: CoachmarkOptions): CoachmarkStep[] => {
         action: step.action,
         targetElement,
         arrow: step.arrow ?? options.arrow,
+        focusTarget: step.focusTarget ?? options.focusTarget,
         side: step.side ?? options.side,
         align: step.align ?? options.align,
         sideOffset: step.sideOffset ?? options.sideOffset,

--- a/packages/react/src/experimental/Overlays/F0Coachmark/imperative.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/imperative.ts
@@ -91,6 +91,7 @@ const open = (options: CoachmarkOptions): CoachmarkId => {
   coachmarkStore.addItem({
     id,
     steps,
+    onEnd: options.onEnd,
     onDismiss: options.onDismiss,
     onComplete: options.onComplete,
     overlay: options.overlay,

--- a/packages/react/src/experimental/Overlays/F0Coachmark/index.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/index.tsx
@@ -14,6 +14,8 @@ export type {
 } from "./guidance"
 export type {
   CoachmarkAction,
+  CoachmarkEnd,
+  CoachmarkEndReason,
   CoachmarkId,
   CoachmarkOptions,
   CoachmarkSequenceOptions,

--- a/packages/react/src/experimental/Overlays/F0Coachmark/index.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/index.tsx
@@ -2,7 +2,16 @@ export { CoachmarkProvider } from "./CoachmarkProvider"
 /**
  * @experimental This is an experimental API use it at your own risk
  */
+export { defineStepByStepCoachmarkGuidance } from "./guidance"
+/**
+ * @experimental This is an experimental API use it at your own risk
+ */
 export { coachmarks } from "./imperative"
+export type {
+  CoachmarkGuidance,
+  CoachmarkGuidanceOptions,
+  CoachmarkGuidanceStep,
+} from "./guidance"
 export type {
   CoachmarkAction,
   CoachmarkId,

--- a/packages/react/src/experimental/Overlays/F0Coachmark/types.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/types.ts
@@ -47,6 +47,48 @@ type CoachmarkPlacement = {
   sideOffset?: number
 }
 
+/**
+ * HOW A COACHMARK ENDED. One value per way out, so a funnel can be read off it
+ * without joining two callbacks together:
+ *
+ * - `completed` — the action on the last step. The reader saw the whole thing.
+ * - `dismissed` — the close button or Escape, before the last step. They left
+ *   part-way through, and `step` says where.
+ * - `skipped` — it gave up after `skipAfterOutsideClicks` presses on the dimmed
+ *   page. Not the same as dismissing: the reader never used the way out they
+ *   were offered, they pressed past it until it went away.
+ * - `unavailable` — it never opened, because nothing it points at was on the
+ *   page (only `defineStepByStepCoachmarkGuidance` reports this). The reason a
+ *   funnel can be missing readers who were never shown anything.
+ */
+export type CoachmarkEndReason =
+  | "completed"
+  | "dismissed"
+  | "skipped"
+  | "unavailable"
+
+/** What `onEnd` is told. */
+export type CoachmarkEnd = {
+  reason: CoachmarkEndReason
+  /**
+   * The step it ended on, 1-based — how far the reader got. `0` when it never
+   * opened (`unavailable`).
+   */
+  step: number
+  /**
+   * How many steps the reader was actually offered. Not necessarily how many
+   * were declared: a guidance leaves out the steps whose element was not there.
+   */
+  totalSteps: number
+  /**
+   * Presses on the dimmed page over the whole coachmark — the wiggles. A tour
+   * that completed with six of these was fought with; one that completed with
+   * none was followed. Always `0` without `overlay`, which has no shield to
+   * press.
+   */
+  outsidePresses: number
+}
+
 type CoachmarkContent = {
   /** Headline. Also the accessible name of the panel. */
   title: string
@@ -98,9 +140,25 @@ type CoachmarkBase = CoachmarkPlacement &
      */
     id?: CoachmarkId
     /**
+     * HOW IT ENDED, IN ONE PLACE — reached the end, left part-way through, or
+     * pressed past until it gave up, and how far the reader got either way. The
+     * callback to reach for when tracking a walkthrough: every ending comes
+     * through here exactly once, so a funnel is one event carrying a `reason`
+     * rather than two callbacks to join up afterwards.
+     *
+     * NOT called when the app itself closes the coachmark (`coachmarks.close`, a
+     * guidance's `stop()`, the page unmounting): nobody ended it, so there is no
+     * outcome to report.
+     */
+    onEnd?: (end: CoachmarkEnd) => void
+    /**
      * Called when the user closes the coachmark with the close button or Escape,
      * before the last step is reached. For tracking only — the coachmark closes
      * itself either way.
+     *
+     * Also fires when a walkthrough gives up after too many presses on the
+     * dimmed page, which is a dismissal by any other name. `onEnd` is what tells
+     * those two apart.
      */
     onDismiss?: () => void
     /**
@@ -161,6 +219,7 @@ export type CoachmarkOptions = CoachmarkSingleOptions | CoachmarkSequenceOptions
 export type CoachmarkItem = {
   id: CoachmarkId
   steps: CoachmarkStep[]
+  onEnd?: (end: CoachmarkEnd) => void
   onDismiss?: () => void
   onComplete?: () => void
   overlay?: boolean

--- a/packages/react/src/experimental/Overlays/F0Coachmark/types.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/types.ts
@@ -75,6 +75,26 @@ type CoachmarkBase = CoachmarkPlacement & {
    * — the coachmark closes itself either way.
    */
   onComplete?: () => void
+  /**
+   * SPOTLIGHT THE TARGET: dims the whole page except the element this step
+   * points at, and swallows every press on the page while the coachmark is up
+   * (see `skipAfterOutsideClicks` for how a user who keeps pressing gets out).
+   *
+   * Off by default — one coachmark pointing something out should not take the
+   * page hostage. Turn it on for a walkthrough that has to be followed in order.
+   */
+  overlay?: boolean
+  /**
+   * HOW MANY PRESSES ON THE DIMMED PAGE END THE COACHMARK. The panel wiggles at
+   * each one to say the press went nowhere, and gives up at this many: a user
+   * pressing outside over and over is telling us they want out, and the way out
+   * cannot be the button they are ignoring. Reported to `onDismiss` like any
+   * other abandonment. Defaults to 5; `0` never gives up.
+   *
+   * Only has an effect alongside `overlay` — without the shield there are no
+   * presses to count, because they reach the page.
+   */
+  skipAfterOutsideClicks?: number
 }
 
 /** One coachmark: its own copy, anchored to one element. */
@@ -110,6 +130,8 @@ export type CoachmarkItem = {
   steps: CoachmarkStep[]
   onDismiss?: () => void
   onComplete?: () => void
+  overlay?: boolean
+  skipAfterOutsideClicks?: number
 }
 
 /**
@@ -128,6 +150,22 @@ export interface F0CoachmarkProps extends CoachmarkPlacement {
   onAction: () => void
   /** Fired by the close button and by Escape. Never by an outside click. */
   onClose: () => void
+  /**
+   * Dims the page except the target and shields it from the pointer. See
+   * `CoachmarkSpotlight`.
+   */
+  overlay?: boolean
+  /**
+   * Fired for every press the shield swallows — only while `overlay` is on. The
+   * panel wiggles on its own; this is for whoever is counting them.
+   */
+  onOutsideInteraction?: () => void
+  /**
+   * The panel is on its way out of the step it is showing: it fades down and
+   * waits there while the next step is committed underneath it. Set by
+   * `CoachmarkProvider`, which owns the handover between two steps.
+   */
+  leaving?: boolean
   /**
    * Position within a sequence, rendered as `current/total` beside the action.
    * Omitted for a single-step coachmark, which shows no indicator.

--- a/packages/react/src/experimental/Overlays/F0Coachmark/types.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/types.ts
@@ -3,9 +3,19 @@ import type { PopoverContentProps } from "@/ui/popover"
 export type CoachmarkId = string
 
 /**
- * What the coachmark points at: a CSS selector that must match exactly one
- * element, or the element itself. A selector is re-resolved while the coachmark
- * is queued, so it may point at something that mounts later.
+ * What the coachmark points at: ANY CSS SELECTOR, or the element itself.
+ *
+ * An id (`"#filters-button"`), a class (`".js-filters"`), an attribute
+ * (`'[data-add-widget="right"]'`), or anything else `querySelector` takes — the
+ * string is handed straight to the DOM, so the choice is about what the page
+ * can promise to keep stable, not about what this accepts. It must match
+ * exactly ONE element: a selector that matches several anchors to the first and
+ * warns in development, because a coachmark pointing at "one of these six
+ * cards" is pointing at nothing in particular.
+ *
+ * A selector is re-resolved while the coachmark is queued, so it may point at
+ * something that mounts later. An ELEMENT is not re-resolved (there is nothing
+ * to re-run), so one that unmounts takes its coachmark off screen with it.
  */
 export type CoachmarkTarget = string | HTMLElement
 
@@ -46,56 +56,79 @@ type CoachmarkContent = {
   action?: CoachmarkAction
 }
 
+type CoachmarkFocus = {
+  /**
+   * PUT THE CARET WHERE THE STEP IS POINTING. Focus goes to the target — or to
+   * the first field inside it — instead of to the panel, so the element the
+   * coachmark is explaining lights up the way it does when the reader lands on
+   * it themselves: a composer with its cursor in it and its own focus glow,
+   * rather than a box being described.
+   *
+   * OFF BY DEFAULT, and worth being deliberate about. The panel takes focus
+   * precisely so a screen reader reads the step out and so Enter cannot fire
+   * the action unread; handing focus to a field instead trades that away —
+   * the step is no longer announced, and typing goes into the page. Use it on a
+   * step whose whole point is the field (a composer, a search box), and leave
+   * every other step to the panel.
+   *
+   * Escape still closes the coachmark from anywhere, and the action button is
+   * still one Tab away.
+   */
+  focusTarget?: boolean
+}
+
 /**
  * One step of a walkthrough. Each step can point at its own element and carry
  * its own placement; anything it leaves out falls back to the value passed
  * alongside `steps`.
  */
 export type CoachmarkStep = CoachmarkContent &
-  CoachmarkPlacement & {
+  CoachmarkPlacement &
+  CoachmarkFocus & {
     /** Falls back to the `targetElement` passed alongside `steps`. */
     targetElement?: CoachmarkTarget
   }
 
-type CoachmarkBase = CoachmarkPlacement & {
-  /**
-   * Stable identity. Opening again with the same id replaces that coachmark
-   * instead of queueing a second one, so an effect that runs twice shows one
-   * coachmark. Defaults to a generated id.
-   */
-  id?: CoachmarkId
-  /**
-   * Called when the user closes the coachmark with the close button or Escape,
-   * before the last step is reached. For tracking only — the coachmark closes
-   * itself either way.
-   */
-  onDismiss?: () => void
-  /**
-   * Called when the user presses the action on the last step. For tracking only
-   * — the coachmark closes itself either way.
-   */
-  onComplete?: () => void
-  /**
-   * SPOTLIGHT THE TARGET: dims the whole page except the element this step
-   * points at, and swallows every press on the page while the coachmark is up
-   * (see `skipAfterOutsideClicks` for how a user who keeps pressing gets out).
-   *
-   * Off by default — one coachmark pointing something out should not take the
-   * page hostage. Turn it on for a walkthrough that has to be followed in order.
-   */
-  overlay?: boolean
-  /**
-   * HOW MANY PRESSES ON THE DIMMED PAGE END THE COACHMARK. The panel wiggles at
-   * each one to say the press went nowhere, and gives up at this many: a user
-   * pressing outside over and over is telling us they want out, and the way out
-   * cannot be the button they are ignoring. Reported to `onDismiss` like any
-   * other abandonment. Defaults to 5; `0` never gives up.
-   *
-   * Only has an effect alongside `overlay` — without the shield there are no
-   * presses to count, because they reach the page.
-   */
-  skipAfterOutsideClicks?: number
-}
+type CoachmarkBase = CoachmarkPlacement &
+  CoachmarkFocus & {
+    /**
+     * Stable identity. Opening again with the same id replaces that coachmark
+     * instead of queueing a second one, so an effect that runs twice shows one
+     * coachmark. Defaults to a generated id.
+     */
+    id?: CoachmarkId
+    /**
+     * Called when the user closes the coachmark with the close button or Escape,
+     * before the last step is reached. For tracking only — the coachmark closes
+     * itself either way.
+     */
+    onDismiss?: () => void
+    /**
+     * Called when the user presses the action on the last step. For tracking only
+     * — the coachmark closes itself either way.
+     */
+    onComplete?: () => void
+    /**
+     * SPOTLIGHT THE TARGET: dims the whole page except the element this step
+     * points at, and swallows every press on the page while the coachmark is up
+     * (see `skipAfterOutsideClicks` for how a user who keeps pressing gets out).
+     *
+     * Off by default — one coachmark pointing something out should not take the
+     * page hostage. Turn it on for a walkthrough that has to be followed in order.
+     */
+    overlay?: boolean
+    /**
+     * HOW MANY PRESSES ON THE DIMMED PAGE END THE COACHMARK. The panel wiggles at
+     * each one to say the press went nowhere, and gives up at this many: a user
+     * pressing outside over and over is telling us they want out, and the way out
+     * cannot be the button they are ignoring. Reported to `onDismiss` like any
+     * other abandonment. Defaults to 5; `0` never gives up.
+     *
+     * Only has an effect alongside `overlay` — without the shield there are no
+     * presses to count, because they reach the page.
+     */
+    skipAfterOutsideClicks?: number
+  }
 
 /** One coachmark: its own copy, anchored to one element. */
 export type CoachmarkSingleOptions = CoachmarkBase &
@@ -150,6 +183,8 @@ export interface F0CoachmarkProps extends CoachmarkPlacement {
   onAction: () => void
   /** Fired by the close button and by Escape. Never by an outside click. */
   onClose: () => void
+  /** Focus the target rather than the panel — see `CoachmarkStep.focusTarget`. */
+  focusTarget?: boolean
   /**
    * Dims the page except the target and shields it from the pointer. See
    * `CoachmarkSpotlight`.

--- a/packages/react/src/experimental/Overlays/exports.tsx
+++ b/packages/react/src/experimental/Overlays/exports.tsx
@@ -5,6 +5,8 @@ export {
   CoachmarkProvider,
   defineStepByStepCoachmarkGuidance,
   type CoachmarkAction,
+  type CoachmarkEnd,
+  type CoachmarkEndReason,
   type CoachmarkGuidance,
   type CoachmarkGuidanceOptions,
   type CoachmarkGuidanceStep,

--- a/packages/react/src/experimental/Overlays/exports.tsx
+++ b/packages/react/src/experimental/Overlays/exports.tsx
@@ -3,7 +3,11 @@ export { Dialog } from "../../deprecated/Dialog"
 export {
   coachmarks,
   CoachmarkProvider,
+  defineStepByStepCoachmarkGuidance,
   type CoachmarkAction,
+  type CoachmarkGuidance,
+  type CoachmarkGuidanceOptions,
+  type CoachmarkGuidanceStep,
   type CoachmarkId,
   type CoachmarkOptions,
   type CoachmarkSequenceOptions,

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -151,8 +151,14 @@ const HOME_WALKTHROUGH = defineStepByStepCoachmarkGuidance({
       side: "left",
     },
   ],
-  onComplete: () => console.log("walkthrough: finished"),
-  onDismiss: () => console.log("walkthrough: abandoned"),
+  // ONE CALLBACK FOR THE WHOLE OUTCOME — what an app would send to analytics:
+  // which way out the reader took, how far they got, and how many times they
+  // pressed past the panel on the way. `completed` / `dismissed` / `skipped`,
+  // plus `unavailable` for the run where nothing it points at was on the page.
+  onEnd: ({ reason, step, totalSteps, outsidePresses }) =>
+    console.log(
+      `walkthrough: ${reason} at ${step}/${totalSteps} (${outsidePresses} presses outside)`
+    ),
 })
 
 /* =============================== main column =============================== */

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -53,6 +53,7 @@ import {
   Target,
   Timer,
 } from "@/icons/app"
+import { defineStepByStepCoachmarkGuidance } from "@/experimental/Overlays/F0Coachmark"
 import { F0AiChatTextArea } from "@/kits/ai/F0AiChatTextArea"
 import { type WelcomeScreenSuggestion } from "@/kits/ai/F0AiChat/types"
 import { F0Box } from "@/lib/F0Box"
@@ -90,6 +91,64 @@ import { Menu as SidebarMenu } from "@/patterns/Navigation/Sidebar/Menu"
 import * as SidebarMenuStories from "@/patterns/Navigation/Sidebar/Menu/index.stories"
 
 import { NewHomeLayout } from "./index"
+
+/* ============================ guided walkthrough =========================== */
+
+/**
+ * THE FIRST-RUN WALKTHROUGH OF THIS HOME — three steps, each NAMING the element
+ * it points at. `HOME_WALKTHROUGH.anchor(…)` marks those elements further down,
+ * and the names are a union the compiler holds both halves to: renaming a step
+ * is a type error at the anchor rather than a coachmark waiting for an element
+ * that is never coming.
+ *
+ * The copy is the prototype's own (factorial-composer's `custom-home` Feed,
+ * where this tour was designed), down to the third step having no description —
+ * its title is the whole sentence.
+ *
+ * The third step points at something THE LAYOUT renders rather than this story,
+ * so it names the handle directly: `data-add-widget="right"`, which the rail's
+ * add control carries as a column AND as a collapsed strip — the step lands on
+ * the same offer either way.
+ *
+ * The overlay comes with the walkthrough (`overlay` defaults to `true`): the
+ * page is dimmed except the step's element, the pointer is shielded from it, and
+ * a reader who keeps pressing past the panel gets out after five presses.
+ */
+const HOME_WALKTHROUGH = defineStepByStepCoachmarkGuidance({
+  id: "new-home-walkthrough",
+  // Longer than the 2s default, for Storybook rather than for Home: the rail's
+  // add control only exists once the layout has measured its own columns, and a
+  // canvas that is still compiling its story takes several times longer to get
+  // there than the app does. Without this the story regularly opens as a
+  // two-step walkthrough — correct behaviour (see `lookForTargetsMs`), wrong
+  // demonstration.
+  lookForTargetsMs: 5000,
+  steps: [
+    {
+      element: "ask-one",
+      title: "Let One do it for you",
+      description:
+        "Ask One to analyse, find information, process expenses, or request holidays; and focus on making decisions.",
+      side: "bottom",
+    },
+    {
+      element: "needs-you",
+      title: "Important things come first",
+      description:
+        "View and complete all the updates and tasks that require your attention at a glance.",
+      side: "right",
+      align: "start",
+    },
+    {
+      // No description: the title is the whole sentence.
+      targetElement: '[data-add-widget="right"]',
+      title: "Customise the Home by adding, reordering, and removing widgets",
+      side: "left",
+    },
+  ],
+  onComplete: () => console.log("walkthrough: finished"),
+  onDismiss: () => console.log("walkthrough: abandoned"),
+})
 
 /* =============================== main column =============================== */
 
@@ -285,7 +344,14 @@ const HomeComposer = () => {
 const HomeHero = () => (
   <F0Box display="flex" flexDirection="column">
     <Greeting />
-    <HomeComposer />
+    {/* The walkthrough's first step points at THE FIELD, not at the whole
+        block: the composer is what the step is about, and the greeting above it
+        is context the reader already has. The anchor goes on this wrapper
+        rather than inside `HomeComposer` so it takes the field's own focus-glow
+        inset with it — the lit region ends where the glow does. */}
+    <div {...HOME_WALKTHROUGH.anchor("ask-one")}>
+      <HomeComposer />
+    </div>
   </F0Box>
 )
 
@@ -376,42 +442,50 @@ const FeedSection = ({
 
 // An ARRAY, not a fragment: the layout inserts pinned widgets BETWEEN these
 // blocks when it stacks, and `Children.toArray` only sees seams in an array.
+//
+// The "Needs you" block is WRAPPED so the walkthrough can point at it: the
+// wrapper is what carries the anchor, since the block's own root is not a DOM
+// element this file can put an attribute on (the composer's own anchor is
+// inside `HomeHero`, on the field). A bare `div` in a flex column changes
+// nothing about how it draws — and an anchor is inert markup, so every story
+// keeps the same blocks whether or not the walkthrough ever runs.
 const mainColumnBlocks = () => [
   <HomeHero key="hero" />,
   <ShortcutCards key="shortcuts" />,
-  <FeedSection
-    key="needs-you"
-    label="Needs you"
-    viewMore={12}
-    rows={[
-      {
-        icon: PalmTree,
-        title: "Request time off",
-        subtitle: "You have 5 days of leave expiring next month.",
-      },
-      {
-        icon: Clock,
-        title: "Missing clock-out",
-        subtitle: "You clocked in but never clocked out yesterday.",
-      },
-      {
-        icon: Receipt,
-        title: "Submit an expense",
-        subtitle: "Snap a receipt and I'll file the expense.",
-      },
-      {
-        icon: Comment,
-        title: "Ask HR anything",
-        subtitle: "Get a policy answer, or have it raised with HR.",
-      },
-      {
-        icon: Target,
-        title: "Draft my self-review",
-        subtitle: "Turn your bullet points into review-ready text.",
-      },
-      { icon: File, title: "Contract to sign", subtitle: "Q3 addendum" },
-    ]}
-  />,
+  <div key="needs-you" {...HOME_WALKTHROUGH.anchor("needs-you")}>
+    <FeedSection
+      label="Needs you"
+      viewMore={12}
+      rows={[
+        {
+          icon: PalmTree,
+          title: "Request time off",
+          subtitle: "You have 5 days of leave expiring next month.",
+        },
+        {
+          icon: Clock,
+          title: "Missing clock-out",
+          subtitle: "You clocked in but never clocked out yesterday.",
+        },
+        {
+          icon: Receipt,
+          title: "Submit an expense",
+          subtitle: "Snap a receipt and I'll file the expense.",
+        },
+        {
+          icon: Comment,
+          title: "Ask HR anything",
+          subtitle: "Get a policy answer, or have it raised with HR.",
+        },
+        {
+          icon: Target,
+          title: "Draft my self-review",
+          subtitle: "Turn your bullet points into review-ready text.",
+        },
+        { icon: File, title: "Contract to sign", subtitle: "Q3 addendum" },
+      ]}
+    />
+  </div>,
   <FeedSection
     key="one-working"
     label="One working for you"
@@ -1740,6 +1814,67 @@ export const Loading: Story = {
       </NewHomeLayout>
     </div>
   ),
+}
+
+/* =========================== guided walkthrough =========================== */
+
+/**
+ * The same Home, walked through: `HOME_WALKTHROUGH.start()` on mount, and a
+ * control to see it again — a walkthrough is over once it is finished or
+ * skipped, and reloading the story is a poor way to review it.
+ */
+const GuidedHome = () => {
+  // A first-run tour is not something the reader asks for, so it starts with the
+  // page. `stop()` on the way out, or the walkthrough would outlive the story
+  // it is describing — Storybook keeps the coachmark store between stories.
+  useEffect(() => {
+    HOME_WALKTHROUGH.start()
+    return () => HOME_WALKTHROUGH.stop()
+  }, [])
+
+  return (
+    <>
+      <Home />
+      {/* Under the shield (`z-[1249]`) on purpose: while the walkthrough is up
+          this is part of the page, dimmed and unpressable like everything else
+          in it. */}
+      <div className="fixed bottom-6 left-6">
+        <F0Button
+          variant="outline"
+          label="Restart the walkthrough"
+          onClick={() => {
+            HOME_WALKTHROUGH.start()
+          }}
+        />
+      </div>
+    </>
+  )
+}
+
+/**
+ * A THREE-STEP WALKTHROUGH of this Home, declared with
+ * `defineStepByStepCoachmarkGuidance` (see `HOME_WALKTHROUGH` at the top of this
+ * file): the composer block, then the "Needs you" list, then the rail's own
+ * add-widget control.
+ *
+ * WHAT THE WALKTHROUGH DOES BEYOND POINTING:
+ * - the page is dimmed except the step's element, which stays lit at full
+ *   strength — the hole is the real element, not a copy of it;
+ * - a shield (`data-f0-coachmark-blocker`) swallows every press on the page, the
+ *   lit element included, so the only way on is the panel's own button;
+ * - a press that went nowhere makes the panel WIGGLE, which is the panel
+ *   answering for it;
+ * - five of those and the walkthrough gives up (`skipAfterOutsideClicks`) and
+ *   reports a dismissal: a reader pressing past it five times is telling us they
+ *   want out, and the way out cannot be the button they are ignoring.
+ *
+ * The first two steps name elements this file anchors (`anchor("ask-one")`,
+ * `anchor("needs-you")`); the third points at `[data-add-widget="right"]`, the
+ * handle the LAYOUT puts on the rail's add control — as a column and as a
+ * collapsed strip, so a narrow window walks the same three steps.
+ */
+export const GuidedWalkthrough: Story = {
+  render: () => <GuidedHome />,
 }
 
 /* ============================= glyph actions ============================= */

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -130,6 +130,11 @@ const HOME_WALKTHROUGH = defineStepByStepCoachmarkGuidance({
       description:
         "Ask One to analyse, find information, process expenses, or request holidays; and focus on making decisions.",
       side: "bottom",
+      // THE ONE STEP THAT TAKES FOCUS: the field is the step, so the caret
+      // starts in it and it wears its own focus glow — the reader can begin
+      // typing the question the panel is describing. Every other step leaves
+      // focus on the panel, where it is announced.
+      focusTarget: true,
     },
     {
       element: "needs-you",

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1339,6 +1339,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                   <motion.button
                     type="button"
                     aria-label={t.widgets.addWidget}
+                    // The same handle the column's own placeholder carries, so
+                    // "the rail's add button" is one selector whether the rail
+                    // is a column or a strip.
+                    data-add-widget="right"
                     onClick={() => onClickAddNewWidget("right")}
                     className="pointer-events-auto flex h-10 w-10 items-center justify-center rounded-lg border border-dashed border-f1-border text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
                     initial={{ opacity: 0 }}

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -125,6 +125,30 @@ describe("WidgetContainer", () => {
     ).toBeInTheDocument()
   })
 
+  test("names the add control by its column, so a page can point at one", () => {
+    zeroRender(
+      <>
+        <WidgetContainer
+          side="main"
+          widgets={WIDGETS}
+          onClickAddNewWidget={() => {}}
+        />
+        <WidgetContainer
+          side="right"
+          widgets={WIDGETS}
+          onClickAddNewWidget={() => {}}
+        />
+      </>
+    )
+
+    // Both are named "Add widget", so the label cannot tell them apart — which
+    // is what this handle is for (a coachmark pointing at the rail's offer).
+    expect(document.querySelectorAll("[data-add-widget]")).toHaveLength(2)
+    expect(
+      document.querySelector('[data-add-widget="right"]')
+    ).toHaveAccessibleName("Add widget")
+  })
+
   test("disableEdition opts the column out of everything, adding included", () => {
     zeroRender(
       <WidgetContainer

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -221,11 +221,7 @@ const AddWidgetPlaceholder = ({
       type="button"
       onClick={onClick}
       aria-label={label}
-      // WHICH COLUMN'S OFFER THIS IS, addressable from outside: a page that
-      // wants to point a coachmark (or a test) at "the rail's add button" has
-      // no other handle on it — the control is named by its tooltip, and both
-      // columns' are named the same. `data-` rather than an `id`, because a
-      // page can hold more than one of these columns.
+      // Which column's offer this is, so a page can point at one of them.
       data-add-widget={side}
       className="flex w-full items-center justify-center rounded-xl border border-dashed border-f1-border py-4 text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
     >

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -210,15 +210,23 @@ const WidgetSlot = ({
 const AddWidgetPlaceholder = ({
   onClick,
   label,
+  side,
 }: {
   onClick: () => void
   label: string
+  side: WidgetContainerSide
 }) => (
   <Tooltip label={label}>
     <button
       type="button"
       onClick={onClick}
       aria-label={label}
+      // WHICH COLUMN'S OFFER THIS IS, addressable from outside: a page that
+      // wants to point a coachmark (or a test) at "the rail's add button" has
+      // no other handle on it — the control is named by its tooltip, and both
+      // columns' are named the same. `data-` rather than an `id`, because a
+      // page can hold more than one of these columns.
+      data-add-widget={side}
       className="flex w-full items-center justify-center rounded-xl border border-dashed border-f1-border py-4 text-f1-foreground-secondary hover:border-f1-border-hover hover:text-f1-foreground"
     >
       <F0Icon size="md" icon={Plus} />
@@ -955,6 +963,7 @@ export function WidgetContainer({
             <AddWidgetPlaceholder
               onClick={onClickAddNewWidget}
               label={addWidgetLabel ?? t.widgets.addWidget}
+              side={side}
             />
           )
         : null}


### PR DESCRIPTION
## Description

F0Coachmark can point at one element, but it cannot walk someone through a page: the page behind it stays live and undimmed, a step swaps its copy in place, and every walkthrough has to invent its own convention for marking the elements it walks — a selector written against someone else's markup, which breaks the next time that markup moves with no type error to say so. This adds `defineStepByStepCoachmarkGuidance`, where steps NAME the elements they point at and `anchor()` marks them, together with the manners a walkthrough needs (the page dimmed to the step it is on, the pointer held off it, a fade between steps, and a way out for the reader who keeps pressing past it), and demonstrates it in `NewHomeLayout`'s story with the three-step tour designed in the [custom-home prototype](https://github.com/factorialco/factorial-composer/pull/48) — the composer field, "Needs you", and the rail's add-widget control, in that prototype's own copy.

### Notes for review

- **This is the prototype's `src/lib/CoachmarkSpotlight.ts`, brought inside the component**, as its own doc comment asks ("even if it's a hack for now we can later bring that into the coachmark's own code"). Once this ships, the prototype can drop that file, its `focusOn` plumbing and `coachmarkScroll.ts`, and pass `overlay: true`.
- **One deliberate difference from the prototype:** it fades everything around the target to `opacity: 0.2` scoped to `<main>`, so the sidebar stays lit. This dims the whole viewport instead — the component cannot know which part of an app is "main", and the shield has to cover everything it is blocking anyway. Happy to add a spotlight-root option if the sidebar should stay lit.
- The scroll into each step is instant, not smooth: a smooth scroll is abandoned the moment anything else touches that scroller, and a virtualized column does exactly that as the scroll passes over it — the rail's add control ended up 6px from where it started, off screen, with the panel anchored to it.
