### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.87.0",
+  "packages/react": "6.87.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.87.1](https://github.com/factorialco/f0/compare/f0-react-v6.87.0...f0-react-v6.87.1) (2026-09-07)
+
+
+### Bug Fixes
+
+* **Widget:** no separator dot when the title is a link ([#5416](https://github.com/factorialco/f0/issues/5416)) ([daf797f](https://github.com/factorialco/f0/commit/daf797fe2a74d017db92fd3f88c13b2d6261fd9f))
+
 ## [6.87.0](https://github.com/factorialco/f0/compare/f0-react-v6.86.5...f0-react-v6.87.0) (2026-09-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.87.0",
+  "version": "6.87.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.87.1</summary>

## [6.87.1](https://github.com/factorialco/f0/compare/f0-react-v6.87.0...f0-react-v6.87.1) (2026-09-07)


### Bug Fixes

* **Widget:** no separator dot when the title is a link ([#5416](https://github.com/factorialco/f0/issues/5416)) ([daf797f](https://github.com/factorialco/f0/commit/daf797fe2a74d017db92fd3f88c13b2d6261fd9f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).