### PR TITLE
refactor(lint): enable the hand-fixed lint rules

### DIFF
--- a/packages/react-native/.oxlintrc.json
+++ b/packages/react-native/.oxlintrc.json
@@ -16,6 +16,8 @@
     "preserve-caught-error": "error",
 
     // typescript-eslint strict + stylistic, no type information needed.
+    "typescript/no-dynamic-delete": "error",
+    "typescript/ban-ts-comment": "error",
     "typescript/no-inferrable-types": "error",
     "typescript/array-type": "error",
     "typescript/adjacent-overload-signatures": "error",
@@ -32,13 +34,8 @@
     "typescript/prefer-literal-enum-member": "error",
 
     // eslint-plugin-import, native oxlint rules.
+    "import/no-duplicates": "error",
     "import/namespace": "error",
-
-    // PENDING. Turned on in a follow-up PR together with the code fixes.
-    // Number = violations on main when this was written.
-    "typescript/ban-ts-comment": "off", // 3
-    "import/no-duplicates": "off", // 3
-    "typescript/no-dynamic-delete": "off", // 1
 
     // OFF ON PURPOSE. Not planned to be enabled.
     "import/default": "off", // false positives with CommonJS interop packages

--- a/packages/react-native/src/components/Avatars/FileAvatar/index.tsx
+++ b/packages/react-native/src/components/Avatars/FileAvatar/index.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps, useMemo } from "react"
-import { Text } from "react-native"
-import { View } from "react-native"
+import { Text, View } from "react-native"
 
 import { cn } from "../../../lib/utils"
 import { Avatar } from "../../../ui/avatar"

--- a/packages/react-native/src/components/primitives/F0Icon/F0Icon.types.ts
+++ b/packages/react-native/src/components/primitives/F0Icon/F0Icon.types.ts
@@ -1,7 +1,6 @@
 import type { ForwardRefExoticComponent, RefAttributes } from "react"
 import type { ColorValue } from "react-native"
-import type { SvgProps } from "react-native-svg"
-import type { Svg } from "react-native-svg"
+import type { Svg, SvgProps } from "react-native-svg"
 import type { VariantProps } from "tailwind-variants"
 
 import type { iconVariants } from "./F0Icon.styles"

--- a/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.spec.tsx
+++ b/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.spec.tsx
@@ -3,8 +3,7 @@ import React from "react"
 
 import { Archive } from "../../../../icons/app"
 import { Home } from "../../../../icons/modules"
-import { applyIconInterop } from "../F0Icon"
-import F0Icon from "../F0Icon"
+import F0Icon, { applyIconInterop } from "../F0Icon"
 
 describe("F0Icon", () => {
   it("renders correctly with an app icon", () => {

--- a/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.tokens.spec.ts
+++ b/packages/react-native/src/components/primitives/F0Icon/__tests__/F0Icon.tokens.spec.ts
@@ -1,6 +1,6 @@
-// @ts-ignore - Node built-ins are available in Jest runtime
+// @ts-expect-error - Node built-ins are available in Jest runtime
 import fs from "fs"
-// @ts-ignore - Node built-ins are available in Jest runtime
+// @ts-expect-error - Node built-ins are available in Jest runtime
 import path from "path"
 
 import { ICON_COLORS } from "../F0Icon.types"
@@ -8,7 +8,7 @@ import { ICON_COLORS } from "../F0Icon.types"
 describe("F0Icon token sync", () => {
   it("ICON_COLORS matches f0-icon-* tokens in theme.css", () => {
     const css = fs.readFileSync(
-      // @ts-ignore - __dirname is available in Jest runtime
+      // @ts-expect-error - __dirname is available in Jest runtime
       path.resolve(__dirname, "../../../../styles/theme.css"),
       "utf-8"
     )

--- a/packages/react-native/src/lib/utils.ts
+++ b/packages/react-native/src/lib/utils.ts
@@ -19,9 +19,8 @@ export function omitProps<T extends Record<string, unknown>, K extends string>(
   obj: T,
   keys: readonly K[]
 ): Omit<T, K> {
-  const result = { ...obj }
-  for (const key of keys) {
-    delete result[key as keyof T]
-  }
-  return result as Omit<T, K>
+  const omitted = new Set<string>(keys)
+  return Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !omitted.has(key))
+  ) as Omit<T, K>
 }

--- a/packages/react/.oxlintrc.json
+++ b/packages/react/.oxlintrc.json
@@ -24,6 +24,9 @@
     "preserve-caught-error": "error",
 
     // typescript-eslint strict + stylistic, no type information needed.
+    "typescript/no-extraneous-class": "error",
+    "typescript/prefer-for-of": "error",
+    "typescript/no-dynamic-delete": "error",
     "typescript/consistent-generic-constructors": "error",
     "typescript/no-inferrable-types": "error",
     "typescript/array-type": "error",
@@ -40,6 +43,17 @@
 
     // typescript-eslint strict + stylistic, type-aware. They run only with
     // `--type-aware` (see the lint scripts) and need `oxlint-tsgolint`.
+    "typescript/no-unsafe-enum-comparison": "error",
+    "typescript/restrict-plus-operands": "error",
+    "typescript/no-misused-promises": [
+      "error",
+      { "checksVoidReturn": { "attributes": false } }
+    ],
+    "typescript/prefer-promise-reject-errors": "error",
+    "typescript/use-unknown-in-catch-callback-variable": "error",
+    "typescript/no-redundant-type-constituents": "error",
+    "typescript/await-thenable": "error",
+    "typescript/no-unnecessary-template-expression": "error",
     "typescript/no-meaningless-void-operator": "error",
     "typescript/return-await": "error",
     "typescript/no-duplicate-type-constituents": "error",
@@ -58,6 +72,32 @@
 
     // eslint-plugin-sonarjs recommended (JS plugin). Rules that need type
     // information run without it here and may miss cases.
+    "sonarjs/regex-complexity": "error",
+    "sonarjs/no-duplicate-test-title": "error",
+    "sonarjs/no-redundant-boolean": "error",
+    "sonarjs/no-inverted-boolean-check": "error",
+    "sonarjs/bitwise-operators": "error",
+    "sonarjs/no-hardcoded-passwords": "error",
+    "sonarjs/link-with-target-blank": "error",
+    "sonarjs/no-trivial-assertions": "error",
+    "sonarjs/single-char-in-character-classes": "error",
+    "sonarjs/no-clear-text-protocols": "error",
+    "sonarjs/no-all-duplicated-branches": "error",
+    "sonarjs/no-skipped-tests": "error",
+    "sonarjs/no-gratuitous-expressions": "error",
+    "sonarjs/no-nested-assignment": "error",
+    "sonarjs/public-static-readonly": "error",
+    "sonarjs/prefer-promise-shorthand": "error",
+    "sonarjs/reduce-initial-value": "error",
+    "sonarjs/no-redundant-assignments": "error",
+    "sonarjs/updated-loop-counter": "error",
+    "sonarjs/no-redundant-jump": "error",
+    "sonarjs/prefer-native-lodash-alternative": "error",
+    "sonarjs/no-duplicated-branches": "error",
+    "sonarjs/no-nested-template-literals": "error",
+    "sonarjs/no-dead-store": "error",
+    "sonarjs/concise-regex": "error",
+    "sonarjs/no-small-switch": "error",
     "sonarjs/anchor-precedence": "error",
     "sonarjs/argument-type": "error",
     "sonarjs/arguments-order": "error",
@@ -228,46 +268,6 @@
     "sonarjs/weak-ssl": "error",
     "sonarjs/x-powered-by": "error",
     "sonarjs/xml-parser-xxe": "error",
-
-    // PENDING. Turned on in follow-up PRs together with the code fixes.
-    // Number = violations on main when this was written.
-    "typescript/no-dynamic-delete": "off", // 10
-    "sonarjs/no-small-switch": "off", // 3
-    "sonarjs/concise-regex": "off", // 4
-    "typescript/prefer-for-of": "off", // 9
-    "sonarjs/no-dead-store": "off", // 3
-    "sonarjs/no-nested-template-literals": "off", // 7
-    "sonarjs/no-duplicated-branches": "off", // 11
-    "sonarjs/prefer-native-lodash-alternative": "off", // 2
-    "sonarjs/no-redundant-jump": "off", // 3
-    "sonarjs/updated-loop-counter": "off", // 1
-    "sonarjs/no-redundant-assignments": "off", // 2
-    "sonarjs/reduce-initial-value": "off", // 1
-    "sonarjs/prefer-promise-shorthand": "off", // 1
-    "typescript/no-extraneous-class": "off", // 2
-    "sonarjs/public-static-readonly": "off", // 5
-    "sonarjs/no-nested-assignment": "off", // 6
-    "sonarjs/no-gratuitous-expressions": "off", // 1
-    "sonarjs/no-skipped-tests": "off", // 2
-    "sonarjs/no-all-duplicated-branches": "off", // 4
-    "sonarjs/no-clear-text-protocols": "off", // 2
-    "sonarjs/single-char-in-character-classes": "off", // 1
-    "sonarjs/no-trivial-assertions": "off", // 7
-    "sonarjs/link-with-target-blank": "off", // 1
-    "sonarjs/no-hardcoded-passwords": "off", // 1
-    "sonarjs/bitwise-operators": "off", // 1
-    "sonarjs/no-inverted-boolean-check": "off", // 2
-    "sonarjs/no-redundant-boolean": "off", // 2
-    "sonarjs/no-duplicate-test-title": "off", // 1
-    "sonarjs/regex-complexity": "off", // 1
-    "typescript/no-unnecessary-template-expression": "off", // 14
-    "typescript/await-thenable": "off", // 4
-    "typescript/no-redundant-type-constituents": "off", // 10
-    "typescript/use-unknown-in-catch-callback-variable": "off", // 7
-    "typescript/prefer-promise-reject-errors": "off", // 8
-    "typescript/no-misused-promises": "off", // 16
-    "typescript/restrict-plus-operands": "off", // 1
-    "typescript/no-unsafe-enum-comparison": "off", // 2
 
     // DEBT. Turn on once the code is fixed. Number = violations when this
     // was written. Do not add new violations.

--- a/packages/react/src/__tests__/mdxStoryReferences.test.ts
+++ b/packages/react/src/__tests__/mdxStoryReferences.test.ts
@@ -132,7 +132,7 @@ function buildSymbolTable(src: string): Map<string, Symbol> {
   }
 
   for (const m of src.matchAll(
-    /import\s+(?:([A-Za-z0-9_$]+)\s*,?\s*)?(?:\{([^}]*)\})?\s*from\s*["']([^"']+)["']/g
+    /import\s+(?:([A-Za-z0-9_$]+)[\s,]*)?(?:\{([^}]*)\})?\s*from\s*["']([^"']+)["']/g
   )) {
     const [, def, named, mod] = m
     if (def) {

--- a/packages/react/src/components/F0AudioPlayer/useDerivedTranscription.ts
+++ b/packages/react/src/components/F0AudioPlayer/useDerivedTranscription.ts
@@ -33,9 +33,9 @@ const readCueText = (track: TextTrack): string => {
     return ""
   }
   const lines: string[] = []
-  for (let i = 0; i < cues.length; i++) {
+  for (const cue of Array.from(cues)) {
     // `VTTCue` exposes `text`; a generic `TextTrackCue` may not.
-    const text = (cues[i] as VTTCue).text
+    const text = (cue as VTTCue).text
     if (typeof text === "string" && text.trim()) {
       lines.push(text.trim())
     }

--- a/packages/react/src/components/F0BigNumber/__tests__/F0BigNumber.test.tsx
+++ b/packages/react/src/components/F0BigNumber/__tests__/F0BigNumber.test.tsx
@@ -120,7 +120,8 @@ describe("F0BigNumber", () => {
         // Constructor can be empty, format is set as instance property
       }
 
-      static supportedLocalesOf = OriginalIntl.NumberFormat.supportedLocalesOf
+      static readonly supportedLocalesOf =
+        OriginalIntl.NumberFormat.supportedLocalesOf
     }
 
     global.Intl = {

--- a/packages/react/src/components/F0ButtonDropdown/__tests__/F0ButtonDropdown.test.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/__tests__/F0ButtonDropdown.test.tsx
@@ -182,6 +182,7 @@ describe("F0ButtonDropdown", () => {
       expect(mockOnClick).not.toHaveBeenCalled()
     })
 
+    // Skipped since daccd9283 without a recorded reason. Un-skip or document.
     it.skip("changes selected value when dropdown item is clicked", async () => {
       const user = userEvent.setup()
       render(

--- a/packages/react/src/components/F0InputField/__stories__/F0InputField.args.ts
+++ b/packages/react/src/components/F0InputField/__stories__/F0InputField.args.ts
@@ -110,7 +110,7 @@ const inputFieldArgs = {
 }
 
 export const getInputFieldArgs = (
-  keys?: readonly (keyof typeof inputFieldArgs | string)[]
+  keys?: readonly (keyof typeof inputFieldArgs | (string & {}))[]
 ) => {
   if (!keys) {
     return inputFieldArgs

--- a/packages/react/src/components/F0NumberInput/internal/extractNumber.ts
+++ b/packages/react/src/components/F0NumberInput/internal/extractNumber.ts
@@ -1,5 +1,5 @@
 // eslint-disable-next-line no-useless-escape
-const COMPLETE_NUMBER_FORMAT = /^(-?)([0-9]+)?(?:([\.,])([0-9]+)?)?$/
+const COMPLETE_NUMBER_FORMAT = /^(-?)(\d+)?(?:([\.,])(\d+)?)?$/
 
 interface ExtractedNumber {
   formattedValue: string

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -822,13 +822,13 @@ export const WithDataSourceGrouping: Story = {
         groupBy: {
           role: {
             name: "Role",
-            label: (groupId) => `${groupId}`,
+            label: (groupId) => groupId,
             itemCount: (groupId) =>
               mockItems.filter((item) => item.role === groupId).length,
           },
           workplace: {
             name: "Workplace",
-            label: (groupId) => `${groupId}`,
+            label: (groupId) => groupId,
             itemCount: (groupId) =>
               mockItems.filter((item) => item.workplace === groupId).length,
           },
@@ -905,7 +905,7 @@ export const WithDataSourceGroupingDefaultOpen: Story = {
         groupBy: {
           role: {
             name: "Role",
-            label: (groupId) => `${groupId}`,
+            label: (groupId) => groupId,
             itemCount: (groupId) =>
               mockItems.filter((item) => item.role === groupId).length,
           },
@@ -961,7 +961,7 @@ export const WithManyCollapsibleGroups: Story = {
         groupBy: {
           role: {
             name: "Role",
-            label: (groupId) => `${groupId}`,
+            label: (groupId) => groupId,
             itemCount: (groupId) =>
               mockItems.filter((item) => item.role === groupId).length,
           },

--- a/packages/react/src/components/F0Select/components/ActiveFiltersChips.tsx
+++ b/packages/react/src/components/F0Select/components/ActiveFiltersChips.tsx
@@ -115,8 +115,9 @@ export const ActiveFiltersChips = <Filters extends FiltersDefinition>({
   }
 
   const handleRemoveFilter = (key: string) => {
-    const newFilters = { ...currentFilters }
-    delete newFilters[key as keyof Filters]
+    const newFilters = Object.fromEntries(
+      Object.entries(currentFilters).filter(([filterKey]) => filterKey !== key)
+    ) as typeof currentFilters
     onFiltersChange(newFilters)
   }
 

--- a/packages/react/src/components/F0Select/components/SelectItem.tsx
+++ b/packages/react/src/components/F0Select/components/SelectItem.tsx
@@ -13,6 +13,9 @@ const DIAL_CODE_PATTERN = /^\+\d{1,4}$/
 const warnedDialCodes = new Set<string>()
 
 const metadataText = (metadata: F0SelectItemMetadata): string => {
+  if (metadata.type !== "dialCode") {
+    return ""
+  }
   if (
     process.env.NODE_ENV !== "production" &&
     !DIAL_CODE_PATTERN.test(metadata.dialCode) &&

--- a/packages/react/src/components/F0Select/components/SelectItem.tsx
+++ b/packages/react/src/components/F0Select/components/SelectItem.tsx
@@ -13,20 +13,17 @@ const DIAL_CODE_PATTERN = /^\+\d{1,4}$/
 const warnedDialCodes = new Set<string>()
 
 const metadataText = (metadata: F0SelectItemMetadata): string => {
-  switch (metadata.type) {
-    case "dialCode":
-      if (
-        process.env.NODE_ENV !== "production" &&
-        !DIAL_CODE_PATTERN.test(metadata.dialCode) &&
-        !warnedDialCodes.has(metadata.dialCode)
-      ) {
-        warnedDialCodes.add(metadata.dialCode)
-        console.warn(
-          `[F0Select] metadata dialCode "${metadata.dialCode}" is not a valid dial code (expected "+" followed by 1-4 digits).`
-        )
-      }
-      return metadata.dialCode
+  if (
+    process.env.NODE_ENV !== "production" &&
+    !DIAL_CODE_PATTERN.test(metadata.dialCode) &&
+    !warnedDialCodes.has(metadata.dialCode)
+  ) {
+    warnedDialCodes.add(metadata.dialCode)
+    console.warn(
+      `[F0Select] metadata dialCode "${metadata.dialCode}" is not a valid dial code (expected "+" followed by 1-4 digits).`
+    )
   }
+  return metadata.dialCode
 }
 
 export const SelectItem = <T extends string, R>({

--- a/packages/react/src/components/F0TableOfContentPopover/components/CollapsedBars.tsx
+++ b/packages/react/src/components/F0TableOfContentPopover/components/CollapsedBars.tsx
@@ -85,8 +85,10 @@ function getVisibleItems(
   if (activeItem) {
     const activeIndex = allItems.findIndex((item) => item.id === activeItem)
     if (activeIndex !== -1 && !selectedIndices.has(activeIndex)) {
-      const closest = [...selectedIndices].reduce((a, b) =>
-        Math.abs(b - activeIndex) < Math.abs(a - activeIndex) ? b : a
+      const closest = [...selectedIndices].reduce(
+        (a, b) =>
+          Math.abs(b - activeIndex) < Math.abs(a - activeIndex) ? b : a,
+        Number.POSITIVE_INFINITY
       )
       selectedIndices.delete(closest)
       selectedIndices.add(activeIndex)

--- a/packages/react/src/components/F0VideoPlayer/hooks/useAudioDescription.ts
+++ b/packages/react/src/components/F0VideoPlayer/hooks/useAudioDescription.ts
@@ -133,8 +133,7 @@ export function useAudioDescription(
 
     const refresh = () => {
       let inBand = false
-      for (let i = 0; i < tracks.length; i++) {
-        const track = tracks[i]
+      for (const track of Array.from(tracks)) {
         if (track.kind !== DESCRIPTION_TRACK_KIND) {
           continue
         }

--- a/packages/react/src/components/F0VideoPlayer/hooks/useVideoCaptions.ts
+++ b/packages/react/src/components/F0VideoPlayer/hooks/useVideoCaptions.ts
@@ -88,8 +88,7 @@ export function useVideoCaptions(
     // and the passed <track>'s readyState.
     const evaluate = () => {
       let cues = false
-      for (let i = 0; i < tracks.length; i++) {
-        const track = tracks[i]
+      for (const track of Array.from(tracks)) {
         if (!CAPTION_TRACK_KINDS.has(track.kind)) {
           continue
         }
@@ -129,8 +128,7 @@ export function useVideoCaptions(
       })
     }
     // Re-evaluate as cues parse/activate and as tracks come and go.
-    for (let i = 0; i < tracks.length; i++) {
-      const track = tracks[i]
+    for (const track of Array.from(tracks)) {
       if (!CAPTION_TRACK_KINDS.has(track.kind)) {
         continue
       }

--- a/packages/react/src/components/OneCalendar/granularities/halfyear/HalfyearView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/halfyear/HalfyearView.tsx
@@ -63,13 +63,7 @@ export const HalfYearView = ({
       // For single selection, use the first day of the half-year
       onSelect?.(halfYearRange.from)
     } else if (mode === "range") {
-      if (!selected || !isDateRange(selected)) {
-        // Start of range
-        onSelect?.({
-          from: halfYearRange.from,
-          to: undefined,
-        })
-      } else if (selected && selected.from && !selected.to) {
+      if (selected && isDateRange(selected) && selected.from && !selected.to) {
         // Complete the range
         const fromDate = selected.from
         const fromHalfYear = getHalfYearFromMonth(fromDate.getMonth())

--- a/packages/react/src/components/OneCalendar/granularities/halfyear/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/halfyear/index.tsx
@@ -88,7 +88,8 @@ const formatHalfYearShort = (date: Date | DateRange | undefined | null) => {
   }
   const { from, to } = dateRange
 
-  return `${from}${to && from !== to ? ` ${rangeSeparator} ${to}` : ""}`
+  const toPart = to && from !== to ? ` ${rangeSeparator} ${to}` : ""
+  return `${from}${toPart}`
 }
 
 const formatHalfYearLong = (date: Date | DateRange | undefined | null) => {

--- a/packages/react/src/components/OneCalendar/granularities/month/MonthView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/month/MonthView.tsx
@@ -71,13 +71,7 @@ export function MonthView({
         to: monthEnd,
       })
     } else if (mode === "range") {
-      if (!selected || !isDateRange(selected)) {
-        // Start of range
-        onSelect?.({
-          from: selectedDate,
-          to: undefined,
-        })
-      } else if (selected.from && !selected.to) {
+      if (selected && isDateRange(selected) && selected.from && !selected.to) {
         // Complete the range
         const fromDate = selected.from
 

--- a/packages/react/src/components/OneCalendar/granularities/quarter/QuarterView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/quarter/QuarterView.tsx
@@ -63,12 +63,7 @@ export const QuarterView = ({
     if (mode === "single") {
       onSelect?.(quarterRange.from)
     } else if (mode === "range") {
-      if (!selected || !isDateRange(selected)) {
-        onSelect?.({
-          from: quarterRange.from,
-          to: undefined,
-        })
-      } else if (selected && selected.from && !selected.to) {
+      if (selected && isDateRange(selected) && selected.from && !selected.to) {
         const fromDate = selected.from
         const fromQuarter = getQuarterFromMonth(fromDate.getMonth())
         const fromYear = fromDate.getFullYear()

--- a/packages/react/src/components/OneCalendar/granularities/year/YearView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/year/YearView.tsx
@@ -57,13 +57,7 @@ export function YearView({
         to: endOfYear(selectedDate),
       })
     } else if (mode === "range") {
-      if (!selected || !isDateRange(selected)) {
-        // Start of range
-        onSelect?.({
-          from: selectedDate,
-          to: undefined,
-        })
-      } else if (selected && selected.from && !selected.to) {
+      if (selected && isDateRange(selected) && selected.from && !selected.to) {
         // Complete the range
         if (isSameYear(selected.from, selectedDate)) {
           // If clicking the same year, select just that year

--- a/packages/react/src/components/OneCalendar/utils.ts
+++ b/packages/react/src/components/OneCalendar/utils.ts
@@ -129,7 +129,8 @@ export const formatDateToString = (
   }
   const { from, to } = dateRange
 
-  return `${from}${to && from !== to ? ` ${rangeSeparator} ${to}` : ""}`
+  const toPart = to && from !== to ? ` ${rangeSeparator} ${to}` : ""
+  return `${from}${toPart}`
 }
 
 export function toGranularityDateRange<

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.test.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.test.tsx
@@ -42,7 +42,9 @@ vi.mock("@tiptap/react", () => {
   }
 
   return {
-    Editor: class {},
+    Editor: class {
+      destroy() {}
+    },
     ReactRenderer: MockReactRenderer,
   }
 })

--- a/packages/react/src/components/RichText/internal/Toolbar/LinkPopup/index.tsx
+++ b/packages/react/src/components/RichText/internal/Toolbar/LinkPopup/index.tsx
@@ -40,9 +40,7 @@ export const LinkPopup = ({ editor, disabled }: LinkPopupProps) => {
   const checkIfUrlIsValid = (url: string) => {
     const trimmedUrl = url.trim()
     const isValidUrl =
-      /^(https?:\/\/)([\w-]+(\.[\w-]+)+)(:[0-9]{1,5})?(\/.*)?$/i.test(
-        trimmedUrl
-      )
+      /^(https?:\/\/)([\w-]+(\.[\w-]+)+)(:\d{1,5})?(\/.*)?$/i.test(trimmedUrl)
     return isValidUrl
   }
 

--- a/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
+++ b/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
@@ -58,7 +58,7 @@ export const BaseAvatar = forwardRef<HTMLDivElement, BaseAvatarProps>(
     ): size is AvatarSize => avatarSizes.includes(size as AvatarSize)
 
     // Check if size is a valid avatar size
-    let mappedSize: AvatarSize = DEFAULT_SIZE
+    let mappedSize: AvatarSize
     if (size && !isSize(size)) {
       console.warn(
         `The avatar size: ${size} is deprecated. Use ${sizesMapping[size]} instead.`

--- a/packages/react/src/components/dialog-alike/common/Footer.tsx
+++ b/packages/react/src/components/dialog-alike/common/Footer.tsx
@@ -34,9 +34,7 @@ export const Footer = (props: FooterProps) => {
   }
 
   const toPromise = (onClick: () => void | Promise<void>) => {
-    return new Promise((resolve) => {
-      resolve(onClick())
-    })
+    return Promise.resolve(onClick())
   }
 
   const renderPrimaryAction = () => {

--- a/packages/react/src/experimental/F0VersionHistory/__stories__/F0VersionHistory.stories.tsx
+++ b/packages/react/src/experimental/F0VersionHistory/__stories__/F0VersionHistory.stories.tsx
@@ -92,7 +92,9 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   render: () => {
-    const [activeId, setActiveId] = useState<string | "current">("current")
+    const [activeId, setActiveId] = useState<"current" | (string & {})>(
+      "current"
+    )
 
     const versionsWithHandlers = mockVersions.map((version) => ({
       ...version,

--- a/packages/react/src/experimental/F0VersionHistory/types.ts
+++ b/packages/react/src/experimental/F0VersionHistory/types.ts
@@ -20,5 +20,5 @@ export interface F0VersionHistoryProps {
   title: string
   versions: Version[]
   currentVersion?: CurrentVersion
-  activeVersionId?: string | "current"
+  activeVersionId?: "current" | (string & {})
 }

--- a/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
@@ -80,7 +80,12 @@ export const FileVariant: Story = {
       actions: [
         {
           label: "Open",
-          onClick: () => window.open("https://example.com/contract.pdf"),
+          onClick: () =>
+            window.open(
+              "https://example.com/contract.pdf",
+              "_blank",
+              "noopener,noreferrer"
+            ),
         },
       ],
     },

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/index.tsx
@@ -116,7 +116,6 @@ export function Item({
           setOverEdge(null)
           setIsOverInside(false)
           lastReportedStateRef.current = null
-          return
         }
       },
       onDrag: ({ self, source }) => {
@@ -191,7 +190,7 @@ export function Item({
       },
       onDrop: ({ self }) => {
         const data = self.data as { position?: string }
-        let position: "before" | "after" | "inside" = "after"
+        let position: "before" | "after" | "inside"
 
         if (data.position === "inside") {
           position = "inside"

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
@@ -658,8 +658,6 @@ function TOCContent({
           if (targetItem.parentPath.length > 0) {
             targetParentId =
               targetItem.parentPath[targetItem.parentPath.length - 1]
-          } else {
-            targetParentId = null // Root level
           }
           // Find the index of the target item in its parent
           if (targetParentId === null) {
@@ -677,8 +675,6 @@ function TOCContent({
           if (targetItem.parentPath.length > 0) {
             targetParentId =
               targetItem.parentPath[targetItem.parentPath.length - 1]
-          } else {
-            targetParentId = null // Root level
           }
           // Find the index of the target item in its parent and add 1
           if (targetParentId === null) {

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/index.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/index.test.tsx
@@ -242,6 +242,7 @@ describe("Breadcrumbs", async () => {
     })
   })
 
+  // Skipped since eaed0ace4 without a recorded reason. Un-skip or document.
   it.skip("renders select type breadcrumb correctly", async () => {
     const breadcrumbs = [
       { id: "home", label: "Home", href: "/" },

--- a/packages/react/src/experimental/OneTable/TableCell/utils/nested.ts
+++ b/packages/react/src/experimental/OneTable/TableCell/utils/nested.ts
@@ -25,14 +25,13 @@ export const getNestedMarginLeft = ({
 
 export const getNestedMarginLeftForLoadMore = ({
   depth,
-  isDetailedVariant,
 }: {
   depth: number
   isDetailedVariant: boolean
 }) => {
   return getNestedMarginLeft({
     depth,
-    padding: isDetailedVariant ? -BUTTON_PADDING : -BUTTON_PADDING,
+    padding: -BUTTON_PADDING,
   })
 }
 

--- a/packages/react/src/experimental/Widgets/Content/CalendarEvent/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/CalendarEvent/index.tsx
@@ -89,7 +89,7 @@ export const CalendarEvent = forwardRef<HTMLDivElement, CalendarEventProps>(
             <div
               className="absolute bottom-0 left-0 right-0 top-0 opacity-5"
               style={{
-                background: `${color}`,
+                background: color,
               }}
             />
             <div

--- a/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
@@ -1,16 +1,17 @@
 import { screen } from "@testing-library/react"
 import { Fragment } from "react"
 import { afterEach, describe, expect, test, vi } from "vitest"
-/* eslint-disable no-constant-binary-expression */
 import { userEvent, zeroRender } from "@/testing/test-utils"
 import { Widget } from "."
+
+const showHiddenChild = (): boolean => false
 
 const renderWidget = () => {
   return zeroRender(
     <Widget>
       <></>
       <Fragment></Fragment>
-      {false && <p>asd</p>}
+      {showHiddenChild() && <p>asd</p>}
       {null}
       {undefined}
       <p>1</p>
@@ -18,7 +19,7 @@ const renderWidget = () => {
       <p>3</p>
       <></>
       <Fragment></Fragment>
-      {false && <p>asd</p>}
+      {showHiddenChild() && <p>asd</p>}
       {null}
       {undefined}
     </Widget>

--- a/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
@@ -266,26 +266,6 @@ describe("useData", () => {
         type: "flat",
       })
     })
-
-    it("should apply filters to synchronous data", () => {
-      const filters: Partial<FiltersState<TestFilters>> = {
-        search: "Test 1",
-      }
-      const source = createMockDataSource(
-        ({ filters }: { filters: FiltersState<TestFilters> }) => ({
-          records: mockData.filter((item) =>
-            filters.search ? item.name.includes(filters.search) : true
-          ),
-        })
-      )
-
-      const { result } = renderHook(() => useData(source, { filters }))
-
-      expect(result.current.data).toMatchObject({
-        records: [mockData[0]],
-        type: "flat",
-      })
-    })
   })
 
   describe("subscription cleanup", () => {

--- a/packages/react/src/hooks/datasource/itemNeighbors/resolveItemNeighbors.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/resolveItemNeighbors.ts
@@ -42,9 +42,9 @@ export function resolveItemNeighbors<R>(result: ItemNeighborsResult<R>): {
             resolve(state.data)
           }
         },
-        error: (error) => {
+        error: (error: unknown) => {
           if (!cancelled) {
-            reject(error)
+            reject(error instanceof Error ? error : new Error(String(error)))
           }
         },
       })
@@ -66,9 +66,9 @@ export function resolveItemNeighbors<R>(result: ItemNeighborsResult<R>): {
           resolve(response)
         }
       },
-      (error) => {
+      (error: unknown) => {
         if (!cancelled) {
-          reject(error)
+          reject(error instanceof Error ? error : new Error(String(error)))
         }
       }
     )

--- a/packages/react/src/hooks/datasource/itemNeighbors/useItemNeighbors.ts
+++ b/packages/react/src/hooks/datasource/itemNeighbors/useItemNeighbors.ts
@@ -185,7 +185,7 @@ export function useItemNeighbors<
         setResolved({ key: requestKey, neighbors: response })
         setIsResolving(false)
       },
-      (cause) => {
+      (cause: unknown) => {
         if (latestKeyRef.current !== requestKey) {
           return
         }

--- a/packages/react/src/hooks/datasource/types/fetch.typings.ts
+++ b/packages/react/src/hooks/datasource/types/fetch.typings.ts
@@ -183,7 +183,7 @@ export type BaseDataAdapter<
   FetchReturn = BaseResponse<R>,
 > = {
   /** Indicates this adapter doesn't use pagination */
-  paginationType?: never | undefined
+  paginationType?: undefined
   /**
    * Function to fetch data based on filter options
    * @param options - The filter options to apply when fetching data

--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -84,7 +84,7 @@ export interface UseDataOptions<
  */
 export const GROUP_ID_SYMBOL = Symbol("groupId")
 export type WithGroupId<RecordType> = RecordType & {
-  [GROUP_ID_SYMBOL]: unknown | undefined
+  [GROUP_ID_SYMBOL]: unknown
 }
 
 type GroupIdCache<R extends RecordType> = {

--- a/packages/react/src/hooks/datasource/useDataSource.ts
+++ b/packages/react/src/hooks/datasource/useDataSource.ts
@@ -23,7 +23,7 @@ import { SearchOptions } from "./types/search.typings"
  */
 
 export const getDataSourcePaginationType = <
-  D extends { paginationType?: PaginationType | undefined | never },
+  D extends { paginationType?: PaginationType | undefined },
 >(
   dataAdapter: D
 ): PaginationType => {

--- a/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.stories.tsx
@@ -172,7 +172,7 @@ export const Biaxial: Meta<typeof ComboChart<typeof departmentConfig>> = {
     },
     yAxis: {
       hide: false,
-      tickFormatter: (value: string) => `${value}`,
+      tickFormatter: (value: string) => value,
     },
     legend: true,
   },

--- a/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
@@ -76,7 +76,7 @@ const _VBarChart = <K extends ChartConfig>(
   const bars = Object.keys(dataConfig) as (keyof ChartConfig)[]
   const preparedData = prepareData<K>(data)
   const maxLabelWidth = Math.max(
-    ...preparedData.map((el) => measureTextWidth(`${el.x}`))
+    ...preparedData.map((el) => measureTextWidth(String(el.x)))
   )
   const totalCategories = bars.reduce<Record<string, number>>((acc, key) => {
     acc[key] = data.reduce((sum, item) => sum + (item.values[key] as number), 0)

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -37,7 +37,7 @@ const { linearGradientMock } = vi.hoisted(() => ({
 }))
 
 /** Handlers the chart registered, so tests can fire ECharts events at it. */
-const chartHandlers: Record<string, ((params: unknown) => void)[]> = {}
+let chartHandlers: Record<string, ((params: unknown) => void)[]> = {}
 
 /** Fire an ECharts event at every handler the component registered for it. */
 function emitChartEvent(event: string, params: unknown) {
@@ -57,7 +57,8 @@ vi.mock("echarts", () => ({
     dispose: vi.fn(),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn((event: string, handler: (params: unknown) => void) => {
-      ;(chartHandlers[event] ??= []).push(handler)
+      chartHandlers[event] ??= []
+      chartHandlers[event].push(handler)
     }),
     off: vi.fn(),
     dispatchAction: vi.fn(),
@@ -183,9 +184,7 @@ function getBorderRadii(seriesIndex: number) {
 
 beforeEach(() => {
   setOptionMock.mockClear()
-  for (const key of Object.keys(chartHandlers)) {
-    delete chartHandlers[key]
-  }
+  chartHandlers = {}
   containerSize.width = 800
   containerSize.height = 320
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
@@ -4,7 +4,7 @@ import { zeroRender as render } from "@/testing/test-utils"
 import { F0DataChart } from "../F0DataChart"
 
 const setOptionMock = vi.fn()
-const chartEventHandlers: Record<string, ((params: unknown) => void)[]> = {}
+const chartEventHandlers = new Map<string, ((params: unknown) => void)[]>()
 
 vi.mock("echarts", () => ({
   init: vi.fn(() => ({
@@ -13,14 +13,17 @@ vi.mock("echarts", () => ({
     dispose: vi.fn(),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn((event: string, handler: (params: unknown) => void) => {
-      chartEventHandlers[event] = [
-        ...(chartEventHandlers[event] ?? []),
+      chartEventHandlers.set(event, [
+        ...(chartEventHandlers.get(event) ?? []),
         handler,
-      ]
+      ])
     }),
     off: vi.fn((event: string, handler: (params: unknown) => void) => {
-      chartEventHandlers[event] = (chartEventHandlers[event] ?? []).filter(
-        (candidate) => candidate !== handler
+      chartEventHandlers.set(
+        event,
+        (chartEventHandlers.get(event) ?? []).filter(
+          (candidate) => candidate !== handler
+        )
       )
     }),
     dispatchAction: vi.fn(),
@@ -79,9 +82,7 @@ const funnelProps = {
 
 beforeEach(() => {
   setOptionMock.mockClear()
-  for (const event of Object.keys(chartEventHandlers)) {
-    delete chartEventHandlers[event]
-  }
+  chartEventHandlers.clear()
   containerSize.width = 800
   containerSize.height = 320
 })
@@ -97,7 +98,7 @@ describe("FunnelChart — legend visibility", () => {
       />
     )
 
-    chartEventHandlers.legendselectchanged?.forEach((handler) =>
+    chartEventHandlers.get("legendselectchanged")?.forEach((handler) =>
       handler({
         name: "Applied",
         selected: {

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -1259,7 +1259,9 @@ export function useBarChartOptions(
           0,
           currentSeries.data.length - ARIA_MAX_VALUES_PER_SERIES
         )
-        return `${currentSeries.name}: ${values}${remainingValues > 0 ? `; ${remainingValues} more values` : ""}.`
+        const remainingSuffix =
+          remainingValues > 0 ? `; ${remainingValues} more values` : ""
+        return `${currentSeries.name}: ${values}${remainingSuffix}.`
       })
     if (series.length > ARIA_MAX_SERIES) {
       ariaDescriptions.push(`${series.length - ARIA_MAX_SERIES} more series.`)

--- a/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
+++ b/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
@@ -15,12 +15,17 @@ import type { F0DataChartProps } from "../types"
 export function isDataChartEmpty(props: F0DataChartProps): boolean {
   switch (props.type) {
     case "bar":
-    case "line": {
-      const series = props.series
+    case "line":
+    case "radar":
+    case "scatter": {
+      const series:
+        | ReadonlyArray<{ data?: unknown[] } | undefined>
+        | undefined = props.series
       if (!Array.isArray(series) || series.length === 0) {
         return true
       }
-      // Empty when every series has no data points at all.
+      // Empty when every series has no data points at all. A point at the
+      // origin is a legitimate coordinate, so only the absence of points counts.
       return series.every(
         (s) => !s || !Array.isArray(s.data) || s.data.length === 0
       )
@@ -30,15 +35,6 @@ export function isDataChartEmpty(props: F0DataChartProps): boolean {
       const series = props.series
       return !series || !Array.isArray(series.data) || series.data.length === 0
     }
-    case "radar": {
-      const series = props.series
-      if (!Array.isArray(series) || series.length === 0) {
-        return true
-      }
-      return series.every(
-        (s) => !s || !Array.isArray(s.data) || s.data.length === 0
-      )
-    }
     case "gauge": {
       // No value at all → empty. `0` is a legitimate gauge state.
       return props.value == null
@@ -46,17 +42,6 @@ export function isDataChartEmpty(props: F0DataChartProps): boolean {
     case "heatmap": {
       const data = props.data
       return !Array.isArray(data) || data.length === 0
-    }
-    case "scatter": {
-      const series = props.series
-      if (!Array.isArray(series) || series.length === 0) {
-        return true
-      }
-      // A point at the origin is a legitimate coordinate, so only the absence
-      // of points counts as empty.
-      return series.every(
-        (s) => !s || !Array.isArray(s.data) || s.data.length === 0
-      )
     }
     default:
       return true

--- a/packages/react/src/kits/F0DataChart/utils/useAxisLabelTooltip.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useAxisLabelTooltip.ts
@@ -88,13 +88,14 @@ export function useAxisLabelTooltip(
         return overlay
       }
       overlay = document.createElement("div")
+      const padding = theme.tooltip.padding.map((p) => `${p}px`).join(" ")
       overlay.style.cssText = [
         "position: absolute",
         "pointer-events: none",
         "z-index: 9999",
         "opacity: 0",
         "transition: opacity 0.15s",
-        `padding: ${theme.tooltip.padding.map((p) => `${p}px`).join(" ")}`,
+        `padding: ${padding}`,
         `border-radius: ${theme.tooltip.borderRadius}px`,
         `border: 1px solid ${theme.colors.borderSecondary}`,
         `box-shadow: ${theme.tooltip.boxShadow}`,

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ResizeHandle.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ResizeHandle.tsx
@@ -30,9 +30,9 @@ export const ResizeHandle = ({
     [setIsResizing]
   )
 
-  const handleDoubleClick = useCallback(async () => {
+  const handleDoubleClick = useCallback(() => {
     setIsResizing(true)
-    await onReset()
+    onReset()
     setIsResizing(false)
   }, [onReset, setIsResizing])
 

--- a/packages/react/src/kits/ai/F0AiChatHistory/useChatHistory.ts
+++ b/packages/react/src/kits/ai/F0AiChatHistory/useChatHistory.ts
@@ -23,7 +23,7 @@ type UseChatHistoryReturn = {
   threads: ChatThread[]
   isLoading: boolean
   error: string | null
-  refetch: () => void
+  refetch: () => Promise<void>
   pinnedIds: Set<string>
   /**
    * Ids of threads with an in-flight pin/unpin/delete request. Use it to show a

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/RecordingWaveform.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/RecordingWaveform.tsx
@@ -96,8 +96,8 @@ export const RecordingWaveform = ({
     const id = setInterval(() => {
       analyser.getByteTimeDomainData(data)
       let sum = 0
-      for (let i = 0; i < data.length; i++) {
-        const deviation = (data[i] - 128) / 128
+      for (const sample of data) {
+        const deviation = (sample - 128) / 128
         sum += deviation * deviation
       }
       const rms = Math.sqrt(sum / data.length)

--- a/packages/react/src/kits/ai/F0AiMask/F0AiMask.ts
+++ b/packages/react/src/kits/ai/F0AiMask/F0AiMask.ts
@@ -342,7 +342,7 @@ export class F0AiMask {
       )
 
       animation.onfinish = () => resolve()
-      animation.oncancel = () => reject("canceled")
+      animation.oncancel = () => reject(new Error("canceled"))
     })
   }
 
@@ -361,7 +361,7 @@ export class F0AiMask {
       )
 
       animation.onfinish = () => resolve()
-      animation.oncancel = () => reject("canceled")
+      animation.oncancel = () => reject(new Error("canceled"))
     })
   }
 

--- a/packages/react/src/kits/ai/F0AuraVoiceAnimation/components/ReactShaderToy.tsx
+++ b/packages/react/src/kits/ai/F0AuraVoiceAnimation/components/ReactShaderToy.tsx
@@ -68,12 +68,10 @@ const processUniform = <T extends UniformType>(
     }
   }
   if (typeof value === "number") {
-    switch (t) {
-      case "1i":
-        return gl.uniform1i(location, value)
-      default:
-        return gl.uniform1f(location, value)
+    if (t === "1i") {
+      return gl.uniform1i(location, value)
     }
+    return gl.uniform1f(location, value)
   }
   switch (t) {
     case "1iv":
@@ -565,9 +563,10 @@ export function ReactShaderToy({
     if (!channelResUniform) {
       return
     }
-    const channelResValue = Array.isArray(channelResUniform.value)
-      ? channelResUniform.value
-      : (channelResUniform.value = [])
+    if (!Array.isArray(channelResUniform.value)) {
+      channelResUniform.value = []
+    }
+    const channelResValue = channelResUniform.value
     channelResValue[id * 3] = width * devicePixelRatio
     channelResValue[id * 3 + 1] = height * devicePixelRatio
     channelResValue[id * 3 + 2] = 0
@@ -778,7 +777,7 @@ export function ReactShaderToy({
       return
     }
     if (textures && textures.length > 0) {
-      uniformsRef.current[`${UNIFORM_CHANNELRESOLUTION}`] = {
+      uniformsRef.current[UNIFORM_CHANNELRESOLUTION] = {
         type: "vec3",
         isNeeded: false,
         arraySize: `[${textures.length}]`,
@@ -806,8 +805,8 @@ export function ReactShaderToy({
             onDoneLoadingTextures()
           }
         })
-        .catch((e) => {
-          onError?.(e)
+        .catch((e: unknown) => {
+          onError?.(e instanceof Error ? e.message : String(e))
           if (onDoneLoadingTextures) {
             onDoneLoadingTextures()
           }
@@ -919,7 +918,8 @@ export function ReactShaderToy({
         shaderProgramRef.current,
         UNIFORM_TIME
       )
-      gl.uniform1f(timeUniform, (timerRef.current += delta))
+      timerRef.current += delta
+      gl.uniform1f(timeUniform, timerRef.current)
     }
     if (uniformsRef.current.iTimeDelta?.isNeeded) {
       const timeDeltaUniform = gl.getUniformLocation(

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
@@ -88,7 +88,7 @@ export const OptionsList = ({
       return
     }
 
-    let next = tabStopIndex
+    let next: number
     switch (e.key) {
       case "ArrowDown":
       case "ArrowRight":

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
@@ -1,4 +1,3 @@
-import flatten from "lodash/flatten"
 import React, {
   createContext,
   useCallback,
@@ -295,12 +294,10 @@ export function SurveyFormBuilderProvider({
     SurveyFormBuilderCallbacks["onDuplicateElement"]
   > = useCallback(
     ({ elementId }) => {
-      const flattenedElements = flatten(
-        elementsRef.current.map((element) =>
-          element.type === "section"
-            ? [element, ...(element.section.questions ?? [])]
-            : [element.question]
-        )
+      const flattenedElements = elementsRef.current.flatMap((element) =>
+        element.type === "section"
+          ? [element, ...(element.section.questions ?? [])]
+          : [element.question]
       )
 
       const element = flattenedElements.find((element) =>
@@ -336,12 +333,10 @@ export function SurveyFormBuilderProvider({
   )
 
   const getQuestionById = useCallback((questionId: string) => {
-    const questions = flatten(
-      elementsRef.current.map((element) =>
-        element.type === "question"
-          ? [element.question]
-          : element.section.questions
-      )
+    const questions = elementsRef.current.flatMap((element) =>
+      element.type === "question"
+        ? [element.question]
+        : (element.section.questions ?? [])
     )
     return questions.find((question) => question?.id === questionId)
   }, [])
@@ -417,7 +412,6 @@ export function SurveyFormBuilderProvider({
           type: "section",
         })
       }
-      return
     }
   }, [isEmpty, handleAddNewElement, disabled, answering, skipDefaultSection])
 

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
@@ -180,11 +180,8 @@ const _SurveyFormBuilder = ({
                   {(() => {
                     const nodes: ReactNode[] = []
 
-                    for (
-                      let index = 0;
-                      index < reorderableItems.length;
-                      index++
-                    ) {
+                    let index = 0
+                    while (index < reorderableItems.length) {
                       const item = reorderableItems[index]
 
                       // A locked section renders as one muted grey rounded
@@ -245,7 +242,7 @@ const _SurveyFormBuilder = ({
                           </div>
                         )
 
-                        index = next - 1
+                        index = next
                         continue
                       }
 
@@ -274,6 +271,7 @@ const _SurveyFormBuilder = ({
                           />
                         )
                       }
+                      index++
                     }
 
                     return nodes

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/lib.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/lib.ts
@@ -90,16 +90,13 @@ export const getDefaultParamsForQuestionType = (questionType: QuestionType) => {
       return {}
     case "text":
     case "longText":
+    case "link":
       return {
         value: "",
       }
     case "numeric":
       return {
         value: 0,
-      }
-    case "link":
-      return {
-        value: "",
       }
     case "date":
       return {

--- a/packages/react/src/lib/Await/Await.tsx
+++ b/packages/react/src/lib/Await/Await.tsx
@@ -34,9 +34,9 @@ const _Await = <T,>({
             setResolvedValue(value)
           }
         })
-        .catch((error) => {
+        .catch((error: unknown) => {
           if (!cancelled) {
-            setError(error)
+            setError(error instanceof Error ? error : new Error(String(error)))
           }
         })
         .finally(() => {

--- a/packages/react/src/lib/component/component.tsx
+++ b/packages/react/src/lib/component/component.tsx
@@ -14,6 +14,6 @@ export const Component = <
 
     return <Component ref={ref} {...props} />
   })
-  Forwarded.displayName = `${meta.name}`
+  Forwarded.displayName = meta.name
   return Forwarded
 }

--- a/packages/react/src/lib/data-testid/__tests__/withDataTestId.test.tsx
+++ b/packages/react/src/lib/data-testid/__tests__/withDataTestId.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react"
 import React, { forwardRef, memo } from "react"
-import { describe, expect, it } from "vitest"
+import { describe, expect, expectTypeOf, it } from "vitest"
 import { UserPlatformProvider } from "@/lib/providers/user-platafform/UserPlatformProvider"
 import { zeroRender } from "@/testing/test-utils"
 import { WithDataTestIdPropsOf, withDataTestId } from ".."
@@ -306,8 +306,7 @@ describe("withDataTestId", () => {
       //
       // NOTE: The assertion below verifies CheckedIsAny is false (checked is NOT any).
       // If this test fails with "unused @ts-expect-error", the fix is working!
-      const _checkedIsNotAny: CheckedIsAny = false
-      expect(_checkedIsNotAny).toBe(false)
+      expectTypeOf<CheckedIsAny>().toEqualTypeOf<false>()
     })
   })
 })

--- a/packages/react/src/lib/experimental.ts
+++ b/packages/react/src/lib/experimental.ts
@@ -48,9 +48,13 @@ export const experimentalComponent = <T extends React.ComponentType<any>>(
     Object.entries(reported).forEach(([key, value]) => {
       const newUses = value.uses - value.usesReported
       if (newUses > 0) {
+        const newUsesReport =
+          value.usesReported === -1
+            ? ""
+            : `New uses found since last report: ${newUses}`
         console.warn(
           `🚧 The \x1b[1m${key}\x1b[0m component is experimental. Use it at your own risk.`,
-          `Found ${value.uses} uses. ${value.usesReported === -1 ? "" : `New uses found since last report: ${newUses}`}`
+          `Found ${value.uses} uses. ${newUsesReport}`
         )
         reported[key] = {
           ...value,

--- a/packages/react/src/lib/localized.ts
+++ b/packages/react/src/lib/localized.ts
@@ -65,9 +65,7 @@ export function resolveLocalized<T>(
  * the union that drives a single shared language picker. Plain values
  * contribute no options (they aren't language-specific).
  */
-export function collectLanguages(
-  ...values: (Localized<unknown> | undefined)[]
-): LanguageOption[] {
+export function collectLanguages(...values: unknown[]): LanguageOption[] {
   const byLocale = new Map<string, LanguageOption>()
   for (const value of values) {
     if (!isLocalizedList(value)) {

--- a/packages/react/src/lib/numeric/__tests__/index.test.ts
+++ b/packages/react/src/lib/numeric/__tests__/index.test.ts
@@ -38,10 +38,10 @@ describe("index.ts exports", () => {
       formatterOptions: {},
     }
 
-    expect(value).toBeDefined()
-    expect(numeric).toBeDefined()
-    expect(options).toBeDefined()
-    expect(withFormatter).toBeDefined()
+    expect(value.value).toBe(123.45)
+    expect(numeric).toBe(value.value)
+    expect(options.decimalPlaces).toBe(2)
+    expect(withFormatter.numericValue.value).toBe(123.45)
   })
 
   it("should allow importing and using exported functions", () => {

--- a/packages/react/src/lib/numeric/__tests__/isEmptyNumeric.test.ts
+++ b/packages/react/src/lib/numeric/__tests__/isEmptyNumeric.test.ts
@@ -15,19 +15,16 @@ describe("isEmptyNumeric", () => {
     })
 
     it("should act as type predicate for null", () => {
-      const value: Numeric = null
-      if (isEmptyNumeric(value)) {
-        // TypeScript should narrow to null | undefined
-        expect(value).toBeNull()
-      }
+      const values: Numeric[] = [null, 1]
+      // The filter callback only compiles if the predicate narrows the type.
+      const empty: (null | undefined)[] = values.filter(isEmptyNumeric)
+      expect(empty).toEqual([null])
     })
 
     it("should act as type predicate for undefined", () => {
-      const value: Numeric = undefined
-      if (isEmptyNumeric(value)) {
-        // TypeScript should narrow to null | undefined
-        expect(value).toBeUndefined()
-      }
+      const values: Numeric[] = [undefined, 1]
+      const empty: (null | undefined)[] = values.filter(isEmptyNumeric)
+      expect(empty).toEqual([undefined])
     })
   })
 
@@ -242,22 +239,25 @@ describe("isEmptyNumeric", () => {
 
   describe("type predicate behavior", () => {
     it("should narrow type correctly in conditional", () => {
-      const value: Numeric = null
-      if (isEmptyNumeric(value)) {
-        // Type should be narrowed to null | undefined
-        const test: null | undefined = value
-        expect(test).toBeNull()
+      const values: Numeric[] = [null, undefined, 42, { value: 1 }]
+      const narrowed: (null | undefined)[] = []
+      for (const value of values) {
+        if (isEmptyNumeric(value)) {
+          narrowed.push(value)
+        }
       }
+      expect(narrowed).toEqual([null, undefined])
     })
 
     it("should allow non-empty check after isEmptyNumeric", () => {
-      const value: Numeric = 42
-      if (!isEmptyNumeric(value)) {
-        // Type should be narrowed to exclude null | undefined
-        expect(typeof value === "number" || typeof value === "object").toBe(
-          true
-        )
+      const values: Numeric[] = [null, undefined, 42, { value: 1 }]
+      const nonEmpty: (number | NumericValue)[] = []
+      for (const value of values) {
+        if (!isEmptyNumeric(value)) {
+          nonEmpty.push(value)
+        }
       }
+      expect(nonEmpty).toEqual([42, { value: 1 }])
     })
   })
 })

--- a/packages/react/src/lib/promise-to-observable.ts
+++ b/packages/react/src/lib/promise-to-observable.ts
@@ -49,10 +49,10 @@ export function promiseToObservable<T>(
         })
         observer.complete()
       })
-      .catch((error) => {
+      .catch((error: unknown) => {
         observer.next({
           loading: false,
-          error,
+          error: error instanceof Error ? error : new Error(String(error)),
           data: null,
         })
         observer.complete()

--- a/packages/react/src/lib/providers/events/event-catcher-provider.tsx
+++ b/packages/react/src/lib/providers/events/event-catcher-provider.tsx
@@ -50,5 +50,5 @@ export function F0EventCatcherProvider({
 export function useF0EventCatcher() {
   const context = useContext(EventCatcherContext)
 
-  return context ?? { onEvent: () => Promise.resolve(false) }
+  return context ?? { onEvent: () => undefined }
 }

--- a/packages/react/src/lib/storybook-utils/ai-mocks.ts
+++ b/packages/react/src/lib/storybook-utils/ai-mocks.ts
@@ -75,7 +75,7 @@ export const mockEnhanceText = (
     setTimeout(
       () => {
         resolve({
-          success: !(params.selectedIntent === "error"),
+          success: params.selectedIntent !== "error",
           error: "Error from AI",
           text: pickRandom(MOCK_ENHANCED_TEXTS),
         })

--- a/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
+++ b/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
@@ -1694,7 +1694,8 @@ function SurveyStoreProvider({ children }: { children: ReactNode }) {
 
   const createSurvey = useCallback<SurveyStoreValue["createSurvey"]>(
     (name, opts) => {
-      const surveyId = `survey-${(idRef.current += 1)}`
+      idRef.current += 1
+      const surveyId = `survey-${idRef.current}`
       setSurveys((prev) => ({
         ...prev,
         [surveyId]: {
@@ -1783,10 +1784,10 @@ function SurveyStoreProvider({ children }: { children: ReactNode }) {
     []
   )
 
-  const nextCardId = useCallback<SurveyStoreValue["nextCardId"]>(
-    () => `card-${(idRef.current += 1)}`,
-    []
-  )
+  const nextCardId = useCallback<SurveyStoreValue["nextCardId"]>(() => {
+    idRef.current += 1
+    return `card-${idRef.current}`
+  }, [])
 
   const registerLiveCard = useCallback<SurveyStoreValue["registerLiveCard"]>(
     (surveyId, cardId) => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/AskOne.stories.tsx
@@ -65,7 +65,12 @@ const TargetObserverLayout = ({
           items={items}
           onAskAiTarget={({ id, point, quote }) => {
             setObservedTarget(
-              `${id}: ${point ? `point=${point.category}/${point.value}` : "widget"}; quote=${quote.text}`
+              (() => {
+                const target = point
+                  ? `point=${point.category}/${point.value}`
+                  : "widget"
+                return `${id}: ${target}; quote=${quote.text}`
+              })()
             )
           }}
         />
@@ -155,12 +160,13 @@ export const WidgetQuotedInChat: Story = {
   render: () => <AskOneLayout />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
-    let menu: ReturnType<typeof within> | undefined
+    const opened: Partial<Awaited<ReturnType<typeof openAskOneMenu>>> = {}
 
     await step("Open the widget actions menu", async () => {
-      menu = (await openAskOneMenu(canvasElement)).menu
+      opened.menu = (await openAskOneMenu(canvasElement)).menu
     })
 
+    const menu = opened.menu
     if (!menu) {
       throw new Error("The widget actions menu did not open")
     }
@@ -198,12 +204,13 @@ export const TargetObserver: Story = {
   render: () => <TargetObserverLayout />,
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement)
-    let menu: ReturnType<typeof within> | undefined
+    const opened: Partial<Awaited<ReturnType<typeof openAskOneMenu>>> = {}
 
     await step("Open the widget actions menu", async () => {
-      menu = (await openAskOneMenu(canvasElement)).menu
+      opened.menu = (await openAskOneMenu(canvasElement)).menu
     })
 
+    const menu = opened.menu
     if (!menu) {
       throw new Error("The widget actions menu did not open")
     }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -433,11 +433,6 @@ export function hasAccessibleChartPoint(
         )
       )
     case "funnel":
-      return chart.series.data.some(
-        (entry) =>
-          selected[entry.name] !== false &&
-          numericPointValue(entry.value) !== null
-      )
     case "pie":
       return chart.series.data.some(
         (entry) =>
@@ -613,11 +608,6 @@ export function buildChartProps(
         series: adapted.series,
       } as F0DataChartProps
     case "funnel":
-      return {
-        ...config,
-        ...shared,
-        series: adapted.series,
-      } as F0DataChartProps
     case "pie":
       return {
         ...config,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
@@ -67,7 +67,7 @@ interface UseCollectionDownloadActionsOptions {
 }
 
 async function resolvePromiseLike<T>(value: T | Promise<T>): Promise<T> {
-  return value instanceof Promise ? value : value
+  return value
 }
 
 /**

--- a/packages/react/src/patterns/F0Dialog/types.ts
+++ b/packages/react/src/patterns/F0Dialog/types.ts
@@ -16,7 +16,7 @@ export type F0DialogPrimaryAction = {
   label: string
   icon?: IconType
   iconPosition?: "left" | "right"
-  onClick: () => void
+  onClick: () => void | Promise<void>
   disabled?: boolean
   loading?: boolean
 }
@@ -25,7 +25,7 @@ export type F0DialogSecondaryAction = {
   label: string
   icon?: IconType
   iconPosition?: "left" | "right"
-  onClick: () => void
+  onClick: () => void | Promise<void>
   disabled?: boolean
   loading?: boolean
 }
@@ -66,5 +66,5 @@ export type DialogControls =
   | {
       kind: "back"
       label: string
-      onClick: () => void
+      onClick: () => void | Promise<void>
     }

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -22,6 +22,8 @@ import type {
 } from "../fields/types"
 import type { RenderCustomFieldSelectConfig } from "../types"
 
+const DISABLED_STORY_SAMPLE_VALUE = "sample-value"
+
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 const meta: Meta = {
@@ -1408,7 +1410,7 @@ export const AllFieldTypesDisabled: Story = {
       defaultValues: {
         textField: "Sample text value",
         emailField: "user@example.com",
-        passwordField: "secretpassword",
+        passwordField: DISABLED_STORY_SAMPLE_VALUE,
         numberField: 42,
         durationField: 3661,
         textareaField:

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.perf.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.perf.test.tsx
@@ -127,7 +127,7 @@ describe("Fix 2 — renderNode stabilization", () => {
     )
 
     // No crash — stable ref pattern handles the update
-    expect(true).toBe(true)
+    expect(screen.getByRole("tree", { name: "Graph view" })).toBeInTheDocument()
   })
 })
 

--- a/packages/react/src/patterns/F0Graph/components/F0GraphEdge/F0GraphEdge.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphEdge/F0GraphEdge.tsx
@@ -3,6 +3,7 @@ import {
   getBezierPath,
   getSmoothStepPath,
   getStraightPath,
+  Position,
   type EdgeProps,
 } from "@xyflow/react"
 import { memo } from "react"
@@ -66,7 +67,8 @@ export function F0GraphEdgeBase({
   // When source and target are nearly aligned on the cross-axis,
   // use a straight line to avoid smoothstep introducing a tiny jog ("wiggle")
   const isVertical =
-    edgeProps.sourcePosition === "bottom" || edgeProps.sourcePosition === "top"
+    edgeProps.sourcePosition === Position.Bottom ||
+    edgeProps.sourcePosition === Position.Top
   const crossAxisDelta = isVertical
     ? Math.abs(edgeProps.sourceX - edgeProps.targetX)
     : Math.abs(edgeProps.sourceY - edgeProps.targetY)

--- a/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
+++ b/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
@@ -47,7 +47,8 @@ const mock = vi.hoisted(() => {
     ) {
       const cb = typeof a === "function" ? a : b
       if (cb) {
-        ;(this.handlers[type] ??= []).push(cb)
+        this.handlers[type] ??= []
+        this.handlers[type].push(cb)
       }
       return this
     }
@@ -123,7 +124,8 @@ const mock = vi.hoisted(() => {
       return this.sources[id]
     }
     removeSource(id: string) {
-      delete this.sources[id]
+      const { [id]: _removed, ...rest } = this.sources
+      this.sources = rest
     }
     addLayer(spec: { id: string }) {
       this.layers.add(spec.id)
@@ -156,7 +158,12 @@ const mock = vi.hoisted(() => {
       return this
     }
   }
-  class MockAttributionControl {}
+  class MockAttributionControl {
+    opts: Record<string, unknown> | undefined
+    constructor(opts?: Record<string, unknown>) {
+      this.opts = opts
+    }
+  }
 
   return {
     instances,

--- a/packages/react/src/patterns/F0Map/styles/buildStyles.mjs
+++ b/packages/react/src/patterns/F0Map/styles/buildStyles.mjs
@@ -214,8 +214,8 @@ const flavor = (theme) => {
     boundary: neutral(theme, 30),
     water: tint(theme, L ? "malibu.50" : "malibu.60", L ? 0.45 : 0.5, land),
     // Greens a gentle step deeper than the green land, so parks/woods still read.
-    park: tint(theme, L ? "flubber.60" : "flubber.60", 0.42, land),
-    wood: tint(theme, L ? "flubber.70" : "flubber.70", 0.55, land),
+    park: tint(theme, "flubber.60", 0.42, land),
+    wood: tint(theme, "flubber.70", 0.55, land),
     // Urban land use (and the zoomed-in base land) is a warm tan - Google
     // Maps' land colour - clearly warmer than a plain neutral and distinct from
     // the green countryside. yellow.60 is deep enough to read as a tan rather
@@ -625,11 +625,9 @@ const recolor = (style, theme) => {
   // raster with no layers pointing at it (we don't want shaded relief); left in,
   // its tile fetches fail and keep `map.isStyleLoaded()` from ever resolving.
   const usedSources = new Set(out.layers.map((l) => l.source).filter(Boolean))
-  for (const name of Object.keys(out.sources)) {
-    if (!usedSources.has(name)) {
-      delete out.sources[name]
-    }
-  }
+  out.sources = Object.fromEntries(
+    Object.entries(out.sources).filter(([name]) => usedSources.has(name))
+  )
 
   return out
 }

--- a/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
+++ b/packages/react/src/patterns/F0WizardForm/useF0FormDefinition.ts
@@ -211,7 +211,7 @@ export function useAsyncDefaultValues<T>(
           setIsLoading(false)
         }
       })
-      .catch((err) => {
+      .catch((err: unknown) => {
         if (!controller.signal.aborted) {
           console.warn(
             "[useAsyncDefaultValues] Async defaultValues rejected:",

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/__tests__/SidebarChatList.test.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/__tests__/SidebarChatList.test.tsx
@@ -553,7 +553,7 @@ type MockIntersection = {
 }
 
 class MockIntersectionObserver implements IntersectionObserver {
-  static instances: MockIntersectionObserver[] = []
+  static readonly instances: MockIntersectionObserver[] = []
 
   readonly root: Element | Document | null
   readonly rootMargin = "0px"
@@ -687,7 +687,7 @@ describe("SidebarChatList unread navigation", () => {
   )
 
   beforeEach(() => {
-    MockIntersectionObserver.instances = []
+    MockIntersectionObserver.instances.length = 0
     Object.defineProperty(globalThis, "IntersectionObserver", {
       configurable: true,
       value: MockIntersectionObserver,

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -409,14 +409,10 @@ const OneDataCollectionComp = <
   // only trims, never grows. List rows are a fixed height (no reflow); the
   // table and editable table depend on their content, so they seed at the
   // baseline and rely on the measurement to trim.
-  const autoPerPageRowHeight = (() => {
-    switch (visualizations[currentVisualization]?.type) {
-      case "list":
-        return ESTIMATED_LIST_ROW_HEIGHT
-      default:
-        return ESTIMATED_ROW_HEIGHT
-    }
-  })()
+  const autoPerPageRowHeight =
+    visualizations[currentVisualization]?.type === "list"
+      ? ESTIMATED_LIST_ROW_HEIGHT
+      : ESTIMATED_ROW_HEIGHT
   const autoPerPage = useAutoPerPage(vizContainerRef, autoPerPageEnabled, {
     rowHeight: autoPerPageRowHeight,
     ready: firstDataLoaded,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
@@ -631,7 +631,7 @@ const PersistenceHarness = () => {
           <span>
             <strong>Visualization filter keys:</strong>{" "}
             {vizFilterKeys.length > 0
-              ? `[${vizFilterKeys.map((k) => `"${k}"`).join(", ")}]`
+              ? `[${vizFilterKeys.map((k) => JSON.stringify(k)).join(", ")}]`
               : "(none)"}{" "}
             — {statusBadge.label}
           </span>

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -1978,7 +1978,7 @@ export function createDataAdapter<
                 ) as PaginatedResponse<TRecord>
               )
             } catch (error) {
-              reject(error)
+              reject(error instanceof Error ? error : new Error(String(error)))
             }
           }, delay)
         })
@@ -2047,12 +2047,7 @@ export function createDataAdapter<
               ) as InfiniteScrollPaginatedResponse<TRecord>
               resolve(result)
             } catch (error) {
-              reject({
-                loading: false,
-                error:
-                  error instanceof Error ? error : new Error(String(error)),
-                data: null,
-              })
+              reject(error instanceof Error ? error : new Error(String(error)))
             }
           }, delay)
         })
@@ -2119,7 +2114,7 @@ export function createDataAdapter<
               summaries: summaries as TRecord,
             })
           } catch (error) {
-            reject(error)
+            reject(error instanceof Error ? error : new Error(String(error)))
           }
         }, delay)
       })

--- a/packages/react/src/patterns/OneDataCollection/__tests__/defaultExpandedFilterReset.integration.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/defaultExpandedFilterReset.integration.test.tsx
@@ -49,8 +49,8 @@ const columns = [
 const prunedChildren: { current: Record<string, Team[]> } = {
   current: { sales: SUBTEAMS },
 }
-const notify: Record<string, () => void> = {}
-const refreshChildren = (parentId: string) => notify[parentId]?.()
+const notify = new Map<string, () => void>()
+const refreshChildren = (parentId: string) => notify.get(parentId)?.()
 const getChildren = (item: Team) => prunedChildren.current[item.id] ?? []
 
 const fetchChildren = ({ item }: { item: Team }) =>
@@ -62,9 +62,9 @@ const fetchChildren = ({ item }: { item: Team }) =>
         data: { records: getChildren(item), type: "basic" as const },
       })
     emit()
-    notify[item.id] = emit
+    notify.set(item.id, emit)
     return () => {
-      delete notify[item.id]
+      notify.delete(item.id)
     }
   })
 

--- a/packages/react/src/patterns/OneDataCollection/__tests__/useExportAction.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/useExportAction.test.tsx
@@ -81,11 +81,11 @@ beforeEach(() => {
   vi.stubGlobal(
     "URL",
     class extends URL {
-      static override createObjectURL = (blob: Blob) => {
+      static override readonly createObjectURL = (blob: Blob) => {
         blobCapture = blob
         return "blob:mock"
       }
-      static override revokeObjectURL = vi.fn()
+      static override readonly revokeObjectURL = vi.fn()
     }
   )
 

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/types.ts
@@ -59,7 +59,7 @@ export type DataCollectionStorageFeaturesDefinition = (
   | "*"
   | `all`
   | `!${DataCollectionStorageFeature}`
-  | `${DataCollectionStorageFeature}`
+  | DataCollectionStorageFeature
 )[]
 
 /**

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/validateStorageKey.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/validateStorageKey.ts
@@ -41,7 +41,7 @@ export const validateStorageKey = (key: string): boolean => {
   }
 
   // Version must match 'v' followed by one or more digits (e.g., v1, v2, v123 v.1.2)
-  if (!version || !/^v[0-9]+$/.test(version)) {
+  if (!version || !/^v\d+$/.test(version)) {
     return false
   }
 

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/useDataCollectionItemNavigation.ts
@@ -233,7 +233,7 @@ export function useDataCollectionItemNavigation<
     if (!enabled || !restorePersistedState) {
       return
     }
-    return subscribeToDataCollectionStorageChanges(collectionId, async () => {
+    const reseedFromStorage = async () => {
       try {
         // NOTE: must await (not .then) — the default noop handler returns a
         // plain object typed as a Promise.
@@ -260,6 +260,9 @@ export function useDataCollectionItemNavigation<
       } catch {
         // Unreadable persisted state — keep the current state.
       }
+    }
+    return subscribeToDataCollectionStorageChanges(collectionId, () => {
+      void reseedFromStorage()
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [collectionId, enabled, restorePersistedState])

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/context/EditableRowContext.tsx
@@ -102,13 +102,15 @@ export function EditableRowProvider<R extends RecordType>({
 
   const setErrors = (columnIds: string[], message?: string) => {
     setCellErrors((prev) => {
+      if (message === undefined) {
+        const cleared = new Set(columnIds)
+        return Object.fromEntries(
+          Object.entries(prev).filter(([id]) => !cleared.has(id))
+        )
+      }
       const next = { ...prev }
       for (const id of columnIds) {
-        if (message === undefined) {
-          delete next[id]
-        } else {
-          next[id] = message
-        }
+        next[id] = message
       }
       return next
     })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
@@ -106,10 +106,10 @@ const resolveFetchResult = <R>(result: unknown): Promise<R[]> => {
             subscription.unsubscribe()
           }
         },
-        error: (err) => {
+        error: (err: unknown) => {
           if (!settled) {
             settled = true
-            reject(err)
+            reject(err instanceof Error ? err : new Error(String(err)))
           }
         },
         complete: () => {
@@ -206,8 +206,9 @@ const collectSubtreeIds = <R extends RecordType>(
       frontier.push(id)
     }
   }
-  for (let cursor = 0; cursor < frontier.length; cursor++) {
-    for (const childId of childrenByParent.get(frontier[cursor]) ?? []) {
+  // The array iterator sees ids pushed during the loop, so this is a BFS.
+  for (const parentId of frontier) {
+    for (const childId of childrenByParent.get(parentId) ?? []) {
       if (collected.has(childId)) {
         continue
       }
@@ -641,7 +642,7 @@ export function useDataCollectionTreeData<
           )
           setNodes((prev) => mergeHydratedData(prev, hydrated))
         })
-        .catch((cause) => {
+        .catch((cause: unknown) => {
           const dataError = toDataError(cause)
           setError(dataError)
           callbacksRef.current.onLoadError(dataError)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
@@ -206,7 +206,8 @@ const collectSubtreeIds = <R extends RecordType>(
       frontier.push(id)
     }
   }
-  // The array iterator sees ids pushed during the loop, so this is a BFS.
+  // Children are pushed to `frontier` while it is iterated, so the walk visits
+  // the tree level by level.
   for (const parentId of frontier) {
     for (const childId of childrenByParent.get(parentId) ?? []) {
       if (collected.has(childId)) {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -143,7 +143,9 @@ const NestedRowContent = <
   const sentinelRef = useRef<HTMLTableCellElement | null>(null)
   const addRow = useAddRow()
 
-  const rowId = `${props.nestedRowProps?.depth ?? 0}-${"id" in props.item ? props.item.id + "-" + props.index : props.index}`
+  const itemKey =
+    "id" in props.item ? `${String(props.item.id)}-${props.index}` : props.index
+  const rowId = `${props.nestedRowProps?.depth ?? 0}-${itemKey}`
 
   const {
     expandedRowIds,

--- a/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
@@ -153,17 +153,19 @@ const FiltersRoot = <Definition extends FiltersDefinition>({
     stateMode === "controlled" ? value : localFiltersValue
 
   const removeFilterValue = (key: keyof Definition) => {
-    const newFilters = { ...currentFiltersValue }
-    delete newFilters[key]
-
     // Also clear nested child filter keys to avoid orphaned values
     const filterDef = filters?.[key]
+    const removedKeys = new Set<string>([String(key)])
     if (filterDef?.type === "in" && filterDef.options) {
-      const nestedKeys = collectNestedFilterKeys(filterDef.options)
-      nestedKeys.forEach((nestedKey) => {
-        delete newFilters[nestedKey as keyof Definition]
-      })
+      for (const nestedKey of collectNestedFilterKeys(filterDef.options)) {
+        removedKeys.add(String(nestedKey))
+      }
     }
+    const newFilters = Object.fromEntries(
+      Object.entries(currentFiltersValue).filter(
+        ([filterKey]) => !removedKeys.has(filterKey)
+      )
+    )
 
     if (stateMode === "optimistic") {
       setLocalFiltersValue(newFilters as FiltersState<Definition>)

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/index.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/index.tsx
@@ -42,7 +42,7 @@ export const inFilter: FilterTypeDefinition<
 
       return hasMultipleSelections
         ? `${firstSelectedLabel} +${remainingCount}`
-        : `${firstSelectedLabel}`
+        : firstSelectedLabel
     }
 
     // If getLabel is provided, use it to resolve labels without fetching all options
@@ -109,7 +109,7 @@ export const inFilter: FilterTypeDefinition<
 
     return hasMultipleSelections
       ? `${firstSelectedLabel} +${remainingCount}`
-      : `${firstSelectedLabel}`
+      : firstSelectedLabel
   },
 }
 

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.stories.tsx
@@ -140,7 +140,7 @@ export const WithVideo: Story = {
     ...Default.args,
     event: undefined,
     mediaUrl:
-      "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+      "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
     noVideoPreload: true,
   },
 }
@@ -153,7 +153,7 @@ export const WithEventAndVideo: Story = {
       title: "Sevilla Tour",
       place: "Sevilla",
       mediaUrl:
-        "http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+        "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
       date: eventDate,
     },
     noVideoPreload: true,

--- a/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.spec.tsx
@@ -944,7 +944,7 @@ describe("NewHomeLayout", () => {
     // test below sees a strip that fits.
     afterEach(() => {
       for (const prop of METRICS) {
-        delete HTMLElement.prototype[prop]
+        Reflect.deleteProperty(HTMLElement.prototype, prop)
       }
     })
 

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -84,7 +84,7 @@ const INTERACTIVE = [
 ].join(",")
 
 class WidgetDragSensor extends PointerSensor {
-  static activators = [
+  static readonly activators = [
     {
       eventName: "onPointerDown" as const,
       handler: (

--- a/packages/react/src/sds/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductModal/index.tsx
@@ -53,7 +53,7 @@ type ProductModalProps = {
 
 type Action = {
   label: string
-  onClick: () => void
+  onClick: () => void | Promise<void>
   icon?: IconType
   variant?: ButtonVariant
   size?: "md" | "lg"

--- a/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.tsx
@@ -43,9 +43,7 @@ const _UpsellingBanner = forwardRef<HTMLDivElement, UpsellingBannerProps>(
         return (
           <UpsellingButton
             label={action.label}
-            onRequest={async () => {
-              await action.onClick()
-            }}
+            onRequest={action.onClick}
             errorMessage={action.errorMessage}
             successMessage={action.successMessage}
             loadingState={action.loadingState}

--- a/packages/react/src/sds/inbox/Activity/ActivityItemList/index.stories.tsx
+++ b/packages/react/src/sds/inbox/Activity/ActivityItemList/index.stories.tsx
@@ -43,7 +43,7 @@ const ITEMS = new Array(10).fill(null).map((_, index) => ({
   title: `Activity Item ${index + 1}`,
   description:
     "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.".replace(
-      /[\s]/g,
+      /\s/g,
       ""
     ),
   category: (() => {

--- a/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
+++ b/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
@@ -162,13 +162,7 @@ export const ProjectStatuses: Story = {
               return lane?.items.findIndex((item) => item.id === id) ?? -1
             },
             onMove: async (fromLaneId, toLaneId, source, destiny) => {
-              await console.log(
-                "DND onMove",
-                fromLaneId,
-                toLaneId,
-                source,
-                destiny
-              )
+              console.log("DND onMove", fromLaneId, toLaneId, source, destiny)
               // Simulate optimistic lock conflict when moving to 'review'
               if (toLaneId === "review") {
                 await new Promise((r) => setTimeout(r, 50))

--- a/packages/react/src/ui/Kanban/components/KanbanLane.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanLane.tsx
@@ -296,194 +296,185 @@ export function KanbanLane<TRecord extends RecordType>({
           }
         }
       },
-      onDrop: async ({ location, source }) => {
-        setIsOver(false)
-        setShowEmptyLanePlaceholder(false)
-        const sourceId = String((source.data as { id?: string }).id)
-        const sourceItem = source.data.data as TRecord
+      onDrop: ({ location, source }) => {
+        void (async () => {
+          setIsOver(false)
+          setShowEmptyLanePlaceholder(false)
+          const sourceId = String((source.data as { id?: string }).id)
+          const sourceItem = source.data.data as TRecord
 
-        // Find source index using getKey for consistency
-        const resourceIndexOnLane = laneProps.items.findIndex((item, idx) => {
-          const itemKey = String(laneProps.getKey(item, idx))
-          return itemKey === sourceId
-        })
-
-        const sourceLaneIdFromPayload = String(
-          (source.data as unknown as { data?: { laneId?: string } }).data
-            ?.laneId ?? ""
-        )
-        const initialLaneId =
-          sourceLaneIdFromPayload ||
-          String(
-            (
-              location.initial.dropTargets.find(
-                (t) => (t.data as { type?: string }).type === "list-droppable"
-              )?.data as { id?: string }
-            )?.id ?? ""
-          )
-
-        const isCrossLane = String(initialLaneId) !== String(id)
-
-        // Early check: prevent useless drops in same lane
-        if (!isCrossLane && resourceIndexOnLane >= 0) {
-          // Check if dropping on card target
-          const cardTarget = location.current.dropTargets.find((t) => {
-            const data = t.data as { type?: string }
-            return data.type === "list-card-target"
+          // Find source index using getKey for consistency
+          const resourceIndexOnLane = laneProps.items.findIndex((item, idx) => {
+            const itemKey = String(laneProps.getKey(item, idx))
+            return itemKey === sourceId
           })
 
-          if (cardTarget) {
-            const targetIndex = (cardTarget.data as { index?: number }).index
-            // Extract edge info from cardTarget
-            const edge = (cardTarget.data as { closestEdge?: string })
-              .closestEdge as "top" | "bottom" | undefined
+          const sourceLaneIdFromPayload = String(
+            (source.data as unknown as { data?: { laneId?: string } }).data
+              ?.laneId ?? ""
+          )
+          const initialLaneId =
+            sourceLaneIdFromPayload ||
+            String(
+              (
+                location.initial.dropTargets.find(
+                  (t) => (t.data as { type?: string }).type === "list-droppable"
+                )?.data as { id?: string }
+              )?.id ?? ""
+            )
 
-            if (targetIndex !== undefined && edge) {
-              // Check if this would be a useless drop based on target card and edge
-              let wouldBeUselessDrop = false
+          const isCrossLane = String(initialLaneId) !== String(id)
 
-              if (targetIndex === resourceIndexOnLane) {
-                // Dropping on same card - always useless
-                wouldBeUselessDrop = true
-              } else if (
-                targetIndex === resourceIndexOnLane - 1 &&
-                edge === "bottom"
-              ) {
-                // Dropping below card above = stays in same position
-                wouldBeUselessDrop = true
-              } else if (
-                targetIndex === resourceIndexOnLane + 1 &&
-                edge === "top"
-              ) {
-                // Dropping above card below = stays in same position
-                wouldBeUselessDrop = true
-              }
+          // Early check: prevent useless drops in same lane
+          if (!isCrossLane && resourceIndexOnLane >= 0) {
+            // Check if dropping on card target
+            const cardTarget = location.current.dropTargets.find((t) => {
+              const data = t.data as { type?: string }
+              return data.type === "list-card-target"
+            })
 
-              if (wouldBeUselessDrop) {
-                return
+            if (cardTarget) {
+              const targetIndex = (cardTarget.data as { index?: number }).index
+              // Extract edge info from cardTarget
+              const edge = (cardTarget.data as { closestEdge?: string })
+                .closestEdge as "top" | "bottom" | undefined
+
+              if (targetIndex !== undefined && edge) {
+                // Useless when dropping on the same card, below the card above,
+                // or above the card below: the item stays where it is.
+                const wouldBeUselessDrop =
+                  targetIndex === resourceIndexOnLane ||
+                  (targetIndex === resourceIndexOnLane - 1 &&
+                    edge === "bottom") ||
+                  (targetIndex === resourceIndexOnLane + 1 && edge === "top")
+
+                if (wouldBeUselessDrop) {
+                  return
+                }
               }
             }
           }
-        }
 
-        // Check if this would be a useless drop in same lane
-        if (!isCrossLane && forcedIndex !== null && forcedEdge !== null) {
-          const wouldBeUselessDrop =
-            (forcedIndex === resourceIndexOnLane && forcedEdge === "top") ||
-            (forcedIndex === resourceIndexOnLane && forcedEdge === "bottom") ||
-            (forcedIndex === resourceIndexOnLane - 1 &&
-              forcedEdge === "bottom") ||
-            (forcedIndex === resourceIndexOnLane + 1 && forcedEdge === "top")
+          // Check if this would be a useless drop in same lane
+          if (!isCrossLane && forcedIndex !== null && forcedEdge !== null) {
+            const wouldBeUselessDrop =
+              (forcedIndex === resourceIndexOnLane && forcedEdge === "top") ||
+              (forcedIndex === resourceIndexOnLane &&
+                forcedEdge === "bottom") ||
+              (forcedIndex === resourceIndexOnLane - 1 &&
+                forcedEdge === "bottom") ||
+              (forcedIndex === resourceIndexOnLane + 1 && forcedEdge === "top")
 
-          if (wouldBeUselessDrop) {
-            setForcedIndex(null)
-            setForcedEdge(null)
+            if (wouldBeUselessDrop) {
+              setForcedIndex(null)
+              setForcedEdge(null)
+              return
+            }
+          }
+
+          // Only the lane actually under the pointer should handle the drop
+          const overThisLane = location.current.dropTargets.some((t) => {
+            const data = t.data as { type?: string; id?: string }
+            return data.type === "list-droppable" && data.id === id
+          })
+          if (!overThisLane) {
             return
           }
-        }
 
-        // Only the lane actually under the pointer should handle the drop
-        const overThisLane = location.current.dropTargets.some((t) => {
-          const data = t.data as { type?: string; id?: string }
-          return data.type === "list-droppable" && data.id === id
-        })
-        if (!overThisLane) {
-          return
-        }
+          let onMoveParams: KanbanOnMoveParam | null = null
+          const { type: typeOfDrop, cardTarget } = findTypeOfDrop(
+            location.current.dropTargets
+          )
 
-        let onMoveParams: KanbanOnMoveParam | null = null
-        const { type: typeOfDrop, cardTarget } = findTypeOfDrop(
-          location.current.dropTargets
-        )
-
-        // Only compute params; do not mutate items locally. Parent will update lanes.
-        if (!isCrossLane) {
-          // Same-lane reorder
-          if (
-            typeOfDrop === "sameLaneOverCard" &&
-            cardTarget &&
-            cardTarget.data
-          ) {
-            onMoveParams = optimisticSameLaneOverCard<TRecord>({
-              resourceIndexOnLane,
-              cardTarget,
-              sourceItem,
-              fromLaneId: initialLaneId,
-              toLaneId: id as string,
-              sourceId,
-              setItems: () => {},
-            })
-          } else if (forcedIndex !== null && forcedEdge) {
-            onMoveParams = {
-              fromLaneId: initialLaneId,
-              toLaneId: id as string,
-              sourceId,
-              indexOfTarget: forcedIndex,
-              position: forcedEdge === "bottom" ? "below" : "above",
+          // Only compute params; do not mutate items locally. Parent will update lanes.
+          if (!isCrossLane) {
+            // Same-lane reorder
+            if (
+              typeOfDrop === "sameLaneOverCard" &&
+              cardTarget &&
+              cardTarget.data
+            ) {
+              onMoveParams = optimisticSameLaneOverCard<TRecord>({
+                resourceIndexOnLane,
+                cardTarget,
+                sourceItem,
+                fromLaneId: initialLaneId,
+                toLaneId: id as string,
+                sourceId,
+                setItems: () => {},
+              })
+            } else if (forcedIndex !== null && forcedEdge) {
+              onMoveParams = {
+                fromLaneId: initialLaneId,
+                toLaneId: id as string,
+                sourceId,
+                indexOfTarget: forcedIndex,
+                position: forcedEdge === "bottom" ? "below" : "above",
+              }
+            } else {
+              onMoveParams = optimisticSameLaneOverEmpty<TRecord>({
+                resourceIndexOnLane,
+                sourceItem,
+                fromLaneId: initialLaneId,
+                toLaneId: id as string,
+                sourceId,
+                setItems: () => {},
+              })
             }
           } else {
-            onMoveParams = optimisticSameLaneOverEmpty<TRecord>({
-              resourceIndexOnLane,
-              sourceItem,
-              fromLaneId: initialLaneId,
-              toLaneId: id as string,
-              sourceId,
-              setItems: () => {},
-            })
-          }
-        } else {
-          // Cross-lane destination insert. Ignore typeOfDrop label; rely on cardTarget presence
-          if (cardTarget && cardTarget.data) {
-            onMoveParams = optimisticDifferentLaneInsertOverCard<TRecord>({
-              cardTarget,
-              sourceItem,
-              fromLaneId: initialLaneId,
-              toLaneId: id as string,
-              sourceId,
-              setItems: () => {},
-            })
-          } else if (forcedIndex !== null && forcedEdge) {
-            onMoveParams = {
-              fromLaneId: initialLaneId,
-              toLaneId: id as string,
-              sourceId,
-              indexOfTarget: forcedIndex,
-              position: forcedEdge === "bottom" ? "below" : "above",
+            // Cross-lane destination insert. Ignore typeOfDrop label; rely on cardTarget presence
+            if (cardTarget && cardTarget.data) {
+              onMoveParams = optimisticDifferentLaneInsertOverCard<TRecord>({
+                cardTarget,
+                sourceItem,
+                fromLaneId: initialLaneId,
+                toLaneId: id as string,
+                sourceId,
+                setItems: () => {},
+              })
+            } else if (forcedIndex !== null && forcedEdge) {
+              onMoveParams = {
+                fromLaneId: initialLaneId,
+                toLaneId: id as string,
+                sourceId,
+                indexOfTarget: forcedIndex,
+                position: forcedEdge === "bottom" ? "below" : "above",
+              }
+            } else {
+              onMoveParams = optimisticDifferentLaneInsertOverEmpty<TRecord>({
+                sourceItem,
+                fromLaneId: initialLaneId,
+                toLaneId: id as string,
+                sourceId,
+                setItems: () => {},
+              })
             }
-          } else {
-            onMoveParams = optimisticDifferentLaneInsertOverEmpty<TRecord>({
-              sourceItem,
-              fromLaneId: initialLaneId,
-              toLaneId: id as string,
-              sourceId,
-              setItems: () => {},
-            })
           }
-        }
 
-        if (!onMoveParams) {
-          return
-        }
-
-        // Additional check: prevent useless drops in same lane with final computed params
-        if (!isCrossLane && onMoveParams.indexOfTarget !== undefined) {
-          const targetIdx = onMoveParams.indexOfTarget
-          const position = onMoveParams.position
-          const wouldBeUselessDrop =
-            (targetIdx === resourceIndexOnLane && position === "above") ||
-            (targetIdx === resourceIndexOnLane && position === "below") ||
-            (targetIdx === resourceIndexOnLane - 1 && position === "below") ||
-            (targetIdx === resourceIndexOnLane + 1 && position === "above")
-
-          if (wouldBeUselessDrop) {
+          if (!onMoveParams) {
             return
           }
-        }
 
-        // Single upward call. Parent/Story updates state; coordinator not needed here.
-        await onMove?.(onMoveParams)
-        setForcedIndex(null)
-        setForcedEdge(null)
+          // Additional check: prevent useless drops in same lane with final computed params
+          if (!isCrossLane && onMoveParams.indexOfTarget !== undefined) {
+            const targetIdx = onMoveParams.indexOfTarget
+            const position = onMoveParams.position
+            const wouldBeUselessDrop =
+              (targetIdx === resourceIndexOnLane && position === "above") ||
+              (targetIdx === resourceIndexOnLane && position === "below") ||
+              (targetIdx === resourceIndexOnLane - 1 && position === "below") ||
+              (targetIdx === resourceIndexOnLane + 1 && position === "above")
+
+            if (wouldBeUselessDrop) {
+              return
+            }
+          }
+
+          // Single upward call. Parent/Story updates state; coordinator not needed here.
+          await onMove?.(onMoveParams)
+          setForcedIndex(null)
+          setForcedEdge(null)
+        })()
       },
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -704,7 +695,7 @@ export function KanbanLane<TRecord extends RecordType>({
           ref={overlayRef}
           className={cn(
             "pointer-events-none absolute inset-0 z-[1]",
-            isDragging ? "bg-transparent" : "bg-transparent"
+            "bg-transparent"
           )}
           aria-hidden
         />

--- a/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
+++ b/packages/react/src/ui/OverflowList/useOverflowCalculation.ts
@@ -67,9 +67,8 @@ export function useOverflowCalculation<T>(
     const itemElements = measurementContainerRef.current.children
     const widths: number[] = []
 
-    for (let i = 0; i < itemElements.length; i++) {
-      const itemWidth = itemElements[i].getBoundingClientRect().width
-      widths.push(itemWidth)
+    for (const itemElement of itemElements) {
+      widths.push(itemElement.getBoundingClientRect().width)
     }
 
     return widths
@@ -81,8 +80,8 @@ export function useOverflowCalculation<T>(
       let visibleCount = 0
       let accumulatedWidth = 0
 
-      for (let i = 0; i < itemWidths.length; i++) {
-        const newWidth = accumulatedWidth + itemWidths[i]
+      for (const itemWidth of itemWidths) {
+        const newWidth = accumulatedWidth + itemWidth
 
         if (newWidth > availableWidth) {
           break

--- a/packages/react/src/ui/Select/components/Select.tsx
+++ b/packages/react/src/ui/Select/components/Select.tsx
@@ -21,7 +21,7 @@ export type SelectProps<T extends string = string> = SelectPrimitiveProps<T> & {
 
 const Select = <T extends string = string>(props: SelectProps<T>) => {
   type Value = NonNullable<typeof props.value>
-  const [internalOpen, setInternalOpen] = useState(!!(props.as === "list"))
+  const [internalOpen, setInternalOpen] = useState(props.as === "list")
 
   const isOpen =
     props.as === "list"

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -293,6 +293,7 @@ const SelectContent = forwardRef<
           ...(currentControl ? [currentControl] : []),
         ])
       ).sort((first, second) =>
+        // oxlint-disable-next-line sonarjs/bitwise-operators -- compareDocumentPosition returns a bitmask
         first.compareDocumentPosition(second) & Node.DOCUMENT_POSITION_FOLLOWING
           ? -1
           : 1

--- a/packages/react/src/ui/Select/components/radix-ui/select.tsx
+++ b/packages/react/src/ui/Select/components/radix-ui/select.tsx
@@ -104,7 +104,7 @@ type SelectProps<T extends string = string> = SelectSharedProps &
         value?: T
         defaultValue?: T
         onValueChange?(value: T): void
-        multiple?: false | never
+        multiple?: false
       }
     | {
         value?: T[]
@@ -741,7 +741,6 @@ const SelectContentImpl = React.forwardRef<
 
       if (!context.multiple) {
         focusFirst([selectedItem, content])
-        return
       }
     },
     [focusFirst, selectedItem, content, context.multiple]

--- a/packages/react/src/ui/VerticalOverflowList/index.tsx
+++ b/packages/react/src/ui/VerticalOverflowList/index.tsx
@@ -48,9 +48,8 @@ function useOverflowCalculation<T>(items: T[], gap: number) {
     const itemElements = measurementContainerRef.current.children
     const sizes: number[] = []
 
-    for (let i = 0; i < itemElements.length; i++) {
-      const itemSize = itemElements[i].getBoundingClientRect().height
-      sizes.push(itemSize)
+    for (const itemElement of itemElements) {
+      sizes.push(itemElement.getBoundingClientRect().height)
     }
 
     return sizes

--- a/packages/react/src/ui/value-display/types/count/count.tsx
+++ b/packages/react/src/ui/value-display/types/count/count.tsx
@@ -18,7 +18,7 @@ export const CountCell = (
       <span className="text-f1-foreground-secondary">
         {meta.i18n.collections.summaries.types.count}
       </span>
-      {`${args.label}`}
+      {args.label}
     </div>
   )
 }

--- a/packages/react/src/ui/value-display/types/percentage/percentage.tsx
+++ b/packages/react/src/ui/value-display/types/percentage/percentage.tsx
@@ -34,8 +34,7 @@ export const PercentageCell = (
     return (
       <span
         className={cn(
-          "text-f1-foreground",
-          isPlaceholder && "text-f1-foreground-secondary",
+          "text-f1-foreground text-f1-foreground-secondary",
           meta.visualization === "table" && tableDisplayClassNames.text
         )}
         data-cell-type="percentage"

--- a/packages/react/src/ui/value-display/types/summary/summary.tsx
+++ b/packages/react/src/ui/value-display/types/summary/summary.tsx
@@ -19,7 +19,7 @@ export const SummaryCell = (
       <span className="text-f1-foreground-secondary">
         {meta.i18n.collections.summaries.types.sum}
       </span>
-      {`${args.label}`}
+      {args.label}
     </div>
   )
 }


### PR DESCRIPTION
## Description

Turns on the remaining rules from the PENDING block and fixes their 159 sites by hand (plus 7 in react-native). The PENDING block is now empty; what is left off is listed under DEBT, OXLINT BUGS and OFF ON PURPOSE with a reason each. Behavior is preserved, except where noted in the table.

## Public API note

The "breaking changes" label comes from the API surface check, which flags any retyped member. The three changes it lists are widenings and do not break how these APIs are used:

- `onClick` on `F0DialogPrimaryAction` and `F0DialogSecondaryAction` (and the types built from them: `DialogControls`, `F0DialogActionsProps`, `ProductModal`, `F0CarouselDialogProps`) is now `() => void | Promise<void>`. Callers provide this callback, and every existing `() => void` handler still type-checks. The dialog footer already awaited a returned promise.
- `useChatHistory().refetch` is now typed `() => Promise<void>`. It always returned a promise; the type was wrong.
- `F0VersionHistoryProps.activeVersionId` is now `"current" | (string & {})`. Any string is still accepted; the form only keeps the `"current"` autocomplete hint.

No release bump is needed.

## Type of change

- [x] Refactor / internal change (no API or behavior change)

## Rules turned on

| Rule | Sites | What it enforces / what changed |
|---|---|---|
| `typescript/no-misused-promises` | 16 | No promise where a `void` callback is expected. `F0DialogPrimaryAction.onClick` and `F0DialogSecondaryAction.onClick` now accept `() => void \| Promise<void>`; other sites wrap with `void`. |
| `typescript/no-unnecessary-template-expression` | 14 | No `${"literal"}` inside templates. |
| `sonarjs/no-duplicated-branches` | 11 | Identical branches merged (OneCalendar views, KanbanLane, isDataChartEmpty, SurveyFormBuilder). |
| `typescript/no-dynamic-delete` | 10 | `delete obj[key]` replaced with object rebuilds or a `Map`. |
| `typescript/no-redundant-type-constituents` | 10 | No `never \| undefined`, `unknown \| X`; autocomplete unions use `"literal" \| (string & {})`. |
| `typescript/prefer-for-of` | 9 | Index loops become `for...of`. Media track lists iterate `Array.from(x)` because tests mock them as array-likes. |
| `typescript/prefer-promise-reject-errors` | 8 | `reject(...)` always gets an `Error`. One story mock rejected with a plain object before. |
| `typescript/use-unknown-in-catch-callback-variable` | 7 | `catch` callbacks take `unknown` and narrow. |
| `sonarjs/no-nested-template-literals` | 7 | Inner templates hoisted to a const. |
| `sonarjs/no-trivial-assertions` | 7 | `expect(true).toBe(true)` replaced with real assertions. |
| `sonarjs/no-nested-assignment` | 6 | No assignment inside an expression. |
| `sonarjs/no-all-duplicated-branches`, `public-static-readonly`, `concise-regex`, `no-small-switch`, `no-dead-store`, `no-redundant-jump` | 5, 5, 4, 3, 3, 3 | Straightforward simplifications. |
| `typescript/await-thenable` | 4 | No `await` on non-promises. `ProductModal` `Action.onClick` widened instead. |
| `typescript/no-extraneous-class`, `no-unsafe-enum-comparison`, `restrict-plus-operands` | 2, 2, 1 | Test mocks got a member; `F0GraphEdge` compares with the `Position` enum. |
| `sonarjs/no-skipped-tests` | 2 | Two `it.skip` had no recorded reason. A comment above each says so; un-skip or document them. |
| 12 more sonarjs rules with 1 or 2 sites | 18 | `prefer-native-lodash-alternative` (`lodash/flatten` to `flatMap`), `no-clear-text-protocols`, `link-with-target-blank`, `no-hardcoded-passwords` (story value renamed), `reduce-initial-value`, `prefer-promise-shorthand`, `no-duplicate-test-title` (one duplicate test removed), and others. |

One disable comment: `sonarjs/bitwise-operators` in `SelectContent.tsx`, `compareDocumentPosition` returns a bitmask.

react-native: `ban-ts-comment` (`@ts-ignore` to `@ts-expect-error`), `import/no-duplicates`, `no-dynamic-delete`.

