### PR TITLE
perf(OneDataCollection): give rows the definition instead of the live source

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
@@ -29,11 +29,7 @@ const people: Person[] = Array.from({ length: TOTAL }, (_, index) => ({
   department: DEPARTMENTS[index % DEPARTMENTS.length],
 }))
 
-/**
- * Counts how many times a row's cells actually ran. A row that skips its render
- * calls none of its column renderers, so this is the row-commit count, taken
- * from where the work would be paid.
- */
+/** A skipped row calls none of its column renderers, so counting there counts commits. */
 const useRowCommitCounter = () => {
   const total = useRef(0)
   const [readout, setReadout] = useState<
@@ -47,8 +43,7 @@ const useRowCommitCounter = () => {
   const measure = useCallback(
     (label: string, rows: number) => {
       const before = total.current
-      // One frame is enough: the render this triggers is synchronous, and an
-      // append settles before the next paint.
+      // The render is synchronous and an append settles before the next paint.
       requestAnimationFrame(() =>
         requestAnimationFrame(() =>
           setReadout((entries) => [
@@ -73,11 +68,9 @@ type Adapter = DataCollectionDataAdapter<
 const pageOf = (offset: number) => people.slice(offset, offset + PER_PAGE)
 
 /**
- * Split by pagination type rather than parameterised: the adapter picks its
- * response shape from a literal `paginationType`, so one function returning both
- * shapes satisfies neither. `fetchData`'s parameters are left to be inferred
- * from the annotation for the same reason — annotating them explicitly stops
- * the union resolving.
+ * Split, not parameterised: the response shape comes from a literal
+ * `paginationType`, so one function returning both satisfies neither. Leave
+ * `fetchData`'s parameters inferred for the same reason.
  */
 const makeAdapter = (
   paginationType: "pages" | "infinite-scroll",
@@ -142,8 +135,8 @@ const Harness = ({
         loadedRef.current = rows
       }),
     },
-    // Nothing here closes over component state, so the definition never has to
-    // be rebuilt. A real consumer must list whatever its callbacks capture.
+    // Nothing here closes over component state. A real consumer must list
+    // whatever its callbacks capture.
     [paginationType]
   )
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
@@ -1,0 +1,244 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+import { useCallback, useRef, useState } from "react"
+
+import type { FiltersDefinition } from "@/hooks/datasource"
+
+import { F0Button } from "@/components/F0Button"
+
+import type { NavigationFiltersDefinition } from "../../navigationFilters/types"
+
+import { useDataCollectionSource } from "../../hooks/useDataCollectionSource"
+import type { DataCollectionDataAdapter } from "../../hooks/useDataCollectionSource/types"
+import { OneDataCollection } from "../../index"
+
+type Person = {
+  id: number
+  name: string
+  email: string
+  department: string
+}
+
+const DEPARTMENTS = ["Engineering", "Design", "Sales", "Support"]
+const PER_PAGE = 25
+const TOTAL = 2000
+
+const people: Person[] = Array.from({ length: TOTAL }, (_, index) => ({
+  id: index + 1,
+  name: `Person ${index + 1}`,
+  email: `person${index + 1}@example.com`,
+  department: DEPARTMENTS[index % DEPARTMENTS.length],
+}))
+
+/**
+ * Counts how many times a row's cells actually ran. A row that skips its render
+ * calls none of its column renderers, so this is the row-commit count, taken
+ * from where the work would be paid.
+ */
+const useRowCommitCounter = () => {
+  const total = useRef(0)
+  const [readout, setReadout] = useState<
+    { label: string; commits: number; rows: number }[]
+  >([])
+
+  const count = useCallback(() => {
+    total.current += 1
+  }, [])
+
+  const measure = useCallback(
+    (label: string, rows: number) => {
+      const before = total.current
+      // One frame is enough: the render this triggers is synchronous, and an
+      // append settles before the next paint.
+      requestAnimationFrame(() =>
+        requestAnimationFrame(() =>
+          setReadout((entries) => [
+            { label, commits: total.current - before, rows },
+            ...entries,
+          ])
+        )
+      )
+    },
+    [total]
+  )
+
+  return { count, measure, readout }
+}
+
+type Adapter = DataCollectionDataAdapter<
+  Person,
+  FiltersDefinition,
+  NavigationFiltersDefinition
+>
+
+const pageOf = (offset: number) => people.slice(offset, offset + PER_PAGE)
+
+/**
+ * Split by pagination type rather than parameterised: the adapter picks its
+ * response shape from a literal `paginationType`, so one function returning both
+ * shapes satisfies neither. `fetchData`'s parameters are left to be inferred
+ * from the annotation for the same reason — annotating them explicitly stops
+ * the union resolving.
+ */
+const makeAdapter = (
+  paginationType: "pages" | "infinite-scroll",
+  onLoaded: (rows: number) => void
+): Adapter => {
+  if (paginationType === "pages") {
+    const adapter: Adapter = {
+      paginationType: "pages",
+      perPage: PER_PAGE,
+      fetchData: async ({ pagination }) => {
+        const currentPage = pagination?.currentPage ?? 1
+        const records = pageOf((currentPage - 1) * PER_PAGE)
+        onLoaded(records.length)
+
+        return {
+          type: "pages" as const,
+          records,
+          total: people.length,
+          perPage: PER_PAGE,
+          currentPage,
+          pagesCount: Math.ceil(people.length / PER_PAGE),
+        }
+      },
+    }
+    return adapter
+  }
+
+  const adapter: Adapter = {
+    paginationType: "infinite-scroll",
+    perPage: PER_PAGE,
+    fetchData: async ({ pagination }) => {
+      const offset = Number(pagination?.cursor ?? 0) || 0
+      const nextCursor = offset + PER_PAGE
+      onLoaded(nextCursor)
+
+      return {
+        type: "infinite-scroll" as const,
+        records: pageOf(offset),
+        total: people.length,
+        perPage: PER_PAGE,
+        cursor: String(nextCursor),
+        hasMore: nextCursor < people.length,
+      }
+    },
+  }
+  return adapter
+}
+
+const Harness = ({
+  paginationType,
+}: {
+  paginationType: "pages" | "infinite-scroll"
+}) => {
+  const { count, measure, readout } = useRowCommitCounter()
+  const [tick, setTick] = useState(0)
+  const loadedRef = useRef(0)
+
+  const source = useDataCollectionSource(
+    {
+      selectable: (item: Person) => item.id,
+      dataAdapter: makeAdapter(paginationType, (rows) => {
+        loadedRef.current = rows
+      }),
+    },
+    // Nothing here closes over component state, so the definition never has to
+    // be rebuilt. A real consumer must list whatever its callbacks capture.
+    [paginationType]
+  )
+
+  const columns = [
+    {
+      label: "Name",
+      render: (item: Person) => {
+        count()
+        return item.name
+      },
+    },
+    { label: "Email", render: (item: Person) => item.email },
+    { label: "Department", render: (item: Person) => item.department },
+  ]
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <F0Button
+          label="Render the consumer"
+          variant="outline"
+          onClick={() => {
+            measure("consumer render", loadedRef.current)
+            setTick(tick + 1)
+          }}
+        />
+        <F0Button
+          label="Measure the next page"
+          variant="outline"
+          onClick={() => measure("next page", loadedRef.current)}
+        />
+        <span className="text-f1-foreground-secondary">
+          consumer renders: {tick}
+        </span>
+      </div>
+
+      <p className="text-f1-foreground-secondary">
+        &ldquo;Render the consumer&rdquo; changes state the collection knows
+        nothing about. Every row commit it reports is waste. &ldquo;Measure the
+        next page&rdquo; arms the counter, then scroll (or page) to load one:
+        under infinite scroll the count should stay near a page&rsquo;s worth
+        however many rows are already loaded, not grow with them.
+      </p>
+
+      {readout.length > 0 && (
+        <table className="w-fit border-collapse text-left">
+          <thead>
+            <tr className="text-f1-foreground-secondary">
+              <th className="pr-6 font-normal">action</th>
+              <th className="pr-6 font-normal">rows loaded</th>
+              <th className="font-normal">row commits</th>
+            </tr>
+          </thead>
+          <tbody>
+            {readout.slice(0, 12).map((entry, index) => (
+              <tr key={`${entry.label}-${index}`}>
+                <td className="pr-6">{entry.label}</td>
+                <td className="pr-6 tabular-nums">{entry.rows}</td>
+                <td className="tabular-nums">{entry.commits}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <OneDataCollection
+        source={source}
+        visualizations={[{ type: "table", options: { columns } }]}
+      />
+    </div>
+  )
+}
+
+const meta = {
+  title: "Data Collection/Performance",
+  component: Harness,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "A measuring harness, not a showcase. It counts row commits so the two costs that dominate a large collection can be read off directly: what a consumer render costs, and whether the cost of loading a page grows with the rows already loaded.",
+      },
+    },
+  },
+  tags: ["experimental", "internal"],
+} satisfies Meta<typeof Harness>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const InfiniteScroll: Story = {
+  args: { paginationType: "infinite-scroll" },
+}
+
+export const Paged: Story = {
+  args: { paginationType: "pages" },
+}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
@@ -120,6 +120,7 @@ const Harness = ({
 
   const source = useDataCollectionSource(
     {
+      memoizeDefinition: true,
       selectable: (item: Person) => item.id,
       dataAdapter: makeAdapter(paginationType, (rows) => {
         loadedRef.current = rows

--- a/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
@@ -1,15 +1,9 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
 import { useCallback, useRef, useState } from "react"
-
-import type { FiltersDefinition } from "@/hooks/datasource"
-
 import { F0Button } from "@/components/F0Button"
-
-import type { NavigationFiltersDefinition } from "../../navigationFilters/types"
-
+import { OneDataCollection } from "../.."
 import { useDataCollectionSource } from "../../hooks/useDataCollectionSource"
 import type { DataCollectionDataAdapter } from "../../hooks/useDataCollectionSource/types"
-import { OneDataCollection } from "../../index"
 
 type Person = {
   id: number
@@ -59,11 +53,7 @@ const useRowCommitCounter = () => {
   return { count, measure, readout }
 }
 
-type Adapter = DataCollectionDataAdapter<
-  Person,
-  FiltersDefinition,
-  NavigationFiltersDefinition
->
+type Adapter = DataCollectionDataAdapter<Person>
 
 const pageOf = (offset: number) => people.slice(offset, offset + PER_PAGE)
 

--- a/packages/react/src/patterns/OneDataCollection/components/itemActions/useItemActions.ts
+++ b/packages/react/src/patterns/OneDataCollection/components/itemActions/useItemActions.ts
@@ -28,10 +28,7 @@ type UseItemActionProps<
   NavigationFilters extends NavigationFiltersDefinition,
   Grouping extends GroupingDefinition<R>,
 > = {
-  /**
-   * Only `itemActions` is read, so this takes the definition rather than the
-   * live source — a row that holds the live source cannot memoize.
-   */
+  /** The definition, not the live source: a row holding the live one cannot memoize. */
   source: DataCollectionSourceDefinition<
     R,
     Filters,

--- a/packages/react/src/patterns/OneDataCollection/components/itemActions/useItemActions.ts
+++ b/packages/react/src/patterns/OneDataCollection/components/itemActions/useItemActions.ts
@@ -8,7 +8,7 @@ import {
   RecordType,
   SortingsDefinition,
 } from "@/hooks/datasource"
-import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
+import { DataCollectionSourceDefinition } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
 import {
   ActionDefinition,
   filterItemActions,
@@ -28,7 +28,11 @@ type UseItemActionProps<
   NavigationFilters extends NavigationFiltersDefinition,
   Grouping extends GroupingDefinition<R>,
 > = {
-  source: DataCollectionSource<
+  /**
+   * Only `itemActions` is read, so this takes the definition rather than the
+   * live source — a row that holds the live source cannot memoize.
+   */
+  source: DataCollectionSourceDefinition<
     R,
     Filters,
     Sortings,

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -218,6 +218,23 @@ export type DataCollectionSource<
     NavigationFilters,
     Grouping
   > & {
+    /**
+     * The definition the consumer passed, memoized on the hook's `deps`.
+     *
+     * The source itself changes identity on every render of the consumer — it
+     * carries live filter, search and sorting state, so it has to. Anything
+     * rendered per record takes this instead, so a memo boundary around a row
+     * can survive a consumer render.
+     */
+    definition?: DataCollectionSourceDefinition<
+      R,
+      Filters,
+      Sortings,
+      Summaries,
+      ItemActions,
+      NavigationFilters,
+      Grouping
+    >
     currentNavigationFilters: NavigationFiltersState<NavigationFilters>
     setCurrentNavigationFilters: React.Dispatch<
       React.SetStateAction<NavigationFiltersState<NavigationFilters>>

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -151,6 +151,13 @@ export type DataCollectionSourceDefinition<
    * Data Collection specific datasource elements / features
    */
 
+  /**
+   * Pin this definition to `deps` so rows can skip a render. Only safe if `deps`
+   * lists everything the callbacks below close over: miss one and a row keeps
+   * calling the closure it mounted with.
+   */
+  memoizeDefinition?: boolean
+
   /** Navigation filters */
   navigationFilters?: NavigationFilters
 
@@ -219,9 +226,8 @@ export type DataCollectionSource<
     Grouping
   > & {
     /**
-     * The definition the consumer passed, memoized on the hook's `deps`. What
-     * is rendered per record takes this, so a row's memo can survive a consumer
-     * render — the source itself changes identity on every one of them.
+     * The definition, pinned to `deps`, for what is rendered per record — the
+     * source itself changes identity every render. Set by `memoizeDefinition`.
      */
     definition?: DataCollectionSourceDefinition<
       R,

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -219,12 +219,9 @@ export type DataCollectionSource<
     Grouping
   > & {
     /**
-     * The definition the consumer passed, memoized on the hook's `deps`.
-     *
-     * The source itself changes identity on every render of the consumer — it
-     * carries live filter, search and sorting state, so it has to. Anything
-     * rendered per record takes this instead, so a memo boundary around a row
-     * can survive a consumer render.
+     * The definition the consumer passed, memoized on the hook's `deps`. What
+     * is rendered per record takes this, so a row's memo can survive a consumer
+     * render — the source itself changes identity on every one of them.
      */
     definition?: DataCollectionSourceDefinition<
       R,

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource.ts
@@ -100,7 +100,11 @@ export const useDataCollectionSource = <
   // Pinned to the same `deps` that already govern the data adapter: the source
   // returned below carries live filter state, so it cannot be memoized itself.
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const definition = useMemo(() => source, deps)
+  const memoizedDefinition = useMemo(() => source, deps)
+
+  // Opt-in: it turns a forgotten dep from harmless into a stale closure, which
+  // is not a decision a version bump should make for a consumer.
+  const definition = source.memoizeDefinition ? memoizedDefinition : undefined
 
   return {
     ...datasource,

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource.ts
@@ -97,13 +97,8 @@ export const useDataCollectionSource = <
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedSummaries = useMemo(() => summaries, deps)
 
-  // The consumer's definition, pinned to the same `deps` that already govern
-  // the data adapter and the filters. The source object returned below cannot
-  // be memoized — it carries live filter/search/sorting state that has to
-  // change — so anything that must not re-render on its identity takes this
-  // instead. Same contract as the rest of the hook: a definition that closes
-  // over consumer state needs that state in `deps`, or the adapter goes stale
-  // first and far more visibly.
+  // Pinned to the same `deps` that already govern the data adapter: the source
+  // returned below carries live filter state, so it cannot be memoized itself.
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const definition = useMemo(() => source, deps)
 

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource.ts
@@ -97,8 +97,19 @@ export const useDataCollectionSource = <
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const memoizedSummaries = useMemo(() => summaries, deps)
 
+  // The consumer's definition, pinned to the same `deps` that already govern
+  // the data adapter and the filters. The source object returned below cannot
+  // be memoized — it carries live filter/search/sorting state that has to
+  // change — so anything that must not re-render on its identity takes this
+  // instead. Same contract as the rest of the hook: a definition that closes
+  // over consumer state needs that state in `deps`, or the adapter goes stale
+  // first and far more visibly.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const definition = useMemo(() => source, deps)
+
   return {
     ...datasource,
+    definition,
     summaries: memoizedSummaries,
     navigationFilters,
     currentNavigationFilters,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -247,6 +247,29 @@ export const TableCollection = <
     [source, showItemActionsProp]
   )
 
+  // What a row reads: the consumer's definition, which `useDataCollectionSource`
+  // pins to its `deps`. The source itself cannot be pinned — it carries the live
+  // filter, search and sorting state — so handing it to rows meant every
+  // consumer render re-rendered all of them, whatever their memo said.
+  // Falls back to the source itself: the interface is public, so a source can be
+  // hand-built (mocks, adapters) without one. Those rows re-render as they did
+  // before rather than breaking.
+  const rowDefinition = source.definition ?? source
+  const rowSource = useMemo(
+    () =>
+      showItemActionsProp === false
+        ? { ...rowDefinition, itemActions: undefined }
+        : rowDefinition,
+    [rowDefinition, showItemActionsProp]
+  )
+
+  // Only a row that renders nested children gets the live source: resolving a
+  // child needs the current filters and sortings, and children are fetched too
+  // late for this component to have resolved anything for them. Flat rows get
+  // `undefined`, which is stable, so their memo still holds.
+  const liveSourceFor = (record: R) =>
+    effectiveSource.itemsWithChildren?.(record) ? effectiveSource : undefined
+
   // Called with no arguments at every use site, so the result is always the same
   // object by value. Building it once stops every row receiving a fresh
   // `variants` prop on each render.
@@ -875,7 +898,8 @@ export const TableCollection = <
                                 custom={index}
                                 key={rowKey}
                                 layout
-                                source={effectiveSource}
+                                source={rowSource}
+                                liveSource={liveSourceFor(item)}
                                 item={item}
                                 index={index}
                                 groupIndex={groupIndex}
@@ -939,7 +963,8 @@ export const TableCollection = <
                       layout
                       isNew={isNew}
                       groupIndex={0}
-                      source={effectiveSource}
+                      source={rowSource}
+                      liveSource={liveSourceFor(item)}
                       item={item}
                       index={index}
                       onItemCheckedChange={stableSelectItemChange}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -247,13 +247,9 @@ export const TableCollection = <
     [source, showItemActionsProp]
   )
 
-  // What a row reads: the consumer's definition, which `useDataCollectionSource`
-  // pins to its `deps`. The source itself cannot be pinned — it carries the live
-  // filter, search and sorting state — so handing it to rows meant every
-  // consumer render re-rendered all of them, whatever their memo said.
-  // Falls back to the source itself: the interface is public, so a source can be
-  // hand-built (mocks, adapters) without one. Those rows re-render as they did
-  // before rather than breaking.
+  // Rows read the pinned definition, never the live source: its identity churns
+  // every consumer render, which no row memo can survive. A hand-built source
+  // has no `definition`, and falls back to re-rendering as it did before.
   const rowDefinition = source.definition ?? source
   const rowSource = useMemo(
     () =>
@@ -263,10 +259,9 @@ export const TableCollection = <
     [rowDefinition, showItemActionsProp]
   )
 
-  // Only a row that renders nested children gets the live source: resolving a
-  // child needs the current filters and sortings, and children are fetched too
-  // late for this component to have resolved anything for them. Flat rows get
-  // `undefined`, which is stable, so their memo still holds.
+  // Children are fetched too late for this component to resolve anything for
+  // them, and resolving one reads the current filters and sortings. Flat rows
+  // get `undefined`, which is stable.
   const liveSourceFor = (record: R) =>
     effectiveSource.itemsWithChildren?.(record) ? effectiveSource : undefined
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
@@ -1,0 +1,116 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type {
+  FiltersDefinition,
+  GroupingDefinition,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+
+import { TextCell } from "@/ui/value-display/types/text"
+import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { SummariesDefinition } from "../../../../summary"
+import { TableCollection } from "../index"
+
+vi.mock("../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+type Person = { id: number; name: string }
+
+const people: Person[] = [
+  { id: 1, name: "Ana" },
+  { id: 2, name: "Bruno" },
+  { id: 3, name: "Carla" },
+]
+
+const renderCounts = new Map<number, number>()
+
+const columns = [
+  {
+    label: "name",
+    render: (item: Person) => {
+      renderCounts.set(item.id, (renderCounts.get(item.id) ?? 0) + 1)
+      return item.name
+    },
+  },
+]
+
+beforeEach(() => renderCounts.clear())
+
+/**
+ * The consumer owns state the table knows nothing about, and rebuilds its
+ * source definition inline on every render — which is what every real consumer
+ * does, since the definition is written as an object literal at the call site.
+ */
+const Harness = () => {
+  const [tick, setTick] = useState(0)
+
+  const source = useDataCollectionSource<
+    Person,
+    FiltersDefinition,
+    SortingsDefinition,
+    SummariesDefinition,
+    ItemActionsDefinition<Person>,
+    NavigationFiltersDefinition,
+    GroupingDefinition<Person>
+  >(
+    {
+      selectable: (item: Person) => item.id,
+      itemUrl: (item: Person) => `/people/${item.id}`,
+      dataAdapter: {
+        fetchData: async () => people,
+      },
+    },
+    []
+  )
+
+  return (
+    <>
+      <button onClick={() => setTick(tick + 1)}>tick</button>
+      <span>ticks: {tick}</span>
+      <TableCollection<
+        Person,
+        FiltersDefinition,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        NavigationFiltersDefinition,
+        GroupingDefinition<Person>
+      >
+        columns={columns}
+        source={source}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    </>
+  )
+}
+
+describe("a consumer render that has nothing to do with the rows", () => {
+  it("does not re-render them", async () => {
+    const user = userEvent.setup()
+    render(<Harness />)
+
+    await waitFor(() => expect(screen.getByText("Carla")).toBeInTheDocument())
+    const before = new Map(renderCounts)
+
+    await user.click(screen.getByText("tick"))
+    await waitFor(() =>
+      expect(screen.getByText("ticks: 1")).toBeInTheDocument()
+    )
+
+    for (const id of [1, 2, 3]) {
+      expect(renderCounts.get(id)).toBe(before.get(id))
+    }
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
@@ -47,7 +47,7 @@ beforeEach(() => renderCounts.clear())
  * State the table knows nothing about, and a definition rebuilt inline every
  * render — an object literal at the call site, as every real consumer writes it.
  */
-const Harness = () => {
+const Harness = ({ memoizeDefinition }: { memoizeDefinition: boolean }) => {
   const [tick, setTick] = useState(0)
 
   const source = useDataCollectionSource<
@@ -60,6 +60,7 @@ const Harness = () => {
     GroupingDefinition<Person>
   >(
     {
+      memoizeDefinition,
       selectable: (item: Person) => item.id,
       itemUrl: (item: Person) => `/people/${item.id}`,
       dataAdapter: {
@@ -92,21 +93,28 @@ const Harness = () => {
   )
 }
 
+const tickAndCount = async (memoizeDefinition: boolean) => {
+  const user = userEvent.setup()
+  render(<Harness memoizeDefinition={memoizeDefinition} />)
+
+  await waitFor(() => expect(screen.getByText("Carla")).toBeInTheDocument())
+  const before = new Map(renderCounts)
+
+  await user.click(screen.getByText("tick"))
+  await waitFor(() => expect(screen.getByText("ticks: 1")).toBeInTheDocument())
+
+  return [1, 2, 3].map(
+    (id) => (renderCounts.get(id) ?? 0) - (before.get(id) ?? 0)
+  )
+}
+
 describe("a consumer render that has nothing to do with the rows", () => {
-  it("does not re-render them", async () => {
-    const user = userEvent.setup()
-    render(<Harness />)
+  it("does not re-render them, once the consumer opts in", async () => {
+    expect(await tickAndCount(true)).toEqual([0, 0, 0])
+  })
 
-    await waitFor(() => expect(screen.getByText("Carla")).toBeInTheDocument())
-    const before = new Map(renderCounts)
-
-    await user.click(screen.getByText("tick"))
-    await waitFor(() =>
-      expect(screen.getByText("ticks: 1")).toBeInTheDocument()
-    )
-
-    for (const id of [1, 2, 3]) {
-      expect(renderCounts.get(id)).toBe(before.get(id))
-    }
+  it("still re-renders them for a consumer that has not", async () => {
+    // A consumer that never asked keeps reading its callbacks fresh.
+    expect(await tickAndCount(false)).toEqual([1, 1, 1])
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
@@ -2,21 +2,18 @@ import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useState } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-
 import type {
   FiltersDefinition,
   GroupingDefinition,
   SortingsDefinition,
 } from "@/hooks/datasource"
-
-import { TextCell } from "@/ui/value-display/types/text"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource"
 import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import { zeroRender as render } from "@/testing/test-utils"
-
+import { TextCell } from "@/ui/value-display/types/text"
+import { TableCollection } from ".."
 import { ItemActionsDefinition } from "../../../../item-actions"
 import { SummariesDefinition } from "../../../../summary"
-import { TableCollection } from "../index"
 
 vi.mock("../../property", () => ({
   propertyRenderers: {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/ConsumerRenderRowCommits.integration.test.tsx
@@ -47,9 +47,8 @@ const columns = [
 beforeEach(() => renderCounts.clear())
 
 /**
- * The consumer owns state the table knows nothing about, and rebuilds its
- * source definition inline on every render — which is what every real consumer
- * does, since the definition is written as an object literal at the call site.
+ * State the table knows nothing about, and a definition rebuilt inline every
+ * render — an object literal at the call site, as every real consumer writes it.
  */
 const Harness = () => {
   const [tick, setTick] = useState(0)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
@@ -1,0 +1,134 @@
+import { screen, waitFor, within } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import type {
+  FiltersDefinition,
+  GroupingDefinition,
+  SortingsDefinition,
+} from "@/hooks/datasource"
+
+import { TextCell } from "@/ui/value-display/types/text"
+import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource"
+import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { SummariesDefinition } from "../../../../summary"
+import { TableCollection } from "../index"
+
+vi.mock("../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+type Person = { id: number; name: string }
+
+const people: Person[] = [
+  { id: 1, name: "Ana" },
+  { id: 2, name: "Bruno" },
+  { id: 3, name: "Carla" },
+]
+
+// Hoisted: a consumer render changes no column identity, so the row memo has
+// nothing but the source to compare on.
+const columns = [{ label: "name", render: (item: Person) => item.name }]
+
+const onSelectItems = vi.fn()
+
+/**
+ * `lockedIds` is consumer state that `selectionDisabled` closes over. Rows are
+ * memoized and the registry they populate is filled from an effect, so this is
+ * the case where "select all" has to keep up with a definition that changed
+ * without any row's own data changing.
+ *
+ * `deps` is a parameter because both answers matter: declared, the definition
+ * is rebuilt and the rows re-register; undeclared, the registry goes stale and
+ * something else has to catch it.
+ */
+const Harness = ({ declareDeps }: { declareDeps: boolean }) => {
+  const [lockedIds, setLockedIds] = useState<number[]>([])
+
+  const source = useDataCollectionSource<
+    Person,
+    FiltersDefinition,
+    SortingsDefinition,
+    SummariesDefinition,
+    ItemActionsDefinition<Person>,
+    NavigationFiltersDefinition,
+    GroupingDefinition<Person>
+  >(
+    {
+      selectable: (item: Person) => item.id,
+      selectionDisabled: (item: Person) => lockedIds.includes(item.id),
+      dataAdapter: {
+        fetchData: async () => people,
+      },
+    },
+    declareDeps ? [lockedIds] : []
+  )
+
+  return (
+    <>
+      <button onClick={() => setLockedIds([2])}>lock Bruno</button>
+      <TableCollection<
+        Person,
+        FiltersDefinition,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        NavigationFiltersDefinition,
+        GroupingDefinition<Person>
+      >
+        columns={columns}
+        source={source}
+        onSelectItems={onSelectItems}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    </>
+  )
+}
+
+const headerCheckbox = () =>
+  within(document.querySelector("thead") as HTMLElement).getByRole("checkbox")
+
+const selectedIds = () => {
+  const last = onSelectItems.mock.calls.at(-1)?.[0] as
+    | { itemsStatus?: { item: Person; checked: boolean }[] }
+    | undefined
+  return (last?.itemsStatus ?? [])
+    .filter((entry) => entry.checked)
+    .map((entry) => entry.item.id)
+    .sort()
+}
+
+const lockBrunoThenSelectAll = async (declareDeps: boolean) => {
+  const user = userEvent.setup()
+  onSelectItems.mockClear()
+  render(<Harness declareDeps={declareDeps} />)
+
+  await waitFor(() => expect(screen.getByText("Carla")).toBeInTheDocument())
+  await user.click(screen.getByText("lock Bruno"))
+  await user.click(headerCheckbox())
+}
+
+describe("select all, after the consumer locks a row", () => {
+  it("skips the row that just became unselectable", async () => {
+    await lockBrunoThenSelectAll(true)
+
+    await waitFor(() => expect(selectedIds()).toEqual([1, 3]))
+  })
+
+  it("skips it even when the registry is stale", async () => {
+    // The definition is pinned to an empty `deps`, so the rows never re-register
+    // and the registry still lists Bruno as selectable. `collectSelectableEntries`
+    // re-filters what the registry hands it through the live `selectionDisabled`,
+    // so the registry only decides which rows exist, never which may be picked.
+    await lockBrunoThenSelectAll(false)
+
+    await waitFor(() => expect(selectedIds()).toEqual([1, 3]))
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
@@ -53,6 +53,7 @@ const Harness = ({ declareDeps }: { declareDeps: boolean }) => {
     GroupingDefinition<Person>
   >(
     {
+      memoizeDefinition: true,
       selectable: (item: Person) => item.id,
       selectionDisabled: (item: Person) => lockedIds.includes(item.id),
       dataAdapter: {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
@@ -2,21 +2,18 @@ import { screen, waitFor, within } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
-
 import type {
   FiltersDefinition,
   GroupingDefinition,
   SortingsDefinition,
 } from "@/hooks/datasource"
-
-import { TextCell } from "@/ui/value-display/types/text"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/useDataCollectionSource"
 import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import { zeroRender as render } from "@/testing/test-utils"
-
+import { TextCell } from "@/ui/value-display/types/text"
+import { TableCollection } from ".."
 import { ItemActionsDefinition } from "../../../../item-actions"
 import { SummariesDefinition } from "../../../../summary"
-import { TableCollection } from "../index"
 
 vi.mock("../../property", () => ({
   propertyRenderers: {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/SelectAllUnderMemo.integration.test.tsx
@@ -32,21 +32,16 @@ const people: Person[] = [
   { id: 3, name: "Carla" },
 ]
 
-// Hoisted: a consumer render changes no column identity, so the row memo has
-// nothing but the source to compare on.
+// Hoisted, so the row memo has nothing but the source to compare on.
 const columns = [{ label: "name", render: (item: Person) => item.name }]
 
 const onSelectItems = vi.fn()
 
 /**
- * `lockedIds` is consumer state that `selectionDisabled` closes over. Rows are
- * memoized and the registry they populate is filled from an effect, so this is
- * the case where "select all" has to keep up with a definition that changed
- * without any row's own data changing.
- *
- * `deps` is a parameter because both answers matter: declared, the definition
- * is rebuilt and the rows re-register; undeclared, the registry goes stale and
- * something else has to catch it.
+ * `selectionDisabled` closes over `lockedIds`, and rows fill the registry from
+ * an effect — so "select all" has to keep up with a definition that changed
+ * while no row's own data did. Declared `deps` re-register the rows; undeclared
+ * leave the registry stale, and something else has to catch it.
  */
 const Harness = ({ declareDeps }: { declareDeps: boolean }) => {
   const [lockedIds, setLockedIds] = useState<number[]>([])
@@ -123,10 +118,9 @@ describe("select all, after the consumer locks a row", () => {
   })
 
   it("skips it even when the registry is stale", async () => {
-    // The definition is pinned to an empty `deps`, so the rows never re-register
-    // and the registry still lists Bruno as selectable. `collectSelectableEntries`
-    // re-filters what the registry hands it through the live `selectionDisabled`,
-    // so the registry only decides which rows exist, never which may be picked.
+    // The rows never re-register, so the registry still lists Bruno.
+    // `collectSelectableEntries` re-filters it through the live
+    // `selectionDisabled`: the registry decides who exists, not who is pickable.
     await lockBrunoThenSelectAll(false)
 
     await waitFor(() => expect(selectedIds()).toEqual([1, 3]))

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -14,7 +14,10 @@ import { cn } from "@/lib/utils"
 import { ItemActionsMobile } from "@/patterns/OneDataCollection/components/itemActions/ItemActionsMobile/ItemActionsMobile"
 import { ItemActionsRowContainer } from "@/patterns/OneDataCollection/components/itemActions/ItemActionsRowContainer"
 import { useItemActions } from "@/patterns/OneDataCollection/components/itemActions/useItemActions"
-import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
+import {
+  DataCollectionSource,
+  DataCollectionSourceDefinition,
+} from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
 import { ItemActionsDefinition } from "@/patterns/OneDataCollection/item-actions"
 import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import { renderProperty } from "@/patterns/OneDataCollection/property-render"
@@ -45,7 +48,27 @@ export type RowProps<
   NavigationFilters extends NavigationFiltersDefinition,
   Grouping extends GroupingDefinition<R>,
 > = {
-  source: DataCollectionSource<
+  /**
+   * The consumer's definition, not the live source. Memoized by
+   * `useDataCollectionSource` on its `deps`, so this row's memo survives a
+   * consumer render — which the live source, carrying filter and search state,
+   * can never allow.
+   */
+  source: DataCollectionSourceDefinition<
+    R,
+    Filters,
+    Sortings,
+    Summaries,
+    ItemActions,
+    NavigationFilters,
+    Grouping
+  >
+  /**
+   * The live source. Supplied only to rows that render nested children, which
+   * need the current filters and sortings to fetch them. Absent — and so
+   * stable — for flat rows.
+   */
+  liveSource?: DataCollectionSource<
     R,
     Filters,
     Sortings,
@@ -144,6 +167,7 @@ const RowComponentInner = <
 >(
   {
     source,
+    liveSource,
     item,
     onItemCheckedChange,
     isSelected: isSelectedProp,
@@ -254,9 +278,17 @@ const RowComponentInner = <
   // clicked mid-exit must not reach them. `true` outside AnimatePresence.
   const isPresent = useIsPresent()
 
+  // A row delegates to NestedRow only if it was handed the live source: fetching
+  // children reads the current filters and sortings. Table supplies it to
+  // exactly the rows whose `itemsWithChildren` says they have children, so this
+  // is the same condition seen from here — and if it ever were not, the row
+  // renders flat rather than throwing.
+  const delegatesToNestedRow =
+    rowWithChildren && hasChildrenLoaded && !!liveSource
+
   // Only the row that owns the rendered checkbox registers (not the one
   // delegating to NestedRow), so each selectable id is registered once.
-  const willRenderOwnRow = !(rowWithChildren && hasChildrenLoaded)
+  const willRenderOwnRow = !delegatesToNestedRow
   const isRegistered =
     id !== undefined && !selectionDisabled && willRenderOwnRow && isPresent
 
@@ -286,10 +318,10 @@ const RowComponentInner = <
     registerSelectable(id, item)
   }, [id, item, isRegistered, registerSelectable])
 
-  if (rowWithChildren && hasChildrenLoaded) {
+  if (delegatesToNestedRow && liveSource) {
     return (
       <NestedRow
-        source={source}
+        source={liveSource}
         item={item}
         onItemCheckedChange={onItemCheckedChange}
         selectedItems={selectedItems}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -49,10 +49,8 @@ export type RowProps<
   Grouping extends GroupingDefinition<R>,
 > = {
   /**
-   * The consumer's definition, not the live source. Memoized by
-   * `useDataCollectionSource` on its `deps`, so this row's memo survives a
-   * consumer render — which the live source, carrying filter and search state,
-   * can never allow.
+   * The definition, memoized on the source's `deps` — not the live source,
+   * whose identity churns on every consumer render.
    */
   source: DataCollectionSourceDefinition<
     R,
@@ -64,9 +62,8 @@ export type RowProps<
     Grouping
   >
   /**
-   * The live source. Supplied only to rows that render nested children, which
-   * need the current filters and sortings to fetch them. Absent — and so
-   * stable — for flat rows.
+   * Supplied only to rows that render nested children, which need the current
+   * filters and sortings to fetch them. Absent, and so stable, for flat rows.
    */
   liveSource?: DataCollectionSource<
     R,
@@ -278,11 +275,8 @@ const RowComponentInner = <
   // clicked mid-exit must not reach them. `true` outside AnimatePresence.
   const isPresent = useIsPresent()
 
-  // A row delegates to NestedRow only if it was handed the live source: fetching
-  // children reads the current filters and sortings. Table supplies it to
-  // exactly the rows whose `itemsWithChildren` says they have children, so this
-  // is the same condition seen from here — and if it ever were not, the row
-  // renders flat rather than throwing.
+  // Requires the live source, which Table hands to exactly the rows
+  // `itemsWithChildren` claims. Should they ever disagree, render flat.
   const delegatesToNestedRow =
     rowWithChildren && hasChildrenLoaded && !!liveSource
 


### PR DESCRIPTION
Follow-up to #5378, now merged and part of `main`.

## Why

#5378 stopped a page append from re-rendering the rows already on screen. It left the other half untouched: **any render of the consumer still re-renders every row.**

`useDataCollectionSource` returns a new object each render and rows take it as a prop, so their memo can never hold.

Pinning that object's identity does not work. `Row` calls `selectable`, `selectionDisabled`, `itemUrl`, `itemOnClick`, `selectionInherited` and `itemsWithChildren` during its own render, so a row that never re-renders never reads a new value — however fresh the object it holds claims to be. `SourceStaleness.integration.test.tsx`, on `main`, is the guard for that.

Memoizing the source does not work either. It holds two things with different lifetimes:

```
return {
  ...rest,          // selectable, itemActions, itemUrl... — the definition
  currentFilters,   // live state; changes on every interaction
  currentSearch,
  currentSortings,
  isLoading,
}
```

Freeze it and the live state freezes with it.

## What this does

Splits them. `useDataCollectionSource` now also exposes `definition` — what the consumer wrote at the call site — memoized on the hook's `deps`. Rows take that.

Rows that render nested children still get the live source, now under `liveSource`. Resolving a child reads `currentFilters` and `currentSortings`, and children arrive too late for the table to have resolved anything on their behalf. Flat rows get `undefined`, which is stable, so nested tables behave exactly as before and flat ones — the large collections — get the memo.

`useItemActions` drops to the definition type too; it only ever read `itemActions`. A source built by hand without a `definition` falls back to the old behaviour rather than breaking, since the interface is public and mocks construct it directly.

## Opt-in, and why

Pinning the definition extends what `deps` governs. `itemActions`, `selectable`, `selectionDisabled`, `itemUrl` and `itemOnClick` ride in `...rest` and are read fresh on every render today, so a missing dep is harmless. Pinned, a missing dep leaves a row calling the closure it mounted with.

On by default, that rule would reach every consumer through a version bump, with nobody reading their `deps` first. The employees list in the monolith is already an example: a careful `deps` array — it even carries `hasAnyBulkAction` with a comment about `selectable` — but `itemActions` closes over an `itemActionsContext` rebuilt each render whose members are not all listed.

So it is off unless the source sets `memoizeDefinition`. A table takes it on in a change where someone can check its `deps`, and everyone else keeps exactly the behaviour they have. `Table.tsx` falls back to the live source when `definition` is absent, which is also what a hand-built source gets.

## Testing

`ConsumerRenderRowCommits.integration.test.tsx` renders a consumer that owns state the table knows nothing about and writes its definition inline, the way every real call site does, then bumps that state. It pins both directions: opted in, that costs no row commits; not opted in, it costs one per row, exactly as before.

The opted-in case is red on `main`:

```
× does not re-render them
  AssertionError: expected 2 to be 1
```

Green here, and `SourceStaleness.integration.test.tsx` still passes — which is the part that matters, because it means the memo holds without anything going stale.

`SelectAllUnderMemo.integration.test.tsx` answers what memoizing rows does to the selection registry, which they fill from an effect. It does not go stale in a way that matters: `collectSelectableEntries` re-filters whatever the registry hands it through the live `selectionDisabled`, so the registry decides which rows *exist* and never which of them may be picked. The test locks a row from the consumer and runs select-all, once with the definition rebuilt on `deps` and once with it pinned to an empty `deps` so the rows never re-register at all. Select-all skips the locked row either way.

Full unit suite: 7677 passing.

## Reading it yourself

`Data Collection/Performance` is a measuring harness, not a showcase. It counts row commits inside a column renderer — work a skipped row never does — and reports them per action:

- **Render the consumer** changes state the collection knows nothing about. Every row commit it reports is waste. Without the opt-in that is one per loaded row; with it, none.
- **Measure the next page** arms the counter, then you load one. Under infinite scroll the count should stay near a page's worth however many rows are already loaded — that is what #5378 fixed, and this is where a regression would show.

Both stories run the same harness, one on `pages` and one on `infinite-scroll`.

## Not in this PR

One caveat is real and worth naming: `Row` now reads `itemsWithChildren` from the pinned definition while the table picks `liveSource` from the live one. Those are the same function unless `deps` is incomplete *and* that predicate depends on consumer state — and if they ever disagree, a row's children silently do not render. It is a stable predicate on a record in every consumer checked, so this is a caveat rather than a finding.

Deriving the selection registry from the loaded data rather than the rendered rows is **not planned**. It would be a cleaner design and would delete N per-row effects, but the correctness argument for it is gone (see above, and windowing is dropped in [FCT-62647](https://factorialmakers.atlassian.net/browse/FCT-62647)), and it needs `NestedDataProvider` lifted above `TableCollection`'s hooks — it is mounted inside its JSX — which means splitting a 1200-line component for a cleanup. Recorded in [FCT-63014](https://factorialmakers.atlassian.net/browse/FCT-63014).

No measurement yet of how often a consumer of a large collection actually re-renders *in the product*. The story measures what a render costs; it cannot say how often the monolith's pages trigger one. If that turns out to be rare, this buys less than it looks.


[FCT-63014]: https://factorialmakers.atlassian.net/browse/FCT-63014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[FCT-62647]: https://factorialmakers.atlassian.net/browse/FCT-62647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
