### PR TITLE
feat(F0Map): put the rendering engine behind a MapAdapter port

### DIFF
--- a/packages/react/src/patterns/F0Map/F0Map.tsx
+++ b/packages/react/src/patterns/F0Map/F0Map.tsx
@@ -437,8 +437,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
       return
     }
     adapterRef.current = adapter
-    // The marker, line and current-location layers still take the engine's own
-    // map; they move behind the port next.
+    // The layers still take the engine's own map; they move next.
     setMapInstance(adapter.native() as maplibregl.Map)
     // A previous run may have failed (and set the list fallback) with props
     // that made creation throw; this run succeeded, so clear it.

--- a/packages/react/src/patterns/F0Map/F0Map.tsx
+++ b/packages/react/src/patterns/F0Map/F0Map.tsx
@@ -22,20 +22,23 @@ import { F0MapList } from "./components/F0MapList"
 import { F0MapMarkersLayer } from "./components/F0MapMarkersLayer"
 import { F0MapVectorLayer } from "./components/F0MapVectorLayer"
 import { CurrentLocationLayer } from "./components/internal/CurrentLocationLayer"
-import { FLY_OPTS, RECOMMENDED_MAX_MARKERS } from "./constants"
+import { RECOMMENDED_MAX_MARKERS } from "./constants"
 import { F0MapSkeleton } from "./F0MapSkeleton"
 import { useCurrentLocation } from "./hooks/useCurrentLocation"
 import { useIsDarkContext } from "./hooks/useIsDarkContext"
+import { createMaplibreAdapter } from "./providers/maplibre"
+import type { MapAdapter, MapEvent } from "./providers/types"
 import { f0MapStyles, type F0MapStyle } from "./styles"
 import type { F0MapArc, F0MapPoint, F0MapRoute, F0MapViewport } from "./types"
 
-/**
- * Narrows the opaque public style to MapLibre's own shape. The single place
- * F0Map trusts a style's provider tag; it moves into the MapLibre adapter once
- * the engine sits behind a port.
- */
-const asEngineStyle = (style: unknown) =>
-  style as maplibregl.StyleSpecification | string
+/** Subscribe for a single firing. */
+const once = (adapter: MapAdapter, event: MapEvent, handler: () => void) => {
+  const off = adapter.on(event, () => {
+    off()
+    handler()
+  })
+  return off
+}
 
 /** City-level default view (Barcelona) used when no `initialViewport` is given. */
 const DEFAULT_VIEWPORT: Required<F0MapViewport> = {
@@ -177,51 +180,48 @@ const framedCoords = (
 ]
 
 type FitToPointsOptions = {
-  map: maplibregl.Map
+  adapter: MapAdapter
   points: F0MapPoint[]
   animate: boolean
   routes?: F0MapRoute[]
   arcs?: F0MapArc[]
-  padding?: number
+  gutter?: number
 }
 
 const fitToPoints = ({
-  map,
+  adapter,
   points,
   animate,
   routes = [],
   arcs = [],
-  padding = 64,
+  gutter = 64,
 }: FitToPointsOptions) => {
   const coords = framedCoords(points, routes, arcs)
   if (coords.length === 0) {
     return
   }
   if (coords.length === 1) {
-    const opts = { center: coords[0], zoom: 14 }
+    const target = { center: coords[0], zoom: 14 }
     if (animate) {
-      map.easeTo(opts)
+      adapter.easeTo(target, { animate })
     } else {
-      map.jumpTo(opts)
+      adapter.jumpTo(target, { animate })
     }
     return
   }
-  const bounds = new maplibregl.LngLatBounds()
-  coords.forEach((c) => bounds.extend(c))
-  map.fitBounds(bounds, { padding, maxZoom: 15, animate })
+  adapter.fitCoordinates(coords, { gutter, maxZoom: 15, animate })
 }
 
 /** Center on a single point, zooming in when the camera isn't already close. */
 const focusPoint = (
-  map: maplibregl.Map,
+  adapter: MapAdapter,
   point: F0MapPoint,
   animate: boolean
 ) => {
-  map.easeTo({
-    center: point.coordinates,
-    zoom: Math.max(map.getZoom(), 15),
-    animate,
-  })
+  adapter.easeTo(
+    { center: point.coordinates, zoom: Math.max(adapter.getZoom(), 15) },
+    { animate }
+  )
 }
 
 const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
@@ -256,7 +256,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
 ) {
   const i18n = useI18n()
   const containerRef = useRef<HTMLDivElement | null>(null)
-  const mapRef = useRef<maplibregl.Map | null>(null)
+  const adapterRef = useRef<MapAdapter | null>(null)
   const [mapInstance, setMapInstance] = useState<maplibregl.Map | null>(null)
   // WebGL missing (map can't be created) -> show the list as the fallback.
   // Tile/style load failure -> a retry banner over the map.
@@ -335,13 +335,13 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   const { coords: currentLocation, request: requestLocation } =
     useCurrentLocation(showCurrentLocation)
 
-  // Control handlers (wired to the MapLibre instance via refs).
-  const handleZoomIn = useCallback(() => mapRef.current?.zoomIn(), [])
-  const handleZoomOut = useCallback(() => mapRef.current?.zoomOut(), [])
+  // Control handlers (wired to the adapter via refs).
+  const handleZoomIn = useCallback(() => adapterRef.current?.zoomIn(), [])
+  const handleZoomOut = useCallback(() => adapterRef.current?.zoomOut(), [])
   const handleFit = useCallback(() => {
-    if (mapRef.current) {
+    if (adapterRef.current) {
       fitToPoints({
-        map: mapRef.current,
+        adapter: adapterRef.current,
         points: markersRef.current,
         animate: !reduceMotion,
         routes: routesRef.current,
@@ -351,12 +351,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   }, [reduceMotion])
   const handleLocate = useCallback(() => {
     requestLocation((c) =>
-      mapRef.current?.flyTo({
-        ...FLY_OPTS,
-        center: c,
-        zoom: Math.max(mapRef.current.getZoom(), 13),
-        animate: !reduceMotion,
-      })
+      adapterRef.current?.flyTo(
+        { center: c, zoom: Math.max(adapterRef.current.getZoom(), 13) },
+        { animate: !reduceMotion }
+      )
     )
   }, [requestLocation, reduceMotion])
 
@@ -364,10 +362,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   // screen-reader users navigate; the map has no focusable pins).
   const handleListSelect = useCallback(
     (id: string) => {
-      const map = mapRef.current
+      const adapter = adapterRef.current
       const point = markersRef.current.find((p) => p.id === id)
-      if (map && point) {
-        focusPoint(map, point, !reduceMotion)
+      if (adapter && point) {
+        focusPoint(adapter, point, !reduceMotion)
       }
       selectMarker(id)
     },
@@ -377,20 +375,20 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   useImperativeHandle(
     ref,
     () => ({
-      getNativeMap: () => mapRef.current,
+      getNativeMap: () => adapterRef.current?.native() ?? null,
       focusMarker: (id) => {
-        const map = mapRef.current
+        const adapter = adapterRef.current
         const point = markersRef.current.find((p) => p.id === id)
-        if (!map || !point) {
+        if (!adapter || !point) {
           return
         }
-        focusPoint(map, point, !reduceMotion)
+        focusPoint(adapter, point, !reduceMotion)
         selectRef.current(id)
       },
       fitToMarkers: () => {
-        if (mapRef.current) {
+        if (adapterRef.current) {
           fitToPoints({
-            map: mapRef.current,
+            adapter: adapterRef.current,
             points: markersRef.current,
             animate: !reduceMotion,
             routes: routesRef.current,
@@ -421,74 +419,66 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
 
     appliedStyleRef.current = styleRef.current
     const viewport = viewportRef.current
-    let map: maplibregl.Map
+    let adapter: MapAdapter
     try {
-      map = new maplibregl.Map({
+      adapter = createMaplibreAdapter({
         container,
-        style: asEngineStyle(styleRef.current),
+        style: styleRef.current,
         center: viewport.center,
         zoom: viewport.zoom ?? DEFAULT_VIEWPORT.zoom,
         minZoom,
         maxZoom,
         interactive,
-        // Plain wheel scrolls the page; Ctrl/⌘ + wheel or two fingers zoom. The
-        // hint overlay MapLibre adds is hidden in F0Map.css.
         cooperativeGestures: gestureHandling === "cooperative",
-        renderWorldCopies: false,
-        attributionControl: { compact: true },
       })
     } catch {
-      // No WebGL (or context creation failed): fall back to the list view.
+      // The engine could not start (no WebGL): fall back to the list view.
       setWebglFailed(true)
       return
     }
-    mapRef.current = map
-    setMapInstance(map)
+    adapterRef.current = adapter
+    // The marker, line and current-location layers still take the engine's own
+    // map; they move behind the port next.
+    setMapInstance(adapter.native() as maplibregl.Map)
     // A previous run may have failed (and set the list fallback) with props
     // that made creation throw; this run succeeded, so clear it.
     setWebglFailed(false)
 
-    // Unify mouse-wheel and trackpad-pinch zoom at the midpoint of their prior
-    // rates (wheel 1/90, pinch 1/40) so both gestures feel the same - neither
-    // exaggerated. Default wheel (1/450) feels sluggish; this stays snappier.
-    const zoomRate = (1 / 90 + 1 / 40) / 2 // ≈ 1/55
-    map.scrollZoom.setWheelZoomRate(zoomRate)
-    map.scrollZoom.setZoomRate(zoomRate)
-
-    // Errors before the first `load` mean the style/tiles failed to come up -
-    // surface the retry banner. Transient per-tile errors after load are
-    // ignored (they don't break the map).
-    let loaded = false
-    map.once("load", () => {
-      loaded = true
+    // Errors before the map is ready mean the style/tiles failed to come up -
+    // surface the retry banner. Transient per-tile errors after are ignored
+    // (they don't break the map).
+    let ready = false
+    const offReady = once(adapter, "ready", () => {
+      ready = true
       setTileError(false)
-      map.resize()
+      adapter.resize()
       if (shouldFit) {
         fitToPoints({
-          map,
+          adapter,
           points: markersRef.current,
           animate: false,
           routes: routesRef.current,
           arcs: arcsRef.current,
         })
       }
-      map.setProjection({ type: projectionRef.current })
+      adapter.setGlobeProjection(projectionRef.current === "globe")
     })
-    const handleError = () => {
-      if (!loaded) {
+    const offError = adapter.on("error", () => {
+      if (!ready) {
         setTileError(true)
       }
-    }
-    map.on("error", handleError)
+    })
     // Background click clears the selection (marker clicks are DOM events on
     // the marker element and never reach the canvas).
-    const handleBackgroundClick = () => selectRef.current(null)
-    map.on("click", handleBackgroundClick)
+    const offClick = adapter.on("click", () => selectRef.current(null))
 
     return () => {
-      mapRef.current = null
+      offReady()
+      offError()
+      offClick()
+      adapterRef.current = null
       setMapInstance(null)
-      map.remove()
+      adapter.destroy()
     }
   }, [loading, interactive, gestureHandling, minZoom, maxZoom, shouldFit])
 
@@ -498,33 +488,22 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   // fires as soon as the new style STARTS loading) is the done signal -
   // setProjection hard-throws on a style that is still loading.
   useEffect(() => {
-    const map = mapRef.current
-    if (!map || appliedStyleRef.current === style) {
+    const adapter = adapterRef.current
+    if (!adapter || appliedStyleRef.current === style) {
       return
     }
     appliedStyleRef.current = style
-    map.setStyle(asEngineStyle(style))
-    map.once("style.load", () =>
-      map.setProjection({ type: projectionRef.current })
+    adapter.applyStyle(style)
+    once(adapter, "styled", () =>
+      adapter.setGlobeProjection(projectionRef.current === "globe")
     )
   }, [style])
 
-  // Re-project live when the `projection` prop changes. The initial application
-  // is left to the creation effect's load handler; this only matters for
-  // post-mount changes. `isStyleLoaded()` can report true while the style is
-  // still finalising (and setProjection then throws anyway), so the guard is
-  // the try - a mid-load failure is safely dropped because the pending load /
-  // style.load handlers re-apply `projectionRef` when the style is ready.
+  // Re-project live when the `projection` prop changes. The initial
+  // application is left to the creation effect's ready handler; this only
+  // matters for post-mount changes.
   useEffect(() => {
-    const map = mapRef.current
-    if (!map) {
-      return
-    }
-    try {
-      map.setProjection({ type: projection })
-    } catch {
-      // Style mid-load; the load handler applies the projection.
-    }
+    adapterRef.current?.setGlobeProjection(projection === "globe")
   }, [projection])
 
   // Reveal: fly to a newly highlighted marker (external search selecting a
@@ -533,10 +512,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
     if (!highlightedId) {
       return
     }
-    const map = mapRef.current
+    const adapter = adapterRef.current
     const point = markersRef.current.find((p) => p.id === highlightedId)
-    if (map && point) {
-      focusPoint(map, point, !reduceMotion)
+    if (adapter && point) {
+      focusPoint(adapter, point, !reduceMotion)
     }
   }, [highlightedId, reduceMotion])
 
@@ -632,12 +611,12 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
               <button
                 type="button"
                 onClick={() => {
-                  const map = mapRef.current
-                  if (!map) {
+                  const adapter = adapterRef.current
+                  if (!adapter) {
                     return
                   }
                   setTileError(false)
-                  map.setStyle(asEngineStyle(styleRef.current))
+                  adapter.applyStyle(styleRef.current)
                 }}
                 className="font-medium underline"
               >

--- a/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
+++ b/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
@@ -1,6 +1,11 @@
 import { createRef } from "react"
 import { beforeEach, describe, expect, it, vi } from "vitest"
-import { fireEvent, screen, zeroRender as render } from "@/testing/test-utils"
+import {
+  fireEvent,
+  screen,
+  waitFor,
+  zeroRender as render,
+} from "@/testing/test-utils"
 import { F0Map, type F0MapHandle } from "../F0Map"
 import type { F0MapArc, F0MapPoint, F0MapRoute } from "../types"
 
@@ -49,11 +54,16 @@ const mock = vi.hoisted(() => {
       if (cb) {
         this.handlers[type] ??= []
         this.handlers[type].push(cb)
+        // A real map fires `load` at whoever is subscribed, `on` and `once`
+        // alike - and the adapter subscribes with `on`. Deferred to a microtask
+        // so the subscription is in place first.
+        if (type === "load") {
+          void Promise.resolve().then(() => cb())
+        }
       }
       return this
     }
     once(type: string, cb: (e?: unknown) => void) {
-      // Fire `load` on a microtask so the component's handler is registered.
       if (type === "load") {
         queueMicrotask(() => cb())
       }
@@ -337,6 +347,20 @@ describe("F0Map", () => {
         cb({ features: [{ properties: { id: "commute", kind: "route" } }] })
       )
       expect(onRouteClick).toHaveBeenCalledWith("commute")
+    })
+  })
+
+  describe("engine readiness", () => {
+    it("frames the markers and applies the projection once ready", async () => {
+      render(<F0Map markers={POINTS} />)
+      // The readiness handler does this, not the imperative handle: nothing
+      // here calls fitToMarkers.
+      await waitFor(() =>
+        expect(mock.instances[0].calls.fitBounds.length).toBeGreaterThan(0)
+      )
+      expect(mock.instances[0].calls.setProjection.at(-1)).toEqual({
+        type: "mercator",
+      })
     })
   })
 

--- a/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
+++ b/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
@@ -58,7 +58,7 @@ const mock = vi.hoisted(() => {
         // alike - and the adapter subscribes with `on`. Deferred to a microtask
         // so the subscription is in place first.
         if (type === "load") {
-          void Promise.resolve().then(() => cb())
+          queueMicrotask(() => cb())
         }
       }
       return this

--- a/packages/react/src/patterns/F0Map/providers/maplibre/index.ts
+++ b/packages/react/src/patterns/F0Map/providers/maplibre/index.ts
@@ -1,0 +1,144 @@
+import maplibregl from "maplibre-gl"
+import { FLY_OPTS } from "../../constants"
+import type {
+  CameraOptions,
+  CameraTarget,
+  LngLat,
+  MapAdapter,
+  MapAdapterFactory,
+  MapCapabilities,
+  MapEvent,
+  ScreenPoint,
+} from "../types"
+
+/**
+ * Unify mouse-wheel and trackpad-pinch zoom at the midpoint of their defaults
+ * (wheel 1/90, pinch 1/40) so both gestures feel the same - neither
+ * exaggerated. MapLibre's own wheel default (1/450) feels sluggish.
+ */
+const ZOOM_RATE = (1 / 90 + 1 / 40) / 2
+
+/** The engine's own style shape, from the port's opaque one. */
+const asEngineStyle = (style: unknown) =>
+  style as maplibregl.StyleSpecification | string
+
+/** MapLibre expresses framing as camera padding. */
+const toPadding = (gutter: number) => ({
+  top: gutter,
+  right: gutter,
+  bottom: gutter,
+  left: gutter,
+})
+
+/** Port event -> MapLibre event. `ready` is `load`: painting and projecting. */
+const EVENTS: Record<MapEvent, string> = {
+  ready: "load",
+  move: "move",
+  zoom: "zoom",
+  resize: "resize",
+  click: "click",
+  error: "error",
+  styled: "style.load",
+}
+
+const CAPABILITIES: MapCapabilities = {
+  globeProjection: true,
+  observableFlight: true,
+}
+
+export const createMaplibreAdapter: MapAdapterFactory = (init): MapAdapter => {
+  // Throws without WebGL; the caller turns that into the list fallback.
+  const map = new maplibregl.Map({
+    container: init.container,
+    style: asEngineStyle(init.style),
+    center: init.center,
+    zoom: init.zoom,
+    minZoom: init.minZoom,
+    maxZoom: init.maxZoom,
+    interactive: init.interactive,
+    // The hint overlay MapLibre adds for this is hidden in F0Map.css.
+    cooperativeGestures: init.cooperativeGestures,
+    renderWorldCopies: false,
+    attributionControl: { compact: true },
+  })
+  map.scrollZoom.setWheelZoomRate(ZOOM_RATE)
+  map.scrollZoom.setZoomRate(ZOOM_RATE)
+
+  let destroyed = false
+  // Every style accessor dereferences `map.style`, which is gone after
+  // `remove()`, so liveness is what guards each of them.
+  const alive = () => !destroyed && Boolean(map.style)
+
+  // Padding only when the caller asked to reframe: MapLibre keeps its current
+  // padding when the option is absent, so always sending a zero would reset
+  // framing out from under a move that never mentioned it.
+  const camera = (
+    target: CameraTarget,
+    options: CameraOptions | undefined
+  ) => ({
+    center: target.center,
+    ...(target.zoom === undefined ? {} : { zoom: target.zoom }),
+    ...(options?.gutter === undefined
+      ? {}
+      : { padding: toPadding(options.gutter) }),
+    animate: options?.animate ?? true,
+  })
+
+  return {
+    provider: "maplibre",
+    capabilities: CAPABILITIES,
+    native: () => map,
+    isAlive: alive,
+    destroy: () => {
+      destroyed = true
+      map.remove()
+    },
+
+    on: (event, handler) => {
+      const name = EVENTS[event]
+      map.on(name, handler)
+      return () => {
+        map.off(name, handler)
+      }
+    },
+
+    project: (at: LngLat) => (alive() ? map.project(at) : null),
+    unproject: (point: ScreenPoint) =>
+      alive() ? (map.unproject([point.x, point.y]).toArray() as LngLat) : null,
+
+    getZoom: () => map.getZoom(),
+    getCenter: () => map.getCenter().toArray() as LngLat,
+
+    jumpTo: (target, options) => map.jumpTo(camera(target, options)),
+    easeTo: (target, options) => map.easeTo(camera(target, options)),
+    flyTo: (target, options) =>
+      map.flyTo({ ...FLY_OPTS, ...camera(target, options) }),
+
+    fitCoordinates: (coordinates, options) => {
+      const bounds = new maplibregl.LngLatBounds()
+      coordinates.forEach((c) => bounds.extend(c))
+      map.fitBounds(bounds, {
+        padding: toPadding(options?.gutter ?? 0),
+        maxZoom: options?.maxZoom,
+        animate: options?.animate ?? true,
+      })
+    },
+
+    zoomIn: () => map.zoomIn(),
+    zoomOut: () => map.zoomOut(),
+    resize: () => map.resize(),
+
+    applyStyle: (style) => map.setStyle(asEngineStyle(style)),
+
+    setGlobeProjection: (enabled) => {
+      // `isStyleLoaded()` can report true while the style is still finalising,
+      // and `setProjection` hard-throws on one that is. Dropping the failure is
+      // safe: the pending `load` / `style.load` handlers re-apply it.
+      try {
+        map.setProjection({ type: enabled ? "globe" : "mercator" })
+      } catch {
+        // Style mid-load.
+      }
+    },
+  }
+}

--- a/packages/react/src/patterns/F0Map/providers/maplibre/index.ts
+++ b/packages/react/src/patterns/F0Map/providers/maplibre/index.ts
@@ -11,11 +11,8 @@ import type {
   ScreenPoint,
 } from "../types"
 
-/**
- * Unify mouse-wheel and trackpad-pinch zoom at the midpoint of their defaults
- * (wheel 1/90, pinch 1/40) so both gestures feel the same - neither
- * exaggerated. MapLibre's own wheel default (1/450) feels sluggish.
- */
+/** Midpoint of MapLibre's wheel (1/90) and pinch (1/40) rates, so both
+ * gestures feel alike; its 1/450 wheel default feels sluggish. */
 const ZOOM_RATE = (1 / 90 + 1 / 40) / 2
 
 /** The engine's own style shape, from the port's opaque one. */
@@ -30,7 +27,7 @@ const toPadding = (gutter: number) => ({
   left: gutter,
 })
 
-/** Port event -> MapLibre event. `ready` is `load`: painting and projecting. */
+/** `ready` is `load`: MapLibre paints and projects at the same moment. */
 const EVENTS: Record<MapEvent, string> = {
   ready: "load",
   move: "move",
@@ -65,13 +62,11 @@ export const createMaplibreAdapter: MapAdapterFactory = (init): MapAdapter => {
   map.scrollZoom.setZoomRate(ZOOM_RATE)
 
   let destroyed = false
-  // Every style accessor dereferences `map.style`, which is gone after
-  // `remove()`, so liveness is what guards each of them.
+  // Every style accessor dereferences `map.style`, gone after `remove()`.
   const alive = () => !destroyed && Boolean(map.style)
 
-  // Padding only when the caller asked to reframe: MapLibre keeps its current
-  // padding when the option is absent, so always sending a zero would reset
-  // framing out from under a move that never mentioned it.
+  // Only when asked: MapLibre keeps its current padding when the option is
+  // absent, so a blanket zero would reset framing.
   const camera = (
     target: CameraTarget,
     options: CameraOptions | undefined
@@ -131,13 +126,10 @@ export const createMaplibreAdapter: MapAdapterFactory = (init): MapAdapter => {
     applyStyle: (style) => map.setStyle(asEngineStyle(style)),
 
     setGlobeProjection: (enabled) => {
-      // `isStyleLoaded()` can report true while the style is still finalising,
-      // and `setProjection` hard-throws on one that is. Dropping the failure is
-      // safe: the pending `load` / `style.load` handlers re-apply it.
       try {
         map.setProjection({ type: enabled ? "globe" : "mercator" })
       } catch {
-        // Style mid-load.
+        // Throws on a style still finalising; the ready handlers re-apply it.
       }
     },
   }

--- a/packages/react/src/patterns/F0Map/providers/types.ts
+++ b/packages/react/src/patterns/F0Map/providers/types.ts
@@ -3,7 +3,7 @@ import type { F0MapProvider } from "../styles"
 /** `[longitude, latitude]`. */
 export type LngLat = [number, number]
 
-/** A point in the map container's own pixel space. */
+/** Pixels relative to the map container. */
 export interface ScreenPoint {
   x: number
   y: number
@@ -15,16 +15,11 @@ export interface CameraTarget {
 }
 
 export interface CameraOptions {
-  /**
-   * Uniform breathing room around the target, in screen px. Omit to leave the
-   * engine's current framing alone: engines that carry framing in the camera
-   * transform would otherwise have it reset by a move that never mentioned it.
-   */
+  /** Breathing room in screen px. Omit to leave the current framing alone. */
   gutter?: number
   animate?: boolean
 }
 
-/** Normalised events. An engine's own names and readiness signals differ. */
 export type MapEvent =
   | "ready"
   | "move"
@@ -34,19 +29,10 @@ export type MapEvent =
   | "error"
   | "styled"
 
-/**
- * What an engine cannot do, declared rather than emulated, so `F0Map` degrades
- * on purpose instead of pretending every engine shares a denominator.
- */
+/** Declared rather than emulated, so F0Map degrades on purpose. */
 export interface MapCapabilities extends Readonly<Record<string, boolean>> {
-  /** Renders the world as a sphere at low zoom. */
   globeProjection: boolean
-  /**
-   * The camera's own getters interpolate while an animation runs, so a flight
-   * can be read - and interrupted - from the model. False on engines that
-   * report the destination in the same tick, where any logic reading the zoom
-   * mid-flight silently becomes a no-op.
-   */
+  /** The camera's getters interpolate mid-animation, so a flight is readable. */
   observableFlight: boolean
 }
 
@@ -63,46 +49,26 @@ export interface MapAdapterInit {
 }
 
 /**
- * One rendering engine behind a single vocabulary.
- *
- * Modelled on what `F0Map` needs, never on what an engine offers - an
- * abstraction shaped like one engine's API does not fit the next one. Two
- * consequences worth knowing before adding a member:
- *
- * - There is no `padding`. That is MapLibre's way of expressing framing, and
- *   Google has no camera padding at all - it reaches the same result from a
- *   pixel offset. The port asks for the outcome and each adapter picks its own
- *   mechanism.
- * - Camera intent lives above the adapter. A camera change landing mid-flight
- *   targets whatever the zoom happens to be at that instant, so the caller
- *   replays the intent; adapters only execute single moves.
+ * One rendering engine behind one vocabulary, modelled on what F0Map needs
+ * rather than on what an engine offers. Hence no `padding` (MapLibre's framing
+ * mechanism, absent in Google) and no camera intent (the caller replays it;
+ * adapters only execute single moves).
  */
 export interface MapAdapter {
   readonly provider: F0MapProvider
   readonly capabilities: MapCapabilities
 
-  /**
-   * The engine's own map object. An escape hatch for code not yet behind the
-   * port; narrowing it is the caller's deliberate decision.
-   */
+  /** Escape hatch for code not yet behind the port. */
   native(): unknown
 
-  /**
-   * False once the engine's map has been torn down. A React render can hand an
-   * effect an adapter whose map was just destroyed (its replacement arrives on
-   * the next render), and most engine accessors throw on it.
-   */
+  /** False once destroyed; a render can hand an effect a dead adapter. */
   isAlive(): boolean
   destroy(): void
 
-  /**
-   * Subscribe; returns the unsubscribe. `"ready"` fires when the map can both
-   * paint and project - not merely when it exists, which on some engines is
-   * several frames earlier.
-   */
+  /** Returns the unsubscribe. `ready` means painting *and* projecting. */
   on(event: MapEvent, handler: () => void): () => void
 
-  /** `null` before the engine can project (see `"ready"`). */
+  /** `null` before the engine can project (see `ready`). */
   project(at: LngLat): ScreenPoint | null
   unproject(point: ScreenPoint): LngLat | null
 
@@ -114,17 +80,9 @@ export interface MapAdapter {
   /** One coupled pan+zoom arc. Falls back to `easeTo` where unsupported. */
   flyTo(target: CameraTarget, options?: CameraOptions): void
   /**
-   * Frame every coordinate in view.
-   *
-   * Takes the coordinates, not a precomputed box, because turning points into
-   * bounds is where engines quietly differ (antimeridian handling among them)
-   * and this port promises no behaviour change yet.
-   *
-   * Still delegated, and it should not stay that way: measured, MapLibre and
-   * Google disagree on the same coordinates by 0.082 deg of longitude (~6.8 km
-   * at 41 deg N). Before a second adapter ships, this has to become a neutral
-   * computation over `project`/`unproject` - which agree to the pixel - handed
-   * down as a plain `easeTo`.
+   * Coordinates rather than a box, because turning points into bounds is where
+   * engines differ. Must become neutral maths before a second adapter ships:
+   * MapLibre and Google disagree here by 0.082 deg of longitude.
    */
   fitCoordinates(
     coordinates: LngLat[],
@@ -135,10 +93,10 @@ export interface MapAdapter {
   zoomOut(): void
   resize(): void
 
-  /** Swap the light/dark style in place, keeping the camera. */
+  /** Swaps the style in place, keeping the camera. */
   applyStyle(style: unknown): void
   setGlobeProjection(enabled: boolean): void
 }
 
-/** Throws when the engine cannot start (no WebGL, context creation refused). */
+/** Throws when the engine cannot start (no WebGL). */
 export type MapAdapterFactory = (init: MapAdapterInit) => MapAdapter

--- a/packages/react/src/patterns/F0Map/providers/types.ts
+++ b/packages/react/src/patterns/F0Map/providers/types.ts
@@ -1,0 +1,144 @@
+import type { F0MapProvider } from "../styles"
+
+/** `[longitude, latitude]`. */
+export type LngLat = [number, number]
+
+/** A point in the map container's own pixel space. */
+export interface ScreenPoint {
+  x: number
+  y: number
+}
+
+export interface CameraTarget {
+  center: LngLat
+  zoom?: number
+}
+
+export interface CameraOptions {
+  /**
+   * Uniform breathing room around the target, in screen px. Omit to leave the
+   * engine's current framing alone: engines that carry framing in the camera
+   * transform would otherwise have it reset by a move that never mentioned it.
+   */
+  gutter?: number
+  animate?: boolean
+}
+
+/** Normalised events. An engine's own names and readiness signals differ. */
+export type MapEvent =
+  | "ready"
+  | "move"
+  | "zoom"
+  | "resize"
+  | "click"
+  | "error"
+  | "styled"
+
+/**
+ * What an engine cannot do, declared rather than emulated, so `F0Map` degrades
+ * on purpose instead of pretending every engine shares a denominator.
+ */
+export interface MapCapabilities extends Readonly<Record<string, boolean>> {
+  /** Renders the world as a sphere at low zoom. */
+  globeProjection: boolean
+  /**
+   * The camera's own getters interpolate while an animation runs, so a flight
+   * can be read - and interrupted - from the model. False on engines that
+   * report the destination in the same tick, where any logic reading the zoom
+   * mid-flight silently becomes a no-op.
+   */
+  observableFlight: boolean
+}
+
+export interface MapAdapterInit {
+  container: HTMLElement
+  style: unknown
+  center: LngLat
+  zoom: number
+  minZoom?: number
+  maxZoom?: number
+  interactive: boolean
+  /** Plain wheel scrolls the page; Ctrl/cmd + wheel or two fingers zoom. */
+  cooperativeGestures: boolean
+}
+
+/**
+ * One rendering engine behind a single vocabulary.
+ *
+ * Modelled on what `F0Map` needs, never on what an engine offers - an
+ * abstraction shaped like one engine's API does not fit the next one. Two
+ * consequences worth knowing before adding a member:
+ *
+ * - There is no `padding`. That is MapLibre's way of expressing framing, and
+ *   Google has no camera padding at all - it reaches the same result from a
+ *   pixel offset. The port asks for the outcome and each adapter picks its own
+ *   mechanism.
+ * - Camera intent lives above the adapter. A camera change landing mid-flight
+ *   targets whatever the zoom happens to be at that instant, so the caller
+ *   replays the intent; adapters only execute single moves.
+ */
+export interface MapAdapter {
+  readonly provider: F0MapProvider
+  readonly capabilities: MapCapabilities
+
+  /**
+   * The engine's own map object. An escape hatch for code not yet behind the
+   * port; narrowing it is the caller's deliberate decision.
+   */
+  native(): unknown
+
+  /**
+   * False once the engine's map has been torn down. A React render can hand an
+   * effect an adapter whose map was just destroyed (its replacement arrives on
+   * the next render), and most engine accessors throw on it.
+   */
+  isAlive(): boolean
+  destroy(): void
+
+  /**
+   * Subscribe; returns the unsubscribe. `"ready"` fires when the map can both
+   * paint and project - not merely when it exists, which on some engines is
+   * several frames earlier.
+   */
+  on(event: MapEvent, handler: () => void): () => void
+
+  /** `null` before the engine can project (see `"ready"`). */
+  project(at: LngLat): ScreenPoint | null
+  unproject(point: ScreenPoint): LngLat | null
+
+  getZoom(): number
+  getCenter(): LngLat
+
+  jumpTo(target: CameraTarget, options?: CameraOptions): void
+  easeTo(target: CameraTarget, options?: CameraOptions): void
+  /** One coupled pan+zoom arc. Falls back to `easeTo` where unsupported. */
+  flyTo(target: CameraTarget, options?: CameraOptions): void
+  /**
+   * Frame every coordinate in view.
+   *
+   * Takes the coordinates, not a precomputed box, because turning points into
+   * bounds is where engines quietly differ (antimeridian handling among them)
+   * and this port promises no behaviour change yet.
+   *
+   * Still delegated, and it should not stay that way: measured, MapLibre and
+   * Google disagree on the same coordinates by 0.082 deg of longitude (~6.8 km
+   * at 41 deg N). Before a second adapter ships, this has to become a neutral
+   * computation over `project`/`unproject` - which agree to the pixel - handed
+   * down as a plain `easeTo`.
+   */
+  fitCoordinates(
+    coordinates: LngLat[],
+    options?: CameraOptions & { maxZoom?: number }
+  ): void
+
+  zoomIn(): void
+  zoomOut(): void
+  resize(): void
+
+  /** Swap the light/dark style in place, keeping the camera. */
+  applyStyle(style: unknown): void
+  setGlobeProjection(enabled: boolean): void
+}
+
+/** Throws when the engine cannot start (no WebGL, context creation refused). */
+export type MapAdapterFactory = (init: MapAdapterInit) => MapAdapter


### PR DESCRIPTION
> **Stacked on #5438**, which targets `main`. Review that one first; the diff below is this PR's commit alone.

## What

The `MapAdapter` port plus its MapLibre implementation. `F0Map`'s lifecycle, camera, projection, events and theme swap now go through it. **Behaviour is unchanged** — the existing suite passes with no assertion touched.

| | lines |
|---|---|
| `providers/types.ts` — the port | +102 |
| `providers/maplibre/index.ts` — the adapter | +136 |
| `F0Map.tsx` | 190 changed, net −60 |

Still on raw MapLibre and moving next ([FCT-63105](https://factorialmakers.atlassian.net/browse/FCT-63105)): the marker, line and current-location layers, which take the engine's own map through `native()`, and `useClusters` / `useLabelCollision` / `useZoomAtLeast`.

## The port is modelled on intent, not on MapLibre's API

This is the whole risk of the exercise: an abstraction shaped like one engine's API will not fit the next one. The decisions came from **measuring both engines**, not from reading docs (harness in `scratchpad/mapspike/`):

- **No `padding` in the port.** That is MapLibre's way of expressing framing; Google has no camera padding at all and reaches an identical result from a pixel offset — measured 0.0 px delta with the zoom untouched. The port takes a uniform `gutter` and each adapter picks its mechanism.
- **`gutter` is only sent when the caller asks to reframe.** MapLibre keeps its current padding when the option is absent, so always passing a zero would reset framing under a move that never mentioned it. Today only the multi-point fit reframes (`gutter: 64`), exactly as before.
- **`fitCoordinates` takes coordinates, not a box.** Turning points into bounds is where engines quietly differ (antimeridian handling among them), and this PR promises no behaviour change, so MapLibre keeps building its own `LngLatBounds`. Flagged in the port: MapLibre and Google disagree by **0.082° of longitude (~6.8 km at 41°N)** on the same input, so this has to become neutral maths over `project`/`unproject` — which agree to the pixel — before a second adapter ships.
- **`ready` means "can paint and project", not "exists".** Google's projection is `null` right after its constructor and arrives ~15 ms later, so anything gated on mere existence reads an empty projection on the first frame.

`capabilities` declares what an engine *cannot* do (`globeProjection`, `observableFlight`) so `F0Map` degrades on purpose instead of assuming a common denominator. `observableFlight` is there because Google's `getZoom()` returns the destination in the same tick — logic that reads the zoom mid-flight does not crash there, it silently becomes a no-op.

`isAlive()` replaces the `!map.style` guard, which existed because a render can hand an effect a map that was just destroyed.

## A gap in the test mock, found by this change

The mock only fired `load` at `once` subscribers. The adapter subscribes with `on`, so the moment it landed, the readiness path — initial fit, resize, initial projection — **stopped being exercised while the suite stayed green**. A real map fires at both, so the mock was simply incomplete.

Fixed, plus a test that asserts the readiness path. Verified red without the mock fix:

```
× frames the markers and applies the projection once ready
  AssertionError: expected 0 to be greater than 0
```

## Testing

- `F0Map` suite: **24/24 green**, no existing assertion changed.
- `pnpm tsc`: 28 errors, all pre-existing (`F0Chat/utils/emoji-*.ts`), same count as the base.
- `format:check` on all of `src/patterns/F0Map` clean.
- `oxlint` cannot run locally (`Cannot find module 'eslint-plugin-import'`, reproduces on untouched files) — left to CI.

No Chromatic diff expected: nothing visual changed.

## What moved off with #5381

This branch was originally cut on top of #5381 and the port carried a free-region vocabulary — `centerInFreeRegion`, `setFreeRegion` and an `inset` threaded through every camera option — because that is what #5381's `viewportInset` machinery needs. None of that exists on `main`, so on this base those members had no caller and would have been dead code. They come back, with the 0.0 px offset measurement behind them, when #5381 lands.

Worth flagging for whoever picks up #5381: its `CameraIntent` and inset effect will need re-expressing against this port. That rebase got harder because this landed first.

## Note on the ticket

[FCT-63104](https://factorialmakers.atlassian.net/browse/FCT-63104) and [FCT-63105](https://factorialmakers.atlassian.net/browse/FCT-63105) were split as "define the port and extract the engine code" then "migrate F0Map onto it", which is not a seam that exists — you cannot extract engine code out of `F0Map.tsx` without `F0Map.tsx` changing. Split by **concern** instead: this PR takes lifecycle, camera, projection, events and theme; the next takes markers, lines, current location and the hooks. Both are individually shippable, which the original split was not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[FCT-63105]: https://factorialmakers.atlassian.net/browse/FCT-63105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FCT-63104]: https://factorialmakers.atlassian.net/browse/FCT-63104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
