### PR TITLE
fix(F0Chat): keep a mention through an edit

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Profiler, type ReactNode, useEffect, useRef, useState } from "react"
-import { expect, userEvent, waitFor, within } from "storybook/test"
+import { expect, fireEvent, userEvent, waitFor, within } from "storybook/test"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
@@ -1300,6 +1300,25 @@ export const ComposerHotkeys: Story = {
       // Radix keeps the popover mounted for its exit animation and only then
       // decides about focus — assert after that window, not before.
       await waitFor(() => expect(composer).toHaveFocus(), { timeout: 3000 })
+    })
+
+    await step("Escape backs out of the quote, keeping the draft", async () => {
+      await userEvent.type(composer, "ya lo miro")
+      await userEvent.keyboard("{Escape}")
+      await waitFor(() =>
+        expect(
+          canvas.queryByRole("button", { name: /remove quote/i })
+        ).not.toBeInTheDocument()
+      )
+      await expect(composer).toHaveValue("ya lo miro")
+    })
+
+    await step("A second Escape clears the composer", async () => {
+      // Fired directly: the window between the two presses is what the feature
+      // measures, and userEvent's own pacing would race a loaded browser.
+      fireEvent.keyDown(composer, { key: "Escape" })
+      fireEvent.keyDown(composer, { key: "Escape" })
+      await waitFor(() => expect(composer).toHaveValue(""))
     })
   },
 }

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Profiler, type ReactNode, useEffect, useRef, useState } from "react"
-import { expect, fireEvent, userEvent, waitFor, within } from "storybook/test"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
@@ -1313,12 +1313,14 @@ export const ComposerHotkeys: Story = {
       await expect(composer).toHaveValue("ya lo miro")
     })
 
-    await step("A second Escape clears the composer", async () => {
-      // Fired directly: the window between the two presses is what the feature
-      // measures, and userEvent's own pacing would race a loaded browser.
-      fireEvent.keyDown(composer, { key: "Escape" })
-      fireEvent.keyDown(composer, { key: "Escape" })
+    await step("The next Escape clears the draft", async () => {
+      await userEvent.keyboard("{Escape}")
       await waitFor(() => expect(composer).toHaveValue(""))
+    })
+
+    await step("Undo puts the cleared draft back", async () => {
+      await userEvent.keyboard("{Meta>}z{/Meta}")
+      await waitFor(() => expect(composer).toHaveValue("ya lo miro"))
     })
   },
 }

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -651,6 +651,44 @@ describe("F0Chat composer escape", () => {
     expect(composer()).toHaveValue("@Ana")
   })
 
+  it("keeps the caret where a removed mention was", async () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "group-1",
+          type: "group",
+          title: "Product",
+          avatar: { type: "team", name: "Product" },
+        },
+        searchMembers: async () => [{ id: "ana", name: "Ana García" }],
+      })
+    )
+    const input = composer() as HTMLTextAreaElement
+
+    await typeInComposer("Hola @Ana")
+    await screen.findByRole("option", { name: "Ana García" })
+    await userEvent.keyboard("{Enter}")
+    await waitFor(() => expect(input).toHaveValue("Hola @Ana García "))
+    // A second line — shift+Enter, since plain Enter sends. A caret dropped at
+    // the end would land on the wrong line entirely, not one character off.
+    await userEvent.type(input, "{Shift>}{Enter}{/Shift}y mañana")
+    await waitFor(() =>
+      expect(input).toHaveValue("Hola @Ana García \ny mañana")
+    )
+
+    // Put the caret inside the name and delete one character: the whole
+    // mention goes, and the caret must stay where it started.
+    input.setSelectionRange(14, 14)
+    fireEvent.select(input)
+    await userEvent.keyboard("{Backspace}")
+
+    // The space the mention inserted after itself is not part of the mention,
+    // so it survives — hence two spaces before the newline.
+    await waitFor(() => expect(input).toHaveValue("Hola  \ny mañana"))
+    expect(input.selectionStart).toBe(5)
+    expect(input.selectionEnd).toBe(5)
+  })
+
   it("never clears the draft, and leaves the key to the host", async () => {
     renderChat(makeRuntime())
     await typeInComposer("un borrador")
@@ -660,11 +698,119 @@ describe("F0Chat composer escape", () => {
     expect(pressEscape()).toBe(true)
     expect(composer()).toHaveValue("un borrador")
   })
+})
 
-  it("leaves Escape to the host when there is nothing to lose", async () => {
+describe("F0Chat composer undo/redo", () => {
+  const group = (overrides: Partial<F0ChatRuntime> = {}) =>
+    makeRuntime({
+      channel: {
+        id: "group-1",
+        type: "group",
+        title: "Product",
+        avatar: { type: "team", name: "Product" },
+      },
+      searchMembers: async () => [{ id: "ana", name: "Ana García" }],
+      ...overrides,
+    })
+
+  const composerEl = () => composer() as HTMLTextAreaElement
+
+  /** Inserts "@Ana García " at the caret through the popover, as a user would. */
+  const insertMention = async () => {
+    await userEvent.type(composerEl(), "@Ana")
+    await screen.findByRole("option", { name: "Ana García" })
+    await userEvent.keyboard("{Enter}")
+    await waitFor(() => expect(composerEl().value).toMatch(/@Ana García $/))
+  }
+
+  it("puts back a whole word at a time", async () => {
     renderChat(makeRuntime())
-    await userEvent.click(composer())
+    await userEvent.click(composerEl())
+    await userEvent.type(composerEl(), "hola mundo")
 
-    expect(pressEscape(1_000)).toBe(true)
+    await userEvent.keyboard("{Meta>}z{/Meta}")
+
+    // A step boundary falls at the space, so the last word goes, not everything.
+    await waitFor(() => expect(composerEl()).toHaveValue("hola "))
+  })
+
+  it("redoes with shift+z and with y", async () => {
+    renderChat(makeRuntime())
+    await userEvent.click(composerEl())
+    await userEvent.type(composerEl(), "hola mundo")
+
+    await userEvent.keyboard("{Meta>}z{/Meta}")
+    await waitFor(() => expect(composerEl()).toHaveValue("hola "))
+
+    await userEvent.keyboard("{Meta>}{Shift>}z{/Shift}{/Meta}")
+    await waitFor(() => expect(composerEl()).toHaveValue("hola mundo"))
+
+    await userEvent.keyboard("{Meta>}z{/Meta}")
+    await waitFor(() => expect(composerEl()).toHaveValue("hola "))
+
+    await userEvent.keyboard("{Meta>}y{/Meta}")
+    await waitFor(() => expect(composerEl()).toHaveValue("hola mundo"))
+  })
+
+  it("works with ctrl as well as meta", async () => {
+    renderChat(makeRuntime())
+    await userEvent.click(composerEl())
+    await userEvent.type(composerEl(), "hola mundo")
+
+    await userEvent.keyboard("{Control>}z{/Control}")
+    await waitFor(() => expect(composerEl()).toHaveValue("hola "))
+    await userEvent.keyboard("{Control>}y{/Control}")
+    await waitFor(() => expect(composerEl()).toHaveValue("hola mundo"))
+  })
+
+  it("restores a removed mention in one step, anchored", async () => {
+    const sendMessage = vi.fn()
+    renderChat(group({ sendMessage }))
+    await userEvent.click(composerEl())
+    await insertMention()
+    await userEvent.type(composerEl(), "hola")
+
+    // Delete a character inside the name: the whole mention goes.
+    const input = composerEl()
+    input.setSelectionRange(9, 9)
+    fireEvent.select(input)
+    await userEvent.keyboard("{Backspace}")
+    await waitFor(() => expect(input).toHaveValue(" hola"))
+
+    // One undo, not two — the half-typed name in between was never a state the
+    // user saw.
+    await userEvent.keyboard("{Meta>}z{/Meta}")
+    await waitFor(() => expect(input).toHaveValue("@Ana García hola"))
+
+    // And it came back as a real mention, not plain text: sending carries the id.
+    await userEvent.keyboard("{Enter}")
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mentions: [expect.objectContaining({ id: "ana" })],
+      })
+    )
+  })
+
+  it("undoes an inserted mention as its own step", async () => {
+    renderChat(group())
+    await userEvent.click(composerEl())
+    await userEvent.type(composerEl(), "hola ")
+    await insertMention()
+
+    await userEvent.keyboard("{Meta>}z{/Meta}")
+
+    await waitFor(() => expect(composerEl()).toHaveValue("hola @Ana"))
+  })
+
+  it("drops the stack once the draft is sent", async () => {
+    renderChat(makeRuntime())
+    await userEvent.click(composerEl())
+    await userEvent.type(composerEl(), "hola mundo")
+    await userEvent.keyboard("{Enter}")
+    await waitFor(() => expect(composerEl()).toHaveValue(""))
+
+    await userEvent.keyboard("{Meta>}z{/Meta}")
+
+    expect(composerEl()).toHaveValue("")
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -579,6 +579,24 @@ describe("F0Chat composer escape", () => {
   /** Returns false when the composer claimed the key. */
   const pressEscape = () => fireEvent.keyDown(composer(), { key: "Escape" })
 
+  /**
+   * Escape presses with Date.now pinned to each value in turn. The pin has to
+   * span every press: restoring it between them lets the handler read the real
+   * clock, which makes two deliberately-distant presses look adjacent. Fake
+   * timers are avoided here because userEvent fights them.
+   */
+  const pressEscapeAt = (...times: number[]) => {
+    const clock = vi.spyOn(Date, "now")
+    try {
+      for (const at of times) {
+        clock.mockReturnValue(at)
+        pressEscape()
+      }
+    } finally {
+      clock.mockRestore()
+    }
+  }
+
   it("backs out of an edit in progress", async () => {
     renderChat(editable())
     await pressArrowUp()
@@ -641,13 +659,15 @@ describe("F0Chat composer escape", () => {
     await typeInComposer("@Ana")
     await screen.findByRole("option", { name: "Ana García" })
 
-    pressEscape()
+    pressEscapeAt(1_000)
 
     await waitFor(() =>
       expect(
         screen.queryByRole("option", { name: "Ana García" })
       ).not.toBeInTheDocument()
     )
+    // The press that closed the popover is not the opening half of a clear.
+    pressEscapeAt(1_100)
     expect(composer()).toHaveValue("@Ana")
   })
 
@@ -689,14 +709,60 @@ describe("F0Chat composer escape", () => {
     expect(input.selectionEnd).toBe(5)
   })
 
-  it("never clears the draft, and leaves the key to the host", async () => {
+  it("clears the composer on a second press", async () => {
     renderChat(makeRuntime())
     await typeInComposer("un borrador")
 
-    // No chip open: the composer has no claim on Escape, so a dialog hosting
-    // the chat can still be closed from a focused composer.
-    expect(pressEscape()).toBe(true)
+    pressEscapeAt(1_000)
     expect(composer()).toHaveValue("un borrador")
+
+    pressEscapeAt(1_000, 1_300)
+    await waitFor(() => expect(composer()).toHaveValue(""))
+  })
+
+  it("leaves the draft alone when the two presses are far apart", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("un borrador")
+
+    pressEscapeAt(1_000, 1_401)
+
+    expect(composer()).toHaveValue("un borrador")
+  })
+
+  it("does not carry a dismissed chip into a clear", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("ya lo miro")
+    await userEvent.dblClick(bubbleAround("Hello there"))
+
+    pressEscapeAt(1_000, 1_100)
+
+    expect(composer()).toHaveValue("ya lo miro")
+  })
+
+  it("claims Escape once there is a draft to protect", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("un borrador")
+
+    expect(pressEscape()).toBe(false)
+  })
+
+  it("leaves Escape to the host when there is nothing to lose", async () => {
+    renderChat(makeRuntime())
+    await userEvent.click(composer())
+
+    expect(pressEscape()).toBe(true)
+  })
+
+  it("gives an Escape-cleared draft back to undo", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("un borrador")
+
+    pressEscapeAt(1_000, 1_300)
+    await waitFor(() => expect(composer()).toHaveValue(""))
+
+    await userEvent.keyboard("{Meta>}z{/Meta}")
+
+    await waitFor(() => expect(composer()).toHaveValue("un borrador"))
   })
 })
 

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -569,3 +569,140 @@ describe("F0Chat compose target lifecycle", () => {
     )
   })
 })
+
+describe("F0Chat composer escape", () => {
+  const typeInComposer = async (text: string) => {
+    await userEvent.click(composer())
+    await userEvent.type(composer(), text)
+  }
+
+  /** Escape is read off Date.now, so the presses are fired synchronously with
+   * the clock pinned — no fake timers to fight userEvent over. */
+  const pressEscape = (at?: number) => {
+    const clock =
+      at === undefined ? null : vi.spyOn(Date, "now").mockReturnValue(at)
+    const notPrevented = fireEvent.keyDown(composer(), { key: "Escape" })
+    clock?.mockRestore()
+    return notPrevented
+  }
+
+  it("backs out of an edit in progress", async () => {
+    renderChat(editable())
+    await pressArrowUp()
+    expect(
+      screen.getByRole("button", { name: /cancel edit/i })
+    ).toBeInTheDocument()
+
+    pressEscape()
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /cancel edit/i })
+      ).not.toBeInTheDocument()
+    )
+  })
+
+  it("backs out of a pending reply quote", async () => {
+    renderChat(makeRuntime())
+    await userEvent.dblClick(bubbleAround("Hello there"))
+    expect(
+      screen.getByRole("button", { name: /remove quote/i })
+    ).toBeInTheDocument()
+
+    pressEscape()
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /remove quote/i })
+      ).not.toBeInTheDocument()
+    )
+  })
+
+  it("keeps the typed draft when it dismisses the quote", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("ya lo miro")
+    await userEvent.dblClick(bubbleAround("Hello there"))
+
+    pressEscape()
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /remove quote/i })
+      ).not.toBeInTheDocument()
+    )
+    expect(composer()).toHaveValue("ya lo miro")
+  })
+
+  it("clears the composer on a second press", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("un borrador")
+
+    pressEscape(1_000)
+    expect(composer()).toHaveValue("un borrador")
+
+    pressEscape(1_300)
+    await waitFor(() => expect(composer()).toHaveValue(""))
+  })
+
+  it("leaves the draft alone when the two presses are far apart", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("un borrador")
+
+    pressEscape(1_000)
+    pressEscape(1_401)
+
+    expect(composer()).toHaveValue("un borrador")
+  })
+
+  it("does not carry a dismissed chip into a clear", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("ya lo miro")
+    await userEvent.dblClick(bubbleAround("Hello there"))
+
+    pressEscape(1_000)
+    pressEscape(1_100)
+
+    expect(composer()).toHaveValue("ya lo miro")
+  })
+
+  it("closes the mention popover before it dismisses anything", async () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "group-1",
+          type: "group",
+          title: "Product",
+          avatar: { type: "team", name: "Product" },
+        },
+        searchMembers: async () => [{ id: "ana", name: "Ana García" }],
+      })
+    )
+    await typeInComposer("@Ana")
+    await screen.findByRole("option", { name: "Ana García" })
+
+    pressEscape(1_000)
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("option", { name: "Ana García" })
+      ).not.toBeInTheDocument()
+    )
+    // The press that closed the popover is not the opening half of a clear.
+    pressEscape(1_100)
+    expect(composer()).toHaveValue("@Ana")
+  })
+
+  it("leaves Escape to the host when there is nothing to lose", async () => {
+    renderChat(makeRuntime())
+    await userEvent.click(composer())
+
+    expect(pressEscape(1_000)).toBe(true)
+  })
+
+  it("claims Escape once there is a draft to protect", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("un borrador")
+
+    expect(pressEscape(1_000)).toBe(false)
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -579,24 +579,6 @@ describe("F0Chat composer escape", () => {
   /** Returns false when the composer claimed the key. */
   const pressEscape = () => fireEvent.keyDown(composer(), { key: "Escape" })
 
-  /**
-   * Escape presses with Date.now pinned to each value in turn. The pin has to
-   * span every press: restoring it between them lets the handler read the real
-   * clock, which makes two deliberately-distant presses look adjacent. Fake
-   * timers are avoided here because userEvent fights them.
-   */
-  const pressEscapeAt = (...times: number[]) => {
-    const clock = vi.spyOn(Date, "now")
-    try {
-      for (const at of times) {
-        clock.mockReturnValue(at)
-        pressEscape()
-      }
-    } finally {
-      clock.mockRestore()
-    }
-  }
-
   it("backs out of an edit in progress", async () => {
     renderChat(editable())
     await pressArrowUp()
@@ -659,15 +641,14 @@ describe("F0Chat composer escape", () => {
     await typeInComposer("@Ana")
     await screen.findByRole("option", { name: "Ana García" })
 
-    pressEscapeAt(1_000)
+    pressEscape()
 
     await waitFor(() =>
       expect(
         screen.queryByRole("option", { name: "Ana García" })
       ).not.toBeInTheDocument()
     )
-    // The press that closed the popover is not the opening half of a clear.
-    pressEscapeAt(1_100)
+    // The popover took that press; the text is untouched.
     expect(composer()).toHaveValue("@Ana")
   })
 
@@ -709,34 +690,31 @@ describe("F0Chat composer escape", () => {
     expect(input.selectionEnd).toBe(5)
   })
 
-  it("clears the composer on a second press", async () => {
+  it("clears the text once no chip is left to dismiss", async () => {
     renderChat(makeRuntime())
     await typeInComposer("un borrador")
 
-    pressEscapeAt(1_000)
-    expect(composer()).toHaveValue("un borrador")
+    pressEscape()
 
-    pressEscapeAt(1_000, 1_300)
     await waitFor(() => expect(composer()).toHaveValue(""))
   })
 
-  it("leaves the draft alone when the two presses are far apart", async () => {
-    renderChat(makeRuntime())
-    await typeInComposer("un borrador")
-
-    pressEscapeAt(1_000, 1_401)
-
-    expect(composer()).toHaveValue("un borrador")
-  })
-
-  it("does not carry a dismissed chip into a clear", async () => {
+  it("takes two presses from a reply chip — chip, then text", async () => {
     renderChat(makeRuntime())
     await typeInComposer("ya lo miro")
     await userEvent.dblClick(bubbleAround("Hello there"))
 
-    pressEscapeAt(1_000, 1_100)
-
+    // The chip goes first and the draft survives, whatever the rhythm.
+    pressEscape()
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("button", { name: /remove quote/i })
+      ).not.toBeInTheDocument()
+    )
     expect(composer()).toHaveValue("ya lo miro")
+
+    pressEscape()
+    await waitFor(() => expect(composer()).toHaveValue(""))
   })
 
   it("claims Escape once there is a draft to protect", async () => {
@@ -757,7 +735,7 @@ describe("F0Chat composer escape", () => {
     renderChat(makeRuntime())
     await typeInComposer("un borrador")
 
-    pressEscapeAt(1_000, 1_300)
+    pressEscape()
     await waitFor(() => expect(composer()).toHaveValue(""))
 
     await userEvent.keyboard("{Meta>}z{/Meta}")

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.hotkeys.test.tsx
@@ -576,15 +576,8 @@ describe("F0Chat composer escape", () => {
     await userEvent.type(composer(), text)
   }
 
-  /** Escape is read off Date.now, so the presses are fired synchronously with
-   * the clock pinned — no fake timers to fight userEvent over. */
-  const pressEscape = (at?: number) => {
-    const clock =
-      at === undefined ? null : vi.spyOn(Date, "now").mockReturnValue(at)
-    const notPrevented = fireEvent.keyDown(composer(), { key: "Escape" })
-    clock?.mockRestore()
-    return notPrevented
-  }
+  /** Returns false when the composer claimed the key. */
+  const pressEscape = () => fireEvent.keyDown(composer(), { key: "Escape" })
 
   it("backs out of an edit in progress", async () => {
     renderChat(editable())
@@ -633,38 +626,6 @@ describe("F0Chat composer escape", () => {
     expect(composer()).toHaveValue("ya lo miro")
   })
 
-  it("clears the composer on a second press", async () => {
-    renderChat(makeRuntime())
-    await typeInComposer("un borrador")
-
-    pressEscape(1_000)
-    expect(composer()).toHaveValue("un borrador")
-
-    pressEscape(1_300)
-    await waitFor(() => expect(composer()).toHaveValue(""))
-  })
-
-  it("leaves the draft alone when the two presses are far apart", async () => {
-    renderChat(makeRuntime())
-    await typeInComposer("un borrador")
-
-    pressEscape(1_000)
-    pressEscape(1_401)
-
-    expect(composer()).toHaveValue("un borrador")
-  })
-
-  it("does not carry a dismissed chip into a clear", async () => {
-    renderChat(makeRuntime())
-    await typeInComposer("ya lo miro")
-    await userEvent.dblClick(bubbleAround("Hello there"))
-
-    pressEscape(1_000)
-    pressEscape(1_100)
-
-    expect(composer()).toHaveValue("ya lo miro")
-  })
-
   it("closes the mention popover before it dismisses anything", async () => {
     renderChat(
       makeRuntime({
@@ -680,16 +641,24 @@ describe("F0Chat composer escape", () => {
     await typeInComposer("@Ana")
     await screen.findByRole("option", { name: "Ana García" })
 
-    pressEscape(1_000)
+    pressEscape()
 
     await waitFor(() =>
       expect(
         screen.queryByRole("option", { name: "Ana García" })
       ).not.toBeInTheDocument()
     )
-    // The press that closed the popover is not the opening half of a clear.
-    pressEscape(1_100)
     expect(composer()).toHaveValue("@Ana")
+  })
+
+  it("never clears the draft, and leaves the key to the host", async () => {
+    renderChat(makeRuntime())
+    await typeInComposer("un borrador")
+
+    // No chip open: the composer has no claim on Escape, so a dialog hosting
+    // the chat can still be closed from a focused composer.
+    expect(pressEscape()).toBe(true)
+    expect(composer()).toHaveValue("un borrador")
   })
 
   it("leaves Escape to the host when there is nothing to lose", async () => {
@@ -697,12 +666,5 @@ describe("F0Chat composer escape", () => {
     await userEvent.click(composer())
 
     expect(pressEscape(1_000)).toBe(true)
-  })
-
-  it("claims Escape once there is a draft to protect", async () => {
-    renderChat(makeRuntime())
-    await typeInComposer("un borrador")
-
-    expect(pressEscape(1_000)).toBe(false)
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -70,6 +70,11 @@ import {
 import { ChatReplyChip } from "./ChatReplyChip"
 import { ChatTextareaField } from "./ChatTextareaField"
 
+/** How long after an Escape a second one still means "clear the composer".
+ * Long enough to be a deliberate double-tap, short enough that an Escape
+ * minutes later starts over rather than wiping a draft. */
+const DOUBLE_ESCAPE_MS = 400
+
 type UploadingAttachment = {
   id: string
   status: "uploading"
@@ -141,6 +146,7 @@ export const ChatComposer = (): ReactNode => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const attachmentStripRef = useRef<HTMLDivElement>(null)
   const localPreviewUrlsRef = useRef(new Set<string>())
+  const lastEscapeAtRef = useRef(0)
   // Where the caret belongs once React has written `forText`. A rAF is too
   // early — it can land before the commit, so the selection is set on the old
   // string and React's own value write then drops the caret at the end. The
@@ -635,22 +641,23 @@ export const ChatComposer = (): ReactNode => {
   const editingMessage = target.kind === "edit" ? target.message : null
   const replyTo = target.kind === "reply" ? target.message : null
 
-  // Must not touch the target: the provider owns it, and calling back would
-  // recurse through `retarget`.
-  const discardDraft = useCallback(() => {
+  // Leaves the undo stack alone on purpose: an Escape-cleared draft is exactly
+  // the thing Cmd+Z should be able to bring back.
+  const clearComposerText = useCallback(() => {
     mentions.close()
     mentions.seedMentions([], "")
     setValue("")
     setCursorPosition(0)
+  }, [mentions.close, mentions.seedMentions])
+
+  // Must not touch the target: the provider owns it, and calling back would
+  // recurse through `retarget`.
+  const discardDraft = useCallback(() => {
+    clearComposerText()
     releaseUploadingPreviews(attachments)
     setAttachments([])
     historyBreakRef.current = true
-  }, [
-    mentions.close,
-    mentions.seedMentions,
-    releaseUploadingPreviews,
-    attachments,
-  ])
+  }, [clearComposerText, releaseUploadingPreviews, attachments])
 
   const loadEditDraft = useCallback(
     (message: F0ChatMessage) => {
@@ -897,14 +904,30 @@ export const ChatComposer = (): ReactNode => {
       if (handleEmojiAutocompleteKeyDown(e)) return
       // The mention popover consumes navigation keys first (↑↓/Enter/Tab/Esc).
       if (mentions.handleKeyDown(e)) return
-      // Escape, once neither autocomplete claimed it, backs out of whichever
-      // chip is open. It never clears the draft: with nothing pending the key
+      // Escape, once neither autocomplete claimed it: back out of an edit or a
+      // reply, else clear the text on a second press. The composer only takes
+      // the key when it has something to lose — with nothing pending, Escape
       // belongs to whatever the chat is mounted in, so a host dialog can still
       // be closed from a focused composer.
-      if (e.key === "Escape" && target.kind !== "none") {
+      if (e.key === "Escape") {
+        if (target.kind !== "none") {
+          e.preventDefault()
+          // Backing out of a chip is not the opening half of a clear.
+          lastEscapeAtRef.current = 0
+          if (isEditing) dismissEdit()
+          else dismissReply()
+          return
+        }
+        if (value.length === 0) return
         e.preventDefault()
-        if (isEditing) dismissEdit()
-        else dismissReply()
+        const now = Date.now()
+        if (now - lastEscapeAtRef.current <= DOUBLE_ESCAPE_MS) {
+          lastEscapeAtRef.current = 0
+          clearComposerText()
+          void stopTyping?.()
+          return
+        }
+        lastEscapeAtRef.current = now
         return
       }
       // A modifier makes ↑ a selection gesture, never this shortcut; and with
@@ -934,6 +957,9 @@ export const ChatComposer = (): ReactNode => {
       dismissEdit,
       dismissReply,
       target.kind,
+      value.length,
+      clearComposerText,
+      stopTyping,
       undo,
       redo,
       isComposerIdle,

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -70,11 +70,6 @@ import {
 import { ChatReplyChip } from "./ChatReplyChip"
 import { ChatTextareaField } from "./ChatTextareaField"
 
-/** How long after an Escape a second one still means "clear the composer".
- * Long enough to be a deliberate double-tap, short enough that an Escape
- * minutes later starts over rather than wiping a draft. */
-const DOUBLE_ESCAPE_MS = 400
-
 type UploadingAttachment = {
   id: string
   status: "uploading"
@@ -146,7 +141,6 @@ export const ChatComposer = (): ReactNode => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const attachmentStripRef = useRef<HTMLDivElement>(null)
   const localPreviewUrlsRef = useRef(new Set<string>())
-  const lastEscapeAtRef = useRef(0)
   // Where the caret belongs once React has written `forText`. A rAF is too
   // early — it can land before the commit, so the selection is set on the old
   // string and React's own value write then drops the caret at the end. The
@@ -904,30 +898,24 @@ export const ChatComposer = (): ReactNode => {
       if (handleEmojiAutocompleteKeyDown(e)) return
       // The mention popover consumes navigation keys first (↑↓/Enter/Tab/Esc).
       if (mentions.handleKeyDown(e)) return
-      // Escape, once neither autocomplete claimed it: back out of an edit or a
-      // reply, else clear the text on a second press. The composer only takes
-      // the key when it has something to lose — with nothing pending, Escape
-      // belongs to whatever the chat is mounted in, so a host dialog can still
-      // be closed from a focused composer.
+      // Escape, once neither autocomplete claimed it, undoes one thing at a
+      // time: the chip if one is open, else the text. No double-tap — a timed
+      // window put the gesture behind an invisible armed state and a rhythm,
+      // and the guard it was there to provide is now Cmd+Z, which puts a
+      // cleared draft straight back.
       if (e.key === "Escape") {
         if (target.kind !== "none") {
           e.preventDefault()
-          // Backing out of a chip is not the opening half of a clear.
-          lastEscapeAtRef.current = 0
           if (isEditing) dismissEdit()
           else dismissReply()
           return
         }
+        // Nothing to lose: the key belongs to whatever the chat is mounted in,
+        // so a host dialog can still be closed from a focused composer.
         if (value.length === 0) return
         e.preventDefault()
-        const now = Date.now()
-        if (now - lastEscapeAtRef.current <= DOUBLE_ESCAPE_MS) {
-          lastEscapeAtRef.current = 0
-          clearComposerText()
-          void stopTyping?.()
-          return
-        }
-        lastEscapeAtRef.current = now
+        clearComposerText()
+        void stopTyping?.()
         return
       }
       // A modifier makes ↑ a selection gesture, never this shortcut; and with

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -27,6 +28,10 @@ import {
   replaceClosedEmojiShortcode,
   useEmojiAutocomplete,
 } from "../hooks/useEmojiAutocomplete"
+import {
+  type ComposerSnapshot,
+  useComposerHistory,
+} from "../hooks/useComposerHistory"
 import { MENTION_EVERYONE_ID, useMentions } from "../hooks/useMentions"
 import { useEditLastOwnMessage } from "../hooks/useEditLastOwnMessage"
 import { useTransientError } from "../hooks/useTransientError"
@@ -136,6 +141,24 @@ export const ChatComposer = (): ReactNode => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const attachmentStripRef = useRef<HTMLDivElement>(null)
   const localPreviewUrlsRef = useRef(new Set<string>())
+  // Where the caret belongs once React has written `forText`. A rAF is too
+  // early — it can land before the commit, so the selection is set on the old
+  // string and React's own value write then drops the caret at the end. The
+  // layout effect below runs after the write and before paint.
+  const pendingSelectionRef = useRef<{
+    caret: number
+    forText: string
+    focus: boolean
+  } | null>(null)
+  const history = useComposerHistory()
+  const lastSnapshotRef = useRef<ComposerSnapshot>({
+    value: "",
+    caret: 0,
+    mentions: [],
+  })
+  const restoringRef = useRef(false)
+  const erasedTextRef = useRef<string | null>(null)
+  const historyBreakRef = useRef(false)
 
   const emojiAutocomplete = useEmojiAutocomplete({
     inputValue: value,
@@ -148,11 +171,22 @@ export const ChatComposer = (): ReactNode => {
   // DMs (mention either person) and groups. Emoji lookup owns the active token
   // while open, so member searches pause until it closes.
   const mentionsEnabled = !!searchMembers
+  const requestSelection = useCallback(
+    (caret: number, forText: string, focus = false) => {
+      pendingSelectionRef.current = { caret, forText, focus }
+    },
+    []
+  )
+  const onMentionErased = useCallback((text: string) => {
+    erasedTextRef.current = text
+  }, [])
   const mentions = useMentions({
     inputValue: value,
     setInputValue: setValue,
     cursorPosition,
     setCursorPosition,
+    requestSelection,
+    onMentionErased,
     textareaRef,
     enabled: mentionsEnabled && !emojiAutocomplete.isOpen,
     searchMembers,
@@ -371,6 +405,64 @@ export const ChatComposer = (): ReactNode => {
     [onInputActivity, stopTyping]
   )
 
+  useLayoutEffect(
+    function applyPendingSelection() {
+      const pending = pendingSelectionRef.current
+      if (!pending) return
+      // A request whose text never got committed is stale; drop it rather than
+      // aim it at whatever the textarea holds now.
+      pendingSelectionRef.current = null
+      if (pending.forText !== value) return
+      const node = textareaRef.current
+      if (!node) return
+      if (pending.focus) node.focus()
+      node.setSelectionRange(pending.caret, pending.caret)
+    },
+    [value]
+  )
+
+  // Every writer to the composer's text goes through state, so watching it is
+  // the only way to catch them all — typing, paste, an inserted mention, an
+  // emoji swap, a transcript append.
+  useEffect(
+    function recordHistory() {
+      const previous = lastSnapshotRef.current
+      if (previous.value === value && previous.mentions === mentions.mentions) {
+        // Caret-only move: keep it, so an undo restores where the user was
+        // before the edit rather than where the last edit left them.
+        lastSnapshotRef.current = { ...previous, caret: cursorPosition }
+        return
+      }
+      const current = {
+        value,
+        caret: cursorPosition,
+        mentions: mentions.mentions,
+      }
+      lastSnapshotRef.current = current
+
+      if (restoringRef.current) {
+        restoringRef.current = false
+        return
+      }
+      // The tail of a mention removal: the keystroke that triggered it is
+      // already recorded, and undo has to put the whole mention back at once.
+      if (erasedTextRef.current === value) {
+        erasedTextRef.current = null
+        return
+      }
+      // The draft the stack described is gone — sent, discarded, or replaced by
+      // an edit. Adopt this state as the new baseline instead of recording a
+      // step that would undo back into it.
+      if (historyBreakRef.current) {
+        historyBreakRef.current = false
+        history.reset()
+        return
+      }
+      history.record(previous, current)
+    },
+    [value, cursorPosition, mentions.mentions, history]
+  )
+
   // Leaving the conversation mid-type must also drop the dots immediately.
   useEffect(
     () => () => {
@@ -552,6 +644,7 @@ export const ChatComposer = (): ReactNode => {
     setCursorPosition(0)
     releaseUploadingPreviews(attachments)
     setAttachments([])
+    historyBreakRef.current = true
   }, [
     mentions.close,
     mentions.seedMentions,
@@ -591,6 +684,9 @@ export const ChatComposer = (): ReactNode => {
         ],
         message.body
       )
+      // Opening an edit is a fresh context; undo must not walk back into the
+      // draft that was in the composer before it.
+      historyBreakRef.current = true
     },
     [
       channel.type,
@@ -684,6 +780,8 @@ export const ChatComposer = (): ReactNode => {
     setValue("")
     setCursorPosition(0)
     setAttachments([])
+    // The message is out; undo must not put the sent draft back.
+    historyBreakRef.current = true
     clearComposeTarget()
   }, [
     attachments,
@@ -735,11 +833,65 @@ export const ChatComposer = (): ReactNode => {
     clearComposeTarget()
   }, [clearComposeTarget, emit, replyTo])
 
+  const applySnapshot = useCallback(
+    (snapshot: ComposerSnapshot) => {
+      restoringRef.current = true
+      lastSnapshotRef.current = snapshot
+      mentions.close()
+      mentions.restoreMentions(snapshot.mentions, snapshot.value)
+      setValue(snapshot.value)
+      setCursorPosition(snapshot.caret)
+      requestSelection(snapshot.caret, snapshot.value)
+    },
+    [mentions.close, mentions.restoreMentions, requestSelection]
+  )
+
+  const undo = useCallback(() => {
+    const snapshot = history.undo({
+      value,
+      caret: cursorPosition,
+      mentions: mentions.mentions,
+    })
+    if (!snapshot) return false
+    applySnapshot(snapshot)
+    return true
+  }, [history, value, cursorPosition, mentions.mentions, applySnapshot])
+
+  const redo = useCallback(() => {
+    const snapshot = history.redo({
+      value,
+      caret: cursorPosition,
+      mentions: mentions.mentions,
+    })
+    if (!snapshot) return false
+    applySnapshot(snapshot)
+    return true
+  }, [history, value, cursorPosition, mentions.mentions, applySnapshot])
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       // Enter confirms the active IME composition. It must never select an
       // autocomplete option or send the message while composition is active.
       if (e.nativeEvent.isComposing) return
+      // Undo/redo before anything else: the composer rewrites its own value
+      // (inserting a mention, removing one whole, swapping an emoji shortcode)
+      // and each write clears the textarea's native undo stack, so the
+      // browser's own Cmd+Z has nothing useful left. Always preventDefault, or
+      // that empty native stack fires too and wipes what we just restored.
+      if ((e.metaKey || e.ctrlKey) && !e.altKey) {
+        const key = e.key.toLowerCase()
+        if (key === "z") {
+          e.preventDefault()
+          if (e.shiftKey) redo()
+          else undo()
+          return
+        }
+        if (key === "y") {
+          e.preventDefault()
+          redo()
+          return
+        }
+      }
       // Emoji shortcode suggestions take precedence when the active caret token
       // starts with `:`; Enter/Tab select instead of sending the message.
       if (handleEmojiAutocompleteKeyDown(e)) return
@@ -782,6 +934,8 @@ export const ChatComposer = (): ReactNode => {
       dismissEdit,
       dismissReply,
       target.kind,
+      undo,
+      redo,
       isComposerIdle,
       editLastOwnMessage,
     ]

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -152,6 +152,7 @@ export const ChatComposer = (): ReactNode => {
     inputValue: value,
     setInputValue: setValue,
     cursorPosition,
+    setCursorPosition,
     textareaRef,
     enabled: mentionsEnabled && !emojiAutocomplete.isOpen,
     searchMembers,
@@ -546,7 +547,7 @@ export const ChatComposer = (): ReactNode => {
   // recurse through `retarget`.
   const discardDraft = useCallback(() => {
     mentions.close()
-    mentions.seedMentions([])
+    mentions.seedMentions([], "")
     setValue("")
     setCursorPosition(0)
     releaseUploadingPreviews(attachments)
@@ -575,18 +576,21 @@ export const ChatComposer = (): ReactNode => {
             attachment,
           }))
       })
-      mentions.seedMentions([
-        ...(message.mentions ?? []).map((m) => ({
-          id: m.id,
-          name: m.name,
-          avatar: m.avatar,
-          subtitle: m.subtitle,
-          profileHref: m.profileHref,
-        })),
-        ...(message.mentionedEveryone && channel.type === "group"
-          ? [{ id: MENTION_EVERYONE_ID, name: i18n.chat.mentionEveryone }]
-          : []),
-      ])
+      mentions.seedMentions(
+        [
+          ...(message.mentions ?? []).map((m) => ({
+            id: m.id,
+            name: m.name,
+            avatar: m.avatar,
+            subtitle: m.subtitle,
+            profileHref: m.profileHref,
+          })),
+          ...(message.mentionedEveryone && channel.type === "group"
+            ? [{ id: MENTION_EVERYONE_ID, name: i18n.chat.mentionEveryone }]
+            : []),
+        ],
+        message.body
+      )
     },
     [
       channel.type,
@@ -676,6 +680,7 @@ export const ChatComposer = (): ReactNode => {
       mentionedEveryone: mentionedEveryone || undefined,
     })
     mentions.close()
+    mentions.seedMentions([], "")
     setValue("")
     setCursorPosition(0)
     setAttachments([])

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -65,6 +65,11 @@ import {
 import { ChatReplyChip } from "./ChatReplyChip"
 import { ChatTextareaField } from "./ChatTextareaField"
 
+/** How long after an Escape a second one still means "clear the composer".
+ * Long enough to be a deliberate double-tap, short enough that an Escape
+ * minutes later starts over rather than wiping a draft. */
+const DOUBLE_ESCAPE_MS = 400
+
 type UploadingAttachment = {
   id: string
   status: "uploading"
@@ -136,6 +141,7 @@ export const ChatComposer = (): ReactNode => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const attachmentStripRef = useRef<HTMLDivElement>(null)
   const localPreviewUrlsRef = useRef(new Set<string>())
+  const lastEscapeAtRef = useRef(0)
 
   const emojiAutocomplete = useEmojiAutocomplete({
     inputValue: value,
@@ -543,21 +549,20 @@ export const ChatComposer = (): ReactNode => {
   const editingMessage = target.kind === "edit" ? target.message : null
   const replyTo = target.kind === "reply" ? target.message : null
 
-  // Must not touch the target: the provider owns it, and calling back would
-  // recurse through `retarget`.
-  const discardDraft = useCallback(() => {
+  const clearComposerText = useCallback(() => {
     mentions.close()
     mentions.seedMentions([], "")
     setValue("")
     setCursorPosition(0)
+  }, [mentions.close, mentions.seedMentions])
+
+  // Must not touch the target: the provider owns it, and calling back would
+  // recurse through `retarget`.
+  const discardDraft = useCallback(() => {
+    clearComposerText()
     releaseUploadingPreviews(attachments)
     setAttachments([])
-  }, [
-    mentions.close,
-    mentions.seedMentions,
-    releaseUploadingPreviews,
-    attachments,
-  ])
+  }, [clearComposerText, releaseUploadingPreviews, attachments])
 
   const loadEditDraft = useCallback(
     (message: F0ChatMessage) => {
@@ -745,10 +750,29 @@ export const ChatComposer = (): ReactNode => {
       if (handleEmojiAutocompleteKeyDown(e)) return
       // The mention popover consumes navigation keys first (↑↓/Enter/Tab/Esc).
       if (mentions.handleKeyDown(e)) return
-      // Escape backs out of an edit (when the popover didn't claim it).
-      if (e.key === "Escape" && isEditing) {
+      // Escape, once neither autocomplete claimed it: back out of an edit or a
+      // reply, else clear the text on a second press. The composer only takes
+      // the key when it has something to lose — with nothing pending, Escape
+      // belongs to whatever the chat is mounted in.
+      if (e.key === "Escape") {
+        if (target.kind !== "none") {
+          e.preventDefault()
+          // Backing out of a chip is not the opening half of a clear.
+          lastEscapeAtRef.current = 0
+          if (isEditing) dismissEdit()
+          else dismissReply()
+          return
+        }
+        if (value.length === 0) return
         e.preventDefault()
-        dismissEdit()
+        const now = Date.now()
+        if (now - lastEscapeAtRef.current <= DOUBLE_ESCAPE_MS) {
+          lastEscapeAtRef.current = 0
+          clearComposerText()
+          void stopTyping?.()
+          return
+        }
+        lastEscapeAtRef.current = now
         return
       }
       // A modifier makes ↑ a selection gesture, never this shortcut; and with
@@ -776,6 +800,11 @@ export const ChatComposer = (): ReactNode => {
       mentions,
       isEditing,
       dismissEdit,
+      dismissReply,
+      target.kind,
+      value.length,
+      clearComposerText,
+      stopTyping,
       isComposerIdle,
       editLastOwnMessage,
     ]

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -118,7 +118,6 @@ export const ChatComposer = (): ReactNode => {
     maxFileSizeBytes,
     channel,
     searchMembers,
-    currentUserId,
     capabilities,
   } = useF0Chat()
   // Uploads need both the runtime hook AND the capability (a frozen channel
@@ -216,7 +215,6 @@ export const ChatComposer = (): ReactNode => {
         inlineCompletion: emojiAutocomplete.isOpen
           ? null
           : mentions.inlineCompletion,
-        currentUserId,
       }),
     [
       value,
@@ -224,7 +222,6 @@ export const ChatComposer = (): ReactNode => {
       cursorPosition,
       mentions.inlineCompletion,
       emojiAutocomplete.isOpen,
-      currentUserId,
     ]
   )
   // Mentions and ghost completions are the only things the overlay paints, so

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -65,11 +65,6 @@ import {
 import { ChatReplyChip } from "./ChatReplyChip"
 import { ChatTextareaField } from "./ChatTextareaField"
 
-/** How long after an Escape a second one still means "clear the composer".
- * Long enough to be a deliberate double-tap, short enough that an Escape
- * minutes later starts over rather than wiping a draft. */
-const DOUBLE_ESCAPE_MS = 400
-
 type UploadingAttachment = {
   id: string
   status: "uploading"
@@ -141,7 +136,6 @@ export const ChatComposer = (): ReactNode => {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const attachmentStripRef = useRef<HTMLDivElement>(null)
   const localPreviewUrlsRef = useRef(new Set<string>())
-  const lastEscapeAtRef = useRef(0)
 
   const emojiAutocomplete = useEmojiAutocomplete({
     inputValue: value,
@@ -549,20 +543,21 @@ export const ChatComposer = (): ReactNode => {
   const editingMessage = target.kind === "edit" ? target.message : null
   const replyTo = target.kind === "reply" ? target.message : null
 
-  const clearComposerText = useCallback(() => {
+  // Must not touch the target: the provider owns it, and calling back would
+  // recurse through `retarget`.
+  const discardDraft = useCallback(() => {
     mentions.close()
     mentions.seedMentions([], "")
     setValue("")
     setCursorPosition(0)
-  }, [mentions.close, mentions.seedMentions])
-
-  // Must not touch the target: the provider owns it, and calling back would
-  // recurse through `retarget`.
-  const discardDraft = useCallback(() => {
-    clearComposerText()
     releaseUploadingPreviews(attachments)
     setAttachments([])
-  }, [clearComposerText, releaseUploadingPreviews, attachments])
+  }, [
+    mentions.close,
+    mentions.seedMentions,
+    releaseUploadingPreviews,
+    attachments,
+  ])
 
   const loadEditDraft = useCallback(
     (message: F0ChatMessage) => {
@@ -750,29 +745,14 @@ export const ChatComposer = (): ReactNode => {
       if (handleEmojiAutocompleteKeyDown(e)) return
       // The mention popover consumes navigation keys first (↑↓/Enter/Tab/Esc).
       if (mentions.handleKeyDown(e)) return
-      // Escape, once neither autocomplete claimed it: back out of an edit or a
-      // reply, else clear the text on a second press. The composer only takes
-      // the key when it has something to lose — with nothing pending, Escape
-      // belongs to whatever the chat is mounted in.
-      if (e.key === "Escape") {
-        if (target.kind !== "none") {
-          e.preventDefault()
-          // Backing out of a chip is not the opening half of a clear.
-          lastEscapeAtRef.current = 0
-          if (isEditing) dismissEdit()
-          else dismissReply()
-          return
-        }
-        if (value.length === 0) return
+      // Escape, once neither autocomplete claimed it, backs out of whichever
+      // chip is open. It never clears the draft: with nothing pending the key
+      // belongs to whatever the chat is mounted in, so a host dialog can still
+      // be closed from a focused composer.
+      if (e.key === "Escape" && target.kind !== "none") {
         e.preventDefault()
-        const now = Date.now()
-        if (now - lastEscapeAtRef.current <= DOUBLE_ESCAPE_MS) {
-          lastEscapeAtRef.current = 0
-          clearComposerText()
-          void stopTyping?.()
-          return
-        }
-        lastEscapeAtRef.current = now
+        if (isEditing) dismissEdit()
+        else dismissReply()
         return
       }
       // A modifier makes ↑ a selection gesture, never this shortcut; and with
@@ -802,9 +782,6 @@ export const ChatComposer = (): ReactNode => {
       dismissEdit,
       dismissReply,
       target.kind,
-      value.length,
-      clearComposerText,
-      stopTyping,
       isComposerIdle,
       editLastOwnMessage,
     ]

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -97,20 +97,24 @@ export const ChatTextareaField = ({
               image's width is gone with it. */}
           {highlightSegments.map((seg, i) =>
             seg.type === "mention" ? (
-              // The bubble's colour, so a mention reads the same before and
-              // after sending: secondary foreground, no background, and no
+              // Exactly the bubble's chip, weight included, so a mention reads
+              // the same before and after sending: no background, and no
               // distinction between mentioning you, `@here` or anyone else.
               //
-              // Colour only — deliberately NOT the bubble's `font-medium`, and
-              // this is load-bearing. A `<textarea>` lays its entire run out at
-              // one weight, so a heavier mention in the overlay paints wider
-              // than the transparent glyphs the caret is positioned from, and
-              // every character from the mention onward sits off its boundary.
-              // Measured at 14px Inter, `font-medium` cost ~0.1px per mention
-              // character, plateauing at 1.25px (8.9% of an em) across the rest
-              // of the line — enough to park the caret inside a glyph instead
-              // of between two.
-              <span key={i} className="text-f1-foreground-secondary">
+              // The weight costs caret accuracy, knowingly. A `<textarea>` lays
+              // its entire run out at one weight, so a heavier mention in the
+              // overlay paints wider than the transparent glyphs the caret is
+              // positioned from, and every character after it sits off its
+              // boundary. Measured at 14px Inter: 1.02px for `@Ana`, 1.48px for
+              // `@Ana García`, 1.91px for `@Bruno Martínez` — it grows with the
+              // name and adds up per mention, so a line with two long ones
+              // drifts by most of a character by its end. Matching the bubble
+              // was judged worth that; this class is the thing to drop if the
+              // caret ever has to be exact again.
+              <span
+                key={i}
+                className="font-medium text-f1-foreground-secondary"
+              >
                 {seg.text}
               </span>
             ) : seg.type === "ghost" ? (

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -97,24 +97,20 @@ export const ChatTextareaField = ({
               image's width is gone with it. */}
           {highlightSegments.map((seg, i) =>
             seg.type === "mention" ? (
-              // Exactly the bubble's chip, weight included, so a mention reads
-              // the same before and after sending: no background, and no
+              // The bubble's colour, so a mention reads the same before and
+              // after sending: secondary foreground, no background, and no
               // distinction between mentioning you, `@here` or anyone else.
               //
-              // The weight costs caret accuracy, knowingly. A `<textarea>` lays
-              // its entire run out at one weight, so a heavier mention in the
-              // overlay paints wider than the transparent glyphs the caret is
-              // positioned from, and every character after it sits off its
-              // boundary. Measured at 14px Inter: 1.02px for `@Ana`, 1.48px for
-              // `@Ana García`, 1.91px for `@Bruno Martínez` — it grows with the
-              // name and adds up per mention, so a line with two long ones
-              // drifts by most of a character by its end. Matching the bubble
-              // was judged worth that; this class is the thing to drop if the
-              // caret ever has to be exact again.
-              <span
-                key={i}
-                className="font-medium text-f1-foreground-secondary"
-              >
+              // Colour only — deliberately NOT the bubble's `font-medium`, and
+              // this is load-bearing. A `<textarea>` lays its entire run out at
+              // one weight, so a heavier mention in the overlay paints wider
+              // than the transparent glyphs the caret is positioned from, and
+              // every character from the mention onward sits off its boundary.
+              // Measured at 14px Inter, `font-medium` cost ~0.1px per mention
+              // character, plateauing at 1.25px (8.9% of an em) across the rest
+              // of the line — enough to park the caret inside a glyph instead
+              // of between two.
+              <span key={i} className="text-f1-foreground-secondary">
                 {seg.text}
               </span>
             ) : seg.type === "ghost" ? (

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -97,25 +97,20 @@ export const ChatTextareaField = ({
               image's width is gone with it. */}
           {highlightSegments.map((seg, i) =>
             seg.type === "mention" ? (
-              // Same colour pattern as the bubble: you / @here amber, others
-              // info. Tone and background carry the whole distinction: no
-              // padding, and — load-bearing — no weight change. A `<textarea>`
-              // lays its entire run out at one weight, so a heavier mention
-              // here paints wider than the transparent glyphs the caret is
-              // positioned from, and every character from the mention onward
-              // sits off its boundary. Measured at 14px Inter, `font-medium`
-              // cost ~0.1px per mention character, plateauing at 1.25px (8.9%
-              // of an em) across the rest of the line — enough to park the
-              // caret inside a glyph instead of between two.
-              <span
-                key={i}
-                className={cn(
-                  "rounded-xs",
-                  seg.tone === "self" || seg.tone === "everyone"
-                    ? "bg-f1-background-warning text-f1-foreground-warning"
-                    : "bg-f1-background-info text-f1-foreground-info"
-                )}
-              >
+              // The bubble's colour, so a mention reads the same before and
+              // after sending: secondary foreground, no background, and no
+              // distinction between mentioning you, `@here` or anyone else.
+              //
+              // Colour only — deliberately NOT the bubble's `font-medium`, and
+              // this is load-bearing. A `<textarea>` lays its entire run out at
+              // one weight, so a heavier mention in the overlay paints wider
+              // than the transparent glyphs the caret is positioned from, and
+              // every character from the mention onward sits off its boundary.
+              // Measured at 14px Inter, `font-medium` cost ~0.1px per mention
+              // character, plateauing at 1.25px (8.9% of an em) across the rest
+              // of the line — enough to park the caret inside a glyph instead
+              // of between two.
+              <span key={i} className="text-f1-foreground-secondary">
                 {seg.text}
               </span>
             ) : seg.type === "ghost" ? (

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
@@ -92,10 +92,10 @@ describe("ChatTextareaField overlay/textarea metric parity", () => {
   // positioned from, and every character from there on sits off its boundary.
   // Measured at 14px Inter: `font-medium` on the chip cost ~0.1px per mention
   // character, plateauing at 1.25px (8.9% of an em) across the rest of the line.
-  const withMention = (tone: "other" | "self") => {
+  const withMention = () => {
     const segments: HighlightSegment[] = [
       { type: "text", text: "Hi " },
-      { type: "mention", text: "@Nora Vidal", tone },
+      { type: "mention", text: "@Nora Vidal" },
       { type: "text", text: " and then a tail" },
     ]
     return zeroRender(
@@ -108,22 +108,28 @@ describe("ChatTextareaField overlay/textarea metric parity", () => {
     )
   }
 
-  it("gives an info-toned mention chip no weight of its own", () => {
-    const { container } = withMention("other")
-    const chip = container.querySelector('[class*="bg-f1-background-info"]')
+  it("gives the mention chip no weight of its own", () => {
+    const { container } = withMention()
+    const chip = container.querySelector(
+      '[class*="text-f1-foreground-secondary"]'
+    )
     expect(chip).not.toBeNull()
     expect(chip?.className).not.toMatch(OFF_WEIGHT)
   })
 
-  it("gives a warning-toned mention chip no weight of its own", () => {
-    const { container } = withMention("self")
-    const chip = container.querySelector('[class*="bg-f1-background-warning"]')
-    expect(chip).not.toBeNull()
-    expect(chip?.className).not.toMatch(OFF_WEIGHT)
+  // The bubble paints a mention with `font-medium`; the overlay must take the
+  // colour and leave the weight, or the caret drifts (see above).
+  it("paints the chip in the same colour as the bubble, with no background", () => {
+    const { container } = withMention()
+    const chip = container.querySelector(
+      '[class*="text-f1-foreground-secondary"]'
+    )
+    expect(chip?.textContent).toBe("@Nora Vidal")
+    expect(chip?.className).not.toMatch(/\bbg-/)
   })
 
   it("leaves the textarea itself on the inherited weight", () => {
-    const { container } = withMention("other")
+    const { container } = withMention()
     expect(container.querySelector("textarea")?.className).not.toMatch(
       OFF_WEIGHT
     )

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
@@ -90,13 +90,8 @@ describe("ChatTextareaField overlay/textarea metric parity", () => {
   // to make it match a per-range weight. So any weight the overlay applies to
   // part of the text paints wider than the transparent glyphs the caret is
   // positioned from, and every character from there on sits off its boundary.
-  // Measured at 14px Inter, `font-medium` on the chip costs 1.02px for `@Ana`,
-  // 1.48px for `@Ana García` and 1.91px for `@Bruno Martínez` — it grows with
-  // the name and accumulates per mention, rather than plateauing.
-  //
-  // The chip carries that weight anyway, by decision: matching the bubble
-  // exactly beat sub-pixel caret accuracy. Everything else in the overlay must
-  // still stay on the inherited weight, which is what these tests hold.
+  // Measured at 14px Inter: `font-medium` on the chip cost ~0.1px per mention
+  // character, plateauing at 1.25px (8.9% of an em) across the rest of the line.
   const withMention = () => {
     const segments: HighlightSegment[] = [
       { type: "text", text: "Hi " },
@@ -113,35 +108,24 @@ describe("ChatTextareaField overlay/textarea metric parity", () => {
     )
   }
 
-  // Deliberate, and the one place the overlay is allowed a weight of its own:
-  // the bubble paints a mention `font-medium`, so the composer does too. Read
-  // the note above before removing it — the cost is caret drift, not nothing.
-  it("gives the mention chip the bubble's colour and weight, no background", () => {
+  it("gives the mention chip no weight of its own", () => {
+    const { container } = withMention()
+    const chip = container.querySelector(
+      '[class*="text-f1-foreground-secondary"]'
+    )
+    expect(chip).not.toBeNull()
+    expect(chip?.className).not.toMatch(OFF_WEIGHT)
+  })
+
+  // The bubble paints a mention with `font-medium`; the overlay must take the
+  // colour and leave the weight, or the caret drifts (see above).
+  it("paints the chip in the same colour as the bubble, with no background", () => {
     const { container } = withMention()
     const chip = container.querySelector(
       '[class*="text-f1-foreground-secondary"]'
     )
     expect(chip?.textContent).toBe("@Nora Vidal")
-    expect(chip?.className).toMatch(/\bfont-medium\b/)
     expect(chip?.className).not.toMatch(/\bbg-/)
-  })
-
-  it("leaves the ghost completion on the inherited weight", () => {
-    const segments: HighlightSegment[] = [
-      { type: "text", text: "Hi @Nor" },
-      { type: "ghost", text: "a Vidal" },
-    ]
-    const { container } = zeroRender(
-      <ChatTextareaField
-        {...baseProps()}
-        value="Hi @Nor"
-        highlightSegments={segments}
-        hasOverlay
-      />
-    )
-    const ghost = container.querySelector('[class*="opacity-50"]')
-    expect(ghost).not.toBeNull()
-    expect(ghost?.className).not.toMatch(OFF_WEIGHT)
   })
 
   it("leaves the textarea itself on the inherited weight", () => {

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
@@ -90,8 +90,13 @@ describe("ChatTextareaField overlay/textarea metric parity", () => {
   // to make it match a per-range weight. So any weight the overlay applies to
   // part of the text paints wider than the transparent glyphs the caret is
   // positioned from, and every character from there on sits off its boundary.
-  // Measured at 14px Inter: `font-medium` on the chip cost ~0.1px per mention
-  // character, plateauing at 1.25px (8.9% of an em) across the rest of the line.
+  // Measured at 14px Inter, `font-medium` on the chip costs 1.02px for `@Ana`,
+  // 1.48px for `@Ana García` and 1.91px for `@Bruno Martínez` — it grows with
+  // the name and accumulates per mention, rather than plateauing.
+  //
+  // The chip carries that weight anyway, by decision: matching the bubble
+  // exactly beat sub-pixel caret accuracy. Everything else in the overlay must
+  // still stay on the inherited weight, which is what these tests hold.
   const withMention = () => {
     const segments: HighlightSegment[] = [
       { type: "text", text: "Hi " },
@@ -108,24 +113,35 @@ describe("ChatTextareaField overlay/textarea metric parity", () => {
     )
   }
 
-  it("gives the mention chip no weight of its own", () => {
-    const { container } = withMention()
-    const chip = container.querySelector(
-      '[class*="text-f1-foreground-secondary"]'
-    )
-    expect(chip).not.toBeNull()
-    expect(chip?.className).not.toMatch(OFF_WEIGHT)
-  })
-
-  // The bubble paints a mention with `font-medium`; the overlay must take the
-  // colour and leave the weight, or the caret drifts (see above).
-  it("paints the chip in the same colour as the bubble, with no background", () => {
+  // Deliberate, and the one place the overlay is allowed a weight of its own:
+  // the bubble paints a mention `font-medium`, so the composer does too. Read
+  // the note above before removing it — the cost is caret drift, not nothing.
+  it("gives the mention chip the bubble's colour and weight, no background", () => {
     const { container } = withMention()
     const chip = container.querySelector(
       '[class*="text-f1-foreground-secondary"]'
     )
     expect(chip?.textContent).toBe("@Nora Vidal")
+    expect(chip?.className).toMatch(/\bfont-medium\b/)
     expect(chip?.className).not.toMatch(/\bbg-/)
+  })
+
+  it("leaves the ghost completion on the inherited weight", () => {
+    const segments: HighlightSegment[] = [
+      { type: "text", text: "Hi @Nor" },
+      { type: "ghost", text: "a Vidal" },
+    ]
+    const { container } = zeroRender(
+      <ChatTextareaField
+        {...baseProps()}
+        value="Hi @Nor"
+        highlightSegments={segments}
+        hasOverlay
+      />
+    )
+    const ghost = container.querySelector('[class*="opacity-50"]')
+    expect(ghost).not.toBeNull()
+    expect(ghost?.className).not.toMatch(OFF_WEIGHT)
   })
 
   it("leaves the textarea itself on the inherited weight", () => {

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
@@ -28,6 +28,7 @@ const makeProps = (over: Partial<Props> = {}): Props => {
     setInputValue: () => {},
     cursorPosition: 0,
     setCursorPosition: () => {},
+    requestSelection: () => {},
     textareaRef: { current: textarea },
     enabled: true,
     searchMembers: (q: string) =>
@@ -245,6 +246,39 @@ describe("useMentions — a mention survives an edit", () => {
       expect(setInputValue).toHaveBeenCalledWith("Hola , ¿vienes?")
     )
     expect(result.current.getMentions().mentions).toEqual([])
+  })
+
+  it("leaves the caret where the mention was, not at the end", async () => {
+    // A multi-line draft is where this shows: dropping the caret at the end
+    // moves it to another line entirely.
+    let value = "Hola @Ana García, ¿vienes?\nY mañana también\nGracias"
+    const setInputValue = vi.fn((next: string) => {
+      value = next
+    })
+    const setCursorPosition = vi.fn()
+    const { rerender } = openForEditing(value, [ANA], {
+      setInputValue,
+      setCursorPosition,
+    })
+
+    // Backspace the "c" of "García" — the caret lands at 13.
+    value = "Hola @Ana Garía, ¿vienes?\nY mañana también\nGracias"
+    rerender(
+      makeProps({
+        inputValue: value,
+        cursorPosition: 13,
+        setInputValue,
+        setCursorPosition,
+      })
+    )
+
+    await waitFor(() =>
+      expect(setInputValue).toHaveBeenCalledWith(
+        "Hola , ¿vienes?\nY mañana también\nGracias"
+      )
+    )
+    // 5 is where the "@" was; the end of that text is 40.
+    expect(setCursorPosition).toHaveBeenCalledWith(5)
   })
 
   it("tracks two people who share a display name independently", async () => {

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { type F0ChatUser } from "../../types"
-import { useMentions } from "../useMentions"
+import { type MentionEntry, useMentions } from "../useMentions"
 
 const MEMBERS: F0ChatUser[] = [
   { id: "ana-g", name: "Ana García" },
@@ -27,6 +27,7 @@ const makeProps = (over: Partial<Props> = {}): Props => {
     inputValue: "",
     setInputValue: () => {},
     cursorPosition: 0,
+    setCursorPosition: () => {},
     textareaRef: { current: textarea },
     enabled: true,
     searchMembers: (q: string) =>
@@ -166,6 +167,107 @@ describe("useMentions", () => {
         mentions: [{ id: "ana-g", name: "Ana García" }],
         mentionedEveryone: false,
       })
+    )
+  })
+})
+
+// Raúl's report: editing a message that has a mention loses it. A mention is
+// re-derived from the text by name on every change and survives only while
+// `@Name` is followed by whitespace — which a saved body often isn't.
+describe("useMentions — a mention survives an edit", () => {
+  const ANA: MentionEntry = { id: "ana-g", name: "Ana García" }
+
+  const withValue = (body: string, over: Partial<Props> = {}) =>
+    makeProps({ inputValue: body, cursorPosition: body.length, ...over })
+
+  /**
+   * Reproduces `loadEditDraft`: seed the message's mentions, then hand the
+   * composer its body. The body arriving is what re-validates the seeded
+   * entries, so the order matters.
+   */
+  const openForEditing = (
+    body: string,
+    seeded: MentionEntry[],
+    over: Partial<Props> = {}
+  ) => {
+    const harness = renderHook((p: Props) => useMentions(p), {
+      initialProps: makeProps(over),
+    })
+    act(() => harness.result.current.seedMentions(seeded, body))
+    harness.rerender(withValue(body, over))
+    return harness
+  }
+
+  it("keeps a mention that ends the message", async () => {
+    const { result } = openForEditing("Ping @Ana García", [ANA])
+    await waitFor(() =>
+      expect(result.current.getMentions().mentions).toEqual([ANA])
+    )
+  })
+
+  it("keeps a mention followed by punctuation", async () => {
+    const { result } = openForEditing("Thanks @Ana García, all set", [ANA])
+    await waitFor(() =>
+      expect(result.current.getMentions().mentions).toEqual([ANA])
+    )
+  })
+
+  it("keeps a mention while the user edits the text around it", async () => {
+    let value = "Hola @Ana García, ¿vienes?"
+    const setInputValue = vi.fn((next: string) => {
+      value = next
+    })
+    const { result, rerender } = openForEditing(value, [ANA], { setInputValue })
+
+    value = "Hola @Ana García, ¿vienes hoy?"
+    rerender(withValue(value, { setInputValue }))
+
+    await waitFor(() =>
+      expect(result.current.getMentions().mentions).toEqual([ANA])
+    )
+    expect(setInputValue).not.toHaveBeenCalled()
+  })
+
+  it("removes the whole mention when the user edits inside it", async () => {
+    let value = "Hola @Ana García, ¿vienes?"
+    const setInputValue = vi.fn((next: string) => {
+      value = next
+    })
+    const { result, rerender } = openForEditing(value, [ANA], { setInputValue })
+
+    // Backspace the "c" of "García" — the caret lands at 13.
+    value = "Hola @Ana Garía, ¿vienes?"
+    rerender(
+      makeProps({ inputValue: value, cursorPosition: 13, setInputValue })
+    )
+
+    await waitFor(() =>
+      expect(setInputValue).toHaveBeenCalledWith("Hola , ¿vienes?")
+    )
+    expect(result.current.getMentions().mentions).toEqual([])
+  })
+
+  it("tracks two people who share a display name independently", async () => {
+    const ANA_TWO: MentionEntry = { id: "ana-p", name: "Ana García" }
+    let value = "@Ana García and @Ana García, both please"
+    const setInputValue = vi.fn((next: string) => {
+      value = next
+    })
+    const { result, rerender } = openForEditing(value, [ANA, ANA_TWO], {
+      setInputValue,
+    })
+    await waitFor(() =>
+      expect(result.current.getMentions().mentions).toEqual([ANA, ANA_TWO])
+    )
+
+    // Delete the second occurrence: only the second id may go.
+    value = "@Ana García and , both please"
+    rerender(
+      makeProps({ inputValue: value, cursorPosition: 16, setInputValue })
+    )
+
+    await waitFor(() =>
+      expect(result.current.getMentions().mentions).toEqual([ANA])
     )
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/hooks/highlight-utils.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/highlight-utils.ts
@@ -1,4 +1,8 @@
-import { MENTION_EVERYONE_ID, type MentionEntry } from "./useMentions"
+import {
+  type AnchoredMention,
+  MENTION_EVERYONE_ID,
+  mentionEnd,
+} from "./useMentions"
 
 /** Same tone classification the bubble uses, so the in-composer highlight
  * matches: a mention of you / `@here` is amber, anyone else is info. */
@@ -29,7 +33,7 @@ const toneOf = (id: string, currentUserId?: string): MentionTone =>
  */
 export function buildHighlightSegments(
   text: string,
-  mentions: MentionEntry[],
+  mentions: AnchoredMention[],
   options?: {
     cursorPosition?: number
     inlineCompletion?: string | null
@@ -41,22 +45,16 @@ export function buildHighlightSegments(
   const ghost = options?.inlineCompletion ?? null
   const currentUserId = options?.currentUserId
 
-  // Build a list of { start, end, tone } ranges for each @Name occurrence.
-  const ranges: { start: number; end: number; tone: MentionTone }[] = []
-
-  for (const mention of mentions) {
-    const pattern = `@${mention.name}`
-    const tone = toneOf(mention.id, currentUserId)
-    let searchFrom = 0
-    while (true) {
-      const idx = text.indexOf(pattern, searchFrom)
-      if (idx === -1) break
-      ranges.push({ start: idx, end: idx + pattern.length, tone })
-      searchFrom = idx + pattern.length
-    }
-  }
-
-  ranges.sort((a, b) => a.start - b.start)
+  // The composer owns the anchors, so the overlay paints exactly the spans the
+  // composer considers mentions — no second, independently-drifting match.
+  const ranges = mentions
+    .map((mention) => ({
+      start: mention.start,
+      end: mentionEnd(mention),
+      tone: toneOf(mention.id, currentUserId),
+    }))
+    .filter((range) => range.start >= 0 && range.end <= text.length)
+    .sort((a, b) => a.start - b.start)
 
   const segments: HighlightSegment[] = []
   let pos = 0

--- a/packages/react/src/sds/chat/F0Chat/hooks/highlight-utils.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/highlight-utils.ts
@@ -1,31 +1,13 @@
-import {
-  type AnchoredMention,
-  MENTION_EVERYONE_ID,
-  mentionEnd,
-} from "./useMentions"
-
-/** Same tone classification the bubble uses, so the in-composer highlight
- * matches: a mention of you / `@here` is amber, anyone else is info. */
-export type MentionTone = "self" | "everyone" | "other"
+import { type AnchoredMention, mentionEnd } from "./useMentions"
 
 export type HighlightSegment = {
   type: "text" | "mention" | "ghost"
   text: string
-  /** Only set on `mention` segments — drives the chip colour. */
-  tone?: MentionTone
 }
-
-const toneOf = (id: string, currentUserId?: string): MentionTone =>
-  id === MENTION_EVERYONE_ID
-    ? "everyone"
-    : currentUserId != null && id === currentUserId
-      ? "self"
-      : "other"
 
 /**
  * Split composer text into plain-text, mention, and ghost (inline-completion)
  * segments so the highlight overlay can render each with distinct styling.
- * Cloned from the AI chat composer so the two behave identically.
  *
  * When `inlineCompletion` is provided together with `cursorPosition`, a "ghost"
  * segment is inserted at the cursor — the remaining portion of the
@@ -37,22 +19,15 @@ export function buildHighlightSegments(
   options?: {
     cursorPosition?: number
     inlineCompletion?: string | null
-    /** Viewer id — a mention of it is toned `self` (amber), like the bubble. */
-    currentUserId?: string
   }
 ): HighlightSegment[] {
   const cursorPos = options?.cursorPosition ?? text.length
   const ghost = options?.inlineCompletion ?? null
-  const currentUserId = options?.currentUserId
 
   // The composer owns the anchors, so the overlay paints exactly the spans the
   // composer considers mentions — no second, independently-drifting match.
   const ranges = mentions
-    .map((mention) => ({
-      start: mention.start,
-      end: mentionEnd(mention),
-      tone: toneOf(mention.id, currentUserId),
-    }))
+    .map((mention) => ({ start: mention.start, end: mentionEnd(mention) }))
     .filter((range) => range.start >= 0 && range.end <= text.length)
     .sort((a, b) => a.start - b.start)
 
@@ -82,11 +57,7 @@ export function buildHighlightSegments(
 
   for (const range of ranges) {
     emitTextWithGhost(range.start)
-    segments.push({
-      type: "mention",
-      text: text.slice(range.start, range.end),
-      tone: range.tone,
-    })
+    segments.push({ type: "mention", text: text.slice(range.start, range.end) })
     pos = range.end
   }
 

--- a/packages/react/src/sds/chat/F0Chat/hooks/useComposerHistory.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useComposerHistory.ts
@@ -1,0 +1,115 @@
+import { useCallback, useRef } from "react"
+
+import { diffSpan } from "../utils/text-diff"
+import { type AnchoredMention } from "./useMentions"
+
+/** Everything an undo step has to put back. */
+export type ComposerSnapshot = {
+  value: string
+  caret: number
+  mentions: AnchoredMention[]
+}
+
+/** Consecutive keystrokes of the same kind collapse into one step while they
+ * stay this close together — one undo per typing burst, not per character. */
+const COALESCE_MS = 600
+
+/** Steps kept. Past this, the oldest is dropped. */
+const LIMIT = 100
+
+type EditKind = "insert" | "delete" | "other"
+
+/**
+ * How a change reads for coalescing. Whitespace is deliberately `other`, so a
+ * step boundary falls at every word break and undo walks back a word at a
+ * time, the way a plain textarea does.
+ */
+const kindOf = (prev: string, next: string): EditKind => {
+  const { start, prevEnd, nextEnd } = diffSpan(prev, next)
+  const removed = prevEnd - start
+  const added = nextEnd - start
+  if (removed === 0 && added === 1) {
+    return /\s/.test(next[start] ?? "") ? "other" : "insert"
+  }
+  if (added === 0 && removed === 1) return "delete"
+  return "other"
+}
+
+export type ComposerHistory = {
+  /** Note that the composer went from `previous` to `current`. */
+  record: (previous: ComposerSnapshot, current: ComposerSnapshot) => void
+  /** The state to go back to, or null. */
+  undo: (current: ComposerSnapshot) => ComposerSnapshot | null
+  /** The state to go forward to, or null. */
+  redo: (current: ComposerSnapshot) => ComposerSnapshot | null
+  /** Forget everything — the draft it described is gone. */
+  reset: () => void
+}
+
+/**
+ * Undo/redo for the composer.
+ *
+ * The composer rewrites its own value — inserting a mention, removing one
+ * whole, swapping an emoji shortcode — and every such write destroys the
+ * textarea's native undo stack, so the browser's Cmd+Z has nothing useful left
+ * to give back. This keeps its own stack of full snapshots (text, caret and
+ * mention anchors together) so a mention comes back anchored rather than as
+ * plain `@name` text.
+ */
+export const useComposerHistory = (): ComposerHistory => {
+  const pastRef = useRef<ComposerSnapshot[]>([])
+  const futureRef = useRef<ComposerSnapshot[]>([])
+  const lastKindRef = useRef<EditKind>("other")
+  const lastAtRef = useRef(0)
+
+  const record = useCallback(
+    (previous: ComposerSnapshot, current: ComposerSnapshot) => {
+      // Editing after an undo abandons the branch that was ahead.
+      futureRef.current = []
+
+      const kind = kindOf(previous.value, current.value)
+      const now = Date.now()
+      const continues =
+        kind !== "other" &&
+        kind === lastKindRef.current &&
+        now - lastAtRef.current <= COALESCE_MS &&
+        previous.mentions === current.mentions &&
+        pastRef.current.length > 0
+
+      lastKindRef.current = kind
+      lastAtRef.current = now
+      if (continues) return
+
+      pastRef.current.push(previous)
+      if (pastRef.current.length > LIMIT) pastRef.current.shift()
+    },
+    []
+  )
+
+  const undo = useCallback((current: ComposerSnapshot) => {
+    const previous = pastRef.current.pop()
+    if (!previous) return null
+    futureRef.current.push(current)
+    // The run is over: the next keystroke starts a fresh step rather than
+    // folding itself into whatever we just restored.
+    lastKindRef.current = "other"
+    return previous
+  }, [])
+
+  const redo = useCallback((current: ComposerSnapshot) => {
+    const next = futureRef.current.pop()
+    if (!next) return null
+    pastRef.current.push(current)
+    lastKindRef.current = "other"
+    return next
+  }, [])
+
+  const reset = useCallback(() => {
+    pastRef.current = []
+    futureRef.current = []
+    lastKindRef.current = "other"
+    lastAtRef.current = 0
+  }, [])
+
+  return { record, undo, redo, reset }
+}

--- a/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
@@ -5,6 +5,7 @@ import { type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatUser } from "../types"
 import { locateMentions } from "../utils/mention-ranges"
+import { diffSpan } from "../utils/text-diff"
 
 /** Sentinel id for the "everyone" (`@here`) option — never a real user id. */
 export const MENTION_EVERYONE_ID = "@everyone"
@@ -60,6 +61,20 @@ export type UseMentionsOptions = {
   cursorPosition: number
   /** Setter for the cursor position — used when removing a mention moves it. */
   setCursorPosition: (position: number) => void
+  /**
+   * Ask the composer to put the textarea caret at `caret` once it has written
+   * `forText`. The composer owns the textarea, so it owns the timing: setting a
+   * selection before React writes the value aims it at the old string and the
+   * write then drops the caret at the end.
+   */
+  requestSelection: (caret: number, forText: string, focus?: boolean) => void
+  /**
+   * Called with the text the hook just wrote when it removed a mention itself.
+   * That write is the tail of the keystroke that caused it, not a new edit —
+   * undo has to put the whole mention back in one step. The text identifies the
+   * write, because a flag would be read a commit too early.
+   */
+  onMentionErased?: (text: string) => void
   /** Ref to the textarea element for reading selection + caret position. */
   textareaRef: React.RefObject<HTMLTextAreaElement | null>
   /**
@@ -101,6 +116,9 @@ export type UseMentionsReturn = {
    * `forText` is the body they belong to; it arrives with them because the
    * composer sets its value in the same commit. */
   seedMentions: (entries: MentionEntry[], forText?: string) => void
+  /** Put back an exact set of anchors for `forText`. Undo/redo carries the
+   * anchors in its snapshot, so it restores rather than re-resolves. */
+  restoreMentions: (anchored: AnchoredMention[], forText: string) => void
   /** Close the popover. */
   close: () => void
   /** Dismiss the current `@` trigger until the caret leaves it. */
@@ -152,19 +170,7 @@ const reanchorMentions = (
   next: string,
   anchored: AnchoredMention[]
 ): { kept: AnchoredMention[]; touched: { start: number; end: number }[] } => {
-  const max = Math.min(prev.length, next.length)
-  let prefix = 0
-  while (prefix < max && prev[prefix] === next[prefix]) prefix++
-  let suffix = 0
-  while (
-    suffix < max - prefix &&
-    prev[prev.length - 1 - suffix] === next[next.length - 1 - suffix]
-  ) {
-    suffix++
-  }
-
-  const prevEnd = prev.length - suffix
-  const nextEnd = next.length - suffix
+  const { start: prefix, prevEnd, nextEnd } = diffSpan(prev, next)
   const delta = next.length - prev.length
 
   // Positions inside the changed span have no image in `next`; clamp a start
@@ -319,6 +325,8 @@ export function useMentions({
   setInputValue,
   cursorPosition,
   setCursorPosition,
+  requestSelection,
+  onMentionErased,
   textareaRef,
   enabled,
   searchMembers,
@@ -335,7 +343,23 @@ export function useMentions({
   // The anchors are read from event handlers and effects that must not depend
   // on them, so state and ref are written together and the ref is the source.
   const mentionsRef = useRef<AnchoredMention[]>(mentions)
+  // Re-anchoring runs on every keystroke and usually produces the same anchors
+  // in a new array. Keeping the old reference when nothing moved saves a state
+  // write per character, and lets callers treat a new identity as real news.
   const commitMentions = useCallback((next: AnchoredMention[]) => {
+    const current = mentionsRef.current
+    const unchanged =
+      current.length === next.length &&
+      current.every((mention, i) => {
+        const candidate = next[i]
+        return (
+          candidate !== undefined &&
+          candidate.id === mention.id &&
+          candidate.name === mention.name &&
+          candidate.start === mention.start
+        )
+      })
+    if (unchanged) return
     mentionsRef.current = next
     setMentions(next)
   }, [])
@@ -495,13 +519,9 @@ export function useMentions({
       emit.onMentionInserted({ isEveryone: candidate.kind === "everyone" })
       close()
 
-      requestAnimationFrame(() => {
-        const textarea = textareaRef.current
-        if (textarea) {
-          textarea.focus()
-          textarea.setSelectionRange(newCursorPos, newCursorPos)
-        }
-      })
+      // Focus too: the candidate may have been clicked, which took focus to
+      // the popover row.
+      requestSelection(newCursorPos, newValue, true)
     },
     [
       inputValue,
@@ -511,6 +531,7 @@ export function useMentions({
       close,
       emit,
       commitMentions,
+      requestSelection,
     ]
   )
 
@@ -608,6 +629,14 @@ export function useMentions({
     [commitMentions]
   )
 
+  const restoreMentions = useCallback(
+    (anchored: AnchoredMention[], forText: string) => {
+      prevValueRef.current = forText
+      commitMentions(anchored)
+    },
+    [commitMentions]
+  )
+
   // Keep the anchors on the text as it changes, and take a mention out whole
   // when an edit lands inside it — a half-typed name is not a mention, and
   // leaving one behind is what silently dropped the id before.
@@ -630,16 +659,19 @@ export function useMentions({
     commitMentions(erased.mentions)
     setInputValue(erased.text)
     setCursorPosition(erased.caret)
-    requestAnimationFrame(() => {
-      textareaRef.current?.setSelectionRange(erased.caret, erased.caret)
-    })
+    // Removing a mention leaves the caret where the mention was, not at the end
+    // of the text — the edit happened here, and the rest of a multi-line draft
+    // is not where the user was looking.
+    requestSelection(erased.caret, erased.text)
+    onMentionErased?.(erased.text)
   }, [
     inputValue,
     cursorPosition,
     setInputValue,
     setCursorPosition,
-    textareaRef,
     commitMentions,
+    requestSelection,
+    onMentionErased,
   ])
 
   const popoverPosition: PopoverPosition = useMemo(() => {
@@ -682,6 +714,7 @@ export function useMentions({
     selectCandidate,
     getMentions,
     seedMentions,
+    restoreMentions,
     close,
     dismissCurrentTrigger,
   }

--- a/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
@@ -4,6 +4,7 @@ import { type AvatarVariant } from "@/components/avatars/F0Avatar"
 
 import { useF0ChatEmit } from "../providers/F0ChatProvider"
 import { type F0ChatUser } from "../types"
+import { locateMentions } from "../utils/mention-ranges"
 
 /** Sentinel id for the "everyone" (`@here`) option — never a real user id. */
 export const MENTION_EVERYONE_ID = "@everyone"
@@ -20,6 +21,24 @@ export type MentionEntry = {
   subtitle?: string
   profileHref?: string
 }
+
+/**
+ * A tracked mention plus where its `@name` sits in the composer text.
+ *
+ * The anchor is what makes a mention a token rather than a substring: it is
+ * maintained across edits instead of being re-derived from the text, so a
+ * mention survives whatever follows it (a comma, the end of the message) and
+ * an edit that lands inside it removes the whole thing rather than silently
+ * dropping the id and leaving a broken name behind.
+ */
+export type AnchoredMention = MentionEntry & {
+  /** Index of the `@` in the composer text. */
+  start: number
+}
+
+/** Index just past the last character of an anchored mention's name. */
+export const mentionEnd = (mention: AnchoredMention): number =>
+  mention.start + mention.name.length + 1
 
 /** A row in the mention popover: a group member, or the "everyone" option. */
 export type MentionCandidate =
@@ -39,6 +58,8 @@ export type UseMentionsOptions = {
   setInputValue: (value: string) => void
   /** Cursor position (selectionStart) in the textarea. */
   cursorPosition: number
+  /** Setter for the cursor position — used when removing a mention moves it. */
+  setCursorPosition: (position: number) => void
   /** Ref to the textarea element for reading selection + caret position. */
   textareaRef: React.RefObject<HTMLTextAreaElement | null>
   /**
@@ -64,8 +85,8 @@ export type UseMentionsReturn = {
   results: MentionCandidate[]
   isLoading: boolean
   selectedIndex: number
-  /** Tracked mentions in the current text (drives overlay highlighting). */
-  mentions: MentionEntry[]
+  /** Tracked mentions, anchored in the current text (drives overlay highlighting). */
+  mentions: AnchoredMention[]
   popoverPosition: PopoverPosition
   /** Ghost-text completion for the selected row, or null. */
   inlineCompletion: string | null
@@ -76,8 +97,10 @@ export type UseMentionsReturn = {
   /** Resolve the mentions/everyone payload to attach when sending. */
   getMentions: () => MentionPayload
   /** Replace the tracked mentions wholesale — used to rehydrate an existing
-   * message's mentions when it's reloaded into the composer for editing. */
-  seedMentions: (entries: MentionEntry[]) => void
+   * message's mentions when it's reloaded into the composer for editing.
+   * `forText` is the body they belong to; it arrives with them because the
+   * composer sets its value in the same commit. */
+  seedMentions: (entries: MentionEntry[], forText?: string) => void
   /** Close the popover. */
   close: () => void
   /** Dismiss the current `@` trigger until the caret leaves it. */
@@ -86,14 +109,13 @@ export type UseMentionsReturn = {
 
 /**
  * Finds the active `@` trigger near the cursor — start index of `@` and the
- * query — or null. Skips `@`s that belong to already-completed mentions so a
- * finished "@Name " doesn't keep re-opening the popover. Cloned verbatim from
- * the AI chat composer.
+ * query — or null. An `@` that starts an anchored mention never re-opens the
+ * popover: that token is already resolved.
  */
 function findAtTrigger(
   text: string,
   cursorPos: number,
-  mentions: MentionEntry[]
+  anchored: AnchoredMention[]
 ): { atIndex: number; query: string } | null {
   const textBeforeCursor = text.slice(0, cursorPos)
   const atIndex = textBeforeCursor.lastIndexOf("@")
@@ -109,22 +131,102 @@ function findAtTrigger(
   const query = text.slice(atIndex + 1, cursorPos)
   if (query.includes("\n")) return null
 
-  for (const mention of mentions) {
-    const afterAt = text.slice(atIndex + 1)
-    const mentionEnd = atIndex + 1 + mention.name.length
-    if (afterAt.startsWith(mention.name) && cursorPos >= mentionEnd) {
-      const charAfterMention = text[mentionEnd]
-      if (
-        charAfterMention === " " ||
-        charAfterMention === "\n" ||
-        charAfterMention === "\t"
-      ) {
-        return null
-      }
-    }
-  }
+  if (anchored.some((mention) => mention.start === atIndex)) return null
 
   return { atIndex, query }
+}
+
+/**
+ * Re-anchor `anchored` after the composer text went from `prev` to `next`, and
+ * report which mentions the edit landed inside.
+ *
+ * The change is read as the single contiguous span between the common prefix
+ * and the common suffix — enough for typing, deletion, paste and the emoji
+ * shortcode swap alike. A mention whose span the change overlaps is *touched*:
+ * its remaining text is reported so the caller can erase it whole. Adjacency
+ * is not overlap, so typing a comma right after a mention (or deleting the
+ * space that followed it) leaves the mention alone.
+ */
+const reanchorMentions = (
+  prev: string,
+  next: string,
+  anchored: AnchoredMention[]
+): { kept: AnchoredMention[]; touched: { start: number; end: number }[] } => {
+  const max = Math.min(prev.length, next.length)
+  let prefix = 0
+  while (prefix < max && prev[prefix] === next[prefix]) prefix++
+  let suffix = 0
+  while (
+    suffix < max - prefix &&
+    prev[prev.length - 1 - suffix] === next[next.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+
+  const prevEnd = prev.length - suffix
+  const nextEnd = next.length - suffix
+  const delta = next.length - prev.length
+
+  // Positions inside the changed span have no image in `next`; clamp a start
+  // down and an end up so an erased range covers the whole disturbed region.
+  const mapStart = (pos: number): number =>
+    pos <= prefix ? pos : pos >= prevEnd ? pos + delta : prefix
+  const mapEnd = (pos: number): number =>
+    pos <= prefix ? pos : pos >= prevEnd ? pos + delta : nextEnd
+
+  const kept: AnchoredMention[] = []
+  const touched: { start: number; end: number }[] = []
+  for (const mention of anchored) {
+    const start = mention.start
+    const end = mentionEnd(mention)
+    if (prefix < end && prevEnd > start) {
+      touched.push({ start: mapStart(start), end: mapEnd(end) })
+    } else {
+      kept.push({ ...mention, start: mapStart(start) })
+    }
+  }
+  return { kept, touched }
+}
+
+/** Cut `spans` out of `text`, sliding the anchors and the caret left to match. */
+const eraseSpans = (
+  text: string,
+  spans: { start: number; end: number }[],
+  anchored: AnchoredMention[],
+  caret: number
+): { text: string; mentions: AnchoredMention[]; caret: number } => {
+  const merged: { start: number; end: number }[] = []
+  for (const span of [...spans].sort((a, b) => a.start - b.start)) {
+    const last = merged[merged.length - 1]
+    if (last && span.start <= last.end) last.end = Math.max(last.end, span.end)
+    else merged.push({ ...span })
+  }
+
+  const removedBefore = (pos: number): number => {
+    let removed = 0
+    for (const span of merged) {
+      if (span.end <= pos) removed += span.end - span.start
+      else if (span.start < pos) removed += pos - span.start
+    }
+    return removed
+  }
+
+  let out = ""
+  let cursor = 0
+  for (const span of merged) {
+    out += text.slice(cursor, span.start)
+    cursor = span.end
+  }
+  out += text.slice(cursor)
+
+  return {
+    text: out,
+    mentions: anchored.map((mention) => ({
+      ...mention,
+      start: mention.start - removedBefore(mention.start),
+    })),
+    caret: caret - removedBefore(caret),
+  }
 }
 
 const MIRROR_PROPERTIES = [
@@ -216,6 +318,7 @@ export function useMentions({
   inputValue,
   setInputValue,
   cursorPosition,
+  setCursorPosition,
   textareaRef,
   enabled,
   searchMembers,
@@ -227,7 +330,20 @@ export function useMentions({
   const [memberResults, setMemberResults] = useState<F0ChatUser[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [mentions, setMentions] = useState<MentionEntry[]>([])
+  const [mentions, setMentions] = useState<AnchoredMention[]>([])
+
+  // The anchors are read from event handlers and effects that must not depend
+  // on them, so state and ref are written together and the ref is the source.
+  const mentionsRef = useRef<AnchoredMention[]>(mentions)
+  const commitMentions = useCallback((next: AnchoredMention[]) => {
+    mentionsRef.current = next
+    setMentions(next)
+  }, [])
+  // The text the anchors are valid for. Every writer to the composer value
+  // goes through the reconciler below, which compares against this.
+  const prevValueRef = useRef(inputValue)
+  const inputValueRef = useRef(inputValue)
+  inputValueRef.current = inputValue
 
   const atIndexRef = useRef<number>(-1)
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -363,10 +479,18 @@ export function useMentions({
               subtitle: candidate.user.subtitle,
               profileHref: candidate.user.profileHref,
             }
-      setMentions((prev) => {
-        const filtered = prev.filter((m) => !(m.id === id && m.name === name))
-        return [...filtered, entry]
-      })
+      // The trigger span [atIndex, cursorPosition) becomes the inserted token,
+      // so anchors past it slide and any the trigger overlapped are gone.
+      const shift = insertedText.length - (cursorPosition - atIndex)
+      const anchored = mentionsRef.current
+        .filter((m) => mentionEnd(m) <= atIndex || m.start >= cursorPosition)
+        .map((m) =>
+          m.start >= cursorPosition ? { ...m, start: m.start + shift } : m
+        )
+      anchored.push({ ...entry, start: atIndex })
+      anchored.sort((a, b) => a.start - b.start)
+      prevValueRef.current = newValue
+      commitMentions(anchored)
 
       emit.onMentionInserted({ isEveryone: candidate.kind === "everyone" })
       close()
@@ -379,7 +503,15 @@ export function useMentions({
         }
       })
     },
-    [inputValue, cursorPosition, setInputValue, textareaRef, close, emit]
+    [
+      inputValue,
+      cursorPosition,
+      setInputValue,
+      textareaRef,
+      close,
+      emit,
+      commitMentions,
+    ]
   )
 
   const handleKeyDown = useCallback(
@@ -433,27 +565,82 @@ export function useMentions({
 
   const getMentions = useCallback((): MentionPayload => {
     const mentionedEveryone = mentions.some((m) => m.id === MENTION_EVERYONE_ID)
-    const users = mentions.filter((m) => m.id !== MENTION_EVERYONE_ID)
-    return { mentions: users, mentionedEveryone }
+    // Anchors are per occurrence; the payload is a set of people, so the same
+    // person mentioned twice is sent once.
+    const users = new Map<string, MentionEntry>()
+    for (const { start: _start, ...entry } of mentions) {
+      if (entry.id === MENTION_EVERYONE_ID) continue
+      if (!users.has(entry.id)) users.set(entry.id, entry)
+    }
+    return { mentions: [...users.values()], mentionedEveryone }
   }, [mentions])
 
-  const seedMentions = useCallback((entries: MentionEntry[]) => {
-    setMentions(entries)
-  }, [])
+  const seedMentions = useCallback(
+    (entries: MentionEntry[], forText?: string) => {
+      const text = forText ?? inputValueRef.current
+      prevValueRef.current = text
 
-  // Drop mentions the user has edited away (deleted, or backspaced into,
-  // removing the trailing separator) so the trigger can fire again.
+      // A saved message carries a set of people, not positions, so the text is
+      // what says where they are. Occurrences of one `@name` are handed out to
+      // the entries sharing that name in order — two people with the same
+      // display name get one each, while one person named twice keeps both.
+      const byName = new Map<string, MentionEntry[]>()
+      for (const entry of entries) {
+        const group = byName.get(entry.name)
+        if (group) group.push(entry)
+        else byName.set(entry.name, [entry])
+      }
+
+      const taken = new Map<string, number>()
+      commitMentions(
+        locateMentions(
+          text,
+          [...byName.keys()].map((name) => ({ name }))
+        ).flatMap(({ entry: { name }, start }) => {
+          const group = byName.get(name) ?? []
+          const index = taken.get(name) ?? 0
+          taken.set(name, index + 1)
+          const picked = group[Math.min(index, group.length - 1)]
+          return picked ? [{ ...picked, start }] : []
+        })
+      )
+    },
+    [commitMentions]
+  )
+
+  // Keep the anchors on the text as it changes, and take a mention out whole
+  // when an edit lands inside it — a half-typed name is not a mention, and
+  // leaving one behind is what silently dropped the id before.
   useEffect(() => {
-    setMentions((prev) =>
-      prev.filter((m) => {
-        const pattern = `@${m.name}`
-        const idx = inputValue.indexOf(pattern)
-        if (idx === -1) return false
-        const charAfter = inputValue[idx + pattern.length]
-        return charAfter === " " || charAfter === "\n" || charAfter === "\t"
-      })
-    )
-  }, [inputValue])
+    const prev = prevValueRef.current
+    if (prev === inputValue) return
+    prevValueRef.current = inputValue
+
+    const anchored = mentionsRef.current
+    if (anchored.length === 0) return
+
+    const { kept, touched } = reanchorMentions(prev, inputValue, anchored)
+    if (touched.length === 0) {
+      commitMentions(kept)
+      return
+    }
+
+    const erased = eraseSpans(inputValue, touched, kept, cursorPosition)
+    prevValueRef.current = erased.text
+    commitMentions(erased.mentions)
+    setInputValue(erased.text)
+    setCursorPosition(erased.caret)
+    requestAnimationFrame(() => {
+      textareaRef.current?.setSelectionRange(erased.caret, erased.caret)
+    })
+  }, [
+    inputValue,
+    cursorPosition,
+    setInputValue,
+    setCursorPosition,
+    textareaRef,
+    commitMentions,
+  ])
 
   const popoverPosition: PopoverPosition = useMemo(() => {
     if (!isOpen || atIndexRef.current === -1) return null

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
@@ -29,6 +29,26 @@ describe("renderBodyWithMentions", () => {
     expect(chip.className).toContain("text-f1-foreground-secondary")
   })
 
+  // The composer's overlay has to paint a mention identically, and it is the
+  // side that cannot carry a weight: a `<textarea>` lays its whole run out at
+  // one weight, so a heavier mention there pushes the caret off the glyphs
+  // (#5274 measured 1.250px worst delta and 44/48 indices off, versus 0.023px
+  // without it). Parity is therefore met here, by this side staying unweighted.
+  it("gives the chip no font-weight, so the composer can match it exactly", () => {
+    const tokens: MentionToken[] = [
+      {
+        name: "Ana",
+        isSelf: false,
+        isEveryone: false,
+        user: { id: "1", name: "Ana" },
+      },
+    ]
+    zeroRender(<div>{renderBodyWithMentions("hi @Ana!", tokens)}</div>)
+    expect(screen.getByText("@Ana").className).not.toMatch(
+      /\bfont-(thin|extralight|light|medium|semibold|bold|extrabold|black)\b/
+    )
+  })
+
   it("renders a self / everyone mention with accessible neutral emphasis", () => {
     const tokens: MentionToken[] = [
       { name: "here", isSelf: false, isEveryone: true },

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -1,0 +1,47 @@
+/** A `@name` occurrence located in a body of text. */
+export type LocatedMention<T> = {
+  entry: T
+  /** Index of the `@`. */
+  start: number
+  /** Index just past the last character of the name. */
+  end: number
+}
+
+/**
+ * Locate every `@name` occurrence of the given entries in `text`.
+ *
+ * Longest names first so `@Ana María` wins over `@Ana`, then overlaps are
+ * dropped left to right. Entry order breaks ties, which is what makes two
+ * different people who share a display name land on one occurrence each.
+ *
+ * The single place `@name` text is matched: the bubble, the composer overlay
+ * and the composer's own anchoring all resolve through here, so they cannot
+ * disagree about which text belongs to which mention.
+ */
+export const locateMentions = <T extends { name: string }>(
+  text: string,
+  entries: readonly T[]
+): LocatedMention<T>[] => {
+  const found: LocatedMention<T>[] = []
+  const byLength = [...entries].sort((a, b) => b.name.length - a.name.length)
+  for (const entry of byLength) {
+    const pattern = `@${entry.name}`
+    let from = 0
+    while (true) {
+      const idx = text.indexOf(pattern, from)
+      if (idx === -1) break
+      found.push({ entry, start: idx, end: idx + pattern.length })
+      from = idx + pattern.length
+    }
+  }
+  found.sort((a, b) => a.start - b.start)
+
+  const clean: LocatedMention<T>[] = []
+  let lastEnd = 0
+  for (const range of found) {
+    if (range.start < lastEnd) continue
+    clean.push(range)
+    lastEnd = range.end
+  }
+  return clean
+}

--- a/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils"
 
 import { ChatUserHoverCard } from "../components/ChatUserHoverCard"
 import { type F0ChatLinkPreview, type F0ChatUser } from "../types"
+import { locateMentions } from "./mention-ranges"
 import { sanitizeDisplayText } from "./sanitize-text"
 
 /** URLs in a body render as clickable links (matches the mobile bubble). */
@@ -104,29 +105,7 @@ export const renderBodyWithMentions = (
   const body = sanitizeDisplayText(rawBody)
   if (tokens.length === 0) return renderBodyWithLinks(body, previews)
 
-  // Collect every `@name` occurrence (longest names first so "@Ana María" wins
-  // over "@Ana"), then drop overlaps left-to-right.
-  const ranges: { start: number; end: number; token: MentionToken }[] = []
-  const byLength = [...tokens].sort((a, b) => b.name.length - a.name.length)
-  for (const token of byLength) {
-    const pattern = `@${token.name}`
-    let from = 0
-    while (true) {
-      const idx = body.indexOf(pattern, from)
-      if (idx === -1) break
-      ranges.push({ start: idx, end: idx + pattern.length, token })
-      from = idx + pattern.length
-    }
-  }
-  ranges.sort((a, b) => a.start - b.start)
-
-  const clean: typeof ranges = []
-  let lastEnd = 0
-  for (const range of ranges) {
-    if (range.start < lastEnd) continue
-    clean.push(range)
-    lastEnd = range.end
-  }
+  const clean = locateMentions(body, tokens)
   if (clean.length === 0) return renderBodyWithLinks(body, previews)
 
   const nodes: ReactNode[] = []
@@ -139,7 +118,7 @@ export const renderBodyWithMentions = (
         </Fragment>
       )
     }
-    const { token } = range
+    const token = range.entry
     const chip = (
       <span
         className={cn(

--- a/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
@@ -76,10 +76,10 @@ export const renderBodyWithLinks = (
   })
 }
 
-/** A `@name` token to highlight in a message body. Slack-style colours: a
- * mention of someone else reads in info colours; a mention of you (`isSelf`) or
- * the whole group (`isEveryone`, `@here`) reads in warning/amber. `user`, when
- * present (any person mention), opens the same profile hover card as the avatar. */
+/** A `@name` token to highlight in a message body. Every mention reads the
+ * same: secondary foreground, no background, whoever it names. `user`, when
+ * present (any person mention), opens the same profile hover card as the
+ * avatar. */
 export type MentionToken = {
   name: string
   isSelf: boolean
@@ -89,10 +89,13 @@ export type MentionToken = {
 
 /**
  * Render a body with its `@name` mentions as chips and everything else through
- * {@link renderBodyWithLinks}. Slack-style: a mention of someone else is an
- * info pill (and opens their profile hover card, like the sender avatar); a
- * mention of you or `@here` is an amber/warning pill that stands out. Falls back to
- * {@link renderBodyWithLinks} when there are no mentions.
+ * {@link renderBodyWithLinks}. A person mention also opens their profile hover
+ * card, like the sender avatar. Falls back to {@link renderBodyWithLinks} when
+ * there are no mentions.
+ *
+ * The composer's highlight overlay paints the same colour, so a mention looks
+ * the same while being typed and once sent — see `hooks/highlight-utils.ts`,
+ * which cannot copy the weight here for caret reasons.
  *
  * Pure (no hooks): callers memoize the result per message.
  */

--- a/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
@@ -93,9 +93,12 @@ export type MentionToken = {
  * card, like the sender avatar. Falls back to {@link renderBodyWithLinks} when
  * there are no mentions.
  *
- * The composer's highlight overlay paints the same colour, so a mention looks
- * the same while being typed and once sent — see `hooks/highlight-utils.ts`,
- * which cannot copy the weight here for caret reasons.
+ * Carries no font-weight, deliberately, so the composer's highlight overlay can
+ * match it exactly and a mention looks the same while being typed and once
+ * sent. The overlay is the side that cannot have a weight — a `<textarea>` lays
+ * its whole run out at one weight, so a heavier mention there moves the caret
+ * off the glyphs (measured in #5274: 1.250px worst delta, 44/48 indices off,
+ * versus 0.023px without). Parity therefore has to be met here.
  *
  * Pure (no hooks): callers memoize the result per message.
  */
@@ -124,9 +127,7 @@ export const renderBodyWithMentions = (
     const token = range.entry
     const chip = (
       <span
-        className={cn(
-          "font-medium text-f1-foreground-secondary hover:text-f1-foreground"
-        )}
+        className={cn("text-f1-foreground-secondary hover:text-f1-foreground")}
       >
         {body.slice(range.start, range.end)}
       </span>

--- a/packages/react/src/sds/chat/F0Chat/utils/text-diff.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/text-diff.ts
@@ -1,0 +1,36 @@
+/** The single contiguous span in which two strings differ. */
+export type TextEdit = {
+  /** First index that differs. */
+  start: number
+  /** End of the changed span in the old string. */
+  prevEnd: number
+  /** End of the changed span in the new string. */
+  nextEnd: number
+}
+
+/**
+ * Read a text change as one contiguous span, by peeling the common prefix and
+ * suffix. Enough for typing, deletion, paste and a programmatic token swap
+ * alike — which is all the composer ever does to its own value in one step.
+ *
+ * Ambiguous when the same characters repeat around the edit (deleting one of
+ * two adjacent spaces could be either); the span it picks is still the right
+ * length, so callers that only care about extent or overlap are unaffected.
+ */
+export const diffSpan = (prev: string, next: string): TextEdit => {
+  const max = Math.min(prev.length, next.length)
+  let start = 0
+  while (start < max && prev[start] === next[start]) start++
+  let suffix = 0
+  while (
+    suffix < max - start &&
+    prev[prev.length - 1 - suffix] === next[next.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+  return {
+    start,
+    prevEnd: prev.length - suffix,
+    nextEnd: next.length - suffix,
+  }
+}


### PR DESCRIPTION
## Description

Editing a message that had a mention lost it. A tracked mention was re-derived from the composer text on every change and survived only while `@Name` was followed by a space, newline or tab, so reopening a message for editing dropped it before the user touched anything whenever the body did not end that way — a comma after the name was enough. Saving then sent no mention id, so the chip and the profile hover card disappeared and the person stopped being mentioned, with no error. Mentions are now anchored and maintained across edits. Escape — which only ever backed out of an edit — also backs out of a reply, and the composer has real undo/redo, which it needs because every time it rewrites its own value it clears the textarea's native undo stack.

## Type of change

- [x] Bug fix
- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots (if applicable)


https://github.com/user-attachments/assets/f6b79369-1177-43c5-b442-f8afc9fc7c9c



## How to use

Nothing to wire up — every change is inside `F0Chat`'s own composer and applies wherever it is already mounted. No new props, and `MentionEntry` and the send/edit payloads are unchanged, so a host that consumes mentions needs no update.

**Mentions behave as one token.** Type `@`, pick from the popover, and the inserted `@Name` is anchored from then on rather than re-matched by name:

| you do | you get |
| --- | --- |
| type a comma, a period, or nothing after the name | the mention survives — what follows it no longer decides whether it exists |
| edit *inside* the name | the whole mention is removed in that one keystroke, and the caret stays where it was |
| edit anywhere else | the mention is untouched |
| mention two people who share a display name | each keeps their own occurrence |
| reopen the message with ↑ or **Edit** and save | the mention is still there |
| look at a mention before and after sending | it renders identically — same colour, no background, no weight |

**Keyboard in the composer:**

| key | what it does |
| --- | --- |
| `Cmd`/`Ctrl` + `Z` | undo — a typing burst at a time, a word at a time, and a removed mention in one step (it comes back anchored, not as plain text) |
| `Cmd`/`Ctrl` + `Shift` + `Z` | redo |
| `Cmd`/`Ctrl` + `Y` | redo |
| `Esc` | undo one thing: the edit or reply chip if one is open, else the draft text. With nothing pending it is left alone, so a dialog hosting the chat still closes |
| `↑` on an empty composer | reopen your last message for editing (unchanged) |
| `Enter` | send · `Shift`+`Enter` newline (unchanged) |

Undo/redo covers the text and its mentions. Attachments are deliberately outside it — they cost an upload, so a keystroke should not be able to drop or resurrect one.

To try it: `pnpm storybook dev` in `packages/react`, then **Domain specific / Communications / F0Chat → Group with mentions**. The **Composer hotkeys** story drives ↑, quote and `Esc` as a play function.

## Implementation details

- fix: anchor each tracked mention to its position instead of re-matching `@name` on every keystroke, so what follows a mention no longer decides whether it exists

  <details>
  <summary>Why?</summary>

  `MentionEntry` carried `{id, name}` and no position, and an effect re-validated every entry against the text on each change, keeping it only if the character after the name was a space, newline or tab. That made three separate failures out of one line: a mention ending the message died on `value.trim()`, a mention followed by punctuation died immediately, and editing inside a name dropped the id while leaving the broken name in the body.

  The anchor is internal to the composer — the public `MentionEntry` and the sent payload are unchanged, still a set of people with no offsets.
  </details>

- fix: remove a mention whole when an edit lands inside it, rather than dropping its id and leaving the text behind

  <details>
  <summary>Why?</summary>

  A mention reads as a chip, so it should behave as one token. Backspacing inside `@Ana García` now takes the whole mention out in that one keystroke instead of silently producing an unlinked `@Ana Garía`. Adjacency is deliberately not overlap: typing a comma straight after a mention, or deleting the space that followed it, leaves the mention alone.
  </details>

- refactor: match `@name` text in one place for the bubble, the composer overlay and the composer's anchors

  <details>
  <summary>Why?</summary>

  Three copies of the same matching existed and disagreed. Only the bubble's ordered by longest name and walked every occurrence; the composer's took the first `indexOf` hit, so two people sharing a display name validated against each other's text. They now share `locateMentions`, and each of those two people keeps their own occurrence.
  </details>

- feat: Escape backs out of a reply as well as an edit, and clears the draft once no chip is left

  <details>
  <summary>Why?</summary>

  A pending reply quote had a dismiss path but no key bound to it, and nothing cleared the composer from the keyboard. Escape now undoes one thing per press — the chip if one is open, else the text.

  This started as a timed double-tap and that was wrong: from a reply chip it cost three presses (chip, arm, clear) and a fourth whenever the rhythm slipped past the window, with nothing on screen showing that a press had armed anything. One press per thing needs no timer and no hidden state, and it is safe here for a reason that would not have held on its own — `Cmd+Z` puts a cleared draft straight back, so an unwanted clear costs one keystroke rather than a message.

  Precedence is unchanged where it existed: the emoji autocomplete and the mention popover still claim Escape first, and with nothing pending the key is left alone so a dialog or panel hosting the chat can still be closed from a focused composer. Attachments are never cleared by it.
  </details>

- fix: leave the caret where a removed mention was, instead of at the end of the text

  <details>
  <summary>Why?</summary>

  The caret was restored in a `requestAnimationFrame`, which can run before React commits the new value — the selection then lands on the old string and React's own value write drops the caret at the end. In a multi-line draft that moves the caret to a different line than the one being edited. The textarea's own component now owns the caret and sets it in a layout effect, after the write and before paint.
  </details>

- feat: Cmd/Ctrl+Z undo, Cmd/Ctrl+Shift+Z and Cmd/Ctrl+Y redo, with a mention as one atomic step

  <details>
  <summary>Why?</summary>

  The composer rewrites its own value — inserting a mention, removing one whole, swapping an emoji shortcode — and every such write clears the textarea's native undo stack, so the browser's Cmd+Z had nothing useful left to give back. The composer now keeps its own stack of snapshots carrying text, caret and mention anchors together, so an undone mention comes back anchored rather than as plain `@name` text.

  Keystrokes of the same kind collapse into one step while they stay within 600 ms, and whitespace always ends a step, so undo walks back a word at a time. Removing a mention is one step rather than two — the half-typed name the re-anchoring passes through was never a state the user saw. Sending, discarding or opening an edit drops the stack, so undo cannot resurrect a draft into a composer that has moved on.
  </details>

- fix: render a mention identically in the composer and the bubble

  <details>
  <summary>Why the composer is not the side that changed</summary>

  The composer painted a mention as an info-blue pill (amber for you or `@here`) while the bubble painted plain secondary grey, so the same `@name` changed appearance on send. Both sides' comments claimed they matched; neither did.

  Parity is met by taking `font-medium` **off the bubble**, because the composer is the side that physically cannot carry a weight. #5274 established that: the composer renders its text twice — a transparent `<textarea>` supplies the caret, an overlay paints the glyphs — and a `<textarea>` lays its entire run out at one weight, with no per-range option. A heavier mention in the overlay paints wider than the glyphs the caret is positioned from: **1.250px worst delta, 44 of 48 indices off**, against **0.023px** without it. Matching the bubble by re-adding the weight would have undone that fix.

  Both sides are now `text-f1-foreground-secondary`, no background, no weight, and each has a test forbidding a weight. Only the composer had that guard before, which is how the two drifted unnoticed. **A mention in a sent message is no longer bold** — the deliberate cost of the parity.

  Also drops the tone machinery this was the only consumer of: `MentionTone`, `toneOf`, the segment's `tone` field, and the `currentUserId` the composer only threaded through to compute it.
  </details>

- perf: stop re-anchoring from allocating a new array when no mention moved, saving a state write per keystroke

- test: five failing-first cases for the mention bug, a caret regression test that fails on the previous rAF timing, six for undo/redo, and the Escape cases — plus the two new Escape steps in the `Composer hotkeys` story

## Notes for the reviewer

- `kits/ai/F0AiChatTextArea/` holds an older copy of this composer's mention code with the same anchoring weakness. It is untouched here — worth a follow-up, but it is a different component with its own behaviour. Its chip carries no weight either, so #5274 stays intact on both twins.
- The undo coalescing window is measured off `Date.now()`, not a timer, so there is nothing to clean up and nothing to leak. Escape carries no timing at all.
- Undo/redo is deliberately text + mentions only. Attachments are not in a snapshot: they cost an upload, and undoing one would mean either re-uploading or resurrecting a released blob URL.
