### PR TITLE
fix(F0Chat): let a dismissed mention popover reopen

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.search-cost.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.search-cost.test.ts
@@ -1,0 +1,288 @@
+import { act } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRenderHook as renderHook } from "@/testing/test-utils"
+
+import { type F0ChatUser } from "../../types"
+import { type MentionCandidate, useMentions } from "../useMentions"
+
+const MEMBERS: F0ChatUser[] = [
+  { id: "ana-g", name: "Ana García" },
+  { id: "bruno", name: "Bruno Martínez" },
+  { id: "hera", name: "Hera Nakamura" },
+  { id: "juana", name: "Juana Pérez" },
+]
+
+beforeEach(() => vi.useFakeTimers())
+afterEach(() => vi.useRealTimers())
+
+type Props = Parameters<typeof useMentions>[0]
+
+const labelsOf = (results: MentionCandidate[]): string[] =>
+  results.map((candidate) =>
+    candidate.kind === "everyone" ? `@${candidate.label}` : candidate.user.name
+  )
+
+describe("useMentions — mention popover cost", () => {
+  let cleanup: () => void
+  let searchCalls: string[]
+  let searchMembers: (query: string) => Promise<F0ChatUser[]>
+  let makeProps: (over?: Partial<Props>) => Props
+
+  beforeEach(() => {
+    searchCalls = []
+    const textarea = document.createElement("textarea")
+    document.body.appendChild(textarea)
+    cleanup = () => textarea.remove()
+    // One identity for the whole test, as a host's useCallback gives.
+    searchMembers = (query: string) => {
+      searchCalls.push(query)
+      const q = query.trim().toLowerCase()
+      return Promise.resolve(
+        MEMBERS.filter((member) => member.name.toLowerCase().includes(q))
+      )
+    }
+    makeProps = (over: Partial<Props> = {}): Props => ({
+      inputValue: "",
+      setInputValue: () => {},
+      cursorPosition: 0,
+      setCursorPosition: () => {},
+      requestSelection: () => {},
+      textareaRef: { current: textarea },
+      enabled: true,
+      searchMembers,
+      everyoneLabel: "here",
+      ...over,
+    })
+  })
+
+  afterEach(() => cleanup())
+
+  /** Advance past DEBOUNCE_MS and flush the search promise. */
+  const settle = async () => {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+  }
+
+  const mount = () =>
+    renderHook((props: Props) => useMentions(props), {
+      initialProps: makeProps(),
+    })
+
+  const type = (rerender: (props: Props) => void, text: string) =>
+    rerender(makeProps({ inputValue: text, cursorPosition: text.length }))
+
+  describe("rows are unchanged", () => {
+    // Each case pins the exact rows and their order, so a change to how the
+    // query selects or orders candidates fails here rather than in review.
+    const cases: [name: string, typed: string, expected: string[]][] = [
+      ["prefix match", "@Bru", ["Bruno Martínez"]],
+      ["mid-word match", "@art", ["Bruno Martínez"]],
+      // "Ana" also sits inside "Juana": both rows come back, in host order.
+      [
+        "mid-word match across two names",
+        "@Ana",
+        ["Ana García", "Juana Pérez"],
+      ],
+      ["diacritic in the name", "@Pér", ["Juana Pérez"]],
+      ["the @here row wins the top slot", "@he", ["@here", "Hera Nakamura"]],
+      [
+        "an empty query lists everyone, host order preserved",
+        "@",
+        [
+          "@here",
+          "Ana García",
+          "Bruno Martínez",
+          "Hera Nakamura",
+          "Juana Pérez",
+        ],
+      ],
+    ]
+
+    for (const [name, typed, expected] of cases) {
+      it(name, async () => {
+        const { result, rerender } = mount()
+        type(rerender, typed)
+        await settle()
+        expect(labelsOf(result.current.results)).toEqual(expected)
+      })
+    }
+
+    it("omits the @here row entirely in a DM", async () => {
+      const props = makeProps({ everyoneLabel: undefined })
+      const { result, rerender } = renderHook(
+        (next: Props) => useMentions(next),
+        { initialProps: props }
+      )
+
+      rerender({ ...props, inputValue: "@he", cursorPosition: 3 })
+      await settle()
+
+      expect(labelsOf(result.current.results)).toEqual(["Hera Nakamura"])
+    })
+  })
+
+  describe("per-keystroke work", () => {
+    it("keeps one row array while the matches behind it are unchanged", async () => {
+      const { result, rerender } = mount()
+
+      type(rerender, "@B")
+      await settle()
+      const settled = result.current.results
+      expect(labelsOf(settled)).toEqual(["Bruno Martínez"])
+
+      // Keep typing. The debounce holds the next search back, so these rows are
+      // still the ones on screen — they must not be rebuilt to say so.
+      type(rerender, "@Br")
+      type(rerender, "@Bru")
+      type(rerender, "@Brun")
+
+      expect(result.current.results).toBe(settled)
+    })
+
+    it("keeps one row array across host re-renders that change nothing", async () => {
+      const { result, rerender } = mount()
+
+      type(rerender, "@Bru")
+      await settle()
+      const settled = result.current.results
+
+      // A group chat re-renders on every transport event (typing, receipts,
+      // new messages) while the popover is open.
+      for (let i = 0; i < 10; i++) type(rerender, "@Bru")
+
+      expect(result.current.results).toBe(settled)
+    })
+
+    it("rebuilds the rows when the @here row actually appears or leaves", async () => {
+      const { result, rerender } = mount()
+
+      type(rerender, "@h")
+      await settle()
+      const withEveryone = result.current.results
+      expect(labelsOf(withEveryone)).toEqual(["@here", "Hera Nakamura"])
+
+      // "hz" no longer prefixes "here", so the row has to go.
+      type(rerender, "@hz")
+      expect(result.current.results).not.toBe(withEveryone)
+      expect(labelsOf(result.current.results)).toEqual(["Hera Nakamura"])
+    })
+  })
+
+  describe("host searches", () => {
+    it("collapses a burst of keystrokes into one member search", async () => {
+      const { rerender } = mount()
+
+      for (const text of ["@", "@A", "@An", "@Ana"]) type(rerender, text)
+      expect(searchCalls).toEqual([])
+
+      await settle()
+      expect(searchCalls).toEqual(["Ana"])
+    })
+
+    it("still collapses the burst when keystrokes land in separate tasks", async () => {
+      const { rerender } = mount()
+
+      for (const text of ["@", "@A", "@An", "@Ana"]) {
+        type(rerender, text)
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(50)
+        })
+      }
+
+      expect(searchCalls).toEqual([])
+      await settle()
+      expect(searchCalls).toEqual(["Ana"])
+    })
+
+    it("searches again once typing pauses between keystrokes", async () => {
+      const { rerender } = mount()
+
+      type(rerender, "@An")
+      await settle()
+      type(rerender, "@Ana")
+      await settle()
+
+      // The debounce delays a search, it never drops the user's final query.
+      expect(searchCalls).toEqual(["An", "Ana"])
+    })
+
+    it("does not re-search when a host re-render leaves the trigger unchanged", async () => {
+      const { rerender } = mount()
+
+      type(rerender, "@Ana")
+      await settle()
+      expect(searchCalls).toEqual(["Ana"])
+
+      for (let i = 0; i < 10; i++) type(rerender, "@Ana")
+      await settle()
+
+      expect(searchCalls).toEqual(["Ana"])
+    })
+
+    it("lets the popover reopen after dismissing a search already in flight", async () => {
+      // The search has to be dispatched but unresolved when Escape lands:
+      // cancelling the timer cannot help once the host has been called, and it
+      // is the empty late result that would otherwise dismiss this `@` for
+      // good — leaving the popover shut for every further keystroke on it.
+      let resolveSearch: (users: F0ChatUser[]) => void = () => {}
+      const props = makeProps({
+        searchMembers: (query: string) => {
+          searchCalls.push(query)
+          return new Promise<F0ChatUser[]>((resolve) => {
+            resolveSearch = resolve
+          })
+        },
+      })
+      const { result, rerender } = renderHook(
+        (next: Props) => useMentions(next),
+        { initialProps: props }
+      )
+
+      rerender({ ...props, inputValue: "@zzz", cursorPosition: 4 })
+      await settle()
+      expect(searchCalls).toEqual(["zzz"])
+
+      act(() => {
+        result.current.handleKeyDown({
+          key: "Escape",
+          preventDefault: () => {},
+        } as React.KeyboardEvent<HTMLTextAreaElement>)
+      })
+
+      // Nobody matches "zzz", and neither does @here.
+      await act(async () => {
+        resolveSearch([])
+        await vi.advanceTimersByTimeAsync(0)
+      })
+
+      rerender({ ...props, inputValue: "@zzzq", cursorPosition: 5 })
+      await settle()
+
+      expect(result.current.isOpen).toBe(true)
+      expect(searchCalls).toEqual(["zzz", "zzzq"])
+    })
+
+    it("drops a search still pending when the popover is dismissed", async () => {
+      const { result, rerender } = mount()
+
+      type(rerender, "@An")
+      act(() => {
+        result.current.handleKeyDown({
+          key: "Escape",
+          preventDefault: () => {},
+        } as React.KeyboardEvent<HTMLTextAreaElement>)
+      })
+      await settle()
+
+      // Nothing can show the rows, so the host must not be asked for them.
+      expect(searchCalls).toEqual([])
+      expect(result.current.isOpen).toBe(false)
+      expect(result.current.results.some((row) => row.kind === "user")).toBe(
+        false
+      )
+      expect(result.current.isLoading).toBe(false)
+    })
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
@@ -382,15 +382,24 @@ export function useMentions({
     [everyoneLabel]
   )
 
+  // The query reaches the rows only as this boolean, which lets the row memo
+  // below keep its array across the keystrokes between two searches. Memoized
+  // rather than called inline so a re-render that leaves the query alone still
+  // costs nothing.
+  const everyoneMatches = useMemo(
+    () => matchesEveryone(query),
+    [matchesEveryone, query]
+  )
+
   // The "everyone" row (when it matches) followed by member matches.
   const results = useMemo<MentionCandidate[]>(() => {
     const out: MentionCandidate[] = []
-    if (everyoneLabel && matchesEveryone(query)) {
+    if (everyoneLabel && everyoneMatches) {
       out.push({ kind: "everyone", label: everyoneLabel })
     }
     for (const user of memberResults) out.push({ kind: "user", user })
     return out
-  }, [everyoneLabel, matchesEveryone, query, memberResults])
+  }, [everyoneLabel, everyoneMatches, memberResults])
 
   // Detect the `@` trigger on every input/cursor change and search.
   useEffect(() => {
@@ -463,10 +472,21 @@ export function useMentions({
   ])
 
   const close = useCallback(() => {
+    // Escape closes without touching the composer text, so the search effect
+    // keeps its dependencies and never runs the cleanup that would cancel a
+    // pending search. Retiring the id matters even once one is in flight: an
+    // empty late result sets `dismissedAtIndexRef`, which would keep the
+    // popover from reopening at this same `@`.
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current)
+      debounceRef.current = null
+    }
+    searchIdRef.current++
     setIsOpen(false)
     setQuery("")
     setMemberResults([])
     setSelectedIndex(0)
+    setIsLoading(false)
     atIndexRef.current = -1
   }, [])
 


### PR DESCRIPTION
## Description

Dismissing the `@`-mention popover left a search running. If that search was already in flight when Escape landed, its empty result marked the trigger as dismissed, and the popover then refused to reopen for every further keystroke on that same `@` — you had to delete the whole token to get it back. This cancels the pending search and retires it so a late result cannot land. A second, smaller change stops the popover's row array being rebuilt on every keystroke.

The starting point was an audit note claiming the popover "rescans and re-sorts the full member list per keystroke". That turned out to be **mis-located**: `searchMembers` is a host-supplied prop, and the scan-and-`localeCompare`-sort it describes lives in the consuming app, not in F0. What F0 owns is the *call schedule*, and that was already right — a 250 ms trailing debounce collapses a keystroke burst into one host call. Re-auditing the path with that settled is what turned up the dismissal bug.

**Related.** Builds on #5404, which rewrote this hook for anchored mentions (the audit note predates it). #5324 is in the same composer area but a different concern (emoji list blur / pointer highlight) and touches only `ChatComposer.tsx`, which this PR does not — no conflict.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

None. The fix is the *absence* of a wrong state — a popover that reopens where it previously stayed shut — and the row set and its order are unchanged for every query (pinned by six explicit cases). No public API change.

## Implementation details

- fix: let the mention popover reopen after dismissing an in-flight search

  <details>
  <summary>Why?</summary>

  `close()` wrote only `isOpen` / `query` / `memberResults` / `selectedIndex`, none of which appear in the search effect's dependency array. Escape does not touch the composer text either, so the effect kept its dependencies, never re-ran, and never ran the cleanup that cancels the pending search.

  Clearing the timer only helps before the debounce fires. Once the host has been called, the half that matters is retiring the search id: the late `.then` writes `dismissedAtIndexRef.current = trigger.atIndex` whenever a non-empty query returns no members and does not match `@here`, and the trigger effect then early-returns for that `@` from then on. That is the user-visible half — type `@zzz`, wait, press Escape, keep typing, and the popover never comes back.

  `setIsLoading(false)` comes along because retiring the search means its `.finally` is no longer there to resolve the flag.
  </details>

- refactor: stop rebuilding the popover rows on every keystroke

  <details>
  <summary>Why?</summary>

  The `results` memo keyed on `query`, a string that changes every keystroke, but `query` reaches the output only as one boolean — whether the `@here` row matches. So each keystroke inside a trigger allocated a fresh array plus one wrapper object per member while the debounce was still holding the next search back, i.e. rebuilding rows already on screen. It now keys on that boolean, which is itself memoized so a re-render that leaves the query alone still costs nothing.

  **Scope of the win, honestly:** this removes allocation, not renders. `ChatMentionPopover` is not memoized and `ChatComposer` re-renders on every keystroke, so `results.map` runs regardless of array identity, and row keys were already stable so reconciliation was already minimal. Making the render win real needs the popover memoized *and* `popoverPosition` stabilised — see side note 1, which is the bigger fish and needs visual verification.
  </details>

- test: cover the dismissal fix and pin the row set, its ordering, and the debounce

## Verification

All commands from `packages/react`.

| Check | Command | Result |
|---|---|---|
| New tests | `pnpm vitest run …/useMentions.search-cost.test.ts` | **16 passed** |
| F0Chat suite | `pnpm vitest run src/sds/chat/` | 72 files, **720 passed**. Baseline on `origin/main` with this file removed: 71 files / **704**. So +1 file, +16 tests, 0 regressions. |
| Whole `packages/react` | `pnpm vitest run` | 608 files, **7681 passed**, 13 skipped, **0 failed** |
| Flake ruled out | see note below | one full-suite run failed `src/ui/Select/.../SelectContent.test.tsx`; it did not reproduce |
| Lint | `… run lint` | 0 warnings, 0 errors (3463 files) |
| Format | `… run format:check` | all files correct (3663 files) |
| Typecheck | `… run tsc` | **40 errors, identical to the clean-`origin/main` baseline**, none in the changed files. Measured both with and without this diff. They are `@factorialco/f0-core` unresolved (core is unbuilt in a fresh worktree) plus pre-existing `ui/Kanban` and `dotTag` story errors. |
| Pre-commit | lefthook | cycle-dependencies, file-sizes, format, lint, ownership, commit-msg — all pass |

Every importer of `useMentions` lives under `src/sds/chat`, so the F0Chat suite covers the blast radius.

**One flake, ruled out.** An early full-suite run failed `src/ui/Select/components/SelectContent.test.tsx > "moves focus from its fallback to a selected option that mounts after the grace period"`. It then passed **3/3 in isolation** and **1/1 on a repeat full-suite run** (the 7681 above). It is a fake-timer grace-period test in `src/ui/Select`, and there is no import path from this diff (`src/sds/chat/F0Chat/hooks/`) to it — `grep` for `sds/chat` or `useMentions` under `src/ui/Select/` returns nothing. Load-sensitive, pre-existing, not this change.

### Mutation matrix

Each fix was reverted in turn to prove no test is vacuous — including the two halves of the dismissal fix **separately**, because one lever covering two mechanisms hides exactly this kind of gap:

| Mutation | Tests that go red |
|---|---|
| drop `searchIdRef.current++` from `close()`, keep the `clearTimeout` | `lets the popover reopen after dismissing a search already in flight` |
| drop the `clearTimeout` from `close()` | `drops a search still pending when the popover is dismissed` |
| put `query` back in the `results` memo deps | `keeps one row array while the matches behind it are unchanged` |
| remove the debounce's supersede-cancellation | `collapses a burst…`, `still collapses the burst when keystrokes land in separate tasks` |
| `DEBOUNCE_MS = 0` | `still collapses the burst when keystrokes land in separate tasks` |

The tests use fake timers deliberately: an earlier real-timer version passed in isolation and then failed under CPU load, reporting per-keystroke searches the code does not perform.

One assertion — `expect(result.current.results).toBe(settled)` — checks referential identity, an implementation detail rather than behaviour. It is deliberate: identity *is* the property the second change buys, and nothing else keeps it from silently regressing.

## Deferred to review

- **Storybook: the F0Chat mention popover in a *visible* Chrome tab** (a hidden tab renders an empty virtualized list). No Storybook or browser check was run for this PR.

## Side notes for the reviewer — found, not fixed here

1. **`popoverPosition` forces a synchronous reflow on every keystroke.** `getTextareaCaretCoordinates` builds a mirror `<div>`, copies ~25 computed style properties onto it, appends it to `document.body`, reads `offsetLeft`/`offsetTop`, then removes it. Almost certainly the **largest** remaining per-keystroke cost here — larger than the allocation this PR removes. Untouched because the value also depends on composer auto-grow, so changing it needs visual verification.
2. **`ChatMentionPopover` is not memoized and caps nothing.** `max-h-60 overflow-y-auto` clips visually but every row mounts, each with an `F0Avatar` and two `OneEllipsis`. Neither F0 nor the host slices the list.
3. **This closes one door of two.** The trigger effect's own early-return paths reset state and return *without* retiring the search id, so an already-dispatched search can still land, refill the rows and poison `dismissedAtIndexRef` when the trigger disappears rather than being dismissed. Same class of bug; left out because covering it properly needs its own deferred-promise tests.
4. **The `searchMembers` prop documents no stability requirement** yet sits in the effect's dep array. A host passing an inline arrow while re-rendering faster than 250 ms would reschedule forever and the search would *never* fire — a permanent skeleton, not merely a slow one. Today's consumers are safe only by discipline. Holding the callback in a ref would make the contract safe by construction.
5. **Normalization asymmetry.** `render-body.tsx` NFC-normalizes the body via `sanitizeDisplayText` but passes raw token names to `locateMentions`, which does a plain `indexOf`; `seedMentions` calls it on unsanitized composer text. An NFD display name against an NFC body would lose the chip in the bubble and the anchor on edit-rehydrate — the same failure class as #5404. Reachability unproven.
6. **`components/RichText/.../Mention/suggestion.tsx` has no debounce at all.** tiptap invokes its `items` callback on every doc change over an O(N) filter. It already pre-lowercases its corpus once, so it is far cheaper than the audit note described, but it is the one place in F0 where "per keystroke, un-debounced, O(N)" is literally true. Its Escape handler also unmounts the popover root without nulling it, so `onExit` double-unmounts.
7. **Enter during the debounce window can insert a stale candidate.** The trigger effect never clears `memberResults` while a trigger stays live, so for ~250 ms the highlighted row can be one that no longer matches the typed text. Pre-existing.
