### PR TITLE
feat(SurveyFormBuilder): freeze a question's wording without locking the question

### DIFF
--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/SurveyFormBuilder.blockedQuestions.test.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/SurveyFormBuilder.blockedQuestions.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
-import { SurveyFormBuilderElement } from "../../types"
+import { LockedFields, SurveyFormBuilderElement } from "../../types"
 import { SurveyFormBuilder } from "../index"
 
 // --- Test fixtures ---
@@ -10,7 +10,11 @@ import { SurveyFormBuilder } from "../index"
 const makeQuestion = (
   id: string,
   title: string,
-  opts: { description?: string } = {}
+  opts: {
+    description?: string
+    locked?: boolean
+    lockedFields?: LockedFields
+  } = {}
 ): SurveyFormBuilderElement => ({
   type: "question",
   question: {
@@ -18,6 +22,8 @@ const makeQuestion = (
     title,
     type: "text" as const,
     ...(opts.description !== undefined && { description: opts.description }),
+    ...(opts.locked !== undefined && { locked: opts.locked }),
+    ...(opts.lockedFields !== undefined && { lockedFields: opts.lockedFields }),
   },
 })
 
@@ -176,5 +182,82 @@ describe("SurveyFormBuilder — blocked questions", () => {
       />
     )
     expect(screen.queryByRole("button", { name: "Locked" })).toBeNull()
+  })
+
+  // --- Partially blocked questions (`lockedFields`) ---
+
+  it("freezes the wording but keeps the actions menu on a partially locked question", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[
+          makeQuestion("q1", "Frozen title", {
+            description: "Frozen description",
+            lockedFields: ["title", "description"],
+          }),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue("Frozen title")).toBeDisabled()
+    expect(screen.getByDisplayValue("Frozen description")).toBeDisabled()
+
+    // The point of the prop: everything the menu offers — required, duplicate,
+    // delete — stays available, so this is not `locked` under another name.
+    expect(screen.getByRole("button", { name: "Actions" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Locked" })).toBeNull()
+  })
+
+  it("freezes only the fields named in lockedFields", () => {
+    const { rerender } = render(
+      <SurveyFormBuilder
+        elements={[
+          makeQuestion("q1", "A title", {
+            description: "A description",
+            lockedFields: ["title"],
+          }),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue("A title")).toBeDisabled()
+    expect(screen.getByDisplayValue("A description")).not.toBeDisabled()
+
+    rerender(
+      <SurveyFormBuilder
+        elements={[
+          makeQuestion("q1", "A title", {
+            description: "A description",
+            lockedFields: ["description"],
+          }),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByDisplayValue("A title")).not.toBeDisabled()
+    expect(screen.getByDisplayValue("A description")).toBeDisabled()
+  })
+
+  it("lets locked win over lockedFields", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[
+          makeQuestion("q1", "Blocked title", {
+            description: "Blocked description",
+            locked: true,
+            lockedFields: ["title"],
+          }),
+        ]}
+        onChange={vi.fn()}
+      />
+    )
+
+    // The stronger form still freezes the description it does not name, and
+    // still takes the actions menu away.
+    expect(screen.getByDisplayValue("Blocked description")).toBeDisabled()
+    expect(screen.getByRole("button", { name: "Locked" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Actions" })).toBeNull()
   })
 })

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.stories.tsx
@@ -38,3 +38,21 @@ export const Default: Story = {
     description: "Optional description",
   },
 }
+
+/**
+ * The wording is frozen, everything else is not: the actions menu stays, so the
+ * question can still be made optional, duplicated or removed. Contrast `locked`,
+ * which freezes the question outright and replaces the menu with the lock.
+ */
+export const WordingLocked: Story = {
+  args: {
+    id: "question-2",
+    title: "Due date",
+    description: "Set the deadline for this purchase.",
+    lockedFields: ["title", "description"],
+    lockedNote: {
+      description:
+        "A request can't be created with a due date already in the past, so this question is set up to ask for one.",
+    },
+  },
+}

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -33,6 +33,32 @@ const TEXT_AREA_STYLE: object = {
   fieldSizing: "content",
 }
 
+/**
+ * Wraps a field that `lockedFields` has frozen. Such a field has no affordance
+ * of its own — no lock, since that icon means the whole card is frozen — so the
+ * notice hangs off this wrapper, which stays pointer-interactive even though the
+ * textarea inside is disabled and fires no hover events.
+ */
+const FrozenFieldNotice = ({
+  notice,
+  className,
+  children,
+}: {
+  notice: { description: string } | null
+  className?: string
+  children: React.ReactNode
+}) => {
+  const content = <div className={className}>{children}</div>
+
+  if (!notice) return content
+
+  return (
+    <Tooltip instant {...notice}>
+      {content}
+    </Tooltip>
+  )
+}
+
 export const BaseQuestion = ({
   id,
   title,
@@ -42,6 +68,7 @@ export const BaseQuestion = ({
   type: questionType,
   hiddenActions,
   locked: ownLocked,
+  lockedFields,
   lockedNote,
 }: BaseQuestionProps) => {
   const {
@@ -61,6 +88,12 @@ export const BaseQuestion = ({
   // A question is locked either on its own (`locked` prop) or by living inside a
   // locked section.
   const locked = !!containingSection?.locked || !!ownLocked
+
+  // `lockedFields` freezes the wording alone. A fully locked question already
+  // freezes everything, so it subsumes them.
+  const titleLocked = locked || !!lockedFields?.includes("title")
+  const descriptionLocked = locked || !!lockedFields?.includes("description")
+  const partiallyLocked = !locked && (titleLocked || descriptionLocked)
 
   const isWithinSection = !!containingSection
 
@@ -140,20 +173,21 @@ export const BaseQuestion = ({
     }
   }, [])
 
-  const inputDisabled = disabled || locked || answering
-
-  const showCursorNotAllowed = !answering && inputDisabled
+  const titleDisabled = disabled || titleLocked || answering
+  const descriptionDisabled = disabled || descriptionLocked || answering
 
   // A read-only question (locked/disabled) with no description has nothing to
   // edit, so hide the input rather than show an editable-looking placeholder.
   // Editable questions always render it so authors can add one.
-  const showDescription = !inputDisabled || !!description
+  const showDescription = !descriptionDisabled || !!description
 
   // Blocked question: an instant, title-less tooltip shown on the lock icon. It
   // prefers the question's own `lockedNote`, falls back to the parent section's
   // `lockedNote`, and finally to a default so a locked question always says
   // something.
-  const lockTooltipProps: { description: string } | null = !locked
+  const lockTooltipProps: { description: string } | null = !(
+    locked || partiallyLocked
+  )
     ? null
     : {
         description:
@@ -181,7 +215,12 @@ export const BaseQuestion = ({
     >
       <div className="flex flex-col gap-0.5">
         <div className="flex flex-row gap-2">
-          <div className="relative w-full">
+          <FrozenFieldNotice
+            className="relative w-full"
+            // Only for a partial lock: a fully locked question already carries
+            // its notice on the lock icon.
+            notice={partiallyLocked && titleLocked ? lockTooltipProps : null}
+          >
             {answering ? (
               <div className="w-full whitespace-pre-wrap break-words px-2 py-1 text-lg font-semibold text-f1-foreground">
                 {title || titlePlaceholder}
@@ -197,10 +236,10 @@ export const BaseQuestion = ({
                   aria-label={t("surveyFormBuilder.labels.title")}
                   placeholder={titlePlaceholder}
                   onChange={handleChangeTitle}
-                  disabled={inputDisabled}
+                  disabled={titleDisabled}
                   className={cn(
                     "w-full resize-none px-2 py-1 text-lg font-semibold text-f1-foreground placeholder:text-f1-foreground-tertiary [&::-webkit-search-cancel-button]:hidden",
-                    showCursorNotAllowed && "cursor-not-allowed"
+                    !answering && titleDisabled && "!cursor-not-allowed"
                   )}
                   style={TEXT_AREA_STYLE}
                 />
@@ -220,30 +259,16 @@ export const BaseQuestion = ({
                 </div>
               </>
             )}
-          </div>
-          {!disabled && !answering && !locked && (
-            <div
-              className={cn(
-                "opacity-0 group-hover/question:opacity-100",
-                actionsDropdownOpen && "opacity-100"
-              )}
-            >
-              <ActionsMenu
-                open={actionsDropdownOpen}
-                setOpen={setActionsDropdownOpen}
-                questionId={id}
-                questionType={questionType}
-                canDeleteQuestion={
-                  !isWithinSection || !isSingleQuestionInSection
-                }
-                hiddenActions={hiddenActions}
-              />
-            </div>
-          )}
+          </FrozenFieldNotice>
           {!answering && locked && (
             // Blocked question: a static lock sits where the actions "⋯" menu
             // would be, signalling the card is predefined and can't be edited.
             // Hovering just the lock (not the whole card) reveals why.
+            //
+            // A partially locked question gets no lock of its own: the icon
+            // reads as "this card is frozen", which is exactly what it is not,
+            // and it would sit next to a menu that still offers delete and
+            // duplicate. Its notice hangs off the frozen field instead.
             <div>
               {lockTooltipProps ? (
                 <Tooltip instant {...lockTooltipProps}>
@@ -277,6 +302,25 @@ export const BaseQuestion = ({
               )}
             </div>
           )}
+          {!disabled && !answering && !locked && (
+            <div
+              className={cn(
+                "opacity-0 group-hover/question:opacity-100",
+                actionsDropdownOpen && "opacity-100"
+              )}
+            >
+              <ActionsMenu
+                open={actionsDropdownOpen}
+                setOpen={setActionsDropdownOpen}
+                questionId={id}
+                questionType={questionType}
+                canDeleteQuestion={
+                  !isWithinSection || !isSingleQuestionInSection
+                }
+                hiddenActions={hiddenActions}
+              />
+            </div>
+          )}
         </div>
         {answering ? (
           description ? (
@@ -285,18 +329,24 @@ export const BaseQuestion = ({
             </p>
           ) : null
         ) : showDescription ? (
-          <textarea
-            value={description}
-            aria-label={t("surveyFormBuilder.labels.description")}
-            placeholder={descriptionPlaceholder}
-            onChange={handleChangeDescription}
-            disabled={inputDisabled}
-            className={cn(
-              "w-full resize-none px-2 text-f1-foreground-secondary placeholder:text-f1-foreground-tertiary disabled:text-f1-foreground-secondary [&::-webkit-search-cancel-button]:hidden",
-              showCursorNotAllowed && "cursor-not-allowed"
-            )}
-            style={TEXT_AREA_STYLE}
-          />
+          <FrozenFieldNotice
+            notice={
+              partiallyLocked && descriptionLocked ? lockTooltipProps : null
+            }
+          >
+            <textarea
+              value={description}
+              aria-label={t("surveyFormBuilder.labels.description")}
+              placeholder={descriptionPlaceholder}
+              onChange={handleChangeDescription}
+              disabled={descriptionDisabled}
+              className={cn(
+                "w-full resize-none px-2 text-f1-foreground-secondary placeholder:text-f1-foreground-tertiary disabled:text-f1-foreground-secondary [&::-webkit-search-cancel-button]:hidden",
+                !answering && descriptionDisabled && "!cursor-not-allowed"
+              )}
+              style={TEXT_AREA_STYLE}
+            />
+          </FrozenFieldNotice>
         ) : null}
       </div>
       {children}

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/types.ts
@@ -1,6 +1,7 @@
 import {
   HiddenAction,
   HiddenActions,
+  LockedFields,
   LockedQuestionNotice,
   LockedSectionNotice,
   QuestionType,
@@ -9,6 +10,7 @@ import {
 export type {
   HiddenAction,
   HiddenActions,
+  LockedFields,
   LockedQuestionNotice,
   LockedSectionNotice,
 }
@@ -27,10 +29,24 @@ export type BaseQuestionProps = {
    */
   locked?: boolean
   /**
+   * Freezes only the named fields, leaving the rest of the question editable —
+   * the actions menu included, so it can still be made optional, duplicated or
+   * removed. Use it when the wording is what the consumer depends on: a
+   * question whose answer feeds a validated field stops meaning the same thing
+   * once it is renamed, while deleting it is a legitimate choice.
+   *
+   * `locked` is the stronger form and wins: a locked question (or one inside a
+   * locked section) freezes everything regardless of this.
+   */
+  lockedFields?: LockedFields
+  /**
    * Optional notice shown in the lock tooltip when the question is locked. Use
    * it to say what this specific question is — it takes precedence over the
    * parent section's `LockedSectionNotice` and over the default question notice
    * from the i18n provider.
+   *
+   * Also used by `lockedFields`, where saying which part is frozen and why is
+   * the only cue the author gets.
    */
   lockedNote?: LockedQuestionNotice
 }

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
@@ -1,7 +1,7 @@
-import type { UseFileUpload } from "@/patterns/F0Form/fields/file/types"
 import type { IconType } from "@/components/F0Icon/F0Icon"
 import type { F0SelectItemObject } from "@/components/F0Select/types"
 import type { DataSourceDefinition, RecordType } from "@/hooks/datasource"
+import type { UseFileUpload } from "@/patterns/F0Form/fields/file/types"
 
 import type { CheckboxQuestionProps } from "./QuestionTypes/CheckboxQuestion"
 import type { DateQuestionProps } from "./QuestionTypes/DateQuestion"
@@ -49,6 +49,13 @@ export type HiddenAction =
   | "delete"
 
 export type HiddenActions = ReadonlyArray<HiddenAction>
+
+/**
+ * The parts of a question that `lockedFields` can freeze on their own, without
+ * locking the question outright. Both are the question's wording — what it asks
+ * — as opposed to the answer it collects.
+ */
+export type LockedFields = ReadonlyArray<"title" | "description">
 
 /**
  * Explanation surfaced in a locked item's lock tooltip (authoring view only —


### PR DESCRIPTION
## Description

Adds `lockedFields` to `SurveyFormBuilder`'s questions: freeze a question's **wording** (title, description) while leaving everything else editable — the actions menu included, so the question can still be made optional, duplicated or removed.

Today `locked` is the only tool for this and it is all or nothing. It disables the title and the description **and** it replaces the actions menu with a lock, which is right for a question the consumer owns outright and wrong for one whose wording it merely depends on.

### Why we need it

Procurement's purchase request form is **generated, then handed to the admin to edit**. The backend creates a default set of questions and gives each one a `field_identifier` binding its answer to a column on the request — `cost`, `vendor`, `url`, `due_date`. From then on the form lives in `SurveyFormBuilder` and the admin can reshape it freely.

One of those bindings is load-bearing in a way the editor cannot see. `Procurement::PurchaseRequest` refuses a deadline that is already in the past, and it reads that deadline from whichever question carries `due_date`. **The rule holds only while that question is still asking for a future date** — and nothing stops an admin renaming it into one that isn't.

When that happens the question quietly stops meaning what the backend still assumes. Asked *"When did you spend that amount?"*, requesters answer with a past date, the request is refused, and there is no answer they could give that would work. One customer renamed it exactly like that and has had **zero** purchase requests since.

So Procurement needs the wording of that one question frozen. What it must **not** freeze is everything else:

- deleting it is a perfectly fair choice — no question, no deadline, no rule to break;
- so is duplicating it, or making it optional.

`locked` cannot express that. It disables the wording *and* replaces the actions menu, so the question can no longer be deleted or duplicated either. We built it that way first, and the product team turned it down for precisely that reason: *"like the lock, but it must still be possible to delete and copy it"*.

The **type** half of the same problem is already covered by `hiddenActions: ["questionType"]` — retyping `due_date` to text sends free prose where an `ISO8601Date` is expected, and every submission of that form then dies at GraphQL coercion. `lockedFields` is the **wording** half, and the two compose on the same question:

```tsx
{
  ...question,
  hiddenActions: ["questionType"],
  lockedFields: ["title", "description"],
  lockedNote: { description: "…why this question asks for a future date…" },
}
```

### Why it belongs here and not in the consumer

The restriction is about a builder-level affordance — which parts of a question the author can edit — and there is no way to express it from outside. A consumer can only reach for `locked` and accept the collateral, or reimplement the editor's input handling.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Demo

**Before** — the deadline question can be renamed and retyped freely:

https://github.com/user-attachments/assets/5a5dbfac-00b5-4f49-9780-c805ed20908c


**After** — the wording is frozen; delete, duplicate and required still work:

https://github.com/user-attachments/assets/bd1c5430-0450-47bf-a870-458f3f78b286


## Implementation details

**`lockedFields?: ReadonlyArray<"title" | "description">`** on `BaseQuestionProps`. `locked` is the stronger form and wins: a locked question (or one inside a locked section) still freezes everything regardless.

`inputDisabled` splits into `titleDisabled` / `descriptionDisabled`; the actions menu keeps its own gate (`!locked`) and is untouched.

Three deliberate choices worth reviewing:

1. **No lock icon for a partial lock.** The lock means *the card is frozen* — it takes the actions menu's place precisely because a fully locked question has no actions left. Beside a menu that still offers delete and duplicate it would claim more than is true, so a partially locked question gets none.

2. **The notice moves to the frozen field.** `lockedNote` still carries the explanation, but it hangs off whichever field is frozen instead of the lock, so the author meets it at the moment they reach for the thing they cannot do. A disabled `textarea` fires no hover events, hence the wrapper — the same reason the existing lock button hangs its tooltip off a `span`.

3. **The blocked cursor needs the important variant.** A disabled control takes `cursor: default` from a rule the plain utility does not outrank; `!cursor-not-allowed` is what the whole-card lock already reaches for. Scoped to the two fields only — the card-level `[&_*]` rule stays exclusive to the full lock, since everything else on a partially locked card is still editable.

## Impact on existing consumers

None: the prop is opt-in and nothing changes when it is absent.

Worth stating explicitly, since the alternative considered was relaxing `locked` itself so it would stop hiding the menu. Every current consumer of `locked` wants the full freeze:

| Consumer | What is locked | Should delete/duplicate appear? |
| --- | --- | --- |
| Trainings | the score question of the effectiveness / satisfaction surveys | no |
| IT Management | a category's native and inherited fields (via locked sections) | no |
| Procurement | `request_title` | no |

So `locked`'s meaning is left alone and the weaker restriction gets its own opt-in prop.

## Testing

Three tests added to `Form/__tests__/SurveyFormBuilder.blockedQuestions.test.tsx`, beside the ones already covering `locked`:

- the wording is frozen **and the actions menu is still rendered** — the point of the prop;
- only the fields named in `lockedFields` are frozen, checked both ways round;
- `locked` still wins over `lockedFields`.

Each was verified to fail against a deliberately broken implementation (menu hidden on a partial lock; every field frozen regardless of which is named; `locked` no longer winning), so they protect the behaviour rather than merely exercising it.

- `WordingLocked` story added to `BaseQuestion`.
- Survey suite green (105 tests), `tsc` and `oxfmt --check` clean.
- Exercised end to end against the Factorial procurement form editor, through a local `pnpm patch` of this change, over every combination:

| `lockedFields` | title | description | notice on hover | actions menu |
| --- | --- | --- | --- | --- |
| `["title"]` | disabled, blocked cursor | editable | yes, on the title | Required, Duplicate, Delete |
| `["description"]` | editable | disabled, blocked cursor | yes, on the description | Required, Duplicate, Delete |
| `["title", "description"]` | disabled, blocked cursor | disabled, blocked cursor | yes, on either | Required, Duplicate, Delete |

No lock icon in any of them, and a fully `locked` question in the same form still behaves as it always did.
