### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.88.0",
+  "packages/react": "6.88.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.88.1](https://github.com/factorialco/f0/compare/f0-react-v6.88.0...f0-react-v6.88.1) (2026-09-07)
+
+
+### Performance Improvements
+
+* **OneDataCollection:** stop a page append re-rendering every row already on screen ([#5378](https://github.com/factorialco/f0/issues/5378)) ([bae8238](https://github.com/factorialco/f0/commit/bae8238f65d3106ebfebabfe7d7a054dabdb1f51))
+
 ## [6.88.0](https://github.com/factorialco/f0/compare/f0-react-v6.87.1...f0-react-v6.88.0) (2026-09-07)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.88.0",
+  "version": "6.88.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.88.1</summary>

## [6.88.1](https://github.com/factorialco/f0/compare/f0-react-v6.88.0...f0-react-v6.88.1) (2026-09-07)


### Performance Improvements

* **OneDataCollection:** stop a page append re-rendering every row already on screen ([#5378](https://github.com/factorialco/f0/issues/5378)) ([bae8238](https://github.com/factorialco/f0/commit/bae8238f65d3106ebfebabfe7d7a054dabdb1f51))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).