### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.86.5",
+  "packages/react": "6.87.0",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.87.0](https://github.com/factorialco/f0/compare/f0-react-v6.86.5...f0-react-v6.87.0) (2026-09-07)
+
+
+### Features
+
+* **F0AiChatTextArea:** neutral credit warning with CTA icon ([#5268](https://github.com/factorialco/f0/issues/5268)) ([ae44231](https://github.com/factorialco/f0/commit/ae44231bb44992c4d5b2bef0be8520a3d6b8fdce))
+
 ## [6.86.5](https://github.com/factorialco/f0/compare/f0-react-v6.86.4...f0-react-v6.86.5) (2026-09-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.86.5",
+  "version": "6.87.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.87.0</summary>

## [6.87.0](https://github.com/factorialco/f0/compare/f0-react-v6.86.5...f0-react-v6.87.0) (2026-09-07)


### Features

* **F0AiChatTextArea:** neutral credit warning with CTA icon ([#5268](https://github.com/factorialco/f0/issues/5268)) ([ae44231](https://github.com/factorialco/f0/commit/ae44231bb44992c4d5b2bef0be8520a3d6b8fdce))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).