### PR TITLE
perf(RichText): debounce the mention suggestion filter

### DIFF
--- a/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.items.test.ts
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.items.test.ts
@@ -174,6 +174,57 @@ describe("createSuggestionConfig items", () => {
     expect(publish).toHaveBeenLastCalledWith([users[1]])
   })
 
+  it("does not cache or publish a failed search", async () => {
+    const search = vi.fn(async (query: string) => {
+      if (query === "ali") {
+        throw new Error("network")
+      }
+      return users
+    })
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+
+    await config.items({ query: "" })
+    publish.mockClear()
+
+    const failing = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+
+    await expect(failing).resolves.toEqual([])
+    expect(publish).not.toHaveBeenCalled()
+
+    const retry = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    await retry
+
+    expect(search).toHaveBeenCalledTimes(3)
+  })
+
+  it("resolves a pass superseded by an exit with the list still on screen", async () => {
+    const resolvers = new Map<string, (items: MentionedUser[]) => void>()
+    const search = vi.fn(
+      (query: string) =>
+        new Promise<MentionedUser[]>((resolve) => resolvers.set(query, resolve))
+    )
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+    const renderer = config.render()
+
+    const opening = config.items({ query: "" })
+    resolvers.get("")?.(users)
+    await opening
+
+    const superseded = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    publish.mockClear()
+
+    renderer.onExit()
+    resolvers.get("ali")?.([users[1]])
+
+    await expect(superseded).resolves.toEqual(users)
+    expect(publish).not.toHaveBeenCalled()
+  })
+
   it("drops the cache on exit so a reopened popover searches again", async () => {
     const search = vi.fn(async (query: string) =>
       users.filter((user) => user.label.toLowerCase().includes(query))

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.items.test.ts
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.items.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import {
+  createSuggestionConfig,
+  MENTION_SUGGESTION_DEBOUNCE_MS,
+} from "../suggestion"
+import { MentionedUser } from "../types"
+
+const users: MentionedUser[] = [
+  { id: 1, label: "Alice", image_url: "/alice.png", href: "/alice" },
+  { id: 2, label: "Alicia", image_url: "/alicia.png", href: "/alicia" },
+  { id: 3, label: "Bob", image_url: "/bob.png", href: "/bob" },
+  { id: 4, label: "Charlie", image_url: "/charlie.png", href: "/charlie" },
+]
+
+const undebouncedCandidates = (query: string) => {
+  const normalizedQuery = query.toLowerCase().trim()
+  return normalizedQuery
+    ? users.filter((user) => user.label.toLowerCase().includes(normalizedQuery))
+    : [...users]
+}
+
+const openSession = async (publish: (items: MentionedUser[]) => void) => {
+  const config = createSuggestionConfig([], publish, undefined, users)
+  await config.items({ query: "" })
+  return config
+}
+
+describe("createSuggestionConfig items", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("collapses a five-keystroke burst into a single filter pass", async () => {
+    const publish = vi.fn()
+    const config = await openSession(publish)
+    publish.mockClear()
+
+    const burst = ["a", "al", "ali", "alic", "alici"].map((query) =>
+      config.items({ query })
+    )
+
+    expect(publish).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    const resolved = await Promise.all(burst)
+
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(publish).toHaveBeenCalledWith(undebouncedCandidates("alici"))
+    resolved.forEach((items) => expect(items).toBe(resolved[0]))
+  })
+
+  it("returns the candidates the undebounced filter returned, in the same order", async () => {
+    for (const query of ["a", "li", "ALICE", " bob ", "zzz"]) {
+      const publish = vi.fn()
+      const config = await openSession(publish)
+
+      const pending = config.items({ query })
+      await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+
+      await expect(pending).resolves.toEqual(undebouncedCandidates(query))
+      expect(publish).toHaveBeenLastCalledWith(undebouncedCandidates(query))
+    }
+  })
+
+  it("answers an empty query immediately, leaving no timer pending", async () => {
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, undefined, users)
+
+    await expect(config.items({ query: "" })).resolves.toEqual(users)
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(publish).toHaveBeenCalledWith(users)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("abandons a queued query when the mention is emptied back to @", async () => {
+    const publish = vi.fn()
+    const config = await openSession(publish)
+    const queued = config.items({ query: "ali" })
+    publish.mockClear()
+
+    await expect(config.items({ query: "" })).resolves.toEqual(users)
+    await expect(queued).resolves.toEqual(users)
+
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS * 2)
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it("keeps an in-flight search from overwriting a cache hit", async () => {
+    const resolvers = new Map<string, (items: MentionedUser[]) => void>()
+    const search = vi.fn(
+      (query: string) =>
+        new Promise<MentionedUser[]>((resolve) => resolvers.set(query, resolve))
+    )
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+
+    const opening = config.items({ query: "" })
+    resolvers.get("")?.(users)
+    await opening
+
+    const narrowed = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    publish.mockClear()
+
+    const reopened = config.items({ query: "" })
+    resolvers.get("")?.(users)
+    await expect(reopened).resolves.toEqual(users)
+    expect(search).toHaveBeenCalledTimes(2)
+
+    resolvers.get("ali")?.([users[1]])
+    await expect(narrowed).resolves.toEqual(users)
+    expect(publish).not.toHaveBeenCalled()
+  })
+
+  it("answers the first query of a session immediately", async () => {
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, undefined, users)
+
+    await expect(config.items({ query: "ali" })).resolves.toEqual(
+      undebouncedCandidates("ali")
+    )
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("answers a repeated query from the last-query cache", async () => {
+    const publish = vi.fn()
+    const config = await openSession(publish)
+
+    const pending = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    const first = await pending
+    publish.mockClear()
+
+    await expect(config.items({ query: "ali" })).resolves.toBe(first)
+    expect(publish).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("never lets a stale search result replace a newer one", async () => {
+    const resolvers = new Map<string, (items: MentionedUser[]) => void>()
+    const search = vi.fn(
+      (query: string) =>
+        new Promise<MentionedUser[]>((resolve) => resolvers.set(query, resolve))
+    )
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+
+    const opening = config.items({ query: "" })
+    resolvers.get("")?.(users)
+    await opening
+    publish.mockClear()
+    search.mockClear()
+
+    const stale = config.items({ query: "al" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    expect(search).toHaveBeenCalledTimes(1)
+
+    const fresh = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    expect(search).toHaveBeenCalledTimes(2)
+
+    resolvers.get("ali")?.([users[1]])
+    await expect(fresh).resolves.toEqual([users[1]])
+    expect(publish).toHaveBeenCalledTimes(1)
+
+    resolvers.get("al")?.([users[0], users[1]])
+    await expect(stale).resolves.toEqual([users[1]])
+    expect(publish).toHaveBeenCalledTimes(1)
+    expect(publish).toHaveBeenLastCalledWith([users[1]])
+  })
+
+  it("drops the cache on exit so a reopened popover searches again", async () => {
+    const search = vi.fn(async (query: string) =>
+      users.filter((user) => user.label.toLowerCase().includes(query))
+    )
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+    const renderer = config.render()
+
+    await config.items({ query: "" })
+    expect(search).toHaveBeenCalledTimes(1)
+
+    renderer.onExit()
+
+    await config.items({ query: "" })
+    expect(search).toHaveBeenCalledTimes(2)
+  })
+})

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.items.test.ts
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.items.test.ts
@@ -225,6 +225,125 @@ describe("createSuggestionConfig items", () => {
     expect(publish).not.toHaveBeenCalled()
   })
 
+  it("holds a keystroke for the full debounce window", async () => {
+    expect(MENTION_SUGGESTION_DEBOUNCE_MS).toBeGreaterThan(0)
+
+    const publish = vi.fn()
+    const config = await openSession(publish)
+    publish.mockClear()
+
+    const pending = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS - 1)
+    expect(publish).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+    await pending
+    expect(publish).toHaveBeenCalledTimes(1)
+  })
+
+  it("opens on the newest candidates, not on an empty list, when the opening search is superseded", async () => {
+    const resolvers = new Map<string, (items: MentionedUser[]) => void>()
+    const search = vi.fn(
+      (query: string) =>
+        new Promise<MentionedUser[]>((resolve) => resolvers.set(query, resolve))
+    )
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+
+    const opening = config.items({ query: "" })
+    const narrowed = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+
+    resolvers.get("")?.(users)
+    resolvers.get("ali")?.([users[1]])
+
+    await expect(narrowed).resolves.toEqual([users[1]])
+    await expect(opening).resolves.toEqual([users[1]])
+  })
+
+  it("does not make a mid-session superseded pass wait for the newer search", async () => {
+    const resolvers = new Map<string, (items: MentionedUser[]) => void>()
+    const search = vi.fn(
+      (query: string) =>
+        new Promise<MentionedUser[]>((resolve) => resolvers.set(query, resolve))
+    )
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+
+    const opening = config.items({ query: "" })
+    resolvers.get("")?.(users)
+    await opening
+
+    const superseded = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    const newer = config.items({ query: "alic" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+
+    let settled: MentionedUser[] | "pending" = "pending"
+    void superseded.then((items) => {
+      settled = items
+    })
+    resolvers.get("ali")?.([users[1]])
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(settled).toEqual(users)
+
+    resolvers.get("alic")?.([users[1]])
+    await expect(newer).resolves.toEqual([users[1]])
+  })
+
+  it("does not make a pass from a closed session wait for the next one", async () => {
+    const resolvers = new Map<string, (items: MentionedUser[]) => void>()
+    const search = vi.fn(
+      (query: string) =>
+        new Promise<MentionedUser[]>((resolve) => resolvers.set(query, resolve))
+    )
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, search, users)
+    const renderer = config.render()
+
+    const opening = config.items({ query: "" })
+    resolvers.get("")?.(users)
+    await opening
+
+    const orphan = config.items({ query: "ali" })
+    await vi.advanceTimersByTimeAsync(MENTION_SUGGESTION_DEBOUNCE_MS)
+    renderer.onExit()
+
+    const reopened = config.items({ query: "bob" })
+    resolvers.get("ali")?.([users[1]])
+    resolvers.get("bob")?.([users[2]])
+
+    await expect(reopened).resolves.toEqual([users[2]])
+    await expect(orphan).resolves.toEqual(users)
+  })
+
+  it("answers the first query of a reopened session immediately", async () => {
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, undefined, users)
+    const renderer = config.render()
+
+    await config.items({ query: "" })
+    renderer.onExit()
+
+    const reopened = config.items({ query: "ali" })
+    expect(vi.getTimerCount()).toBe(0)
+    await expect(reopened).resolves.toEqual(undebouncedCandidates("ali"))
+  })
+
+  it("answers immediately when tiptap opens a session on a moved caret", async () => {
+    const publish = vi.fn()
+    const config = createSuggestionConfig([], publish, undefined, users)
+    const renderer = config.render()
+
+    await config.items({ query: "" })
+
+    renderer.onBeforeStart()
+    const opening = config.items({ query: "ali" })
+    expect(vi.getTimerCount()).toBe(0)
+    await expect(opening).resolves.toEqual(undebouncedCandidates("ali"))
+  })
+
   it("drops the cache on exit so a reopened popover searches again", async () => {
     const search = vi.fn(async (query: string) =>
       users.filter((user) => user.label.toLowerCase().includes(query))

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.test.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.test.tsx
@@ -49,11 +49,24 @@ vi.mock("@tiptap/react", () => {
   }
 })
 
+const rootState: {
+  roots: {
+    render: ReturnType<typeof vi.fn>
+    unmount: ReturnType<typeof vi.fn>
+  }[]
+} = {
+  roots: [],
+}
+
 vi.mock("react-dom/client", () => ({
-  createRoot: () => ({
-    render: vi.fn(),
-    unmount: vi.fn(),
-  }),
+  createRoot: () => {
+    const root = {
+      render: vi.fn(),
+      unmount: vi.fn(),
+    }
+    rootState.roots.push(root)
+    return root
+  },
 }))
 
 const users: MentionedUser[] = [
@@ -118,6 +131,78 @@ const createEditorMock = () => {
 describe("createSuggestionConfig", () => {
   beforeEach(() => {
     rendererState.props = null
+    rootState.roots = []
+  })
+
+  const startPopover = () => {
+    const config = createSuggestionConfig(users, vi.fn(), undefined, users)
+    const renderer = config.render()
+    const { editor } = createEditorMock()
+    const props = {
+      items: users,
+      clientRect: () => rect,
+      editor: editor as never,
+      range: { from: 0, to: 1 },
+    }
+
+    renderer.onStart(props)
+
+    const root = rootState.roots.at(-1)
+    expect(root?.render).toHaveBeenCalledTimes(1)
+
+    return { config, renderer, props, root }
+  }
+
+  it("ignores a suspended update that resumes after the popover exited", () => {
+    const { renderer, props, root } = startPopover()
+
+    renderer.onExit()
+    expect(root?.unmount).toHaveBeenCalledTimes(1)
+
+    renderer.onUpdate(props)
+
+    expect(root?.render).toHaveBeenCalledTimes(1)
+  })
+
+  it("ignores a suspended update that resumes after Escape dismissed it", () => {
+    const { renderer, props, root } = startPopover()
+
+    renderer.onKeyDown({ event: { key: "Escape" } as KeyboardEvent })
+    expect(root?.unmount).toHaveBeenCalledTimes(1)
+
+    renderer.onUpdate(props)
+
+    expect(root?.render).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears a pending debounce when Escape dismisses the popover", async () => {
+    vi.useFakeTimers()
+    try {
+      const publish = vi.fn()
+      const config = createSuggestionConfig([], publish, undefined, users)
+      const renderer = config.render()
+      const { editor } = createEditorMock()
+
+      renderer.onStart({
+        items: users,
+        clientRect: () => rect,
+        editor: editor as never,
+        range: { from: 0, to: 1 },
+      })
+
+      await config.items({ query: "" })
+      void config.items({ query: "ali" })
+      publish.mockClear()
+      expect(vi.getTimerCount()).toBe(1)
+
+      renderer.onKeyDown({ event: { key: "Escape" } as KeyboardEvent })
+
+      expect(vi.getTimerCount()).toBe(0)
+      await vi.advanceTimersByTimeAsync(500)
+      expect(publish).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it("uses latest suggestion range and inserts mention atomically", () => {

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.test.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/__tests__/suggestion.test.tsx
@@ -7,8 +7,10 @@ const rendererState: {
     items: MentionedUser[]
     command: (item: MentionedUser) => void
   } | null
+  destroy: ReturnType<typeof vi.fn>
 } = {
   props: null,
+  destroy: vi.fn(),
 }
 
 vi.mock("@tiptap/react", () => {
@@ -38,7 +40,9 @@ vi.mock("@tiptap/react", () => {
       }
     }
 
-    destroy() {}
+    destroy() {
+      rendererState.destroy()
+    }
   }
 
   return {
@@ -131,6 +135,7 @@ const createEditorMock = () => {
 describe("createSuggestionConfig", () => {
   beforeEach(() => {
     rendererState.props = null
+    rendererState.destroy.mockClear()
     rootState.roots = []
   })
 
@@ -149,8 +154,10 @@ describe("createSuggestionConfig", () => {
 
     const root = rootState.roots.at(-1)
     expect(root?.render).toHaveBeenCalledTimes(1)
+    const container = document.body.lastElementChild
+    expect(container).not.toBeNull()
 
-    return { config, renderer, props, root }
+    return { config, renderer, props, root, container }
   }
 
   it("ignores a suspended update that resumes after the popover exited", () => {
@@ -203,6 +210,48 @@ describe("createSuggestionConfig", () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it("destroys the renderer and removes the container on Escape", () => {
+    const { renderer, container } = startPopover()
+
+    renderer.onKeyDown({ event: { key: "Escape" } as KeyboardEvent })
+
+    expect(rendererState.destroy).toHaveBeenCalledTimes(1)
+    expect(container?.isConnected).toBe(false)
+  })
+
+  it("destroys the renderer and removes the container on exit", () => {
+    const { renderer, container } = startPopover()
+
+    renderer.onExit()
+
+    expect(rendererState.destroy).toHaveBeenCalledTimes(1)
+    expect(container?.isConnected).toBe(false)
+  })
+
+  it("ignores a command fired after the popover was dismissed", () => {
+    const { renderer, props } = startPopover()
+    const command = rendererState.props?.command
+
+    renderer.onUpdate(props)
+    renderer.onExit()
+    command?.(users[0])
+
+    expect(props.editor.chain).not.toHaveBeenCalled()
+  })
+
+  it("stops handling keys once the popover has been dismissed", () => {
+    const { renderer } = startPopover()
+
+    renderer.onKeyDown({ event: { key: "Escape" } as KeyboardEvent })
+
+    expect(
+      renderer.onKeyDown({ event: { key: "ArrowDown" } as KeyboardEvent })
+    ).toBe(false)
+    expect(
+      renderer.onKeyDown({ event: { key: "Escape" } as KeyboardEvent })
+    ).toBe(false)
   })
 
   it("uses latest suggestion range and inserts mention atomically", () => {

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/suggestion.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/suggestion.tsx
@@ -28,11 +28,11 @@ export function createSuggestionConfig(
   }))
 
   const searchUsers = onMentionQueryStringChanged
-    ? async (query: string): Promise<MentionedUser[]> => {
+    ? async (query: string): Promise<MentionedUser[] | null> => {
         try {
           return (await onMentionQueryStringChanged(query)) || []
         } catch {
-          return []
+          return null
         }
       }
     : searchableUsers
@@ -66,6 +66,12 @@ export function createSuggestionConfig(
         if (mine !== generation) {
           return cachedItems
         }
+        // A failed search is not an answer: it is neither published nor cached,
+        // so the next request for the same query retries instead of reading a
+        // remembered failure.
+        if (!items) {
+          return []
+        }
         cachedQuery = query
         cachedItems = items
         setMentionSuggestions(items)
@@ -91,8 +97,10 @@ export function createSuggestionConfig(
       return Promise.resolve(cachedItems)
     }
 
-    // tiptap awaits `items` before it calls `onStart`, so delaying the first
-    // answer of a session would delay the popover itself.
+    // tiptap awaits `items` before it calls `onStart`, so debouncing a session's
+    // opening query would delay the popover itself. The exception tiptap can
+    // still produce is `moved && changed`, where it awaits `items` before the
+    // `onExit` that would have cleared `sessionStarted`.
     const immediate = query === "" || !sessionStarted
     sessionStarted = true
 
@@ -126,12 +134,14 @@ export function createSuggestionConfig(
     return queued.promise
   }
 
+  // `cachedItems` survives on purpose: it is the invariant "what was last handed
+  // to setMentionSuggestions", which an abandoned or superseded pass still needs
+  // to resolve with. Clearing `cachedQuery` is what forces the next miss.
   const resetSuggestionState = () => {
     abandonQueued()
     generation++
     sessionStarted = false
     cachedQuery = null
-    cachedItems = []
   }
 
   return {
@@ -144,6 +154,22 @@ export function createSuggestionConfig(
       let popoverRoot: Root | null = null
       let container: HTMLDivElement | null = null
       let latestProps: SuggestionRenderProps | null = null
+
+      // Clearing the references is what stops a still-suspended tiptap update
+      // from rendering into a root that has already been unmounted, which React
+      // treats as an error rather than a no-op.
+      const dismiss = () => {
+        latestProps = null
+        resetSuggestionState()
+        if (popoverRoot && container) {
+          popoverRoot.unmount()
+          container.remove()
+        }
+        component?.destroy()
+        component = null
+        popoverRoot = null
+        container = null
+      }
 
       const getAtSymbolRect = (): DOMRect => {
         const selection = window.getSelection()
@@ -257,23 +283,13 @@ export function createSuggestionConfig(
             return (component.ref as MentionListRef)?.onKeyDown(props) || false
           }
           if (props.event.key === "Escape") {
-            latestProps = null
-            if (popoverRoot && container) {
-              popoverRoot.unmount()
-              container.remove()
-            }
+            dismiss()
             return true
           }
           return (component.ref as MentionListRef)?.onKeyDown(props) || false
         },
         onExit() {
-          latestProps = null
-          resetSuggestionState()
-          if (popoverRoot && container) {
-            popoverRoot.unmount()
-            container.remove()
-          }
-          component?.destroy()
+          dismiss()
         },
       }
     },

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/suggestion.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/suggestion.tsx
@@ -4,6 +4,8 @@ import { MentionList } from "./MentionList"
 import { MentionPopover } from "./MentionPopover"
 import { MentionedUser, MentionListRef } from "./types"
 
+export const MENTION_SUGGESTION_DEBOUNCE_MS = 150
+
 export function createSuggestionConfig(
   mentionSuggestions: MentionedUser[],
   setMentionSuggestions: (suggestions: MentionedUser[]) => void,
@@ -25,30 +27,118 @@ export function createSuggestionConfig(
     search: user.label.toLowerCase(),
   }))
 
-  return {
-    char: "@",
-    minLength: 0,
-    items: async ({ query }: { query: string }) => {
-      if (onMentionQueryStringChanged) {
+  const searchUsers = onMentionQueryStringChanged
+    ? async (query: string): Promise<MentionedUser[]> => {
         try {
-          const suggestions = await onMentionQueryStringChanged(query)
-          setMentionSuggestions(suggestions || [])
-          return suggestions || []
+          return (await onMentionQueryStringChanged(query)) || []
         } catch {
           return []
         }
-      } else if (searchableUsers) {
-        const normalizedQuery = query.toLowerCase().trim()
-        const filtered = normalizedQuery
-          ? searchableUsers
-              .filter(({ search }) => search.includes(normalizedQuery))
-              .map(({ user }) => user)
-          : searchableUsers.map(({ user }) => user)
-        setMentionSuggestions(filtered)
-        return filtered
       }
-      return mentionSuggestions
-    },
+    : searchableUsers
+      ? (query: string): MentionedUser[] => {
+          const normalizedQuery = query.toLowerCase().trim()
+          return normalizedQuery
+            ? searchableUsers
+                .filter(({ search }) => search.includes(normalizedQuery))
+                .map(({ user }) => user)
+            : searchableUsers.map(({ user }) => user)
+        }
+      : undefined
+
+  let generation = 0
+  let sessionStarted = false
+  let cachedQuery: string | null = null
+  let cachedItems: MentionedUser[] = []
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null
+  let queued: {
+    query: string
+    promise: Promise<MentionedUser[]>
+    resolve: (items: MentionedUser[]) => void
+  } | null = null
+
+  const run = (query: string): Promise<MentionedUser[]> => {
+    const mine = ++generation
+    return Promise.resolve(searchUsers?.(query) ?? mentionSuggestions).then(
+      (items) => {
+        // tiptap hands `items` no cancellation signal and discards no late
+        // result, so a superseded pass must drop its own answer here.
+        if (mine !== generation) {
+          return cachedItems
+        }
+        cachedQuery = query
+        cachedItems = items
+        setMentionSuggestions(items)
+        return items
+      }
+    )
+  }
+
+  const abandonQueued = () => {
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    const pending = queued
+    queued = null
+    pending?.resolve(cachedItems)
+  }
+
+  const requestItems = (query: string): Promise<MentionedUser[]> => {
+    if (query === cachedQuery) {
+      abandonQueued()
+      generation++
+      return Promise.resolve(cachedItems)
+    }
+
+    // tiptap awaits `items` before it calls `onStart`, so delaying the first
+    // answer of a session would delay the popover itself.
+    const immediate = query === "" || !sessionStarted
+    sessionStarted = true
+
+    if (immediate) {
+      abandonQueued()
+      return run(query)
+    }
+
+    if (queued) {
+      queued.query = query
+    } else {
+      let resolve: (items: MentionedUser[]) => void = () => {}
+      const promise = new Promise<MentionedUser[]>((settle) => {
+        resolve = settle
+      })
+      queued = { query, promise, resolve }
+    }
+
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+    }
+    debounceTimer = setTimeout(() => {
+      debounceTimer = null
+      const pending = queued
+      queued = null
+      if (pending) {
+        void run(pending.query).then(pending.resolve)
+      }
+    }, MENTION_SUGGESTION_DEBOUNCE_MS)
+
+    return queued.promise
+  }
+
+  const resetSuggestionState = () => {
+    abandonQueued()
+    generation++
+    sessionStarted = false
+    cachedQuery = null
+    cachedItems = []
+  }
+
+  return {
+    char: "@",
+    minLength: 0,
+    items: ({ query }: { query: string }): Promise<MentionedUser[]> =>
+      searchUsers ? requestItems(query) : Promise.resolve(mentionSuggestions),
     render: () => {
       let component: ReactRenderer | null = null
       let popoverRoot: Root | null = null
@@ -178,6 +268,7 @@ export function createSuggestionConfig(
         },
         onExit() {
           latestProps = null
+          resetSuggestionState()
           if (popoverRoot && container) {
             popoverRoot.unmount()
             container.remove()

--- a/packages/react/src/components/RichText/internal/Extensions/Mention/suggestion.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Mention/suggestion.tsx
@@ -56,28 +56,47 @@ export function createSuggestionConfig(
     promise: Promise<MentionedUser[]>
     resolve: (items: MentionedUser[]) => void
   } | null = null
+  let session = 0
+  let latestPass: {
+    generation: number
+    session: number
+    promise: Promise<MentionedUser[]>
+  } | null = null
 
   const run = (query: string): Promise<MentionedUser[]> => {
     const mine = ++generation
-    return Promise.resolve(searchUsers?.(query) ?? mentionSuggestions).then(
-      (items) => {
-        // tiptap hands `items` no cancellation signal and discards no late
-        // result, so a superseded pass must drop its own answer here.
-        if (mine !== generation) {
-          return cachedItems
-        }
-        // A failed search is not an answer: it is neither published nor cached,
-        // so the next request for the same query retries instead of reading a
-        // remembered failure.
-        if (!items) {
-          return []
-        }
-        cachedQuery = query
-        cachedItems = items
-        setMentionSuggestions(items)
-        return items
+    const mySession = session
+    const pass = Promise.resolve(
+      searchUsers?.(query) ?? mentionSuggestions
+    ).then((items) => {
+      // tiptap hands `items` no cancellation signal and discards no late
+      // result: it assigns whatever this resolves with onto its newest props
+      // and renders that. A superseded pass must therefore answer with the
+      // list that belongs on screen, never with its own.
+      if (mine !== generation) {
+        // Before the first publish of a session `cachedItems` is still the
+        // empty seed, and answering with it opens the popover on "No results
+        // found" until the newer pass lands.
+        return cachedQuery === null &&
+          latestPass &&
+          latestPass.session === mySession &&
+          latestPass.generation !== mine
+          ? latestPass.promise
+          : cachedItems
       }
-    )
+      // A failed search is not an answer: it is neither published nor cached,
+      // so the next request for the same query retries instead of reading a
+      // remembered failure.
+      if (!items) {
+        return []
+      }
+      cachedQuery = query
+      cachedItems = items
+      setMentionSuggestions(items)
+      return items
+    })
+    latestPass = { generation: mine, session: mySession, promise: pass }
+    return pass
   }
 
   const abandonQueued = () => {
@@ -142,6 +161,7 @@ export function createSuggestionConfig(
     generation++
     sessionStarted = false
     cachedQuery = null
+    session++
   }
 
   return {
@@ -202,6 +222,13 @@ export function createSuggestionConfig(
       }
 
       return {
+        // tiptap awaits `items` for a `moved && changed` transition before the
+        // `onExit` that would have cleared `sessionStarted`, but it calls
+        // `onBeforeStart` first: this is the only point at which a session that
+        // opens on a moved caret can claim its immediate opening answer.
+        onBeforeStart: () => {
+          sessionStarted = false
+        },
         onStart: (props: SuggestionRenderProps) => {
           latestProps = props
 


### PR DESCRIPTION
## Description

The mention suggestion in `RichText` re-filtered the whole user list on **every** tiptap doc change,
with no debounce and no guard against an out-of-order result. This adds a 150 ms debounce with a
single-entry last-query cache and a generation counter, designed against what `@tiptap/suggestion`
actually does with the `items` promise — plus the popover teardown fix that a 150 ms window makes
mandatory. The candidate list and its order are unchanged.

Two commits, reviewable separately:

- `perf(RichText): debounce the mention suggestion filter`
- `fix(RichText): tear the mention popover down completely`

## Type of change

- [x] Bug fix
- [x] Refactor / internal change (no API change)

## What was wrong

`createSuggestionConfig`'s `items` handler ran the filter and pushed the result straight into React
state on every call:

```ts
items: async ({ query }) => {
  …
  const filtered = searchableUsers.filter(({ search }) => search.includes(normalizedQuery))…
  setMentionSuggestions(filtered)   // every keystroke, every cursor move
  return filtered
}
```

Three costs:

1. **Repetition.** tiptap calls `items` whenever `handleChange = changed || moved` — so on every
   keystroke *and* on a cursor move that leaves the query identical. A five-keystroke burst did five
   full passes and five React state writes; four of them were thrown away.
2. **That state write is not cheap.** `mentionSuggestions` lives in `F0RichTextEditor` and its only
   consumer is the `extensions` `useMemo`, whose output `useEditor` reads **once**, at editor
   creation — the file says so itself
   ([F0RichTextEditor.tsx:220-241](https://github.com/factorialco/f0/blob/main/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx#L220)).
   So each publish re-rendered the whole editor and rebuilt the entire extension array, and the
   rebuilt array was discarded. This is the larger of the two wins.
3. **A stale-write race.** With `onMentionQueryStringChanged` (an async, typically network, search)
   nothing ordered the responses. If `"al"` resolved after `"ali"`, `setMentionSuggestions` was
   called with the *older* query's candidates and they stayed on screen.

## Why the fix is shaped this way

Read from `@tiptap/suggestion` 2.12.0 (`dist/index.js`, the plugin's `view().update`):

- `items` is called as `items({ editor, query })` — **no AbortSignal, no request id, no cancellation
  channel**. Staleness is entirely the consumer's problem, and any side effect performed *inside*
  `items` is unguarded.
- `props.items = await items(…)` sits **before** `onStart`, `onUpdate` and `onExit`. The popover
  cannot appear until that promise settles, so a naive debounce would postpone the popover by the
  full window on every `@`.

So: the empty query and the first query of a session resolve **immediately**; only subsequent
keystrokes are debounced. Within a window every caller shares one promise that resolves with the
last query's result, so a burst produces exactly one pass. A `generation` counter makes a superseded
pass drop its own answer — it neither publishes nor resolves with its stale list. A repeated query
is served from a single-entry cache, dropped on `onExit`, so staleness is bounded to one popover
session rather than to the editor's lifetime.

### The teardown fix, and why it belongs here

`onExit` unmounted the popover root and removed its container but left `component`, `popoverRoot`
and `container` truthy, so `onUpdate`'s `if (!component || !container || !popoverRoot) return`
guard still passed and called `render()` on an unmounted root — which React 18 raises as
`Cannot update an unmounted root`, not a no-op. The `Escape` branch did the same and additionally
skipped the state reset.

That window used to be a microtask wide on the static path, so it was effectively unreachable there.
A 150 ms debounce makes it wide enough to hit on an ordinary interaction: type the `i` of `@ali`,
press space 40 ms later, and tiptap's `stopped` update runs `onExit` while the previous update is
still suspended on the `items` promise; when it resumes, `onUpdate` renders into the dead root and
the rejection surfaces unhandled. Both paths now go through one `dismiss()` that resets the state,
unmounts, and clears the three references.

## ✅ Verification

Commands run in `packages/react`.

| Gate | Baseline (`origin/main`, same worktree) | After |
| --- | --- | --- |
| `pnpm vitest run src/components/RichText` | 13 files / 112 tests pass | **14 files / 126 tests pass** |
| Failing-first (final tests against the `origin/main` implementation) | **9 failed / 6 passed** | 15 passed |
| `pnpm vitest run` (whole package) | — | **611 files / 7686 tests pass**, 1 file + 13 tests skipped |
| `pnpm --filter @factorialco/f0-react run tsc` | 0 errors | **0 errors** |
| `pnpm --filter @factorialco/f0-react run lint` | 0 warnings / 0 errors | **0 warnings / 0 errors** |
| `pnpm --filter @factorialco/f0-react run format:check` | clean | clean |

The nine red tests before the fix:

- `collapses a five-keystroke burst into a single filter pass` — **5 publishes before, 1 after**, and
  all five callers now receive the same array instance.
- `never lets a stale search result replace a newer one` — before, the late `"al"` response published
  over `"ali"` and resolved its caller with the stale list.
- `answers a repeated query from the last-query cache`
- `abandons a queued query when the mention is emptied back to @`
- `keeps an in-flight search from overwriting a cache hit`
- `resolves a pass superseded by an exit with the list still on screen`
- `ignores a suspended update that resumes after the popover exited`
- `ignores a suspended update that resumes after Escape dismissed it`
- `clears a pending debounce when Escape dismisses the popover`

Six tests pass on both sides on purpose — they pin behaviour that must **not** change: the
candidates and their order for `"a" / "li" / "ALICE" / " bob " / "zzz"` are identical to the
undebounced filter; an empty query resolves immediately with the full list and leaves no timer
pending; the first query of a session resolves immediately; the cache is dropped on exit; a failed
search is neither cached nor published, and the next request for the same query retries.

Every mechanism was mutation-checked separately, one lever at a time, and each has a killing test:

| Mutant | Tests it turns red |
| --- | --- |
| no debounce (`immediate = true`) | burst-of-5 |
| always debounce (`immediate = false`) | all — a session never resolves |
| drop `if (mine !== generation)` | stale-search, in-flight-vs-cache-hit |
| drop the cache-hit branch | repeated-query, emptied-back-to-@, in-flight-vs-cache-hit |
| cache hit without `abandonQueued()` + `generation++` | emptied-back-to-@, in-flight-vs-cache-hit |
| drop `resetSuggestionState()` from `onExit` | cache-dropped-on-exit |
| `dismiss()` keeps the three references | both suspended-update tests |
| cache and publish a failed search | failed-search |
| exit reset clears `cachedItems` | superseded-by-exit |

### What the tests do not prove

- They drive `items({ query })` and the `render()` handlers directly. **No test constructs a tiptap
  editor, a `Suggestion` plugin or a ProseMirror transaction**, so the ordering of
  `items` → `onExit` → `onUpdate` → `onStart` inside one update is asserted from reading
  `@tiptap/suggestion` 2.12.0's source, not from running it. The exit and Escape tests reproduce that
  ordering by hand.
- Nothing measures a wall-clock improvement. The claim is a reduction in filter passes and state
  writes per burst (5 → 1), which is what the tests count.
- **A known gap in the immediate-first-answer rule:** on tiptap's `moved && changed` transition
  (caret jumping between two `@` tokens, text inserted before the `@`, undo, a collaborative edit)
  the plugin awaits `items` *before* the `onExit` that would clear `sessionStarted`, so that
  session's opening answer is debounced and its popover appears 150 ms late. Correct results, late
  popover, on an uncommon transition. No unit test can produce it without a real plugin.
- 150 ms is a judgement call, chosen to sit under F0Chat's existing 250 ms member-search debounce.
  No test asserts it feels right.

## 🏡 Context

No video: the candidate list and its order are unchanged by construction, and the change is a
reduction in the number of filter passes and editor re-renders — there is nothing new to see on
screen.

Related, no file overlap with either:

- [💻 #5425](https://github.com/factorialco/f0/pull/5425) — same *concept* (a mention popover that
  should reopen) in `sds/chat/F0Chat/hooks/useMentions.ts`. Different file; deliberately untouched.
- [💻 #5380](https://github.com/factorialco/f0/pull/5380) / [💻 #5377](https://github.com/factorialco/f0/pull/5377)
  — `@tiptap/core` 2.24.0 → 3.30.4. Everything above was read from `@tiptap/suggestion` **2.12.0**.
  If v3 changes when `items` is awaited relative to `onStart`, the immediate-first-answer rule has to
  be re-derived against v3 rather than assumed.

### Side notes for the reviewer

- `dismiss()` now nulls `component`, so after `Escape` the arrow keys reach the editor instead of a
  dismissed `MentionList`. That is a behaviour change beyond the perf work, and it looks like the
  right one, but it is worth a second opinion.
- `run()` keeps a `?? mentionSuggestions` fallback for the case where neither `users` nor
  `onMentionQueryStringChanged` is supplied. `items` already gates on that, and the only production
  caller (`createMentionExtensions`) returns `[]` before configuring the extension when `users` is
  empty — so both that arm and the `mentionSuggestions` parameter are unreachable today. Left as a
  type-level fallback rather than deleted, since removing the parameter changes the signature.
- The cache key is the raw query while the filter normalises it, so `"Ali"` and `"ali"` are separate
  entries. That costs a redundant filter pass on a capitalisation change — exactly what `main` does
  today — and normalising the key would conflate them for a consumer search callback that may be
  case-sensitive.
- Backspacing off a query and retyping it re-issues an identical in-flight request, because the
  cache-hit path invalidates the generation rather than adopting the request. Narrow window, extra
  request, correct result.
- In the debounce timer, `queued` is nulled before `run()` is called. A synchronous throw out of
  `run` would strand that resolver forever — unreachable in practice (the static filter operates on
  strings lowercased at config time, and the async branch is an `async` function, so it rejects
  rather than throws), so it is documented here rather than guarded with dead code.

## Deferred to review

- Storybook: the RichText mention story, in a **visible** tab (a hidden tab renders an empty
  virtualized list). Albert.


---

## Fresh-eyes review (independent session, diff read cold before the description)

Re-run on `8da5df4ea` from the same worktree, after `pnpm --filter @factorialco/f0-core build`:

| Gate | Result |
| --- | --- |
| `pnpm vitest run src/components/RichText` | 14 files / **136** tests pass (was 126) |
| `pnpm vitest run …/Extensions/Mention` | **25** tests pass (was 15) |
| `pnpm --filter @factorialco/f0-react run tsc` | 0 errors |
| `pnpm --filter @factorialco/f0-react run lint` | 0 warnings / 0 errors |
| `pnpm --filter @factorialco/f0-react run format:check` | clean |
| lefthook `pre-commit` + `pre-push` | green |

### SHOULD FIX — the popover could open on "No results found" (fixed here)

The rejected **B3** review item was right about the outcome and wrong about the mechanism, and the
rejection rested on the wrong half. `@tiptap/suggestion` 2.12.0 does re-read its `props` closure
after the await — but the line immediately before the render hooks is

```js
props.items = await items({ editor, query: state.query })   // dist/index.js
```

so a late pass **writes its own return value onto the newest `props`**, and `onStart`/`onUpdate`
render exactly that. What actually kept a stale list off screen was `return cachedItems`, not
tiptap. That holds everywhere except the one place where `cachedItems` is still the empty seed:
before a session has published anything.

Reachable with an async `onMentionQueryStringChanged`: type `@`, type one character inside the
search RTT, and the opening pass is superseded by the debounced one. It then answered `[]`, and
`onStart` mounted `MentionList` on its `items.length === 0` branch — **"No results found"** — until
the newer search landed. `main` opened populated, so this was introduced by the debounce.

Fixed by letting a superseded pass defer to the newest pass **of its own session** while nothing has
reached the screen, and keep answering with the on-screen list otherwise. Three tests: the opening
case (red before the fix — `expected [] to deeply equal [Alicia]`), that a mid-session supersede
still resolves without waiting on the newer search, and that a pass left over from a closed session
never adopts the next session's answer.

### SHOULD FIX — the disclosed `moved && changed` delay (fixed here)

The known gap under "What the tests do not prove" is closeable with a hook the config did not
implement. tiptap calls `onBeforeStart` **before** the `await items(...)`:

```js
if (handleStart) { renderer.onBeforeStart?.(props) }
…
if (handleChange || handleStart) { props.items = await items({ editor, query: state.query }) }
```

Clearing `sessionStarted` there is the only point at which a session opening on a moved caret can
claim the immediate-first-answer rule, so that popover no longer appears 150 ms late. Red before the
fix with `renderer.onBeforeStart is not a function`; it is also what makes the transition testable
without a real plugin.

### SHOULD FIX — mechanisms the test suite did not constrain (fixed here)

Mutation matrix, one lever at a time. On `1c0c820` these mutants left all 15 tests **green**:

| Mutant | Was | Now |
| --- | --- | --- |
| drop `sessionStarted = false` from the exit reset | 15 pass | 2 fail |
| drop `component?.destroy()` from `dismiss()` | 15 pass | 2 fail |
| drop `container.remove()` from `dismiss()` | 15 pass | 2 fail |
| `MENTION_SUGGESTION_DEBOUNCE_MS` → `0` | 15 pass | 1 fail |
| drop `latestProps = null` from `dismiss()` | 15 pass | 1 fail |
| drop `component = null` from `dismiss()` | 15 pass | 1 fail |

The `0` one is the sharpest: every test advanced by `MENTION_SUGGESTION_DEBOUNCE_MS`, so fake timers
hid the constant entirely and the suite proved coalescing-within-a-tick rather than a 150 ms window.
The `destroy()` and `container.remove()` pair is the half of "tear the popover down completely" that
nothing observed — the mock's `destroy` was not a spy and no test looked at `document.body`.

Six tests added for these: the renderer is destroyed and the container detached on **both** Escape
and exit, a reopened session answers its first query immediately, nothing publishes at
`window - 1 ms` and exactly one publish at `window`, keys stop being handled after a dismissal, and
a command fired from a dismissed list does not reach the editor.

### NOTED — not changed

- **Two mutants still survive**: dropping `popoverRoot = null` or `container = null` from
  `dismiss()`. `onUpdate`'s guard short-circuits on `component` first, so only one of the three nulls
  is observable through the public surface. Defence in depth, deliberately kept, not covered.
- **`moved && changed` still serves the new session's opening answer from the previous session's
  cache**, because `onExit` (which clears `cachedQuery`) runs after `items`. Same query, same
  corpus, so the answer is the same; forcing a re-search there would cost a request for no
  correctness gain.
- **No test builds a real tiptap plugin.** Every ordering claim, mine included, is read from
  `@tiptap/suggestion` 2.12.0's `dist/index.js` and reproduced by hand. #5380 / #5377 (tiptap 3.x)
  would invalidate all of it.
- **Not verified live.** The `[]`-at-`onStart` path needs an async `onMentionQueryStringChanged`
  whose first response outlives a keystroke plus the debounce; no Storybook story wires one.
  Confirming it in the RichText mention story (visible tab) is still Albert's.
