### PR TITLE
fix(Widget): no separator dot when the title is a link

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -384,10 +384,6 @@ const Container = forwardRef<
                   )}
                   {header.subtitle && (
                     <div className="flex flex-row items-center gap-1">
-                      {/* The dot separates the title from the subtitle — unless
-                        the title is a LINK, which already ends in a chevron:
-                        the two together read as a stray glyph between them
-                        ("Wellness programs › · Boosting workplace health"). */}
                       {!header.link && <InlineDot />}
                       <CardSubtitle className="truncate">
                         {header.subtitle}

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -384,7 +384,11 @@ const Container = forwardRef<
                   )}
                   {header.subtitle && (
                     <div className="flex flex-row items-center gap-1">
-                      <InlineDot />
+                      {/* The dot separates the title from the subtitle — unless
+                        the title is a LINK, which already ends in a chevron:
+                        the two together read as a stray glyph between them
+                        ("Wellness programs › · Boosting workplace health"). */}
+                      {!header.link && <InlineDot />}
                       <CardSubtitle className="truncate">
                         {header.subtitle}
                       </CardSubtitle>

--- a/packages/react/src/experimental/Widgets/Widget/subtitleSeparator.test.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/subtitleSeparator.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import { Widget } from "./index"
+
+/**
+ * A LINKED TITLE ALREADY SEPARATES ITSELF from the subtitle: it ends in a
+ * chevron. Drawing the dot as well put two separators between them, reading as
+ * a stray glyph — "Wellness programs › · Boosting workplace health".
+ *
+ * jsdom computes no layout, so the dot is found by the classes that draw it.
+ */
+describe("the widget header's separator dot", () => {
+  const header = {
+    title: "Wellness programs",
+    subtitle: "Boosting workplace health",
+  }
+
+  const dotsIn = (container: HTMLElement) =>
+    container.querySelectorAll(".rounded-full.bg-f1-foreground-secondary")
+      .length
+
+  test("separates a plain title from its subtitle", () => {
+    const { container } = zeroRender(<Widget header={header}>Content</Widget>)
+
+    expect(dotsIn(container)).toBe(1)
+  })
+
+  test("is dropped when the title is a link", () => {
+    const { container } = zeroRender(
+      <Widget header={{ ...header, link: { url: "/", title: "Go to link" } }}>
+        Content
+      </Widget>
+    )
+
+    expect(dotsIn(container)).toBe(0)
+  })
+})


### PR DESCRIPTION
## Description

A widget whose header carries both a `link` and a `subtitle` draws two separators between them: the linked title ends in a chevron, and the subtitle is preceded by an `InlineDot`. Together they read as a stray glyph — `Wellness programs › · Boosting workplace health`.

The dot now shows only for a plain title, which is where it is doing work.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

Reproduced by the existing stories `Widget/WithLink` and `Widget/WithLinkAndCustomIcon`, which both pair a link with a subtitle:

| | Header reads |
| --- | --- |
| before | `Wellness programs › · Boosting workplace health` |
| after | `Wellness programs › Boosting workplace health` |

Found on Factorial's new Home, where the celebrations card names its range in the subtitle and points at the communities feed from its title.

## Implementation details

One condition in `Widget`'s header: `{!header.link && <InlineDot />}`. A plain title keeps its separator, since nothing else separates it there. No API change, and the two stories above cover the combination already, so no new story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)