### PR TITLE
fix(F0Coachmark): dim the page, and keep the panel on it

### DIFF
--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkSpotlight.tsx
@@ -25,6 +25,25 @@ const isSameRect = (a: Rect, b: Rect) =>
   a.width === b.width &&
   a.height === b.height
 
+const litRadius = (target: HTMLElement): number => {
+  const radiusOf = (element: Element) =>
+    parseFloat(getComputedStyle(element).borderTopLeftRadius) || 0
+
+  const own = radiusOf(target)
+  if (own > 0) return own + HIGHLIGHT_PADDING
+
+  const box = target.getBoundingClientRect()
+  for (const element of [...target.querySelectorAll("*")].slice(0, 24)) {
+    const radius = radiusOf(element)
+    if (radius === 0) continue
+    const inner = element.getBoundingClientRect()
+    if (inner.width < box.width * 0.8) continue
+    return radius + (inner.left - box.left) + HIGHLIGHT_PADDING
+  }
+
+  return HIGHLIGHT_PADDING
+}
+
 /**
  * The target's box in viewport coordinates, kept current FRAME BY FRAME.
  *
@@ -62,6 +81,12 @@ const useTargetRect = (target: HTMLElement): Rect => {
   }, [target])
 
   return rect
+}
+
+const useLitRadius = (target: HTMLElement): number => {
+  const [radius, setRadius] = useState(() => litRadius(target))
+  useEffect(() => setRadius(litRadius(target)), [target])
+  return radius
 }
 
 /** How long the light takes to travel from one step's element to the next's. */
@@ -124,6 +149,7 @@ export const CoachmarkSpotlight = ({
   onOutsideInteraction,
 }: CoachmarkSpotlightProps) => {
   const rect = useTargetRect(target)
+  const radius = useLitRadius(target)
   const reducedMotion = useReducedMotion()
   const travelling = useTravelling(target, !reducedMotion)
 
@@ -182,30 +208,15 @@ export const CoachmarkSpotlight = ({
       // focus glow with it, on the reader's first press anywhere on the page.
       onMouseDown={(event) => event.preventDefault()}
     >
-      {/* The lit region: a clear box with no edge of its own. NO BORDER — the
-          element inside already has whatever border it has, and a second line
-          around it drew a box around a box: two rounded rectangles a few pixels
-          apart, neither of them the card.
-
-          TWO SHADOWS, GLOW FIRST. The glow is the page's own surface colour
-          (`--neutral-0`: white in light, the dark ground in dark) blurred
-          outward over the dim, so the lit element reads as GLOWING rather than
-          as a hole cut in a sheet — the same thing a focused field does, for an
-          element that may not have a focus state to lend us. It is also the only
-          thing separating the light from the dim now, which is why it is soft
-          rather than tight. It has to come first in the list: shadows paint
-          first over last, and the 100vmax dim would otherwise bury it. */}
       <div
         className={cn(
-          "absolute rounded-xl",
-          "shadow-[0_0_24px_6px_hsl(var(--neutral-0)/0.7),0_0_0_100vmax_hsl(var(--neutral-40))]",
-          // Only while it has somewhere to go — see `useTravelling`. The dim
-          // itself never fades: the light travels to the next step's element,
-          // rather than the page coming up to full brightness in between.
+          "absolute",
+          "shadow-[0_0_0_100vmax_hsl(var(--shadow)/0.5)]",
+          "dark:shadow-[0_0_0_100vmax_hsl(var(--shadow)/0.85)]",
           travelling &&
             "transition-[top,left,width,height] duration-300 ease-out"
         )}
-        style={rect}
+        style={{ ...rect, borderRadius: radius }}
       />
     </div>,
     container ?? document.body

--- a/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
@@ -5,6 +5,7 @@ import {
   useId,
   useMemo,
   useRef,
+  useState,
 } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
@@ -63,6 +64,59 @@ const fieldIn = (target: HTMLElement): HTMLElement | null => {
   )
 }
 
+const useCentredWhenItCannotFit = (
+  ref: RefObject<HTMLElement>,
+  step: number | undefined,
+  target: HTMLElement
+) => {
+  const [centred, setCentred] = useState(false)
+  const latched = useRef(false)
+
+  useEffect(() => {
+    latched.current = false
+    setCentred(false)
+
+    const element = ref.current
+    if (!element || typeof ResizeObserver !== "function") return
+
+    const check = () => {
+      if (latched.current) return
+      const style = getComputedStyle(element)
+      const room = parseFloat(
+        style.getPropertyValue("--radix-popover-content-available-height")
+      )
+      if (!Number.isFinite(room)) return
+
+      const body = element.querySelector<HTMLElement>("[data-coachmark-body]")
+      const padding =
+        parseFloat(style.paddingTop) + parseFloat(style.paddingBottom)
+      const needed = (body?.scrollHeight ?? element.scrollHeight) + padding
+      if (room >= needed) return
+
+      latched.current = true
+      setCentred(true)
+    }
+
+    check()
+    const observer = new ResizeObserver(check)
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [ref, step, target])
+
+  return centred
+}
+
+const useViewportCentre = () =>
+  useMemo(
+    () => ({
+      current: {
+        getBoundingClientRect: () =>
+          new DOMRect(window.innerWidth / 2, window.innerHeight / 2, 0, 0),
+      },
+    }),
+    []
+  )
+
 const useWiggle = (ref: RefObject<HTMLElement>) => {
   const reducedMotion = useReducedMotion()
 
@@ -108,6 +162,8 @@ const CoachmarkPanel = ({
   const contentRef = useRef<HTMLDivElement>(null)
   const previouslyFocused = useRef<HTMLElement | null>(null)
   const wiggle = useWiggle(contentRef)
+  const centred = useCentredWhenItCannotFit(contentRef, step?.current, target)
+  const viewportCentre = useViewportCentre()
 
   /**
    * WHERE FOCUS BELONGS FOR THIS STEP. The panel, so the step is announced and
@@ -159,7 +215,7 @@ const CoachmarkPanel = ({
         if (!nextOpen) onClose()
       }}
     >
-      <PopoverAnchor virtualRef={anchorRef} />
+      <PopoverAnchor virtualRef={centred ? viewportCentre : anchorRef} />
       {/* Under the panel and over everything else. Rendered from here rather
           than by the provider so the two always agree on which element is lit:
           the panel points at `target`, and so does the hole. */}
@@ -176,10 +232,11 @@ const CoachmarkPanel = ({
       <PopoverContent
         ref={contentRef}
         container={container}
-        side={side}
-        align={align}
-        sideOffset={sideOffset}
+        side={centred ? "bottom" : side}
+        align={centred ? "center" : align}
+        sideOffset={centred ? 0 : sideOffset}
         collisionPadding={8}
+        data-coachmark-centred={centred || undefined}
         tabIndex={-1}
         aria-labelledby={titleId}
         aria-describedby={description ? descriptionId : undefined}
@@ -245,9 +302,11 @@ const CoachmarkPanel = ({
         // finished going.
         className={cn(
           "w-72 overflow-visible rounded-lg border-none p-4",
+          "flex flex-col",
           "shadow-lg backdrop-blur-sm",
           "bg-f1-background-inverse text-f1-foreground-inverse",
           "dark:bg-f1-background-tertiary",
+          overlay && "dark:bg-f1-background-secondary",
           "transition-opacity",
           leaving ? "opacity-0 duration-150" : "opacity-100 duration-200"
         )}
@@ -256,7 +315,10 @@ const CoachmarkPanel = ({
             surface, exactly as F0Toast and F0ActionBar do. Safe to hardcode
             because this panel is dark in both themes. This is what keeps the
             buttons below free of colour overrides. */}
-        <div className="dark flex flex-col gap-3">
+        <div
+          data-coachmark-body
+          className="dark flex min-h-0 flex-col gap-3 overflow-y-auto"
+        >
           {/* Title and description are their own group on a tighter gap-1, the
               same pairing F0Toast uses, so they read as one block. The outer
               gap-3 still separates that block from the action row. */}
@@ -304,7 +366,7 @@ const CoachmarkPanel = ({
             />
           </div>
         </div>
-        {arrow && (
+        {arrow && !centred && (
           <PopoverArrow asChild width={ARROW_WIDTH} height={ARROW_HEIGHT}>
             {/* The fill uses the panel's own surface tokens, alpha included, so
                 both composite over the same backdrop to the same colour. It is

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/overlay.test.tsx
@@ -246,10 +246,6 @@ describe("the handover between two steps", () => {
   })
 })
 
-/**
- * `focusTarget` on a step whose whole point is a field: the caret starts in it,
- * so it wears its own focus state instead of being described from outside.
- */
 describe("a step that focuses what it points at", () => {
   beforeEach(() => {
     coachmarks.closeAll()
@@ -358,19 +354,6 @@ describe("what the shield does to focus", () => {
     coachmarks.closeAll()
   })
 
-  /**
-   * A press on the shield must not take focus off the page.
-   *
-   * Preventing the POINTER event is not enough: the mouse event that follows it
-   * has its own default action — "focus what was pressed" — and on a shield that
-   * means blurring whatever held focus and leaving it on the body. A step that
-   * focused its own field lost that field's focus glow on the reader's first
-   * press anywhere on the page.
-   *
-   * `defaultPrevented` is the observable here rather than `document.activeElement`:
-   * jsdom does not move focus on a mouse press at all, so only the real browser
-   * can show the blur — and only the prevention can be asserted here.
-   */
   it("swallows the press without moving focus", async () => {
     renderApp()
     open({
@@ -391,11 +374,6 @@ describe("what the shield does to focus", () => {
   })
 })
 
-/**
- * ONE CALLBACK FOR THE WHOLE OUTCOME. Every ending arrives at `onEnd` exactly
- * once, carrying which way out the reader took and how far they got — the shape
- * a funnel is read off, rather than two callbacks to join up afterwards.
- */
 describe("what onEnd reports", () => {
   beforeEach(() => {
     coachmarks.closeAll()
@@ -504,5 +482,96 @@ describe("what onEnd reports", () => {
     // Nobody ended it, so there is no outcome — counting this as a drop-off
     // would blame the reader for a navigation.
     expect(onEnd).not.toHaveBeenCalled()
+  })
+})
+
+describe("what the dim is painted in", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("dims and glows in colours that do not flip with the theme", async () => {
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+    })
+    await screen.findByRole("dialog")
+
+    const lit = blocker()?.firstElementChild
+    const paint = lit?.className ?? ""
+
+    // `--shadow` is `218 48% 10%` in BOTH themes — the colour f0 casts every
+    // elevation shadow in — so the same declaration darkens either way.
+    expect(paint).toContain("hsl(var(--shadow)/0.5)")
+    // The tokens that flip are the ones this must not go back to.
+    expect(paint).not.toContain("--neutral-40")
+    expect(paint).not.toContain("--neutral-0")
+  })
+})
+
+describe("how deep the dim goes", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("goes deeper in dark than in light", async () => {
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+    })
+    await screen.findByRole("dialog")
+
+    const paint = blocker()?.firstElementChild?.className ?? ""
+    expect(paint).toContain("shadow-[0_0_0_100vmax_hsl(var(--shadow)/0.5)]")
+    expect(paint).toContain(
+      "dark:shadow-[0_0_0_100vmax_hsl(var(--shadow)/0.85)]"
+    )
+    expect(paint).not.toContain("24px")
+    // And the panel gets the extra surface that depth costs it.
+    expect(screen.getByRole("dialog").className).toContain(
+      "dark:bg-f1-background-secondary"
+    )
+  })
+})
+
+describe("how the light is drawn", () => {
+  beforeEach(() => {
+    coachmarks.closeAll()
+  })
+
+  it("measures its corner rather than wearing a fixed one", async () => {
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+    })
+    await screen.findByRole("dialog")
+
+    const lit = blocker()?.firstElementChild as HTMLElement | null
+    expect(lit?.style.borderRadius).toMatch(/^[\d.]+px$/)
+    expect(lit?.className).not.toContain("rounded-")
+  })
+
+  it("scrolls its content inside the box rather than spilling out of it", async () => {
+    renderApp()
+    open({
+      targetElement: "#filters",
+      title: "Filters got smarter",
+      overlay: true,
+    })
+
+    const panel = await screen.findByRole("dialog")
+    expect(panel.className).toContain("overflow-visible")
+    expect(panel.className).not.toContain("max-h-none")
+    const group = panel.querySelector(".overflow-y-auto")
+    expect(group?.className).toContain("min-h-0")
+    expect(group).toContainElement(
+      screen.getByRole("button", { name: "Got it" })
+    )
   })
 })

--- a/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.stories.tsx
@@ -141,8 +141,7 @@ const HOME_WALKTHROUGH = defineStepByStepCoachmarkGuidance({
       title: "Important things come first",
       description:
         "View and complete all the updates and tasks that require your attention at a glance.",
-      side: "right",
-      align: "start",
+      side: "bottom",
     },
     {
       // No description: the title is the whole sentence.


### PR DESCRIPTION
## Description

Dark-mode review of the coachmark walkthrough turned up four things, all in how the spotlight and the panel are drawn. The dim was *fogging* a dark app rather than dimming it (`background-overlay` is white/40 in dark) and took the panel's translucent surface up with it; the lit area had a blurred glow around its edge; its corner was a fixed radius while sitting 8px outside the card it lights, so the corner pinched inwards; and the panel could either be squeezed to a 31px sliver with a scrollbar or sent off-screen, depending on whether its height was capped.
