### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.86.3",
+  "packages/react": "6.86.4",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.86.4](https://github.com/factorialco/f0/compare/f0-react-v6.86.3...f0-react-v6.86.4) (2026-09-07)
+
+
+### Bug Fixes
+
+* **NewHomeLayout:** keep widgets mounted when the layout stacks ([#5402](https://github.com/factorialco/f0/issues/5402)) ([530eddc](https://github.com/factorialco/f0/commit/530eddc813e71b3e16d59fd1c1627c3edfb279d8))
+
 ## [6.86.3](https://github.com/factorialco/f0/compare/f0-react-v6.86.2...f0-react-v6.86.3) (2026-09-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.86.3",
+  "version": "6.86.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.86.4</summary>

## [6.86.4](https://github.com/factorialco/f0/compare/f0-react-v6.86.3...f0-react-v6.86.4) (2026-09-07)


### Bug Fixes

* **NewHomeLayout:** keep widgets mounted when the layout stacks ([#5402](https://github.com/factorialco/f0/issues/5402)) ([530eddc](https://github.com/factorialco/f0/commit/530eddc813e71b3e16d59fd1c1627c3edfb279d8))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).