### PR TITLE
feat(F0AiCallout): add the AI callout and deprecate F0Callout

### DIFF
--- a/packages/react/.storybook/manager.ts
+++ b/packages/react/.storybook/manager.ts
@@ -23,13 +23,10 @@ const STATUS_MARKER: Record<string, { emoji: string; title: string }> = {
   },
 }
 
-/** Must match `normalizeComponentName`/`leafName` in component-status-build.mjs. */
+/** Must match `sidebarStatusKey`/`leafName` in component-status-build.mjs. */
 function normalizeLeaf(name: string) {
   const leaf = name.split("/").pop() ?? name
-  return leaf
-    .toLowerCase()
-    .replace(/^f0/, "")
-    .replace(/[^a-z0-9]/g, "")
+  return leaf.toLowerCase().replace(/[^a-z0-9]/g, "")
 }
 
 const theme = create({

--- a/packages/react/scripts/component-status-build.mjs
+++ b/packages/react/scripts/component-status-build.mjs
@@ -76,6 +76,18 @@ export function effectiveStatusOf(c) {
 }
 
 /** Normalize a component name for matching (drop F0 prefix + punctuation). */
+/**
+ * Key for the sidebar's status badge. Unlike `normalizeComponentName` this does
+ * *not* drop an `F0` prefix, because the two functions do opposite jobs: that
+ * one matches two spellings of the same component (the export `F0Callout`
+ * against the story `AICallout`), while this one has to tell two different
+ * components apart. Stripping here collapsed `F0AiCallout` and `AICallout` onto
+ * one key, so a deprecated component's ❌ landed on its replacement.
+ */
+export function sidebarStatusKey(name) {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "")
+}
+
 export function normalizeComponentName(name) {
   return name
     .toLowerCase()
@@ -97,7 +109,7 @@ export function leafName(name) {
 export function effectiveStatusByLeaf(components) {
   const byLeaf = {}
   for (const c of components) {
-    const key = normalizeComponentName(leafName(c.name))
+    const key = sidebarStatusKey(leafName(c.name))
     const prev = byLeaf[key]
     if (!prev || (c.zone === "components" && prev.zone !== "components")) {
       byLeaf[key] = { zone: c.zone, status: effectiveStatusOf(c) }

--- a/packages/react/src/component-status/component-status.test.ts
+++ b/packages/react/src/component-status/component-status.test.ts
@@ -261,6 +261,24 @@ describe("getComponentStatus (name matching)", () => {
     expect(getComponentStatus("Button", dataset)?.zone).toBe("components")
   })
 
+  test("prefers the spelling asked for over an F0-stripped twin", () => {
+    const twins: ComponentEntry[] = [
+      entry({ name: "AI/AICallout", zone: "kits", apiStatus: "deprecated" }),
+      entry({
+        name: "AI/F0AiCallout",
+        zone: "kits",
+        apiStatus: "experimental",
+      }),
+    ]
+
+    // `normalize` drops the F0 prefix, so both land in the same pool. Asking
+    // for the live one must not return the deprecated twin.
+    expect(getComponentStatus("F0AiCallout", twins)?.name).toBe(
+      "AI/F0AiCallout"
+    )
+    expect(getComponentStatus("AICallout", twins)?.name).toBe("AI/AICallout")
+  })
+
   test("resolves a fully-qualified Storybook title to its exact entry", () => {
     const withGrouped: ComponentEntry[] = [
       ...dataset,

--- a/packages/react/src/component-status/component-status.ts
+++ b/packages/react/src/component-status/component-status.ts
@@ -434,9 +434,19 @@ export function getComponentStatus(
   const target = normalize(name)
   const targetLeaf = normalize(leaf(name))
 
-  // When several entries match, prefer the one in the "components" zone.
-  const pick = (pool: ComponentEntry[]) =>
-    pool.find((c) => c.zone === "components") ?? pool[0]
+  // When several entries match, prefer the one spelled exactly like the query.
+  // `normalize` drops an `F0` prefix so that "Button" finds "F0Button", which
+  // also means "F0AiCallout" and "AICallout" land in the same pool — and
+  // without this the deprecated twin could win and report a live component as
+  // scheduled for removal. Zone is the next tie-break, as before.
+  // It narrows the pool rather than replacing the zone rule: with two entries
+  // both named "Button", both are exact and the zone still decides.
+  const queryLeaf = leaf(name).toLowerCase()
+  const pick = (pool: ComponentEntry[]) => {
+    const exact = pool.filter((c) => leaf(c.name).toLowerCase() === queryLeaf)
+    const candidates = exact.length > 0 ? exact : pool
+    return candidates.find((c) => c.zone === "components") ?? candidates[0]
+  }
 
   // Tier 1 — exact full-name match. Handles fully-qualified Storybook titles
   // like "Data Collection/Visualizations/Card" resolving to that exact entry.

--- a/packages/react/src/kits/ai/Banners/F0AiBanner/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiBanner/index.stories.tsx
@@ -8,8 +8,28 @@ import { F0AiBanner, F0AiBannerProps } from "."
 const meta = {
   title: "AI/AiBanner",
   component: F0AiBanner,
+  // The tag is what the sidebar badge and the component-status API read. No
+  // "(deprecated)" title suffix: that changes the page id and 404s every
+  // existing link, and marks nothing the tag does not already mark.
+  tags: ["deprecated"],
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component: [
+          "**Deprecated — use `F0AiCallout`.**",
+          "",
+          "This one has no status, so it cannot say how much a message matters, and it signals its",
+          "authorship with a gradient built from raw hex — two signals for one message, and one that",
+          "cannot follow a theme. Both of its actions are outlined, which reads as two peers where",
+          "there is a recommendation and a way out of it.",
+          "",
+          'Migration: `content` becomes `children` (nodes, not a string), add `status="neutral"` with',
+          "an `icon` describing the content, and `primaryAction` becomes `action`. The byline is not a",
+          "prop — every F0AiCallout renders it.",
+        ].join("\n"),
+      },
+    },
   },
   argTypes: {
     title: {

--- a/packages/react/src/kits/ai/Banners/F0AiBanner/index.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiBanner/index.tsx
@@ -18,6 +18,27 @@ const F0AiBannerSkeleton = ({ compact }: AiBannerSkeletonProps) => {
 
 F0AiBannerBase.displayName = "F0AiBanner"
 
+/**
+ * @deprecated Use `F0AiCallout` instead.
+ *
+ * It carries no status, so it cannot say how much a message matters, and it
+ * signals "this came from AI" with a gradient instead — two signals for one
+ * message, drawn from raw hex rather than tokens, so it cannot follow a theme.
+ * Its two actions are both outlined, which reads as two peers where there is
+ * really a recommendation and a way out of it.
+ *
+ * `F0AiCallout` says where the message came from in words, in every shape, and
+ * `status="neutral"` is the rung for exactly this case: AI output with nothing
+ * to decide.
+ *
+ * @removeIn 7.0.0
+ * @migration `title` unchanged. `content` becomes `children` and takes nodes
+ * rather than a string. Add `status="neutral"` with an `icon` that describes
+ * the content (e.g. `Summary` from `@/icons/ai`) — `neutral` has no glyph of
+ * its own. `primaryAction` becomes `action` and `secondaryAction` stays, but
+ * only when it is the way out of the first rather than a second peer.
+ * `F0AiBanner.Skeleton` becomes `F0AiCallout.Skeleton`.
+ */
 export const F0AiBanner = withSkeleton(
   withDataTestId(F0AiBannerBase),
   F0AiBannerSkeleton

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from "motion/react"
-import { forwardRef, useEffect, useState } from "react"
+import { forwardRef, useEffect, useState, type ReactNode } from "react"
 import { F0Button } from "@/components/F0Button"
-import { F0Icon } from "@/components/F0Icon"
+import { F0Icon, IconType } from "@/components/F0Icon"
 import { One } from "@/icons/ai"
 import { ChevronDown, ChevronUp, Cross } from "@/icons/app"
 import { useReducedMotion } from "@/lib/a11y"
@@ -124,6 +124,444 @@ const FindingRow = ({
 const neutralRing = (status: AiCalloutStatus) =>
   status === "neutral" && "border-transparent bg-clip-padding"
 
+/**
+ * Folded, the findings read as a pile of individual cards; open, they are rows
+ * inside one container. So the fold needs more than a hint that something is
+ * behind — it needs edges, each one step narrower and one step lower, painted
+ * farthest-first so the nearer ones cover them.
+ *
+ * Capped at two. The count is not the job of the illusion: a pile of eight
+ * would be a stack of hairlines, and past two edges nobody counts anyway.
+ */
+const deckLayersFor = (foldableCount: number) => {
+  if (foldableCount === 0) {
+    return []
+  }
+  if (foldableCount === 1) {
+    return [{ inset: "inset-x-3", offset: "bottom-0" }]
+  }
+  // Figma stacks three whole callouts at 526 / 500 / 476 wide and 8px apart:
+  // 13px narrower per side per step. 12 and 24 keep it on the spacing scale
+  // and land within a pixel.
+  return [
+    { inset: "inset-x-6", offset: "bottom-0" },
+    { inset: "inset-x-3", offset: "bottom-2" },
+  ]
+}
+
+/**
+ * Development-only, and in an effect rather than in a render body: a
+ * console.warn while rendering fires again on every re-render, so a single
+ * violation turns into a stream. The deps are the *presence* of an action and
+ * of a headline rather than the objects themselves — products pass those
+ * inline, so a new identity every render would re-log exactly what this is
+ * here to stop.
+ */
+const useCalloutWarnings = ({
+  status,
+  icon,
+  stacked,
+  hasAction,
+  hasHeadline,
+  evidenceEmpty,
+}: {
+  status: AiCalloutStatus
+  icon: IconType | undefined
+  stacked: boolean
+  hasAction: boolean
+  hasHeadline: boolean
+  evidenceEmpty: boolean
+}) => {
+  useEffect(() => {
+    if (process.env.NODE_ENV === "production") {
+      return
+    }
+
+    // The `neutral`/`info` line is enforced here rather than left in a doc:
+    // if there is something to do, the callout is not neutral. Without this
+    // the two rungs collapse into "grey or blue" and whichever feels calmer
+    // wins.
+    if (status === "neutral" && hasAction) {
+      console.warn(
+        "F0AiCallout: `neutral` means there is nothing to do, so it cannot carry an action. A callout that offers a move with nothing wrong is `info`."
+      )
+    }
+
+    if (status === "neutral" && !icon) {
+      console.warn(
+        "F0AiCallout: `neutral` carries no semantic glyph, so it needs an `icon` that describes the content (e.g. `Summary` from @/icons/ai)."
+      )
+    }
+
+    if (stacked && !hasHeadline) {
+      console.warn(
+        "F0AiCallout: `findings` is empty. A callout titled like a verdict with nothing under it tells the reader something is wrong and not what — rendering nothing instead."
+      )
+    }
+
+    // Unlike empty `findings` this still leaves a complete verdict on screen,
+    // so it renders rather than bailing. It is worth saying out loud all the
+    // same: the product named something ("the 5 checks") and there is no
+    // disclosure to open, which from the outside looks like a broken toggle
+    // rather than an empty array.
+    if (evidenceEmpty) {
+      console.warn(
+        "F0AiCallout: `evidence` has no items, so no disclosure renders. Leave `evidence` out entirely when there is nothing behind it."
+      )
+    }
+  }, [status, hasAction, icon, stacked, hasHeadline, evidenceEmpty])
+}
+
+const CalloutHeader = ({
+  status,
+  title,
+  headerIcon,
+  stacked,
+  canFold,
+  open,
+  onClose,
+}: {
+  status: AiCalloutStatus
+  title: string
+  headerIcon: IconType | null | undefined
+  stacked: boolean
+  canFold: boolean
+  open: boolean
+  onClose?: () => void
+}) => {
+  const i18n = useI18n()
+  const { actions, ai } = i18n
+
+  return (
+    // `min-h-9` pins the header at Figma's 36px in every combination. With
+    // the 24px glyph the row reaches it on its own (6 + 24 + 6), but a
+    // `neutral` callout given no icon has only a 20px title row and would
+    // otherwise sit 4px shorter than its neighbours.
+    <div className="flex min-h-9 flex-row items-center gap-2 px-3 py-1.5">
+      <div className="flex min-w-0 flex-1 flex-row items-center gap-2">
+        {/* 24px, and outlined. Every current node uses `ExclamationCircle` at
+            24 rather than the `…Solid` glyph at 20 the first cut measured,
+            which closes the "F0 has no solid icons" gap that was open all
+            along: there is nothing left to substitute. */}
+        {headerIcon ? (
+          <F0Icon
+            icon={headerIcon}
+            size="lg"
+            color={statusIconColors[status]}
+            aria-hidden
+          />
+        ) : null}
+        <OneEllipsis
+          className={cn(
+            "text-base font-medium",
+            statusForegroundVariants({ status })
+          )}
+        >
+          {title}
+        </OneEllipsis>
+        {stacked ? (
+          // Figma gives the stacked header's byline the *status* foreground at
+          // 50%, in Medium, and hides the One glyph — unlike the single
+          // callout's footer byline, which is grey and keeps the mark. The
+          // difference holds up: in the footer the byline is the row's own
+          // content, while here it is a suffix to a coloured title and a grey
+          // one would read as a different message pasted on.
+          <span
+            className={cn(
+              // Subordinate by size (12 against the title's 14), not by
+              // opacity: at 50% the status foreground lands around 2:1.
+              "flex min-w-0 flex-row items-center gap-1 text-sm font-medium",
+              statusForegroundVariants({ status })
+            )}
+          >
+            {/* The separator is presentation, so it stays out of the
+                translated string. */}
+            <span aria-hidden>·</span>
+            <span className="truncate">{ai.attribution}</span>
+          </span>
+        ) : null}
+      </div>
+      {stacked && canFold ? (
+        <CollapsibleTrigger asChild>
+          <F0Button
+            variant="ghost"
+            size="sm"
+            icon={open ? ChevronUp : ChevronDown}
+            label={i18n.t(
+              open ? "actions.collapseItem" : "actions.expandItem",
+              { title }
+            )}
+            hideLabel
+          />
+        </CollapsibleTrigger>
+      ) : null}
+      {onClose ? (
+        <F0Button
+          variant="ghost"
+          size="sm"
+          icon={Cross}
+          hideLabel
+          label={actions.close}
+          onClick={onClose}
+        />
+      ) : null}
+    </div>
+  )
+}
+
+const FindingsBody = ({
+  status,
+  headline,
+  foldable,
+  open,
+  canFold,
+  shouldReduceMotion,
+}: {
+  status: AiCalloutStatus
+  headline: AiCalloutFinding | undefined
+  foldable: AiCalloutFinding[]
+  open: boolean
+  canFold: boolean
+  shouldReduceMotion: boolean
+}) =>
+  // The headline row never folds away. Folding to just the header would
+  // leave a tinted strip saying "Issues to resolve" with no issue on it —
+  // which is dismissing the callout under another name.
+  headline && (
+    <div
+      className={cn(
+        cardClasses,
+        cardBorderVariants({ status }),
+        neutralRing(status)
+      )}
+    >
+      <FindingRow
+        finding={headline}
+        status={status}
+        first
+        last={!open || !canFold}
+      />
+      <AnimatePresence initial={false}>
+        {open && canFold ? (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+            className="overflow-hidden"
+          >
+            <CollapsibleContent forceMount asChild>
+              <div>
+                {foldable.map((finding, index) => (
+                  <FindingRow
+                    key={finding.id}
+                    finding={finding}
+                    status={status}
+                    last={index === foldable.length - 1}
+                  />
+                ))}
+              </div>
+            </CollapsibleContent>
+          </motion.div>
+        ) : null}
+      </AnimatePresence>
+    </div>
+  )
+
+/**
+ * The byline and, when there is a decision to take, the pair that takes it:
+ * the recommended move outlined, its way out ghost and to the left, so the two
+ * read as one hierarchy rather than as two peers.
+ */
+const VerdictFooter = ({
+  status,
+  action,
+  secondaryAction,
+}: {
+  status: AiCalloutStatus
+  action?: AiCalloutAction
+  secondaryAction?: AiCalloutAction
+}) => (
+  <div className={cn(rowClasses, "px-4 py-3", cardBorderVariants({ status }))}>
+    <Byline />
+    {secondaryAction || action ? (
+      <div className="flex flex-row items-center gap-2">
+        {secondaryAction ? (
+          <F0Button
+            variant="ghost"
+            size="md"
+            label={secondaryAction.label}
+            icon={secondaryAction.icon}
+            disabled={secondaryAction.disabled}
+            onClick={secondaryAction.onClick}
+          />
+        ) : null}
+        {action ? <ActionButton action={action} /> : null}
+      </div>
+    ) : null}
+  </div>
+)
+
+const VerdictBody = ({
+  status,
+  summary,
+  children,
+  action,
+  secondaryAction,
+  evidence,
+  isSteps,
+  hasEvidence,
+  open,
+  shouldReduceMotion,
+}: {
+  status: AiCalloutStatus
+  summary?: string
+  children: ReactNode
+  action?: AiCalloutAction
+  secondaryAction?: AiCalloutAction
+  evidence: F0AiCalloutProps["evidence"]
+  isSteps: boolean
+  hasEvidence: boolean
+  open: boolean
+  shouldReduceMotion: boolean
+}) => {
+  const i18n = useI18n()
+  const EvidenceList = isSteps ? "ol" : "ul"
+
+  return (
+    <div
+      className={cn(
+        cardClasses,
+        cardBorderVariants({ status }),
+        neutralRing(status)
+      )}
+    >
+      {/* One padded block on one white surface: description, the disclosure
+          that belongs to it, and the reasoning it opens. Nothing changes
+          colour or plane — the hierarchy is carried by the type scale and by
+          the bullets. */}
+      <div className="flex flex-col items-start gap-2 p-4">
+        {/* Title and description are one text block at Figma's 2px, not two
+            children of the body's 8px rhythm: 8px between them read as two
+            separate things, when the description is the same sentence
+            continuing. The 8px stays between this block and the disclosure,
+            which *is* a separate thing. */}
+        <div className="flex flex-col gap-0.5">
+          {summary ? (
+            <span className="text-base font-medium text-f1-foreground">
+              {summary}
+            </span>
+          ) : null}
+          {/* Secondary, and the `summary` above is what makes that work. Three
+              earlier cuts got this wrong in three different ways: dark item
+              labels over a grey description (the detail outranked the body),
+              then everything secondary (flat), then everything dark (flat in
+              black). The anchor was never the description — it is the summary
+              line. With a dark title in front of it, body copy can sit in
+              secondary and the ladder reads by itself.
+
+              Never clipped: the design shows the description whole and folds
+              only the detail list, so the "max 3 lines" the feedback asked
+              for is not in it. */}
+          <div className="text-base text-f1-foreground-secondary">
+            {children}
+          </div>
+        </div>
+        {hasEvidence ? (
+          <>
+            {/* The disclosure sits here, under the description it belongs to,
+                and not in the header — that placement is the clearest signal
+                of the relationship. A control in the header says "there are
+                more items"; one under a sentence says "there is reasoning
+                behind this sentence". Ghost, so it never competes with the
+                outlined CTA in the footer. */}
+            {/* The wrapper's `-ml-2` cancels the ghost button's own 8px of
+                inline padding so its label lands on the same left edge as the
+                description above and the list below — without it the text
+                column jogs 8px right for one line and back. It goes on a
+                wrapper because `F0Button` omits `className` by design. */}
+            <div className="-ml-2">
+              <CollapsibleTrigger asChild>
+                <F0Button
+                  variant="ghost"
+                  size="sm"
+                  // Only the verb changes. Replacing the whole label costs
+                  // the reader the one thing it is for — naming what is
+                  // behind it — and moves the control's width under the
+                  // pointer; leaving it identical makes a control that has
+                  // just done something look like it did nothing. See/Hide
+                  // differ by a character, so the noun stays put.
+                  label={i18n.t(
+                    open ? "ai.evidence.hide" : "ai.evidence.show",
+                    { name: evidence!.name }
+                  )}
+                  icon={open ? ChevronUp : ChevronDown}
+                  iconPosition="right"
+                />
+              </CollapsibleTrigger>
+            </div>
+            <AnimatePresence initial={false}>
+              {open ? (
+                <motion.div
+                  initial={{ height: 0, opacity: 0 }}
+                  animate={{ height: "auto", opacity: 1 }}
+                  exit={{ height: 0, opacity: 0 }}
+                  transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+                  className="w-full overflow-hidden"
+                >
+                  <CollapsibleContent forceMount asChild>
+                    {/* Preflight is disabled here, so a bare `ul` renders
+                        with no marker, no indent and no margin — every one
+                        of these is explicit on purpose.
+
+                        A rationale bullets: `outside` puts the discs in the
+                        padding so they land on the column the description
+                        starts at and the sentences hang off them, which is
+                        what stops the text block from stepping sideways.
+
+                        A plan numbers instead, in an `ol`, because the order
+                        is part of what it says — and one marker per row
+                        either way, which is what ruled out putting a
+                        checkbox in front of a disc.
+
+                        Keyed by index on purpose: unlike findings, neither a
+                        rationale nor a plan is resolved and removed item by
+                        item, so there is no reordering for an index key to
+                        get wrong.
+
+                        `[&_strong]:font-medium` is not cosmetic: F0's weight
+                        scale stops at 400/500/600, and with preflight
+                        disabled nothing normalises the browser's own
+                        `strong`, which lands on 700 — off-scale and heavier
+                        than the verdict's own title. Products emphasise
+                        inline with `strong`; this is what keeps that on the
+                        scale. */}
+                    <EvidenceList
+                      className={cn(
+                        "m-0 flex list-outside flex-col gap-1 pl-5 text-base font-normal text-f1-foreground-secondary [&_b]:font-medium [&_strong]:font-medium",
+                        isSteps ? "list-decimal" : "list-disc"
+                      )}
+                    >
+                      {evidence!.items.map((item, index) => (
+                        <li key={index}>{item}</li>
+                      ))}
+                    </EvidenceList>
+                  </CollapsibleContent>
+                </motion.div>
+              ) : null}
+            </AnimatePresence>
+          </>
+        ) : null}
+      </div>
+      <VerdictFooter
+        status={status}
+        action={action}
+        secondaryAction={secondaryAction}
+      />
+    </div>
+  )
+}
+
 export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
   function AiCalloutInternal(
     {
@@ -144,8 +582,6 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
     },
     ref
   ) {
-    const i18n = useI18n()
-    const { actions, ai } = i18n
     const shouldReduceMotion = useReducedMotion()
     const stacked = findings !== undefined
     // The two shapes fold in opposite directions, so they cannot share a
@@ -163,82 +599,25 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
     // control would promise a change it cannot deliver.
     const hasEvidence = (evidence?.items.length ?? 0) > 0
     const isSteps = evidence?.kind === "steps"
-    const EvidenceList = isSteps ? "ol" : "ul"
     // Two things can fold, and they are not the same thing: findings that are
     // hidden away, or a rationale that is revealed. Only the first is a pile.
     const canFold = foldable.length > 0 || hasEvidence
     const showDeck = stacked && foldable.length > 0 && !open
-    /**
-     * Folded, the findings read as a pile of individual cards; open, they are
-     * rows inside one container. So the fold needs more than a hint that
-     * something is behind — it needs edges, each one step narrower and one step
-     * lower, painted farthest-first so the nearer ones cover them.
-     *
-     * Capped at two. The count is not the job of the illusion: a pile of eight
-     * would be a stack of hairlines, and past two edges nobody counts anyway.
-     */
-    const deckLayers =
-      foldable.length === 0
-        ? []
-        : foldable.length === 1
-          ? [{ inset: "inset-x-3", offset: "bottom-0" }]
-          : [
-              // Figma stacks three whole callouts at 526 / 500 / 476 wide and
-              // 8px apart: 13px narrower per side per step. 12 and 24 keep it
-              // on the spacing scale and land within a pixel.
-              { inset: "inset-x-6", offset: "bottom-0" },
-              { inset: "inset-x-3", offset: "bottom-2" },
-            ]
+    const deckLayers = deckLayersFor(foldable.length)
     const headerIcon = icon ?? statusIcons[status]
 
-    // Development-only, and in an effect rather than in the render body: a
-    // console.warn during render fires again on every re-render, so a single
-    // violation turns into a stream. The deps are the *presence* of an action
-    // and of a headline rather than the objects themselves — products pass
-    // those inline, so a new identity every render would re-log exactly what
-    // the effect is here to stop.
     const hasAction = Boolean(action || secondaryAction)
     const hasHeadline = Boolean(headline)
     const evidenceEmpty = Boolean(evidence) && !hasEvidence
 
-    useEffect(() => {
-      if (process.env.NODE_ENV === "production") {
-        return
-      }
-
-      // The `neutral`/`info` line is enforced here rather than left in a doc:
-      // if there is something to do, the callout is not neutral. Without this
-      // the two rungs collapse into "grey or blue" and whichever feels calmer
-      // wins.
-      if (status === "neutral" && hasAction) {
-        console.warn(
-          "F0AiCallout: `neutral` means there is nothing to do, so it cannot carry an action. A callout that offers a move with nothing wrong is `info`."
-        )
-      }
-
-      if (status === "neutral" && !icon) {
-        console.warn(
-          "F0AiCallout: `neutral` carries no semantic glyph, so it needs an `icon` that describes the content (e.g. `Summary` from @/icons/ai)."
-        )
-      }
-
-      if (stacked && !hasHeadline) {
-        console.warn(
-          "F0AiCallout: `findings` is empty. A callout titled like a verdict with nothing under it tells the reader something is wrong and not what — rendering nothing instead."
-        )
-      }
-
-      // Unlike empty `findings` this still leaves a complete verdict on screen,
-      // so it renders rather than bailing. It is worth saying out loud all the
-      // same: the product named something ("the 5 checks") and there is no
-      // disclosure to open, which from the outside looks like a broken toggle
-      // rather than an empty array.
-      if (evidenceEmpty) {
-        console.warn(
-          "F0AiCallout: `evidence` has no items, so no disclosure renders. Leave `evidence` out entirely when there is nothing behind it."
-        )
-      }
-    }, [status, hasAction, icon, stacked, hasHeadline, evidenceEmpty])
+    useCalloutWarnings({
+      status,
+      icon,
+      stacked,
+      hasAction,
+      hasHeadline,
+      evidenceEmpty,
+    })
 
     // And actually render nothing, which the warning above promises. The header
     // and shell are built unconditionally below, so without this an empty
@@ -249,275 +628,40 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
     }
 
     const header = (
-      // `min-h-9` pins the header at Figma's 36px in every combination. With
-      // the 24px glyph the row reaches it on its own (6 + 24 + 6), but a
-      // `neutral` callout given no icon has only a 20px title row and would
-      // otherwise sit 4px shorter than its neighbours.
-      <div className="flex min-h-9 flex-row items-center gap-2 px-3 py-1.5">
-        <div className="flex min-w-0 flex-1 flex-row items-center gap-2">
-          {/* 24px, and outlined. Every current node uses `ExclamationCircle` at
-              24 rather than the `…Solid` glyph at 20 the first cut measured,
-              which closes the "F0 has no solid icons" gap that was open all
-              along: there is nothing left to substitute. */}
-          {headerIcon ? (
-            <F0Icon
-              icon={headerIcon}
-              size="lg"
-              color={statusIconColors[status]}
-              aria-hidden
-            />
-          ) : null}
-          <OneEllipsis
-            className={cn(
-              "text-base font-medium",
-              statusForegroundVariants({ status })
-            )}
-          >
-            {title}
-          </OneEllipsis>
-          {stacked ? (
-            // Figma gives the stacked header's byline the *status* foreground at
-            // 50%, in Medium, and hides the One glyph — unlike the single
-            // callout's footer byline, which is grey and keeps the mark. The
-            // difference holds up: in the footer the byline is the row's own
-            // content, while here it is a suffix to a coloured title and a grey
-            // one would read as a different message pasted on.
-            <span
-              className={cn(
-                // Subordinate by size (12 against the title's 14), not by
-                // opacity: at 50% the status foreground lands around 2:1.
-                "flex min-w-0 flex-row items-center gap-1 text-sm font-medium",
-                statusForegroundVariants({ status })
-              )}
-            >
-              {/* The separator is presentation, so it stays out of the
-                  translated string. */}
-              <span aria-hidden>·</span>
-              <span className="truncate">{ai.attribution}</span>
-            </span>
-          ) : null}
-        </div>
-        {stacked && canFold ? (
-          <CollapsibleTrigger asChild>
-            <F0Button
-              variant="ghost"
-              size="sm"
-              icon={open ? ChevronUp : ChevronDown}
-              label={i18n.t(
-                open ? "actions.collapseItem" : "actions.expandItem",
-                { title }
-              )}
-              hideLabel
-            />
-          </CollapsibleTrigger>
-        ) : null}
-        {onClose ? (
-          <F0Button
-            variant="ghost"
-            size="sm"
-            icon={Cross}
-            hideLabel
-            label={actions.close}
-            onClick={onClose}
-          />
-        ) : null}
-      </div>
+      <CalloutHeader
+        status={status}
+        title={title}
+        headerIcon={headerIcon}
+        stacked={stacked}
+        canFold={canFold}
+        open={open}
+        onClose={onClose}
+      />
     )
 
     const body = stacked ? (
-      // The headline row never folds away. Folding to just the header would
-      // leave a tinted strip saying "Issues to resolve" with no issue on it —
-      // which is dismissing the callout under another name.
-      headline && (
-        <div
-          className={cn(
-            cardClasses,
-            cardBorderVariants({ status }),
-            neutralRing(status)
-          )}
-        >
-          <FindingRow
-            finding={headline}
-            status={status}
-            first
-            last={!open || !canFold}
-          />
-          <AnimatePresence initial={false}>
-            {open && canFold ? (
-              <motion.div
-                initial={{ height: 0, opacity: 0 }}
-                animate={{ height: "auto", opacity: 1 }}
-                exit={{ height: 0, opacity: 0 }}
-                transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
-                className="overflow-hidden"
-              >
-                <CollapsibleContent forceMount asChild>
-                  <div>
-                    {foldable.map((finding, index) => (
-                      <FindingRow
-                        key={finding.id}
-                        finding={finding}
-                        status={status}
-                        last={index === foldable.length - 1}
-                      />
-                    ))}
-                  </div>
-                </CollapsibleContent>
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
-        </div>
-      )
+      <FindingsBody
+        status={status}
+        headline={headline}
+        foldable={foldable}
+        open={open}
+        canFold={canFold}
+        shouldReduceMotion={shouldReduceMotion}
+      />
     ) : (
-      <div
-        className={cn(
-          cardClasses,
-          cardBorderVariants({ status }),
-          neutralRing(status)
-        )}
+      <VerdictBody
+        status={status}
+        summary={summary}
+        action={action}
+        secondaryAction={secondaryAction}
+        evidence={evidence}
+        isSteps={isSteps}
+        hasEvidence={hasEvidence}
+        open={open}
+        shouldReduceMotion={shouldReduceMotion}
       >
-        {/* One padded block on one white surface: description, the disclosure
-            that belongs to it, and the reasoning it opens. Nothing changes
-            colour or plane — the hierarchy is carried by the type scale and by
-            the bullets. */}
-        <div className="flex flex-col items-start gap-2 p-4">
-          {/* Title and description are one text block at Figma's 2px, not two
-              children of the body's 8px rhythm: 8px between them read as two
-              separate things, when the description is the same sentence
-              continuing. The 8px stays between this block and the disclosure,
-              which *is* a separate thing. */}
-          <div className="flex flex-col gap-0.5">
-            {summary ? (
-              <span className="text-base font-medium text-f1-foreground">
-                {summary}
-              </span>
-            ) : null}
-            {/* Secondary, and the `summary` above is what makes that work. Three
-                earlier cuts got this wrong in three different ways: dark item
-                labels over a grey description (the detail outranked the body),
-                then everything secondary (flat), then everything dark (flat in
-                black). The anchor was never the description — it is the summary
-                line. With a dark title in front of it, body copy can sit in
-                secondary and the ladder reads by itself.
-
-                Never clipped: the design shows the description whole and folds
-                only the detail list, so the "max 3 lines" the feedback asked
-                for is not in it. */}
-            <div className="text-base text-f1-foreground-secondary">
-              {children}
-            </div>
-          </div>
-          {hasEvidence ? (
-            <>
-              {/* The disclosure sits here, under the description it belongs to,
-                  and not in the header — that placement is the clearest signal
-                  of the relationship. A control in the header says "there are
-                  more items"; one under a sentence says "there is reasoning
-                  behind this sentence". Ghost, so it never competes with the
-                  outlined CTA in the footer. */}
-              {/* The wrapper's `-ml-2` cancels the ghost button's own 8px of
-                  inline padding so its label lands on the same left edge as the
-                  description above and the list below — without it the text
-                  column jogs 8px right for one line and back. It goes on a
-                  wrapper because `F0Button` omits `className` by design. */}
-              <div className="-ml-2">
-                <CollapsibleTrigger asChild>
-                  <F0Button
-                    variant="ghost"
-                    size="sm"
-                    // Only the verb changes. Replacing the whole label costs
-                    // the reader the one thing it is for — naming what is
-                    // behind it — and moves the control's width under the
-                    // pointer; leaving it identical makes a control that has
-                    // just done something look like it did nothing. See/Hide
-                    // differ by a character, so the noun stays put.
-                    label={i18n.t(
-                      open ? "ai.evidence.hide" : "ai.evidence.show",
-                      { name: evidence!.name }
-                    )}
-                    icon={open ? ChevronUp : ChevronDown}
-                    iconPosition="right"
-                  />
-                </CollapsibleTrigger>
-              </div>
-              <AnimatePresence initial={false}>
-                {open ? (
-                  <motion.div
-                    initial={{ height: 0, opacity: 0 }}
-                    animate={{ height: "auto", opacity: 1 }}
-                    exit={{ height: 0, opacity: 0 }}
-                    transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
-                    className="w-full overflow-hidden"
-                  >
-                    <CollapsibleContent forceMount asChild>
-                      {/* Preflight is disabled here, so a bare `ul` renders
-                          with no marker, no indent and no margin — every one
-                          of these is explicit on purpose.
-
-                          A rationale bullets: `outside` puts the discs in the
-                          padding so they land on the column the description
-                          starts at and the sentences hang off them, which is
-                          what stops the text block from stepping sideways.
-
-                          A plan numbers instead, in an `ol`, because the order
-                          is part of what it says — and one marker per row
-                          either way, which is what ruled out putting a
-                          checkbox in front of a disc.
-
-                          Keyed by index on purpose: unlike findings, neither a
-                          rationale nor a plan is resolved and removed item by
-                          item, so there is no reordering for an index key to
-                          get wrong.
-
-                          `[&_strong]:font-medium` is not cosmetic: F0's weight
-                          scale stops at 400/500/600, and with preflight
-                          disabled nothing normalises the browser's own
-                          `strong`, which lands on 700 — off-scale and heavier
-                          than the verdict's own title. Products emphasise
-                          inline with `strong`; this is what keeps that on the
-                          scale. */}
-                      <EvidenceList
-                        className={cn(
-                          "m-0 flex list-outside flex-col gap-1 pl-5 text-base font-normal text-f1-foreground-secondary [&_b]:font-medium [&_strong]:font-medium",
-                          isSteps ? "list-decimal" : "list-disc"
-                        )}
-                      >
-                        {evidence!.items.map((item, index) => (
-                          <li key={index}>{item}</li>
-                        ))}
-                      </EvidenceList>
-                    </CollapsibleContent>
-                  </motion.div>
-                ) : null}
-              </AnimatePresence>
-            </>
-          ) : null}
-        </div>
-        <div
-          className={cn(
-            rowClasses,
-            "px-4 py-3",
-            cardBorderVariants({ status })
-          )}
-        >
-          <Byline />
-          {secondaryAction || action ? (
-            <div className="flex flex-row items-center gap-2">
-              {secondaryAction ? (
-                <F0Button
-                  variant="ghost"
-                  size="md"
-                  label={secondaryAction.label}
-                  icon={secondaryAction.icon}
-                  disabled={secondaryAction.disabled}
-                  onClick={secondaryAction.onClick}
-                />
-              ) : null}
-              {action ? <ActionButton action={action} /> : null}
-            </div>
-          ) : null}
-        </div>
-      </div>
+        {children}
+      </VerdictBody>
     )
 
     const shell = (

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -1,0 +1,563 @@
+import { AnimatePresence, motion } from "motion/react"
+import { forwardRef, useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { F0Icon } from "@/components/F0Icon"
+import { One } from "@/icons/ai"
+import { ChevronDown, ChevronUp, Cross } from "@/icons/app"
+import { useReducedMotion } from "@/lib/a11y"
+import { OneEllipsis } from "@/lib/OneEllipsis"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/ui/collapsible"
+
+import type {
+  AiCalloutAction,
+  AiCalloutFinding,
+  AiCalloutStatus,
+  F0AiCalloutProps,
+} from "./types"
+
+import {
+  cardBorderVariants,
+  cardClasses,
+  rowClasses,
+  statusForegroundVariants,
+  statusIconColors,
+  statusIcons,
+  statusTintVariants,
+} from "./variants"
+
+const Byline = () => {
+  const { ai } = useI18n()
+
+  return (
+    <span className="flex min-w-0 flex-row items-center gap-1 text-base font-normal text-f1-foreground-secondary opacity-50">
+      <F0Icon icon={One} size="md" color="currentColor" aria-hidden />
+      <span className="truncate">{ai.attribution}</span>
+    </span>
+  )
+}
+
+const ActionButton = ({ action }: { action: AiCalloutAction }) => (
+  <F0Button
+    variant="outline"
+    size="md"
+    label={action.label}
+    icon={action.icon}
+    disabled={action.disabled}
+    onClick={action.onClick}
+  />
+)
+
+/**
+ * Open, the findings are rows of **one continuous white block** split by
+ * hairlines — not separate cards with gaps. Figma composes it as sibling cards
+ * that share their edges (`border-b/l/r` only, `mb-[-2px]` to overlap, radius
+ * on the first and last alone, a Divider between); one container with internal
+ * rules is the same pixels with none of the arithmetic.
+ *
+ * Tighter than a single verdict: `py-1.5` between text blocks against the
+ * single card's `p-4`, because a list is read by scanning and one card is read
+ * by stopping. The outer edges get the 12px Figma gives them.
+ *
+ * `first`/`last` are props rather than CSS `first:`/`last:` variants because
+ * the animation splits the rows across two parents: the foldable ones live
+ * inside the collapsible box, so the pseudo-class would strip the rule that
+ * separates the first of them from the headline row.
+ */
+const FindingRow = ({
+  finding,
+  status,
+  first = false,
+  last = false,
+}: {
+  finding: AiCalloutFinding
+  status: AiCalloutStatus
+  first?: boolean
+  last?: boolean
+}) => (
+  <div
+    className={cn(
+      "flex flex-row items-center justify-between gap-3 border-x-0 border-b-0 border-t border-solid px-3 py-1.5",
+      cardBorderVariants({ status }),
+      first && "border-t-0 pt-3",
+      last && "pb-3"
+    )}
+  >
+    <div className="flex min-w-0 flex-col gap-0.5">
+      <span className="text-base font-medium text-f1-foreground">
+        {finding.title}
+      </span>
+      <div className="text-base text-f1-foreground-secondary">
+        {finding.description}
+      </div>
+    </div>
+    {finding.action && <ActionButton action={finding.action} />}
+  </div>
+)
+
+/**
+ * `neutral` is the one status with no colour to ring with, and F0's border scale
+ * starts at `neutral-20` (10%) where the design asks for `neutral-10` (6%) — so
+ * every coloured status draws its ring at exactly its tint's alpha (measured
+ * ratio 1) while `neutral` came out 2.5× darker than its own 4% surface, reading
+ * as an outline rather than a joint.
+ *
+ * Rather than borrow a background token for a border, this applies the design's
+ * own rule literally: the ring *is* the tint. A transparent border plus
+ * `bg-clip-padding` stops the card's white from painting under the border box,
+ * so the shell's tint shows through it. No token invented, no value borrowed.
+ *
+ * Foundations still owes a neutral border token at the 6% step; until then the
+ * 1px hairlines keep using `border-secondary`, where 10% is not a problem.
+ */
+const neutralRing = (status: AiCalloutStatus) =>
+  status === "neutral" && "border-transparent bg-clip-padding"
+
+export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
+  function AiCalloutInternal(
+    {
+      status,
+      title,
+      summary,
+      children,
+      icon,
+      action,
+      secondaryAction,
+      onClose,
+      findings,
+      evidence,
+      open: controlledOpen,
+      defaultOpen,
+      onOpenChange,
+      ...rest
+    },
+    ref
+  ) {
+    const i18n = useI18n()
+    const { actions, ai } = i18n
+    const shouldReduceMotion = useReducedMotion()
+    const stacked = findings !== undefined
+    // The two shapes fold in opposite directions, so they cannot share a
+    // default. Stacked starts open because the pile is the summary: folded it
+    // hides verdicts the reader has not seen yet. A rationale starts folded
+    // because it is the reverse — the verdict is already on screen, and the
+    // reasoning is there for whoever wants to check it.
+    const [uncontrolledOpen, setUncontrolledOpen] = useState(
+      defaultOpen ?? stacked
+    )
+    const open = controlledOpen ?? uncontrolledOpen
+    const [headline, ...foldable] = findings ?? []
+    // Only worth a toggle when folding would actually hide something. With a
+    // single finding the folded and unfolded states are identical, so the
+    // control would promise a change it cannot deliver.
+    const hasEvidence = (evidence?.items.length ?? 0) > 0
+    const isSteps = evidence?.kind === "steps"
+    const EvidenceList = isSteps ? "ol" : "ul"
+    // Two things can fold, and they are not the same thing: findings that are
+    // hidden away, or a rationale that is revealed. Only the first is a pile.
+    const canFold = foldable.length > 0 || hasEvidence
+    const showDeck = stacked && foldable.length > 0 && !open
+    /**
+     * Folded, the findings read as a pile of individual cards; open, they are
+     * rows inside one container. So the fold needs more than a hint that
+     * something is behind — it needs edges, each one step narrower and one step
+     * lower, painted farthest-first so the nearer ones cover them.
+     *
+     * Capped at two. The count is not the job of the illusion: a pile of eight
+     * would be a stack of hairlines, and past two edges nobody counts anyway.
+     */
+    const deckLayers =
+      foldable.length === 0
+        ? []
+        : foldable.length === 1
+          ? [{ inset: "inset-x-3", offset: "bottom-0" }]
+          : [
+              // Figma stacks three whole callouts at 526 / 500 / 476 wide and
+              // 8px apart: 13px narrower per side per step. 12 and 24 keep it
+              // on the spacing scale and land within a pixel.
+              { inset: "inset-x-6", offset: "bottom-0" },
+              { inset: "inset-x-3", offset: "bottom-2" },
+            ]
+    const headerIcon = icon ?? statusIcons[status]
+
+    // The rule that keeps `neutral` and `info` apart, enforced where it is used
+    // rather than left in a doc: if there is something to do, the callout is not
+    // neutral. Without this the two rungs collapse into "grey or blue" and
+    // whichever feels calmer wins.
+    if (status === "neutral" && (action || secondaryAction)) {
+      console.warn(
+        "F0AiCallout: `neutral` means there is nothing to do, so it cannot carry an action. A callout that offers a move with nothing wrong is `info`."
+      )
+    }
+
+    if (status === "neutral" && !icon) {
+      console.warn(
+        "F0AiCallout: `neutral` carries no semantic glyph, so it needs an `icon` that describes the content (e.g. `Summary` from @/icons/ai)."
+      )
+    }
+
+    if (stacked && !headline) {
+      console.warn(
+        "F0AiCallout: `findings` is empty. A callout titled like a verdict with nothing under it tells the reader something is wrong and not what — render nothing instead."
+      )
+    }
+
+    const header = (
+      // `min-h-9` pins the header at Figma's 36px in every combination. With
+      // the 24px glyph the row reaches it on its own (6 + 24 + 6), but a
+      // `neutral` callout given no icon has only a 20px title row and would
+      // otherwise sit 4px shorter than its neighbours.
+      <div className="flex min-h-9 flex-row items-center gap-2 px-3 py-1.5">
+        <div className="flex min-w-0 flex-1 flex-row items-center gap-2">
+          {/* 24px, and outlined. Every current node uses `ExclamationCircle` at
+              24 rather than the `…Solid` glyph at 20 the first cut measured,
+              which closes the "F0 has no solid icons" gap that was open all
+              along: there is nothing left to substitute. */}
+          {headerIcon && (
+            <F0Icon
+              icon={headerIcon}
+              size="lg"
+              color={statusIconColors[status]}
+              aria-hidden
+            />
+          )}
+          <OneEllipsis
+            className={cn(
+              "text-base font-medium",
+              statusForegroundVariants({ status })
+            )}
+          >
+            {title}
+          </OneEllipsis>
+          {stacked && (
+            // Figma gives the stacked header's byline the *status* foreground at
+            // 50%, in Medium, and hides the One glyph — unlike the single
+            // callout's footer byline, which is grey and keeps the mark. The
+            // difference holds up: in the footer the byline is the row's own
+            // content, while here it is a suffix to a coloured title and a grey
+            // one would read as a different message pasted on.
+            <span
+              className={cn(
+                "flex min-w-0 flex-row items-center gap-1 text-sm font-medium opacity-50",
+                statusForegroundVariants({ status })
+              )}
+            >
+              {/* The separator is presentation, so it stays out of the
+                  translated string. */}
+              <span aria-hidden>·</span>
+              <span className="truncate">{ai.attribution}</span>
+            </span>
+          )}
+        </div>
+        {stacked && canFold && (
+          <CollapsibleTrigger asChild>
+            <F0Button
+              variant="ghost"
+              size="sm"
+              icon={open ? ChevronUp : ChevronDown}
+              label={i18n.t(
+                open ? "actions.collapseItem" : "actions.expandItem",
+                { title }
+              )}
+              hideLabel
+            />
+          </CollapsibleTrigger>
+        )}
+        {onClose && (
+          <F0Button
+            variant="ghost"
+            size="sm"
+            icon={Cross}
+            hideLabel
+            label={actions.close}
+            onClick={onClose}
+          />
+        )}
+      </div>
+    )
+
+    const body = stacked ? (
+      // The headline row never folds away. Folding to just the header would
+      // leave a tinted strip saying "Issues to resolve" with no issue on it —
+      // which is dismissing the callout under another name.
+      headline && (
+        <div
+          className={cn(
+            cardClasses,
+            cardBorderVariants({ status }),
+            neutralRing(status)
+          )}
+        >
+          <FindingRow
+            finding={headline}
+            status={status}
+            first
+            last={!open || !canFold}
+          />
+          <AnimatePresence initial={false}>
+            {open && canFold && (
+              <motion.div
+                initial={{ height: 0, opacity: 0 }}
+                animate={{ height: "auto", opacity: 1 }}
+                exit={{ height: 0, opacity: 0 }}
+                transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+                className="overflow-hidden"
+              >
+                <CollapsibleContent forceMount asChild>
+                  <div>
+                    {foldable.map((finding, index) => (
+                      <FindingRow
+                        key={finding.id}
+                        finding={finding}
+                        status={status}
+                        last={index === foldable.length - 1}
+                      />
+                    ))}
+                  </div>
+                </CollapsibleContent>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      )
+    ) : (
+      <div
+        className={cn(
+          cardClasses,
+          cardBorderVariants({ status }),
+          neutralRing(status)
+        )}
+      >
+        {/* One padded block on one white surface: description, the disclosure
+            that belongs to it, and the reasoning it opens. Nothing changes
+            colour or plane — the hierarchy is carried by the type scale and by
+            the bullets. */}
+        <div className="flex flex-col items-start gap-2 p-4">
+          {/* Title and description are one text block at Figma's 2px, not two
+              children of the body's 8px rhythm: 8px between them read as two
+              separate things, when the description is the same sentence
+              continuing. The 8px stays between this block and the disclosure,
+              which *is* a separate thing. */}
+          <div className="flex flex-col gap-0.5">
+            {summary && (
+              <span className="text-base font-medium text-f1-foreground">
+                {summary}
+              </span>
+            )}
+            {/* Secondary, and the `summary` above is what makes that work. Three
+                earlier cuts got this wrong in three different ways: dark item
+                labels over a grey description (the detail outranked the body),
+                then everything secondary (flat), then everything dark (flat in
+                black). The anchor was never the description — it is the summary
+                line. With a dark title in front of it, body copy can sit in
+                secondary and the ladder reads by itself.
+
+                Never clipped: the design shows the description whole and folds
+                only the detail list, so the "max 3 lines" the feedback asked
+                for is not in it. */}
+            <div className="text-base text-f1-foreground-secondary">
+              {children}
+            </div>
+          </div>
+          {hasEvidence && (
+            <>
+              {/* The disclosure sits here, under the description it belongs to,
+                  and not in the header — that placement is the clearest signal
+                  of the relationship. A control in the header says "there are
+                  more items"; one under a sentence says "there is reasoning
+                  behind this sentence". Ghost, so it never competes with the
+                  outlined CTA in the footer. */}
+              {/* The wrapper's `-ml-2` cancels the ghost button's own 8px of
+                  inline padding so its label lands on the same left edge as the
+                  description above and the list below — without it the text
+                  column jogs 8px right for one line and back. It goes on a
+                  wrapper because `F0Button` omits `className` by design. */}
+              <div className="-ml-2">
+                <CollapsibleTrigger asChild>
+                  <F0Button
+                    variant="ghost"
+                    size="sm"
+                    // Only the verb changes. Replacing the whole label costs
+                    // the reader the one thing it is for — naming what is
+                    // behind it — and moves the control's width under the
+                    // pointer; leaving it identical makes a control that has
+                    // just done something look like it did nothing. See/Hide
+                    // differ by a character, so the noun stays put.
+                    label={i18n.t(
+                      open ? "ai.evidence.hide" : "ai.evidence.show",
+                      { name: evidence!.name }
+                    )}
+                    icon={open ? ChevronUp : ChevronDown}
+                    iconPosition="right"
+                  />
+                </CollapsibleTrigger>
+              </div>
+              <AnimatePresence initial={false}>
+                {open && (
+                  <motion.div
+                    initial={{ height: 0, opacity: 0 }}
+                    animate={{ height: "auto", opacity: 1 }}
+                    exit={{ height: 0, opacity: 0 }}
+                    transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
+                    className="w-full overflow-hidden"
+                  >
+                    <CollapsibleContent forceMount asChild>
+                      {/* Preflight is disabled here, so a bare `ul` renders
+                          with no marker, no indent and no margin — every one
+                          of these is explicit on purpose.
+
+                          A rationale bullets: `outside` puts the discs in the
+                          padding so they land on the column the description
+                          starts at and the sentences hang off them, which is
+                          what stops the text block from stepping sideways.
+
+                          A plan numbers instead, in an `ol`, because the order
+                          is part of what it says — and one marker per row
+                          either way, which is what ruled out putting a
+                          checkbox in front of a disc.
+
+                          Keyed by index on purpose: unlike findings, neither a
+                          rationale nor a plan is resolved and removed item by
+                          item, so there is no reordering for an index key to
+                          get wrong.
+
+                          `[&_strong]:font-medium` is not cosmetic: F0's weight
+                          scale stops at 400/500/600, and with preflight
+                          disabled nothing normalises the browser's own
+                          `strong`, which lands on 700 — off-scale and heavier
+                          than the verdict's own title. Products emphasise
+                          inline with `strong`; this is what keeps that on the
+                          scale. */}
+                      <EvidenceList
+                        className={cn(
+                          "m-0 flex list-outside flex-col gap-1 pl-5 text-base font-normal text-f1-foreground-secondary [&_b]:font-medium [&_strong]:font-medium",
+                          isSteps ? "list-decimal" : "list-disc"
+                        )}
+                      >
+                        {evidence!.items.map((item, index) => (
+                          <li key={index}>{item}</li>
+                        ))}
+                      </EvidenceList>
+                    </CollapsibleContent>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </>
+          )}
+        </div>
+        <div
+          className={cn(
+            rowClasses,
+            "px-4 py-3",
+            cardBorderVariants({ status })
+          )}
+        >
+          <Byline />
+          {(secondaryAction || action) && (
+            <div className="flex flex-row items-center gap-2">
+              {secondaryAction && (
+                <F0Button
+                  variant="ghost"
+                  size="md"
+                  label={secondaryAction.label}
+                  icon={secondaryAction.icon}
+                  disabled={secondaryAction.disabled}
+                  onClick={secondaryAction.onClick}
+                />
+              )}
+              {action && <ActionButton action={action} />}
+            </div>
+          )}
+        </div>
+      </div>
+    )
+
+    const shell = (
+      <div
+        ref={ref}
+        // Never `role="alert"`. The byline says a machine reached this
+        // conclusion, and an assessment is not a system emergency — it should
+        // not interrupt whatever the reader is doing.
+        role="status"
+        aria-live="polite"
+        // The pile lives out here, as siblings of the callout rather than
+        // inside it. That is the whole difference: in Figma the layers are
+        // three frames at the same level, so their edges sit on the page, and
+        // nested inside the tinted shell — which also clips — they read as
+        // shapes trapped in a red box instead of loose cards behind this one.
+        // The padding is the room they show through.
+        className={cn(
+          "relative w-full",
+          showDeck && (deckLayers.length === 1 ? "pb-2" : "pb-4")
+        )}
+        {...rest}
+      >
+        {showDeck &&
+          deckLayers.map(({ inset, offset }) => (
+            // A whole callout behind: its own tint with its own white card
+            // pinned to the bottom, exactly as Figma stacks three complete
+            // Cards. Only ~8px shows, so the content is left out — rendering it
+            // twice would hand a screen reader a copy of what the fold hides.
+            <div
+              key={inset}
+              aria-hidden
+              className={cn(
+                // Tall enough that its 16px corners are never clamped: a box
+                // shorter than 32px makes the browser scale both radii to fit,
+                // and a scaled radius here no longer matches the white card's.
+                "absolute h-12 overflow-hidden rounded-xl",
+                inset,
+                offset,
+                statusTintVariants({ status })
+              )}
+            >
+              {/* `rounded-b-xl` rather than `rounded-xl`, and 32px tall. At 20px
+                  with all four corners the radii summed past the height, so the
+                  browser scaled them to 10 while the layer kept 16 — and the
+                  tint showed through the gap between the two curves as a red
+                  smear in the corner. Bottom-only radii on a box this tall are
+                  never clamped, so both curves coincide. */}
+              <div
+                className={cn(
+                  "absolute inset-x-0 bottom-0 top-4 rounded-b-xl border-x-2 border-b-2 border-t-0 border-solid bg-f1-background",
+                  cardBorderVariants({ status })
+                )}
+              />
+            </div>
+          ))}
+        {/* Positioned so DOM order decides the painting: the absolute layers
+            would otherwise sit above a static sibling. */}
+        <div
+          className={cn(
+            "relative w-full overflow-hidden rounded-xl",
+            statusTintVariants({ status })
+          )}
+        >
+          {header}
+          {body}
+        </div>
+      </div>
+    )
+
+    if (!canFold) return shell
+
+    return (
+      <Collapsible
+        open={open}
+        onOpenChange={(next) => {
+          setUncontrolledOpen(next)
+          onOpenChange?.(next)
+        }}
+        asChild
+      >
+        {shell}
+      </Collapsible>
+    )
+  }
+)

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -1,6 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
 import { forwardRef, useEffect, useState } from "react"
-
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
 import { One } from "@/icons/ai"
@@ -14,14 +13,12 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/ui/collapsible"
-
 import type {
   AiCalloutAction,
   AiCalloutFinding,
   AiCalloutStatus,
   F0AiCalloutProps,
 } from "./types"
-
 import {
   cardBorderVariants,
   cardClasses,
@@ -104,7 +101,7 @@ const FindingRow = ({
         {finding.description}
       </div>
     </div>
-    {finding.action && <ActionButton action={finding.action} />}
+    {finding.action ? <ActionButton action={finding.action} /> : null}
   </div>
 )
 
@@ -205,7 +202,9 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
     const evidenceEmpty = Boolean(evidence) && !hasEvidence
 
     useEffect(() => {
-      if (process.env.NODE_ENV === "production") return
+      if (process.env.NODE_ENV === "production") {
+        return
+      }
 
       // The `neutral`/`info` line is enforced here rather than left in a doc:
       // if there is something to do, the callout is not neutral. Without this
@@ -260,14 +259,14 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
               24 rather than the `…Solid` glyph at 20 the first cut measured,
               which closes the "F0 has no solid icons" gap that was open all
               along: there is nothing left to substitute. */}
-          {headerIcon && (
+          {headerIcon ? (
             <F0Icon
               icon={headerIcon}
               size="lg"
               color={statusIconColors[status]}
               aria-hidden
             />
-          )}
+          ) : null}
           <OneEllipsis
             className={cn(
               "text-base font-medium",
@@ -276,7 +275,7 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
           >
             {title}
           </OneEllipsis>
-          {stacked && (
+          {stacked ? (
             // Figma gives the stacked header's byline the *status* foreground at
             // 50%, in Medium, and hides the One glyph — unlike the single
             // callout's footer byline, which is grey and keeps the mark. The
@@ -296,9 +295,9 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
               <span aria-hidden>·</span>
               <span className="truncate">{ai.attribution}</span>
             </span>
-          )}
+          ) : null}
         </div>
-        {stacked && canFold && (
+        {stacked && canFold ? (
           <CollapsibleTrigger asChild>
             <F0Button
               variant="ghost"
@@ -311,8 +310,8 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
               hideLabel
             />
           </CollapsibleTrigger>
-        )}
-        {onClose && (
+        ) : null}
+        {onClose ? (
           <F0Button
             variant="ghost"
             size="sm"
@@ -321,7 +320,7 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
             label={actions.close}
             onClick={onClose}
           />
-        )}
+        ) : null}
       </div>
     )
 
@@ -344,7 +343,7 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
             last={!open || !canFold}
           />
           <AnimatePresence initial={false}>
-            {open && canFold && (
+            {open && canFold ? (
               <motion.div
                 initial={{ height: 0, opacity: 0 }}
                 animate={{ height: "auto", opacity: 1 }}
@@ -365,7 +364,7 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
                   </div>
                 </CollapsibleContent>
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
         </div>
       )
@@ -388,11 +387,11 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
               continuing. The 8px stays between this block and the disclosure,
               which *is* a separate thing. */}
           <div className="flex flex-col gap-0.5">
-            {summary && (
+            {summary ? (
               <span className="text-base font-medium text-f1-foreground">
                 {summary}
               </span>
-            )}
+            ) : null}
             {/* Secondary, and the `summary` above is what makes that work. Three
                 earlier cuts got this wrong in three different ways: dark item
                 labels over a grey description (the detail outranked the body),
@@ -408,7 +407,7 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
               {children}
             </div>
           </div>
-          {hasEvidence && (
+          {hasEvidence ? (
             <>
               {/* The disclosure sits here, under the description it belongs to,
                   and not in the header — that placement is the clearest signal
@@ -442,7 +441,7 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
                 </CollapsibleTrigger>
               </div>
               <AnimatePresence initial={false}>
-                {open && (
+                {open ? (
                   <motion.div
                     initial={{ height: 0, opacity: 0 }}
                     animate={{ height: "auto", opacity: 1 }}
@@ -489,10 +488,10 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
                       </EvidenceList>
                     </CollapsibleContent>
                   </motion.div>
-                )}
+                ) : null}
               </AnimatePresence>
             </>
-          )}
+          ) : null}
         </div>
         <div
           className={cn(
@@ -502,9 +501,9 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
           )}
         >
           <Byline />
-          {(secondaryAction || action) && (
+          {secondaryAction || action ? (
             <div className="flex flex-row items-center gap-2">
-              {secondaryAction && (
+              {secondaryAction ? (
                 <F0Button
                   variant="ghost"
                   size="md"
@@ -513,10 +512,10 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
                   disabled={secondaryAction.disabled}
                   onClick={secondaryAction.onClick}
                 />
-              )}
-              {action && <ActionButton action={action} />}
+              ) : null}
+              {action ? <ActionButton action={action} /> : null}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     )
@@ -541,39 +540,40 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
         )}
         {...rest}
       >
-        {showDeck &&
-          deckLayers.map(({ inset, offset }) => (
-            // A whole callout behind: its own tint with its own white card
-            // pinned to the bottom, exactly as Figma stacks three complete
-            // Cards. Only ~8px shows, so the content is left out — rendering it
-            // twice would hand a screen reader a copy of what the fold hides.
-            <div
-              key={inset}
-              aria-hidden
-              className={cn(
-                // Tall enough that its 16px corners are never clamped: a box
-                // shorter than 32px makes the browser scale both radii to fit,
-                // and a scaled radius here no longer matches the white card's.
-                "absolute h-12 overflow-hidden rounded-xl",
-                inset,
-                offset,
-                statusTintVariants({ status })
-              )}
-            >
-              {/* `rounded-b-xl` rather than `rounded-xl`, and 32px tall. At 20px
+        {showDeck
+          ? deckLayers.map(({ inset, offset }) => (
+              // A whole callout behind: its own tint with its own white card
+              // pinned to the bottom, exactly as Figma stacks three complete
+              // Cards. Only ~8px shows, so the content is left out — rendering it
+              // twice would hand a screen reader a copy of what the fold hides.
+              <div
+                key={inset}
+                aria-hidden
+                className={cn(
+                  // Tall enough that its 16px corners are never clamped: a box
+                  // shorter than 32px makes the browser scale both radii to fit,
+                  // and a scaled radius here no longer matches the white card's.
+                  "absolute h-12 overflow-hidden rounded-xl",
+                  inset,
+                  offset,
+                  statusTintVariants({ status })
+                )}
+              >
+                {/* `rounded-b-xl` rather than `rounded-xl`, and 32px tall. At 20px
                   with all four corners the radii summed past the height, so the
                   browser scaled them to 10 while the layer kept 16 — and the
                   tint showed through the gap between the two curves as a red
                   smear in the corner. Bottom-only radii on a box this tall are
                   never clamped, so both curves coincide. */}
-              <div
-                className={cn(
-                  "absolute inset-x-0 bottom-0 top-4 rounded-b-xl border-x-2 border-b-2 border-t-0 border-solid bg-f1-background",
-                  cardBorderVariants({ status })
-                )}
-              />
-            </div>
-          ))}
+                <div
+                  className={cn(
+                    "absolute inset-x-0 bottom-0 top-4 rounded-b-xl border-x-2 border-b-2 border-t-0 border-solid bg-f1-background",
+                    cardBorderVariants({ status })
+                  )}
+                />
+              </div>
+            ))
+          : null}
         {/* Positioned so DOM order decides the painting: the absolute layers
             would otherwise sit above a static sibling. */}
         <div
@@ -588,7 +588,9 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
       </div>
     )
 
-    if (!canFold) return shell
+    if (!canFold) {
+      return shell
+    }
 
     return (
       <Collapsible

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -202,6 +202,7 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
     // the effect is here to stop.
     const hasAction = Boolean(action || secondaryAction)
     const hasHeadline = Boolean(headline)
+    const evidenceEmpty = Boolean(evidence) && !hasEvidence
 
     useEffect(() => {
       if (process.env.NODE_ENV === "production") return
@@ -227,7 +228,18 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
           "F0AiCallout: `findings` is empty. A callout titled like a verdict with nothing under it tells the reader something is wrong and not what — rendering nothing instead."
         )
       }
-    }, [status, hasAction, icon, stacked, hasHeadline])
+
+      // Unlike empty `findings` this still leaves a complete verdict on screen,
+      // so it renders rather than bailing. It is worth saying out loud all the
+      // same: the product named something ("the 5 checks") and there is no
+      // disclosure to open, which from the outside looks like a broken toggle
+      // rather than an empty array.
+      if (evidenceEmpty) {
+        console.warn(
+          "F0AiCallout: `evidence` has no items, so no disclosure renders. Leave `evidence` out entirely when there is nothing behind it."
+        )
+      }
+    }, [status, hasAction, icon, stacked, hasHeadline, evidenceEmpty])
 
     // And actually render nothing, which the warning above promises. The header
     // and shell are built unconditionally below, so without this an empty

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -114,7 +114,8 @@ const FindingRow = ({
  * so the shell's tint shows through it. No token invented, no value borrowed.
  *
  * Foundations still owes a neutral border token at the 6% step; until then the
- * 1px hairlines keep using `border-secondary`, where 10% is not a problem.
+ * 1px hairlines keep using `border-f1-border-secondary`, where 10% is
+ * not a problem.
  */
 const neutralRing = (status: AiCalloutStatus) =>
   status === "neutral" && "border-transparent bg-clip-padding"

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -32,6 +32,9 @@ import {
   statusTintVariants,
 } from "./variants"
 
+// One string and not a set of them: how much the message claims is the status's
+// job, so a byline that also modulated the claim would be a second signal for
+// the same thing. That is why there is no `attribution` prop.
 const Byline = () => {
   const { ai } = useI18n()
 

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react"
-import { forwardRef, useState } from "react"
+import { forwardRef, useEffect, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Icon } from "@/components/F0Icon"
@@ -191,26 +191,47 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
             ]
     const headerIcon = icon ?? statusIcons[status]
 
-    // The rule that keeps `neutral` and `info` apart, enforced where it is used
-    // rather than left in a doc: if there is something to do, the callout is not
-    // neutral. Without this the two rungs collapse into "grey or blue" and
-    // whichever feels calmer wins.
-    if (status === "neutral" && (action || secondaryAction)) {
-      console.warn(
-        "F0AiCallout: `neutral` means there is nothing to do, so it cannot carry an action. A callout that offers a move with nothing wrong is `info`."
-      )
-    }
+    // Development-only, and in an effect rather than in the render body: a
+    // console.warn during render fires again on every re-render, so a single
+    // violation turns into a stream. The deps are the *presence* of an action
+    // and of a headline rather than the objects themselves — products pass
+    // those inline, so a new identity every render would re-log exactly what
+    // the effect is here to stop.
+    const hasAction = Boolean(action || secondaryAction)
+    const hasHeadline = Boolean(headline)
 
-    if (status === "neutral" && !icon) {
-      console.warn(
-        "F0AiCallout: `neutral` carries no semantic glyph, so it needs an `icon` that describes the content (e.g. `Summary` from @/icons/ai)."
-      )
-    }
+    useEffect(() => {
+      if (process.env.NODE_ENV === "production") return
 
-    if (stacked && !headline) {
-      console.warn(
-        "F0AiCallout: `findings` is empty. A callout titled like a verdict with nothing under it tells the reader something is wrong and not what — render nothing instead."
-      )
+      // The `neutral`/`info` line is enforced here rather than left in a doc:
+      // if there is something to do, the callout is not neutral. Without this
+      // the two rungs collapse into "grey or blue" and whichever feels calmer
+      // wins.
+      if (status === "neutral" && hasAction) {
+        console.warn(
+          "F0AiCallout: `neutral` means there is nothing to do, so it cannot carry an action. A callout that offers a move with nothing wrong is `info`."
+        )
+      }
+
+      if (status === "neutral" && !icon) {
+        console.warn(
+          "F0AiCallout: `neutral` carries no semantic glyph, so it needs an `icon` that describes the content (e.g. `Summary` from @/icons/ai)."
+        )
+      }
+
+      if (stacked && !hasHeadline) {
+        console.warn(
+          "F0AiCallout: `findings` is empty. A callout titled like a verdict with nothing under it tells the reader something is wrong and not what — rendering nothing instead."
+        )
+      }
+    }, [status, hasAction, icon, stacked, hasHeadline])
+
+    // And actually render nothing, which the warning above promises. The header
+    // and shell are built unconditionally below, so without this an empty
+    // `findings` array puts a critical pill on the page reading like a verdict
+    // with no content under it.
+    if (stacked && !hasHeadline) {
+      return null
     }
 
     const header = (

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutInternal.tsx
@@ -36,7 +36,11 @@ const Byline = () => {
   const { ai } = useI18n()
 
   return (
-    <span className="flex min-w-0 flex-row items-center gap-1 text-base font-normal text-f1-foreground-secondary opacity-50">
+    // No `opacity-50` here, though Figma draws the byline faint: halving the
+    // secondary token takes it from 4.96:1 to 2:1, well under AA, and an
+    // attribution nobody can read is the one thing this component cannot
+    // ship. It stays subordinate by token and weight instead.
+    <span className="flex min-w-0 flex-row items-center gap-1 text-base font-normal text-f1-foreground-secondary">
       <F0Icon icon={One} size="md" color="currentColor" aria-hidden />
       <span className="truncate">{ai.attribution}</span>
     </span>
@@ -245,7 +249,9 @@ export const AiCalloutInternal = forwardRef<HTMLDivElement, F0AiCalloutProps>(
             // one would read as a different message pasted on.
             <span
               className={cn(
-                "flex min-w-0 flex-row items-center gap-1 text-sm font-medium opacity-50",
+                // Subordinate by size (12 against the title's 14), not by
+                // opacity: at 50% the status foreground lands around 2:1.
+                "flex min-w-0 flex-row items-center gap-1 text-sm font-medium",
                 statusForegroundVariants({ status })
               )}
             >

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutSkeleton.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutSkeleton.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/utils"
+import { Skeleton } from "@/ui/skeleton"
+
+import type { AiCalloutSkeletonProps } from "./types"
+import {
+  cardBorderVariants,
+  cardClasses,
+  rowClasses,
+  statusTintVariants,
+} from "./variants"
+
+export const AiCalloutSkeleton = ({
+  status = "neutral",
+  compact = false,
+}: AiCalloutSkeletonProps) => {
+  return (
+    <div
+      className={cn(
+        "w-full overflow-hidden rounded-xl",
+        statusTintVariants({ status })
+      )}
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="flex min-h-9 flex-row items-center gap-2 px-3 py-1.5">
+        <Skeleton className="h-5 w-40 rounded-md" />
+      </div>
+      <div className={cn(cardClasses, cardBorderVariants({ status }))}>
+        <div className="flex flex-col gap-2 p-4">
+          <Skeleton className="h-4 w-full rounded-md" />
+          <Skeleton className="h-4 w-3/4 rounded-md" />
+        </div>
+        {!compact && (
+          <div
+            className={cn(
+              rowClasses,
+              "px-4 py-3",
+              cardBorderVariants({ status })
+            )}
+          >
+            <Skeleton className="h-5 w-32 rounded-md" />
+            <Skeleton className="h-8 w-24 rounded-md" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutSkeleton.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/AiCalloutSkeleton.tsx
@@ -1,6 +1,5 @@
 import { cn } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
-
 import type { AiCalloutSkeletonProps } from "./types"
 import {
   cardBorderVariants,
@@ -30,7 +29,7 @@ export const AiCalloutSkeleton = ({
           <Skeleton className="h-4 w-full rounded-md" />
           <Skeleton className="h-4 w-3/4 rounded-md" />
         </div>
-        {!compact && (
+        {!compact ? (
           <div
             className={cn(
               rowClasses,
@@ -41,7 +40,7 @@ export const AiCalloutSkeleton = ({
             <Skeleton className="h-5 w-32 rounded-md" />
             <Skeleton className="h-8 w-24 rounded-md" />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.mdx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.mdx
@@ -170,6 +170,8 @@ Same disclosure, different content: steps the reader works through instead of re
 
 ### Design best practices
 
+AI output with nothing to decide — a draft, a summary of a history — is not an exception to this component: it is `status="neutral"`, with an `icon` that describes the content. `F0AiBanner` used to serve that case and is deprecated.
+
 **Where it goes and how long it lives**
 
 - **It belongs to a record, so it sits with that record** — in the page flow, above the content it judges. Never fixed, floating or page-level: a message about the product itself is `F0Alert`, and one that follows the reader everywhere is a global banner.
@@ -245,11 +247,9 @@ Same disclosure, different content: steps the reader works through instead of re
         </td>
       </tr>
       <tr>
+        <td>A turn in a conversation the reader is having with One</td>
         <td>
-          AI content with no verdict at all — a draft, a summary, a chat turn
-        </td>
-        <td>
-          <code>F0AiBanner</code> or <code>F0AiChat</code>.
+          <code>F0AiChat</code> — a reply is not an assessment of a record.
         </td>
       </tr>
     </tbody>

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.mdx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.mdx
@@ -1,0 +1,388 @@
+import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+import { F0AiCallout } from ".."
+
+import * as Stories from "./F0AiCallout.stories"
+
+<Meta of={Stories} />
+
+# F0AiCallout
+
+Shows what One — Factorial's AI — found about the record on screen, and what it needs from the reader. People meet One in conversation, where they ask and it answers; this is how it reaches them on a record instead, having looked without being asked.
+
+That nobody asked is what shapes the component. It always says the message came from One, and it never interrupts to say it: an assessment a machine volunteered has to be attributable and must not seize the reader's attention the way a system failure may.
+
+It replaces `F0Callout`, which is deprecated. For a message the system raises about itself — a failed save, an offline warning — use `F0Alert`: the difference is authorship, and this component always says so.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Statuses
+
+The status says how much the message matters, from a report the reader can skim to something they have to act on now. It is required and has no default: a blocking finding sent as `info` still looks correct.
+
+<Canvas of={Stories.Statuses} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Status</th>
+        <th className="text-left">Use it when</th>
+        <th className="text-left">Example</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>neutral</code>
+        </td>
+        <td>
+          Nothing is asked of the reader: a record to read and move on from.
+          Never carries an action, and takes an <code>icon</code> because it has
+          no glyph of its own.
+        </td>
+        <td>Summary of a device history</td>
+      </tr>
+      <tr>
+        <td>
+          <code>info</code>
+        </td>
+        <td>
+          The reader has something to do and nothing is wrong. The work is often
+          elsewhere, so there may be no button — the status is about the work,
+          not the button.
+        </td>
+        <td>5 invoices linked</td>
+      </tr>
+      <tr>
+        <td>
+          <code>positive</code>
+        </td>
+        <td>
+          Nothing is wrong and One's read is favourable — it endorses what it
+          found. There is still something to do, which is what separates it from{" "}
+          <code>neutral</code>.
+        </td>
+        <td>Approval recommended</td>
+      </tr>
+      <tr>
+        <td>
+          <code>warning</code>
+        </td>
+        <td>Something may be wrong — look before continuing.</td>
+        <td>Requires review</td>
+      </tr>
+      <tr>
+        <td>
+          <code>critical</code>
+        </td>
+        <td>Something is wrong — act.</td>
+        <td>Not reimbursable</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Shapes
+
+One component, four shapes, and the content decides which: the props you pass are what selects it. There is no `shape` or `stacked` flag, because the product already knows whether it holds one verdict or several.
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Shape</th>
+        <th className="text-left">Turned on by</th>
+        <th className="text-left">Use it for</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Verdict</td>
+        <td>
+          <code>children</code>
+        </td>
+        <td>One assessment, self-contained.</td>
+      </tr>
+      <tr>
+        <td>Findings</td>
+        <td>
+          <code>findings</code>
+        </td>
+        <td>Several issues on one record, each with its own action.</td>
+      </tr>
+      <tr>
+        <td>Verdict with a rationale</td>
+        <td>
+          <code>evidence</code>
+        </td>
+        <td>One recommendation, plus the reasoning behind it.</td>
+      </tr>
+      <tr>
+        <td>Verdict with a plan</td>
+        <td>
+          <code>evidence</code> + <code>kind="steps"</code>
+        </td>
+        <td>One assessment whose answer is several things to do, in order.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**One callout is one evaluation with one severity.** Mixed severity is two callouts side by side — "Suggestions to review" in `warning` next to "Issues to resolve" in `critical` — never one callout with two colours.
+
+#### Verdict
+
+A verdict, the reason under it, and the facts under that. Nothing folds, so nothing is hidden — reach for `evidence` only when there is reasoning worth checking, not to shorten a body that is already short.
+
+<Canvas of={Stories.Verdict} />
+
+#### Findings
+
+Several issues on one record, each resolvable on its own, so **every row keeps its own action** and the title is a roll-up of what they add up to.
+
+This is the shape that stacks: the rows share one white block split by hairlines, and folding piles them into a deck — the front finding stays readable, the rest are slivers behind it. "Stacked" throughout this page means that layout, never a prop; the shape is selected by passing `findings`.
+
+<Canvas of={Stories.Findings} />
+
+#### Verdict with a rationale
+
+**One recommended action for the whole callout**, and the reasoning one click away. The pair in the footer is one decision, not two: `action` is the move the verdict recommends, outlined, and `secondaryAction` is the way out of it, ghost — "Reject" against "Approve anyway", never a third path.
+
+What the rows never have is an action of their own, and that absence is the contract: a check that needs its own button has become a finding. Folding hides reasoning rather than work, so there is no deck — and it starts folded, the opposite of the findings default.
+
+<Canvas of={Stories.WithRationale} />
+
+#### Verdict with a plan
+
+Same disclosure, different content: steps the reader works through instead of reasons they check. `kind="steps"` numbers them, because the order is part of what they say, and no step carries an action of its own.
+
+<Canvas of={Stories.ResolutionPlanFlow} />
+
+**What can go behind the disclosure**, and it is a short list on purpose: bulleted **reasons** (`kind: "rationale"`, the default) or numbered **steps** (`kind: "steps"`). `items` takes nodes, so more detail is one longer item rather than a new shape, and emphasis goes inline with `strong` where the number or the rule actually is. What must never go in there is anything with a button.
+
+## Guidelines
+
+### Design best practices
+
+**Where it goes and how long it lives**
+
+- **It belongs to a record, so it sits with that record** — in the page flow, above the content it judges. Never fixed, floating or page-level: a message about the product itself is `F0Alert`, and one that follows the reader everywhere is a global banner.
+- **One evaluation per callout, and at most two on a record.** Two are only justified when the severities genuinely differ — "Suggestions to review" beside "Issues to resolve". Past that, several colours compete and the reader cannot tell what to answer first.
+- **It persists, and it does not travel.** It is not transient — that is `F0Toast` — and it does not follow the reader to the next page. It stays until they act on it or put it away.
+- **When the reader acts, the product takes back what was resolved.** Findings disappear one at a time, and the last one leaves the shell without a toggle or a deck, because there is nothing left to fold. When nothing is left to say, remove the callout rather than leave an empty one.
+- **`onClose` means "not now", not "resolved".** Offer it where the reader may reasonably ignore the message, and leave it out where the verdict has to be answered — which is why it is unavailable with `findings`.
+- **The callout asks; it does not collect.** What it owns is one decision — the move it recommends, and at most the way out of it. When answering needs a form, a choice between options or a confirmation, the action opens a dialog: the reader stays on the record, and the message never holds a value they have not submitted yet.
+
+**When to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0AiCallout when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>One assessed the record on screen</td>
+        <td>
+          The assessment has a severity and the reader's next move is to accept
+          or override it in place.
+        </td>
+      </tr>
+      <tr>
+        <td>One found several problems with one object</td>
+        <td>
+          Each is resolvable on its own — pass <code>findings</code> so every
+          one keeps its action.
+        </td>
+      </tr>
+      <tr>
+        <td>The recommendation needs to be auditable</td>
+        <td>
+          Pass <code>evidence</code> so the reader can verify the conclusion
+          without leaving the page.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>The system is reporting about itself, not about a record</td>
+        <td>
+          <code>F0Alert</code> — no authorship to disclose.
+        </td>
+      </tr>
+      <tr>
+        <td>Transient confirmation of something the user just did</td>
+        <td>
+          <code>F0Toast</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>The reader must decide before continuing</td>
+        <td>
+          <code>F0Dialog</code> — a callout can be scrolled past.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          AI content with no verdict at all — a draft, a summary, a chat turn
+        </td>
+        <td>
+          <code>F0AiBanner</code> or <code>F0AiChat</code>.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do's and don'ts**
+
+<DoDonts
+  stacked
+  do={{
+    description:
+      "Pass findings when each row is resolvable on its own, so every one keeps the button that resolves it.",
+    children: (
+      <F0AiCallout
+        status="critical"
+        title="Issues to resolve"
+        findings={[
+          {
+            id: "duplicate",
+            title: "Possible duplicate",
+            description: "A similar invoice already exists for this vendor.",
+            action: { label: "Review", onClick: () => {} },
+          },
+          {
+            id: "bank",
+            title: "Bank details changed",
+            description: "The vendor's account changed since the last payment.",
+            action: { label: "Verify", onClick: () => {} },
+          },
+        ]}
+      />
+    ),
+  }}
+  dont={{
+    description:
+      "Don't put them behind the disclosure: evidence rows carry no action, so the reader can see two problems and resolve neither.",
+    children: (
+      <F0AiCallout
+        status="critical"
+        title="Issues to resolve"
+        defaultOpen
+        evidence={{
+          name: "the 2 issues",
+          items: [
+            "Possible duplicate: a similar invoice already exists for this vendor.",
+            "Bank details changed: the vendor's account changed since the last payment.",
+          ],
+        }}
+      >
+        Two issues need resolving before this invoice can be paid.
+      </F0AiCallout>
+    ),
+  }}
+/>
+
+### Content best practices
+
+- **The tinted title is _what this is_; `summary` is _why_.** They are the same size and weight on purpose — one sentence broken in two, not a heading and a subheading — so they must never be two nouns of the same kind. The title never says "One", because the byline right below it already does, and never names the record, because the page does; `summary` never carries the record's identity or a score.
+  - **Correct:** "Six steps to set up this workstation" · "No role details yet, so the device is the first thing to confirm"
+  - **Incorrect:** "One drafted a resolution plan" · "Six steps, 2 of 6 done"
+- **Read only the title and the summary: that has to be a decision.** If those two lines alone do not tell the reader what is happening and what it means for them, the copy is in the wrong slots. `children` carries the nuance that changes what they do, not the part that makes the message make sense. Findings have no `summary`, so there the roll-up title carries the decision by itself.
+- **The title is not the button.** If `title` and the action's label are the same words, one of them is doing no work: the title says what is true about the record, the button says what to do about it.
+  - **Correct:** "Rejection recommended" · "Two of five policy checks failed"
+  - **Incorrect:** "Rejection recommended" · "Client lunch · $712.65"
+- **The outlined action is the one the verdict recommends.** If the reasoning concludes something else, the verdict is wrong, not the button.
+  - **Correct:** "Rejection recommended" with `Reject` outlined and `Approve anyway` ghost
+  - **Incorrect:** "Rejection recommended" with `Request changes` outlined — that is a third path, not the override
+- Findings are named for the problem, not the fix: "Possible duplicate", not "Check the invoice".
+- **`evidence.name` names the content, not the gesture.** "the 5 checks", "the six steps" — the component writes "See" and "Hide" around it, so a label can only ever name something.
+- **One evidence item is one fact.** Usually a sentence; when a reason needs more, make it a longer item rather than splitting it into a bolded name and a body. Emphasise inline with `strong` where the number or the rule actually is.
+
+<DoDonts
+  stacked
+  do={{
+    description:
+      "The title says what the reader is looking at, so the two emphasised lines are a decision on their own.",
+    children: (
+      <F0AiCallout
+        status="info"
+        title="Six steps to set up this workstation"
+        summary="No role details yet, so the device is the first thing to confirm"
+      >
+        A first day setup for a new joiner starting 4 September.
+      </F0AiCallout>
+    ),
+  }}
+  dont={{
+    description:
+      "Don't spend it on where the message came from — the byline is already saying it, three lines below.",
+    children: (
+      <F0AiCallout
+        status="info"
+        title="One drafted a resolution plan"
+        summary="Six steps, 2 of 6 done"
+      >
+        A first day setup for a new joiner starting 4 September.
+      </F0AiCallout>
+    ),
+  }}
+/>
+
+### Behavior
+
+- **`role="status"` with `aria-live="polite"`, always — never `role="alert"`.** Because the byline is always rendered, every callout is a machine's assessment, and an assessment is not a system emergency: it must not interrupt what the reader is doing.
+- **Folding never empties the callout.** Findings keep the first one on screen and pile the rest behind it; the rationale shape keeps the whole description and folds only the checks. A callout reduced to its header would say something needs attention without saying what, which is dismissal under another name — and it is also why `onClose` is unavailable while stacked.
+- **Folded content is unmounted, not hidden.** A folded group offers a screen reader nothing the eye cannot see.
+- **The deck caps at two layers.** With five findings you see three cards, not five: past two edges the pile stops reading as a count and nobody counts it anyway.
+- **A list of one keeps its shape but loses its controls.** An evaluation that has had three of four findings resolved does not change form on the last one — it simply drops the toggle and the deck, because folding would hide nothing.
+- **Uncontrolled defaults differ by shape.** `findings` starts open, because a folded finding is a finding nobody read. `evidence` starts folded, because a rationale is read on demand. Pass `open` with `onOpenChange` to drive it yourself.
+- **Only the verb of the disclosure changes.** `evidence.name` is a noun phrase — "the 5 checks" — and the component supplies the verb: "See the 5 checks" closed, "Hide the 5 checks" open. Replacing the whole label would cost the reader the one thing it is for, naming what is behind it, and move the control's width under the pointer; leaving it identical would make a control that just did something look like it did nothing.
+- Passing an empty `findings` array warns in development and renders no card.
+
+### Usage examples
+
+**Reporting work One already did**
+
+An automation that finished and needs nothing from the reader does **not** take `findings`: that promises an action per row, and here there are none. `title` carries the outcome — "5 invoices linked", not "One found 5 invoices in your Gmail and Teams", which reports activity and is long enough to truncate below 480px. The results go in `evidence`, which also retires any hand-written "and 2 more".
+
+<Canvas of={Stories.ReportingCompletedWork} />
+
+**A fork One cannot resolve**
+
+Only a person knows which of two documents is wrong. One action, and the choice happens after the click — see "A choice is not a message" above.
+
+<Canvas of={Stories.MismatchWithOneAction} />
+
+## Accessibility
+
+Most of what a callout needs it gets for free: the controls are `F0Button`s, so `Tab` reaches them in reading order and `Enter` or `Space` activates them. What follows is only what this component decides for itself.
+
+- **It stays a polite live region even at `critical`** — `role="status"` with `aria-live="polite"`, never `role="alert"`. This is where it parts company with `F0Alert`, which promotes `warning` and `critical` to `role="alert"`. The reason is authorship: `F0Alert` speaks for the system, and a system failure may interrupt; a callout is a machine's opinion about a record the reader is already looking at, and an opinion does not get to seize their attention. A callout injected after load is therefore announced, but at the next pause.
+- **The disclosure changes one word of its accessible name and moves `aria-expanded`.** "See the 5 checks" becomes "Hide the 5 checks", so the control is recognisably the same one; the state is carried by the attribute either way.
+- **The findings toggle is icon-only and named from the callout's title.** Several callouts on one page therefore do not all announce "Expand".
+- **The status glyph and the One mark are `aria-hidden`.** Meaning is carried by the title and the byline, never by colour alone.
+- **Folded content is absent, not hidden.** The rows are unmounted and the deck edges behind them are decorative and `aria-hidden`, so a screen reader is offered nothing the eye cannot see.

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite"
-
 import { Summary } from "@/icons/ai"
-
 import { F0AiCallout } from ".."
 import { aiCalloutStatuses, type F0AiCalloutProps } from "../types"
 

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__stories__/F0AiCallout.stories.tsx
@@ -1,0 +1,496 @@
+import type { Meta, StoryFn, StoryObj } from "@storybook/react-vite"
+
+import { Summary } from "@/icons/ai"
+
+import { F0AiCallout } from ".."
+import { aiCalloutStatuses, type F0AiCalloutProps } from "../types"
+
+const meta = {
+  title: "AI/F0AiCallout",
+  component: F0AiCallout,
+  // `!autodocs` is required, not optional: this repo enables autodocs globally
+  // in `.storybook/preview.tsx`, so dropping the tag from meta would leave the
+  // generated page competing with the hand-written MDX.
+  // `experimental` is declared rather than inferred: untagged already reads as
+  // experimental in the sidebar, but the status API reports it as `unknown`.
+  tags: ["!autodocs", "experimental"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component: [
+          "Shows what One found about the record on screen, and what it needs from the reader.",
+          "",
+          "`status` carries the force, from `neutral` (reports) to `critical` (you must act), and it has no",
+          "default — defaulting a blocking finding to a mild status is the one mistake that survives review,",
+          "because the callout still looks correct. The byline is not a choice for the same reason in reverse:",
+          "a callout that cannot say where it came from is an alert, and `F0Alert` already does that job.",
+        ].join("\n"),
+      },
+    },
+  },
+  // Every prop is declared here, and that is not busywork: the props come from
+  // a discriminated union, which react-docgen does not walk, so without this
+  // both the docs table and the Controls panel resolve 5 of the 13 and show no
+  // descriptions. Declaring them is what makes the generated table complete
+  // *and* interactive — which is why the MDX renders <Controls> and no
+  // hand-written table.
+  //
+  // `type.required` is set by hand for the same reason: docgen cannot tell
+  // which branch of the union a prop belongs to, so nothing else marks the
+  // three that are always required.
+  argTypes: {
+    status: {
+      control: "select",
+      options: aiCalloutStatuses,
+      type: { name: "string", required: true },
+      description:
+        "How much the callout asks of the reader. No default: a blocking finding sent as `info` still looks correct.",
+    },
+    title: {
+      control: "text",
+      type: { name: "string", required: true },
+      description:
+        "The verdict, or what a list of findings adds up to. The only text in the tinted zone, and always about the record.",
+    },
+    summary: {
+      control: "text",
+      description:
+        "The reason, in one line — the white card's title. `title` plus this must stand alone as a decision.",
+    },
+    children: {
+      control: "text",
+      type: { name: "string", required: true },
+      description:
+        "The nuance that changes what the reader does. Not available with `findings`.",
+    },
+    icon: {
+      control: false,
+      description:
+        "Overrides the glyph the status picks. Required for `neutral`, which has none of its own.",
+    },
+    action: {
+      control: false,
+      description:
+        "The move the verdict recommends, outlined. Optional — `info` with no action is a normal shape.",
+    },
+    secondaryAction: {
+      control: false,
+      description:
+        "The way out of the recommendation, ghost. Must be the override, never a third path.",
+    },
+    evidence: {
+      control: false,
+      description:
+        'What the disclosure holds: `{ label, items, kind }`. `kind: "rationale"` bullets the reasoning, `"steps"` numbers a plan.',
+    },
+    findings: {
+      control: false,
+      description:
+        "Switches to the stacked layout: several addressable issues, each with its own action. Folds into a deck.",
+    },
+    defaultOpen: {
+      control: "boolean",
+      description:
+        "Initial fold state. Defaults to open for `findings` and folded for `evidence` — the two fold in opposite directions.",
+    },
+    open: {
+      control: false,
+      description: "Controlled fold state. Pair with `onOpenChange`.",
+    },
+    onOpenChange: { control: false, description: "Fires on fold and unfold." },
+    onClose: {
+      control: false,
+      description:
+        "Dismisses the callout. Acts on the container, so it lives in the header. Not available with `findings`.",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[32rem]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof F0AiCallout>
+
+export default meta
+
+type Story = StoryObj<F0AiCalloutProps>
+
+export const Default: Story = {
+  args: {
+    status: "critical",
+    title: "Not reimbursable",
+    summary: "Gift cards are never allowed, whatever the amount",
+    children:
+      "The receipt also appears to be AI-generated, so the amount itself is unverified.",
+    action: {
+      label: "Request repayment",
+      onClick: () => {},
+    },
+    onClose: () => {},
+  },
+}
+
+/**
+ * The five statuses are degrees of force, not flavours of one message — so each
+ * one is paired here with copy that actually fits it.
+ *
+ * The pairing follows one rule: a status that takes a stance needs an
+ * copy that admits to judging, and
+ * `neutral` needs one that only reports (`generated`, `extracted`, `automated`).
+ * A summary that claims to be a suggestion is asking for a decision nobody made.
+ *
+ */
+export const Statuses: Story = {
+  parameters: { docs: { story: { inline: true } } },
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <F0AiCallout
+        status="neutral"
+        title="Summary"
+        icon={Summary}
+        onClose={() => {}}
+      >
+        MacBook Pro MB-0472 repeatedly dropped from disk-encryption policy,
+        causing compliance and security risk for the user. The issue was flagged
+        as urgent and now shows as complete, so it is resolved.
+      </F0AiCallout>
+
+      <F0AiCallout
+        status="info"
+        title="Two attendees missing from the record"
+        action={{ label: "Add attendees", onClick: () => {} }}
+        onClose={() => {}}
+      >
+        {/* Preflight is disabled in this repo, so a bare `ul` renders with no
+            bullets and no indent — both have to be asked for explicitly. */}
+        <ul className="m-0 flex list-disc flex-col gap-1 pl-4">
+          <li>
+            The client lunch for 6 attendees cost $712.65, comfortably under the
+            $900 domestic limit.
+          </li>
+          <li>Receipt has been auto-verified.</li>
+        </ul>
+      </F0AiCallout>
+
+      <F0AiCallout
+        status="positive"
+        title="Approval recommended"
+        action={{ label: "Approve", onClick: () => {} }}
+        onClose={() => {}}
+      >
+        The client lunch for 6 attendees cost $712.65, comfortably under the
+        $900 domestic limit set by the $150-per-person domestic cap. Receipt has
+        been auto-verified.
+      </F0AiCallout>
+
+      <F0AiCallout
+        status="warning"
+        title="Requires review"
+        action={{ label: "Review", onClick: () => {} }}
+        onClose={() => {}}
+      >
+        <ul className="m-0 flex list-disc flex-col gap-1 pl-4">
+          <li>
+            The transaction amount exceeds the $50 meal allowance for a single
+            employee by $225.76.
+          </li>
+          <li>
+            The presence of 4 guests on the receipt may justify the total if
+            relevant attendees are added.
+          </li>
+        </ul>
+      </F0AiCallout>
+
+      <F0AiCallout
+        status="critical"
+        title="Not reimbursable"
+        action={{ label: "Request repayment", onClick: () => {} }}
+        onClose={() => {}}
+      >
+        Gift cards are explicitly listed as never allowed, which requires
+        repayment regardless of amount or context. The receipt appears to be
+        AI-generated.
+      </F0AiCallout>
+    </div>
+  ),
+}
+
+/**
+ */
+export const Narrow: Story = {
+  decorators: [
+    (Story: StoryFn) => (
+      <div className="w-72">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    status: "critical",
+    title: "Gift cards are never allowed under this policy",
+    children: "The receipt appears to be AI-generated.",
+    action: { label: "Request repayment", onClick: () => {} },
+    onClose: () => {},
+  },
+}
+
+/**
+ * An automation that finished and needs nothing decided. It is **not** a stacked
+ * callout — `findings` promises a CTA per row and here there are none — it is
+ * the rationale shape, with each piece of content in the slot that fits it.
+ *
+ * `title` carries the outcome, not the activity: "5 invoices linked", never
+ * "One found 5 invoices in your Gmail and Teams". `summary` carries why nothing
+ * is needed, which is the sentence that would otherwise end up buried at the
+ * bottom of the description. The five results go in `evidence`, because they
+ * are what you check if you want to rather than the message itself — which
+ * also retires the hand-written "and 2 more on this order", since all five fit
+ * behind the disclosure.
+ *
+ * `info` and not `neutral`: there is an action, and `neutral` means there is
+ * nothing to do. That decides it without anyone having to judge whether linking
+ * five invoices is newsworthy, and it is why no borrowed content icon appears
+ * here — `info` brings its own glyph.
+ *
+ */
+/**
+ * The base shape: a verdict, the reason under it, and the facts under that.
+ * Nothing folds, so nothing is hidden — reach for `evidence` only when there is
+ * reasoning worth checking, not to shorten a body that is already short.
+ *
+ * `positive` because nothing is wrong and One's read is favourable. There is
+ * still something to do, which is what separates it from `neutral`.
+ */
+export const Verdict: Story = {
+  args: {
+    status: "positive",
+    title: "Approval recommended",
+    summary: "All five policy checks passed",
+    action: { label: "Approve", onClick: () => {} },
+    children: (
+      <>
+        <strong>€48.20</strong> for a client lunch with two attendees, both on
+        the record, and the receipt matches the amount.
+      </>
+    ),
+  },
+}
+
+/**
+ * **Several issues on one record, each resolvable on its own.** The list *is*
+ * the work, so every row keeps its own action and the title is a roll-up of
+ * what they add up to — not one of the issues.
+ *
+ * The byline moves up beside the title because the whole evaluation shares one
+ * provenance. Fold it with the header toggle and the rows pile into a deck: the
+ * front one stays readable and the rest are two slivers behind it, so the shape
+ * still says "there are more" without spending the height.
+ *
+ */
+export const Findings: Story = {
+  args: {
+    status: "critical",
+    title: "Issues to resolve",
+    findings: [
+      {
+        id: "duplicate",
+        title: "Possible duplicate",
+        description:
+          "A similar invoice already exists for this vendor — paying both would double-pay.",
+        action: { label: "Review", onClick: () => {} },
+      },
+      {
+        id: "bank",
+        title: "Bank details changed",
+        description:
+          "The vendor's bank account changed since the last paid invoice.",
+        action: { label: "Verify", onClick: () => {} },
+      },
+      {
+        id: "tax",
+        title: "Tax mismatch",
+        description: "The VAT does not match the expected rate.",
+        action: { label: "Review", onClick: () => {} },
+      },
+    ],
+  },
+}
+
+/**
+ * **One recommendation, with the reasoning it rests on one click away.** The
+ * title is the verdict, the body is short enough to read at a glance, and the
+ * footer pair is one decision rather than two: `action` is the move the verdict
+ * recommends and `secondaryAction` is the way out of it, never a third path.
+ *
+ * What the disclosure holds is the reasoning, and the rows have no action slot.
+ * That absence is the contract: the day a policy check needs its own button it
+ * has stopped being evidence and become a finding, and the callout should carry
+ * `findings` instead.
+ *
+ * Folding here hides *reasoning*, not work, which is why there is no deck — and
+ * why it starts folded, the opposite of the stacked default.
+ *
+ */
+export const WithRationale: Story = {
+  args: {
+    status: "warning",
+    title: "Rejection recommended",
+    summary: "Two of five policy checks failed",
+    action: { label: "Reject", onClick: () => {} },
+    secondaryAction: { label: "Approve anyway", onClick: () => {} },
+    onClose: () => {},
+    evidence: {
+      name: "the 5 checks",
+      items: [
+        <>
+          Per-person cap exceeded: <strong>$178.16</strong> per attendee against
+          a $150 domestic limit.
+        </>,
+        "Four guests on the receipt and none on the record — adding them would justify the total.",
+        "Receipt verified against the attached document.",
+        "Vendor is on the approved list.",
+        "Currency matches the policy.",
+      ],
+    },
+    children:
+      "The meal is $225.76 over the allowance for a single employee, and the four guests on the receipt are not on the record.",
+  },
+}
+
+export const ReportingCompletedWork: Story = {
+  args: {
+    status: "info",
+    title: "5 invoices linked",
+    summary: "Nothing left to decide — every line reconciles",
+    action: { label: "See them on Linked documents", onClick: () => {} },
+    evidence: {
+      name: "the 5 invoices",
+      items: [
+        "INV-2026-0811 · €520.00 — found in Gmail, kulimannweyel.com",
+        "INV-2026-0812 · €487.50 — found in Teams, Vendor invoices",
+        "INV-2026-0813 · €455.00 — found in Gmail, kulimannweyel.com",
+        "INV-2026-0814 · €1,320.00 — found in Gmail, kulimannweyel.com",
+        "INV-2026-0815 · €1,242.50 — found in Teams, Vendor invoices",
+      ],
+    },
+    children:
+      "Every one quotes PO-00011. They are linked to this order, not approved and not paid.",
+  },
+}
+
+/**
+ * An assessment whose answer is several things to do: the plan goes behind the
+ * disclosure, numbered, and the callout stays one message.
+ *
+ * `kind: "steps"` numbers instead of bulleting, because the order is part of
+ * the content — you confirm the device before you order it. No checkboxes: the
+ * record tracks per-item state better than a message can.
+ *
+ * The tinted title is about the record, so it is "Six steps to set up this
+ * workstation" and not "One drafted a resolution plan", which spends it
+ * re-announcing the byline right below.
+ *
+ * There is no action button, and `info` is still right: the status asks whether
+ * the reader has work, not whether the callout can offer a click. Here the work
+ * is six things across the Marketplace, IT and a conversation with HR.
+ */
+export const ResolutionPlanFlow: Story = {
+  parameters: { docs: { story: { inline: true } } },
+  decorators: [
+    (Story: StoryFn) => (
+      <div className="w-full max-w-[40rem]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    status: "info",
+    title: "Six steps to set up this workstation",
+    summary: "No role details yet, so the device is the first thing to confirm",
+    evidence: {
+      name: "the six steps",
+      kind: "steps",
+      items: [
+        "Confirm with HR whether the new joiner needs a laptop or other devices",
+        "If a laptop is needed, order or rent one from the Marketplace",
+        "Reserve and prepare a workspace — desk, chair and peripherals",
+        "Coordinate with IT for system access permissions",
+        "Communicate the setup status to the new joiner or HR",
+        "Assign the ticket to an Operations team member",
+      ],
+    },
+    children: (
+      <>
+        A first day setup for a new joiner still named{" "}
+        <strong>No role picked</strong>, starting <strong>4 September</strong>.
+        It needs a device, a workspace and system access.
+      </>
+    ),
+  },
+}
+
+/**
+ * A fork One cannot resolve: the invoice over-bills the order, and only a
+ * person knows which of the two documents is wrong. **One action, and the
+ * choice lives in a dialog.**
+ *
+ * The either/or is not the resolution, it is the routing — whichever document
+ * is wrong, work follows: a credit note, an amended order. That work needs
+ * room, a cancel and a confirm, which a dialog has and a callout does not. A
+ * radio inside the body would also leave a selection on screen that has not
+ * been submitted, and a message does not hold unsaved state.
+ *
+ * `secondaryAction` is not the answer either. That pair is "Reject" against
+ * "Approve anyway", where One has a verdict and the ghost is the override;
+ * here One has no verdict to override.
+ *
+ * The title names `PO-00011` because the verdict *is* the relationship between
+ * two records, and drops the invoice's own id because that is the page the
+ * reader is already on.
+ */
+export const MismatchWithOneAction: Story = {
+  parameters: { docs: { story: { inline: true } } },
+  decorators: [
+    (Story: StoryFn) => (
+      <div className="w-full max-w-[40rem]">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    status: "critical",
+    title: "Billed €196.67 over PO-00011",
+    summary: "Three lines disagree, and one is not on the order at all",
+    action: { label: "Resolve the mismatch", onClick: () => {} },
+    evidence: {
+      name: "the 3 lines",
+      items: [
+        <>
+          Aerial Mapping and Survey: <strong>3 units</strong> billed against the
+          2 authorised — €116.67 over.
+        </>,
+        <>
+          Data processing: <strong>€450.00</strong> billed against €400.00
+          authorised.
+        </>,
+        <>
+          Report delivery: <strong>€80.00</strong> billed, and the line is not
+          on the order at all.
+        </>,
+      ],
+    },
+    children: "Nothing else on the invoice differs from the order.",
+  },
+}
+
+export const Loading: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <F0AiCallout.Skeleton status="critical" />
+      <F0AiCallout.Skeleton status="neutral" compact />
+    </div>
+  ),
+}

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
@@ -123,7 +123,7 @@ describe("F0AiCallout", () => {
   })
 
   describe("action", () => {
-    it("renders at most one action and fires it", async () => {
+    it("renders the action and fires it", async () => {
       const onClick = vi.fn()
       render(
         <F0AiCallout
@@ -139,6 +139,35 @@ describe("F0AiCallout", () => {
         screen.getByRole("button", { name: "Request repayment" })
       )
       expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("puts the override before the recommended move, and ghosts it", async () => {
+      const reject = vi.fn()
+      const approve = vi.fn()
+      render(
+        <F0AiCallout
+          {...defaultProps}
+          action={{ label: "Reject", onClick: reject }}
+          secondaryAction={{ label: "Approve anyway", onClick: approve }}
+        />
+      )
+
+      const override = screen.getByRole("button", { name: "Approve anyway" })
+      const recommended = screen.getByRole("button", { name: "Reject" })
+
+      // The recommended move comes last, so it reads as the end of the
+      // sentence rather than competing with its own way out.
+      expect(
+        override.compareDocumentPosition(recommended) &
+          Node.DOCUMENT_POSITION_FOLLOWING
+      ).toBeTruthy()
+      // Ghost against outline: the pair has to read as a hierarchy.
+      expect(override.className).toContain("bg-transparent")
+      expect(recommended.className).not.toContain("bg-transparent")
+
+      await userEvent.click(override)
+      expect(approve).toHaveBeenCalledTimes(1)
+      expect(reject).not.toHaveBeenCalled()
     })
 
     it("keeps the byline row when there is no action", () => {
@@ -376,6 +405,25 @@ describe("F0AiCallout", () => {
       // and a live region announces it.
       expect(container).toBeEmptyDOMElement()
       expect(screen.queryByRole("status")).toBeNull()
+    })
+
+    it("warns when evidence has no items", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      render(
+        <F0AiCallout
+          {...defaultProps}
+          evidence={{ name: "the 5 checks", items: [] }}
+        />
+      )
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("F0AiCallout: `evidence` has no items")
+      )
+      // Still a complete verdict, so unlike empty `findings` it renders — it
+      // just has no toggle.
+      expect(screen.getByText("Not reimbursable")).toBeVisible()
+      expect(screen.queryByRole("button", { name: /the 5 checks/ })).toBeNull()
     })
 
     it("says nothing in a production build", () => {

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
@@ -1,0 +1,513 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
+
+import { Summary } from "@/icons/ai"
+
+import { F0AiCallout } from ".."
+import { aiCalloutStatuses } from "../types"
+
+const defaultProps = {
+  status: "critical" as const,
+  title: "Not reimbursable",
+  children: "Gift cards are explicitly listed as never allowed.",
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("F0AiCallout", () => {
+  it("renders the title, the body and the byline", () => {
+    render(<F0AiCallout {...defaultProps} />)
+
+    expect(screen.getByText("Not reimbursable")).toBeInTheDocument()
+    expect(
+      screen.getByText("Gift cards are explicitly listed as never allowed.")
+    ).toBeInTheDocument()
+    expect(screen.getByText("Suggested by One")).toBeInTheDocument()
+  })
+
+  it("always renders the byline, and it is not configurable", () => {
+    render(<F0AiCallout {...defaultProps} />)
+
+    expect(screen.getByText("Suggested by One")).toBeVisible()
+  })
+
+  describe("status", () => {
+    it("colours the title with the status token", () => {
+      render(<F0AiCallout {...defaultProps} status="warning" />)
+
+      expect(screen.getByText("Not reimbursable")).toHaveClass(
+        "text-f1-foreground-warning"
+      )
+    })
+
+    it("never leaves the title uncoloured for critical", () => {
+      // The bug that F0Callout shipped: `critical` fell through the variant
+      // maps, so the strongest status was the only one with no colour and no
+      // glyph. Assert the fallthrough cannot come back.
+      const { container } = render(
+        <F0AiCallout {...defaultProps} status="critical" />
+      )
+
+      expect(screen.getByText("Not reimbursable")).toHaveClass(
+        "text-f1-foreground-critical"
+      )
+      expect(
+        container.querySelector("[aria-hidden='true']")
+      ).toBeInTheDocument()
+    })
+
+    it("gives every status except neutral a glyph of its own", () => {
+      for (const status of aiCalloutStatuses) {
+        const { container, unmount } = render(
+          <F0AiCallout {...defaultProps} status={status} />
+        )
+
+        const glyphs = container.querySelectorAll("[aria-hidden='true']")
+        // The byline logo is always one of them; a semantic glyph makes two.
+        expect(glyphs.length).toBe(status === "neutral" ? 1 : 2)
+        unmount()
+      }
+    })
+
+    it("warns when neutral carries an action", () => {
+      // The rule that keeps `neutral` and `info` apart: if there is something
+      // to do, the callout is not neutral. Enforced here because otherwise the
+      // two rungs collapse into "grey or blue" and whichever feels calmer wins.
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      render(
+        <F0AiCallout
+          {...defaultProps}
+          status="neutral"
+          icon={Summary}
+          action={{ label: "Go and look", onClick: vi.fn() }}
+        />
+      )
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("`neutral` means there is nothing to do")
+      )
+    })
+
+    it("does not warn when neutral only reports", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      render(<F0AiCallout {...defaultProps} status="neutral" icon={Summary} />)
+
+      expect(warn).not.toHaveBeenCalled()
+    })
+
+    it("warns when neutral is used without a content icon", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      render(<F0AiCallout {...defaultProps} status="neutral" />)
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("F0AiCallout: `neutral` carries no semantic")
+      )
+    })
+
+    it("takes a content icon for neutral without warning", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      const { container } = render(
+        <F0AiCallout {...defaultProps} status="neutral" icon={Summary} />
+      )
+
+      expect(warn).not.toHaveBeenCalled()
+      expect(container.querySelectorAll("[aria-hidden='true']").length).toBe(2)
+    })
+  })
+
+  describe("action", () => {
+    it("renders at most one action and fires it", async () => {
+      const onClick = vi.fn()
+      render(
+        <F0AiCallout
+          {...defaultProps}
+          action={{ label: "Request repayment", onClick }}
+        />
+      )
+
+      const buttons = screen.getAllByRole("button")
+      expect(buttons).toHaveLength(1)
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Request repayment" })
+      )
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+
+    it("keeps the byline row when there is no action", () => {
+      render(<F0AiCallout {...defaultProps} />)
+
+      expect(screen.getByText("Suggested by One")).toBeInTheDocument()
+      expect(screen.queryAllByRole("button")).toHaveLength(0)
+    })
+
+    it("honours a disabled action", () => {
+      render(
+        <F0AiCallout
+          {...defaultProps}
+          action={{ label: "Review", onClick: vi.fn(), disabled: true }}
+        />
+      )
+
+      expect(screen.getByRole("button", { name: "Review" })).toBeDisabled()
+    })
+  })
+
+  describe("dismissing", () => {
+    it("renders the close button only when onClose is given", async () => {
+      const onClose = vi.fn()
+      const { rerender } = render(<F0AiCallout {...defaultProps} />)
+      expect(screen.queryByRole("button", { name: "Close" })).toBeNull()
+
+      rerender(<F0AiCallout {...defaultProps} onClose={onClose} />)
+      await userEvent.click(screen.getByRole("button", { name: "Close" }))
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("accessibility", () => {
+    it("announces politely and never as an alert, even when critical", () => {
+      // An assessment by a machine is not a system emergency. Because
+      // the byline is always rendered, this holds for every possible callout.
+      render(<F0AiCallout {...defaultProps} status="critical" />)
+
+      const region = screen.getByRole("status")
+      expect(region).toHaveAttribute("aria-live", "polite")
+      expect(screen.queryByRole("alert")).toBeNull()
+    })
+  })
+
+  describe("stacked", () => {
+    const findings = [
+      {
+        id: "duplicate",
+        title: "Possible duplicate",
+        description: "A similar invoice already exists for this vendor.",
+        action: { label: "Review duplicate", onClick: vi.fn() },
+      },
+      {
+        id: "tax",
+        title: "Tax mismatch",
+        description: "The VAT does not match the expected rate.",
+        action: { label: "Review tax", onClick: vi.fn() },
+      },
+    ]
+
+    const stackedProps = {
+      status: "critical" as const,
+      title: "Issues to resolve",
+    }
+
+    it("renders every finding with its own action", () => {
+      render(<F0AiCallout {...stackedProps} findings={findings} />)
+
+      expect(screen.getByText("Possible duplicate")).toBeInTheDocument()
+      expect(screen.getByText("Tax mismatch")).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Review duplicate" })
+      ).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Review tax" })
+      ).toBeInTheDocument()
+    })
+
+    it("fires the action of the finding it belongs to, not the first one", async () => {
+      const onDuplicate = vi.fn()
+      const onTax = vi.fn()
+      render(
+        <F0AiCallout
+          {...stackedProps}
+          findings={[
+            { ...findings[0]!, action: { label: "A", onClick: onDuplicate } },
+            { ...findings[1]!, action: { label: "B", onClick: onTax } },
+          ]}
+        />
+      )
+
+      await userEvent.click(screen.getByRole("button", { name: "B" }))
+
+      expect(onTax).toHaveBeenCalledTimes(1)
+      expect(onDuplicate).not.toHaveBeenCalled()
+    })
+
+    it("shows the byline once, in the header, not per finding", () => {
+      render(<F0AiCallout {...stackedProps} findings={findings} />)
+
+      expect(screen.getAllByText("Suggested by One")).toHaveLength(1)
+    })
+
+    it("keeps one tint for the whole evaluation, not one per finding", () => {
+      // One callout is one evaluation with one severity, however many findings
+      // hang off it. Mixed severity is two callouts, not one with two colours.
+      const { container } = render(
+        <F0AiCallout {...stackedProps} findings={findings} />
+      )
+
+      expect(
+        container.querySelectorAll(".bg-f1-background-critical")
+      ).toHaveLength(1)
+    })
+
+    it("never folds the headline finding away, and shows a deck edge instead", async () => {
+      // Asserting on presence rather than visibility on purpose: jsdom's
+      // `toBeVisible` does not resolve inline `visibility`, so a hidden-but-
+      // mounted implementation would pass a visibility assertion.
+      const { container } = render(
+        <F0AiCallout {...stackedProps} findings={findings} />
+      )
+      expect(container.querySelector("div[aria-hidden='true']")).toBeNull()
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Collapse Issues to resolve" })
+      )
+
+      expect(screen.getByText("Possible duplicate")).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Review duplicate" })
+      ).toBeInTheDocument()
+      expect(screen.queryByText("Tax mismatch")).not.toBeInTheDocument()
+      // The deck edge is what makes folded read as "there are more of these"
+      // rather than "this is the only one". Selected structurally: it is the only
+      // aria-hidden *div* (the glyphs are svgs, the separator a span), because
+      // the first version of this test matched on `.mx-3` and broke the moment
+      // the inset changed.
+      expect(
+        container.querySelector("div[aria-hidden='true']")
+      ).toBeInTheDocument()
+    })
+
+    it("piles up an edge per hidden finding, capped at two", () => {
+      // Folded, the findings should read as a pile of individual cards rather
+      // than as one card with something vague behind it. Past two edges the
+      // illusion stops paying for itself, so the cap is deliberate and the
+      // count is not its job.
+      const edges = (root: HTMLElement) =>
+        root.querySelectorAll("div[aria-hidden='true']").length
+
+      const one = render(
+        <F0AiCallout
+          {...stackedProps}
+          defaultOpen={false}
+          findings={findings}
+        />
+      )
+      expect(edges(one.container)).toBe(1)
+      one.unmount()
+
+      const many = render(
+        <F0AiCallout
+          {...stackedProps}
+          defaultOpen={false}
+          findings={[
+            ...findings,
+            { ...findings[0]!, id: "third", title: "Third" },
+            { ...findings[0]!, id: "fourth", title: "Fourth" },
+          ]}
+        />
+      )
+      expect(edges(many.container)).toBe(2)
+    })
+
+    it("starts folded when asked, and the toggle label follows the state", async () => {
+      render(
+        <F0AiCallout
+          {...stackedProps}
+          defaultOpen={false}
+          findings={findings}
+        />
+      )
+
+      const toggle = screen.getByRole("button", {
+        name: "Expand Issues to resolve",
+      })
+      expect(screen.queryByText("Tax mismatch")).not.toBeInTheDocument()
+
+      await userEvent.click(toggle)
+
+      expect(screen.getByText("Tax mismatch")).toBeInTheDocument()
+      expect(
+        screen.getByRole("button", { name: "Collapse Issues to resolve" })
+      ).toHaveAttribute("aria-expanded", "true")
+    })
+
+    it("keeps the stacked shell for a single finding but drops the toggle and the deck", () => {
+      const { container } = render(
+        <F0AiCallout {...stackedProps} findings={[findings[0]!]} />
+      )
+
+      // An evaluation that has had all but one finding resolved should not
+      // change shape — the header byline survives. But there is nothing left to
+      // fold, so a toggle would promise a change it cannot deliver and a deck
+      // edge would claim cards that are not there.
+      expect(screen.getByText("Suggested by One")).toBeInTheDocument()
+      expect(screen.getByText("Possible duplicate")).toBeInTheDocument()
+      expect(
+        screen.queryByRole("button", { name: /Collapse|Expand/ })
+      ).toBeNull()
+      expect(container.querySelector("div[aria-hidden='true']")).toBeNull()
+      expect(screen.getAllByRole("button")).toHaveLength(1)
+    })
+
+    it("offers no close button while stacked", () => {
+      render(<F0AiCallout {...stackedProps} findings={findings} />)
+
+      expect(screen.queryByRole("button", { name: "Close" })).toBeNull()
+    })
+
+    it("warns and renders no card when findings is empty", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      render(<F0AiCallout {...stackedProps} findings={[]} />)
+
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("F0AiCallout: `findings` is empty")
+      )
+      expect(screen.queryAllByRole("button")).toHaveLength(0)
+    })
+
+    it("lets the caller drive the state", async () => {
+      const onOpenChange = vi.fn()
+      render(
+        <F0AiCallout
+          {...stackedProps}
+          open={false}
+          onOpenChange={onOpenChange}
+          findings={findings}
+        />
+      )
+
+      expect(screen.queryByText("Tax mismatch")).not.toBeInTheDocument()
+
+      await userEvent.click(
+        screen.getByRole("button", { name: "Expand Issues to resolve" })
+      )
+
+      expect(onOpenChange).toHaveBeenCalledWith(true)
+      // Still folded: the caller owns the state and has not changed it.
+      expect(screen.queryByText("Tax mismatch")).not.toBeInTheDocument()
+    })
+  })
+
+  it("forwards data attributes", () => {
+    const { container } = render(
+      <F0AiCallout {...defaultProps} data-foo="bar" />
+    )
+
+    expect(container.querySelector("[data-foo='bar']")).toBeInTheDocument()
+  })
+
+  it("exposes a skeleton that announces itself as busy", () => {
+    const { container } = render(<F0AiCallout.Skeleton />)
+
+    expect(container.querySelector("[aria-busy='true']")).toBeInTheDocument()
+  })
+
+  it("numbers the evidence when it is a plan", async () => {
+    const { container } = render(
+      <F0AiCallout
+        status="info"
+        title="One drafted a resolution plan"
+        defaultOpen
+        evidence={{
+          name: "the 6 steps",
+          kind: "steps",
+          items: [<span key="a">Order a laptop</span>],
+        }}
+      >
+        Six steps.
+      </F0AiCallout>
+    )
+
+    const list = container.querySelector("ol")
+    expect(list).toHaveClass("list-decimal")
+    expect(container.querySelector("ul")).toBeNull()
+  })
+
+  it("keeps the bullets for a rationale", async () => {
+    const { container } = render(
+      <F0AiCallout
+        status="warning"
+        title="Requires review"
+        defaultOpen
+        evidence={{
+          name: "the 3 policy checks",
+          items: [<span key="a">Receipt verified</span>],
+        }}
+      >
+        Three checks failed.
+      </F0AiCallout>
+    )
+
+    const list = container.querySelector("ul")
+    expect(list).toHaveClass("list-disc")
+    expect(list).not.toHaveClass("list-none")
+  })
+
+  it("starts a rationale folded", async () => {
+    render(
+      <F0AiCallout
+        status="warning"
+        title="Requires review"
+        evidence={{
+          name: "the 3 checks",
+          items: [<span key="a">Receipt verified</span>],
+        }}
+      >
+        Three checks failed.
+      </F0AiCallout>
+    )
+
+    expect(
+      screen.getByRole("button", { name: "See the 3 checks" })
+    ).toBeVisible()
+    expect(screen.queryByText("Receipt verified")).not.toBeInTheDocument()
+  })
+
+  it("starts a stack open", async () => {
+    render(
+      <F0AiCallout
+        status="warning"
+        title="3 issues found"
+        findings={[
+          { id: "a", title: "First", description: "One" },
+          { id: "b", title: "Second", description: "Two" },
+        ]}
+      />
+    )
+
+    expect(screen.getByText("Second")).toBeVisible()
+  })
+
+  it("changes only the verb of the disclosure when it opens", async () => {
+    render(
+      <F0AiCallout
+        status="warning"
+        title="Rejection recommended"
+        evidence={{
+          name: "the 5 checks",
+          items: [<span key="a">Receipt verified</span>],
+        }}
+      >
+        Two checks failed.
+      </F0AiCallout>
+    )
+
+    const trigger = screen.getByRole("button", { name: "See the 5 checks" })
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+
+    await userEvent.click(trigger)
+
+    const open = screen.getByRole("button", { name: "Hide the 5 checks" })
+    expect(open).toHaveAttribute("aria-expanded", "true")
+    expect(
+      screen.queryByRole("button", { name: "See the 5 checks" })
+    ).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
@@ -361,15 +361,43 @@ describe("F0AiCallout", () => {
       expect(screen.queryByRole("button", { name: "Close" })).toBeNull()
     })
 
-    it("warns and renders no card when findings is empty", () => {
+    it("warns and renders nothing at all when findings is empty", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
 
-      render(<F0AiCallout {...stackedProps} findings={[]} />)
+      const { container } = render(
+        <F0AiCallout {...stackedProps} findings={[]} />
+      )
 
       expect(warn).toHaveBeenCalledWith(
         expect.stringContaining("F0AiCallout: `findings` is empty")
       )
-      expect(screen.queryAllByRole("button")).toHaveLength(0)
+      // Not just "no buttons": the shell must not render either, or a critical
+      // pill reading like a verdict lands on the page with nothing under it —
+      // and a live region announces it.
+      expect(container).toBeEmptyDOMElement()
+      expect(screen.queryByRole("status")).toBeNull()
+    })
+
+    it("warns once per violation, not once per render", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+
+      const { rerender } = render(
+        <F0AiCallout status="neutral" title="Summary">
+          A device history.
+        </F0AiCallout>
+      )
+
+      const afterMount = warn.mock.calls.length
+
+      for (let i = 0; i < 5; i++) {
+        rerender(
+          <F0AiCallout status="neutral" title="Summary">
+            A device history.
+          </F0AiCallout>
+        )
+      }
+
+      expect(warn.mock.calls.length).toBe(afterMount)
     })
 
     it("lets the caller drive the state", async () => {

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
@@ -65,7 +65,7 @@ describe("F0AiCallout", () => {
 
         const glyphs = container.querySelectorAll("[aria-hidden='true']")
         // The byline logo is always one of them; a semantic glyph makes two.
-        expect(glyphs.length).toBe(status === "neutral" ? 1 : 2)
+        expect(glyphs).toHaveLength(status === "neutral" ? 1 : 2)
         unmount()
       }
     })
@@ -116,7 +116,7 @@ describe("F0AiCallout", () => {
       )
 
       expect(warn).not.toHaveBeenCalled()
-      expect(container.querySelectorAll("[aria-hidden='true']").length).toBe(2)
+      expect(container.querySelectorAll("[aria-hidden='true']")).toHaveLength(2)
     })
   })
 
@@ -465,7 +465,7 @@ describe("F0AiCallout", () => {
         )
       }
 
-      expect(warn.mock.calls.length).toBe(afterMount)
+      expect(warn.mock.calls).toHaveLength(afterMount)
     })
 
     it("lets the caller drive the state", async () => {

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
@@ -1,9 +1,7 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
-import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
-
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { Summary } from "@/icons/ai"
-
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 import { F0AiCallout } from ".."
 import { aiCalloutStatuses } from "../types"
 

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/__tests__/F0AiCallout.test.tsx
@@ -378,6 +378,28 @@ describe("F0AiCallout", () => {
       expect(screen.queryByRole("status")).toBeNull()
     })
 
+    it("says nothing in a production build", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+      vi.stubEnv("NODE_ENV", "production")
+
+      try {
+        // Two violations at once: `neutral` with an action and no icon.
+        render(
+          <F0AiCallout
+            status="neutral"
+            title="Summary"
+            action={{ label: "Review", onClick: () => {} }}
+          >
+            A device history.
+          </F0AiCallout>
+        )
+
+        expect(warn).not.toHaveBeenCalled()
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    })
+
     it("warns once per violation, not once per render", () => {
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
 

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/index.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/index.tsx
@@ -1,8 +1,6 @@
 import { forwardRef } from "react"
-
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
-
 import { AiCalloutInternal } from "./AiCalloutInternal"
 import { AiCalloutSkeleton } from "./AiCalloutSkeleton"
 import type { AiCalloutSkeletonProps, F0AiCalloutProps } from "./types"

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/index.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/index.tsx
@@ -1,0 +1,33 @@
+import { forwardRef } from "react"
+
+import { withDataTestId } from "@/lib/data-testid"
+import { withSkeleton } from "@/lib/skeleton"
+
+import { AiCalloutInternal } from "./AiCalloutInternal"
+import { AiCalloutSkeleton } from "./AiCalloutSkeleton"
+import type { AiCalloutSkeletonProps, F0AiCalloutProps } from "./types"
+
+const F0AiCalloutBase = forwardRef<HTMLDivElement, F0AiCalloutProps>(
+  (props, ref) => {
+    return <AiCalloutInternal ref={ref} {...props} />
+  }
+)
+
+const F0AiCalloutSkeleton = ({ status, compact }: AiCalloutSkeletonProps) => {
+  return <AiCalloutSkeleton status={status} compact={compact} />
+}
+
+F0AiCalloutBase.displayName = "F0AiCallout"
+
+export const F0AiCallout = withSkeleton(
+  withDataTestId(F0AiCalloutBase),
+  F0AiCalloutSkeleton
+)
+
+export type { F0AiCalloutProps }
+export {
+  aiCalloutStatuses,
+  type AiCalloutAction,
+  type AiCalloutFinding,
+  type AiCalloutStatus,
+} from "./types"

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/types.ts
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/types.ts
@@ -1,0 +1,258 @@
+import type { ReactNode } from "react"
+
+import type { IconType } from "@/components/F0Icon"
+import type { DataAttributes } from "@/global.types"
+
+/**
+ * How much the message matters, from a report the reader can skim to something
+ * they have to act on now.
+ *
+ * | status     | use it when                                   | example                     |
+ * | ---------- | --------------------------------------------- | --------------------------- |
+ * | `neutral`  | nothing is asked of the reader                | Summary of a device history |
+ * | `info`     | there is something to do, nothing is wrong    | 5 invoices linked           |
+ * | `positive` | One endorses what the reader already did      | Approval recommended        |
+ * | `warning`  | something may be wrong — look                 | Requires review             |
+ * | `critical` | something is wrong — act                      | Request repayment           |
+ *
+ * `neutral` or `info` is the only pair worth spelling out. `neutral` is the
+ * absence of a status — 4% surface, uncoloured title, no glyph of its own —
+ * and means there is nothing to do at all, so passing it an `action` warns in
+ * development. `info` means the reader has work even when there is no button
+ * to offer: the work is often elsewhere, and the button is a convenience,
+ * never what earns the colour.
+ *
+ * One callout is **one evaluation with one severity**. Mixed severity is two
+ * callouts, not one.
+ */
+export const aiCalloutStatuses = [
+  "neutral",
+  "info",
+  "positive",
+  "warning",
+  "critical",
+] as const
+
+export type AiCalloutStatus = (typeof aiCalloutStatuses)[number]
+
+export type AiCalloutAction = {
+  label: string
+  onClick: () => void
+  icon?: IconType
+  disabled?: boolean
+}
+
+/**
+ * One entry in a stacked callout. Each finding is resolved on its own, so each
+ * carries its own action — "Review" on a duplicate invoice does something
+ * different from "Review" on a tax mismatch.
+ */
+export type AiCalloutFinding = {
+  /**
+   * Stable across renders. Findings are resolved and removed one at a time, so
+   * an index would re-key the survivors and animate the wrong rows out.
+   */
+  id: string
+  title: string
+  description: ReactNode
+  action?: AiCalloutAction
+}
+
+type AiCalloutSharedProps = DataAttributes & {
+  /**
+   * Required on purpose — there is no safe default. Defaulting a blocking
+   * finding to a mild status is the one mistake nobody catches in review,
+   * because the callout still looks correct.
+   *
+   * One callout is **one evaluation with one severity**, whether it carries a
+   * single verdict or a list of findings. Mixed severity is two callouts, not
+   * one: "Suggestions to review" in `warning` beside "Issues to resolve" in
+   * `critical`, which is how the design draws it.
+   */
+  status: AiCalloutStatus
+  /**
+   * A single verdict ("Possible duplicate") when the callout carries one, or
+   * what the list adds up to ("Issues to resolve") when it stacks.
+   *
+   * **This is the only text in the tinted zone, and it is always about the
+   * record — never about One and never the record's identity.** Both are
+   * already on screen: the byline says who produced this, and the page says
+   * which record it is. "One drafted a resolution plan" spends the coloured
+   * zone re-announcing the byline; "Six steps to set up this workstation" says
+   * what the reader is looking at. It carries the colour because it is the one
+   * line that carries severity, so it has to be the conclusion, not the
+   * provenance.
+   */
+  title: string
+  /**
+   * Overrides the glyph the status would pick. Required for `neutral`, which
+   * has no semantic glyph of its own — pass one that describes the content
+   * (e.g. `Summary` from `@/icons/ai`).
+   */
+  icon?: IconType
+}
+
+type AiCalloutSingleProps = AiCalloutSharedProps & {
+  /**
+   * The reason, in one line. "Two of five policy checks failed."
+   *
+   * **This is the title of the white card**, and the split from the tinted one
+   * is by job, not by importance: up there is *what it is*, down here is *why*.
+   * Same size and weight on purpose — they are one sentence broken in two, not
+   * a heading and a subheading — which is exactly why they must not be two
+   * nouns of the same kind. Never a score, a count or a status word here.
+   *
+   * There are four prose jobs in this shape and each slot gets exactly one:
+   * `title` is the verdict, this is the reason, `children` is the nuance that
+   * changes what the reader does, and `evidence` is the proof. The test: read
+   * only the emphasised text — `title` plus this — and it has to stand alone as
+   * a decision. "Rejection recommended · Two of five policy checks failed"
+   * does; "Rejection recommended · Client lunch · $712.65" does not, which is
+   * why this must not carry the record's identity. The page around the callout
+   * already says which expense this is.
+   */
+  summary?: string
+  /** The reasoning behind the verdict. Accepts a list when there is more than one reason. */
+  children: ReactNode
+  /**
+   * **The move the verdict recommends**, rendered outlined. That binding is the
+   * rule: if the reasoning above actually concludes something else, the verdict
+   * is wrong, not the button. A callout titled "Rejection recommended" whose
+   * outlined action is "Request changes" is telling the reader two different
+   * things and making them guess which one One meant.
+   */
+  action?: AiCalloutAction
+  /**
+   * **The way out of the recommendation** — "Approve anyway" against "Reject".
+   * Ghost, so the pair reads as a hierarchy and not as two peers.
+   *
+   * It has to be the *override*, not a third option. Pairing "Reject" with
+   * "Request changes" looks like two buttons but is really three paths with one
+   * missing, and the reader cannot tell which of them One is recommending.
+   *
+   * This reopens the "one action, and only one" rule on purpose. That rule was
+   * right for a plain callout, where two outlined buttons were noise for a
+   * message with no room to justify either. A recommendation with an auditable
+   * rationale is the case the rule pointed at: a decision that needs two paths,
+   * somewhere that has the room to explain them.
+   */
+  secondaryAction?: AiCalloutAction
+  /** Dismisses the callout. Acts on the container, so it lives in the header. */
+  onClose?: () => void
+  /**
+   * The reasoning that led to the verdict, revealed on demand. The header
+   * gains a toggle; nothing in the body is truncated or clamped, so the
+   * description stays fully readable whether this is open or closed.
+   */
+  evidence?: {
+    /**
+     * **Names what is behind the disclosure, as a noun phrase** — "the 5
+     * checks", "the six steps", "why this was rejected". The component supplies
+     * the verb, so it renders as "See the 5 checks" closed and "Hide the 5
+     * checks" open.
+     *
+     * It is required because a bare chevron says "there is more", which is what
+     * a list of separate recommendations says too; naming the content is what
+     * tells the reader these are not more verdicts. Splitting it this way is
+     * also what keeps the label honest: the product cannot pass a verb, so the
+     * label can only ever name something.
+     */
+    name: string
+    /**
+     * One line per step of the reasoning. Plain nodes rather than
+     * title/description pairs: a policy check is usually a single fact, and
+     * splitting it in two padded "Receipt verified / Passed." into a heading
+     * with a body. Emphasis goes inline, where the number or the rule actually
+     * is, instead of always landing on the check's name.
+     *
+     * They carry no action, and that absence is the contract: the day one
+     * needs a button it has become a finding, and the callout should carry
+     * `findings`. Work with no button is still fine here — see `kind`.
+     */
+    items: ReactNode[]
+    /**
+     * What the disclosure holds, which is the one thing the label cannot
+     * enforce on its own.
+     *
+     * `rationale` (the default) is why the verdict is the verdict: sentences,
+     * bulleted, read once and never touched again.
+     *
+     * `steps` is a plan the reader works through, and the only difference is
+     * the marker: numbered, because the order is part of the content — you
+     * confirm the device before you order it. Numbers do that job on their own,
+     * which is why there are no checkboxes here. Per-item state is work the
+     * record already tracks better than a message can, and a message that
+     * remembers things is no longer a message.
+     *
+     * The contract above holds in both: no CTA per item. A step is work the
+     * reader does elsewhere, over hours or days, and the moment one needs its
+     * own button this is `findings`.
+     */
+    kind?: "rationale" | "steps"
+  }
+  /**
+   * Uncontrolled initial state of the rationale. Defaults to folded, which is
+   * the opposite of the stacked default and deliberately so: here the verdict
+   * is already on screen and the reasoning is optional, so opening it is the
+   * reader's move, not ours.
+   */
+  defaultOpen?: boolean
+  /** Controlled state. */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  findings?: never
+}
+
+type AiCalloutStackedProps = AiCalloutSharedProps & {
+  /**
+   * Switches the callout to its stacked layout: the byline moves up beside the
+   * title because the whole evaluation shares one provenance, each finding gets
+   * its own row and its own action, and the header gains a toggle. Passing the
+   * list is what turns this on — there is no `stacked` flag, because the product
+   * already knows whether it holds one verdict or several.
+   *
+   * **Order matters.** `findings[0]` is the headline: it stays on screen when
+   * the rest are folded, so it is the one row the reader is guaranteed to see.
+   * Sort by severity, not by detection order.
+   *
+   * A list of one is a valid state, not a degenerate case: an evaluation that
+   * started with four findings and has had three resolved should not change
+   * shape on the last one. It simply loses the toggle and the deck, since
+   * folding would hide nothing.
+   */
+  findings: AiCalloutFinding[]
+  /**
+   * Uncontrolled initial state. Defaults to open — a folded finding is a
+   * finding nobody read. Folded still shows the headline row behind a deck edge,
+   * never just the header.
+   */
+  defaultOpen?: boolean
+  /** Controlled state, for folding several callouts together. */
+  open?: boolean
+  onOpenChange?: (open: boolean) => void
+  children?: never
+  summary?: never
+  action?: never
+  secondaryAction?: never
+  /**
+   * A stacked callout already is its own list. Evidence is the other shape:
+   * one verdict whose reasoning can be audited.
+   */
+  evidence?: never
+  /**
+   * Not available while stacked, and the fold is why. Folding keeps the headline
+   * finding on screen, so there is deliberately no state in which the callout
+   * shows nothing — one that can be reduced to a tinted strip with no finding on
+   * it is dismissable under another name, and unresolved findings would go with
+   * it.
+   */
+  onClose?: never
+}
+
+export type F0AiCalloutProps = AiCalloutSingleProps | AiCalloutStackedProps
+
+export interface AiCalloutSkeletonProps {
+  status?: AiCalloutStatus
+  /** Drops the footer, for callouts that will load without an action. */
+  compact?: boolean
+}

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/types.ts
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/types.ts
@@ -1,5 +1,4 @@
 import type { ReactNode } from "react"
-
 import type { IconType } from "@/components/F0Icon"
 import type { DataAttributes } from "@/global.types"
 

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/variants.ts
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/variants.ts
@@ -1,0 +1,105 @@
+import { cva } from "cva"
+
+import type { F0IconProps, IconType } from "@/components/F0Icon"
+import { AlertCircle, CheckCircle, InfoCircle, Warning } from "@/icons/app"
+
+import type { AiCalloutStatus } from "./types"
+
+/**
+ * The tint, and nothing else. It deliberately carries no `w-full`: the deck
+ * layers are absolutely positioned with `inset-x-*`, and a width declared
+ * alongside both `left` and `right` wins over `right` — which shifted every
+ * layer sideways at full width instead of insetting it, so they hung off the
+ * edge.
+ *
+ * One tint per callout however many findings it holds: the status colour
+ * appears three times (tint, title, glyph) whether the callout carries one
+ * verdict or five, where one tinted card per finding would repeat all three per
+ * row. `neutral` has no status tint of its own, so it borrows the flat grey
+ * surface.
+ */
+export const statusTintVariants = cva({
+  variants: {
+    status: {
+      neutral: "bg-f1-background-tertiary",
+      info: "bg-f1-background-info",
+      positive: "bg-f1-background-positive",
+      warning: "bg-f1-background-warning",
+      critical: "bg-f1-background-critical",
+    },
+  },
+})
+
+/**
+ * Used for the 2px ring around the white card, the hairline between rows, and
+ * the deck edge. All of them must be pinned with `border-solid` — this repo
+ * disables Tailwind's preflight, so a border with no style computes to zero
+ * width and renders nothing at all while still applying its colour.
+ */
+export const cardBorderVariants = cva({
+  variants: {
+    status: {
+      neutral: "border-f1-border-secondary",
+      info: "border-f1-border-info",
+      positive: "border-f1-border-positive",
+      warning: "border-f1-border-warning",
+      critical: "border-f1-border-critical",
+    },
+  },
+})
+
+/**
+ * Kept apart from the type scale because two different sizes need it: the
+ * title at 14/20 Medium and, when stacked, the header byline at 12/16 Medium.
+ * Folding the size into the colour variant meant `text-base` overriding
+ * `text-sm` through `cn`.
+ */
+export const statusForegroundVariants = cva({
+  variants: {
+    status: {
+      neutral: "text-f1-foreground",
+      info: "text-f1-foreground-info",
+      positive: "text-f1-foreground-positive",
+      warning: "text-f1-foreground-warning",
+      critical: "text-f1-foreground-critical",
+    },
+  },
+})
+
+/**
+ * `neutral` is deliberately empty: there is no glyph that means "no stance",
+ * so the caller passes one that describes the content instead.
+ */
+export const statusIcons: Record<AiCalloutStatus, IconType | null> = {
+  neutral: null,
+  info: InfoCircle,
+  positive: CheckCircle,
+  warning: Warning,
+  critical: AlertCircle,
+}
+
+/**
+ * The glyph runs one tone brighter than the title (Figma's `Icon/{status}` is
+ * the 50 tone, `Foreground/{status}` the 70) so the icon reads as the signal
+ * and the title stays legible as text.
+ */
+export const statusIconColors = {
+  neutral: "default",
+  info: "info",
+  positive: "positive",
+  warning: "warning",
+  critical: "critical",
+} as const satisfies Record<AiCalloutStatus, F0IconProps["color"]>
+
+export const cardClasses =
+  "flex flex-col overflow-hidden rounded-xl border-2 border-solid bg-f1-background"
+
+export const rowClasses =
+  "flex flex-row items-center justify-between gap-3 border-x-0 border-b-0 border-t border-solid"
+
+/**
+ * The single callout's footer byline: grey, 14/20, and it keeps the One mark.
+ * The stacked header's byline is deliberately different — status colour, 12/16
+ * Medium, no mark — because there it is a suffix to a coloured title rather
+ * than a row's own content. Both come straight from their Figma nodes.
+ */

--- a/packages/react/src/kits/ai/Banners/F0AiCallout/variants.ts
+++ b/packages/react/src/kits/ai/Banners/F0AiCallout/variants.ts
@@ -1,8 +1,6 @@
 import { cva } from "cva"
-
 import type { F0IconProps, IconType } from "@/components/F0Icon"
 import { AlertCircle, CheckCircle, InfoCircle, Warning } from "@/icons/app"
-
 import type { AiCalloutStatus } from "./types"
 
 /**

--- a/packages/react/src/kits/ai/Banners/F0Callout/CalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/CalloutInternal.tsx
@@ -5,10 +5,8 @@ import { F0Icon, IconType } from "@/components/F0Icon"
 import { CheckCircle, Cross, InfoCircle, Warning } from "@/icons/app"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { cn } from "@/lib/utils"
-import { Skeleton } from "@/ui/skeleton"
-import { CalloutInternalProps, CalloutSkeletonProps } from "./types"
-
-const calloutVariants = cva({
+import { CalloutInternalProps } from "./types"
+export const calloutVariants = cva({
   base: "flex w-full flex-col rounded-lg p-[1px]",
   variants: {
     variant: {
@@ -111,41 +109,3 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
     )
   }
 )
-
-export const CalloutSkeleton = ({
-  compact,
-  variant = "ai",
-}: CalloutSkeletonProps) => {
-  return (
-    <div
-      className={calloutVariants({ variant })}
-      aria-busy="true"
-      aria-live="polite"
-    >
-      <div className="flex flex-row items-center justify-between px-4 py-2">
-        <Skeleton className="h-5 w-32 rounded-md" />
-      </div>
-
-      <div className="flex flex-col gap-[1px]">
-        <div
-          className={cn(
-            "rounded-t-[13.25px] bg-f1-background px-4 py-3",
-            compact && "rounded-[13.25px]"
-          )}
-        >
-          <div className="flex flex-col gap-2">
-            <Skeleton className="h-4 w-full rounded-md" />
-            <Skeleton className="h-4 w-3/4 rounded-md" />
-            <Skeleton className="h-4 w-1/2 rounded-md" />
-          </div>
-        </div>
-        {!compact ? (
-          <div className="flex flex-row items-center justify-between gap-3 rounded-b-[13.25px] bg-f1-background px-4 py-3">
-            <Skeleton className="h-8 w-24 rounded-md" />
-            <Skeleton className="h-8 w-28 rounded-md" />
-          </div>
-        ) : null}
-      </div>
-    </div>
-  )
-}

--- a/packages/react/src/kits/ai/Banners/F0Callout/CalloutSkeleton.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/CalloutSkeleton.tsx
@@ -34,12 +34,12 @@ export const CalloutSkeleton = ({
             <Skeleton className="h-4 w-1/2 rounded-md" />
           </div>
         </div>
-        {!compact && (
+        {!compact ? (
           <div className="flex flex-row items-center justify-between gap-3 rounded-b-[13.25px] bg-f1-background px-4 py-3">
             <Skeleton className="h-8 w-24 rounded-md" />
             <Skeleton className="h-8 w-28 rounded-md" />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/kits/ai/Banners/F0Callout/CalloutSkeleton.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/CalloutSkeleton.tsx
@@ -1,0 +1,46 @@
+import { cn } from "@/lib/utils"
+import { Skeleton } from "@/ui/skeleton"
+import { calloutVariants } from "./CalloutInternal"
+import { CalloutSkeletonProps } from "./types"
+
+/* Split out of `CalloutInternal` so each file exports one component:
+   react-docgen 8 fails a file with two exported components with "Multiple
+   exported component definitions found", and Storybook surfaces that as an
+   empty docs page. */
+export const CalloutSkeleton = ({
+  compact,
+  variant = "ai",
+}: CalloutSkeletonProps) => {
+  return (
+    <div
+      className={calloutVariants({ variant })}
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="flex flex-row items-center justify-between px-4 py-2">
+        <Skeleton className="h-5 w-32 rounded-md" />
+      </div>
+
+      <div className="flex flex-col gap-[1px]">
+        <div
+          className={cn(
+            "rounded-t-[13.25px] bg-f1-background px-4 py-3",
+            compact && "rounded-[13.25px]"
+          )}
+        >
+          <div className="flex flex-col gap-2">
+            <Skeleton className="h-4 w-full rounded-md" />
+            <Skeleton className="h-4 w-3/4 rounded-md" />
+            <Skeleton className="h-4 w-1/2 rounded-md" />
+          </div>
+        </div>
+        {!compact && (
+          <div className="flex flex-row items-center justify-between gap-3 rounded-b-[13.25px] bg-f1-background px-4 py-3">
+            <Skeleton className="h-8 w-24 rounded-md" />
+            <Skeleton className="h-8 w-28 rounded-md" />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/kits/ai/Banners/F0Callout/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/index.stories.tsx
@@ -2,9 +2,8 @@ import { StoryFn, StoryObj } from "@storybook/react-vite"
 import { expect, within } from "storybook/test"
 import { CheckDouble, ExternalLink } from "@/icons/app"
 import { WithDataTestIdProps } from "@/lib/data-testid"
-import { CalloutSkeleton } from "./CalloutInternal"
+import { CalloutSkeleton } from "./CalloutSkeleton"
 import { F0Callout, F0CalloutProps } from "."
-
 const meta = {
   title: "AI/AICallout (deprecated)",
   component: F0Callout,

--- a/packages/react/src/kits/ai/Banners/F0Callout/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/index.stories.tsx
@@ -5,10 +5,12 @@ import { WithDataTestIdProps } from "@/lib/data-testid"
 import { CalloutSkeleton } from "./CalloutSkeleton"
 import { F0Callout, F0CalloutProps } from "."
 const meta = {
-  title: "AI/AICallout (deprecated)",
+  title: "AI/AICallout",
   component: F0Callout,
-  // The tag is what the sidebar badge and the component-status API read; the
-  // title suffix alone marks nothing.
+  // The tag is what the sidebar badge (❌) and the component-status API read.
+  // Deliberately not a "(deprecated)" title suffix: that changes the Storybook
+  // id, so every existing link and bookmark to this page 404s, and it marks
+  // nothing the tag does not already mark.
   tags: ["deprecated"],
   parameters: {
     layout: "centered",

--- a/packages/react/src/kits/ai/Banners/F0Callout/index.stories.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/index.stories.tsx
@@ -6,10 +6,30 @@ import { CalloutSkeleton } from "./CalloutInternal"
 import { F0Callout, F0CalloutProps } from "."
 
 const meta = {
-  title: "AI/AICallout",
+  title: "AI/AICallout (deprecated)",
   component: F0Callout,
+  // The tag is what the sidebar badge and the component-status API read; the
+  // title suffix alone marks nothing.
+  tags: ["deprecated"],
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component: [
+          "**Deprecated — use `F0AiCallout`.** Same construction, brought in line with the design.",
+          "",
+          "This one leaves `critical` with no glyph and an uncoloured title, so the strongest status",
+          "is the only one that is not signalled, and its `ai` variant stacks a gradient on a semantic",
+          "colour — two signals for one message. It is also silent about authorship, which for AI",
+          "output is the thing a reader needs most.",
+          "",
+          'Migration: `variant` → `status` (`variant="ai"` becomes `status="neutral"`, which needs an',
+          "`icon`), `actions: [a, b]` → `action` plus `secondaryAction` where the second really is the",
+          "way out of the first, and `children` unchanged. The byline is not a prop: every F0AiCallout",
+          "renders it.",
+        ].join("\n"),
+      },
+    },
   },
   argTypes: {
     title: {

--- a/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
@@ -2,7 +2,8 @@ import { forwardRef } from "react"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
 import { CalloutInternal } from "./CalloutInternal"
-import { CalloutSkeleton } from "./CalloutSkeleton"import { CalloutInternalProps, CalloutSkeletonProps } from "./types"
+import { CalloutSkeleton } from "./CalloutSkeleton"
+import { CalloutInternalProps, CalloutSkeletonProps } from "./types"
 
 export type F0CalloutProps = CalloutInternalProps
 

--- a/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
@@ -18,6 +18,25 @@ const F0CalloutSkeleton = ({ compact, variant }: CalloutSkeletonProps) => {
 
 F0CalloutBase.displayName = "F0Callout"
 
+/**
+ * @deprecated Use `F0AiCallout` instead.
+ *
+ * `F0AiCallout` is the same construction — tinted container, white card, action
+ * row — brought in line with the design, and it fixes two things this one gets
+ * wrong: `critical` renders with no icon and an uncoloured title (the strongest
+ * status is the only one that isn't signalled), and the `ai` variant stacks a
+ * gradient on top of a semantic colour, which is two signals for one message.
+ * It also makes attribution structural: the byline is always rendered, so the
+ * callout can never fail to say where it came from.
+ *
+ * Migration:
+ * - `variant` → `status`; `variant="ai"` becomes `status="neutral"`, which
+ *   requires an `icon` because `neutral` has no glyph of its own
+ * - `children` unchanged
+ * - `actions: [a, b]` → `action` plus `secondaryAction`, and only when the
+ *   second is the way out of the first rather than a third path
+ * - the byline is not a prop: every `F0AiCallout` renders it
+ */
 export const F0Callout = withSkeleton(
   withDataTestId(F0CalloutBase),
   F0CalloutSkeleton

--- a/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
@@ -1,8 +1,8 @@
 import { forwardRef } from "react"
 import { withDataTestId } from "@/lib/data-testid"
 import { withSkeleton } from "@/lib/skeleton"
-import { CalloutInternal, CalloutSkeleton } from "./CalloutInternal"
-import { CalloutInternalProps, CalloutSkeletonProps } from "./types"
+import { CalloutInternal } from "./CalloutInternal"
+import { CalloutSkeleton } from "./CalloutSkeleton"import { CalloutInternalProps, CalloutSkeletonProps } from "./types"
 
 export type F0CalloutProps = CalloutInternalProps
 

--- a/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/index.tsx
@@ -29,13 +29,14 @@ F0CalloutBase.displayName = "F0Callout"
  * It also makes attribution structural: the byline is always rendered, so the
  * callout can never fail to say where it came from.
  *
- * Migration:
- * - `variant` → `status`; `variant="ai"` becomes `status="neutral"`, which
- *   requires an `icon` because `neutral` has no glyph of its own
- * - `children` unchanged
- * - `actions: [a, b]` → `action` plus `secondaryAction`, and only when the
- *   second is the way out of the first rather than a third path
- * - the byline is not a prop: every `F0AiCallout` renders it
+ * @removeIn 7.0.0
+ * @migration Replace `F0Callout` with `F0AiCallout` from the same entry point.
+ * `variant` becomes `status`, and `variant="ai"` becomes `status="neutral"`,
+ * which additionally requires an `icon` because `neutral` has no glyph of its
+ * own. `children` is unchanged. `actions: [a, b]` becomes `action={a}` plus
+ * `secondaryAction={b}`, and only when the second is the way out of the first
+ * rather than a third path — otherwise drop it. Remove nothing for the byline:
+ * it is not a prop, every `F0AiCallout` renders it.
  */
 export const F0Callout = withSkeleton(
   withDataTestId(F0CalloutBase),

--- a/packages/react/src/kits/ai/Banners/exports.tsx
+++ b/packages/react/src/kits/ai/Banners/exports.tsx
@@ -1,3 +1,4 @@
 export * from "./BaseBanner"
 export * from "./F0AiBanner"
+export * from "./F0AiCallout"
 export * from "./F0Callout"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -401,6 +401,18 @@ export const defaultTranslations = {
     // reads badly past a couple of minutes — the consumer picks.
     thinkingElapsedSeconds: "{{seconds}}s",
     thinkingElapsedMinutes: "{{minutes}}m {{seconds}}s",
+    // Byline shown wherever One's own output is displayed, so the reader can
+    // always tell an assessment from a fact. One string, not a set: how much
+    // the message claims is the status's job, and a byline that also modulated
+    // the claim would be a second signal for the same thing.
+    attribution: "Suggested by One",
+    // The disclosure's verb belongs to the component and its noun to the
+    // product: the state then shows in one word instead of replacing the whole
+    // label, and the name of what is behind it never disappears.
+    evidence: {
+      show: "See {{name}}",
+      hide: "Hide {{name}}",
+    },
     feedbackModal: {
       positive: {
         title: "What did you like about this response?",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -401,14 +401,7 @@ export const defaultTranslations = {
     // reads badly past a couple of minutes — the consumer picks.
     thinkingElapsedSeconds: "{{seconds}}s",
     thinkingElapsedMinutes: "{{minutes}}m {{seconds}}s",
-    // Byline shown wherever One's own output is displayed, so the reader can
-    // always tell an assessment from a fact. One string, not a set: how much
-    // the message claims is the status's job, and a byline that also modulated
-    // the claim would be a second signal for the same thing.
     attribution: "Suggested by One",
-    // The disclosure's verb belongs to the component and its noun to the
-    // product: the state then shows in one word instead of replacing the whole
-    // label, and the name of what is behind it never disappears.
     evidence: {
       show: "See {{name}}",
       hide: "Hide {{name}}",


### PR DESCRIPTION
Adds `F0AiCallout` to `kits/ai/Banners`: what One found about the record on screen, and what it needs from the reader. Figma: [`RiV4xYq8R839J8NzTaBCr8`, frame `2863-49931`](https://www.figma.com/design/RiV4xYq8R839J8NzTaBCr8?node-id=2863-49931).
<img width="366" height="697" alt="Screenshot 2026-09-07 at 15 22 15" src="https://github.com/user-attachments/assets/b8aab215-a6d4-40cc-b2e4-68ed799b0367" />


## One component, four shapes

The content selects the shape — there is no `shape` or `stacked` flag, because the product already knows what it holds.

| Shape | Turned on by | For |
| --- | --- | --- |
| Verdict | `children` | One assessment, self-contained |
| Findings | `findings` | Several issues on one record, each with its own action |
| Verdict with a rationale | `evidence` | One recommendation, plus the reasoning behind it |
| Verdict with a plan | `evidence` + `kind: "steps"` | One assessment whose answer is several things to do, in order |

## Decisions worth reviewing

- **`status` is required, with no default.** A blocking finding sent as `info` still *looks* correct, which is the one mistake that survives review. The status asks whether the **reader** has work, not whether we can offer them a click — so `info` with no action is a normal shape, not an oversight.
- **The byline is not a prop.** How much a message claims is the status's job; a configurable attribution would be a second signal for the same thing. Every callout renders "Suggested by One".
- **`role="status"` + `aria-live="polite"`, always.** This diverges from `F0Alert`, which promotes `warning` and `critical` to `role="alert"`. The reason is authorship: `F0Alert` speaks for the system and a system failure may interrupt; a machine's opinion about a record the reader is already looking at does not get to seize their attention.
- **Folding differs by shape.** `findings` starts open, because a folded finding is a finding nobody read; `evidence` starts folded, because a rationale is read on demand. Folded rows are unmounted rather than hidden, and the deck behind a folded group caps at two layers.
- **The disclosure's noun comes from the product (`evidence.name`) and its verb from the component** — "See the 5 checks" / "Hide the 5 checks". The state shows in one word instead of replacing the label, and the label can only ever *name* what is behind it.
- **No per-item state anywhere** — no checkboxes, no radios. A message holding a value nobody submitted has stopped being a message, so a choice between options belongs in a dialog behind the action.

## Deprecation

`F0Callout` is deprecated: `tags: ["deprecated"]` (which is what the sidebar badge and the component-status API read), a deprecation note on its docs page, and a `@deprecated` JSDoc carrying `@removeIn 7.0.0` and `@migration`. Its Storybook title is deliberately unchanged — a "(deprecated)" suffix changes the page id, and the docs-index check flagged that it would 404 every existing link. It gets `critical` wrong — no glyph and an uncoloured title, so the strongest status is the only one not signalled — and its `ai` variant stacks a gradient on a semantic colour.

**It keeps working and none of its product call sites move.** Its skeleton is split into its own file, though: exporting two components from `CalloutInternal.tsx` made react-docgen fail with "Multiple exported component definitions found", which Storybook renders as an empty docs page — the page someone reads to migrate.

## Verified

- 33 unit tests; `tsc` and `oxlint` clean on the touched paths
- **Contrast measured, not assumed.** The byline originally carried `opacity-50` from Figma, which halves the secondary token to **2.00:1** where AA asks 4.5 — axe reported it as a serious failure on every story. Both bylines drop the opacity; re-measured across `Verdict`, `Statuses` and `Findings`, nothing falls under 4.55 and axe now reports no issues.
- The development warnings run in an effect rather than during render, so one violation logs once instead of once per re-render, and an empty `findings` array renders nothing rather than an empty critical shell
- Docs page renders 8 canvases, 0 empty, no overflow; `AICallout` reports `deprecated` and `F0AiCallout` `experimental` through the status API

`tsc` also reports one pre-existing error in `src/sds/chat/F0Chat/utils/emoji-support.ts`, from a stale `@factorialco/f0-core` in my worktree rather than from this branch.

## Translation keys

`ai.attribution` and `ai.evidence` are added to the dictionary. Additive, but consumers that maintain a full translation object have to add them — flagged by the API-breaking check for that reason, and called out here rather than shipped as a major.

## Worth deciding, not applied here

`kits/ai/exports.ts` never exports `./Banners`, so no banner — `F0AiCallout` included — reaches the `ai` entry point. The only public route is `experimental`, whose re-export is marked `@deprecated` and points at `@/kits/ai/Banners`, which is not a build entry. So this component currently ships only through a deprecated path, and so do `F0AiBanner` and `BaseBanner`.

One line in `kits/ai/exports.ts` fixes it and matches what those deprecation notices already say, but it changes what `@factorialco/f0-react/ai` exposes — happy to add it if the team wants it in this PR.

## Open, and deliberately not in this PR

- Foundations: a neutral **border** token at the 6% step (F0's scale starts at `neutral-20`, 10%, where the design asks for 6%), and a `neutral` **glyph** meaning "done"/"informative" — today `neutral` has to borrow a content icon, which is why it requires `icon`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

