### PR TITLE
feat(F0Select): search inside the trigger, on by default

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -66,14 +66,34 @@ import { SelectItem } from "./components/SelectItem"
 import { SelectTopActions } from "./components/SelectTopActions"
 export * from "./types"
 
+/**
+ * Matches a query against EVERYTHING THE ROW SHOWS, not just its label.
+ *
+ * A row that reads "Spain +34" has to be findable by "34" — a substring, so
+ * the "+" nobody types is optional — and one with a `description` by the words
+ * in it. Matching the label alone made the search quietly ignore half of what
+ * was on screen: the documented contract already claimed descriptions were
+ * matched, and consumers were passing their own `searchFn` to get back
+ * behavior they had been promised.
+ *
+ * Metadata is matched per variant rather than by walking the object, so a new
+ * `F0SelectItemMetadata` variant is a deliberate decision about whether it is
+ * searchable — not something that silently becomes part of the query surface.
+ */
 const defaultSearchFn = (
   option: F0SelectItemProps<string>,
   search?: string
 ) => {
-  return (
-    option.type === "separator" ||
-    !search ||
-    option.label.toLowerCase().includes(search.toLowerCase())
+  if (option.type === "separator" || !search) {
+    return true
+  }
+
+  const query = search.toLowerCase()
+  const metadata =
+    option.metadata?.type === "dialCode" ? option.metadata.dialCode : undefined
+
+  return [option.label, option.description, metadata].some((field) =>
+    field?.toLowerCase().includes(query)
   )
 }
 
@@ -1299,6 +1319,22 @@ const F0SelectComponent = forwardRef(function Select<
       showLoadingIndicator={!!children}
       portalContainer={effectivePortalContainer}
       retainTrigger={searchesInTrigger}
+      onEscapeKeyDown={(event) => {
+        /**
+         * Escape drops the QUERY first, and only closes the list on the second
+         * press, once there is nothing left to undo.
+         *
+         * Through Radix's own hook, never the input's `onKeyDown`: the dismiss
+         * runs from a listener on `document` in the CAPTURE phase, so it has
+         * already fired by the time the event reaches anything inside — no
+         * amount of `stopPropagation` from a descendant can get in front of
+         * it. This hook is the one place that can.
+         */
+        if (searchesInTrigger && currentSearch) {
+          event.preventDefault()
+          onSearchChangeLocal("")
+        }
+      }}
       onPointerDownOutside={(event) => {
         /**
          * With the search inside the trigger, the trigger is part of the thing
@@ -1496,14 +1532,6 @@ const F0SelectComponent = forwardRef(function Select<
       }
 
       return
-    }
-
-    if (event.key === "Escape" && currentSearch) {
-      // Escape drops the query first and only closes on the second press, once
-      // there is nothing left to undo.
-      event.preventDefault()
-      event.stopPropagation()
-      onSearchChangeLocal("")
     }
   }
 
@@ -1718,7 +1746,15 @@ const F0SelectComponent = forwardRef(function Select<
                 />
               ) : (
                 <button
-                  className="flex w-full items-center justify-between"
+                  /**
+                   * No outline of its own: the FIELD draws the focus ring, from
+                   * `focus-within` on the wrapper, and this button fills it.
+                   * `reset.css` does the same for `input` and `textarea` and
+                   * stops at buttons, so once the dropdown started handing
+                   * focus back here on close, Chrome drew its own heavy ring
+                   * inside F0's.
+                   */
+                  className="flex w-full items-center justify-between focus-visible:outline-none"
                   aria-label={label || placeholder}
                   onKeyDown={handleTriggerKeyDown}
                   onClick={(e) => {

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -1530,8 +1530,6 @@ const F0SelectComponent = forwardRef(function Select<
       if (!multiple) {
         handleChangeOpenLocal(false)
       }
-
-      return
     }
   }
 

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -233,18 +233,69 @@ const F0SelectComponent = forwardRef(function Select<
     "disableSelectAll" in props ? props.disableSelectAll : false
   type ActualRecordType = ResolvedRecordType<R>
 
+  /**
+   * SEARCH: whether there is one, and where it goes.
+   *
+   * A search box at the top of the dropdown is extra chrome above the list, so
+   * it has always been something consumers switch on. INSIDE the trigger it
+   * costs nothing — the field is already on screen — so wherever it can live
+   * there it is on by default, and `showSearchBox` is only needed to turn it
+   * off.
+   *
+   * It can live there only when this select renders its own field: `asList`
+   * and a custom `children` trigger have no input to type into, and the
+   * inline variant's trigger is a compact borderless button. Filters keep it in
+   * the dropdown too — the filter picker and the search are one query, and
+   * splitting them puts half of it in the trigger and half in the popup.
+   *
+   * Turning it on by default covers static `options` only, which this
+   * component filters itself. A `source` is searched by the consumer's own
+   * adapter, so a box we switched on for them would be a field that filters
+   * nothing: those keep opting in, and get the inline placement once they do.
+   */
+  const canSearchInTrigger =
+    variant === "field" && !asList && !children && !source?.filters
+  const isSearchEnabled = showSearchBox ?? (canSearchInTrigger && !source)
+  const searchesInTrigger = isSearchEnabled && canSearchInTrigger
+  const searchesInDropdown = isSearchEnabled && !searchesInTrigger
+
   const [openLocal, setOpenLocal] = useState(open)
   const inlineTriggerRef = useRef<HTMLButtonElement>(null)
   const composedTriggerRef = useComposedRefs(ref, inlineTriggerRef)
+  /**
+   * The trigger's CHILD: the button that shows the selection, or the text input
+   * the inline search swaps it for. `inlineTriggerRef` holds the field's
+   * wrapper, which isn't focusable, so this is where focus has to be handed
+   * back when the dropdown closes — the input unmounts with it, and
+   * SelectContent prevents Radix's own focus restoration, which would leave
+   * focus on the body.
+   */
+  const triggerFieldRef = useRef<HTMLElement>(null)
   const previousOpenRef = useRef(openLocal)
   const isApplyingRef = useRef(false)
 
   useEffect(() => {
-    if (variant === "inline" && previousOpenRef.current && !openLocal) {
-      inlineTriggerRef.current?.focus({ preventScroll: true })
+    if (previousOpenRef.current && !openLocal) {
+      if (variant === "inline") {
+        inlineTriggerRef.current?.focus({ preventScroll: true })
+      } else if (searchesInTrigger) {
+        /**
+         * Only when nothing else has taken focus: picking an option leaves it
+         * on a row that is being unmounted, and it lands on the body — but a
+         * close caused by clicking another field must not yank it back here.
+         */
+        const active = document.activeElement
+        const focusIsLoose =
+          active === null ||
+          active === document.body ||
+          !!inlineTriggerRef.current?.contains(active)
+        if (focusIsLoose) {
+          triggerFieldRef.current?.focus({ preventScroll: true })
+        }
+      }
     }
     previousOpenRef.current = openLocal
-  }, [openLocal, variant])
+  }, [openLocal, variant, searchesInTrigger])
 
   const defaultItems = useMemo(
     () =>
@@ -337,9 +388,9 @@ const F0SelectComponent = forwardRef(function Select<
           ? String(mappedOption.value)
           : undefined
       },
-      search: showSearchBox
+      search: isSearchEnabled
         ? {
-            enabled: showSearchBox,
+            enabled: true,
             sync: !source,
           }
         : undefined,
@@ -1198,7 +1249,7 @@ const F0SelectComponent = forwardRef(function Select<
             searchValue={currentSearch}
             onSearchChange={onSearchChangeLocal}
             searchBoxPlaceholder={searchBoxPlaceholder}
-            showSearchBox={showSearchBox}
+            showSearchBox={searchesInDropdown}
             grouping={localSource.grouping}
             currentGrouping={localSource.currentGrouping}
             onGroupingChange={localSource.setCurrentGrouping}
@@ -1224,7 +1275,7 @@ const F0SelectComponent = forwardRef(function Select<
               onChange={handleSelectAllWithTracking}
               hideCheckbox={disableSelectAll}
               items={getDisplayItemsForSelection}
-              paddingTop={!showSearchBox && !localSource.filters}
+              paddingTop={!searchesInDropdown && !localSource.filters}
             />
           )}
         </>
@@ -1247,6 +1298,22 @@ const F0SelectComponent = forwardRef(function Select<
       isLoading={isLoading || loading}
       showLoadingIndicator={!!children}
       portalContainer={effectivePortalContainer}
+      retainTrigger={searchesInTrigger}
+      onPointerDownOutside={(event) => {
+        /**
+         * With the search inside the trigger, the trigger is part of the thing
+         * that is open: clicking into the field to move the caret must not
+         * dismiss the list it is driving.
+         */
+        const target = event.target
+        if (
+          searchesInTrigger &&
+          target instanceof Node &&
+          inlineTriggerRef.current?.contains(target)
+        ) {
+          event.preventDefault()
+        }
+      }}
     />
   )
 
@@ -1266,6 +1333,204 @@ const F0SelectComponent = forwardRef(function Select<
     .map((item) => item.selectedLabel ?? item.label)
     .filter(Boolean)
     .join(", ")
+
+  /**
+   * INLINE SEARCH — the trigger IS the search box.
+   *
+   * While the dropdown is open the field swaps the selection it displays for a
+   * real text input, so the query is typed where the user is already looking
+   * instead of in a second box that opens underneath it. Closed, the field goes
+   * back to the selection with its avatars and tags; open, that selection
+   * becomes the input's placeholder, so it stays readable until the first
+   * keystroke replaces it.
+   */
+  const isSearchingInTrigger = searchesInTrigger && openLocal
+
+  /**
+   * A query never outlives the dropdown it was typed into: the field shows the
+   * selection again on close, and what it reopens on is the whole list.
+   *
+   * On the CLOSE, not while closed — a keystroke on the closed field seeds the
+   * query and opens the dropdown in that order, and "while closed" would wipe
+   * the first character before the input ever mounts.
+   */
+  /**
+   * THE HANDOVER: this input replaces the button the click or the keystroke
+   * landed on, so it has to take focus, or the query would be typed into
+   * nothing.
+   *
+   * From an effect and a timeout, NOT React's `autoFocus`. autoFocus focuses
+   * during the commit, and around an open popup `focus` is patched by the
+   * instrumentation Storybook and the test tooling install — patched into
+   * something that schedules React work. React then throws "Should not already
+   * be working" mid-commit and the select renders nothing at all. The timeout
+   * puts the call after the commit, which is also where the popup's own
+   * opening focus runs: ours lands first, and Radix leaves a trigger-focused
+   * select alone.
+   */
+  useEffect(() => {
+    if (!isSearchingInTrigger) {
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      const field = triggerFieldRef.current
+      if (field && document.activeElement !== field) {
+        field.focus({ preventScroll: true })
+      }
+    }, 0)
+
+    return () => clearTimeout(timeout)
+  }, [isSearchingInTrigger])
+
+  const wasOpenForSearchRef = useRef(openLocal)
+  useEffect(() => {
+    if (searchesInTrigger && wasOpenForSearchRef.current && !openLocal) {
+      setCurrentSearch(undefined)
+    }
+    wasOpenForSearchRef.current = openLocal
+  }, [searchesInTrigger, openLocal, setCurrentSearch])
+
+  /**
+   * What Enter picks: the first option the query left standing. Typing
+   * `light` and carrying straight on is the point of typing in the trigger,
+   * and it can't require arrowing into the list first.
+   */
+  const firstSelectableOption = useMemo(() => {
+    const records =
+      data.type === "grouped"
+        ? data.groups.flatMap((group) => group.records)
+        : data.records
+
+    for (const record of records) {
+      const option = optionMapper(record)
+      if (option.type !== "separator" && !option.disabled) {
+        return option
+      }
+    }
+
+    return undefined
+  }, [data, optionMapper])
+
+  /**
+   * The arrows hand focus over to the list, which is where Radix takes the
+   * navigation from — the same handover the dropdown's own search box makes.
+   * The listbox is whatever the field already points `aria-controls` at, so
+   * it is found through that rather than through a second id of our own.
+   */
+  const focusOptionInList = (
+    field: HTMLElement,
+    position: "first" | "last"
+  ) => {
+    const listboxId = field.getAttribute("aria-controls")
+    const listbox = listboxId ? document.getElementById(listboxId) : null
+    const options = Array.from(
+      listbox?.querySelectorAll<HTMLElement>(
+        '[role="option"]:not([aria-disabled="true"])'
+      ) ?? []
+    )
+    const option =
+      position === "first" ? options[0] : options[options.length - 1]
+
+    option?.scrollIntoView({ block: "nearest" })
+    option?.focus({ preventScroll: true })
+  }
+
+  const clearTriggerSelection = () => {
+    hasUserInteracted.current = true
+    clearSelection()
+    // Clear the cache when clearing selection
+    selectedItemsCache.current.clear()
+    // Call with undefined to indicate no item is selected
+    ;(
+      onChangeSelectedOption as (option: undefined, checked: boolean) => void
+    )?.(undefined, false)
+  }
+
+  const handleTriggerSearchChange = (value: string) => {
+    onSearchChangeLocal(value)
+    if (!openLocal) {
+      handleChangeOpenLocal(true)
+    }
+  }
+
+  const handleTriggerClear = () => {
+    // The text goes first: while the field is a search box, its clear button is
+    // clearing a query, not a selection.
+    if (isSearchingInTrigger && currentSearch) {
+      onSearchChangeLocal("")
+      return
+    }
+
+    clearTriggerSelection()
+  }
+
+  const handleTriggerSearchKeyDown = (
+    event: React.KeyboardEvent<HTMLInputElement>
+  ) => {
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault()
+      focusOptionInList(
+        event.currentTarget,
+        event.key === "ArrowUp" ? "last" : "first"
+      )
+      return
+    }
+
+    if (event.key === "Enter") {
+      // Never a form submit: this input is a select's trigger.
+      event.preventDefault()
+
+      if (!firstSelectableOption) {
+        return
+      }
+
+      const optionValue = String(firstSelectableOption.value)
+      onItemCheckChange(
+        optionValue,
+        multiple ? !localValue.includes(optionValue) : true
+      )
+
+      if (!multiple) {
+        handleChangeOpenLocal(false)
+      }
+
+      return
+    }
+
+    if (event.key === "Escape" && currentSearch) {
+      // Escape drops the query first and only closes on the second press, once
+      // there is nothing left to undo.
+      event.preventDefault()
+      event.stopPropagation()
+      onSearchChangeLocal("")
+    }
+  }
+
+  /**
+   * The CLOSED field takes the first keystroke too. Typing is the way into a
+   * searchable select, so a character opens the dropdown and becomes the query
+   * instead of being swallowed while the input mounts. Space is left alone —
+   * it is how a focused button is pressed.
+   */
+  const handleTriggerKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (!searchesInTrigger || openLocal) {
+      return
+    }
+
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault()
+      handleChangeOpenLocal(true)
+      return
+    }
+
+    const isModifierKey = event.ctrlKey || event.altKey || event.metaKey
+    if (!isModifierKey && event.key.length === 1 && event.key !== " ") {
+      event.preventDefault()
+      onSearchChangeLocal(event.key)
+      handleChangeOpenLocal(true)
+    }
+  }
 
   const withTriggerTooltip = (trigger: React.ReactNode) => {
     /**
@@ -1377,35 +1642,46 @@ const F0SelectComponent = forwardRef(function Select<
               icon={icon}
               labelIcon={labelIcon}
               hideLabel={hideLabel}
+              inputRef={triggerFieldRef}
+              aria-autocomplete={isSearchingInTrigger ? "list" : undefined}
               value={
-                multiple
-                  ? // For multiple: use count of selected items
-                    Math.max(
-                      localValue.length,
-                      selectionMeta.selectedItemsCount
-                    ).toString()
-                  : // For single: use the selected value directly
-                    (localValue[0] ?? undefined)
+                isSearchingInTrigger
+                  ? // While searching, the field's value IS the query
+                    (currentSearch ?? "")
+                  : multiple
+                    ? // For multiple: use count of selected items
+                      Math.max(
+                        localValue.length,
+                        selectionMeta.selectedItemsCount
+                      ).toString()
+                    : // For single: use the selected value directly
+                      (localValue[0] ?? undefined)
               }
               isEmpty={(value) =>
-                multiple ? !value || +(value ?? 0) === 0 : !value
+                isSearchingInTrigger
+                  ? !value
+                  : multiple
+                    ? !value || +(value ?? 0) === 0
+                    : !value
               }
-              onClear={() => {
-                hasUserInteracted.current = true
-                clearSelection()
-                // Clear the cache when clearing selection
-                selectedItemsCache.current.clear()
-                // Call with undefined to indicate no item is selected
-                ;(
-                  onChangeSelectedOption as (
-                    option: undefined,
-                    checked: boolean
-                  ) => void
-                )?.(undefined, false)
-              }}
-              placeholder={placeholder || ""}
+              onChange={
+                isSearchingInTrigger ? handleTriggerSearchChange : undefined
+              }
+              onClear={handleTriggerClear}
+              placeholder={
+                isSearchingInTrigger
+                  ? /**
+                     * What is selected, held in the placeholder so an open field
+                     * still says what it is set to until the first keystroke
+                     * replaces it. Multiple selection keeps the field's own
+                     * placeholder: the checkmarks in the list are the readable
+                     * answer there, and a joined list of labels is not.
+                     */
+                    (!multiple ? selectedTooltipText : "") || placeholder || ""
+                  : placeholder || ""
+              }
               disabled={disabled}
-              clearable={clearable}
+              clearable={clearable || !!(isSearchingInTrigger && currentSearch)}
               size={effectiveSize}
               loadingIndicator={{
                 asOverlay: true,
@@ -1414,6 +1690,11 @@ const F0SelectComponent = forwardRef(function Select<
               loading={isInitialLoading || loading || isLoading}
               name={name}
               onClickContent={() => {
+                // A click into an open search field is placing the caret, not
+                // toggling the dropdown shut. The arrow still closes it.
+                if (isSearchingInTrigger) {
+                  return
+                }
                 handleChangeOpenLocal(!openLocal)
               }}
               append={
@@ -1421,42 +1702,56 @@ const F0SelectComponent = forwardRef(function Select<
                   open={openLocal}
                   disabled={disabled}
                   size={effectiveSize}
+                  onChange={
+                    isSearchingInTrigger ? handleChangeOpenLocal : undefined
+                  }
                 />
               }
             >
-              <button
-                className="flex w-full items-center justify-between"
-                aria-label={label || placeholder}
-                onClick={(e) => {
-                  e.preventDefault()
-                }}
-              >
-                {(multiple
-                  ? localValue.length > 0 ||
-                    selectionMeta.selectedItemsCount > 0
-                  : !!localValue[0]) && (
-                  <SelectedItems
-                    multiple={multiple}
-                    totalSelectedCount={
-                      multiple
-                        ? Math.max(
-                            localValue.length,
-                            selectionMeta.selectedItemsCount
-                          )
-                        : localValue[0]
-                          ? 1
-                          : 0
-                    }
-                    allSelected={selectedState.allSelected}
-                    selection={getDisplayItemsForSelection}
-                    // The field's own icon already occupies the trigger's glyph
-                    // slot, and the two are drawn in different places — showing
-                    // both put two icons 4px apart on one trigger. Options keep
-                    // their icons for the rows regardless.
-                    hideItemIcon={!!icon}
-                  />
-                )}
-              </button>
+              {isSearchingInTrigger ? (
+                <input
+                  type="text"
+                  autoComplete="off"
+                  spellCheck={false}
+                  className="bg-transparent"
+                  onKeyDown={handleTriggerSearchKeyDown}
+                />
+              ) : (
+                <button
+                  className="flex w-full items-center justify-between"
+                  aria-label={label || placeholder}
+                  onKeyDown={handleTriggerKeyDown}
+                  onClick={(e) => {
+                    e.preventDefault()
+                  }}
+                >
+                  {(multiple
+                    ? localValue.length > 0 ||
+                      selectionMeta.selectedItemsCount > 0
+                    : !!localValue[0]) && (
+                    <SelectedItems
+                      multiple={multiple}
+                      totalSelectedCount={
+                        multiple
+                          ? Math.max(
+                              localValue.length,
+                              selectionMeta.selectedItemsCount
+                            )
+                          : localValue[0]
+                            ? 1
+                            : 0
+                      }
+                      allSelected={selectedState.allSelected}
+                      selection={getDisplayItemsForSelection}
+                      // The field's own icon already occupies the trigger's
+                      // glyph slot, and the two are drawn in different places —
+                      // showing both put two icons 4px apart on one trigger.
+                      // Options keep their icons for the rows regardless.
+                      hideItemIcon={!!icon}
+                    />
+                  )}
+                </button>
+              )}
             </F0InputField>
           )}
         </SelectTrigger>

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -145,7 +145,7 @@ const meta: Meta = {
     },
     showSearchBox: {
       description:
-        "Whether the options can be searched. On by default where the search fits inside the trigger — a field select with no filters carrying static options — and only needed to turn it off there. A data source, or a select with filters, opts in and gets the search box at the top of the dropdown. The component filters static options by label unless a searchFn is in use",
+        "Whether the options can be searched. On by default where the search fits inside the trigger — a field select with no filters carrying static options — and only needed to turn it off there. A data source, or a select with filters, opts in and gets the search box at the top of the dropdown. Static options match on their label, description and metadata dial code unless a searchFn is in use",
     },
     searchValue: {
       description: "Default value for the search box",
@@ -158,7 +158,7 @@ const meta: Meta = {
     },
     searchFn: {
       description:
-        "Function to filter the options. If not provided, the component will filter the options by label. Only applies when options are passed in the options prop, not when a data source is used (use fetchData options for this)",
+        "Function to filter the options. If not provided, an option matches on anything its row shows: label, description, and a metadata dial code. Only applies when options are passed in the options prop, not when a data source is used (use fetchData options for this)",
       table: {
         type: {
           summary:

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -20,6 +20,7 @@ import {
   Employee,
   employeeNestedPaginatedSource,
   employeeNonPaginatedSource,
+  employeePaginatedSource,
   getEmployeeById,
   MockItem,
   mockItems,
@@ -144,7 +145,7 @@ const meta: Meta = {
     },
     showSearchBox: {
       description:
-        "Shows a search box. The component will filter the items by name and by description unless searchFunc will be in use",
+        "Whether the options can be searched. On by default where the search fits inside the trigger — a field select with no filters carrying static options — and only needed to turn it off there. A data source, or a select with filters, opts in and gets the search box at the top of the dropdown. The component filters static options by label unless a searchFn is in use",
     },
     searchValue: {
       description: "Default value for the search box",
@@ -236,7 +237,6 @@ const meta: Meta = {
       }
     }),
     disabled: false,
-    showSearchBox: false,
   },
   decorators: [
     ((Story, { args }) => {
@@ -723,6 +723,49 @@ export const WithSearchBox: Story = {
         />
       </>
     )
+  },
+}
+
+/**
+ * With no filters to share the dropdown with, the search lives in the trigger:
+ * the field the user is already looking at takes the query, and there is no
+ * second box below it.
+ */
+export const SearchInTheTrigger: Story = {
+  args: {
+    label: "Select a theme",
+    placeholder: "Search themes",
+  },
+}
+
+/**
+ * Filters keep the search where the filters are. The two are one query, and
+ * splitting them would put half of it in the trigger and half in the popup.
+ */
+export const SearchBoxWithFilters: Story = {
+  args: {
+    label: "Select Employee",
+    showSearchBox: true,
+    searchBoxPlaceholder: "Search employees",
+    onChange: fn(),
+    source: employeePaginatedSource,
+    mapOptions: (item: Employee) => ({
+      value: item.value,
+      label: item.label,
+      avatar: item.avatar,
+      description: item.jobTitle,
+    }),
+  },
+}
+
+/**
+ * `showSearchBox={false}` for a short, closed set of options where typing
+ * has nothing to narrow.
+ */
+export const WithoutSearch: Story = {
+  args: {
+    label: "Select a theme",
+    showSearchBox: false,
   },
 }
 

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -814,7 +814,7 @@ describe("Select", () => {
     })
   })
 
-  it("renders search box when showSearchBox is true", async () => {
+  it("searches from the trigger itself, with no second box in the dropdown", async () => {
     const user = userEvent.setup()
     render(
       <F0Select
@@ -828,7 +828,194 @@ describe("Select", () => {
 
     await openSelect(user)
 
+    const trigger = screen.getByRole("combobox")
+    expect(trigger.tagName).toBe("INPUT")
+    expect(trigger).toHaveAttribute("aria-autocomplete", "list")
+    expect(trigger).toHaveAttribute(
+      "aria-controls",
+      screen.getByRole("listbox").id
+    )
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument()
+    expect(screen.queryByText("Search options")).not.toBeInTheDocument()
+  })
+
+  it("keeps the trigger in the accessibility tree while the list is open", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+      />
+    )
+
+    await openSelect(user)
+
+    // An open select aria-hides the rest of the page. The field the user is
+    // typing into cannot be part of that: hiding it takes the combobox that
+    // the listbox is paired with out of the tree entirely.
+    const trigger = screen.getByRole("combobox")
+    expect(trigger).not.toHaveAttribute("aria-hidden")
+    expect(trigger.closest("[data-aria-hidden]")).toBeNull()
+  })
+
+  it("searches the options without being asked to", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+      />
+    )
+
+    await openSelect(user)
+    await user.type(screen.getByRole("combobox"), "1")
+
+    expect(screen.getByText("Option 1")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByText("Option 2")).not.toBeInTheDocument()
+    )
+  })
+
+  it("leaves the trigger a plain button when search is turned off", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+        showSearchBox={false}
+      />
+    )
+
+    await openSelect(user)
+
+    // Aria-hidden while the popup is open — the point is that it was never
+    // swapped for an input.
+    expect(screen.getByRole("combobox", { hidden: true }).tagName).toBe(
+      "BUTTON"
+    )
+    expect(screen.queryByRole("searchbox")).not.toBeInTheDocument()
+  })
+
+  it("keeps the search box in the dropdown when the select has filters", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        source={createDataSourceDefinition<RecordType>({
+          filters: {
+            department: {
+              type: "in",
+              label: "Department",
+              options: { options: [{ value: "design", label: "Design" }] },
+            },
+          },
+          dataAdapter: {
+            paginationType: "infinite-scroll",
+            fetchData: () => ({
+              type: "infinite-scroll" as const,
+              cursor: undefined,
+              perPage: 100,
+              hasMore: false,
+              records: [{ id: "option1", name: "Option 1" }],
+              total: 1,
+            }),
+          },
+        })}
+        mapOptions={(item) => ({
+          value: item.id as string,
+          label: item.name as string,
+        })}
+        showSearchBox
+        searchBoxPlaceholder="Search options"
+      />
+    )
+
+    await openSelect(user)
+
+    expect(screen.getByRole("searchbox")).toBeInTheDocument()
     expect(screen.getByText("Search options")).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { hidden: true }).tagName).toBe(
+      "BUTTON"
+    )
+  })
+
+  it("picks the first standing option on Enter", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={onChange}
+      />
+    )
+
+    await openSelect(user)
+    await user.type(screen.getByRole("combobox"), "3")
+    await waitFor(() =>
+      expect(screen.queryByText("Option 1")).not.toBeInTheDocument()
+    )
+    await user.keyboard("{Enter}")
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenCalledWith(
+        "option3",
+        expect.anything(),
+        expect.anything()
+      )
+    )
+  })
+
+  it("hands focus to the list on ArrowDown", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+      />
+    )
+
+    await openSelect(user)
+    await user.keyboard("{ArrowDown}")
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole("listbox")).getByRole("option", {
+          name: /Option 1/,
+        })
+      ).toHaveFocus()
+    )
+  })
+
+  it("drops the query when the dropdown closes", async () => {
+    const user = userEvent.setup()
+    const onSearchChange = vi.fn()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+        onSearchChange={onSearchChange}
+      />
+    )
+
+    await openSelect(user)
+    await user.type(screen.getByRole("combobox"), "1")
+    await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith("1"))
+
+    await user.keyboard("{Escape}{Escape}")
+
+    await waitFor(() =>
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    )
+    expect(screen.getByRole("combobox")).toHaveValue("")
+
+    await openSelect(user)
+    expect(screen.getByText("Option 2")).toBeInTheDocument()
   })
 
   it("renders icon tags with text", async () => {
@@ -1025,7 +1212,7 @@ describe("Select", () => {
     )
 
     await openSelect(user)
-    await user.type(screen.getByRole("searchbox"), "1")
+    await user.type(screen.getByRole("combobox"), "1")
 
     expect(screen.getByText("Option 1")).toBeInTheDocument()
     await waitFor(() =>
@@ -1047,7 +1234,7 @@ describe("Select", () => {
     )
 
     await openSelect(user)
-    const searchInput = screen.getByRole("searchbox")
+    const searchInput = screen.getByRole("combobox")
     await user.type(searchInput, "Option 1")
 
     await waitFor(() =>
@@ -1079,7 +1266,7 @@ describe("Select", () => {
     )
 
     await openSelect(user)
-    const searchInput = screen.getByRole("searchbox")
+    const searchInput = screen.getByRole("combobox")
     await waitFor(() => expect(searchInput).toHaveFocus())
 
     deferredOptions.resolve()
@@ -1114,11 +1301,11 @@ describe("Select", () => {
     )
 
     await openSelect(user)
-    const searchInput = screen.getByRole("searchbox")
+    const searchInput = screen.getByRole("combobox")
     const footerAction = screen.getByRole("button", { name: "Manage options" })
     await waitFor(() => expect(searchInput).toHaveFocus())
 
-    await user.tab()
+    footerAction.focus()
     expect(footerAction).toHaveFocus()
 
     deferredOptions.resolve()
@@ -1146,7 +1333,7 @@ describe("Select", () => {
     )
 
     await openSelect(user)
-    await user.type(screen.getByRole("searchbox"), "xyz")
+    await user.type(screen.getByRole("combobox"), "xyz")
 
     await waitFor(async () => {
       const emptyMessage = await screen.findByText("No results found")
@@ -1172,7 +1359,7 @@ describe("Select", () => {
 
     await openSelect(user)
 
-    const searchInput = screen.getByRole("searchbox")
+    const searchInput = screen.getByRole("combobox")
 
     // Focus the search input
     await user.click(searchInput)
@@ -1874,7 +2061,7 @@ describe("Select", () => {
 
       await openSelect(user)
 
-      const searchInput = screen.getByRole("searchbox")
+      const searchInput = screen.getByRole("combobox")
       await user.type(searchInput, "nonexistent")
 
       await waitFor(() => {
@@ -1921,7 +2108,7 @@ describe("Select", () => {
 
       await openSelect(user)
 
-      const searchInput = screen.getByRole("searchbox")
+      const searchInput = screen.getByRole("combobox")
       await user.type(searchInput, "new item")
 
       await waitFor(() => {
@@ -1958,7 +2145,7 @@ describe("Select", () => {
 
       await openSelect(user)
 
-      const searchInput = screen.getByRole("searchbox")
+      const searchInput = screen.getByRole("combobox")
       await user.type(searchInput, "new item")
 
       await waitFor(() => {

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -839,6 +839,56 @@ describe("Select", () => {
     expect(screen.queryByText("Search options")).not.toBeInTheDocument()
   })
 
+  // Regression: the search matched `label` and nothing else, so a row reading
+  // "Spain +34" could not be found by its dial code and a row with a
+  // `description` could not be found by the words in it — even though the
+  // documented contract claimed descriptions were matched.
+  it.each([
+    ["a dial code, without the plus", "34", "Spain"],
+    ["a dial code, with the plus", "+49", "Germany"],
+    ["a description", "seoul", "South Korea"],
+  ])("finds an option by %s", async (_case, query, expected) => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        onChange={() => {}}
+        options={[
+          {
+            value: "es",
+            label: "Spain",
+            metadata: { type: "dialCode", dialCode: "+34" },
+          },
+          {
+            value: "de",
+            label: "Germany",
+            metadata: { type: "dialCode", dialCode: "+49" },
+          },
+          {
+            value: "kr",
+            label: "South Korea",
+            description: "Seoul",
+            metadata: { type: "dialCode", dialCode: "+82" },
+          },
+        ]}
+      />
+    )
+
+    await openSelect(user)
+    await user.type(screen.getByRole("combobox"), query)
+
+    await waitFor(() =>
+      expect(
+        within(screen.getByRole("listbox")).getAllByRole("option")
+      ).toHaveLength(1)
+    )
+    expect(
+      within(screen.getByRole("listbox")).getByRole("option", {
+        name: new RegExp(expected),
+      })
+    ).toBeInTheDocument()
+  })
+
   it("keeps the trigger in the accessibility tree while the list is open", async () => {
     const user = userEvent.setup()
     render(
@@ -991,7 +1041,12 @@ describe("Select", () => {
     )
   })
 
-  it("drops the query when the dropdown closes", async () => {
+  // The first Escape must be ABSORBED by the query. Radix dismisses from a
+  // capture-phase listener on `document`, so a handler on the input can never
+  // get in front of it — this only holds while it goes through Radix's own
+  // `onEscapeKeyDown`. Asserting the two presses separately: pressing Escape
+  // twice passes either way, because the query is dropped on close regardless.
+  it("drops the query on the first Escape and closes on the second", async () => {
     const user = userEvent.setup()
     const onSearchChange = vi.fn()
     render(
@@ -1006,16 +1061,21 @@ describe("Select", () => {
     await openSelect(user)
     await user.type(screen.getByRole("combobox"), "1")
     await waitFor(() => expect(onSearchChange).toHaveBeenCalledWith("1"))
+    await waitFor(() =>
+      expect(screen.queryByText("Option 2")).not.toBeInTheDocument()
+    )
 
-    await user.keyboard("{Escape}{Escape}")
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => expect(screen.getByRole("combobox")).toHaveValue(""))
+    expect(screen.getByRole("listbox")).toBeInTheDocument()
+    expect(screen.getByText("Option 2")).toBeInTheDocument()
+
+    await user.keyboard("{Escape}")
 
     await waitFor(() =>
       expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
     )
-    expect(screen.getByRole("combobox")).toHaveValue("")
-
-    await openSelect(user)
-    expect(screen.getByText("Option 2")).toBeInTheDocument()
   })
 
   it("renders icon tags with text", async () => {

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -36,7 +36,26 @@ type F0SelectPopupProps<T extends string, R = unknown> = {
     checked: boolean
   ) => void
   open?: boolean
+  /**
+   * Whether the options can be searched.
+   *
+   * Defaults to `true` where the search can live INSIDE the trigger — a
+   * `field` select with no filters, no `asList` and no custom `children`
+   * trigger — and the options are static, which this component filters itself.
+   * There the search costs nothing: the field is already on screen, so it is
+   * always on and this prop is only needed to turn it OFF.
+   *
+   * Everywhere else it defaults to `false` and stays opt-in. A `source` is
+   * searched by the consumer's own adapter, so a box switched on for them
+   * would filter nothing; and with filters, or with no field to type into, the
+   * search is a separate box at the top of the dropdown — chrome the consumer
+   * should choose to spend.
+   */
   showSearchBox?: boolean
+  /**
+   * Placeholder for the search box in the dropdown. The inline search reuses
+   * the trigger's own `placeholder`, falling back to the selected label.
+   */
   searchBoxPlaceholder?: string
   onSearchChange?: (value: string) => void
   searchValue?: string

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -168,6 +168,12 @@ type F0SelectDataProps<T extends string, R = unknown> =
   | {
       source?: never
       mapOptions?: never
+      /**
+       * Replaces how a query is matched against an option. Without it, an
+       * option matches on anything the row shows: its `label`, its
+       * `description`, and a `metadata` dial code. Static `options` only —
+       * a `source` is searched through its own `fetchData`.
+       */
       searchFn?: (
         option: F0SelectItemProps<T, unknown>,
         search?: string

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/LocationSelector.spec.tsx
@@ -175,7 +175,7 @@ describe("LocationSelector", () => {
     // `fireEvent.change`, not `user.type`: the search box is controlled and
     // re-renders per keystroke, which drops characters here — "Barcelona" reached
     // the adapter as "brcelona", and the search then correctly found nothing.
-    fireEvent.change(screen.getByRole("searchbox"), {
+    fireEvent.change(screen.getByRole("combobox"), {
       target: { value: "Barcelona" },
     })
 

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/ProjectSelector.spec.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/ProjectSelector.spec.tsx
@@ -138,7 +138,7 @@ describe("ProjectSelector", () => {
     await waitFor(() => expect(screen.getByText("Alpha 1")).toBeInTheDocument())
 
     // "Kilo" names no leaf — only a parent — and its children must still show.
-    await user.type(screen.getByRole("searchbox"), "Kilo")
+    await user.type(screen.getByRole("combobox"), "Kilo")
 
     await waitFor(() => expect(screen.getByText("Kilo 1")).toBeInTheDocument())
     expect(screen.queryByText("Alpha 1")).not.toBeInTheDocument()

--- a/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupDialogPortal.test.tsx
+++ b/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupDialogPortal.test.tsx
@@ -113,7 +113,11 @@ describe("DatePickerPopup portal container", () => {
 
     const yearList = await screen.findByRole("listbox")
     expect(portalContainer).toContainElement(yearList)
-    expect(yearSelector).toHaveAttribute("aria-expanded", "true")
+    // Re-queried: an open searchable select swaps the trigger button for its
+    // search input, so the node captured above is no longer the combobox.
+    expect(
+      screen.getByRole("combobox", { name: "Select year" })
+    ).toHaveAttribute("aria-expanded", "true")
     expect(portalContainer).toContainElement(document.activeElement)
   })
 })

--- a/packages/react/src/ui/Select/components/radix-ui/select.tsx
+++ b/packages/react/src/ui/Select/components/radix-ui/select.tsx
@@ -595,6 +595,17 @@ interface SelectContentImplProps
    * Useful for "list" mode where the select is always open.
    */
   disableScrollLock?: boolean
+
+  /**
+   * Keeps the TRIGGER in the accessibility tree while the content is open.
+   *
+   * An open select aria-hides everything but its content, which is right while
+   * the trigger is only a button. It is wrong when the trigger is where the
+   * user is typing: a select whose search box lives in its own field keeps
+   * focus there, and hiding it takes both the field and its
+   * combobox/listbox pairing out of the tree the screen reader is reading.
+   */
+  retainTrigger?: boolean
 }
 
 const Slot = createSlot("SelectContent.RemoveScroll")
@@ -631,6 +642,7 @@ const SelectContentImpl = React.forwardRef<
     onEscapeKeyDown,
     onPointerDownOutside,
     disableScrollLock = false,
+    retainTrigger = false,
     //
     // PopperContent props
     side,
@@ -679,7 +691,9 @@ const SelectContentImpl = React.forwardRef<
     // Skip in item-aligned mode (list mode) where content is always visible
     if (context.open && position === "popper") {
       // Only hide others when open and ensure cleanup runs properly
-      const cleanup = hideOthers(content)
+      const cleanup = hideOthers(
+        retainTrigger && context.trigger ? [content, context.trigger] : content
+      )
       hideOthersCleanupRef.current = cleanup
       return () => {
         if (cleanup) {
@@ -688,7 +702,7 @@ const SelectContentImpl = React.forwardRef<
         hideOthersCleanupRef.current = null
       }
     }
-  }, [content, context.open, position])
+  }, [content, context.open, context.trigger, position, retainTrigger])
 
   // Make sure the whole tree has focus guards as our `Select` may be
   // the last element in the DOM (because of the `Portal`)


### PR DESCRIPTION
## Description

A select with no filters no longer opens a second search box above its list — the field itself takes the query. Because the field is already on screen, the search now costs nothing, so it is on by default wherever it can live there and `showSearchBox` is only needed to turn it off. Filters keep the search in the dropdown, next to the filter picker; a data source still opts in, since only the consumer's own adapter can answer a query. This implements what Ángel Moreno and I agreed in Slack on 7 Sep ("en los casos en los que no haya filtros, y se ponga la prop de search en el select, en vez de que salga fuera, que salga en el input" → "Deal?" / "Agreed").

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Two things to settle before merge

1. **How far "search always automatic" goes.** The agreement ends with "yo haría que el search lo tuviéramos siempre de forma automática entonces" / "Agreed". I read that as _wherever the search is free_ — i.e. filterless field selects carrying static `options`, which this component filters itself. It deliberately does **not** auto-enable for a `source`: only the consumer's adapter can implement the query, so a box we switched on for them would be a field that filters nothing. If the intent was "on for everything", it is a one-line change to `isSearchEnabled`.
2. **Marcos.** The thread ended with "pregúntale a Marcos incluso si quieres por confirmar" and there is no sign that happened. This changes how every filterless `F0Select` in the product behaves when opened, so it wants his and Ángel's sign-off, not just mine.

## Screenshots

No Chromatic diff: every snapshot story renders its select closed, and closed is unchanged. To see it, open **Components/Select → Search In The Trigger** in Storybook and click the field.

- **Closed** — unchanged: the selection with its dot tag, avatar or status pill.
- **Open** — the field becomes a focused text input, with the selected label carried into the placeholder so it still reads as set until the first keystroke replaces it.

One consequence worth a designer's eye: while open, a single selection's **avatar / tag / icon is not drawn** — the field is a text input at that point, and the label moves into the placeholder. That is the part of this I would most expect Ángel to want to change.

## Implementation details

- feat: search renders inside the trigger for `field` selects with no filters, no `asList` and no custom `children` trigger; everywhere else the box stays at the top of the dropdown, exactly as before

- feat: `showSearchBox` defaults to `true` for those selects when they carry static `options`, and to `false` (opt-in) otherwise

  <details>
  <summary>Why the split</summary>

  Static options are filtered by this component, so a search there always works. A `source` is searched through the consumer's `fetchData`; enabling a search box they never asked for would render a field that silently filters nothing. Selects with filters keep the search in the dropdown because the filter picker and the search are one query — splitting them would put half of it in the trigger and half in the popup.
  </details>

- feat: keyboard contract for the inline search — a character typed on the closed field opens the list and becomes the query, Arrow Up/Down hands focus to the list (the same handover the dropdown's search box makes), Enter picks the first option the query left standing, and Escape drops the query before it closes the list

- fix: the vendored Radix select can keep the trigger in the accessibility tree while its content is open (`retainTrigger`)

  <details>
  <summary>Why</summary>

  An open select calls `hideOthers(content)`, which aria-hides everything else — including the trigger. That is right while the trigger is only a button and wrong once it is where the user is typing: it took both the field and the combobox/listbox pairing out of the tree the screen reader reads. `hideOthers` now retains the trigger as well when the search lives there. The pre-existing debt for the `inline` variant's trigger is untouched.
  </details>

- fix: a pointer-down on the open search field no longer dismisses the list it is driving — clicking into the field is placing the caret; the chevron still closes it

- fix: focus the search input from an effect rather than React's `autoFocus`

  <details>
  <summary>Why</summary>

  `autoFocus` focuses during the commit, and around an open popup `focus` is patched by the instrumentation Storybook installs into something that schedules React work. React threw "Should not already be working" mid-commit and the story rendered nothing at all. Focusing from an effect (the pattern `F0SearchInput` already uses for the same reason) puts the call after the commit.
  </details>

- fix: an option matches on anything its row SHOWS — `label`, `description`, and a `metadata` dial code — not just its label

  <details>
  <summary>Why</summary>

  Reported while reviewing this PR against **Components/Select → With Metadata**: a row reading "Spain +34" could not be found by its dial code, and one with a `description` could not be found by the words in it. The documented contract already claimed descriptions were matched and never did, which is why the `WithSearchBox` story passes its own `searchFn` — consumers were reimplementing behavior they had been promised. Matching is a substring, so "34" finds "+34" without the plus nobody types. Metadata is matched per variant, so a new `F0SelectItemMetadata` variant stays a deliberate decision about whether it is searchable.
  </details>

- fix: the trigger button no longer draws its own native focus ring

  <details>
  <summary>Why</summary>

  `reset.css` clears the native `:focus-visible` outline for `input` and `textarea` and stops at buttons. Nothing focused that button before, but closing the dropdown now hands focus back to it, so Chrome drew its heavy blue ring inside F0's own — two rings, after every Enter. The field draws the ring from `focus-within` on its wrapper; the button just stops competing.
  </details>

- fix: Escape drops the query before it closes the list, through Radix's `onEscapeKeyDown`

  <details>
  <summary>Why</summary>

  This started on the input's `onKeyDown`, where it can never work: the dismiss runs from a listener on `document` in the CAPTURE phase, so it has already fired by the time the event reaches anything inside, and no `stopPropagation` from a descendant gets in front of it. Worth flagging that the first test of this passed anyway — pressing Escape twice closes either way, since the query is dropped on close regardless. It now asserts the two presses separately, and the behavior was confirmed in a browser.
  </details>

- test: 12 new cases — both placements, the default being on, `showSearchBox={false}` leaving a plain button, Enter, ArrowDown, the query being dropped on close, and the trigger staying out of the `aria-hidden` sweep
- test: the tests that drove the dropdown's search box now drive the trigger, in F0Select and in the three consumers that reached for `role="searchbox"` (LocationSelector, ProjectSelector, the DatePickerPopup portal test)
- docs: `showSearchBox` documents the conditional default, in `types.ts` and in the Storybook `argTypes`; new `SearchInTheTrigger`, `SearchBoxWithFilters` and `WithoutSearch` stories

## Verified

`pnpm tsc`, `pnpm lint src`, `pnpm format:check src`, and the full unit suite (7672 passed, 608 files) all green. The inline trigger was also driven by hand in Storybook: input, focus, `role="combobox"` with `aria-expanded` / `aria-controls` → the listbox / `aria-autocomplete="list"`, and typing all behave. The dropdown body does not paint in the headless browser I used (pre-existing — `WithoutSearch` on `main`'s code path is equally blank there), so list rendering is covered by the unit tests rather than by eye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
