### PR TITLE
fix(F0ClarifyingPanel): lighter type, header alignment and motion timings

### DIFF
--- a/packages/react/src/kits/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
@@ -10,9 +10,14 @@ import { ConfirmFooter } from "./components/ConfirmFooter"
 import { OptionsList } from "./components/OptionsList"
 import { StepHeader } from "./components/StepHeader"
 
-// One easing / duration shared by every animation in the panel.
+// Curva compartida por el panel. Ojo: OptionsList usa la suya para el
+// escalonado de las opciones, que es una entrada y pide otra curva.
 const EASE = "easeOut" as const
-const DURATION = 0.3
+// Asimétricas a propósito: la salida es el sistema respondiendo y va rápida,
+// la entrada es lo que el usuario va a leer. Con mode="wait" se serializan, así
+// que lo que se percibe es la suma.
+const FADE_IN = 0.15
+const FADE_OUT = 0.1
 
 interface F0ClarifyingPanelProps {
   clarifyingQuestion: ClarifyingQuestionState
@@ -150,7 +155,8 @@ const F0ClarifyingPanelContent = ({
     }
   }
 
-  const fadeDuration = shouldReduceMotion ? 0 : DURATION / 2
+  const fadeIn = shouldReduceMotion ? 0 : FADE_IN
+  const fadeOut = shouldReduceMotion ? 0 : FADE_OUT
 
   return (
     <div className="flex flex-col" onKeyDown={handleKeyDown}>
@@ -158,11 +164,15 @@ const F0ClarifyingPanelContent = ({
         <AnimatePresence mode="wait" initial={false}>
           <motion.div
             key={currentStepIndex}
-            className="flex flex-col gap-3"
+            // Este gap es el aire bajo la pregunta: separa el enunciado de las
+            // opciones.
+            className="flex flex-col gap-2"
             initial={{ opacity: 0 }}
-            animate={{ opacity: 1 }}
-            exit={{ opacity: 0 }}
-            transition={{ duration: fadeDuration, ease: EASE }}
+            animate={{
+              opacity: 1,
+              transition: { duration: fadeIn, ease: EASE },
+            }}
+            exit={{ opacity: 0, transition: { duration: fadeOut, ease: EASE } }}
           >
             <StepHeader
               question={question}

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionRow.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionRow.tsx
@@ -28,7 +28,7 @@ export const OptionRow = forwardRef<HTMLDivElement, OptionRowProps>(
           aria-checked={isSelected}
           tabIndex={isTabStop ? 0 : -1}
           className={cn(
-            "flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 transition-colors hover:bg-f1-background-secondary",
+            "flex cursor-pointer items-center gap-2 rounded-md px-2 py-2 transition-[background-color,transform] hover:bg-f1-background-secondary active:scale-[0.99]",
             focusRing()
           )}
           onClick={() => onToggle(option.id)}
@@ -42,7 +42,7 @@ export const OptionRow = forwardRef<HTMLDivElement, OptionRowProps>(
           }}
         >
           <RadioIndicator isSelected={isSelected} />
-          <span className="text-base font-medium text-f1-foreground">
+          <span className="text-base font-normal text-f1-foreground">
             {option.label}
           </span>
         </div>
@@ -53,7 +53,7 @@ export const OptionRow = forwardRef<HTMLDivElement, OptionRowProps>(
       <div
         ref={ref}
         className={cn(
-          "flex cursor-pointer items-center rounded-md pl-2 transition-colors hover:bg-f1-background-secondary"
+          "flex cursor-pointer items-center rounded-md pl-2 transition-[background-color,transform] hover:bg-f1-background-secondary active:scale-[0.99]"
         )}
       >
         <F0Checkbox
@@ -63,7 +63,7 @@ export const OptionRow = forwardRef<HTMLDivElement, OptionRowProps>(
           hideLabel
         />
         <span
-          className="w-full py-2 pl-2 pr-2 text-base font-medium text-f1-foreground"
+          className="w-full py-2 pl-2 pr-2 text-base font-normal text-f1-foreground"
           onClick={() => onToggle(option.id)}
         >
           {option.label}

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
@@ -8,6 +8,18 @@ import type { ClarifyingOption, ClarifyingSelectionMode } from "../types"
 import { CustomAnswerRow } from "./CustomAnswerRow"
 import { OptionRow } from "./OptionRow"
 
+// Las filas ENTRAN, así que ease-out fuerte: en 200ms lo único que se percibe
+// es el arranque, y la curva estándar de Material ([0.4,0,0.2,1]) es un
+// ease-in-out que lo retrasa.
+const ROW_EASE: [number, number, number, number] = [0.23, 1, 0.32, 1]
+const ROW_DURATION = 0.2
+// Sin retardo base: los 120ms que había eran tiempo muerto con la pregunta ya
+// visible y la lista en blanco. 30ms por fila mantiene la cascada sin que la
+// última llegue tarde. Si el desplazamiento deja de ser 4px, el pb-1 del
+// contenedor va con él.
+const ROW_STAGGER = 0.03
+const ROW_OFFSET_Y = 4
+
 interface OptionsListProps {
   mode: ClarifyingSelectionMode
   question: string
@@ -102,23 +114,35 @@ export const OptionsList = ({
     // "no selection" enables Skip / Esc).
   }
 
+  // Una sola definición para todas las filas: la de respuesta libre quedaba
+  // fuera del escalonado y aparecía de golpe a opacidad plena justo donde la
+  // cascada terminaba. Ahora es la fila `options.length`, la siguiente.
+  const rowEnter = (idx: number) => ({
+    initial: shouldReduceMotion
+      ? (false as const)
+      : { opacity: 0, y: ROW_OFFSET_Y },
+    animate: { opacity: 1, y: 0 },
+    transition: {
+      duration: shouldReduceMotion ? 0 : ROW_DURATION,
+      ease: ROW_EASE,
+      delay: shouldReduceMotion ? 0 : idx * ROW_STAGGER,
+    },
+  })
+
   return (
     <div
-      className="flex flex-col gap-0 overflow-y-auto px-1.5 py-0.5"
+      // pb-1 (4px) y no py-0.5: las opciones entran desplazadas 4px hacia
+      // abajo, y con este contenedor en overflow-y-auto esos 4px producían
+      // desbordamiento real durante ~100ms — una barra de scroll que aparecía
+      // y desaparecía en cada cambio de paso. El padding-bottom cuenta dentro
+      // de scrollHeight, así que absorbe el desplazamiento sin tocar la
+      // animación. Si cambia el `y` del enter, este 4 va con él.
+      className="flex flex-col gap-0 overflow-y-auto px-1.5 pb-1 pt-0.5"
       role={mode === "single" ? "radiogroup" : "group"}
       aria-label={question}
     >
       {options.map((option, idx) => (
-        <motion.div
-          key={option.id}
-          initial={shouldReduceMotion ? false : { opacity: 0, y: 4 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{
-            duration: shouldReduceMotion ? 0 : 0.2,
-            ease: [0.4, 0, 0.2, 1],
-            delay: shouldReduceMotion ? 0 : 0.12 + idx * 0.06,
-          }}
-        >
+        <motion.div key={option.id} {...rowEnter(idx)}>
           <OptionRow
             ref={(el) => {
               itemRefs.current[idx] = el
@@ -134,19 +158,21 @@ export const OptionsList = ({
       ))}
 
       {allowCustomAnswer && (
-        <CustomAnswerRow
-          mode={mode}
-          hasSelection={hasSelection}
-          hasCustomText={hasCustomText}
-          customAnswerText={customAnswerText}
-          isCustomAnswerActive={isCustomAnswerActive}
-          canProceed={canProceed}
-          inputRef={customInputRef}
-          onActivate={onActivateCustom}
-          onChangeText={onChangeCustomText}
-          onToggleActive={onToggleCustomActive}
-          onConfirm={onConfirm}
-        />
+        <motion.div {...rowEnter(options.length)}>
+          <CustomAnswerRow
+            mode={mode}
+            hasSelection={hasSelection}
+            hasCustomText={hasCustomText}
+            customAnswerText={customAnswerText}
+            isCustomAnswerActive={isCustomAnswerActive}
+            canProceed={canProceed}
+            inputRef={customInputRef}
+            onActivate={onActivateCustom}
+            onChangeText={onChangeCustomText}
+            onToggleActive={onToggleCustomActive}
+            onConfirm={onConfirm}
+          />
+        </motion.div>
       )}
     </div>
   )

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/StepHeader.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/StepHeader.tsx
@@ -28,8 +28,16 @@ export const StepHeader = ({
 
   return (
     <div className="flex items-start gap-0.5 pl-4 pr-3">
+      {/*
+        mt-0.5 centra la primera línea con los botones de la cabecera: la caja
+        de línea del enunciado mide 20px y los botones 24, así que `items-start`
+        lo deja 2px alto — (24-20)/2. Si cambia el tamaño de los botones o el
+        cuerpo del texto, este 2 hay que recalcularlo.
+        pr-3 separa el enunciado del grupo de botones; el gap-0.5 del contenedor
+        es la separación DENTRO del grupo, no la del texto.
+      */}
       <OneEllipsis
-        className="min-w-0 flex-1 text-lg font-semibold text-f1-foreground"
+        className="mt-0.5 min-w-0 flex-1 pr-3 text-base font-medium text-f1-foreground"
         lines={3}
       >
         {question}
@@ -47,7 +55,16 @@ export const StepHeader = ({
             hideLabel
             icon={ChevronLeft}
           />
-          <span className="text-sm font-semibold text-f1-foreground-tertiary">
+          {/*
+            La cabecera mezcla tres reglas de alineación: los iconos de 24px se
+            centran con la primera línea de la pregunta, pero el contador es
+            TEXTO y el ojo lo alinea por línea base. Centrado en el mismo eje,
+            un cuerpo de 12px deja su base 1px por encima de la de 14px. El
+            translate lo corrige sin tocar el layout (un margen cambiaría el
+            alto de la cabecera). Si cambia el cuerpo del contador o de la
+            pregunta, este 1 hay que recalcularlo.
+          */}
+          <span className="translate-y-px text-sm font-semibold text-f1-foreground-tertiary">
             {stepLabel}
           </span>
           <F0Button


### PR DESCRIPTION

<img width="1715" height="812" alt="Screenshot 2026-09-04 at 12 41 37" src="https://github.com/user-attachments/assets/820ec81d-0430-4d0f-949a-4ae81ae2c4f1" />


Three stories captured at 2× with Playwright, against the deployed Storybook (before) and a local one running this branch (after). Several of these changes are 1–2px, so at 1× there is nothing to judge.

## Typography

The question was `text-lg font-semibold` (16/600) and the options `text-base font-medium` (14/500): two steps of hierarchy at once, in body **and** weight, which reads dense. Everything moves to `text-base` and the hierarchy rests on weight alone.

| Element | Before | After |
|---|---|---|
| Question | `text-lg font-semibold` · 16/600 | `text-base font-medium` · 14/500 |
| Radio and checkbox options | `text-base font-medium` · 14/500 | `text-base font-normal` · 14/400 |
| Custom answer row | `text-base` | unchanged |

Dropping the question to `text-base` also carries its line-height (24→20) and tracking (−0.01em→−0.005em), because both live inside the token.

## Header alignment

Two separate defects, both visible against a guide line.

**The question sat 2px above the header buttons.** `items-start` lines up a 20px line box with 24px buttons, and nothing corrected the `(24−20)/2`.

**The step counter's baseline sat 1px above the question's.** Everything was centred on the same axis — all four elements at 534 — but text aligns by baseline, and a 12px body centred next to a 14px one never shares it. My earlier verification reported 0 because it measured centres, which is the wrong metric for text against text.

I tried `items-baseline` first, which removes the magic numbers and matches the baselines exactly, and rejected it with data: it scatters the icon buttons, whose centres go from `[534, 534, 534]` to `[538, 538, 543]` — the ✕ drifts 5px.

**The question also had no separation from the button group**: `gap-0.5` left 2px between the text and "1 of 3". The padding now lives on the question rather than on the header gap, so the button group keeps its own tight spacing.

## Motion

A step change took **~800ms** to settle. Measured, as the opacity trace of the five options:

```
before                       after
337ms  [0.11 0 0 0 1]        137ms  [0.13 0    0    0    1]
454ms  [0.97 0.73 0.09 0 1]  176ms  [0.76 0.36 0    0    1]
804ms  [1 1 1 1 1]           384ms  [1    1    1    1    1]
```

150ms exit + 150ms enter serialised by `mode="wait"`, plus a 120ms base delay and 60ms per item on top. Now **~370ms**: the stagger loses its base delay and drops to 30ms per row, the enter easing becomes a real ease-out (the options **enter**; the Material standard curve is an ease-in-out that delays the only part perceptible within 200ms), and the fade becomes asymmetric — 100ms out, 150ms in.

## Phantom scrollbar

The list is `overflow-y-auto` and its rows enter offset 4px down. With few options the container height is exactly the content height, so those 4px produced real overflow: **`scrollHeight` 114 against `clientHeight` 112 for ~100ms**, a scrollbar that appeared and vanished on every step change. The container's bottom padding now absorbs the offset — verified at 0 frames with a scrollbar.

## Custom answer row and press feedback

The custom answer row sat **outside** the staggered wrapper, so it appeared at full opacity from the first frame, right where the cascade ended (`[0 0 0 0 1]`). It is now the last row of the sequence. The enter config moved into shared constants so the two call sites cannot drift.

Option rows gain `active:scale-[0.99]`: they are the component's primary interaction and had only a hover colour change. 0.99 and not less because the row is 346px wide; a 0.97 there reads as a jump, not a press.

## On the magic numbers

There are two in the header: `mt-0.5` on the question (2px = (24−20)/2) and `translate-y-px` on the counter (1px, from the 14→12 step). Both are commented with their derivation. The root cause is that this row asks for **three** alignment rules — icons by centre, text by baseline, two different bodies — and only two of them are compatible. If it ever gets redesigned, the right move is to match the counter's body to the question's, or take it out of the question's row.

## Why this carries `skip-red-green`

What this branch fixes is baselines, `scrollHeight` and timings, and **jsdom has no layout engine**: `getComputedStyle` does not resolve Tailwind classes, there is no real `scrollHeight`, and there is no animation clock. Everything verified here was measured in a real browser.

I looked for a testable angle and they all degenerate into asserting that a class exists. The best candidate — that the rows' 4px enter offset fits inside the container's `padding-bottom`, which is literally the cause of the scrollbar — can only be written in jsdom as `expect(className).toMatch(/pb-1/)`. That would be red on `main` and would pass the gate, but it is an implementation test that does not check the pixel that matters. I would rather ask for the exception than slip that in.

This component has no Chromatic snapshot either, so the real safety net remains visual review.

## Verification

`pnpm tsc` 0 errors · `pnpm lint` 0/0 · `pnpm format:check` clean · `pnpm build` OK in 1m27s · full suite **600 files / 7561 tests**, 0 failures. Rebased onto current `main`; nobody else touched the panel.
