### PR TITLE
perf(F0Chat): memoize the mention popover rows

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
@@ -1,12 +1,5 @@
-import {
-  memo,
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from "react"
-import { type AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
+import { memo, useCallback, useEffect, useLayoutEffect, useRef } from "react"
+import { F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Icon } from "@/components/F0Icon"
 import { People } from "@/icons/app"
 import { OneEllipsis } from "@/lib/OneEllipsis"
@@ -40,7 +33,7 @@ const optionId = (listboxId: string, candidate: MentionCandidate): string => {
 export const getChatMentionOptionId = optionId
 
 type MentionOptionProps = {
-  optionId: string
+  id: string
   index: number
   isSelected: boolean
   onSelect: (index: number) => void
@@ -49,7 +42,7 @@ type MentionOptionProps = {
 }
 
 function MentionOption({
-  optionId,
+  id,
   index,
   isSelected,
   onSelect,
@@ -67,7 +60,7 @@ function MentionOption({
   return (
     <div
       ref={innerRef}
-      id={optionId}
+      id={id}
       role="option"
       aria-selected={isSelected}
       className={cn(
@@ -112,14 +105,18 @@ const UserRow = memo(function UserRow({
   user,
   ...option
 }: MentionRowProps & { user: F0ChatUser }) {
-  const avatar = useMemo<AvatarVariant>(
-    () => user.avatar ?? { type: "person", firstName: user.name, lastName: "" },
-    [user]
-  )
-
   return (
     <MentionOption {...option}>
-      <F0Avatar size="xs" avatar={avatar} />
+      <F0Avatar
+        size="xs"
+        avatar={
+          user.avatar ?? {
+            type: "person",
+            firstName: user.name,
+            lastName: "",
+          }
+        }
+      />
       <div className="flex min-w-0 flex-1 flex-col">
         <OneEllipsis className="text-base font-medium text-f1-foreground">
           {user.name}
@@ -156,9 +153,14 @@ export function ChatMentionPopover({
   // handed either of them directly would re-render on every keystroke however
   // it was memoized. Rows get an index and this handler instead, both stable.
   const resultsRef = useRef(results)
-  resultsRef.current = results
   const onSelectRef = useRef(onSelect)
-  onSelectRef.current = onSelect
+  // Committed values only: a render a host discards (a transition, a Suspense
+  // retry) must not leave these pointing at candidates that never reached the
+  // DOM, or a click would insert someone the list never showed.
+  useLayoutEffect(() => {
+    resultsRef.current = results
+    onSelectRef.current = onSelect
+  })
 
   const handleSelect = useCallback((index: number) => {
     const candidate = resultsRef.current[index]
@@ -215,7 +217,7 @@ export function ChatMentionPopover({
         return candidate.kind === "everyone" ? (
           <EveryoneRow
             key="@everyone"
-            optionId={id}
+            id={id}
             index={index}
             isSelected={isSelected}
             onSelect={handleSelect}
@@ -226,7 +228,7 @@ export function ChatMentionPopover({
         ) : (
           <UserRow
             key={candidate.user.id}
-            optionId={id}
+            id={id}
             index={index}
             isSelected={isSelected}
             onSelect={handleSelect}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
@@ -1,5 +1,12 @@
-import { useEffect, useLayoutEffect, useRef } from "react"
-import { F0Avatar } from "@/components/avatars/F0Avatar"
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+} from "react"
+import { type AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Icon } from "@/components/F0Icon"
 import { People } from "@/icons/app"
 import { OneEllipsis } from "@/lib/OneEllipsis"
@@ -9,6 +16,7 @@ import {
   type MentionCandidate,
   type PopoverPosition,
 } from "../hooks/useMentions"
+import { type F0ChatUser } from "../types"
 
 export type ChatMentionPopoverProps = {
   isOpen: boolean
@@ -31,10 +39,105 @@ const optionId = (listboxId: string, candidate: MentionCandidate): string => {
 
 export const getChatMentionOptionId = optionId
 
+type MentionOptionProps = {
+  optionId: string
+  index: number
+  isSelected: boolean
+  onSelect: (index: number) => void
+  innerRef: React.Ref<HTMLDivElement> | undefined
+  children: React.ReactNode
+}
+
+function MentionOption({
+  optionId,
+  index,
+  isSelected,
+  onSelect,
+  innerRef,
+  children,
+}: MentionOptionProps) {
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent<HTMLDivElement>) => {
+      e.preventDefault()
+      onSelect(index)
+    },
+    [onSelect, index]
+  )
+
+  return (
+    <div
+      ref={innerRef}
+      id={optionId}
+      role="option"
+      aria-selected={isSelected}
+      className={cn(
+        "flex cursor-pointer items-center gap-2 p-2 rounded",
+        "transition-colors",
+        isSelected
+          ? "bg-f1-background-secondary"
+          : "hover:bg-f1-background-secondary-hover"
+      )}
+      onMouseDown={handleMouseDown}
+    >
+      {children}
+    </div>
+  )
+}
+
+type MentionRowProps = Omit<MentionOptionProps, "children">
+
+const EveryoneRow = memo(function EveryoneRow({
+  label,
+  description,
+  ...option
+}: MentionRowProps & { label: string; description: string }) {
+  return (
+    <MentionOption {...option}>
+      <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-f1-background-secondary">
+        <F0Icon icon={People} size="sm" color="default" />
+      </span>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <OneEllipsis className="text-base font-medium text-f1-foreground">
+          {label}
+        </OneEllipsis>
+        <OneEllipsis className="text-sm text-f1-foreground-secondary">
+          {description}
+        </OneEllipsis>
+      </div>
+    </MentionOption>
+  )
+})
+
+const UserRow = memo(function UserRow({
+  user,
+  ...option
+}: MentionRowProps & { user: F0ChatUser }) {
+  const avatar = useMemo<AvatarVariant>(
+    () => user.avatar ?? { type: "person", firstName: user.name, lastName: "" },
+    [user]
+  )
+
+  return (
+    <MentionOption {...option}>
+      <F0Avatar size="xs" avatar={avatar} />
+      <div className="flex min-w-0 flex-1 flex-col">
+        <OneEllipsis className="text-base font-medium text-f1-foreground">
+          {user.name}
+        </OneEllipsis>
+      </div>
+    </MentionOption>
+  )
+})
+
 /**
  * Inline `@`-mention autocomplete, positioned above the textarea — the comms
  * twin of the AI chat's MentionPopover (same chrome, positioning and skeletons).
  * Renders group members, with the "everyone" (`@here`) option pinned on top.
+ *
+ * Every candidate the search returned stays mounted — the keyboard cycles
+ * through all of them and nothing in the contract caps the list — but rows are
+ * memoized on the candidate they render, so a keystroke that leaves the
+ * candidates alone re-renders none of them.
  */
 export function ChatMentionPopover({
   isOpen,
@@ -48,6 +151,21 @@ export function ChatMentionPopover({
 }: ChatMentionPopoverProps) {
   const listRef = useRef<HTMLDivElement>(null)
   const selectedItemRef = useRef<HTMLDivElement>(null)
+
+  // The composer rebuilds `results` and `onSelect` on every keystroke, so a row
+  // handed either of them directly would re-render on every keystroke however
+  // it was memoized. Rows get an index and this handler instead, both stable.
+  const resultsRef = useRef(results)
+  resultsRef.current = results
+  const onSelectRef = useRef(onSelect)
+  onSelectRef.current = onSelect
+
+  const handleSelect = useCallback((index: number) => {
+    const candidate = resultsRef.current[index]
+    if (candidate) {
+      onSelectRef.current(candidate)
+    }
+  }, [])
 
   useEffect(() => {
     selectedItemRef.current?.scrollIntoView({ block: "nearest" })
@@ -92,61 +210,29 @@ export function ChatMentionPopover({
     >
       {results.map((candidate, index) => {
         const isSelected = index === selectedIndex
-        const key =
-          candidate.kind === "everyone" ? "@everyone" : candidate.user.id
-        return (
-          <div
-            key={key}
-            ref={isSelected ? selectedItemRef : undefined}
-            id={optionId(listboxId, candidate)}
-            role="option"
-            aria-selected={isSelected}
-            className={cn(
-              "flex cursor-pointer items-center gap-2 p-2 rounded",
-              "transition-colors",
-              isSelected
-                ? "bg-f1-background-secondary"
-                : "hover:bg-f1-background-secondary-hover"
-            )}
-            onMouseDown={(e) => {
-              e.preventDefault()
-              onSelect(candidate)
-            }}
-          >
-            {candidate.kind === "everyone" ? (
-              <>
-                <span className="flex size-5 shrink-0 items-center justify-center rounded-full bg-f1-background-secondary">
-                  <F0Icon icon={People} size="sm" color="default" />
-                </span>
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <OneEllipsis className="text-base font-medium text-f1-foreground">
-                    {candidate.label}
-                  </OneEllipsis>
-                  <OneEllipsis className="text-sm text-f1-foreground-secondary">
-                    {everyoneDescription}
-                  </OneEllipsis>
-                </div>
-              </>
-            ) : (
-              <>
-                <F0Avatar
-                  size="xs"
-                  avatar={
-                    candidate.user.avatar ?? {
-                      type: "person",
-                      firstName: candidate.user.name,
-                      lastName: "",
-                    }
-                  }
-                />
-                <div className="flex min-w-0 flex-1 flex-col">
-                  <OneEllipsis className="text-base font-medium text-f1-foreground">
-                    {candidate.user.name}
-                  </OneEllipsis>
-                </div>
-              </>
-            )}
-          </div>
+        const innerRef = isSelected ? selectedItemRef : undefined
+        const id = optionId(listboxId, candidate)
+        return candidate.kind === "everyone" ? (
+          <EveryoneRow
+            key="@everyone"
+            optionId={id}
+            index={index}
+            isSelected={isSelected}
+            onSelect={handleSelect}
+            innerRef={innerRef}
+            label={candidate.label}
+            description={everyoneDescription}
+          />
+        ) : (
+          <UserRow
+            key={candidate.user.id}
+            optionId={id}
+            index={index}
+            isSelected={isSelected}
+            onSelect={handleSelect}
+            innerRef={innerRef}
+            user={candidate.user}
+          />
         )
       })}
 

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMentionPopover.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMentionPopover.test.tsx
@@ -1,4 +1,10 @@
-import { forwardRef, StrictMode, useState } from "react"
+import {
+  forwardRef,
+  startTransition,
+  StrictMode,
+  Suspense,
+  useState,
+} from "react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import {
   act,
@@ -170,6 +176,95 @@ describe("ChatMentionPopover row render cost", () => {
 
     expect(rowRenders.texts).toHaveLength(10)
     expect(rowRenders.texts[0]).toBe("Member 0 (renamed)")
+  })
+})
+
+describe("ChatMentionPopover committed-render safety", () => {
+  /**
+   * F0Chat is a library, so the host owns concurrency. A transition render that
+   * suspends is thrown away: React keeps the committed rows on screen and never
+   * runs that render's effects. The candidates the click path resolves against
+   * have to follow the rows the user can see, so a click cannot insert someone
+   * the popover never displayed.
+   */
+  it("selects a displayed candidate when a transition render is discarded", () => {
+    let settled = false
+    let release: () => void = () => {}
+    const pending = new Promise<void>((resolve) => {
+      release = () => {
+        settled = true
+        resolve()
+      }
+    })
+
+    function Suspender({ suspend }: { suspend: boolean }) {
+      if (suspend && !settled) {
+        throw pending
+      }
+      return null
+    }
+
+    let search: () => void = () => {}
+
+    function SuspendingHarness() {
+      const [users, setUsers] = useState(members.slice(0, 3))
+      const [suspend, setSuspend] = useState(false)
+      search = () =>
+        startTransition(() => {
+          setUsers(members.slice(10, 13))
+          setSuspend(true)
+        })
+
+      return (
+        <Suspense fallback={<div data-testid="fallback" />}>
+          <ChatMentionPopover
+            isOpen
+            listboxId={LISTBOX_ID}
+            results={users.map((user) => ({ kind: "user" as const, user }))}
+            isLoading={false}
+            selectedIndex={0}
+            position={{ left: 0, bottom: 0 }}
+            onSelect={(candidate) => selections.push(candidate)}
+            everyoneDescription={EVERYONE_DESCRIPTION}
+          />
+          <Suspender suspend={suspend} />
+        </Suspense>
+      )
+    }
+
+    render(<SuspendingHarness />)
+
+    act(() => search())
+
+    expect(screen.queryByTestId("fallback")).not.toBeInTheDocument()
+    const options = screen.getAllByRole("option")
+    expect(options[0]).toHaveTextContent("Member 0")
+
+    fireEvent.mouseDown(options[0]!)
+
+    expect(selections).toEqual([{ kind: "user", user: members[0] }])
+
+    act(() => release())
+  })
+
+  it("leaves no option selected when a narrower search drops the highlighted row", () => {
+    const scrolled: HTMLElement[] = []
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(
+      function (this: HTMLElement) {
+        scrolled.push(this)
+      }
+    )
+
+    const { rerender } = render(<Harness users={members.slice(0, 5)} />)
+    act(() => controls.setSelectedIndex(4))
+    const dropped = screen.getAllByRole("option")[4]!
+    scrolled.length = 0
+
+    rerender(<Harness users={members.slice(0, 2)} />)
+
+    expect(screen.getAllByRole("option")).toHaveLength(2)
+    expect(screen.queryAllByRole("option", { selected: true })).toHaveLength(0)
+    expect(scrolled).not.toContain(dropped)
   })
 })
 

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMentionPopover.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMentionPopover.test.tsx
@@ -1,6 +1,11 @@
-import { act, fireEvent, render, screen } from "@testing-library/react"
-import { type ComponentProps, useState } from "react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { forwardRef, StrictMode, useState } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  act,
+  fireEvent,
+  screen,
+  zeroRender as render,
+} from "@/testing/test-utils"
 import {
   type MentionCandidate,
   type PopoverPosition,
@@ -12,21 +17,25 @@ import {
 } from "../ChatMentionPopover"
 
 /**
- * Every candidate row renders `OneEllipsis` and nothing else in the popover
- * does, so counting its renders counts row renders without the test having to
- * know whether a row is inline JSX or its own component.
+ * Rows are the only thing in the popover that renders `OneEllipsis` — one per
+ * member row, two for the `@here` row — so recording its renders records row
+ * renders without the test knowing whether a row is inline JSX or its own
+ * component, which is what lets one test produce both the before and the after
+ * number. Keeping the text says *which* rows re-rendered, not just how many.
  */
-const rowRenders = { count: 0 }
+const rowRenders = vi.hoisted(() => ({ texts: [] as string[] }))
 
 vi.mock("@/lib/OneEllipsis", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/OneEllipsis")>()
-  return {
-    ...actual,
-    OneEllipsis: (props: ComponentProps<typeof actual.OneEllipsis>) => {
-      rowRenders.count++
-      return <actual.OneEllipsis {...props} />
-    },
-  }
+  const Counted = forwardRef<
+    HTMLElement,
+    React.ComponentProps<typeof actual.OneEllipsis>
+  >((props, ref) => {
+    rowRenders.texts.push(props.children)
+    return <actual.OneEllipsis {...props} ref={ref} />
+  })
+  Counted.displayName = "CountedOneEllipsis"
+  return { ...actual, OneEllipsis: Counted }
 })
 
 const LISTBOX_ID = "mention-listbox"
@@ -43,7 +52,6 @@ type Controls = {
 }
 
 let controls: Controls
-
 const selections: MentionCandidate[] = []
 
 /**
@@ -90,48 +98,67 @@ function Harness({
 }
 
 beforeEach(() => {
-  rowRenders.count = 0
+  rowRenders.texts = []
   selections.length = 0
+  controls = undefined as unknown as Controls
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe("ChatMentionPopover row render cost", () => {
   it("mounts one row per candidate", () => {
     render(<Harness />)
+
     expect(screen.getAllByRole("option")).toHaveLength(50)
-    expect(rowRenders.count).toBe(50)
+    expect(rowRenders.texts).toHaveLength(50)
   })
 
   it("re-renders only the two rows the highlight moved between", () => {
     render(<Harness />)
-    rowRenders.count = 0
+    rowRenders.texts = []
 
     act(() => controls.setSelectedIndex(1))
 
-    expect(rowRenders.count).toBe(2)
+    expect(rowRenders.texts).toEqual(["Member 0", "Member 1"])
   })
 
   it("re-renders no rows when a keystroke leaves the candidates unchanged", () => {
-    render(<Harness />)
-    rowRenders.count = 0
+    render(<Harness everyoneLabel="here" />)
+    rowRenders.texts = []
 
     act(() => controls.setQuery("An"))
 
-    expect(rowRenders.count).toBe(0)
+    expect(rowRenders.texts).toEqual([])
+  })
+
+  it("re-renders no rows when the keystroke lands under StrictMode's double render", () => {
+    render(
+      <StrictMode>
+        <Harness everyoneLabel="here" />
+      </StrictMode>
+    )
+    rowRenders.texts = []
+
+    act(() => controls.setQuery("An"))
+
+    expect(rowRenders.texts).toEqual([])
   })
 
   it("drops the rows a narrower search removed and leaves the survivors alone", () => {
     const { rerender } = render(<Harness />)
-    rowRenders.count = 0
+    rowRenders.texts = []
 
     rerender(<Harness users={members.slice(0, 10)} />)
 
     expect(screen.getAllByRole("option")).toHaveLength(10)
-    expect(rowRenders.count).toBe(0)
+    expect(rowRenders.texts).toEqual([])
   })
 
   it("still re-renders a row whose candidate the search replaced", () => {
     const { rerender } = render(<Harness users={members.slice(0, 10)} />)
-    rowRenders.count = 0
+    rowRenders.texts = []
 
     rerender(
       <Harness
@@ -141,10 +168,8 @@ describe("ChatMentionPopover row render cost", () => {
       />
     )
 
-    expect(rowRenders.count).toBe(10)
-    expect(screen.getAllByRole("option")[0]).toHaveTextContent(
-      "Member 0 (renamed)"
-    )
+    expect(rowRenders.texts).toHaveLength(10)
+    expect(rowRenders.texts[0]).toBe("Member 0 (renamed)")
   })
 })
 
@@ -152,8 +177,7 @@ describe("ChatMentionPopover accessibility", () => {
   it("exposes the listbox and one option per candidate, in order, with the ids the composer points aria-activedescendant at", () => {
     render(<Harness users={members.slice(0, 3)} everyoneLabel="here" />)
 
-    const listbox = screen.getByRole("listbox")
-    expect(listbox).toHaveAttribute("id", LISTBOX_ID)
+    expect(screen.getByRole("listbox")).toHaveAttribute("id", LISTBOX_ID)
 
     const options = screen.getAllByRole("option")
     expect(options).toHaveLength(4)
@@ -190,11 +214,11 @@ describe("ChatMentionPopover accessibility", () => {
 
   it("scrolls the newly highlighted option into view, including when the highlight moves up", () => {
     const scrolled: HTMLElement[] = []
-    const spy = vi
-      .spyOn(HTMLElement.prototype, "scrollIntoView")
-      .mockImplementation(function (this: HTMLElement) {
+    vi.spyOn(HTMLElement.prototype, "scrollIntoView").mockImplementation(
+      function (this: HTMLElement) {
         scrolled.push(this)
-      })
+      }
+    )
 
     render(<Harness users={members.slice(0, 5)} />)
     act(() => controls.setSelectedIndex(3))
@@ -202,8 +226,8 @@ describe("ChatMentionPopover accessibility", () => {
 
     act(() => controls.setSelectedIndex(1))
 
-    expect(scrolled).toEqual([screen.getAllByRole("option")[1]])
-    spy.mockRestore()
+    expect(scrolled).toHaveLength(1)
+    expect(scrolled[0]).toBe(screen.getAllByRole("option")[1])
   })
 
   it("selects the pointed-at candidate without taking focus off the textarea", () => {
@@ -217,14 +241,26 @@ describe("ChatMentionPopover accessibility", () => {
     expect(selections).toEqual([{ kind: "user", user: members[1] }])
   })
 
+  it("selects from the candidates on screen after a narrower search", () => {
+    const { rerender } = render(
+      <Harness users={members.slice(0, 5)} everyoneLabel="here" />
+    )
+
+    rerender(<Harness users={members.slice(2, 5)} everyoneLabel="here" />)
+    fireEvent.mouseDown(screen.getAllByRole("option")[1]!)
+
+    expect(selections).toEqual([{ kind: "user", user: members[2] }])
+  })
+
   it("keeps loading skeletons out of the accessible option list", () => {
     render(<Harness users={[]} everyoneLabel="here" isLoading />)
 
     expect(screen.getAllByRole("option")).toHaveLength(1)
-    document
-      .querySelectorAll('[aria-hidden="true"]')
-      .forEach((skeleton) => expect(skeleton).toBeInTheDocument())
-    expect(document.querySelectorAll('[aria-hidden="true"]')).toHaveLength(3)
+    const skeletons = screen.getAllByTestId("skeleton")
+    expect(skeletons).toHaveLength(6)
+    skeletons.forEach((skeleton) =>
+      expect(skeleton.closest('[aria-hidden="true"]')).not.toBeNull()
+    )
   })
 
   it("renders nothing when closed, or when nothing matches and nothing is loading", () => {

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMentionPopover.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMentionPopover.test.tsx
@@ -1,0 +1,237 @@
+import { act, fireEvent, render, screen } from "@testing-library/react"
+import { type ComponentProps, useState } from "react"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  type MentionCandidate,
+  type PopoverPosition,
+} from "../../hooks/useMentions"
+import { type F0ChatUser } from "../../types"
+import {
+  ChatMentionPopover,
+  getChatMentionOptionId,
+} from "../ChatMentionPopover"
+
+/**
+ * Every candidate row renders `OneEllipsis` and nothing else in the popover
+ * does, so counting its renders counts row renders without the test having to
+ * know whether a row is inline JSX or its own component.
+ */
+const rowRenders = { count: 0 }
+
+vi.mock("@/lib/OneEllipsis", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/OneEllipsis")>()
+  return {
+    ...actual,
+    OneEllipsis: (props: ComponentProps<typeof actual.OneEllipsis>) => {
+      rowRenders.count++
+      return <actual.OneEllipsis {...props} />
+    },
+  }
+})
+
+const LISTBOX_ID = "mention-listbox"
+const EVERYONE_DESCRIPTION = "Notify everyone in this group"
+
+const members: F0ChatUser[] = Array.from({ length: 50 }, (_, i) => ({
+  id: `user-${i}`,
+  name: `Member ${i}`,
+}))
+
+type Controls = {
+  setQuery: (query: string) => void
+  setSelectedIndex: (index: number) => void
+}
+
+let controls: Controls
+
+const selections: MentionCandidate[] = []
+
+/**
+ * Stands in for `ChatComposer` + `useMentions`: a keystroke re-renders the
+ * host, which hands the popover a fresh `results` array, fresh candidate
+ * wrappers, a fresh `position` and a fresh `onSelect` — while the underlying
+ * `F0ChatUser` objects keep their identity until a search resolves.
+ */
+function Harness({
+  users = members,
+  everyoneLabel,
+  isLoading = false,
+  isOpen = true,
+}: {
+  users?: F0ChatUser[]
+  everyoneLabel?: string
+  isLoading?: boolean
+  isOpen?: boolean
+}) {
+  const [query, setQuery] = useState("")
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  controls = { setQuery, setSelectedIndex }
+
+  const results: MentionCandidate[] = [
+    ...(everyoneLabel
+      ? [{ kind: "everyone" as const, label: everyoneLabel }]
+      : []),
+    ...users.map((user) => ({ kind: "user" as const, user })),
+  ]
+  const position: PopoverPosition = { left: 0, bottom: query.length }
+
+  return (
+    <ChatMentionPopover
+      isOpen={isOpen}
+      listboxId={LISTBOX_ID}
+      results={results}
+      isLoading={isLoading}
+      selectedIndex={selectedIndex}
+      position={position}
+      onSelect={(candidate) => selections.push(candidate)}
+      everyoneDescription={EVERYONE_DESCRIPTION}
+    />
+  )
+}
+
+beforeEach(() => {
+  rowRenders.count = 0
+  selections.length = 0
+})
+
+describe("ChatMentionPopover row render cost", () => {
+  it("mounts one row per candidate", () => {
+    render(<Harness />)
+    expect(screen.getAllByRole("option")).toHaveLength(50)
+    expect(rowRenders.count).toBe(50)
+  })
+
+  it("re-renders only the two rows the highlight moved between", () => {
+    render(<Harness />)
+    rowRenders.count = 0
+
+    act(() => controls.setSelectedIndex(1))
+
+    expect(rowRenders.count).toBe(2)
+  })
+
+  it("re-renders no rows when a keystroke leaves the candidates unchanged", () => {
+    render(<Harness />)
+    rowRenders.count = 0
+
+    act(() => controls.setQuery("An"))
+
+    expect(rowRenders.count).toBe(0)
+  })
+
+  it("drops the rows a narrower search removed and leaves the survivors alone", () => {
+    const { rerender } = render(<Harness />)
+    rowRenders.count = 0
+
+    rerender(<Harness users={members.slice(0, 10)} />)
+
+    expect(screen.getAllByRole("option")).toHaveLength(10)
+    expect(rowRenders.count).toBe(0)
+  })
+
+  it("still re-renders a row whose candidate the search replaced", () => {
+    const { rerender } = render(<Harness users={members.slice(0, 10)} />)
+    rowRenders.count = 0
+
+    rerender(
+      <Harness
+        users={members
+          .slice(0, 10)
+          .map((user) => ({ ...user, name: `${user.name} (renamed)` }))}
+      />
+    )
+
+    expect(rowRenders.count).toBe(10)
+    expect(screen.getAllByRole("option")[0]).toHaveTextContent(
+      "Member 0 (renamed)"
+    )
+  })
+})
+
+describe("ChatMentionPopover accessibility", () => {
+  it("exposes the listbox and one option per candidate, in order, with the ids the composer points aria-activedescendant at", () => {
+    render(<Harness users={members.slice(0, 3)} everyoneLabel="here" />)
+
+    const listbox = screen.getByRole("listbox")
+    expect(listbox).toHaveAttribute("id", LISTBOX_ID)
+
+    const options = screen.getAllByRole("option")
+    expect(options).toHaveLength(4)
+    expect(options.map((option) => option.id)).toEqual([
+      getChatMentionOptionId(LISTBOX_ID, { kind: "everyone", label: "here" }),
+      ...members
+        .slice(0, 3)
+        .map((user) =>
+          getChatMentionOptionId(LISTBOX_ID, { kind: "user", user })
+        ),
+    ])
+    expect(options[0]).toHaveTextContent("here")
+    expect(options[0]).toHaveTextContent(EVERYONE_DESCRIPTION)
+    expect(options[1]).toHaveTextContent("Member 0")
+    expect(options[3]).toHaveTextContent("Member 2")
+  })
+
+  it("marks exactly one option selected and moves it with the highlight", () => {
+    render(<Harness users={members.slice(0, 3)} />)
+
+    expect(screen.getAllByRole("option", { selected: true })).toHaveLength(1)
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute(
+      "aria-selected",
+      "true"
+    )
+
+    act(() => controls.setSelectedIndex(2))
+
+    const options = screen.getAllByRole("option")
+    expect(screen.getAllByRole("option", { selected: true })).toHaveLength(1)
+    expect(options[0]).toHaveAttribute("aria-selected", "false")
+    expect(options[2]).toHaveAttribute("aria-selected", "true")
+  })
+
+  it("scrolls the newly highlighted option into view, including when the highlight moves up", () => {
+    const scrolled: HTMLElement[] = []
+    const spy = vi
+      .spyOn(HTMLElement.prototype, "scrollIntoView")
+      .mockImplementation(function (this: HTMLElement) {
+        scrolled.push(this)
+      })
+
+    render(<Harness users={members.slice(0, 5)} />)
+    act(() => controls.setSelectedIndex(3))
+    scrolled.length = 0
+
+    act(() => controls.setSelectedIndex(1))
+
+    expect(scrolled).toEqual([screen.getAllByRole("option")[1]])
+    spy.mockRestore()
+  })
+
+  it("selects the pointed-at candidate without taking focus off the textarea", () => {
+    render(<Harness users={members.slice(0, 3)} everyoneLabel="here" />)
+
+    const defaultAllowed = fireEvent.mouseDown(
+      screen.getAllByRole("option")[2]!
+    )
+
+    expect(defaultAllowed).toBe(false)
+    expect(selections).toEqual([{ kind: "user", user: members[1] }])
+  })
+
+  it("keeps loading skeletons out of the accessible option list", () => {
+    render(<Harness users={[]} everyoneLabel="here" isLoading />)
+
+    expect(screen.getAllByRole("option")).toHaveLength(1)
+    document
+      .querySelectorAll('[aria-hidden="true"]')
+      .forEach((skeleton) => expect(skeleton).toBeInTheDocument())
+    expect(document.querySelectorAll('[aria-hidden="true"]')).toHaveLength(3)
+  })
+
+  it("renders nothing when closed, or when nothing matches and nothing is loading", () => {
+    const { rerender } = render(<Harness isOpen={false} />)
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+
+    rerender(<Harness users={[]} />)
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Description

The `@`-mention popover re-rendered **every** candidate row on every keystroke in the composer. Rows are now memoized on the candidate they render, so a keystroke that leaves the candidate list alone re-renders none of them. Nothing about the rendered output changes.

## Type of change

- [x] Refactor / internal change (no API or behavior change)

## Implementation details

### What was wrong

`ChatMentionPopover` rendered its rows as inline JSX inside `results.map(...)`. Each row mounts an `F0Avatar` and one or two `OneEllipsis` subtrees, and `OneEllipsis` is not cheap — a `forwardRef` around a component with `useState`, a `useMemo`, a `ResizeObserver`, a `requestAnimationFrame` and a 100 ms `setTimeout`. In a 50-member group, one keystroke re-rendered all 50.

A `memo()` on the row would not have helped on its own, because **both** props a row needs are rebuilt by `useMentions` on every keystroke:

- `results` is a `useMemo` keyed on `query`, so each keystroke allocates fresh `{ kind: "user", user }` wrappers — though the inner `F0ChatUser` objects only change when a search resolves;
- `onSelect` is `selectCandidate`, whose `useCallback` deps include `inputValue` and `cursorPosition`.

### What changed

Rows became two memoized components (`EveryoneRow`, `UserRow`) that receive only stable things: the `F0ChatUser` itself, an index, and one `handleSelect` with `[]` deps that resolves the candidate through refs at click time. `onSelect` still receives exactly the same `MentionCandidate` object it did before.

Those refs are synced in a **layout effect**, not during render. F0Chat is a library, so the host owns concurrency: a transition or a Suspense retry can start a render and discard it, and a render-phase write would leave the refs holding candidates that never reached the DOM while the rows on screen still carried their old indices — a click would then insert someone the list never showed. Syncing on commit closes that without costing any of the win.

The DOM is unchanged — same element structure, same class strings, same option ids, same `role="listbox"` / `role="option"` / `aria-selected`, same `aria-hidden` skeletons, same early returns, same `useLayoutEffect` overflow nudge. `getChatMentionOptionId` and `ChatMentionPopoverProps` are untouched, so `ChatComposer`'s `aria-activedescendant` wiring is unaffected.

### The list is deliberately not capped

`useMentions.results` is the optional `@here` row plus every member `searchMembers` returned, and `handleKeyDown` cycles with `% results.length`, so the keyboard reaches all of them. `searchMembers` is a host prop (`types.ts:782`) with no f0-side limit, and `max-h-60 overflow-y-auto` is scroll, not truncation. Capping would have made keyboard-reachable candidates unreachable, so every candidate stays mounted — they just stop re-rendering.

## ✅ Verification

### Row renders per interaction, 50 candidates

Measured by mocking `@/lib/OneEllipsis` with a `forwardRef` stand-in that records the text it renders and then renders the real component. Rows are the only thing in the popover that renders `OneEllipsis`, so the same test yields both numbers without knowing whether a row is inline JSX or a component — and recording the text says *which* rows re-rendered, not only how many.

| Scenario | Before | After |
| --- | ---: | ---: |
| Highlight moves one row | **50** | **2** (`["Member 0", "Member 1"]`) |
| Keystroke, candidate list unchanged (with the `@here` row) | **52** | **0** |
| The same keystroke under `StrictMode`'s double render | **104** | **0** |
| Search narrows 50 → 10 (surviving rows) | **10** | **0** |

### Suites

| Check | Result |
| --- | --- |
| `ChatMentionPopover.test.tsx` with the base implementation restored | **4 failed / 9 passed (13)** — the red run, against these exact tests |
| the same file, with the change | **13 passed** |
| `vitest run src/sds/chat`, clean base | 71 files / **704** tests passed |
| `vitest run src/sds/chat`, with the change | 72 files / **717** tests passed |
| `pnpm tsc` (after `pnpm --filter @factorialco/f0-core build`) | **0** errors |
| `oxlint --type-aware src/sds/chat/F0Chat` | 0 warnings, 0 errors |
| `oxfmt --check src/sds/chat/F0Chat` | clean |
| lefthook pre-commit + commit-msg | green on both commits |

### Mutation matrix — one lever per mechanism, each reverted separately

| Lever reverted | Tests that went red |
| --- | --- |
| `memo` off `UserRow` | the 4 render-count tests |
| `memo` off `EveryoneRow` | the 2 keystroke tests |
| `onSelect={(i) => handleSelect(i)}` instead of the stable handler | the 4 render-count tests |
| `innerRef` forced to `undefined` | only "scrolls the newly highlighted option into view" |
| select handler reads `resultsRef.current[0]` | only the 2 selection tests |
| the layout-effect ref sync made a no-op | only "selects from the candidates on screen after a narrower search" |

The third row is the one worth reading: with `memo` in place but an unstable `onSelect`, every count reverts — the memo alone buys nothing.

### Accessibility, asserted unchanged

`role="listbox"` with the given id · one `role="option"` per candidate in order, ids equal to `getChatMentionOptionId(...)` (what the composer points `aria-activedescendant` at) · exactly one `aria-selected="true"`, moving with the highlight · `scrollIntoView` fires on the newly highlighted row, asserted by node identity, in **both** directions · `mousedown` still calls `preventDefault` so the textarea keeps focus · the six loading `Skeleton` nodes stay inside `aria-hidden` containers and out of the option list.

### What the tests do not prove

- **Render counts, not time.** No wall-clock, frame-time or profiler evidence. The parent still allocates a fresh `results` array and reconciles N memo fibres per keystroke; that cost lives in `useMentions.ts` and is out of scope here (#5425).
- **The win is bounded to keystrokes between search resolutions.** `setMemberResults(data)` replaces every `F0ChatUser` when a search resolves, so a host returning fresh objects from a network call re-renders all rows at that moment — which is exactly what the "still re-renders a row whose candidate the search replaced" test documents. Because the 250 ms debounce is cleared on each keystroke, every keystroke in a typing burst is saved and the one resolution after it is not.
- **A keystroke that also moves the highlight costs 2, not 0.** A real keystroke also resets `selectedIndex`; the harness drives `query` and the highlight separately.
- **jsdom, not a browser.** No layout, paint or compositing; `ResizeObserver` and `scrollIntoView` are stubs, and the `useLayoutEffect` overflow nudge never runs there (it was untested before this PR too).
- **The DOM-equality claim was verified by reading the diff, not by a test.** Class strings are asserted nowhere and the repo bans snapshots, so future class drift would not be caught.
- **"Nothing is capped" is verified by reading `useMentions`, not by a keydown test.** The popover has no keyboard handling of its own; cycling lives in `useMentions.ts`, which this PR does not touch.
- **A host that mutates an `F0ChatUser` in place**, without changing its identity, will no longer see the row repaint on the next keystroke. Not part of the `searchMembers` contract, but it is a real behaviour difference.

### Fresh-eyes re-verification (independent session)

| Check | Result |
| --- | --- |
| `ChatMentionPopover.test.tsx` | **15 passed** (13 + 2 added by the review) |
| the 2 added tests, each against the mutation it exists to catch | **red first**, then green |
| `vitest run src/sds/chat` | 72 files / **719** tests passed |
| `pnpm tsc` (after `pnpm --filter @factorialco/f0-core build`) | **0** errors |
| `oxlint --type-aware src/sds/chat/F0Chat` | 0 warnings, 0 errors |
| `oxfmt --check src/sds/chat/F0Chat` | clean |
| lefthook pre-commit, commit-msg, pre-push preflight | green |
| the "Before" column re-measured by swapping the merge-base component under these exact tests | **50 / 52 / 104 / 10** — every number reproduced |


## 🔍 Fresh-eyes review

Independent session; the diff was read cold, before this description. One commit added: `test(F0Chat): pin the mention popover's committed-render contract`. No production code changed by the review.

### BLOCKER

None — stated as a finding, not a shrug. The three hazards this design invites were each hunted specifically. React 18 runs mutation → ref detach → layout effect → ref attach inside one synchronous commit block, so no pointer or key event can interleave; and a `memo` bail-out *implies* `index` is unchanged, so `resultsRef.current[index]` is by construction the candidate at that DOM position. Reordering, shrinking, the `@here` row appearing and disappearing, and an unmounting highlighted row were all walked through without finding a divergence.

### SHOULD FIX — both fixed here

**1. The `fix:` commit shipped no red-green test.** *Measured.* Replacing the layout effect with the render-phase write it replaced — the literal revert of `c55e54702` — left **13/13 green**. The matrix row above ("the layout-effect ref sync made a no-op") is accurate for its lever, but it is the wrong lever: it proves the refs are updated *at all*, not that they are updated *on commit rather than during render*, which is the whole content of that commit.

Now pinned by `selects a displayed candidate when a transition render is discarded` — a `startTransition` whose sibling suspends, so React keeps the committed rows and throws the render away. With the render-phase write, clicking the row that reads **Member 0** inserts **Member 10**, someone the popover never displayed:

```
- "id": "user-0",   "name": "Member 0",
+ "id": "user-10",  "name": "Member 10",
```

So the fix commit is correct *and* load-bearing — and no longer silently revertible.

**2. No coverage for `selectedIndex` past the end of a shrunken list**, the boundary the index-based handler makes newly interesting. Added `leaves no option selected when a narrower search drops the highlighted row`; it goes red if `isSelected` is clamped to `Math.min(selectedIndex, results.length - 1)`, a plausible future "helpful" change that would silently mark the wrong row.

### NOTED — left alone deliberately, for Albert

1. **The memo is defeated by every resolved search.** `setMemberResults(data)` replaces every `F0ChatUser`, so a typist slower than the 250 ms debounce gets a full N-row render per keystroke anyway; the saving is real only *within* a burst. The body's "what the tests do not prove" already says this — the code comment at `ChatMentionPopover.tsx:134-137` reads more absolute than the behaviour. The identity-preserving fix belongs in `useMentions.ts` (#5425), so nothing was changed here.
2. **The repo's own two mocks disagree on this**, which is the cheapest illustration of (1): `createMockChatRuntime.ts:594` filters a stable array and keeps identity; `MockChatApp.tsx:164` maps to fresh objects and loses it on every search. Any GraphQL-backed host will look like the second.
3. **Mount cost is untouched and unbounded.** `max-h-60` shows ~6 rows while all N mount, and each `OneEllipsis` installs a `ResizeObserver`, a `rAF` and a `setTimeout(100)`. A 400-member group on a bare `@` mounts 400 of each. Pre-existing, and memoizing renders does not touch it — but the "deliberately not capped" section argues against the one change that would.
4. **`handleSelect`'s `if (candidate)` guard is unreachable by construction and untested** — removing it leaves 15/15 green. It is a silencer rather than a safety net: if the invariant ever breaks, the user gets a dead click and no signal.
5. **`optionId` collision, pre-existing:** `replace(/[^a-zA-Z0-9_-]/g, "-")` maps user ids `a.b` and `a/b` to the same DOM id, and the id test asserts through the same helper, so it can never catch it.
6. **Still Albert's:** Storybook in a visible tab. Nothing visual changed, so the "no recording" deferral below still holds.

## Deferred to review

- **Storybook in a visible tab** — Albert checks the popover there himself (a hidden tab renders an empty list and looks broken).
- No video or screenshot: the rendered DOM, classes, ids, roles and aria attributes are unchanged, so there is nothing visual to record.

## 🏡 Context

- Complementary to **#5425** (`fix(F0Chat): let a dismissed mention popover reopen`), which owns `hooks/useMentions.ts` and is deliberately untouched here. No file overlaps.
- No other open PR touches `ChatMentionPopover.tsx`. #5324 (emoji autocomplete) and #5409 (community channels) touch neighbouring `F0Chat` files but not this one.

### Side notes for the reviewer

- The tests were moved onto `zeroRender` and `vi.hoisted` per `f0-unit-testing` after a first pass used `@testing-library/react` directly.
- `toEqual` on two DOM nodes is a near-tautology — elements have no own enumerable properties, so any two option rows compare equal. The scroll assertion uses `toBe`.
- `F0Avatar` is `withDataTestId(_F0Avatar)`, a plain function rather than a memo, so it re-renders with its parent regardless of prop identity. A `useMemo` on the avatar fallback was removed once that was clear.

