### PR TITLE
fix(Widget): draw both footer actions when given two

### DIFF
--- a/packages/react/src/experimental/Widgets/Widget/footerActions.test.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/footerActions.test.tsx
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest"
+import { screen, zeroRender } from "@/testing/test-utils"
+import { Widget } from "."
+
+/**
+ * `action` TAKES ONE OR TWO. It was typed as a single button and spread
+ * straight onto `F0Button`, so a card that handed it an array — which the
+ * component's own story did — spread the ARRAY instead: one button, keyed `0`
+ * and `1`, with no label and nothing to press. Two buttons now draw as two.
+ *
+ * A PAIR IS OUTLINE at every width. Alone in the rail a footer button is filled
+ * (`neutral`) so it doesn't read as one more row under a dense stack; two of
+ * them are a set of equals, and filling either would nominate it as the card's
+ * answer. jsdom computes no layout, so that is asserted on the classes each
+ * variant draws with.
+ */
+describe("the widget's footer actions", () => {
+  const both = [
+    { label: "Sign now", onClick: () => {} },
+    { label: "Go to Documents", onClick: () => {} },
+  ]
+
+  test("draws one button for a single action", () => {
+    zeroRender(
+      <Widget
+        header={{ title: "Documents" }}
+        action={{ label: "Sign now", onClick: () => {} }}
+      >
+        Content
+      </Widget>
+    )
+
+    expect(screen.getAllByRole("button")).toHaveLength(1)
+    expect(screen.getByRole("button", { name: "Sign now" })).toBeVisible()
+  })
+
+  test("draws both buttons of a pair, each with its own label", () => {
+    zeroRender(
+      <Widget header={{ title: "Documents" }} action={both}>
+        Content
+      </Widget>
+    )
+
+    expect(screen.getAllByRole("button")).toHaveLength(2)
+    expect(screen.getByRole("button", { name: "Sign now" })).toBeVisible()
+    expect(
+      screen.getByRole("button", { name: "Go to Documents" })
+    ).toBeVisible()
+  })
+
+  test("separates them, rather than butting them together", () => {
+    zeroRender(
+      <Widget header={{ title: "Documents" }} action={both}>
+        Content
+      </Widget>
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Sign now" }).parentElement
+    ).toHaveClass("gap-2")
+  })
+
+  test("draws a pair as equals — outline, not one filled", () => {
+    zeroRender(
+      <Widget header={{ title: "Documents" }} action={both}>
+        Content
+      </Widget>
+    )
+
+    // `outline` rings its border in; `neutral` paints a fill. The narrow card's
+    // single button would be the filled one.
+    for (const name of ["Sign now", "Go to Documents"]) {
+      const button = screen.getByRole("button", { name })
+      expect(button).toHaveClass("after:ring-f1-border")
+      expect(button).not.toHaveClass("bg-f1-background-secondary")
+    }
+  })
+
+  test("still lets a caller pick the variant of either one", () => {
+    zeroRender(
+      <Widget
+        header={{ title: "Documents" }}
+        action={[
+          { label: "Sign now", variant: "critical", onClick: () => {} },
+          both[1],
+        ]}
+      >
+        Content
+      </Widget>
+    )
+
+    expect(screen.getByRole("button", { name: "Sign now" })).toHaveClass(
+      "text-f1-foreground-critical"
+    )
+  })
+})

--- a/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.stories.tsx
@@ -80,6 +80,10 @@ export const WithAction: Story = {
 /**
  * Two footer buttons: `action` takes an ARRAY for a card that carries both its
  * own call to action and the way out of it, side by side in the footer.
+ *
+ * A pair is drawn `outline` at every width, where a lone button in the rail is
+ * filled. Two buttons in a footer are a set of equals; filling one of them
+ * would nominate it as the card's answer.
  */
 export const WithTwoActions: Story = {
   args: {

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -75,8 +75,17 @@ export interface WidgetProps {
     }
     count?: number
   }
-  /** The card's footer button — its call to action. `neutral`/`sm` by default. */
-  action?: F0ButtonProps
+  /**
+   * The card's footer button — its call to action. `neutral`/`sm` by default,
+   * `outline`/`md` once the card is wide.
+   *
+   * AN ARRAY draws TWO, side by side, for a card that carries both its own call
+   * to action and the way out of it ("Sign now", "Go to Documents"). A pair is
+   * drawn `outline` at every width: two buttons in a footer are a set of equals,
+   * and filling one of them nominates it as the card's answer. Two is the
+   * ceiling — a third belongs in `actions`, the overflow menu.
+   */
+  action?: F0ButtonProps | F0ButtonProps[]
   /**
    * Extra classes for the FOOTER row that `action` draws in. For content that
    * BLEEDS past the card's content box and wants the footer brought onto its
@@ -314,6 +323,11 @@ const Container = forwardRef<
   const composedRef = useComposedRefs(ref, cardRef)
   const isWide = useIsWide(cardRef)
 
+  // One or two, drawn the same way either way — the footer's only difference is
+  // how many buttons are in the row.
+  const footerActions = action ? [action].flat() : []
+  const isPairOfActions = footerActions.length > 1
+
   useEffect(() => {
     if (!isDragging || !onDragEnd) {
       return
@@ -497,22 +511,28 @@ const Container = forwardRef<
               )
             })}
         </CardContent>
-        {action && (
-          <CardFooter className={cn(footerClassName)}>
-            {/* Both are DEFAULTS, not decisions: `action` is spread after them,
-              so a widget that asks for a particular variant or size still gets
-              it.
+        {footerActions.length > 0 && (
+          <CardFooter className={cn("gap-2", footerClassName)}>
+            {footerActions.map((footerAction, index) => (
+              /* Both are DEFAULTS, not decisions: each action is spread after
+                them, so a widget that asks for a particular variant or size
+                still gets it.
 
-              `outline` only once the card is WIDE. In the rail the footer button
-              sits directly under a dense stack of rows, and a bordered rectangle
-              across the card there reads as one more row; the filled `neutral`
-              reads as a control. With the room a wide card has, that fill
-              becomes the heaviest thing on the card and the border is enough. */}
-            <F0Button
-              variant={isWide ? "outline" : "neutral"}
-              size={isWide ? "md" : "sm"}
-              {...action}
-            />
+                `outline` once the card is WIDE, and whenever there are TWO.
+                Alone in the rail the footer button sits directly under a dense
+                stack of rows, and a bordered rectangle across the card there
+                reads as one more row; the filled `neutral` reads as a control.
+                With the room a wide card has, that fill becomes the heaviest
+                thing on the card and the border is enough — and a PAIR is a set
+                of equals, where one filled button would nominate itself as the
+                card's answer. */
+              <F0Button
+                key={index}
+                variant={isPairOfActions || isWide ? "outline" : "neutral"}
+                size={isWide ? "md" : "sm"}
+                {...footerAction}
+              />
+            ))}
           </CardFooter>
         )}
       </Card>


### PR DESCRIPTION
## Description

`WidgetProps["action"]` was typed as a single `F0ButtonProps` and spread straight onto one `F0Button`, so a card that handed it an array — which this component's own `WithTwoActions` story does, under a doc comment stating the array is supported — spread the *array* instead: one button keyed `0` and `1`, with no label and nothing to press. The type, the docs and the story disagreed, and the story was the one telling the truth about the intent. `action` now accepts one or two and draws a button for each.

## Screenshots (if applicable)

**Widgets → Widget → With Two Actions.** Before: a single empty grey stub in the footer. After: "Sign now" and "Go to Documents", side by side, both outline. Verified they still fit a 288px rail card without overflow (77px + 8px gap + 131px in 254px of footer), and a squeezed label truncates through `OneEllipsis` with its recovery tooltip rather than spilling.

## Implementation details

- fix: accept `action` as one `F0ButtonProps` or an array of two, drawing a button for each with a `gap-2` between them

  <details>
  <summary>Why a pair is outline at every width</summary>

  A lone footer button stays as it was — `neutral` in the rail, `outline` once the card is wide — because under a dense stack of rows a bordered rectangle reads as one more row, while the fill reads as a control. Two buttons are a different object: a set of equals, where filling either one nominates it as the card's answer. So a pair is `outline` at both widths. Each button is still spread after its defaults, so a caller can override the variant or size of either one.
  </details>

- test: add `footerActions.test.tsx` — one action, two actions, the gap, the pair's variant, and a per-button override (4 of the 5 fail on `main`)
- docs: document the array on the `action` prop and in the story, including the two-button ceiling — a third belongs in `actions`, the overflow menu