### PR TITLE
fix(F0Chat): find mentions whose name has a combining accent

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import { locateMentions } from "../mention-ranges"
+import { sanitizeDisplayText } from "../sanitize-text"
+
+// Written as escapes on purpose: the two spellings are the point of these
+// tests and are indistinguishable when pasted as literal characters.
+/** `Garcia` with a precomposed i-acute (U+00ED) — the NFC spelling. */
+const NFC_NAME = "Garc\u00EDa"
+/** The same name as `i` + U+0301 COMBINING ACUTE ACCENT — the NFD spelling. */
+const NFD_NAME = "Garci\u0301a"
+
+describe("locateMentions", () => {
+  it("locates a plain ASCII name", () => {
+    expect(locateMentions("hi @Ana!", [{ name: "Ana" }])).toEqual([
+      { entry: { name: "Ana" }, start: 3, end: 7 },
+    ])
+  })
+
+  it("prefers the longest name and drops the overlap", () => {
+    const entries = [{ name: "Ana" }, { name: "Ana Maria" }]
+    expect(locateMentions("hi @Ana Maria!", entries)).toEqual([
+      { entry: { name: "Ana Maria" }, start: 3, end: 13 },
+    ])
+  })
+
+  it("locates a decomposed name in a body the renderer already composed", () => {
+    const body = sanitizeDisplayText(`hi @${NFD_NAME}!`)
+    const located = locateMentions(body, [{ name: NFD_NAME }])
+
+    expect(located).toHaveLength(1)
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFC_NAME}`)
+  })
+
+  it("locates a composed name in a body that is still decomposed", () => {
+    const body = `hi @${NFD_NAME}!`
+    const located = locateMentions(body, [{ name: NFC_NAME }])
+
+    expect(located).toHaveLength(1)
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFD_NAME}`)
+  })
+
+  it("locates both occurrences when the two spellings are mixed in one body", () => {
+    const body = `@${NFC_NAME} and @${NFD_NAME}`
+    const located = locateMentions(body, [{ name: NFC_NAME }])
+
+    expect(located).toHaveLength(2)
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFC_NAME}`)
+    expect(body.slice(located[1]!.start, located[1]!.end)).toBe(`@${NFD_NAME}`)
+  })
+
+  it("marks only the `@` occurrence when the name also appears as plain text", () => {
+    const body = `${NFC_NAME} wrote: hi @${NFD_NAME}`
+    const located = locateMentions(body, [{ name: NFD_NAME }])
+
+    expect(located).toHaveLength(1)
+    expect(located[0]!.start).toBe(body.indexOf("@"))
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFD_NAME}`)
+  })
+
+  it("does not swallow the accent of the character that ends the name", () => {
+    expect(locateMentions("hi @Ana\u0301!", [{ name: "Ana" }])).toEqual([])
+  })
+
+  // `hooks/useMentions.ts` (`seedMentions`) calls this with bare `{ name }`
+  // objects and reads back `{ entry: { name }, start }` to anchor a saved
+  // message's mentions on its text. That shape has to keep resolving.
+  it("keeps the `seedMentions` call shape resolving", () => {
+    const text = `hi @${NFD_NAME}, ping @Ana`
+    const byName = new Map([
+      [NFC_NAME, [{ id: "1", name: NFC_NAME }]],
+      ["Ana", [{ id: "2", name: "Ana" }]],
+    ])
+
+    const anchored = locateMentions(
+      text,
+      [...byName.keys()].map((name) => ({ name }))
+    ).flatMap(({ entry: { name }, start }) => {
+      const picked = byName.get(name)?.[0]
+      return picked ? [{ ...picked, start }] : []
+    })
+
+    expect(anchored).toEqual([
+      { id: "1", name: NFC_NAME, start: 3 },
+      { id: "2", name: "Ana", start: text.indexOf("@Ana") },
+    ])
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -95,6 +95,36 @@ describe("locateMentions", () => {
     ).toEqual([])
   })
 
+  // The same walk is why a name *held* as jamo needs the spelling it was given
+  // as well as the composed one: jamo compose with each other rather than as
+  // marks, so the walk can never reach them and the name would stop being
+  // found in the very spelling it is stored in.
+  it("locates a name held as jamo in a body spelled the same way", () => {
+    const jamo = "\u1100\u1161\u11A8"
+    const body = `hi @${jamo}!`
+
+    expect(locateMentions(body, [{ name: jamo }])).toEqual([
+      { entry: { name: jamo }, start: 3, end: body.indexOf("!") },
+    ])
+  })
+
+  it("locates a name held as jamo in a body that composed it", () => {
+    const jamo = "\u1100\u1161\u11A8"
+    const body = "hi @\uAC01!"
+
+    expect(locateMentions(body, [{ name: jamo }])).toEqual([
+      { entry: { name: jamo }, start: 3, end: body.indexOf("!") },
+    ])
+  })
+
+  it("does not swallow the accent that follows a name held as jamo", () => {
+    expect(
+      locateMentions("hi @\u1100\u1161\u11A8\u0301", [
+        { name: "\u1100\u1161\u11A8" },
+      ])
+    ).toEqual([])
+  })
+
   it("gives up on a trailing `@`", () => {
     expect(locateMentions("hi @", [{ name: "Ana" }])).toEqual([])
   })

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -140,6 +140,12 @@ describe("locateMentions", () => {
     expect(locateMentions("hi @Ana\u0301!", [{ name: "Ana" }])).toEqual([])
   })
 
+  // A mark outside the BMP is two code units, and a lone surrogate is not
+  // `\p{M}`, so reading one unit at the end of a match waves it straight past.
+  it("does not swallow an astral combining mark either", () => {
+    expect(locateMentions("hi @Ana\u{1D167} x", [{ name: "Ana" }])).toEqual([])
+  })
+
   // `hooks/useMentions.ts` (`seedMentions`) calls this with bare `{ name }`
   // objects and reads back `{ entry: { name }, start }` to anchor a saved
   // message's mentions on its text. That shape has to keep resolving.

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -117,6 +117,28 @@ describe("locateMentions", () => {
     ])
   })
 
+  // Jamo compose with each other rather than as marks, so a jamo name sits
+  // inside a longer jamo syllable exactly the way `@Ana` sits inside `@Aná`.
+  // Neither literal spelling may end there, and neither may the fold.
+  it("does not chip a syllable whose jamo a shorter name prefixes", () => {
+    expect(
+      locateMentions("@\u1100\u1175\u11B7 hi", [{ name: "\u1100\u1175" }])
+    ).toEqual([])
+  })
+
+  it("does not chip a syllable open on its leading jamo", () => {
+    expect(locateMentions("@\u1100\u1161 hi", [{ name: "\u1100" }])).toEqual([])
+  })
+
+  it("still matches a jamo name that a new syllable follows", () => {
+    const name = "\u1100\u1161\u11A8"
+    const body = `@${name}\u1100\u1161 hi`
+
+    expect(locateMentions(body, [{ name }])).toEqual([
+      { entry: { name }, start: 0, end: 1 + name.length },
+    ])
+  })
+
   it("does not swallow the accent that follows a name held as jamo", () => {
     expect(
       locateMentions("hi @\u1100\u1161\u11A8\u0301", [

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -55,6 +55,55 @@ describe("locateMentions", () => {
     expect(located).toHaveLength(1)
     expect(located[0]!.start).toBe(body.indexOf("@"))
     expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFD_NAME}`)
+    // Text and name spelled alike: the span an existing caller derives from
+    // the name length is still the span this returns.
+    expect(located[0]!.end).toBe(located[0]!.start + NFD_NAME.length + 1)
+  })
+
+  // `end` is the only authority on where an occurrence stops. A caller that
+  // measures the name instead lands one index short here, which is why the
+  // field says so and why this case is pinned.
+  it("reports an end no caller can derive from the name length", () => {
+    const body = `hi @${NFD_NAME}!`
+    const [located] = locateMentions(body, [{ name: NFC_NAME }])
+
+    expect(located!.end).toBe(body.indexOf("!"))
+    expect(located!.end).not.toBe(located!.start + NFC_NAME.length + 1)
+  })
+
+  it("folds a singleton so a legacy code point still matches", () => {
+    const angstrom = "\u212Bngel"
+    const letterA = "\u00C5ngel"
+    const located = locateMentions(`hi @${angstrom}`, [{ name: letterA }])
+
+    expect(located).toHaveLength(1)
+  })
+
+  it("keeps a surrogate pair whole", () => {
+    const name = "Ana\u{1F916}"
+    const body = `hi @${name} there`
+    expect(locateMentions(body, [{ name }])).toEqual([
+      { entry: { name }, start: 3, end: body.indexOf(" there") },
+    ])
+  })
+
+  it("leaves a Hangul syllable written as jamo alone", () => {
+    // The boundary walk groups marks, not jamo, so a syllable could be cut in
+    // half here. It is not: the run stops being a canonical prefix first.
+    expect(
+      locateMentions("@\u1100\u1161\u11A8 hi", [{ name: "\uAC00" }])
+    ).toEqual([])
+  })
+
+  it("gives up on a trailing `@`", () => {
+    expect(locateMentions("hi @", [{ name: "Ana" }])).toEqual([])
+  })
+
+  it("keeps scanning past an `@` that is not a mention", () => {
+    const body = "write a@b.example or ping @Ana"
+    expect(locateMentions(body, [{ name: "Ana" }])).toEqual([
+      { entry: { name: "Ana" }, start: body.indexOf("@Ana"), end: body.length },
+    ])
   })
 
   it("does not swallow the accent of the character that ends the name", () => {

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
@@ -74,6 +74,29 @@ describe("renderBodyWithMentions", () => {
     zeroRender(<div>{renderBodyWithMentions("hey @Ana María", tokens)}</div>)
     expect(screen.getByText("@Ana María")).toBeInTheDocument()
   })
+
+  // The body is composed before the ranges are taken, so a name carrying the
+  // decomposed spelling reaches a chip only if matching folds both sides.
+  // Escapes, not literal characters: the two spellings are the point here and
+  // are indistinguishable on screen.
+  it("chips a name whose accent is stored decomposed", () => {
+    const decomposed = "Garci\u0301a"
+    const composed = "Garc\u00EDa"
+    const tokens: MentionToken[] = [
+      {
+        name: decomposed,
+        isSelf: false,
+        isEveryone: false,
+        user: { id: "1", name: decomposed },
+      },
+    ]
+    zeroRender(
+      <div>{renderBodyWithMentions(`hi @${decomposed}!`, tokens)}</div>
+    )
+    expect(screen.getByText(`@${composed}`).className).toContain(
+      "text-f1-foreground-secondary"
+    )
+  })
 })
 
 describe("renderBodyWithLinks (preview titles)", () => {

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -1,3 +1,5 @@
+import { CANONICAL_FORM } from "./sanitize-text"
+
 /** A `@name` occurrence located in a body of text. */
 export type LocatedMention<T> = {
   entry: T
@@ -8,11 +10,53 @@ export type LocatedMention<T> = {
 }
 
 /**
+ * One code point plus the combining marks that belong to it. Canonical
+ * composition joins a base with its marks, so a candidate may only start or
+ * end here — cut between the two and a bare `a` gets compared against an `á`.
+ */
+const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
+
+const nextBoundary = (text: string, at: number): number => {
+  BASE_WITH_MARKS.lastIndex = at
+  return BASE_WITH_MARKS.exec(text) ? BASE_WITH_MARKS.lastIndex : text.length
+}
+
+/**
+ * Index just past the run starting at `from` whose canonical form is
+ * `pattern`, or `-1` when no run there has it.
+ *
+ * Comparing canonical forms instead of raw code units is what lets a name held
+ * as `i` + combining acute match a body the renderer already composed to `í`,
+ * and the reverse. The index counts characters of `text` exactly as the caller
+ * passed it, so a caller can still slice or anchor on its own string.
+ */
+const canonicalMatchEnd = (
+  text: string,
+  from: number,
+  pattern: string
+): number => {
+  let cursor = from
+  while (true) {
+    const seen = text.slice(from, cursor).normalize(CANONICAL_FORM)
+    if (seen === pattern) {
+      return cursor
+    }
+    if (cursor === text.length || seen.length > pattern.length) {
+      return -1
+    }
+    cursor = nextBoundary(text, cursor)
+  }
+}
+
+/**
  * Locate every `@name` occurrence of the given entries in `text`.
  *
  * Longest names first so `@Ana María` wins over `@Ana`, then overlaps are
  * dropped left to right. Entry order breaks ties, which is what makes two
  * different people who share a display name land on one occurrence each.
+ *
+ * Names and body are matched by canonical form, so which of the two spellings
+ * of `í` each side happens to carry never decides whether a mention is found.
  *
  * The single place `@name` text is matched: the bubble, the composer overlay
  * and the composer's own anchoring all resolve through here, so they cannot
@@ -23,17 +67,26 @@ export const locateMentions = <T extends { name: string }>(
   entries: readonly T[]
 ): LocatedMention<T>[] => {
   const found: LocatedMention<T>[] = []
-  const byLength = [...entries].sort((a, b) => b.name.length - a.name.length)
-  for (const entry of byLength) {
-    const pattern = `@${entry.name}`
+  const byLength = entries
+    .map((entry) => ({
+      entry,
+      pattern: `@${entry.name}`.normalize(CANONICAL_FORM),
+    }))
+    .sort((a, b) => b.pattern.length - a.pattern.length)
+  for (const { entry, pattern } of byLength) {
     let from = 0
     while (true) {
-      const idx = text.indexOf(pattern, from)
-      if (idx === -1) {
+      const at = text.indexOf("@", from)
+      if (at === -1) {
         break
       }
-      found.push({ entry, start: idx, end: idx + pattern.length })
-      from = idx + pattern.length
+      const end = canonicalMatchEnd(text, at, pattern)
+      if (end === -1) {
+        from = at + 1
+        continue
+      }
+      found.push({ entry, start: at, end })
+      from = end
     }
   }
   found.sort((a, b) => a.start - b.start)

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -71,24 +71,48 @@ const canonicalMatchEnd = (
 }
 
 /**
+ * Index just past `needle` sitting literally at `from`, or `-1`. The mark test
+ * is what keeps the shortcut honest: `@Ana` sits inside a decomposed `@Aná`,
+ * and matching it there chips somebody else's name and strands the accent
+ * outside the chip.
+ */
+const literalMatchEnd = (
+  text: string,
+  from: number,
+  needle: string
+): number => {
+  const end = from + needle.length
+  return text.startsWith(needle, from) && !COMBINING_MARK.test(text.charAt(end))
+    ? end
+    : -1
+}
+
+/**
  * Both sides spelled the same way is the overwhelming majority — the renderer
  * composes the body one line before it asks — and needs no normalizing at all.
- * The mark test is what keeps the shortcut honest: `@Ana` sits inside a
- * decomposed `@Aná`, and matching it there chips somebody else's name and
- * strands the accent outside the chip.
+ *
+ * The name as it is actually held is tried too, and is not redundant with the
+ * fold: {@link canonicalMatchEnd} walks base+mark groups, while Hangul jamo
+ * compose with each other rather than as marks, so a run of jamo is never a
+ * canonical prefix of the syllable it composes to. Without this a name kept as
+ * jamo would stop being found in a body carrying those very same jamo.
  */
 const matchEnd = (
   text: string,
   from: number,
   pattern: string,
+  asWritten: string,
   foldable: boolean
 ): number => {
-  const exact = from + pattern.length
-  if (
-    text.startsWith(pattern, from) &&
-    !COMBINING_MARK.test(text.charAt(exact))
-  ) {
-    return exact
+  const composed = literalMatchEnd(text, from, pattern)
+  if (composed !== -1) {
+    return composed
+  }
+  if (asWritten !== pattern) {
+    const literal = literalMatchEnd(text, from, asWritten)
+    if (literal !== -1) {
+      return literal
+    }
   }
   return foldable ? canonicalMatchEnd(text, from, pattern) : -1
 }
@@ -113,20 +137,20 @@ export const locateMentions = <T extends { name: string }>(
 ): LocatedMention<T>[] => {
   const found: LocatedMention<T>[] = []
   const byLength = entries
-    .map((entry) => ({
-      entry,
-      pattern: `@${entry.name}`.normalize(CANONICAL_FORM),
-    }))
+    .map((entry) => {
+      const asWritten = `@${entry.name}`
+      return { entry, asWritten, pattern: asWritten.normalize(CANONICAL_FORM) }
+    })
     .sort((a, b) => b.pattern.length - a.pattern.length)
   const foldable = NON_ASCII.test(text)
-  for (const { entry, pattern } of byLength) {
+  for (const { entry, asWritten, pattern } of byLength) {
     let from = 0
     while (true) {
       const at = text.indexOf("@", from)
       if (at === -1) {
         break
       }
-      const end = matchEnd(text, at, pattern, foldable)
+      const end = matchEnd(text, at, pattern, asWritten, foldable)
       if (end === -1) {
         from = at + 1
         continue

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -5,20 +5,40 @@ export type LocatedMention<T> = {
   entry: T
   /** Index of the `@`. */
   start: number
-  /** Index just past the last character of the name. */
+  /**
+   * Index just past the occurrence **as it is spelled in `text`**, which is
+   * not always `start + 1 + name.length`: an accent held decomposed on one
+   * side and composed on the other takes one more index there than here.
+   * Slice and anchor on this, never on the length of the name.
+   */
   end: number
 }
 
 /**
- * One code point plus the combining marks that belong to it. Canonical
- * composition joins a base with its marks, so a candidate may only start or
- * end here — cut between the two and a bare `a` gets compared against an `á`.
+ * One code point plus the combining marks that belong to it. A candidate may
+ * only start or end here — cut between a letter and its accent and a bare `a`
+ * gets compared against an `á`. Marks are the only thing this covers: Hangul
+ * jamo compose with each other, and {@link canonicalMatchEnd} is what keeps a
+ * syllable from being cut in half.
  */
 const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
 
+/** Marks never open a name, so one sitting after a match extends the letter. */
+const COMBINING_MARK = /\p{M}/u
+
+/**
+ * No ASCII character carries an accent or composes with a neighbour, so in a
+ * body without one there is nothing for a canonical fold to find that an exact
+ * comparison has not already found — whatever the names are spelled like.
+ */
+const NON_ASCII = /\P{ASCII}/u
+
 const nextBoundary = (text: string, at: number): number => {
   BASE_WITH_MARKS.lastIndex = at
-  return BASE_WITH_MARKS.exec(text) ? BASE_WITH_MARKS.lastIndex : text.length
+  BASE_WITH_MARKS.exec(text)
+  // The walk ends by reaching the end of the text, so the cursor may never
+  // stand still, whatever the regex leaves behind.
+  return Math.max(BASE_WITH_MARKS.lastIndex, at + 1)
 }
 
 /**
@@ -26,9 +46,11 @@ const nextBoundary = (text: string, at: number): number => {
  * `pattern`, or `-1` when no run there has it.
  *
  * Comparing canonical forms instead of raw code units is what lets a name held
- * as `i` + combining acute match a body the renderer already composed to `í`,
- * and the reverse. The index counts characters of `text` exactly as the caller
- * passed it, so a caller can still slice or anchor on its own string.
+ * as `i` + combining acute match a body the renderer already composed to `í`.
+ * Giving up the moment the run stops being a canonical prefix keeps a wrong
+ * `@` cheap, and is also what leaves decomposed Hangul alone: the boundary
+ * above would cut a syllable between its jamo, and the prefix test rejects
+ * that rather than chipping two thirds of it.
  */
 const canonicalMatchEnd = (
   text: string,
@@ -41,11 +63,34 @@ const canonicalMatchEnd = (
     if (seen === pattern) {
       return cursor
     }
-    if (cursor === text.length || seen.length > pattern.length) {
+    if (cursor === text.length || !pattern.startsWith(seen)) {
       return -1
     }
     cursor = nextBoundary(text, cursor)
   }
+}
+
+/**
+ * Both sides spelled the same way is the overwhelming majority — the renderer
+ * composes the body one line before it asks — and needs no normalizing at all.
+ * The mark test is what keeps the shortcut honest: `@Ana` sits inside a
+ * decomposed `@Aná`, and matching it there chips somebody else's name and
+ * strands the accent outside the chip.
+ */
+const matchEnd = (
+  text: string,
+  from: number,
+  pattern: string,
+  foldable: boolean
+): number => {
+  const exact = from + pattern.length
+  if (
+    text.startsWith(pattern, from) &&
+    !COMBINING_MARK.test(text.charAt(exact))
+  ) {
+    return exact
+  }
+  return foldable ? canonicalMatchEnd(text, from, pattern) : -1
 }
 
 /**
@@ -73,6 +118,7 @@ export const locateMentions = <T extends { name: string }>(
       pattern: `@${entry.name}`.normalize(CANONICAL_FORM),
     }))
     .sort((a, b) => b.pattern.length - a.pattern.length)
+  const foldable = NON_ASCII.test(text)
   for (const { entry, pattern } of byLength) {
     let from = 0
     while (true) {
@@ -80,7 +126,7 @@ export const locateMentions = <T extends { name: string }>(
       if (at === -1) {
         break
       }
-      const end = canonicalMatchEnd(text, at, pattern)
+      const end = matchEnd(text, at, pattern, foldable)
       if (end === -1) {
         from = at + 1
         continue

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -23,8 +23,18 @@ export type LocatedMention<T> = {
  */
 const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
 
-/** Marks never open a name, so one sitting after a match extends the letter. */
-const COMBINING_MARK = /\p{M}/u
+/**
+ * Marks never open a name, so one sitting after a match extends the letter.
+ * Sticky rather than a single-character test: a mark outside the BMP is two
+ * code units and a lone surrogate is not `\p{M}`, so reading one unit would
+ * wave an astral mark straight past the guard.
+ */
+const COMBINING_MARK = /\p{M}/uy
+
+const startsWithMark = (text: string, at: number): boolean => {
+  COMBINING_MARK.lastIndex = at
+  return COMBINING_MARK.test(text)
+}
 
 /**
  * No ASCII character carries an accent or composes with a neighbour, so in a
@@ -82,9 +92,7 @@ const literalMatchEnd = (
   needle: string
 ): number => {
   const end = from + needle.length
-  return text.startsWith(needle, from) && !COMBINING_MARK.test(text.charAt(end))
-    ? end
-    : -1
+  return text.startsWith(needle, from) && !startsWithMark(text, end) ? end : -1
 }
 
 /**

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -24,16 +24,22 @@ export type LocatedMention<T> = {
 const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
 
 /**
- * Marks never open a name, so one sitting after a match extends the letter.
+ * A code point that composes with whatever precedes it, so no match may end
+ * just before one. Combining marks are the general case; Hangul jungseong and
+ * jongseong are the rest of it, because they compose with a preceding jamo
+ * rather than as marks — a name held as `\uAE30` in jamo sits inside a
+ * jamo-spelled `\uAE40` exactly the way `@Ana` sits inside a decomposed
+ * `@Aná`, and ending there chips two thirds of somebody's syllable.
+ *
  * Sticky rather than a single-character test: a mark outside the BMP is two
  * code units and a lone surrogate is not `\p{M}`, so reading one unit would
- * wave an astral mark straight past the guard.
+ * wave an astral mark straight past.
  */
-const COMBINING_MARK = /\p{M}/uy
+const CONTINUES_PREVIOUS = /[\p{M}\u1161-\u1175\u11A8-\u11C2]/uy
 
-const startsWithMark = (text: string, at: number): boolean => {
-  COMBINING_MARK.lastIndex = at
-  return COMBINING_MARK.test(text)
+const continuesPrevious = (text: string, at: number): boolean => {
+  CONTINUES_PREVIOUS.lastIndex = at
+  return CONTINUES_PREVIOUS.test(text)
 }
 
 /**
@@ -71,7 +77,7 @@ const canonicalMatchEnd = (
   while (true) {
     const seen = text.slice(from, cursor).normalize(CANONICAL_FORM)
     if (seen === pattern) {
-      return cursor
+      return continuesPrevious(text, cursor) ? -1 : cursor
     }
     if (cursor === text.length || !pattern.startsWith(seen)) {
       return -1
@@ -81,10 +87,10 @@ const canonicalMatchEnd = (
 }
 
 /**
- * Index just past `needle` sitting literally at `from`, or `-1`. The mark test
- * is what keeps the shortcut honest: `@Ana` sits inside a decomposed `@Aná`,
- * and matching it there chips somebody else's name and strands the accent
- * outside the chip.
+ * Index just past `needle` sitting literally at `from`, or `-1`. The
+ * continuation test is what keeps the shortcut honest: `@Ana` sits inside a
+ * decomposed `@Aná`, and matching it there chips somebody else's name and
+ * strands the accent outside the chip.
  */
 const literalMatchEnd = (
   text: string,
@@ -92,7 +98,9 @@ const literalMatchEnd = (
   needle: string
 ): number => {
   const end = from + needle.length
-  return text.startsWith(needle, from) && !startsWithMark(text, end) ? end : -1
+  return text.startsWith(needle, from) && !continuesPrevious(text, end)
+    ? end
+    : -1
 }
 
 /**

--- a/packages/react/src/sds/chat/F0Chat/utils/sanitize-text.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/sanitize-text.ts
@@ -10,12 +10,19 @@ const EXCESS_COMBINING_MARKS = /(\p{M}{3})\p{M}+/gu
 const BIDI_CONTROLS = /[\u202A-\u202E\u2066-\u2069]/g
 
 /**
+ * The one Unicode form displayed text is folded into. Exported because mention
+ * matching has to fold names the same way: two spellings of the same name
+ * compare equal only in a shared form.
+ */
+export const CANONICAL_FORM = "NFC"
+
+/**
  * Make an untrusted message string safe to DISPLAY: normalize to NFC, cap
  * combining-mark stacks (zalgo) and drop bidi overrides. Emojis (ZWJ
  * sequences, variation selectors, skin tones) pass through untouched.
  */
 export const sanitizeDisplayText = (text: string): string =>
   text
-    .normalize("NFC")
+    .normalize(CANONICAL_FORM)
     .replace(EXCESS_COMBINING_MARKS, "$1")
     .replace(BIDI_CONTROLS, "")


### PR DESCRIPTION
## Description

A mention whose name carries a combining accent never became a chip. `renderBodyWithMentions`
composes the body to NFC before it takes the mention ranges, but `locateMentions` matched the raw
token names with `indexOf` and normalized nothing. A name held decomposed — `García` as `i` + U+0301
rather than the precomposed `í` — could not match the composed body: no chip, no hover card, the
mention rendered as ordinary text. Which of the two spellings each side happens to carry is now
irrelevant to whether a mention is found.

The same walk closes a second defect that was live on `main`: `locateMentions` matched a bare `@Ana`
inside a decomposed `@Aná`, because `indexOf` found `@Ana` and stopped before the combining mark.
That chipped three letters of a name belonging to somebody else and left the accent stranded outside
the chip.

## Type of change

- [x] Bug fix

## Implementation details

The `NFC` constant moves to an export of `sanitize-text.ts`, so display and matching cannot drift
apart. `locateMentions` then walks a candidate one `base + combining marks` boundary at a time,
comparing canonical forms. The boundary is what stops a candidate being cut between a letter and its
accent — the trap a plain "normalize both sides, then `indexOf`" fix falls straight into.

**Offsets keep counting characters of the string the caller passed in.** Both callers need that, for
different strings: `utils/render-body.tsx` passes the already-composed body and slices it with the
returned range; `hooks/useMentions.ts` (`seedMentions`, untouched here) passes the **raw** composer
text and stores `start` as a live anchor into that same string. Returning offsets into an NFC copy
would have silently mis-anchored every mention in a decomposed draft.

Two guards keep it cheap, and both are provable rather than heuristic:

- a run already spelled like the name is taken exactly, so the common path never normalizes at all
  (the mark test above is what keeps that shortcut honest);
- a body with no character above ASCII cannot carry an accent or compose with a neighbour, so there
  is nothing left for a fold to find.

Giving up as soon as a run stops being a canonical prefix is also what leaves **Hangul** alone: jamo
compose with each other rather than with marks, so the boundary walk could otherwise cut a syllable
in half and chip two thirds of it.

`end` is now documented as the only authority on where an occurrence stops, because it is no longer
always `start + 1 + name.length`.

## Verification

Run from `packages/react`, after `pnpm --filter @factorialco/f0-core build`.

| Check | Clean base | With this change |
|---|---|---|
| `vitest run src/sds/chat` | 71 files / 704 tests | **72 files / 719 tests**, all pass |
| The new tests with `mention-ranges.ts` reverted to `main` | **8 failed / 18 passed** | 26 passed |
| `pnpm --filter @factorialco/f0-react run tsc` | 0 errors | 0 errors |
| `format:check` (oxfmt) · `lint --max-warnings 0` (oxlint) | clean | clean |

The base column was measured in a separate pristine checkout of `origin/main`, not by subtracting.
The red column was re-measured against the *final* tests, with one lever: `mention-ranges.ts`
restored from `origin/main`. Working tree verified clean afterwards.

Fifteen new tests: composed body + decomposed name, decomposed body + composed name, both spellings
in one body, the name also present as plain text without an `@`, the accent-swallowing case above,
a singleton fold (U+212B matching U+00C5), a surrogate-pair name, a decomposed Hangul syllable
left alone, a trailing `@`, an `@` that is not a mention, the `seedMentions` call shape, `end` not
being derivable from the name length, and a `render-body` test proving the chip actually renders.
Fixtures are written as `\u` escapes on purpose — the two spellings are the whole point and are
indistinguishable when pasted as literal characters.

**Cost**, measured in Node against the previous implementation on the same inputs:

| body | tokens | before | after |
|---|---|---|---|
| realistic 2.2 KB body | 20 | 0.004 ms | 0.008 ms |
| `"@"` × 10 000 (ASCII) | 20 | 0.014 ms | 1.6 ms |
| `"@"` × 10 000 with one accent | 20 | 0.036 ms | 25.5 ms |

The last row is the adversarial worst case and the honest ceiling: a pasted body of nothing but `@`
plus one accented character. `ChatBubble` memoizes the parse per message content, so it is paid once.
An earlier revision of this branch cost **459 ms** on that same input; the two guards above are what
took it down.

No video: this is pure text-location logic with no visual change of its own, and the rendered output
for an ASCII mention is byte-identical. Albert will check a mention with a diacritic in Storybook.

### Re-run by the fresh-eyes review (appended)

Run from `packages/react` on `91198d459`.

| Check | Result |
|---|---|
| `pnpm vitest run src/sds/chat/F0Chat` | **72 files / 726 tests**, all pass (719 before this review's 7 tests) |
| `pnpm tsc` | 0 errors |
| `pnpm format:check src/sds/chat/F0Chat` (oxfmt) | clean, 184 files |
| `pnpm lint src/sds/chat/F0Chat` (oxlint `--max-warnings 0`) | 0 warnings / 0 errors |
| lefthook `pre-commit`, `commit-msg`, `pre-push` preflight | green |

Three checks this review added:

- **Differential fuzz against `origin/main`, 200 000 generated bodies.** Alphabet: `@`, ASCII,
  U+00ED, U+0301, U+0316, U+0327, U+00C5, U+212A, U+212B, U+0958, Hangul jamo L/V/T, U+AC00,
  U+AE30/U+AE40, an astral emoji, U+200D, U+FE0F and the astral mark U+1D167; 19 name fixtures.
  Every occurrence `origin/main` located is classified against this branch. On `91198d459`:
  **lost 0 · start-or-end shifted 0** · 389 blocked because a composing code point follows ·
  17 re-attributed between entries whose names are canonically equal.
- **The no-chipping invariant, fuzzed.** 150 000 bodies drawn from an alphabet of jamo, syllables,
  BMP and astral marks: **2 015 located ranges, 0** ending on a code point that composes with what
  precedes it.
- **The ASCII skip guard, proven rather than argued.** 40 000 ASCII bodies against the same
  algorithm with `foldable` forced `true`: identical on every case. NFC and NFD are the identity on
  all 128 ASCII code points and on 20 000 random ASCII strings. The guard is sound *because the
  pattern is normalized first*: exactly three non-ASCII code points fold to pure ASCII (U+037E,
  U+1FEF, U+212A), and all three are caught by the literal path.

## Fresh-eyes review

Independent second-opinion pass. The diff was read cold — before the description, the commits or the
lane notes — then every claim here was reconciled against the code, then the branch was stress-tested
with two diff-only sub-agents that had no access to any narrative. Three commits were added on this
branch, each with a failing-first test: `579cc25d5`, `98c110c6f`, `91198d459`.

Two of the three fix defects **this review itself introduced or missed**, which is said plainly
rather than smoothed over: `579cc25d5` restored a lost match and in doing so reopened a syllable
chip, and `91198d459` is what closes it.

### BLOCKER 1 (fixed in `579cc25d5`) — a name held as Hangul jamo was lost in a body spelled the same way

The Deferred bullet below and commit `354a60dbf` both say decomposed Hangul jamo names "still do not
match, exactly as on `main`". True in one direction, **contradicted** in the other:

```
body  "hi @" + U+1100 U+1161 U+11A8 + "!"       (jamo)
name          U+1100 U+1161 U+11A8              (the same jamo, byte for byte)

origin/main   [{ start: 3, end: 7 }]   ← plain indexOf matched it
354a60dbf     []                        ← lost
```

Normalizing the pattern composes the jamo to U+AC01, removing the literal match, and
`canonicalMatchEnd` cannot recover it: it advances one `base + \p{M}*` group at a time, and jamo
compose with each other rather than as marks, so a partial jamo run is never a canonical prefix of
the syllable. A sweep of the code space found **837** starter+starter canonical compositions in this
class — every Hangul syllable, plus Myanmar and Tibetan sequences.

It is the **composer** that loses it, not the bubble. `renderBodyWithMentions` sanitizes the body to
NFC one line before it asks, so the jamo are already composed and the pattern matches them literally;
`seedMentions` passes `inputValueRef.current` unsanitized, and NFD is what macOS hands over for
Hangul, so a paste is enough. That is the caller this PR's design note is built around.

Fixed by trying the name **as it is written** after the canonical form. Failing-first test
`locates a name held as jamo in a body spelled the same way`.

### BLOCKER 2 (fixed in `98c110c6f`) — the trailing guard could not see a mark outside the BMP

`text.charAt(exact)` reads **one code unit**. A mark above U+FFFF is two, and the unit read is a lone
high surrogate, which is not `\p{M}`:

```
U+0301  (BMP)     \p{M} by code point = true   by charAt = true    → guard fires, [] as intended
U+1D167 (astral)  \p{M} by code point = true   by charAt = false   → guard bypassed
locateMentions("hi @Ana" + U+1D167 + " x", [{ name: "Ana" }])  →  [{ start: 3, end: 7 }]
```

The exact path did precisely what the guard exists to stop — chip `@Ana` and strand the mark — for
every combining mark above U+FFFF (U+101FD, U+1E944, U+E0101 all reproduce it). Live on `354a60dbf`;
not something `main` got right either, so a hole rather than a regression. The fold path was never
affected, since `\p{M}*` under `/u` consumes astral marks — the invariant the `end` docstring claims
held on one path only. Fixed with a sticky test at the index, which reads the whole code point.

### BLOCKER 3 (introduced by `579cc25d5`, fixed in `91198d459`) — the literal path chipped a Hangul syllable in half

This is the one a sub-agent caught in **this review's own first fix**. Jamo are category `Lo`, not
`\p{M}`, so the trailing guard waved them through, and a jamo-held name that is a literal prefix of a
longer jamo-held syllable matched inside it:

```
body   "@" + U+1100 U+1175 U+11B7 + " hi"    (김, jamo)
name         U+1100 U+1175                    (기, jamo — both are real Korean display names)

579cc25d5  [{ start: 0, end: 3 }]   ← chip covers "@기"; the jongseong is stranded outside it
91198d459  []
```

That is exactly the failure `354a60dbf`'s canonical-prefix test was written to prevent, reintroduced
through a path that never consults it. A fuzz put **11.2%** of all newly-gained ranges in this class.
The same shape also existed on `main` and on `354a60dbf` for a lone leading jamo
(`locateMentions("@" + U+1100 U+1161, [{ name: U+1100 }])` → `[0,2)`), through the fold path.

Fixed by asking the question the guard was always asking — *does the code point after the match
compose with what precedes it?* — with jungseong (U+1161–U+1175) and jongseong (U+11A8–U+11C2)
answering yes alongside every combining mark, consulted by **both** literal spellings and the
canonical walk. A jamo that opens a *new* syllable is not a continuation, so a name the next syllable
follows still matches whole; that direction is pinned by its own test. Three failing-first tests.

### SHOULD FIX (left for Albert — both live in `useMentions.ts`, which is #5425's file)

**4 — two people whose names are canonically equal but differently spelled: one is anchored twice,
the other silently dropped.** `seedMentions` keys `byName` on the **raw** name, so both spellings go
in as separate entries; both now match both occurrences, and the overlap dropper hands each one to
whichever sorted first:

```
text = "@José and @José"        (one precomposed, one decomposed)
origin/main anchors  [{ userA, start: 0 }, { userB, start: 10 }]
this branch anchors  [{ userA, start: 0 }, { userA, start: 10 }]   ← userB never anchored
```

`mentionPayload` dedupes by id, so re-sending the edited message silently un-mentions userB. A real
**regression**, though narrow. It cannot be fixed inside `locateMentions`, which does not know how
`seedMentions` groups; the fix is to key `byName` on the canonical form.

**5 — `mentionEnd` can *overshoot*, not only undershoot.** The Deferred bullet describes the span as
"short by one index per accent". NFC grows strings as well as shrinking them:

| body | name | `end − start` | `mentionEnd` | error |
|---|---|---|---|---|
| `@Garci` U+0301 `a` | `García` (NFC) | 9 | 8 | 1 short |
| `@` U+0958 | U+0915 U+093C | 2 | 3 | **1 long** |
| composed U+AC01 | jamo U+1100 U+1161 U+11A8 | 2 | 4 | **2 long, past the end of the string** |

The overshoot is the destructive one: `useMentions.ts:191` marks a mention touched when
`prefix < end && prevEnd > start`, so an over-long end makes typing a character *after* the mention
erase the whole mention — the behaviour `reanchorMentions`' own docstring promises cannot happen.
Both stay unreachable for occurrences that matched before this branch, so "not a regression" stands.

### NOTED — cost, with a correction to this review's own first answer

`canonicalMatchEnd` re-slices and re-normalizes a growing prefix at every boundary step, so the scan
is `O(E · #@ · L²)` in entries, `@`-signs and name length.

**This review first called the cost "not a hazard" on the strength of a 5 ms measurement. That was
wrong, and the measurement was why: the body shape used made the walk bail after two steps, so it
never exercised the quadratic.** The shape that does is a body mirroring the pattern, which needs the
display name to contain `@`. Re-measured:

| input | cost |
|---|---|
| 4 001-char body, **4 001-char** name containing `@` | **10 525 ms** |
| same body, 255-char name containing `@` — 1 / 10 / 50 entries | 1.0 / 12.0 / 57.0 ms |
| 8 000- and 40 000-char bodies, 100–255-char names, 50–200 entries, no `@` in the name | 0.0–0.2 ms |

So the blow-up is real and cubic in the name length, but reaching seconds needs a display name of
thousands of characters. Under any realistic name cap the worst case found is **57 ms** — twenty
times the 25.5 ms ceiling in the table above, on the per-message render path, but not a freeze.
`locateMentions` imposes no bound of its own on `pattern.length`, which is the part worth a decision.
Sub-agents reported 63–310 ms for bodies with no `@` in the name; those shapes re-measured at
0.0–0.2 ms here, so that table is **not** reproduced as fact and the order of magnitude is disputed.

### NOTED — smaller

6. **U+FE0F and U+FE0E are `\p{M}`**, so `@Ana` followed by a variation selector matches nothing
   where `main` chipped it. Deliberate under the stated rule; worth knowing it is not only accents.
7. **U+200D is not.** A match can still end inside an emoji ZWJ sequence — pre-existing on the
   pattern path, newly reachable on the literal one. Left alone deliberately: a ZWJ after a letter is
   not a canonical continuation, so folding it into the guard would be a different rule, not this
   one.
8. **When the guard fires there is no fallback**: the fold then fails too and the occurrence
   disappears, where `main` chipped the name and stranded the mark. Every occurrence `main` located
   and this branch does not is of exactly that shape.
9. **`Math.max` in `nextBoundary` is unreachable, not defensive.** `canonicalMatchEnd` tests
   `cursor === text.length` first, and a sticky `[\s\S]\p{M}*` always matches at an in-range index.
   Instrumented over 97 073 real walk steps: the fallback fired 0 times, 0 walks split a surrogate
   pair. Harmless; the comment's stated reason is really why it is *not* needed.

### Mutation matrix — what the tests constrain

One lever per mechanism, run against `mention-ranges.test.ts` + `render-body.test.tsx`.

| Mutation | Result |
|---|---|
| Continuation guard → marks only (no jamo) | RED — 2 tests |
| Guard drops jongseong only | RED — `does not chip a syllable whose jamo…` |
| Guard widened to swallow leading jamo too | RED — `still matches a jamo name that a new syllable follows` |
| Fold path stops consulting the guard | RED — `does not chip a syllable open on its leading jamo` |
| Guard back to a single-code-unit `charAt` | RED — `does not swallow an astral combining mark either` |
| Guard removed entirely | RED — 3 tests |
| `continuesPrevious` without its `lastIndex` reset | RED — 3 tests |
| Drop the as-written branch from `matchEnd` | RED — `locates a name held as jamo…` |
| Stop normalizing the pattern | RED — 3 tests |
| `foldable` forced **false** | RED — 6 tests |
| Canonical-prefix early-out → a length bound | RED — `leaves a Hangul syllable…` |
| `BASE_WITH_MARKS` without `\p{M}*` | RED — 6 tests |
| Sort shortest pattern first | RED — 2 tests |
| Overlap dropper disabled | RED — `prefers the longest name…` |
| Try the as-written form **before** the canonical one | **SURVIVED** |
| Run the as-written branch unconditionally | **SURVIVED** |
| `foldable` forced **true** | **SURVIVED** |
| `nextBoundary` without the min-advance clamp | **SURVIVED** |
| **Sort by raw name length (the pre-PR comparator)** | **SURVIVED** |

Four survivors are survivors *by construction*: the ASCII guard is a provably unobservable
optimization; the `Math.max` clamp is unreachable; and neither the ordering of the two literal
attempts nor running the second unconditionally can change a result, because `pattern` is
`NFC(asWritten)` — wherever they differ they differ at some character, so a text cannot start with
both spellings at once (confirmed at 400 000 cases, 0 disagreements). The fifth is a genuine gap:
**the sort-key change from raw name length to NFC pattern length is pinned by nothing.** Restoring
the old comparator leaves every test green.

### What the tests still do not prove

- The sort-key change is uncovered, and NFC ties two jamo names of different lengths to the same key
  (`@기` and `@김` both normalize to length 2), so which wins falls to entry order — which
  `seedMentions` takes from Map insertion order, i.e. arbitrary. No strict inversion was found in
  2 983 × 2 983 exhaustive pairs; 168 order-dependent ties were.
- Nothing constrains cost. The ceiling in the table is a claim, re-measured by hand, not a check that
  would catch a future revision reintroducing the 459 ms one.
- Several tests pass on `origin/main` unchanged and so constrain nothing this PR adds: the plain
  ASCII name, the trailing `@`, the non-mention `@`, and `marks only the @ occurrence`.
- `folds a singleton so a legacy code point still matches` asserts only `toHaveLength(1)`; an
  implementation returning `{ start: at, end: at + 1 }` for every fold match passes it.
- `keeps the seedMentions call shape resolving` reads only `{ name, start }`, so any `end` passes —
  the one test aimed at the consumer in SHOULD FIX 5 cannot detect that problem.
- `locates a name held as jamo in a body that composed it` (added by this review) passes on
  `354a60dbf` too: it pins the pre-existing direction, not the branch it accompanies.
- Nothing exercises `useMentions` with a cross-spelling draft, so SHOULD FIX 4 and 5 are read off the
  code, not observed.
- Storybook was not run by this review. The visual check is still Albert's — and it is worth adding a
  Korean name to it.

## Deferred to review

- Storybook in a visible tab — a mention of someone whose name has an accent (Albert records it).
- **`hooks/useMentions.ts` L40** derives a span end as `start + name.length + 1` rather than reading
  the located `end`. For a composer draft where the text and the saved name are spelled differently,
  that span is now off by one index per accent. It is **not a regression**: every occurrence that
  matched before this change still matches with the same `start` and `end` (the one exception is the
  accent-swallowing case above, which is the defect being fixed), so the gap only touches mentions
  that were previously not found at all — where the mention id was simply lost. Fixing it properly
  means carrying `end` into `AnchoredMention`, which belongs to #5425.
- Decomposed **Hangul jamo** names still do not match, exactly as on `main`. Latin, Greek and
  Cyrillic diacritics all do.
- `BASE_WITH_MARKS` is a module-scoped sticky regex whose `lastIndex` is assigned before every use;
  the `Math.max` in `nextBoundary` makes even a stale value harmless. Kept deliberately over a
  per-call allocation.

## Context

Two behaviour changes worth a reviewer's eye, both intended:

- `@Name` immediately followed by a combining mark no longer matches `Name` (it used to, and chipped
  the wrong person).
- The longest-name-first sort now keys on the canonical pattern length rather than the raw name
  length, so the ordering does not flip just because one name is stored decomposed. The sort is
  stable, so the entry-order tie-break the previous code relied on is unchanged.
- NFC folds singletons, so a name spelled `Å` (U+00C5) now also matches a body using the ANGSTROM
  SIGN (U+212B). Pinned by a test.

Related PRs:

- [💻 Related PR](https://github.com/factorialco/f0/pull/5425) — open draft on `hooks/useMentions.ts`,
  a **caller** of `locateMentions`. No file overlap with this diff; the `seedMentions` call-shape
  test exists so that PR keeps working, and the `mentionEnd` note above is for its author.
- [💻 Related PR](https://github.com/factorialco/f0/pull/5404) — merged, introduced `locateMentions`
  and the single-place-of-matching invariant this change preserves.

