### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.86.2",
+  "packages/react": "6.86.3",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.86.3](https://github.com/factorialco/f0/compare/f0-react-v6.86.2...f0-react-v6.86.3) (2026-09-07)
+
+
+### Bug Fixes
+
+* **F0RichTextDisplay:** prevent props spread bypassing sanitizer ([#5389](https://github.com/factorialco/f0/issues/5389)) ([bd8b248](https://github.com/factorialco/f0/commit/bd8b248ef3129e7fb5b28869b71ec7798bf4716c))
+
 ## [6.86.2](https://github.com/factorialco/f0/compare/f0-react-v6.86.1...f0-react-v6.86.2) (2026-09-04)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.86.2",
+  "version": "6.86.3",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.86.3</summary>

## [6.86.3](https://github.com/factorialco/f0/compare/f0-react-v6.86.2...f0-react-v6.86.3) (2026-09-07)


### Bug Fixes

* **F0RichTextDisplay:** prevent props spread bypassing sanitizer ([#5389](https://github.com/factorialco/f0/issues/5389)) ([bd8b248](https://github.com/factorialco/f0/commit/bd8b248ef3129e7fb5b28869b71ec7798bf4716c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).