### PR TITLE
chore(F0GraphEdge): meet the stable DoD

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -20,7 +20,6 @@
     "EmptyState",
     "Filters/FilterPicker",
     "Graph/F0GraphControls",
-    "Graph/F0GraphEdge",
     "Graph/F0GraphNode",
     "Heading",
     "Image",

--- a/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__stories__/F0GraphEdge.mdx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__stories__/F0GraphEdge.mdx
@@ -1,25 +1,36 @@
 import { Canvas, Meta } from "@storybook/addon-docs/blocks"
 
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
 import * as Stories from "./F0GraphEdge.stories"
 
 <Meta of={Stories} />
 
 # F0GraphEdge
 
-The default edge connector between nodes in F0Graph. Adapts its visual
-treatment based on the relationship context (highlighted, dimmed, or
-default).
+The default connector between nodes in `F0Graph`. It draws the line and nothing
+else: no label, no handlers, no focus. The relationship it represents is carried
+by the tree semantics on the nodes, not by the line.
+
+> `F0Graph` mounts its own `ReactFlowProvider`, so you never wrap it yourself.
+> Every canvas below mounts a small `<F0Graph>` per panel so each edge is shown
+> in the context it actually renders in.
 
 ---
 
-## Overview
+## Anatomy
 
-F0GraphEdge is used internally by `<F0Graph>` for all edges
-unless a custom `renderEdge` is provided. It renders a smooth
-SVG path that stays visually quiet so nodes remain the primary
-focus.
+An edge is one SVG path plus an optional dot at the target end.
 
-> When using `<F0Graph>`, you do NOT need to wrap with `ReactFlowProvider` — `F0Graph` mounts its own. The Storybook stories below render `F0GraphEdge` indirectly by mounting a small `<F0Graph>` per variant so each edge appears in its real context.
+- **Path** — the geometry, chosen by `pathType` and drawn by xyflow. When source
+  and target sit within 2px on the cross-axis the path snaps straight regardless
+  of `pathType`, because a smoothstep curve over that distance reads as a jog.
+- **Stroke colour** — one token per variant, defined as CSS vars on `.f0-graph`
+  in `F0Graph.css` so they flip in dark mode.
+- **Stroke width** — derived from the graph's zoom level, not from a prop. 1px
+  at `detail`, 2px at `compact`, 4px at `dot`.
+- **End dot** — a `<marker>` circle in the stroke colour. `F0Graph` decides when
+  it appears; see the note under Props.
 
 <Canvas of={Stories.Status} />
 
@@ -27,47 +38,137 @@ focus.
 
 ## Variants
 
-All four variants shown side by side in the `Status` canvas above.
-
 ### Default
 
-Standard low-contrast connector. Used for most parent–child
-relationships.
+The quiet connector for an ordinary parent–child link. Most edges in a graph are
+this.
 
 ### Hover
 
-Mid-contrast connector used when an interactive edge is hovered. Only
-applied to edges that opt in to interactivity via `onEdgeClick` or
-`onEdgeHover`.
+A mid-contrast stroke applied while an interactive edge is under the pointer.
+Only edges that opt in with `onEdgeClick` or `onEdgeHover` ever reach it — an
+edge without handlers stays `default` on pointer-enter.
+
+<Canvas of={Stories.NonInteractive} />
 
 ### Highlighted
 
-Accent-colored edge drawn when the connected node is selected
-or hovered. Draws attention to the specific relationship.
+The accent stroke, for the relationship connected to the selected or hovered
+node.
 
 ### Dimmed
 
-Reduced-opacity edge used to de-emphasize non-relevant
-relationships during selection or search.
+The default stroke at 50% opacity, for de-emphasising the relationships that are
+not relevant to the current selection or search.
+
+---
+
+## Path types
+
+`pathType` picks the path algorithm. Pass it through the edge's `data`, which is
+the route that survives `F0Graph`'s render model.
+
+<Canvas of={Stories.PathTypes} />
 
 ---
 
 ## Props
 
-| Prop          | Type                                                | Default        | Description                                   |
-| ------------- | --------------------------------------------------- | -------------- | --------------------------------------------- |
-| `type`        | `"smoothstep" \| "straight" \| "bezier"`            | `"smoothstep"` | Edge path rendering algorithm                 |
-| `variant`     | `"default" \| "hover" \| "highlighted" \| "dimmed"` | `"default"`    | Visual treatment                              |
-| `strokeWidth` | `number`                                            | —              | Stroke width (adjusts with zoom when omitted) |
+| Prop          | Type                                                | Default        | Description                                                     |
+| ------------- | --------------------------------------------------- | -------------- | --------------------------------------------------------------- |
+| `pathType`    | `"smoothstep" \| "straight" \| "bezier"`            | `"smoothstep"` | Path algorithm. Named `pathType` because xyflow reserves `type` |
+| `variant`     | `"default" \| "hover" \| "highlighted" \| "dimmed"` | `"default"`    | Visual treatment                                                |
+| `strokeWidth` | `number`                                            | `1`            | Ignored inside `F0Graph` — the zoom level always wins           |
+
+Both `pathType` and `variant` can also arrive as `data.pathType` /
+`data.variant` when the edge renders as a registered xyflow edge type, which is
+the default path. An explicit prop wins over `data`.
+
+`strokeWidth` only takes effect for a standalone mount with no graph zoom
+context around it. Inside `<F0Graph>` the zoom-derived width is always defined
+and short-circuits both the prop and `style.strokeWidth`.
+
+`showDot` is not a consumer knob. `F0Graph`'s render model computes it and
+overwrites whatever the edge data carried, hiding the dot on expander links and
+on any edge whose source is an expanded parent.
+
+---
+
+## Guidelines
+
+### Design best practices
+
+Keep the line subordinate to the nodes. An edge that competes with its endpoints
+makes the hierarchy harder to read, not easier.
+
+#### When to use
+
+- You need the standard connector — which is automatic, `F0Graph` uses
+  `F0GraphEdge` for every edge unless you pass `renderEdge`
+- You are passing `renderEdge` and want the default look with one variant
+  overridden
+
+#### When not to use
+
+- **For a per-edge label.** `F0GraphEdge` renders no text. Labels belong on the
+  nodes, or on a custom xyflow edge if the relationship genuinely needs one.
+- **For decoration.** Every edge is part of the graph's announced structure, so
+  a line drawn purely for looks adds noise for screen reader users.
+- **To encode meaning in the stroke alone.** The four variants are emphasis
+  levels, not categories.
+- **To change geometry beyond `pathType`.** Drop down to xyflow's edge API
+  instead of fighting the path getter.
+
+<DoDonts
+  do={{
+    description:
+      "Use the variants as emphasis, and let the nodes carry what the relationship means.",
+    guidelines: [
+      "highlighted for the link into the current selection",
+      "dimmed to push unrelated branches back during a search",
+      "default everywhere else, which is most edges",
+    ],
+  }}
+  dont={{
+    description: "Don't make a variant stand for a category of relationship.",
+    guidelines: [
+      "Don't use highlighted to mean 'dotted-line manager' — nothing announces it and it collides with selection",
+      "Don't leave every edge highlighted; if nothing is quiet, nothing reads as emphasised",
+      "Don't rely on the hover stroke to signal that an edge is clickable, since it only appears once the pointer is already on it",
+    ],
+  }}
+/>
+
+### Content best practices
+
+There is no copy in an edge. The only writing decision nearby is the node titles
+it connects, which should read as the two ends of the relationship.
+
+---
+
+## Accessibility
+
+- The path is decorative. Structure is announced from the `role="tree"` /
+  `role="treeitem"` model on the graph and its nodes, with `aria-level`,
+  `aria-setsize` and `aria-posinset` carrying the hierarchy.
+- Because the line itself is never announced, **anything it means through colour
+  or weight has to exist somewhere else too** — in a node title, a tag, or a
+  legend. The variants are safe as emphasis precisely because they add no
+  information.
+- `hover` is pointer-only by nature. Don't build an interaction whose only
+  affordance is the hover stroke; give the same action a keyboard route through
+  the nodes.
+- Stroke colours are tokens, so contrast follows the theme in both light and
+  dark mode. A custom `renderEdge` that hardcodes a colour takes that guarantee
+  on itself.
 
 ---
 
 ## Usage
 
-Most consumers never render `F0GraphEdge` directly — F0Graph
-handles edge rendering internally. Use `renderEdge` on
-`<F0Graph>` only when the relationship itself carries semantic
-meaning (e.g. dotted-line managers, team color coding).
+Most consumers never touch `F0GraphEdge` — `F0Graph` renders it for every edge.
+Reach for `renderEdge` only when the relationship carries meaning the default
+does not express.
 
 ```tsx
 import { F0Graph, F0GraphEdge } from "@factorialco/f0-react"
@@ -83,4 +184,5 @@ function Example() {
 }
 ```
 
-> `renderEdge` receives the edge and its variant only — `F0Graph` computes the path. To customize geometry directly, drop down to xyflow's edge API.
+> `renderEdge` receives the edge and its computed variant. `F0Graph` still owns
+> the path geometry.

--- a/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__stories__/F0GraphEdge.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__stories__/F0GraphEdge.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
-
+import { expect, userEvent, waitFor } from "storybook/test"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import type { GraphEdge, GraphNode } from "../../../types"
@@ -27,6 +27,28 @@ const NODES: GraphNode<Person>[] = [
   },
 ]
 
+// A single centred child puts source and target within `crossAxisDelta < 2`,
+// where F0GraphEdge snaps every path type straight. Two children offset the
+// edges so the path algorithms actually differ on screen.
+const FORKED_NODES: GraphNode<Person>[] = [
+  {
+    id: "a",
+    parentId: null,
+    data: { name: "Alice Moreno", title: "Manager" },
+    childrenCount: 2,
+  },
+  {
+    id: "b",
+    parentId: "a",
+    data: { name: "Bob Smith", title: "Engineer" },
+  },
+  {
+    id: "c",
+    parentId: "a",
+    data: { name: "Carol Diaz", title: "Designer" },
+  },
+]
+
 function renderPerson(node: GraphNode<Person>, ctx: F0GraphNodeRenderContext) {
   const [firstName = "", lastName = ""] = node.data.name.split(" ")
   return (
@@ -44,31 +66,35 @@ function EdgeStory({
   width = 400,
   height = 220,
   interactive = false,
+  pathType,
+  nodes = NODES,
 }: {
   variant?: "default" | "hover" | "highlighted" | "dimmed"
   width?: number
   height?: number
   interactive?: boolean
+  pathType?: "smoothstep" | "straight" | "bezier"
+  nodes?: GraphNode<Person>[]
 }) {
-  const edges: GraphEdge[] = [
-    {
-      id: "a-b",
-      source: "a",
-      target: "b",
-      data: { variant },
+  const edges: GraphEdge[] = nodes
+    .filter((n) => n.parentId !== null)
+    .map((n) => ({
+      id: `${n.parentId}-${n.id}`,
+      source: n.parentId!,
+      target: n.id,
+      data: { variant, ...(pathType ? { pathType } : {}) },
       ...(interactive
         ? {
             onEdgeClick: () => {},
             onEdgeHover: () => {},
           }
         : {}),
-    },
-  ]
+    }))
 
   return (
     <div style={{ width, height }} className="bg-f1-background">
       <F0Graph
-        nodes={NODES}
+        nodes={nodes}
         edges={edges}
         renderNode={renderPerson}
         defaultExpandDepth={1}
@@ -135,6 +161,54 @@ export const NonInteractive: Story = {
         </span>
         <EdgeStory width={320} height={200} interactive />
       </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    // Edges reach the DOM only after React Flow measures both nodes and the
+    // initial fitView settles, so the query has to be retried.
+    const paths = await waitFor(() => {
+      const found = canvasElement.querySelectorAll<SVGPathElement>(
+        ".react-flow__edge-path"
+      )
+      expect(found).toHaveLength(2)
+      return found
+    })
+    // Panel order is left (no handlers) then right (handlers), matching the JSX.
+    const plain = paths[0]!
+    const interactive = paths[1]!
+
+    await userEvent.hover(interactive.closest(".react-flow__edge")!)
+
+    await waitFor(() =>
+      expect(interactive.style.stroke).toBe("var(--f0-graph-edge-hover)")
+    )
+    await expect(plain.style.stroke).toBe("var(--f0-graph-edge-default)")
+  },
+}
+
+/**
+ * `data.pathType` picks the path algorithm. It survives F0Graph's render model
+ * untouched, so it is the supported route for a consumer edge; the `pathType`
+ * prop only applies to a standalone `renderEdge` mount.
+ *
+ * Two children per parent here on purpose: with a single centred child the
+ * source and target fall inside `crossAxisDelta < 2` and every path type snaps
+ * straight, so the three would look identical.
+ */
+export const PathTypes: Story = {
+  render: () => (
+    <div className="flex flex-wrap gap-4">
+      {(["smoothstep", "straight", "bezier"] as const).map((p) => (
+        <div key={p} className="flex flex-col gap-2">
+          <span className="text-sm text-f1-foreground-secondary">{p}</span>
+          <EdgeStory
+            pathType={p}
+            nodes={FORKED_NODES}
+            width={260}
+            height={180}
+          />
+        </div>
+      ))}
     </div>
   ),
 }

--- a/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__stories__/F0GraphEdge.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__stories__/F0GraphEdge.stories.tsx
@@ -110,6 +110,7 @@ const meta = {
   tags: ["stable", "!autodocs"],
   parameters: {
     layout: "centered",
+    a11y: { test: "error" },
   },
 } satisfies Meta<typeof F0GraphEdge>
 

--- a/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__tests__/F0GraphEdge.test.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphEdge/__tests__/F0GraphEdge.test.tsx
@@ -6,8 +6,9 @@ import { zeroRender as render } from "@/testing/test-utils"
 import { F0GraphEdge } from "../F0GraphEdge"
 import { edgeTypes, edgeVariants } from "../types"
 
-const { baseEdgeRenderSpy } = vi.hoisted(() => ({
+const { baseEdgeRenderSpy, baseEdgePropsSpy } = vi.hoisted(() => ({
   baseEdgeRenderSpy: vi.fn(),
+  baseEdgePropsSpy: vi.fn(),
 }))
 
 vi.mock("@xyflow/react", async () => {
@@ -16,9 +17,15 @@ vi.mock("@xyflow/react", async () => {
 
   return {
     ...actual,
-    BaseEdge: ({ id }: { id: string }) => {
-      baseEdgeRenderSpy(id)
-      return <div data-testid={`base-edge-${id}`} />
+    BaseEdge: (props: {
+      id: string
+      path: string
+      markerEnd?: string
+      style?: Record<string, unknown>
+    }) => {
+      baseEdgeRenderSpy(props.id)
+      baseEdgePropsSpy(props)
+      return <div data-testid={`base-edge-${props.id}`} />
     },
   }
 })
@@ -44,7 +51,17 @@ function makeEdgeProps(): ComponentProps<typeof F0GraphEdge> {
 describe("F0GraphEdge", () => {
   beforeEach(() => {
     baseEdgeRenderSpy.mockClear()
+    baseEdgePropsSpy.mockClear()
   })
+
+  function lastStyle(): Record<string, unknown> {
+    const call = baseEdgePropsSpy.mock.calls.at(-1)?.[0]
+    return (call?.style ?? {}) as Record<string, unknown>
+  }
+
+  function lastPath(): string {
+    return (baseEdgePropsSpy.mock.calls.at(-1)?.[0]?.path ?? "") as string
+  }
 
   it("exports correct edge types", () => {
     expect(edgeTypes).toEqual(["smoothstep", "straight", "bezier"])
@@ -65,5 +82,155 @@ describe("F0GraphEdge", () => {
 
     rerender(<F0GraphEdge {...edgeProps} variant="highlighted" />)
     expect(baseEdgeRenderSpy).toHaveBeenCalledTimes(2)
+  })
+
+  describe("stroke color", () => {
+    it.each([
+      ["default", "var(--f0-graph-edge-default)"],
+      ["hover", "var(--f0-graph-edge-hover)"],
+      ["highlighted", "var(--f0-graph-edge-highlighted)"],
+      // dimmed reuses the default colour and separates itself by opacity
+      ["dimmed", "var(--f0-graph-edge-default)"],
+    ] as const)("maps the %s variant to its token", (variant, expected) => {
+      render(<F0GraphEdge {...makeEdgeProps()} variant={variant} />)
+      expect(lastStyle().stroke).toBe(expected)
+    })
+
+    it("falls back to data.variant when the prop is absent", () => {
+      const props = makeEdgeProps()
+      render(
+        <F0GraphEdge
+          {...props}
+          data={{ ...props.data, variant: "highlighted" }}
+        />
+      )
+      expect(lastStyle().stroke).toBe("var(--f0-graph-edge-highlighted)")
+    })
+
+    it("prefers the explicit prop over data.variant", () => {
+      const props = makeEdgeProps()
+      render(
+        <F0GraphEdge
+          {...props}
+          variant="hover"
+          data={{ ...props.data, variant: "highlighted" }}
+        />
+      )
+      expect(lastStyle().stroke).toBe("var(--f0-graph-edge-hover)")
+    })
+  })
+
+  describe("dimmed opacity", () => {
+    it("halves the opacity when dimmed", () => {
+      render(<F0GraphEdge {...makeEdgeProps()} variant="dimmed" />)
+      expect(lastStyle().opacity).toBe(0.5)
+    })
+
+    it("leaves opacity unset for every other variant", () => {
+      render(<F0GraphEdge {...makeEdgeProps()} variant="highlighted" />)
+      expect(lastStyle().opacity).toBeUndefined()
+    })
+  })
+
+  describe("path type", () => {
+    // `makeEdgeProps` is cross-axis aligned, which triggers the straight snap
+    // below and would mask pathType entirely, so these offset the target.
+    const offset = { targetY: 60 } as const
+
+    // A cubic segment is what separates a bezier from the rest.
+    it("draws a curve for bezier", () => {
+      render(
+        <F0GraphEdge
+          {...makeEdgeProps()}
+          {...offset}
+          data={{ pathType: "bezier" }}
+        />
+      )
+      expect(lastPath()).toContain("C")
+    })
+
+    it("draws no curve for straight", () => {
+      render(
+        <F0GraphEdge
+          {...makeEdgeProps()}
+          {...offset}
+          data={{ pathType: "straight" }}
+        />
+      )
+      expect(lastPath()).not.toContain("C")
+    })
+
+    it("snaps straight when the cross-axis offset is under 2px", () => {
+      render(
+        <F0GraphEdge
+          {...makeEdgeProps()}
+          sourcePosition="bottom"
+          targetPosition="top"
+          sourceX={0}
+          sourceY={0}
+          targetX={1}
+          targetY={100}
+          data={{ pathType: "bezier" }}
+        />
+      )
+      // The straight snap outranks pathType, so the curve never appears.
+      expect(lastPath()).not.toContain("C")
+    })
+
+    it("honours pathType once the offset clears the snap threshold", () => {
+      render(
+        <F0GraphEdge
+          {...makeEdgeProps()}
+          sourcePosition="bottom"
+          targetPosition="top"
+          sourceX={0}
+          sourceY={0}
+          targetX={80}
+          targetY={100}
+          data={{ pathType: "bezier" }}
+        />
+      )
+      expect(lastPath()).toContain("C")
+    })
+  })
+
+  describe("stroke width outside a zoom context", () => {
+    it("defaults to 1", () => {
+      render(<F0GraphEdge {...makeEdgeProps()} />)
+      expect(lastStyle().strokeWidth).toBe(1)
+    })
+
+    it("takes the prop", () => {
+      render(<F0GraphEdge {...makeEdgeProps()} strokeWidth={3} />)
+      expect(lastStyle().strokeWidth).toBe(3)
+    })
+
+    it("takes style.strokeWidth over the prop", () => {
+      render(
+        <F0GraphEdge
+          {...makeEdgeProps()}
+          strokeWidth={3}
+          style={{ strokeWidth: 7 }}
+        />
+      )
+      expect(lastStyle().strokeWidth).toBe(7)
+    })
+  })
+
+  describe("end dot", () => {
+    it("points markerEnd at the edge's own marker by default", () => {
+      render(<F0GraphEdge {...makeEdgeProps()} />)
+      expect(baseEdgePropsSpy.mock.calls.at(-1)?.[0].markerEnd).toBe(
+        "url(#f0-edge-dot-edge-1)"
+      )
+    })
+
+    it("drops the marker when data.showDot is false", () => {
+      const props = makeEdgeProps()
+      render(
+        <F0GraphEdge {...props} data={{ ...props.data, showDot: false }} />
+      )
+      expect(baseEdgePropsSpy.mock.calls.at(-1)?.[0].markerEnd).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
## Description

Closes the three stable DoD gaps on `Graph/F0GraphEdge`: 

- adds a play function 
- adds MDX docs at the `good` tier
- axe not enforced.

**Stacked on #5191.** Base branch is `fix/f0graph-accessible-tree-stable-dod`, so review that first. The axe gap cannot be closed without it, and the diff here is four files.

Every F0GraphEdge story mounts a real `<F0Graph>`, so enforcing axe puts F0GraphView's DOM under a blocking run. On `main` that fails:

```
aria-required-children  [critical]  wcag2a wcag131
Element has children which are not allowed: [role=application]
```

React Flow hardcodes `role="application"` on its wrapper, after the props spread, and on `main` that wrapper is a child of the graph's `role="tree"`. #5191 moves the tree to an empty sibling that claims its treeitems through `aria-owns`.

## Type of change

- [x] Documentation only
- [x] Other: clears `Graph/F0GraphEdge` from `stable-dod-debt.json`

## Lifecycle phase (if applicable)

Not a promotion. F0GraphEdge is already tagged `stable` and sat on the ratchet because it did not meet the mechanical DoD.

## Implementation details

**Play function.** `NonInteractive` claims that hover is opt-in per edge, so the play function tests exactly that: the panel with `onEdgeClick`/`onEdgeHover` swaps to `var(--f0-graph-edge-hover)`, the panel without handlers stays on the default stroke. Edges only enter the DOM after React Flow measures both nodes and the initial `fitView` settles, so the query sits inside `waitFor`.

**New `PathTypes` story.** It renders a parent with two children rather than one. With a single centred child, source and target fall inside `crossAxisDelta < 2`, where F0GraphEdge snaps every path type straight to avoid a one-pixel jog, and all three panels would have looked identical.

**MDX `stub` to `good`.** The old page had headings Overview, Variants, Props and Usage, none of which the doc scorer counts, so `sectionsCount` was 0 and the tier could not rise above `stub`. Added Anatomy, Guidelines with when-to-use and when-not-to-use, Accessibility, a Do/Don't pair on variant usage, and canvases for `NonInteractive` and `PathTypes`.

Three things the old page got wrong:

- The props table documented `type`. That prop does not exist. The real one is `pathType`, renamed to avoid xyflow's reserved `type` key, so anyone copying the table got silently ignored props.
- `strokeWidth` was documented with a default of `—` and "adjusts with zoom when omitted". Inside `<F0Graph>` the zoom context is always present, so the zoom-derived width short-circuits both the prop and `style.strokeWidth`. The prop only applies to a standalone mount.
- `showDot` is now documented as computed rather than as a knob. `useGraphRenderModel` spreads consumer edge data and then overwrites `showDot`, and it resolves to `false` for any edge whose source is an expanded parent.

**Unit tests, 3 to 20.** The existing file replaced `BaseEdge` with a stub that dropped its props, so nothing covered the stroke, opacity or path that the docs describe. The mock now captures them, and the tests cover the variant-to-token map, the `data.variant` fallback and prop precedence, the dimmed opacity, the sub-2px straight snap, `pathType` selection, standalone stroke width, and the end-dot marker.

## Verification

From `packages/react`:

- `pnpm tsc` clean
- `npx oxlint src/patterns/F0Graph --max-warnings 0` 0 warnings, 0 errors (`pnpm lint` is a no-op in this package)
- `npx oxfmt --check` clean
- `pnpm vitest --project=unit run src/patterns/F0Graph` 39 files, 385 tests
- `axe-probe` against a built Storybook: 4/4 stories clean
- `pnpm test-storybook src/patterns/F0Graph` 4 suites, 30 tests

The plan also flagged `target-size` and `color-contrast` as likely real-browser failures. Neither appears. 11 enabled targets measure under 24x24 CSS px and axe flagged none, because `target-size` is an ANY-of rule that `target-offset` satisfies on its own.

## Notes for the reviewer

`F0Graph.stories.tsx` failed once in a full-suite `test-storybook` run and passed on a rerun and in isolation. It takes 23s isolated and 32s in the run that failed, so it is close to the timeout under parallel load. That file belongs to #5191, not to this PR, and F0GraphEdge passed in every run.

This branch sits 83 commits behind `main`, inherited from #5191's base. It will need restacking when #5191 rebases.
