### PR TITLE
fix(F0Map): bound a flight's duration instead of discarding the animation

### DIFF
--- a/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
+++ b/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
@@ -340,6 +340,37 @@ describe("F0Map", () => {
     })
   })
 
+  describe("flight tuning", () => {
+    it("bounds a flight's duration instead of discarding the animation", () => {
+      Object.defineProperty(navigator, "geolocation", {
+        configurable: true,
+        value: {
+          getCurrentPosition: (success: PositionCallback) =>
+            success({
+              coords: { longitude: -3.7, latitude: 40.42 },
+            } as GeolocationPosition),
+        },
+      })
+
+      render(
+        <F0Map
+          markers={POINTS}
+          showCurrentLocation
+          controlLabels={{ locate: "Locate me" }}
+        />
+      )
+      fireEvent.click(screen.getByRole("button", { name: "Locate me" }))
+
+      // `maxDuration` resets the computed duration to 0 whenever the flight
+      // would run longer, so every flight past a short hop teleports. An
+      // explicit `duration` bounds it and still animates.
+      const flyTo = mock.instances[0].calls.flyTo.at(-1)
+      expect(flyTo).toBeDefined()
+      expect(flyTo).not.toHaveProperty("maxDuration")
+      expect(flyTo?.duration).toBeGreaterThan(0)
+    })
+  })
+
   describe("projection", () => {
     it("applies the globe projection when requested", () => {
       render(<F0Map markers={POINTS} projection="globe" />)

--- a/packages/react/src/patterns/F0Map/constants.ts
+++ b/packages/react/src/patterns/F0Map/constants.ts
@@ -1,13 +1,13 @@
 /**
- * Shared `flyTo` tuning. The flight couples pan and zoom at a constant screen
- * speed, so the camera heads straight to the target instead of the zoom
- * outrunning the pan (which `easeTo` does - it interpolates them
- * independently). Zoom-in flights don't arc, so the path stays direct.
+ * Shared `flyTo` tuning. The flight couples pan and zoom into one arc, so the
+ * zoom never outruns the pan the way `easeTo` does (it interpolates them
+ * independently). `duration` bounds every flight however far the target -
+ * never `maxDuration`, which drops the animation outright whenever the
+ * computed flight would run longer, teleporting the camera instead.
  */
 export const FLY_OPTS = {
   curve: 1.42,
-  speed: 0.8,
-  maxDuration: 1400,
+  duration: 1400,
 } as const
 
 /**


### PR DESCRIPTION
## What

`FLY_OPTS` set `maxDuration: 1400`. In MapLibre that does not cap the animation — when the computed flight would run longer, **the duration resets to 0 and the camera teleports**. Only a same-city hop stayed under the ceiling, so in practice both `flyTo` call sites jumped.

The two call sites are the "locate me" control ([F0Map.tsx:332](https://github.com/factorialco/f0/blob/main/packages/react/src/patterns/F0Map/F0Map.tsx#L332)) and the cluster zoom-to-expand ([F0MapMarkersLayer.tsx:148](https://github.com/factorialco/f0/blob/main/packages/react/src/patterns/F0Map/components/F0MapMarkersLayer.tsx#L148)).

## Measured

Real map, `curve 1.42 / speed 0.8`, natural flight duration against what the cap did:

| case | natural | with `maxDuration: 1400` |
|---|---|---|
| locate-me, same city — BCN z11 → BCN z13 | 1230 ms | animated |
| locate-me, regional — BCN z11 → Madrid z13 | 6791 ms | **JUMPED** |
| locate-me, far — BCN z11 → Tokyo z13 | >12 s | **JUMPED** |
| cluster expand — BCN z12 → z16 | >1400 ms | **JUMPED** |

The local cluster expand is the one that matters: a four-level zoom already exceeds the ceiling, so clicking *any* cluster teleported.

## Why not just drop `maxDuration`

Because the author's instinct was right and only the mechanism was wrong — the natural flight is 6.8 s to Madrid and past 12 s intercontinentally, which is far too slow for a locate-me.

An explicit `duration` bounds every flight *and* keeps the animation. The same Madrid case, with `duration: 1400`:

```
regional BCN -> Madrid z13   ANIMATED  settled 1407ms
  zoom 11.0 -> [10.24  7.44  10.79  12.58  13  13]
```

The `flyTo` arc survives — it pulls back to z7.44 mid-flight and comes back in, which is exactly the coupled pan+zoom the constant's comment asks for.

`speed` is dropped because it becomes inert once `duration` is set: `speed: 0.8` and `speed: 5.0` give identical trajectories (`10.09 7.44 10.83 12.57 13`) and identical settle times (~1403 ms). Leaving it in would be dead config.

## Testing

New regression test drives the real locate path (stubbed geolocation → click the locate control) and asserts on the options that reach `flyTo`.

Verified red before green, by running it:

```
AssertionError: expected { curve: 1.42, speed: 0.8, …(4) } to not have property "maxDuration"
- Expected: undefined
+ Received: 1400
```

With the fix, the full `F0Map` suite is green (18/18), and `check:bugfix-red-green` confirms it independently:

```
✔ Red-green verified: the changed unit tests fail on latest main and pass with this PR's changes.
```

`pnpm tsc`: 28 errors, all pre-existing (`src/sds/chat/F0Chat/utils/emoji-*.ts`, module resolution for `emojibase-data`) — the same 28 report on the base commit, so this diff adds none. `oxlint` could not be run locally (`Cannot find module 'eslint-plugin-import'` — reproduces on untouched files, so it is a local install issue rather than this diff); leaving it to CI.

## Notes for the reviewer

Found while spiking [FCT-63102](https://factorialmakers.atlassian.net/browse/FCT-63102) (making `F0Map`'s engine a parameter) — ticket [FCT-63110](https://factorialmakers.atlassian.net/browse/FCT-63110). Independent of that work, hence a standalone PR off `main`.

Worth a separate look, not changed here: the search reveal and `focusMarker` go through `easeTo`, not `flyTo`, so they never used this tuning at all — even though `easeTo` interpolates pan and zoom independently, which is the behaviour the `FLY_OPTS` comment says it wants to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FCT-63102]: https://factorialmakers.atlassian.net/browse/FCT-63102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
