### PR TITLE
feat(NewHomeLayout): add mainFootnote to the main column

### DIFF
--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -686,6 +686,69 @@ describe("NewHomeLayout", () => {
     })
   })
 
+  /**
+   * The main column's FOOTNOTE — a sentence at the foot of the column that is
+   * not a widget. What these tests pin is its POSITION: under every widget the
+   * column is drawing and above the offer to add another, whichever of those
+   * two the layout is currently doing. What the string itself may say is
+   * `Footnote`'s own test.
+   */
+  describe("mainFootnote", () => {
+    /** Whether `later` comes after `earlier` in the document. */
+    const comesAfter = (earlier: Element, later: Element) =>
+      Boolean(
+        earlier.compareDocumentPosition(later) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+      )
+
+    /**
+     * The three things whose order is the whole point: the last widget the main
+     * column draws, the footnote, and that column's own add placeholder. The
+     * main column comes before the rail in the document, so the FIRST
+     * placeholder is this column's.
+     */
+    const footOfColumn = (lastWidget: string) => ({
+      widget: screen.getAllByText(lastWidget)[0]!,
+      footnote: screen.getByText(/footnote/),
+      add: screen.getAllByRole("button", { name: "Add widget" })[0]!,
+    })
+
+    test("sits under the main column's widgets and over the add placeholder", () => {
+      renderLayout(1400, {
+        leftWidgets: [widget("left-a")],
+        mainFootnote: "footnote",
+      })
+      const foot = footOfColumn("left-a")
+
+      expect(comesAfter(foot.widget, foot.footnote)).toBe(true)
+      expect(comesAfter(foot.footnote, foot.add)).toBe(true)
+    })
+
+    test("stays at the foot when the rail's widgets fold into the column", () => {
+      renderLayout(700, {
+        leftWidgets: [widget("left-a")],
+        mainFootnote: "footnote",
+      })
+      // Stacked, the loose pin (`events`) is the column's last widget — the
+      // footnote still comes after it, and the placeholder after the footnote.
+      const foot = footOfColumn("events")
+
+      expect(comesAfter(foot.widget, foot.footnote)).toBe(true)
+      expect(comesAfter(foot.footnote, foot.add)).toBe(true)
+    })
+
+    test("draws the string's markdown link as a link", () => {
+      renderLayout(1400, {
+        mainFootnote: "You can [go back](/home?legacy=1) any time.",
+      })
+
+      expect(screen.getByRole("link", { name: "go back" })).toHaveAttribute(
+        "href",
+        "/home?legacy=1"
+      )
+    })
+  })
+
   describe("stacked, below md", () => {
     test("drops the rail entirely — not even the strip", () => {
       renderLayout(700)

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -1490,7 +1490,7 @@ const CATALOG = CATALOG_ITEMS.map((item) => ({
   areas: CATALOG_AREAS[item.id],
 }))
 
-const Home = () => {
+const Home = ({ mainFootnote }: { mainFootnote?: string }) => {
   const [open, setOpen] = useState(false)
   const [side, setSide] = useState<WidgetContainerSide>("main")
   // The configurable widget's params live with the app, next to the rail's
@@ -1559,6 +1559,7 @@ const Home = () => {
           setSide(s)
           setOpen(true)
         }}
+        mainFootnote={mainFootnote}
       >
         {mainColumnBlocks()}
       </NewHomeLayout>
@@ -1712,6 +1713,30 @@ export const Default: Story = {
 export const BannerAboveLayout: Story = {
   parameters: { frameBanner: true },
   render: () => <Home />,
+}
+
+/**
+ * A NOTE AT THE FOOT OF THE COLUMN, which is not a widget: `mainFootnote` puts
+ * one sentence under every main-column widget and above the "+ Add widget"
+ * placeholder — Home's last word rather than content.
+ *
+ * IT IS A STRING, and the only markdown in it is the inline link
+ * `[label](href)`. f0 draws it: centered, secondary, one paragraph. Nothing
+ * about how it looks is the caller's to pass, which is the point — the foot of
+ * the column is a sentence everywhere, not a place a Home can grow a second
+ * layout in.
+ *
+ * It has no card, cannot be dragged, removed or reordered, and stays at the foot
+ * of the column however the widgets above it are arranged. It arrives on the
+ * same stagger they do, one beat after the last of them.
+ *
+ * `children` is still the other end of the same column: freeform content ABOVE
+ * the widgets, where a Home really does compose its own blocks.
+ */
+export const MainFootnote: Story = {
+  render: () => (
+    <Home mainFootnote="You are viewing Factorial's new home, if you want you can [go back to the old home.](/home?legacy=1)" />
+  ),
 }
 
 /**

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -535,6 +535,28 @@ export interface NewHomeLayoutProps {
   children?: ReactNode
   /** Main column: widget slots stacked below `children`. */
   leftWidgets?: HomeWidgetItem[]
+  /**
+   * THE MAIN COLUMN'S FOOTNOTE: one sentence under every widget and above the
+   * "+ Add widget" placeholder — Home's last word rather than a widget.
+   *
+   * `"You are viewing Factorial's new home, if you want you can [go back to the
+   * old home.](/home?legacy=1)"`
+   *
+   * A STRING, NOT A NODE. The one piece of markdown it honours is the inline
+   * link, `[label](href)`; f0 decides the rest — centered, secondary, one
+   * paragraph — so the foot of the column cannot become a second layout. Text
+   * that isn't a link is printed as written, and an href a sentence has no
+   * business carrying (`javascript:`) keeps its label and loses its link.
+   *
+   * It is not part of the arrangement: no card, no drag, no "Remove widget",
+   * and it stays at the bottom whatever the widgets above it do. It arrives on
+   * the same stagger they do, one beat after the last of them.
+   *
+   * STACKED (below `md`) the rail's pinned widgets fold into the main column,
+   * and this still comes after all of them — it is the column's foot, not the
+   * widgets' end.
+   */
+  mainFootnote?: string
   /** Side rail: spec-conforming widgets. */
   rightWidgets?: HomeWidgetItem[]
   /** Freeform side-rail content, rendered above `rightWidgets` (expanded rail only). */
@@ -687,6 +709,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
   function NewHomeLayout(
     {
       children,
+      mainFootnote,
       leftWidgets = [],
       rightWidgets = [],
       aside,
@@ -1212,6 +1235,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
             widgets={
               stacked ? [...leftWidgets, ...loosePins.rest] : leftWidgets
             }
+            footnote={mainFootnote}
             slotRenderers={slotRenderers}
             renderWidget={renderWidget}
             ctx={ctx}

--- a/packages/react/src/sds/Home/WidgetContainer/Footnote.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/Footnote.tsx
@@ -1,0 +1,83 @@
+import { Fragment } from "react"
+
+import { F0Link } from "@/components/F0Link"
+
+/**
+ * THE ONE PIECE OF MARKDOWN A FOOTNOTE MAY CARRY: an inline link, `[label](href)`.
+ *
+ * Not a markdown renderer, and deliberately not one. A column's footnote is a
+ * SENTENCE with somewhere to go — "you are viewing the new Home, go back to the
+ * old one" — so the string a caller passes is text plus links, and everything a
+ * general markdown pass would also bring (headings, lists, images, a block of
+ * code at the foot of the column) is exactly the freedom this prop exists to
+ * refuse. Anything that isn't this pattern stays the literal text it is.
+ *
+ * A label holds no bracket and no line break, and an href no whitespace, so a
+ * bracket left open earlier in the sentence cannot reach forward and swallow
+ * the words up to the next real link: it fails to match and is printed.
+ */
+const LINK = /\[([^[\]\n]+)\]\(([^)\s]+)\)/g
+
+/**
+ * WHERE A FOOTNOTE'S LINK MAY POINT. The string can come from a server-side
+ * setting or a translation, which is far enough from the component for
+ * `javascript:` (or `data:`) to be worth refusing outright: a footnote is a
+ * sentence, and no sentence needs to run code.
+ *
+ * A refused href is not a broken link — the label is printed as the plain text
+ * it already is, so the sentence still reads.
+ */
+const SAFE_HREF = /^(https?:\/\/|mailto:|tel:|\/|\.\/|\.\.\/|#|\?)/i
+
+type Piece = { text: string } | { label: string; href: string }
+
+/**
+ * The sentence taken apart into what it is made of: runs of text and the links
+ * between them, in the order they were written.
+ */
+export const footnotePieces = (text: string): Piece[] => {
+  const pieces: Piece[] = []
+  let cursor = 0
+
+  for (const match of text.matchAll(LINK)) {
+    const label = match[1] ?? ""
+    const href = match[2] ?? ""
+    const at = match.index
+    // `![label](src)` IS AN IMAGE and a footnote draws no images — the label is
+    // all that is left of it, and it is text: a sentence that linked to the
+    // image file instead would be a worse answer than none.
+    const image = text[at - 1] === "!"
+    const before = text.slice(cursor, image ? at - 1 : at)
+    if (before) pieces.push({ text: before })
+    pieces.push(
+      image || !SAFE_HREF.test(href) ? { text: label } : { label, href }
+    )
+    cursor = at + match[0].length
+  }
+  if (cursor < text.length) pieces.push({ text: text.slice(cursor) })
+
+  return pieces
+}
+
+/**
+ * A COLUMN'S FOOTNOTE, drawn the one way it is drawn: centered, secondary, one
+ * line under the widgets. The caller hands over the words and nothing else — no
+ * node, no class, no element of its own — which is what keeps every Home's
+ * footnote the same thing rather than a second layout at the foot of the column.
+ *
+ * A `div` rather than a `p`: `F0Link` brings wrappers of its own, and a
+ * paragraph may not hold them.
+ */
+export const Footnote = ({ text }: { text: string }) => (
+  <div className="text-center text-f1-foreground-secondary">
+    {footnotePieces(text).map((piece, index) => (
+      <Fragment key={index}>
+        {"href" in piece ? (
+          <F0Link href={piece.href}>{piece.label}</F0Link>
+        ) : (
+          piece.text
+        )}
+      </Fragment>
+    ))}
+  </div>
+)

--- a/packages/react/src/sds/Home/WidgetContainer/footnote.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/footnote.spec.tsx
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "vitest"
+
+import { screen, zeroRender } from "@/testing/test-utils"
+
+import { Footnote } from "./Footnote"
+
+/**
+ * A footnote is a STRING, so this is where the contract of that string lives:
+ * what f0 turns into a link, what it prints as written, and what it refuses.
+ * Where the sentence sits in a column is `WidgetContainer`'s own test.
+ */
+describe("Footnote", () => {
+  test("draws a plain sentence as one paragraph", () => {
+    zeroRender(<Footnote text="You are viewing Factorial's new home." />)
+
+    expect(
+      screen.getByText("You are viewing Factorial's new home.")
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+
+  test("turns an inline markdown link into a link, keeping the words around it", () => {
+    const { container } = zeroRender(
+      <Footnote text="You are viewing the new home, you can [go back](/home?legacy=1) any time." />
+    )
+
+    const link = screen.getByRole("link", { name: "go back" })
+    expect(link).toHaveAttribute("href", "/home?legacy=1")
+    // One sentence, in the order it was written — the link is INSIDE it rather
+    // than a second line under it.
+    expect(container.textContent).toBe(
+      "You are viewing the new home, you can go back any time."
+    )
+  })
+
+  test("takes more than one link in the same sentence", () => {
+    zeroRender(
+      <Footnote text="Read the [notes](/notes) or [go back](/home)." />
+    )
+
+    expect(screen.getByRole("link", { name: "notes" })).toHaveAttribute(
+      "href",
+      "/notes"
+    )
+    expect(screen.getByRole("link", { name: "go back" })).toHaveAttribute(
+      "href",
+      "/home"
+    )
+  })
+
+  test("prints anything that is not that pattern as the text it is", () => {
+    const { container } = zeroRender(
+      <Footnote text="**Not bold**, [not a link, and ![no image](/i.png)" />
+    )
+
+    // The bracket left open stays open — it does not reach forward and eat the
+    // words up to the next link-shaped thing. And the one link-shaped thing in
+    // there is an IMAGE, which a footnote does not draw: its label is all that
+    // is left of it, as text.
+    expect(container.textContent).toBe(
+      "**Not bold**, [not a link, and no image"
+    )
+    expect(screen.queryByRole("img")).not.toBeInTheDocument()
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+
+  test("keeps the label and drops the href of a link that points at code", () => {
+    zeroRender(
+      <Footnote text="You can [go back](javascript:alert(1)) any time." />
+    )
+
+    expect(screen.getByText(/go back/)).toBeInTheDocument()
+    expect(screen.queryByRole("link")).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -55,6 +55,7 @@ import {
   type WidgetVirtualization,
 } from "./useWidgetVirtualizer"
 import { verticalOnly } from "./verticalOnly"
+import { Footnote } from "./Footnote"
 import { WidgetMotion, type WidgetStow } from "./WidgetMotion"
 
 export type { WidgetVirtualization } from "./useWidgetVirtualizer"
@@ -233,6 +234,25 @@ export interface WidgetContainerProps {
   side?: WidgetContainerSide
   /** Freeform content above the widgets (the main column's greeting, feed, …). */
   children?: ReactNode
+  /**
+   * THE COLUMN'S FOOTNOTE, as a string: one sentence below the widgets and above
+   * the add placeholder — the column's last word rather than a widget ("you are
+   * viewing the new Home, [go back to the old one](/home?legacy=1)").
+   *
+   * A STRING, NOT A NODE, on purpose. The one piece of markdown it honours is
+   * the inline link, `[label](href)`; the column decides everything else about
+   * how the sentence is drawn (centered, secondary, one paragraph), so no Home
+   * grows a second layout at the foot of its column. Text that isn't that
+   * pattern is printed as the literal text it is, and a link that points
+   * somewhere a sentence has no business pointing (`javascript:`) keeps its
+   * label and loses its href.
+   *
+   * It is NOT part of the arrangement: no card, no drag, no "Remove widget",
+   * and it stays at the foot of the column whatever the widgets above it do.
+   * It arrives on the same stagger they do, one beat after the last of them, so
+   * it lands as part of the column rather than on top of it.
+   */
+  footnote?: string
   /** Per-visualization renderers, MERGED OVER the kit's `defaultSlotRenderers`. */
   slotRenderers?: SlotRenderers
   /** Full override of how a whole widget is drawn. Defaults to `SlotWidget`. */
@@ -366,7 +386,7 @@ export interface WidgetContainerProps {
  * how a column is arranged.
  *
  * It renders its `children` (freeform content) followed by each widget through
- * `SlotWidget`, ending in an "Add widget" placeholder. THERE IS NO EDIT MODE:
+ * `SlotWidget`, then any `footnote`, ending in an "Add widget" placeholder. THERE IS NO EDIT MODE:
  * every widget is draggable (the whole card, no handle) and carries "Remove
  * widget" in its own overflow menu, so rearranging a Home is something you just
  * do rather than something you switch into. `disableEdition` opts a column out
@@ -380,6 +400,7 @@ export function WidgetContainer({
   widgets = [],
   side = "main",
   children,
+  footnote,
   slotRenderers,
   renderWidget,
   disableEdition = false,
@@ -947,11 +968,18 @@ export function WidgetContainer({
       ) : (
         list
       )}
+      {/* THE COLUMN'S FOOTNOTE: under every widget, above the offer to add
+          another. It takes the beat after the last widget and the placeholder
+          takes the one after it, so the arrival still runs straight down the
+          column. */}
+      {footnote == null
+        ? null
+        : enter(widgets.length, <Footnote text={footnote} />)}
       {/* Adding, like removing and reordering, is always on offer.
           `disableEdition` columns never offer any of it. */}
       {!disableEdition && onClickAddNewWidget
         ? enter(
-            widgets.length,
+            widgets.length + (footnote == null ? 0 : 1),
             <AddWidgetPlaceholder
               onClick={onClickAddNewWidget}
               label={addWidgetLabel ?? t.widgets.addWidget}


### PR DESCRIPTION
## Description

Home needed a place for its own last word — "You are viewing Factorial's new home, if you want you can go back to the old home." — at the foot of the main column, above the "+ Add widget" placeholder, and there was nowhere to put it: `children` is the top of the column, and the note is not a widget. `mainFootnote` is that place. It takes a **string**, not a node: the one piece of markdown it honours is the inline link `[label](href)`, and f0 draws the rest (centered, secondary, one line, on the widgets' own arrival stagger), so the foot of a column stays a sentence everywhere instead of becoming a second layout each Home composes for itself.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
