### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.86.1",
+  "packages/react": "6.86.2",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.86.2](https://github.com/factorialco/f0/compare/f0-react-v6.86.1...f0-react-v6.86.2) (2026-09-04)
+
+
+### Bug Fixes
+
+* **F0Coachmark:** dim the page, and keep the panel on it ([#5399](https://github.com/factorialco/f0/issues/5399)) ([303e582](https://github.com/factorialco/f0/commit/303e5827b3137abfe85a300181bf205b3896684e))
+
 ## [6.86.1](https://github.com/factorialco/f0/compare/f0-react-v6.86.0...f0-react-v6.86.1) (2026-09-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.86.1",
+  "version": "6.86.2",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.86.2</summary>

## [6.86.2](https://github.com/factorialco/f0/compare/f0-react-v6.86.1...f0-react-v6.86.2) (2026-09-04)


### Bug Fixes

* **F0Coachmark:** dim the page, and keep the panel on it ([#5399](https://github.com/factorialco/f0/issues/5399)) ([303e582](https://github.com/factorialco/f0/commit/303e5827b3137abfe85a300181bf205b3896684e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).