### PR TITLE
refactor(F0Map): make the public surface provider-agnostic

### DIFF
--- a/packages/react/src/patterns/F0Map/F0Map.tsx
+++ b/packages/react/src/patterns/F0Map/F0Map.tsx
@@ -398,7 +398,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   // down on toggle), so it reads the current style and viewport through refs.
   const styleRef = useRef(style)
   styleRef.current = style
-  const appliedStyleRef = useRef<typeof style | null>(null)
+  const appliedStyleRef = useRef<unknown>(null)
   const viewportRef = useRef(initialViewport ?? DEFAULT_VIEWPORT)
 
   useEffect(() => {

--- a/packages/react/src/patterns/F0Map/F0Map.tsx
+++ b/packages/react/src/patterns/F0Map/F0Map.tsx
@@ -26,8 +26,16 @@ import { FLY_OPTS, RECOMMENDED_MAX_MARKERS } from "./constants"
 import { F0MapSkeleton } from "./F0MapSkeleton"
 import { useCurrentLocation } from "./hooks/useCurrentLocation"
 import { useIsDarkContext } from "./hooks/useIsDarkContext"
-import { f0MapStyles, type F0MapStylePair } from "./styles"
+import { f0MapStyles, type F0MapStyle } from "./styles"
 import type { F0MapArc, F0MapPoint, F0MapRoute, F0MapViewport } from "./types"
+
+/**
+ * Narrows the opaque public style to MapLibre's own shape. The single place
+ * F0Map trusts a style's provider tag; it moves into the MapLibre adapter once
+ * the engine sits behind a port.
+ */
+const asEngineStyle = (style: unknown) =>
+  style as maplibregl.StyleSpecification | string
 
 /** City-level default view (Barcelona) used when no `initialViewport` is given. */
 const DEFAULT_VIEWPORT: Required<F0MapViewport> = {
@@ -43,8 +51,13 @@ export type F0MapProjection = "mercator" | "globe"
 
 /** Imperative handle exposed via `ref`. */
 export interface F0MapHandle {
-  /** The raw MapLibre instance (escape hatch). `null` until the map has mounted. */
-  getMap: () => maplibregl.Map | null
+  /**
+   * The rendering engine's own map object, as an escape hatch. Typed `unknown`
+   * on purpose: what comes back depends on the provider, so narrowing it is a
+   * deliberate decision at the call site instead of an implicit dependency on
+   * whichever engine F0Map happens to use. `null` until the map has mounted.
+   */
+  getNativeMap: () => unknown
   /** Center on a marker (and select it). Always animates unless reduced-motion. */
   focusMarker: (id: string) => void
   /** Frame all markers in view. */
@@ -97,7 +110,7 @@ export interface F0MapProps extends WithDataTestIdProps {
   /** Initial camera. Defaults to a city-level view. Read once on mount. */
   initialViewport?: F0MapViewport
   /** Light/dark style pair. Defaults to the f0-themed OpenFreeMap styles. */
-  mapStyle?: F0MapStylePair
+  mapStyle?: F0MapStyle
   /**
    * Allow pan/zoom. Defaults to `true`. Read on mount: changing it recreates
    * the map (and resets the camera), so treat it as static.
@@ -355,7 +368,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   useImperativeHandle(
     ref,
     () => ({
-      getMap: () => mapRef.current,
+      getNativeMap: () => mapRef.current,
       focusMarker: (id) => {
         const map = mapRef.current
         const point = markersRef.current.find((p) => p.id === id)
@@ -403,7 +416,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
     try {
       map = new maplibregl.Map({
         container,
-        style: styleRef.current,
+        style: asEngineStyle(styleRef.current),
         center: viewport.center,
         zoom: viewport.zoom ?? DEFAULT_VIEWPORT.zoom,
         minZoom,
@@ -481,7 +494,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
       return
     }
     appliedStyleRef.current = style
-    map.setStyle(style)
+    map.setStyle(asEngineStyle(style))
     map.once("style.load", () =>
       map.setProjection({ type: projectionRef.current })
     )
@@ -615,7 +628,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
                     return
                   }
                   setTileError(false)
-                  map.setStyle(styleRef.current)
+                  map.setStyle(asEngineStyle(styleRef.current))
                 }}
                 className="font-medium underline"
               >

--- a/packages/react/src/patterns/F0Map/__stories__/F0Map.mdx
+++ b/packages/react/src/patterns/F0Map/__stories__/F0Map.mdx
@@ -278,7 +278,7 @@ Clustering is automatic (no prop) - see [Clustering](#clustering).
 
 | Method             | Description                                                                 |
 | ------------------ | --------------------------------------------------------------------------- |
-| `getNativeMap()`   | The engine's own map object (escape hatch). `unknown` - narrow it yourself.  |
+| `getNativeMap()`   | The engine's own map object (escape hatch). `unknown` - narrow it yourself. |
 | `focusMarker(id)`  | Center on a marker and select it.                                           |
 | `fitToMarkers()`   | Frame all markers.                                                          |
 | `clearSelection()` | Clear the current selection.                                                |

--- a/packages/react/src/patterns/F0Map/__stories__/F0Map.mdx
+++ b/packages/react/src/patterns/F0Map/__stories__/F0Map.mdx
@@ -264,7 +264,7 @@ Clustering is automatic (no prop) - see [Clustering](#clustering).
 
 | Prop                  | Type                        | Default         | Description                                               |
 | --------------------- | --------------------------- | --------------- | --------------------------------------------------------- |
-| `mapStyle`            | `F0MapStylePair`            | f0 styles       | Light/dark style pair override.                           |
+| `mapStyle`            | `F0MapStyle`                | f0 styles       | Light/dark style pair override.                           |
 | `interactive`         | `boolean`                   | `true`          | Allow pan/zoom.                                           |
 | `gestureHandling`     | `"cooperative" \| "greedy"` | `"cooperative"` | Cooperative requires Ctrl/⌘ + wheel to zoom (embed-safe). |
 | `fullScreen`          | `boolean`                   | `false`         | `false` frames as a card; `true` is edge-to-edge.         |
@@ -276,9 +276,9 @@ Clustering is automatic (no prop) - see [Clustering](#clustering).
 
 ### Imperative handle (`ref`)
 
-| Method             | Description                               |
-| ------------------ | ----------------------------------------- |
-| `getMap()`         | The raw MapLibre instance (escape hatch). |
-| `focusMarker(id)`  | Center on a marker and select it.         |
-| `fitToMarkers()`   | Frame all markers.                        |
-| `clearSelection()` | Clear the current selection.              |
+| Method             | Description                                                                 |
+| ------------------ | --------------------------------------------------------------------------- |
+| `getNativeMap()`   | The engine's own map object (escape hatch). `unknown` - narrow it yourself.  |
+| `focusMarker(id)`  | Center on a marker and select it.                                           |
+| `fitToMarkers()`   | Frame all markers.                                                          |
+| `clearSelection()` | Clear the current selection.                                                |

--- a/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
+++ b/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
@@ -272,10 +272,10 @@ describe("F0Map", () => {
       expect(onMarkerSelect).toHaveBeenCalledWith(null)
     })
 
-    it("getMap returns the underlying instance", () => {
+    it("getNativeMap returns the engine's own instance", () => {
       const ref = createRef<F0MapHandle>()
       render(<F0Map ref={ref} markers={POINTS} />)
-      expect(ref.current?.getMap()).toBe(mock.instances[0])
+      expect(ref.current?.getNativeMap()).toBe(mock.instances[0])
     })
   })
 
@@ -337,6 +337,23 @@ describe("F0Map", () => {
         cb({ features: [{ properties: { id: "commute", kind: "route" } }] })
       )
       expect(onRouteClick).toHaveBeenCalledWith("commute")
+    })
+  })
+
+  describe("style", () => {
+    it("hands the engine the matching half of the style pair", () => {
+      // The pair is opaque to F0Map (its shape belongs to the engine), so the
+      // only thing worth asserting is that the right half reaches the map
+      // unchanged - jsdom has no `.dark` ancestor, so that is `light`.
+      const light = { version: 8, name: "light" }
+      const dark = { version: 8, name: "dark" }
+      render(
+        <F0Map
+          markers={POINTS}
+          mapStyle={{ provider: "maplibre", light, dark }}
+        />
+      )
+      expect(mock.instances[0].opts.style).toBe(light)
     })
   })
 

--- a/packages/react/src/patterns/F0Map/index.tsx
+++ b/packages/react/src/patterns/F0Map/index.tsx
@@ -35,6 +35,7 @@ export type {
  * fallback. `F0Map` renders it automatically; exported for custom use. */
 export { F0MapList } from "./components/F0MapList"
 export type { F0MapListProps } from "./components/F0MapList"
-/** f0-themed MapLibre style pair (light + dark) and its type. */
+/** f0-themed style pair (light + dark), its provider-tagged type, and the
+ * provider identity the tag draws from. */
 export { f0MapStyles } from "./styles"
-export type { F0MapStylePair } from "./styles"
+export type { F0MapStyle, F0MapProvider } from "./styles"

--- a/packages/react/src/patterns/F0Map/styles/index.ts
+++ b/packages/react/src/patterns/F0Map/styles/index.ts
@@ -1,7 +1,7 @@
 // Bundled with the package as a same-origin URL asset (not a runtime CDN
 // fetch), so it works offline and adds no third-party dependency.
 import rtlTextPluginUrl from "@mapbox/mapbox-gl-rtl-text/mapbox-gl-rtl-text.js?url"
-import maplibregl, { type StyleSpecification } from "maplibre-gl"
+import maplibregl from "maplibre-gl"
 import darkStyle from "./f0-dark.json"
 import lightStyle from "./f0-light.json"
 
@@ -21,12 +21,22 @@ if (
 }
 
 /**
- * A light/dark pair of MapLibre styles. Each entry is either a hosted style
- * URL or an inline `StyleSpecification`.
+ * Which rendering engine a style is written for. The tag exists so a style
+ * built for one engine can never be handed to another: the shapes are not
+ * interchangeable, and without it the mismatch would only surface at runtime.
  */
-export interface F0MapStylePair {
-  light: string | StyleSpecification
-  dark: string | StyleSpecification
+export type F0MapProvider = "maplibre"
+
+/**
+ * A light/dark style pair for one engine. `light` and `dark` are deliberately
+ * opaque - their real shape belongs to the engine (a MapLibre
+ * `StyleSpecification` or a style URL today), and F0Map's public surface must
+ * never make a consumer import an engine's types to describe a style.
+ */
+export interface F0MapStyle {
+  provider: F0MapProvider
+  light: unknown
+  dark: unknown
 }
 
 /**
@@ -37,7 +47,8 @@ export interface F0MapStylePair {
  * resolved to concrete hex for the light and dark neutral ramps. Regenerate with
  * `node src/patterns/F0Map/styles/buildStyles.mjs`.
  */
-export const f0MapStyles: F0MapStylePair = {
-  light: lightStyle as unknown as StyleSpecification,
-  dark: darkStyle as unknown as StyleSpecification,
+export const f0MapStyles: F0MapStyle = {
+  provider: "maplibre",
+  light: lightStyle,
+  dark: darkStyle,
 }


### PR DESCRIPTION
> Targets `main`. Was stacked on #5381; moved off it because that PR is delayed, and this one only needed a two-line hunk in a test file #5381 adds. That hunk is dropped here and belongs back in #5381 (its map-visualization test builds a mock `F0MapHandle`, so `getMap` there becomes `getNativeMap`).

## What

Two MapLibre types leaked through `F0Map`'s exported surface, so any consumer touching either welded itself to the engine:

```ts
F0MapHandle.getMap: () => maplibregl.Map | null
F0MapStylePair.light/dark: string | StyleSpecification
```

- **`getMap` → `getNativeMap(): unknown`.** The escape hatch stays; what comes back depends on the engine, so narrowing it becomes a deliberate decision at the call site instead of an implicit dependency on whichever engine `F0Map` happens to use.
- **`F0MapStylePair` → `F0MapStyle`**, tagged with the engine the style is written for, with `light`/`dark` opaque. Describing a custom style no longer requires importing an engine's types, and the tag is what will stop a style built for one engine being handed to another once there is more than one. `F0MapProvider` is the tag's type — one member today, widens as providers are added.

`F0Map` still talks to MapLibre directly, so the narrowing lives in exactly one place (`asEngineStyle`), which moves into the MapLibre adapter once the engine sits behind a port.

## Why now

This is groundwork for making the rendering engine a parameter ([FCT-63102](https://factorialmakers.atlassian.net/browse/FCT-63102) / [FCT-63103](https://factorialmakers.atlassian.net/browse/FCT-63103)). Both renames are breaking, and they are cheapest today: `F0Map` ships from the `experimental` entry point and has a single consumer — the Workplaces map, still in draft ([factorialco/factorial#112511](https://github.com/factorialco/factorial/pull/112511), [#112512](https://github.com/factorialco/factorial/pull/112512)). In six months with several products attached, they are not cheap.

Nothing else changes: no behaviour, no rendering, no camera.

## Deliberately not marked breaking for release-please

No `!` and no `BREAKING CHANGE:` footer, because `experimental` is the entry point for unstable API. `check:api-surface` will correctly report the two removals as BREAKING — that is the expected signal, not a regression. 

## Testing

- `F0Map` + map-visualization suites: **60/60 green**.
- New test asserts the right half of the style pair reaches the engine unchanged. Nothing covered that before, and the narrowing is exactly the kind of change that could break it in silence.
- Renamed the handle test to `getNativeMap`, and the visualization test's mock handle along with it.
- `pnpm tsc`: **28 errors, all pre-existing** — verified by running it on the base commit with my changes stashed, which reports the same 28, all in `src/sds/chat/F0Chat/utils/emoji-*.ts` (module resolution for `emojibase-data`, plus a missing `fontFamily` export). Zero added by this diff.
- `format:check`, `check-cycle-dependencies` and `check-animated-css-variables` clean.
- `oxlint` could not run locally (`Cannot find module 'eslint-plugin-import'`, reproduces on files I never touched), so it is left to CI.

## Docs

`F0Map.mdx` props and handle tables updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FCT-63102]: https://factorialmakers.atlassian.net/browse/FCT-63102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
