### PR TITLE
fix(F0AiChatTextArea): keep a mention whatever follows it

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -158,6 +158,7 @@ export const F0AiChatTextArea = ({
     inputValue,
     setInputValue,
     cursorPosition,
+    setCursorPosition,
     searchPersons,
     textareaRef,
   })
@@ -302,7 +303,7 @@ export const F0AiChatTextArea = ({
         }
       }
 
-      const transformed = mentions.transformMentions(inputValue.trim())
+      const transformed = mentions.transformMentions().trim()
       // Escape markdown/HTML in the user's own text so `*hola*` stays literal
       // and only features we control (@mentions) produce rich rendering.
       const safeUserText = escapeUserText(transformed)

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.mentions.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.mentions.test.tsx
@@ -1,0 +1,64 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
+import { type PersonProfile } from "../../F0AiChat/types"
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+const ANA: PersonProfile = { id: "ana-g", firstName: "Ana", lastName: "García" }
+
+const ANA_REF = `<entity-ref type="person" id="ana-g">Ana García</entity-ref>`
+
+/**
+ * Type `@Ana`, take the popover's first row, and hand back the composer.
+ * Mirrors what a user does before they keep writing the sentence.
+ */
+const composeMention = async () => {
+  const onSubmit = vi.fn()
+  const searchPersons = vi.fn(() => Promise.resolve([ANA]))
+  const user = userEvent.setup()
+
+  render(<F0AiChatTextArea onSubmit={onSubmit} searchPersons={searchPersons} />)
+
+  const textarea = screen.getByRole("textbox")
+  await user.click(textarea)
+  await user.type(textarea, "Hola @Ana")
+  await screen.findByRole("option", { name: /Ana García/ })
+  await user.keyboard("{Enter}")
+  await waitFor(() => expect(textarea).toHaveValue("Hola @Ana García "))
+
+  return { user, textarea, onSubmit }
+}
+
+const send = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("button", { name: /send message/i }))
+}
+
+describe("F0AiChatTextArea — the sent payload keeps the mention", () => {
+  it("sends the mention id when a comma follows the name", async () => {
+    const { user, textarea, onSubmit } = await composeMention()
+
+    await user.keyboard("{Backspace},")
+    await waitFor(() => expect(textarea).toHaveValue("Hola @Ana García,"))
+
+    await send(user)
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      text: `Hola ${ANA_REF},`,
+    })
+  })
+
+  it("sends the mention id when the name ends the message", async () => {
+    const { user, textarea, onSubmit } = await composeMention()
+
+    await user.keyboard("{Backspace}")
+    await waitFor(() => expect(textarea).toHaveValue("Hola @Ana García"))
+
+    await send(user)
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
+    expect(onSubmit.mock.calls[0]?.[0]).toMatchObject({
+      text: `Hola ${ANA_REF}`,
+    })
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/highlight-utils.test.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/highlight-utils.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+import { buildHighlightSegments, escapeXml } from "../highlight-utils"
+
+const ana = (start: number) => ({ id: "ana-g", name: "Ana García", start })
+
+describe("buildHighlightSegments", () => {
+  it("paints the span the anchor points at", () => {
+    expect(
+      buildHighlightSegments("Hola @Ana García, ¿vienes?", [ana(5)])
+    ).toEqual([
+      { type: "text", text: "Hola " },
+      { type: "mention", text: "@Ana García" },
+      { type: "text", text: ", ¿vienes?" },
+    ])
+  })
+
+  it("gives two people who share a name one span each", () => {
+    expect(
+      buildHighlightSegments("@Ana García y @Ana García", [ana(0), ana(14)])
+    ).toEqual([
+      { type: "mention", text: "@Ana García" },
+      { type: "text", text: " y " },
+      { type: "mention", text: "@Ana García" },
+    ])
+  })
+
+  it("paints nothing where an anchor no longer sits on its own name", () => {
+    // The anchors are reconciled in an effect, so a keystroke that moves one
+    // lands a render early. Painting the old span would highlight glyphs the
+    // sent payload will not tag.
+    expect(buildHighlightSegments("Hola y@Ana García", [ana(5)])).toEqual([
+      { type: "text", text: "Hola y@Ana García" },
+    ])
+  })
+
+  it("puts the ghost completion at the cursor", () => {
+    expect(
+      buildHighlightSegments("Hola @Ana", [], {
+        cursorPosition: 9,
+        inlineCompletion: " García",
+      })
+    ).toEqual([
+      { type: "text", text: "Hola @Ana" },
+      { type: "ghost", text: " García" },
+    ])
+  })
+})
+
+describe("escapeXml", () => {
+  it("neutralizes the characters that would break out of an attribute", () => {
+    expect(escapeXml('a&b<c>d"e')).toBe("a&amp;b&lt;c&gt;d&quot;e")
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/mention-anchors.test.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/mention-anchors.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from "vitest"
+import { anchorEnd, diffSpan, eraseSpans, reanchor } from "../mention-anchors"
+
+const ana = (start: number) => ({ id: "ana-g", name: "Ana García", start })
+const bruno = (start: number) => ({
+  id: "bruno",
+  name: "Bruno Martínez",
+  start,
+})
+
+describe("diffSpan", () => {
+  it("reads an insertion as an empty span in the old string", () => {
+    expect(diffSpan("Hola mundo", "Hola y mundo")).toEqual({
+      start: 5,
+      prevEnd: 5,
+      nextEnd: 7,
+    })
+  })
+
+  it("reads a deletion as an empty span in the new string", () => {
+    expect(diffSpan("Hola mundo", "Hola undo")).toEqual({
+      start: 5,
+      prevEnd: 6,
+      nextEnd: 5,
+    })
+  })
+
+  it("picks a span of the right length when the edit is ambiguous", () => {
+    // Deleting either of two adjacent spaces gives the same string; whichever
+    // one it names, the span has to be exactly one character wide.
+    const { start, prevEnd, nextEnd } = diffSpan("a  b", "a b")
+    expect(prevEnd - start).toBe(1)
+    expect(nextEnd - start).toBe(0)
+  })
+
+  it("reads a whole-string replacement as one span", () => {
+    expect(diffSpan("Hola", "Adiós")).toEqual({
+      start: 0,
+      prevEnd: 4,
+      nextEnd: 5,
+    })
+  })
+})
+
+describe("reanchor", () => {
+  it("slides an anchor when text is inserted immediately before it", () => {
+    // The insertion point and the anchor are the same index; the mention is
+    // what moves, not the text typed in front of it.
+    expect(
+      reanchor("Hola @Ana García ", "Hola y@Ana García ", [ana(5)])
+    ).toEqual({ kept: [ana(6)], touched: [] })
+  })
+
+  it("slides an anchor sitting at index 0", () => {
+    expect(reanchor("@Ana García ", "H@Ana García ", [ana(0)])).toEqual({
+      kept: [ana(1)],
+      touched: [],
+    })
+  })
+
+  it("pulls an anchor back when text before it is deleted", () => {
+    expect(reanchor("Hola @Ana García ", "Hol @Ana García ", [ana(5)])).toEqual(
+      {
+        kept: [ana(4)],
+        touched: [],
+      }
+    )
+  })
+
+  it("treats adjacency as adjacency, not overlap", () => {
+    expect(
+      reanchor("Hola @Ana García ", "Hola @Ana García,", [ana(5)])
+    ).toEqual({ kept: [ana(5)], touched: [] })
+  })
+
+  it("reports what is left of a mention an edit landed inside", () => {
+    const { kept, touched } = reanchor(
+      "Hola @Ana García, gracias",
+      "Hola @Ana Garía, gracias",
+      [ana(5)]
+    )
+    expect(kept).toEqual([])
+    expect(touched).toEqual([{ start: 5, end: 15 }])
+  })
+
+  it("drops a mention the change replaced outright, erasing nothing", () => {
+    // Select all, type "x": the mention's own text is already gone, and the
+    // span that replaced it is the keystroke.
+    expect(reanchor("Hola @Ana García,", "x", [ana(5)])).toEqual({
+      kept: [],
+      touched: [],
+    })
+  })
+
+  it("keeps text typed over a selection that straddles two mentions", () => {
+    const { kept, touched } = reanchor(
+      "@Ana García y @Bruno Martínez ok",
+      "@Ana X Martínez ok",
+      [ana(0), bruno(14)]
+    )
+    expect(kept).toEqual([])
+    // "@Ana " survives from the first, " Martínez" from the second — the "X"
+    // between them is the user's and is not in either span.
+    expect(touched).toEqual([
+      { start: 0, end: 5 },
+      { start: 6, end: 15 },
+    ])
+  })
+})
+
+describe("eraseSpans", () => {
+  it("cuts several spans and slides the anchors and the caret", () => {
+    expect(
+      eraseSpans(
+        "0123456789",
+        [
+          { start: 6, end: 8 },
+          { start: 1, end: 3 },
+        ],
+        [ana(9)],
+        7
+      )
+    ).toEqual({ text: "034589", mentions: [ana(5)], caret: 4 })
+  })
+
+  it("merges overlapping spans instead of cutting twice", () => {
+    expect(
+      eraseSpans(
+        "0123456789",
+        [
+          { start: 1, end: 4 },
+          { start: 3, end: 6 },
+        ],
+        [],
+        10
+      )
+    ).toEqual({ text: "06789", mentions: [], caret: 5 })
+  })
+})
+
+describe("anchorEnd", () => {
+  it("counts the @ as part of the token", () => {
+    expect(anchorEnd(ana(5))).toBe(16)
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/mention-anchors.test.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/mention-anchors.test.ts
@@ -67,6 +67,33 @@ describe("reanchor", () => {
     )
   })
 
+  it("slides an anchor when the inserted text repeats its own @", () => {
+    // Starting a second mention in front of an existing one. The keystroke is
+    // the same character it lands on, so the change reads just as well as an
+    // edit inside the token, and reading it that way costs the user the name
+    // they already picked.
+    expect(
+      reanchor("Hola @Ana García ", "Hola @@Ana García ", [ana(5)])
+    ).toEqual({ kept: [ana(6)], touched: [] })
+  })
+
+  it("pulls an anchor back when the deleted text repeats its own @", () => {
+    // The undo of the case above, ambiguous in the same way.
+    expect(reanchor("@@Ana García ", "@Ana García ", [ana(1)])).toEqual({
+      kept: [ana(0)],
+      touched: [],
+    })
+  })
+
+  it("takes the mention when its own @ is the character deleted", () => {
+    // The `@` is part of the token, so losing it is an edit inside the
+    // mention — not a change that happened in front of it.
+    expect(reanchor("@Ana García ", "Ana García ", [ana(0)])).toEqual({
+      kept: [],
+      touched: [{ start: 0, end: 10 }],
+    })
+  })
+
   it("treats adjacency as adjacency, not overlap", () => {
     expect(
       reanchor("Hola @Ana García ", "Hola @Ana García,", [ana(5)])

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
@@ -25,22 +25,32 @@ const fullName = (person: PersonProfile): string =>
 const refFor = (person: PersonProfile): string =>
   `<entity-ref type="person" id="${person.id}">${fullName(person)}</entity-ref>`
 
-/** Drives the hook the way the composer does: one controlled value plus caret. */
+/**
+ * Drives the hook the way the composer does: one controlled value plus caret,
+ * with the hook's own writes fed back through `flush` so a rewrite it makes can
+ * be observed settling instead of only being recorded.
+ */
 const mountComposer = (people: PersonProfile[]) => {
   const textarea = document.createElement("textarea")
   document.body.appendChild(textarea)
 
-  const setInputValue = vi.fn<(next: string) => void>()
-  const setCursorPosition = vi.fn<(next: number) => void>()
+  let value = ""
+  let caret = 0
+  const setInputValue = vi.fn<(next: string) => void>((next) => {
+    value = next
+  })
+  const setCursorPosition = vi.fn<(next: number) => void>((next) => {
+    caret = next
+  })
   const searchPersons = vi.fn((query: string) =>
     Promise.resolve(
       people.filter((person) =>
-        fullName(person).toLowerCase().includes(query.toLowerCase())
+        fullName(person).toLowerCase().includes(query.trim().toLowerCase())
       )
     )
   )
 
-  const props = (value: string, caret = value.length): Props => ({
+  const props = (): Props => ({
     inputValue: value,
     setInputValue,
     cursorPosition: caret,
@@ -50,16 +60,26 @@ const mountComposer = (people: PersonProfile[]) => {
   })
 
   const harness = renderHook((next: Props) => useMentions(next), {
-    initialProps: props(""),
+    initialProps: props(),
   })
 
   return {
     ...harness,
     setInputValue,
     setCursorPosition,
+    textarea,
     /** Hand the hook a new composer value, as the textarea's onChange would. */
-    type: (value: string, caret?: number) =>
-      harness.rerender(props(value, caret)),
+    type: (next: string, at?: number) => {
+      value = next
+      caret = at ?? next.length
+      textarea.value = value
+      harness.rerender(props())
+    },
+    /** Re-render with whatever the hook wrote back, as the composer would. */
+    flush: () => {
+      textarea.value = value
+      harness.rerender(props())
+    },
   }
 }
 
@@ -139,6 +159,16 @@ describe("useMentions — a mention is a token, not a substring", () => {
     )
     expect(composer.setCursorPosition).toHaveBeenLastCalledWith(5)
     expect(composer.result.current.mentions).toHaveLength(0)
+
+    // Applying the hook's own rewrite settles: no second erase, and no
+    // half-typed name left for the popover to reopen on.
+    composer.setInputValue.mockClear()
+    composer.flush()
+    expect(composer.setInputValue).not.toHaveBeenCalled()
+    expect(composer.result.current.isOpen).toBe(false)
+    // The caret is where the mention was, in the textarea and not only in the
+    // component's state.
+    expect(composer.textarea.selectionStart).toBe(5)
   })
 
   it("keeps the tag on the name when the message starts with whitespace", async () => {
@@ -151,6 +181,56 @@ describe("useMentions — a mention is a token, not a substring", () => {
     expect(composer.result.current.transformMentions()).toBe(
       `  ${refFor(ANA)},`
     )
+  })
+
+  it("slides the anchor when the user types immediately before a mention", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("@Ana")
+    await pick(composer, 0, "@Ana García ")
+    composer.setInputValue.mockClear()
+
+    // Caret at 0, type "H". The insertion point and the anchor are the same
+    // index: the mention moves, it is not edited.
+    composer.type("H@Ana García ", 1)
+
+    expect(composer.setInputValue).not.toHaveBeenCalled()
+    expect(composer.result.current.mentions).toEqual([
+      { id: "ana-g", name: "Ana García", start: 1 },
+    ])
+    expect(composer.result.current.transformMentions()).toBe(`H${refFor(ANA)} `)
+    // The trigger sits on a resolved mention, so the popover stays shut.
+    expect(composer.result.current.isOpen).toBe(false)
+  })
+
+  it("escapes a name and an id on the way into the tag", async () => {
+    const AWKWARD: PersonProfile = {
+      id: 'a&b"c',
+      firstName: "<Ana>",
+      lastName: "García",
+    }
+    const composer = mountComposer([AWKWARD])
+    composer.type("@<Ana")
+    await pick(composer, 0, "@<Ana> García ")
+
+    expect(composer.result.current.transformMentions()).toBe(
+      '<entity-ref type="person" id="a&amp;b&quot;c">&lt;Ana&gt; García</entity-ref> '
+    )
+  })
+
+  it("returns focus to the textarea when the pick rewrites nothing", async () => {
+    // Typing the name out in full and then picking it writes the same string
+    // back, so nothing about the value changes — but the row may have been
+    // clicked, and the caret and focus still have to come home.
+    const composer = mountComposer([ANA])
+    composer.type("@Ana García ")
+    await waitFor(() => expect(composer.result.current.results).toHaveLength(1))
+    composer.textarea.blur()
+
+    act(() => composer.result.current.selectPerson(ANA))
+
+    expect(composer.setInputValue).toHaveBeenLastCalledWith("@Ana García ")
+    expect(document.activeElement).toBe(composer.textarea)
+    expect(composer.textarea.selectionStart).toBe(12)
   })
 
   it("keeps what the user types when a selection replaces the whole mention", async () => {

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
@@ -1,0 +1,169 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+import { type PersonProfile } from "../../F0AiChat/types"
+import { useMentions } from "../useMentions"
+
+const ANA: PersonProfile = { id: "ana-g", firstName: "Ana", lastName: "García" }
+// Same display name, different person — the case a name-based match cannot tell
+// apart.
+const ANA_TWIN: PersonProfile = {
+  id: "ana-p",
+  firstName: "Ana",
+  lastName: "García",
+}
+const BRUNO: PersonProfile = {
+  id: "bruno",
+  firstName: "Bruno",
+  lastName: "Martínez",
+}
+
+type Props = Parameters<typeof useMentions>[0]
+
+const fullName = (person: PersonProfile): string =>
+  `${person.firstName} ${person.lastName}`.trim()
+
+const refFor = (person: PersonProfile): string =>
+  `<entity-ref type="person" id="${person.id}">${fullName(person)}</entity-ref>`
+
+/** Drives the hook the way the composer does: one controlled value plus caret. */
+const mountComposer = (people: PersonProfile[]) => {
+  const textarea = document.createElement("textarea")
+  document.body.appendChild(textarea)
+
+  const setInputValue = vi.fn<(next: string) => void>()
+  const setCursorPosition = vi.fn<(next: number) => void>()
+  const searchPersons = vi.fn((query: string) =>
+    Promise.resolve(
+      people.filter((person) =>
+        fullName(person).toLowerCase().includes(query.toLowerCase())
+      )
+    )
+  )
+
+  const props = (value: string, caret = value.length): Props => ({
+    inputValue: value,
+    setInputValue,
+    cursorPosition: caret,
+    setCursorPosition,
+    searchPersons,
+    textareaRef: { current: textarea },
+  })
+
+  const harness = renderHook((next: Props) => useMentions(next), {
+    initialProps: props(""),
+  })
+
+  return {
+    ...harness,
+    setInputValue,
+    setCursorPosition,
+    /** Hand the hook a new composer value, as the textarea's onChange would. */
+    type: (value: string, caret?: number) =>
+      harness.rerender(props(value, caret)),
+  }
+}
+
+type Composer = ReturnType<typeof mountComposer>
+
+/** Wait for the popover, take the row at `index`, and apply the text it writes. */
+const pick = async (composer: Composer, index: number, expected: string) => {
+  await waitFor(() =>
+    expect(composer.result.current.results.length).toBeGreaterThan(index)
+  )
+  const person = composer.result.current.results[index]!
+  act(() => composer.result.current.selectPerson(person))
+  expect(composer.setInputValue).toHaveBeenLastCalledWith(expected)
+  composer.type(expected)
+}
+
+// A tracked mention used to be re-derived from the text on every change and
+// kept only while `@Name` was followed by a space, a newline or a tab. What came
+// after the name therefore decided whether the mention existed at all.
+describe("useMentions — a mention is a token, not a substring", () => {
+  it("keeps a mention that is followed by a comma", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+
+    // The user replaces the inserted trailing space with a comma.
+    composer.type("Hola @Ana García,")
+
+    expect(composer.result.current.mentions).toHaveLength(1)
+    expect(composer.result.current.transformMentions()).toBe(
+      `Hola ${refFor(ANA)},`
+    )
+  })
+
+  it("keeps a mention that ends the message", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+
+    // The user deletes the inserted trailing space: nothing follows the name.
+    composer.type("Hola @Ana García")
+
+    expect(composer.result.current.mentions).toHaveLength(1)
+    expect(composer.result.current.transformMentions()).toBe(
+      `Hola ${refFor(ANA)}`
+    )
+  })
+
+  it("survives an edit made elsewhere in the text", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+    composer.type("Hola @Ana García, ¿vienes?")
+    composer.setInputValue.mockClear()
+
+    // Typing at the very front shifts the mention seven characters right.
+    composer.type("Buenas Hola @Ana García, ¿vienes?", 7)
+
+    expect(composer.result.current.mentions).toHaveLength(1)
+    expect(composer.setInputValue).not.toHaveBeenCalled()
+    expect(composer.result.current.transformMentions()).toBe(
+      `Buenas Hola ${refFor(ANA)}, ¿vienes?`
+    )
+  })
+
+  it("removes the whole mention when an edit lands inside it", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+    composer.type("Hola @Ana García, gracias")
+
+    // Backspace the "c" of "García": the caret lands at 13.
+    composer.type("Hola @Ana Garía, gracias", 13)
+
+    await waitFor(() =>
+      expect(composer.setInputValue).toHaveBeenLastCalledWith("Hola , gracias")
+    )
+    expect(composer.setCursorPosition).toHaveBeenLastCalledWith(5)
+    expect(composer.result.current.mentions).toHaveLength(0)
+  })
+
+  it("keeps the tag on the name when the message starts with whitespace", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("  @Ana")
+    await pick(composer, 0, "  @Ana García ")
+    composer.type("  @Ana García,")
+
+    // The anchors index the raw value: whoever trims has to trim afterwards.
+    expect(composer.result.current.transformMentions()).toBe(
+      `  ${refFor(ANA)},`
+    )
+  })
+
+  it("anchors two people who share a display name independently", async () => {
+    const composer = mountComposer([ANA, ANA_TWIN])
+    composer.type("@Ana")
+    await pick(composer, 0, "@Ana García ")
+
+    composer.type("@Ana García y @Ana")
+    await pick(composer, 1, "@Ana García y @Ana García ")
+
+    expect(composer.result.current.mentions).toHaveLength(2)
+    expect(composer.result.current.transformMentions()).toBe(
+      `${refFor(ANA)} y ${refFor(ANA_TWIN)} `
+    )
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
@@ -202,6 +202,47 @@ describe("useMentions — a mention is a token, not a substring", () => {
     expect(composer.result.current.isOpen).toBe(false)
   })
 
+  it("keeps the mention when the user types @ in front of it", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+    composer.setInputValue.mockClear()
+
+    // Caret at 5, type "@" to start a second mention in front of the first.
+    // The keystroke repeats the character it lands on, which is the one shape
+    // of insertion that can also be read as landing inside the token.
+    composer.type("Hola @@Ana García ", 6)
+
+    expect(composer.setInputValue).not.toHaveBeenCalled()
+    expect(composer.result.current.mentions).toEqual([
+      { id: "ana-g", name: "Ana García", start: 6 },
+    ])
+    expect(composer.result.current.transformMentions()).toBe(
+      `Hola @${refFor(ANA)} `
+    )
+    // The new trigger is a trigger: the popover opens on it, not on the
+    // resolved mention behind it.
+    expect(composer.result.current.isOpen).toBe(true)
+  })
+
+  it("keeps the mention when that @ is deleted again", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+    composer.type("Hola @@Ana García ", 6)
+    composer.setInputValue.mockClear()
+
+    composer.type("Hola @Ana García ", 5)
+
+    expect(composer.setInputValue).not.toHaveBeenCalled()
+    expect(composer.result.current.mentions).toEqual([
+      { id: "ana-g", name: "Ana García", start: 5 },
+    ])
+    expect(composer.result.current.transformMentions()).toBe(
+      `Hola ${refFor(ANA)} `
+    )
+  })
+
   it("escapes a name and an id on the way into the tag", async () => {
     const AWKWARD: PersonProfile = {
       id: 'a&b"c',
@@ -245,6 +286,69 @@ describe("useMentions — a mention is a token, not a substring", () => {
 
     expect(composer.setInputValue).not.toHaveBeenCalled()
     expect(composer.result.current.mentions).toHaveLength(0)
+  })
+
+  it("does not reopen the popover on a resolved mention", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+
+    // Caret at the end of the name. The `@` behind it starts a resolved token,
+    // so it is not a trigger — the whole reason the anchor, not the character
+    // after the name, decides what is a mention.
+    composer.type("Hola @Ana García ", 16)
+
+    expect(composer.result.current.isOpen).toBe(false)
+  })
+
+  it("anchors a pick where the token lands, not where the trigger was", async () => {
+    const composer = mountComposer([ANA])
+
+    // A query that matched nobody is remembered as dismissed, and the effect
+    // that remembers it returns without closing the popover or clearing the
+    // trigger it recorded.
+    composer.type("@zzz")
+    await waitFor(() => expect(composer.result.current.isOpen).toBe(true))
+    await waitFor(() => expect(composer.result.current.isOpen).toBe(false))
+
+    composer.type("@zzz @Ana")
+    await waitFor(() => expect(composer.result.current.results).toHaveLength(1))
+
+    // Back to the dismissed query: the popover stays open on a trigger index
+    // the text no longer has.
+    composer.type("@zzz", 4)
+    act(() => composer.result.current.selectPerson(ANA))
+    composer.flush()
+
+    // The `@` lands at 4, so the anchor has to say 4. Saying 5 is the failure
+    // this composer anchors mentions to prevent: the tag never reaches the
+    // agent, and nothing reports it.
+    expect(composer.result.current.mentions).toEqual([
+      { id: "ana-g", name: "Ana García", start: 4 },
+    ])
+    expect(composer.result.current.transformMentions()).toBe(
+      `@zzz${refFor(ANA)} `
+    )
+  })
+
+  it("slides an existing mention when a pick lands in front of it", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("@Ana")
+    await pick(composer, 0, "@Ana García ")
+
+    // A second trigger typed in front of the first mention. Picking there grows
+    // the text before it, so its anchor has to move with it — the pick rewrites
+    // the value itself, so the reconciler never sees this change.
+    composer.type("@Bru@Ana García ", 4)
+    await pick(composer, 0, "@Bruno Martínez @Ana García ")
+
+    expect(composer.result.current.mentions).toEqual([
+      { id: "bruno", name: "Bruno Martínez", start: 0 },
+      { id: "ana-g", name: "Ana García", start: 16 },
+    ])
+    expect(composer.result.current.transformMentions()).toBe(
+      `${refFor(BRUNO)} ${refFor(ANA)} `
+    )
   })
 
   it("anchors two people who share a display name independently", async () => {

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/useMentions.test.ts
@@ -153,6 +153,20 @@ describe("useMentions — a mention is a token, not a substring", () => {
     )
   })
 
+  it("keeps what the user types when a selection replaces the whole mention", async () => {
+    const composer = mountComposer([ANA, BRUNO])
+    composer.type("Hola @Ana")
+    await pick(composer, 0, "Hola @Ana García ")
+    composer.setInputValue.mockClear()
+
+    // Select all, then type. The mention's own text is already gone, so there
+    // is nothing left to erase — and erasing anyway eats the keystroke.
+    composer.type("x", 1)
+
+    expect(composer.setInputValue).not.toHaveBeenCalled()
+    expect(composer.result.current.mentions).toHaveLength(0)
+  })
+
   it("anchors two people who share a display name independently", async () => {
     const composer = mountComposer([ANA, ANA_TWIN])
     composer.type("@Ana")

--- a/packages/react/src/kits/ai/F0AiChatTextArea/highlight-utils.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/highlight-utils.ts
@@ -1,4 +1,5 @@
-import type { MentionEntry } from "./useMentions"
+import { anchorEnd } from "./mention-anchors"
+import type { AnchoredMention } from "./useMentions"
 
 /**
  * Escape a string for safe embedding inside XML/HTML attributes and text
@@ -27,7 +28,7 @@ export type HighlightSegment = {
  */
 export function buildHighlightSegments(
   text: string,
-  mentions: MentionEntry[],
+  mentions: AnchoredMention[],
   options?: {
     cursorPosition?: number
     inlineCompletion?: string | null
@@ -36,24 +37,12 @@ export function buildHighlightSegments(
   const cursorPos = options?.cursorPosition ?? text.length
   const ghost = options?.inlineCompletion ?? null
 
-  // Build a list of { start, end } ranges for each @Name occurrence
-  const ranges: { start: number; end: number }[] = []
-
-  for (const mention of mentions) {
-    const pattern = `@${mention.name}`
-    let searchFrom = 0
-    while (true) {
-      const idx = text.indexOf(pattern, searchFrom)
-      if (idx === -1) {
-        break
-      }
-      ranges.push({ start: idx, end: idx + pattern.length })
-      searchFrom = idx + pattern.length
-    }
-  }
-
-  // Sort by start position
-  ranges.sort((a, b) => a.start - b.start)
+  // The textarea owns the anchors, so the overlay paints exactly the spans it
+  // considers mentions — no second, independently-drifting match.
+  const ranges = mentions
+    .map((mention) => ({ start: mention.start, end: anchorEnd(mention) }))
+    .filter((range) => range.start >= 0 && range.end <= text.length)
+    .sort((a, b) => a.start - b.start)
 
   // Collect all "split points": mention ranges + the ghost insertion point
   // Then walk through the text emitting segments in order.

--- a/packages/react/src/kits/ai/F0AiChatTextArea/highlight-utils.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/highlight-utils.ts
@@ -37,11 +37,14 @@ export function buildHighlightSegments(
   const cursorPos = options?.cursorPosition ?? text.length
   const ghost = options?.inlineCompletion ?? null
 
-  // The textarea owns the anchors, so the overlay paints exactly the spans it
-  // considers mentions — no second, independently-drifting match.
+  // Paint the anchors the textarea owns, but only where one still sits on its
+  // own `@name` — the same test the sent payload applies. The anchors are
+  // reconciled in an effect, so they trail the text by a commit whenever an
+  // edit moves them; without this the overlay would paint a pill over glyphs
+  // that will not be tagged, which is worse than painting none for a frame.
   const ranges = mentions
+    .filter((mention) => text.startsWith(`@${mention.name}`, mention.start))
     .map((mention) => ({ start: mention.start, end: anchorEnd(mention) }))
-    .filter((range) => range.start >= 0 && range.end <= text.length)
     .sort((a, b) => a.start - b.start)
 
   // Collect all "split points": mention ranges + the ghost insertion point

--- a/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
@@ -49,14 +49,21 @@ export const diffSpan = (prev: string, next: string): TextEdit => {
 
 /**
  * Re-anchor `anchored` after the composer text went from `prev` to `next`, and
- * report which mentions the edit landed inside.
+ * report what is left of the mentions the change ran into.
  *
- * A mention the change partly overlaps is *touched*: its remaining text is
- * reported so the caller can erase it whole. Adjacency is not overlap, so
- * typing a comma right after a mention — or deleting the space that followed
- * it — leaves the mention alone. A mention the change swallowed entirely is
- * simply dropped: its text is already gone, and the span that replaced it is
- * whatever the user just typed or pasted.
+ * A mention the change missed is kept, shifted. One the change ran into is
+ * *touched*: the spans it still occupies in `next` are reported so the caller
+ * can erase them and take the token out whole. Three rules make that safe:
+ *
+ * - Adjacency is not overlap, on either side. Typing a comma right after a
+ *   mention, deleting the space that followed it, or typing immediately in
+ *   front of the `@` all leave the mention alone — the last of those is a pure
+ *   insertion at the anchor's own index, which moves the mention rather than
+ *   editing it.
+ * - A change strictly inside a mention takes the whole token, including what
+ *   was typed in its place: a half-typed name was never a state the user meant.
+ * - A change that swallowed a mention outright erases nothing. Its text is
+ *   already gone, and what replaced it is the user's own keystroke or paste.
  */
 export const reanchor = <T extends Anchored>(
   prev: string,
@@ -66,26 +73,29 @@ export const reanchor = <T extends Anchored>(
   const { start: prefix, prevEnd, nextEnd } = diffSpan(prev, next)
   const delta = next.length - prev.length
 
-  // Positions inside the changed span have no image in `next`; clamp a start
-  // down and an end up so an erased range covers the whole disturbed region.
-  const mapStart = (pos: number): number =>
-    pos <= prefix ? pos : pos >= prevEnd ? pos + delta : prefix
-  const mapEnd = (pos: number): number =>
-    pos <= prefix ? pos : pos >= prevEnd ? pos + delta : nextEnd
-
   const kept: T[] = []
   const touched: Span[] = []
   for (const mention of anchored) {
     const start = mention.start
     const end = anchorEnd(mention)
+
     if (prefix >= end || prevEnd <= start) {
-      kept.push({ ...mention, start: mapStart(start) })
+      kept.push({ ...mention, start: start < prefix ? start : start + delta })
       continue
     }
-    if (start >= prefix && end <= prevEnd) {
+
+    const headSurvives = start < prefix
+    const tailSurvives = end > prevEnd
+    if (headSurvives && tailSurvives) {
+      touched.push({ start, end: end + delta })
       continue
     }
-    touched.push({ start: mapStart(start), end: mapEnd(end) })
+    if (headSurvives) {
+      touched.push({ start, end: prefix })
+    }
+    if (tailSurvives) {
+      touched.push({ start: nextEnd, end: end + delta })
+    }
   }
   return { kept, touched }
 }

--- a/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
@@ -51,10 +51,12 @@ export const diffSpan = (prev: string, next: string): TextEdit => {
  * Re-anchor `anchored` after the composer text went from `prev` to `next`, and
  * report which mentions the edit landed inside.
  *
- * A mention whose span the change overlaps is *touched*: its remaining text is
+ * A mention the change partly overlaps is *touched*: its remaining text is
  * reported so the caller can erase it whole. Adjacency is not overlap, so
  * typing a comma right after a mention — or deleting the space that followed
- * it — leaves the mention alone.
+ * it — leaves the mention alone. A mention the change swallowed entirely is
+ * simply dropped: its text is already gone, and the span that replaced it is
+ * whatever the user just typed or pasted.
  */
 export const reanchor = <T extends Anchored>(
   prev: string,
@@ -76,11 +78,14 @@ export const reanchor = <T extends Anchored>(
   for (const mention of anchored) {
     const start = mention.start
     const end = anchorEnd(mention)
-    if (prefix < end && prevEnd > start) {
-      touched.push({ start: mapStart(start), end: mapEnd(end) })
-    } else {
+    if (prefix >= end || prevEnd <= start) {
       kept.push({ ...mention, start: mapStart(start) })
+      continue
     }
+    if (start >= prefix && end <= prevEnd) {
+      continue
+    }
+    touched.push({ start: mapStart(start), end: mapEnd(end) })
   }
   return { kept, touched }
 }

--- a/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
@@ -48,6 +48,29 @@ export const diffSpan = (prev: string, next: string): TextEdit => {
 }
 
 /**
+ * Can the change from `prev` to `next` be read as replacing `[at, at + removed)`
+ * with the `inserted` characters that start there?
+ *
+ * {@link diffSpan} names the rightmost reading of an ambiguous change, which is
+ * the right bias at a mention's tail and the wrong one at its head: typing `@`
+ * in front of `@Ana García` — the way a second mention gets started there —
+ * repeats the character it lands on, so the rightmost reading puts it inside
+ * the token and takes the whole name with it. The readings of one change form
+ * a contiguous interval, so testing the anchor's own index settles whether a
+ * reading that leaves the mention whole exists at all.
+ */
+const readsAs = (
+  prev: string,
+  next: string,
+  at: number,
+  removed: number,
+  inserted: number
+): boolean =>
+  at >= 0 &&
+  next.slice(0, at) === prev.slice(0, at) &&
+  next.slice(at + inserted) === prev.slice(at + removed)
+
+/**
  * Re-anchor `anchored` after the composer text went from `prev` to `next`, and
  * report what is left of the mentions the change ran into.
  *
@@ -59,7 +82,8 @@ export const diffSpan = (prev: string, next: string): TextEdit => {
  *   mention, deleting the space that followed it, or typing immediately in
  *   front of the `@` all leave the mention alone — the last of those is a pure
  *   insertion at the anchor's own index, which moves the mention rather than
- *   editing it.
+ *   editing it. That holds even when the change is ambiguous and `diffSpan`
+ *   named a reading inside the token; see {@link readsAs}.
  * - A change strictly inside a mention takes the whole token, including what
  *   was typed in its place: a half-typed name was never a state the user meant.
  * - A change that swallowed a mention outright erases nothing. Its text is
@@ -72,6 +96,8 @@ export const reanchor = <T extends Anchored>(
 ): { kept: T[]; touched: Span[] } => {
   const { start: prefix, prevEnd, nextEnd } = diffSpan(prev, next)
   const delta = next.length - prev.length
+  const removed = prevEnd - prefix
+  const inserted = nextEnd - prefix
 
   const kept: T[] = []
   const touched: Span[] = []
@@ -81,6 +107,11 @@ export const reanchor = <T extends Anchored>(
 
     if (prefix >= end || prevEnd <= start) {
       kept.push({ ...mention, start: start < prefix ? start : start + delta })
+      continue
+    }
+
+    if (readsAs(prev, next, start - removed, removed, inserted)) {
+      kept.push({ ...mention, start: start + delta })
       continue
     }
 

--- a/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/mention-anchors.ts
@@ -1,0 +1,133 @@
+/** A tracked mention plus where its `@name` starts in the composer text. */
+export type Anchored = { name: string; start: number }
+
+/** A half-open `[start, end)` range of the composer text. */
+export type Span = { start: number; end: number }
+
+/** Index just past the last character of an anchored mention's name. */
+export const anchorEnd = (anchored: Anchored): number =>
+  anchored.start + anchored.name.length + 1
+
+/** The single contiguous span in which two strings differ. */
+export type TextEdit = {
+  /** First index that differs. */
+  start: number
+  /** End of the changed span in the old string. */
+  prevEnd: number
+  /** End of the changed span in the new string. */
+  nextEnd: number
+}
+
+/**
+ * Read a text change as one contiguous span, by peeling the common prefix and
+ * suffix. Enough for typing, deletion, paste and a programmatic token swap
+ * alike — which is all the composer ever does to its own value in one step.
+ *
+ * Ambiguous when the same characters repeat around the edit (deleting one of
+ * two adjacent spaces could be either); the span it picks is still the right
+ * length, so callers that only care about extent or overlap are unaffected.
+ */
+export const diffSpan = (prev: string, next: string): TextEdit => {
+  const max = Math.min(prev.length, next.length)
+  let start = 0
+  while (start < max && prev[start] === next[start]) {
+    start++
+  }
+  let suffix = 0
+  while (
+    suffix < max - start &&
+    prev[prev.length - 1 - suffix] === next[next.length - 1 - suffix]
+  ) {
+    suffix++
+  }
+  return {
+    start,
+    prevEnd: prev.length - suffix,
+    nextEnd: next.length - suffix,
+  }
+}
+
+/**
+ * Re-anchor `anchored` after the composer text went from `prev` to `next`, and
+ * report which mentions the edit landed inside.
+ *
+ * A mention whose span the change overlaps is *touched*: its remaining text is
+ * reported so the caller can erase it whole. Adjacency is not overlap, so
+ * typing a comma right after a mention — or deleting the space that followed
+ * it — leaves the mention alone.
+ */
+export const reanchor = <T extends Anchored>(
+  prev: string,
+  next: string,
+  anchored: readonly T[]
+): { kept: T[]; touched: Span[] } => {
+  const { start: prefix, prevEnd, nextEnd } = diffSpan(prev, next)
+  const delta = next.length - prev.length
+
+  // Positions inside the changed span have no image in `next`; clamp a start
+  // down and an end up so an erased range covers the whole disturbed region.
+  const mapStart = (pos: number): number =>
+    pos <= prefix ? pos : pos >= prevEnd ? pos + delta : prefix
+  const mapEnd = (pos: number): number =>
+    pos <= prefix ? pos : pos >= prevEnd ? pos + delta : nextEnd
+
+  const kept: T[] = []
+  const touched: Span[] = []
+  for (const mention of anchored) {
+    const start = mention.start
+    const end = anchorEnd(mention)
+    if (prefix < end && prevEnd > start) {
+      touched.push({ start: mapStart(start), end: mapEnd(end) })
+    } else {
+      kept.push({ ...mention, start: mapStart(start) })
+    }
+  }
+  return { kept, touched }
+}
+
+/** Cut `spans` out of `text`, sliding the anchors and the caret left to match. */
+export const eraseSpans = <T extends Anchored>(
+  text: string,
+  spans: readonly Span[],
+  anchored: readonly T[],
+  caret: number
+): { text: string; mentions: T[]; caret: number } => {
+  const merged: Span[] = []
+  for (const span of [...spans].sort((a, b) => a.start - b.start)) {
+    const last = merged[merged.length - 1]
+    if (last && span.start <= last.end) {
+      last.end = Math.max(last.end, span.end)
+    } else {
+      merged.push({ ...span })
+    }
+  }
+
+  const removedBefore = (pos: number): number => {
+    let removed = 0
+    for (const span of merged) {
+      if (span.end <= pos) {
+        removed += span.end - span.start
+      } else if (span.start < pos) {
+        removed += pos - span.start
+      }
+    }
+    return removed
+  }
+
+  let out = ""
+  let cursor = 0
+  for (const span of merged) {
+    out += text.slice(cursor, span.start)
+    cursor = span.end
+  }
+  out += text.slice(cursor)
+
+  return {
+    text: out,
+    mentions: anchored.map((mention) => ({
+      ...mention,
+      start: mention.start - removedBefore(mention.start),
+    })),
+    caret: caret - removedBefore(caret),
+  }
+}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/useMentions.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/useMentions.ts
@@ -34,13 +34,13 @@ export type AnchoredMention = MentionEntry & {
   start: number
 }
 
-/** Index just past the last character of an anchored mention's name. */
-export const mentionEnd = anchorEnd
-
 export type UseMentionsOptions = {
   /** Current textarea value (controlled) */
   inputValue: string
-  /** Setter for the textarea value */
+  /** Setter for the textarea value. Writes are assumed to land: the anchors are
+   * re-indexed against the value the hook just asked for, so a parent that
+   * rejects or rewrites one would leave them indexed against a string that
+   * never reached the textarea. */
   setInputValue: (value: string) => void
   /** Cursor position (selectionStart) in the textarea */
   cursorPosition: number
@@ -228,8 +228,8 @@ export function useMentions({
   const [selectedIndex, setSelectedIndex] = useState(0)
   const [mentions, setMentions] = useState<AnchoredMention[]>([])
 
-  // The anchors are read from event handlers and effects that must not depend
-  // on them, so state and ref are written together and the ref is the source.
+  // The reconciler and `selectPerson` read the anchors without depending on
+  // them, so state and ref are written together and the ref is the source.
   const mentionsRef = useRef<AnchoredMention[]>(mentions)
   // Re-anchoring runs on every keystroke and usually produces the same anchors
   // in a new array. Keeping the old reference when nothing moved saves a state
@@ -272,23 +272,24 @@ export function useMentions({
     },
     []
   )
+  // Every commit, not only the ones that change the value: picking a person the
+  // composer had already spelled out in full writes the same string back, and
+  // that request still has to return focus from the clicked popover row. A
+  // request waits until its own text is on screen rather than being spent on
+  // the first commit that is not it, so a parent that applies the write a
+  // render later still gets its caret.
   useLayoutEffect(() => {
     const pending = pendingSelectionRef.current
-    if (!pending) {
-      return
-    }
-    // Whether it applies or was superseded by a later write, this request is
-    // spent — nothing is left scheduled that could fire against a dead owner.
-    pendingSelectionRef.current = null
     const textarea = textareaRef.current
-    if (pending.forText !== inputValue || !textarea) {
+    if (!pending || !textarea || pending.forText !== inputValue) {
       return
     }
+    pendingSelectionRef.current = null
     if (pending.focus) {
       textarea.focus()
     }
     textarea.setSelectionRange(pending.caret, pending.caret)
-  }, [inputValue, textareaRef])
+  })
 
   // Track the position of the @ that triggered the current search
   const atIndexRef = useRef<number>(-1)
@@ -400,7 +401,7 @@ export function useMentions({
       // so anchors past it slide and any the trigger overlapped are gone.
       const shift = insertedText.length - (cursorPosition - atIndex)
       const anchored = mentionsRef.current
-        .filter((m) => mentionEnd(m) <= atIndex || m.start >= cursorPosition)
+        .filter((m) => anchorEnd(m) <= atIndex || m.start >= cursorPosition)
         .map((m) =>
           m.start >= cursorPosition ? { ...m, start: m.start + shift } : m
         )
@@ -490,9 +491,9 @@ export function useMentions({
    *
    * It takes no text on purpose: the anchors index the raw value, so a caller
    * handing in a trimmed or otherwise derived copy would silently read them at
-   * the wrong offsets. An anchor that does not sit on its own `@name` is
-   * skipped rather than applied, so a desync can only cost a tag — never
-   * mislabel somebody else's name.
+   * the wrong offsets. An anchor is verified against the text before it is
+   * applied — the same test the overlay uses, so the two cannot disagree about
+   * which glyphs are a mention.
    */
   const transformMentions = useCallback((): string => {
     const text = inputValue

--- a/packages/react/src/kits/ai/F0AiChatTextArea/useMentions.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/useMentions.ts
@@ -397,15 +397,23 @@ export function useMentions({
 
       setInputValue(newValue)
 
-      // The trigger span [atIndex, cursorPosition) becomes the inserted token,
-      // so anchors past it slide and any the trigger overlapped are gone.
-      const shift = insertedText.length - (cursorPosition - atIndex)
+      // The trigger span becomes the inserted token, so anchors past it slide
+      // and any the trigger overlapped are gone. It is measured from the same
+      // clamped slices the new text is built from, never from the recorded
+      // indices: `atIndexRef` and the caret are read from an earlier render and
+      // both outlive a value that has since shrunk under them — the popover can
+      // still be open on a trigger the text no longer has. An anchor taken from
+      // the stale index would point past its own `@`, and an anchor that does
+      // not sit on its name is dropped from the sent payload without a word.
+      const triggerStart = before.length
+      const triggerEnd = Math.min(cursorPosition, inputValue.length)
+      const shift = insertedText.length - (triggerEnd - triggerStart)
       const anchored = mentionsRef.current
-        .filter((m) => anchorEnd(m) <= atIndex || m.start >= cursorPosition)
+        .filter((m) => anchorEnd(m) <= triggerStart || m.start >= triggerEnd)
         .map((m) =>
-          m.start >= cursorPosition ? { ...m, start: m.start + shift } : m
+          m.start >= triggerEnd ? { ...m, start: m.start + shift } : m
         )
-      anchored.push({ id, name, start: atIndex })
+      anchored.push({ id, name, start: triggerStart })
       anchored.sort((a, b) => a.start - b.start)
       prevValueRef.current = newValue
       commitMentions(anchored)

--- a/packages/react/src/kits/ai/F0AiChatTextArea/useMentions.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/useMentions.ts
@@ -1,6 +1,14 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import type { PersonProfile } from "../F0AiChat/types"
 import { escapeXml } from "./highlight-utils"
+import { anchorEnd, eraseSpans, reanchor } from "./mention-anchors"
 
 /**
  * A tracked mention in the textarea text.
@@ -12,6 +20,23 @@ export type MentionEntry = {
   name: string
 }
 
+/**
+ * A tracked mention plus where its `@name` sits in the textarea text.
+ *
+ * The anchor is what makes a mention a token rather than a substring: it is
+ * maintained across edits instead of being re-derived from the text, so a
+ * mention survives whatever follows it (a comma, the end of the message), and
+ * an edit landing inside it removes the whole thing instead of dropping the id
+ * and leaving a broken name behind.
+ */
+export type AnchoredMention = MentionEntry & {
+  /** Index of the `@` in the textarea text. */
+  start: number
+}
+
+/** Index just past the last character of an anchored mention's name. */
+export const mentionEnd = anchorEnd
+
 export type UseMentionsOptions = {
   /** Current textarea value (controlled) */
   inputValue: string
@@ -19,6 +44,8 @@ export type UseMentionsOptions = {
   setInputValue: (value: string) => void
   /** Cursor position (selectionStart) in the textarea */
   cursorPosition: number
+  /** Setter for the cursor position — used when removing a mention moves it */
+  setCursorPosition: (position: number) => void
   /** Search function for person mentions (@mention autocomplete) */
   searchPersons?: (query: string) => Promise<PersonProfile[]>
   /** Ref to the textarea element for reading selection */
@@ -36,8 +63,8 @@ export type UseMentionsReturn = {
   isLoading: boolean
   /** Currently highlighted index in the results list */
   selectedIndex: number
-  /** Active mentions in the current text */
-  mentions: MentionEntry[]
+  /** Active mentions, anchored in the current text */
+  mentions: AnchoredMention[]
   /** Pixel position for the popover, relative to the textarea's offset parent */
   popoverPosition: PopoverPosition
   /**
@@ -51,8 +78,8 @@ export type UseMentionsReturn = {
   handleKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => boolean
   /** Select a person from the results list */
   selectPerson: (person: PersonProfile) => void
-  /** Transform text, replacing @Name mentions with <entity-ref> tags */
-  transformMentions: (text: string) => string
+  /** The current text with each anchored mention as an <entity-ref> tag */
+  transformMentions: () => string
   /** Close the popover */
   close: () => void
 }
@@ -61,12 +88,13 @@ export type UseMentionsReturn = {
  * Finds the active @ trigger near the cursor.
  * Returns the start index of @ and the query string, or null if no active trigger.
  *
- * Skips @ signs that belong to already-completed mentions (tracked in `mentions`).
+ * An `@` that starts an anchored mention never re-opens the popover: that token
+ * is already resolved.
  */
 function findAtTrigger(
   text: string,
   cursorPos: number,
-  mentions: MentionEntry[]
+  anchored: AnchoredMention[]
 ): { atIndex: number; query: string } | null {
   // Search backwards from cursor for @
   const textBeforeCursor = text.slice(0, cursorPos)
@@ -93,25 +121,8 @@ function findAtTrigger(
     return null
   }
 
-  // Skip if the text after @ matches an already-completed mention AND the
-  // cursor is past the mention with a word-boundary separator after it.
-  // This means "@Name " (with trailing space) is skipped, but "@Name" with
-  // cursor right at the end is NOT skipped — allowing the user to backspace
-  // into a mention and re-trigger search.
-  for (const mention of mentions) {
-    const afterAt = text.slice(atIndex + 1)
-    const mentionEnd = atIndex + 1 + mention.name.length
-    if (afterAt.startsWith(mention.name) && cursorPos >= mentionEnd) {
-      // Only skip if there is a separator after the mention name
-      const charAfterMention = text[mentionEnd]
-      if (
-        charAfterMention === " " ||
-        charAfterMention === "\n" ||
-        charAfterMention === "\t"
-      ) {
-        return null
-      }
-    }
+  if (anchored.some((mention) => mention.start === atIndex)) {
+    return null
   }
 
   return { atIndex, query }
@@ -206,6 +217,7 @@ export function useMentions({
   inputValue,
   setInputValue,
   cursorPosition,
+  setCursorPosition,
   searchPersons,
   textareaRef,
 }: UseMentionsOptions): UseMentionsReturn {
@@ -214,7 +226,69 @@ export function useMentions({
   const [results, setResults] = useState<PersonProfile[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [selectedIndex, setSelectedIndex] = useState(0)
-  const [mentions, setMentions] = useState<MentionEntry[]>([])
+  const [mentions, setMentions] = useState<AnchoredMention[]>([])
+
+  // The anchors are read from event handlers and effects that must not depend
+  // on them, so state and ref are written together and the ref is the source.
+  const mentionsRef = useRef<AnchoredMention[]>(mentions)
+  // Re-anchoring runs on every keystroke and usually produces the same anchors
+  // in a new array. Keeping the old reference when nothing moved saves a state
+  // write per character, and lets callers treat a new identity as real news.
+  const commitMentions = useCallback((next: AnchoredMention[]) => {
+    const current = mentionsRef.current
+    const unchanged =
+      current.length === next.length &&
+      current.every((mention, i) => {
+        const candidate = next[i]
+        return (
+          candidate !== undefined &&
+          candidate.id === mention.id &&
+          candidate.name === mention.name &&
+          candidate.start === mention.start
+        )
+      })
+    if (unchanged) {
+      return
+    }
+    mentionsRef.current = next
+    setMentions(next)
+  }, [])
+
+  // The text the anchors are valid for. Every writer to the textarea value goes
+  // through the reconciler below, which compares against this.
+  const prevValueRef = useRef(inputValue)
+
+  // A caret the hook wants applied once React has written `forText`. Setting a
+  // selection before the value is committed aims it at the old string, and the
+  // write then drops the caret at the end of the text.
+  const pendingSelectionRef = useRef<{
+    caret: number
+    forText: string
+    focus: boolean
+  } | null>(null)
+  const requestSelection = useCallback(
+    (caret: number, forText: string, focus = false) => {
+      pendingSelectionRef.current = { caret, forText, focus }
+    },
+    []
+  )
+  useLayoutEffect(() => {
+    const pending = pendingSelectionRef.current
+    if (!pending) {
+      return
+    }
+    // Whether it applies or was superseded by a later write, this request is
+    // spent — nothing is left scheduled that could fire against a dead owner.
+    pendingSelectionRef.current = null
+    const textarea = textareaRef.current
+    if (pending.forText !== inputValue || !textarea) {
+      return
+    }
+    if (pending.focus) {
+      textarea.focus()
+    }
+    textarea.setSelectionRange(pending.caret, pending.caret)
+  }, [inputValue, textareaRef])
 
   // Track the position of the @ that triggered the current search
   const atIndexRef = useRef<number>(-1)
@@ -322,25 +396,33 @@ export function useMentions({
 
       setInputValue(newValue)
 
-      // Track this mention
-      setMentions((prev) => {
-        // Avoid duplicate mention for same person in same position
-        const filtered = prev.filter((m) => !(m.id === id && m.name === name))
-        return [...filtered, { id, name }]
-      })
+      // The trigger span [atIndex, cursorPosition) becomes the inserted token,
+      // so anchors past it slide and any the trigger overlapped are gone.
+      const shift = insertedText.length - (cursorPosition - atIndex)
+      const anchored = mentionsRef.current
+        .filter((m) => mentionEnd(m) <= atIndex || m.start >= cursorPosition)
+        .map((m) =>
+          m.start >= cursorPosition ? { ...m, start: m.start + shift } : m
+        )
+      anchored.push({ id, name, start: atIndex })
+      anchored.sort((a, b) => a.start - b.start)
+      prevValueRef.current = newValue
+      commitMentions(anchored)
 
       close()
 
-      // Restore cursor position after React re-render
-      requestAnimationFrame(() => {
-        const textarea = textareaRef.current
-        if (textarea) {
-          textarea.focus()
-          textarea.setSelectionRange(newCursorPos, newCursorPos)
-        }
-      })
+      // Focus too: the person may have been clicked, which took focus to the
+      // popover row.
+      requestSelection(newCursorPos, newValue, true)
     },
-    [inputValue, cursorPosition, setInputValue, textareaRef, close]
+    [
+      inputValue,
+      cursorPosition,
+      setInputValue,
+      close,
+      commitMentions,
+      requestSelection,
+    ]
   )
 
   const handleKeyDown = useCallback(
@@ -403,56 +485,78 @@ export function useMentions({
   )
 
   /**
-   * Transform the input text by replacing @Name patterns (that match
-   * tracked mentions) with <entity-ref> tags before sending to the agent.
+   * The current textarea text with each anchored mention replaced by an
+   * `<entity-ref>` tag, ready to send to the agent.
+   *
+   * It takes no text on purpose: the anchors index the raw value, so a caller
+   * handing in a trimmed or otherwise derived copy would silently read them at
+   * the wrong offsets. An anchor that does not sit on its own `@name` is
+   * skipped rather than applied, so a desync can only cost a tag — never
+   * mislabel somebody else's name.
    */
-  const transformMentions = useCallback(
-    (text: string): string => {
-      if (mentions.length === 0) {
-        return text
+  const transformMentions = useCallback((): string => {
+    const text = inputValue
+    if (mentions.length === 0) {
+      return text
+    }
+
+    const ordered = [...mentions].sort((a, b) => a.start - b.start)
+
+    let result = ""
+    let cursor = 0
+    for (const mention of ordered) {
+      const pattern = `@${mention.name}`
+      if (mention.start < cursor || !text.startsWith(pattern, mention.start)) {
+        continue
       }
+      result += text.slice(cursor, mention.start)
+      result += `<entity-ref type="person" id="${escapeXml(mention.id)}">${escapeXml(mention.name)}</entity-ref>`
+      cursor = mention.start + pattern.length
+    }
+    return result + text.slice(cursor)
+  }, [inputValue, mentions])
 
-      let result = text
-
-      // Sort mentions by name length descending to avoid partial replacements
-      const sorted = [...mentions].sort((a, b) => b.name.length - a.name.length)
-
-      for (const mention of sorted) {
-        // Replace all occurrences of @Name with entity-ref
-        const pattern = `@${mention.name}`
-        const replacement = `<entity-ref type="person" id="${escapeXml(mention.id)}">${escapeXml(mention.name)}</entity-ref>`
-
-        // Replace all occurrences
-        while (result.includes(pattern)) {
-          result = result.replace(pattern, replacement)
-        }
-      }
-
-      return result
-    },
-    [mentions]
-  )
-
-  // Clean up mentions that no longer exist in the text, or where the user
-  // is actively editing them (backspaced into the mention, removing the
-  // trailing separator). This re-enables trigger detection for that @.
+  // Keep the anchors on the text as it changes, and take a mention out whole
+  // when an edit lands inside it — a half-typed name is not a mention, and
+  // leaving one behind is what silently dropped the id before.
   useEffect(() => {
-    setMentions((prev) =>
-      prev.filter((m) => {
-        const pattern = `@${m.name}`
-        const idx = inputValue.indexOf(pattern)
-        if (idx === -1) {
-          return false
-        }
+    const prev = prevValueRef.current
+    if (prev === inputValue) {
+      return
+    }
+    prevValueRef.current = inputValue
 
-        // A mention is only "completed" when it has a word-boundary separator
-        // right after it. If the separator was deleted, the user is editing
-        // the mention and we should remove it to re-enable search.
-        const charAfter = inputValue[idx + pattern.length]
-        return charAfter === " " || charAfter === "\n" || charAfter === "\t"
-      })
-    )
-  }, [inputValue])
+    const anchored = mentionsRef.current
+    if (anchored.length === 0) {
+      return
+    }
+
+    const { kept, touched } = reanchor(prev, inputValue, anchored)
+    if (touched.length === 0) {
+      commitMentions(kept)
+      return
+    }
+
+    const erased = eraseSpans(inputValue, touched, kept, cursorPosition)
+    commitMentions(erased.mentions)
+    if (erased.text === inputValue) {
+      return
+    }
+    prevValueRef.current = erased.text
+    setInputValue(erased.text)
+    setCursorPosition(erased.caret)
+    // Removing a mention leaves the caret where the mention was, not at the end
+    // of the text — the edit happened here, and the rest of a multi-line draft
+    // is not where the user was looking.
+    requestSelection(erased.caret, erased.text)
+  }, [
+    inputValue,
+    cursorPosition,
+    setInputValue,
+    setCursorPosition,
+    commitMentions,
+    requestSelection,
+  ])
 
   // Compute popover position: pixel coordinates of the @ character
   // relative to the textarea, then offset so the popover sits above it.


### PR DESCRIPTION
## Description

Typing a comma after an `@mention` in the AI composer deleted the mention. So did leaving the name at the end of the message. The person stopped being mentioned — no chip, no profile hover card, no error — because the sent payload carried no `<entity-ref>` for them. Mentions are now anchored to a position and maintained across edits, so what follows a mention no longer decides whether it exists.

## Type of change

- [x] Bug fix
- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots (if applicable)

[ Upload video or screenshot demo here ]

## Implementation details

- fix: anchor each tracked mention to its position instead of re-matching `@name` on every keystroke

  <details>
  <summary>Why?</summary>

  `MentionEntry` carried `{id, name}` and no position, and an effect re-derived every entry from the text on each change, keeping it only when the character after the name was a space, a newline or a tab. One line, three failures: a mention followed by punctuation died immediately, a mention ending the message had no character after it and died too (and `inputValue.trim()` on send made that the normal case), and an edit inside a name dropped the id while leaving the broken text behind.

  The anchor is internal. `F0AiChatTextAreaProps` and the `onSubmit` payload are unchanged, and `useMentions` is not exported from the package — `index.ts` exports `F0AiChatTextArea`, `DropOverlay` and the types.
  </details>

- fix: remove a mention whole when an edit lands inside it, instead of leaving an unlinked name

  <details>
  <summary>Why?</summary>

  A mention renders as one chip, so it should behave as one token. Backspacing inside `@Ana García` now takes the whole mention out in that keystroke rather than silently producing an unlinked `@Ana Garía` that still looks mentioned. Adjacency is deliberately not overlap, on either side: typing a comma straight after a mention, deleting the space that followed it, or typing immediately in front of the `@` all leave the mention alone.
  </details>

- fix: never erase text the user typed over a mention

  <details>
  <summary>Why?</summary>

  Re-anchoring reads a change as one contiguous span, and the first version mapped a mention the span had swallowed onto the whole disturbed region — so erasing "what is left of the mention" erased the replacement instead. Select all and type a character and the composer went empty; paste over a draft containing a mention and the paste was wiped; replace a selection straddling two mentions and the typed text vanished between them.

  A change is now read as three cases rather than one clamp: a mention the change missed is shifted, one it ran into gives up only the spans it still occupies, and one it swallowed outright gives up nothing — its text is already gone, and what replaced it is the user's.
  </details>

- fix: give two people who share a display name their own occurrence

  <details>
  <summary>Why?</summary>

  `transformMentions` took the first `indexOf` hit per tracked name and replaced every occurrence with it, so mentioning two different colleagues who are both "Ana García" sent the first one's id twice. Anchors are per occurrence, so each keeps their own.

  The rewrite also drops `String.prototype.replace`, which had two latent hazards on a hand-built replacement string: `$&`, `` $` ``, `$'` and `$1` in an id or name were interpreted as replacement patterns, and the `while (result.includes(pattern))` loop it sat in would never terminate if a name or id ever contained its own `@Name` (`escapeXml` does not touch `@`).
  </details>

- fix: leave the caret where a removed mention was, and set it once React has committed the value

  <details>
  <summary>Why?</summary>

  Removing a mention rewrites the composer text, so the caret has to be placed or it drops to the end — in a multi-line draft, onto a different line than the one being edited. The previous caret restore ran in a `requestAnimationFrame`, which can fire before React commits the new value; the selection then lands on the old string and React's own write moves the caret to the end. It is now a layout effect that applies a request only once the text it was made for is on screen, which also removes a callback that could fire after unmount.
  </details>

- refactor: paint the overlay from the anchors the composer owns, verified against the text

  <details>
  <summary>Why?</summary>

  `buildHighlightSegments` matched `@name` independently of the hook, so the two could disagree about which text is a mention — and with two people sharing a name it highlighted both occurrences for whichever entry was found first. It now reads the anchors and applies the same "does this still sit on its own `@name`" test the payload applies, so the overlay can no longer show a pill for a mention the message will not carry.
  </details>

- test: 31 cases — the mention lifecycle through the hook, the re-anchoring module on its own, the overlay's contract, and two end-to-end cases asserting the id reaches `onSubmit`

## Verification

| check | result |
| --- | --- |
| `pnpm vitest run src/kits/ai/F0AiChatTextArea`, before any edit | 14 files / **93** tests pass |
| the same suite with the new tests against the **`origin/main`** implementation | **13 failed** / 97 passed (110) |
| the same suite, after | 18 files / **124** pass |
| `pnpm vitest run src/kits/ai` (adds F0AiChat + F0ClarifyingPanel), `origin/main` implementation | **376** passed |
| `pnpm vitest run src/kits/ai`, after | 55 files / **407** pass (376 + 31) |
| `pnpm tsc` | **0** errors, and 0 on `origin/main` in the same worktree |
| `oxlint --type-aware` | 0 warnings, 0 errors across 3470 files |
| `oxfmt --check` | clean |
| lefthook pre-commit | cycle-dependencies, file-sizes, format, lint, ownership, commit-msg — green on all three commits |

The red count was measured against the **final** tests, by writing the `origin/main` versions over the production files and restoring them afterwards — no `git stash`, no `checkout`. 14 of the 31 tests cover `mention-anchors.ts`, which does not exist on `origin/main`, so they are excluded from that run and pinned by mutation instead.

Each mechanism was checked by mutating it away on its own:

| lever | goes red |
| --- | --- |
| adjacency counted as overlap | 7 — every "the mention survives" case |
| a touched mention is never reported | 2 — the inner-edit cases, hook and module |
| an anchor does not slide when text is inserted at its own index | 3 — the two module cases and the hook case |
| the tail fragment swallows the inserted text | exactly the two-mention straddle |
| `selectPerson` de-dupes anchors by name | exactly the shared-display-name case |
| the reconciler drops `setCursorPosition` | exactly the caret assertion |
| a mention swallowed whole is erased anyway | exactly the select-all case |
| the overlay paints an unverified anchor | exactly the stale-anchor case |
| the caret effect runs only when the value changes | exactly the focus-returns-to-the-textarea case |

**What the tests do not prove.** They are jsdom: the caret and focus are asserted on the DOM textarea, but pixel positions are not — the popover's measured coordinates and the overlay's visual alignment with the textarea's glyphs are unverified, and the mention chip's appearance is not compared against the sent bubble. The anchors are reconciled in an effect, so they trail the text by one commit whenever an edit moves them; the overlay now paints nothing rather than something wrong in that window, and neither state is observable in jsdom. Dictation combined with a mention is untested: `dictationBaseRef` is captured when recording starts and is not refreshed when the hook rewrites the value, so erasing a mention mid-dictation can re-instate it as untagged text — pre-existing in shape, and left alone here.

**Deferred to review.** Storybook for `F0AiChatTextArea` / `F0AiChat` in a *visible* tab — a hidden tab renders an empty virtualized list, so it needs a human pass. Albert records the video.

## Context

- [💻 Related PR](https://github.com/factorialco/f0/pull/5404) — merged. The same bug in `F0Chat`'s composer; this ports its anchoring design to the AI kit's separate copy of the hook.
- [💻 Related PR](https://github.com/factorialco/f0/pull/5425) — open draft, complementary. It touches `sds/chat/F0Chat/hooks/useMentions.ts`; this PR touches only `kits/ai/F0AiChatTextArea/**`. Zero shared files.

### Side notes for the reviewer

- **Two of the fixes above are defects in #5404's design, not in the port**, found by executing the re-anchoring against edge inputs rather than reading it: a mention swallowed by a replacement takes the replacement with it, and an insertion at a mention's own index leaves the anchor behind. `sds/chat/F0Chat` has both on `main` today. Not touched here — #5425 owns that file — but worth a follow-up, and the reason the two hooks converging is worth doing eventually.
- **The two hooks are still two hooks.** They now share a design and roughly a third of their logic, but nothing is shared as code, deliberately: unifying them here would collide with #5425. The new `mention-anchors.ts` is generic and React-free, so it is the obvious seam when we do.
- **What did not get ported, and why:** `locateMentions`, `seedMentions`, `restoreMentions`, `onMentionErased`, the undo stack and `@here` all serve F0Chat's edit-a-saved-message flow. This composer never reloads a saved body, so it has nothing to re-seed anchors from.
- **One behaviour genuinely changed.** Backspacing into a mention used to drop the entry and reopen the search popover on the half-typed name. It now removes the mention whole, so there is no half-name left to search with. That is the intended semantics from #5404, and it has a test, but a heavy user of the old behaviour would notice.
- `transformMentions()` lost its `text` parameter. Anchors index the raw value and its only caller passed `inputValue.trim()`, which would have read every anchor one leading space out of place; the function now reads the value itself and the caller trims the result.

## Skill tags

skill:frontend



<!-- Append to the PR body. Do NOT rewrite the author's text — the Verification
     table gains rows, and the Fresh-eyes review section is new. -->

### Verification — fresh-eyes review pass (appended)

| check | result |
| --- | --- |
| `pnpm vitest run src/kits/ai/F0AiChatTextArea`, the review's new tests against this branch | **4 failed** / 124 passed (128), plus a 5th on its own file |
| the same, after the review's fixes | **132 pass** |
| `pnpm vitest run src/kits/ai` | 55 files / **415 pass** (407 + 8) |
| `pnpm vitest run src/sds/chat` (untouched — regression guard) | 71 files / **704 pass** |
| `pnpm tsc` | **0** errors |
| `oxlint --type-aware` | 0 warnings, 0 errors, 3470 files |
| `oxfmt --check` | clean |
| randomised corpus of 148,930 edits applied outside a mention | **0** mentions erased (14,950 before) |

## Fresh-eyes review

Independent session; the diff was read before the description.

**BLOCKER 1 — fixed here.** Typing `@` immediately in front of an existing mention deleted the
mention *and its name*: `"Hola @Ana García "` became `"Hola  "` on one keystroke, and backspacing
that `@` away again lost the mention too. `diffSpan` reports the rightmost reading of a change,
which is the right bias at a mention's tail and the wrong one at its head — an inserted character
that repeats the one it lands on reads just as well as an edit inside the token. The PR's own
sentence, *"typing immediately in front of the `@` leaves the mention alone"*, held only while the
change was unambiguous; the existing test for it used a letter. Re-anchoring now asks whether a
change can be read as happening entirely in front of an anchor, and slides the mention when it can.
Evidence: a randomised corpus of 148,930 outside-the-mention edits erased a mention **14,950** times
before and **0** times after.

**BLOCKER 2 — fixed here, and a regression against the merge base.** Picking a person while the
popover stood over a stale trigger anchored the mention one character past its own `@`, and an
anchor that does not sit on its name is skipped by the overlay *and* by the payload. A query that
matched nobody is remembered in `dismissedAtIndexRef`, and the effect that remembers it returns
without closing the popover or clearing `atIndexRef`; `selectPerson` then built its text from a
clamped slice and its anchor from the unclamped index. Type `@zzz`, then ` @Ana`, backspace to
`@zzz`, pick Ana: the composer sends `@zzz@Ana García` with no `<entity-ref>` at all. The merge
base tolerated this — substring replacement did not care about the index — so anchoring is what
made it fatal. The trigger span is now measured from the same clamped slices the new value is built
from.

**SHOULD FIX — reported, not fixed** (each measured; details and repro scripts in the review notes):
the erase cuts on UTF-16 code units and can leave a lone surrogate or an orphaned combining mark in
the composer; the *tail* side of the same ambiguity can delete one character of prose after a
mention (518 hits in 400,000 random realistic edits) — this is the one to fix next, and it needs
`reanchor`'s head-extent computed from the leftmost reading rather than from `prefix`; `eraseSpans`
would grow the text and emit a negative caret if ever handed a malformed span (proven unreachable
today); a caret request survives the textarea unmounting via the `clarifyingUI` branch and can
later steal focus; and the overlay does not de-overlap or sort, so the comment claiming it and the
payload "cannot disagree" is overstated. Separately, the side note about `sds/chat/F0Chat` is right
and understates it: there the drifted anchor also paints the composer pill over the wrong glyphs
and reopens the popover on a resolved mention.

**What the tests still do not prove.** A mutation matrix over the original 31 tests killed 23 and
left 12; the review's 8 new tests kill 3 more. The 9 that remain — `selectPerson`'s filter and sort,
`transformMentions`' verification, overlap guard and sort, the reconciler reading `mentionsRef`
rather than state, `eraseSpans` merging *adjacent* spans, and the overlay's sort — are each a wrong
implementation that keeps the whole suite green. They are listed in full in the review notes.

Everything else in the description reconciles against the code, including the unchanged public
props and payload, the per-occurrence anchoring for two people sharing a display name, and every
number in the Verification table.
