### PR TITLE
chore(charts): deprecate RadarChart in favour of F0DataChart

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -14,7 +14,6 @@
     "Avatars/AvatarPerson",
     "Avatars/AvatarTeam",
     "BigNumber",
-    "Charts/RadarChart",
     "Checkbox",
     "DatePicker",
     "EmptyState",

--- a/packages/react/docs/migrations/f0-radarchart-to-f0datachart.md
+++ b/packages/react/docs/migrations/f0-radarchart-to-f0datachart.md
@@ -1,0 +1,125 @@
+# Migrating from `RadarChart` to `F0DataChart`
+
+**Status:** deprecated in `v6.89.0` · removed in `v7.0.0` (no earlier than 90 days after deprecation)
+**Owner:** `@factorialco/f0-devs` · questions in [#f0-support](https://factorialteam.slack.com/archives/C082ZNKS403)
+
+## What changed, in one line
+
+> `RadarChart` — the last tagged component of the deprecated recharts-based `kits/Charts` kit — is replaced by `F0DataChart` with `type="radar"`, the echarts-based chart the rest of F0 already runs on.
+
+## Finding every usage
+
+```bash
+# imports (main entry and the deprecated experimental entry)
+rg "\bRadarChart\b" frontend/src -l
+rg "RadarChartProps" frontend/src -l
+# JSX call sites
+rg "<RadarChart" frontend/src -l
+```
+
+`RadarChart` is exported from both `@factorialco/f0-react` and
+`@factorialco/f0-react/dist/experimental`, so check imports from both.
+
+Do not confuse it with `F0DataChart`'s own radar: a file already importing
+`F0DataChart` and passing `type="radar"` is on the new surface and needs nothing.
+
+## Mapping: `RadarChart` → `F0DataChart`
+
+The two components model radar data along opposite axes. `RadarChart` keys values
+**by series** inside each row (`data[].values[seriesKey]`); `F0DataChart` keys them
+**by axis position** (`indicators[]` in order, each series carrying a parallel
+`data: number[]`). Transposing that structure is the bulk of the migration.
+
+| `RadarChart`                                         | `F0DataChart`                                                                     |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `import { RadarChart } from "@factorialco/f0-react"` | `import { F0DataChart } from "@factorialco/f0-react"`                             |
+| `<RadarChart … />`                                   | `<F0DataChart type="radar" … />`                                                  |
+| `dataConfig: { alice: { label: "Alice" } }`          | `series: [{ name: "Alice", data: [...] }]`                                        |
+| `data: [{ label: "Communication", values: { … } }]`  | `indicators: [{ name: "Communication" }]`                                         |
+| `data[i].values[key]`                                | `series[key].data[i]` (same index as the indicator)                               |
+| `dataConfig[key].color`                              | `series[n].color` — must be a `ChartColorToken`                                   |
+| `scaleMax`                                           | `indicators[n].max` (per axis, not global)                                        |
+| `scaleMin`                                           | **removed** — radar axes always start at 0                                        |
+| `aspect`                                             | **removed** — size the chart through its container                                |
+| `defaultHiddenSeries`                                | **removed** — the legend starts fully visible                                     |
+| —                                                    | `onLegendSelectionChange` reports live legend state (read-only)                   |
+| —                                                    | `showArea`, `showLegend`, `showLabels`, `valueFormatter`, `tooltipValueFormatter` |
+
+Types: `F0DataChartRadarProps`, `F0DataChartRadarIndicator`, `F0DataChartRadarSeries`
+in `src/kits/F0DataChart/types.ts`. Live examples: Storybook → `F0DataChart/Radar`.
+
+## Step by step
+
+1. Swap the import and add `type="radar"`.
+2. Transpose the data. Every key of `dataConfig` becomes one entry in `series`; every
+   row of `data` becomes one entry in `indicators`, and its `values` are distributed
+   into the series arrays at that row's index.
+
+   ```tsx
+   // before
+   <RadarChart
+     dataConfig={{ alice: { label: "Alice" }, bob: { label: "Bob" } }}
+     data={[
+       { label: "Communication", values: { alice: 80, bob: 65 } },
+       { label: "Technical", values: { alice: 95, bob: 88 } },
+     ]}
+     scaleMax={100}
+   />
+
+   // after
+   <F0DataChart
+     type="radar"
+     indicators={[
+       { name: "Communication", max: 100 },
+       { name: "Technical", max: 100 },
+     ]}
+     series={[
+       { name: "Alice", data: [80, 95] },
+       { name: "Bob", data: [65, 88] },
+     ]}
+   />
+   ```
+
+   The order of `series[n].data` must match the order of `indicators` exactly.
+   A misaligned array is silently wrong, not a type error — this is the step to
+   review by hand.
+
+3. Replace `scaleMax` with a `max` on each indicator. Drop `scaleMin`: if your chart
+   relied on a non-zero floor to spread values apart, the new chart will look flatter,
+   and you should decide whether to rescale the data instead.
+4. Drop `aspect` and size the chart from its wrapper.
+5. Drop `defaultHiddenSeries`. If a series was hidden by default to reduce noise, either
+   omit it from `series` or let the reader hide it with the legend.
+6. Convert any `dataConfig[key].color` to `series[n].color`. The new prop only accepts
+   F0 chart color tokens — a raw hex or CSS color will not type-check.
+
+## Codemod (if available)
+
+None. The transpose in step 2 and the three dropped props (`scaleMin`, `aspect`,
+`defaultHiddenSeries`) each need a judgment call about how the chart should read,
+so this migration is deliberately manual.
+
+## Running the migration at scale
+
+To migrate many usages across a product, don't do it by hand — run the
+**`factorial-migrations`** skill with this guide as the plan. It will find every usage
+(patterns above), group files that share a backend resource, and dispatch one subagent
+per independent unit. For F0 component conventions the subagents follow, they also load
+the **`factorial-f0`** skill.
+
+## Verify
+
+- [ ] All affected files migrated (re-run the find patterns — zero results for `RadarChart`).
+- [ ] Each series' `data` array is aligned with `indicators`, index by index.
+- [ ] Charts that used `scaleMin` still read correctly starting from 0.
+- [ ] Colors resolve — no raw hex left in `series[n].color`.
+- [ ] Tests and visual snapshots updated and green.
+
+## Timeline
+
+- **`v6.89.0`** — `RadarChart` marked `@deprecated` (IDE warning points here). `F0DataChart` already ships.
+- **`v7.0.0`** — `RadarChart` and the rest of the `kits/Charts` kit removed. Migrate before upgrading past this version.
+
+## Questions
+
+Ask in [#f0-support](https://factorialteam.slack.com/archives/C082ZNKS403) — tag the owner above.

--- a/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.stories.tsx
@@ -5,7 +5,7 @@ import { RadarChart } from "."
 const meta: Meta = {
   title: "Charts/RadarChart",
   component: RadarChart,
-  tags: ["autodocs", "stable", "no-sidebar"],
+  tags: ["autodocs", "deprecated", "no-sidebar"],
   decorators: [
     (Story) => (
       <div className="h-80">

--- a/packages/react/src/kits/Charts/RadarChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.tsx
@@ -18,6 +18,11 @@ import { getCategoricalColor, getColor } from "../utils/colors"
 import { fixedForwardRef } from "../utils/forwardRef"
 import { ChartConfig, ChartItem } from "../utils/types"
 
+/**
+ * @deprecated Use F0DataChartRadarProps from @/kits/F0DataChart instead.
+ * @removeIn 7.0.0
+ * @migration https://github.com/factorialco/f0/blob/main/packages/react/docs/migrations/f0-radarchart-to-f0datachart.md
+ */
 export type RadarChartProps<K extends ChartConfig> = {
   dataConfig: K
   data: ChartItem<K>[]
@@ -164,4 +169,9 @@ const _RadarChart = <K extends ChartConfig>(
   )
 }
 
+/**
+ * @deprecated Use F0DataChart with `type="radar"` instead.
+ * @removeIn 7.0.0
+ * @migration https://github.com/factorialco/f0/blob/main/packages/react/docs/migrations/f0-radarchart-to-f0datachart.md
+ */
 export const RadarChart = fixedForwardRef(_RadarChart)

--- a/packages/react/src/kits/Charts/exports.ts
+++ b/packages/react/src/kits/Charts/exports.ts
@@ -48,6 +48,11 @@ export const ComboChart = withDataTestId(
   Component({ name: "ComboChart", type: "info" }, ComboChartComponent)
 )
 
+/**
+ * @deprecated Use F0DataChart with `type="radar"` instead.
+ * @removeIn 7.0.0
+ * @migration https://github.com/factorialco/f0/blob/main/packages/react/docs/migrations/f0-radarchart-to-f0datachart.md
+ */
 export const RadarChart = withDataTestId(
   Component({ name: "RadarChart", type: "info" }, RadarChartComponent)
 )


### PR DESCRIPTION
## Description

`RadarChart` claimed to be stable and never was. It is the only story in `kits/Charts` carrying a maturity tag at all, and that tag arrived as a side effect of [#4110](https://github.com/factorialco/f0/pull/4110), a PR about the interactive legend, rather than as a decision, six months after we had already hidden the kit from the sidebar for being deprecated.

So this PR does not pay down the debt on the component, it removes a claim that was never true: the three JSDoc tags the deprecation policy requires, a story tag that says `deprecated`, and a migration guide pointing at `F0DataChart`, which is what the rest of F0 already draws its radars with.

## Type of change

- [x] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)

## Implementation details

### The deprecation markers

Both the public `RadarChart` export and the `RadarChartProps` type now carry `@deprecated`, `@removeIn 7.0.0` and `@migration`, the three tags the policy requires together. The export is tagged in the kit barrel because that is the path consumers import through, twice over: `src/f0.ts` for the main entry and `src/experimental.ts` for the deprecated one. Tagging the type as well means the warning fires on a type-only import too.

> [!WARNING]
> The version in the `@removein` tag is provisional, as the ≥90-day SLA must be aligned with this version.

### The story tag

`stable` becomes `deprecated`. `no-sidebar` stays. Every sibling chart has it, [#4812](https://github.com/factorialco/f0/pull/4812) put it there deliberately, and removing it would surface a dead component in the sidebar.

One consequence to know about: `component-status-build.mjs` skips any `no-sidebar` story that is not `stable`, so the component now leaves the component-status dataset entirely, exactly like its nine siblings. 

### The migration guide

The two components model radar data along opposite axes. `RadarChart` keys values by series inside each row, as `data[].values[seriesKey]`. `F0DataChart` keys them by axis position, as `indicators[]` in order with each series carrying a parallel `data: number[]`. The guide's mapping table covers that transpose row by row, with a worked before/after example.

No codemod, deliberately. The transpose is mechanical but three props have no successor:

| Prop | Why it is gone |
| --- | --- |
| `scaleMin` | Radar axes always start at 0. A chart that used a non-zero floor to spread its values apart will read flatter, and the author has to decide whether to rescale the data. |
| `aspect` | Size the chart through its container instead. |
| `defaultHiddenSeries` | The legend starts fully visible. `onLegendSelectionChange` only reports state, it does not set it. |

Each of those needs a judgment call about how the chart should read, so the guide gives steps rather than a command.

## Evidence

Nothing internal depends on the deprecated component. `F0AnalyticsDashboard` already imports its radar indicators, series and skeletons from `@/kits/F0DataChart`. A grep across `src` finds exactly one importer, the kit's own `exports.ts`; every other `RadarChart*` hit is `RadarChartConfig`, `RadarChartSkeleton` or `ChatDashboardRadarChartConfig`, all of which belong to `F0DataChart`.

`pnpm check:stable-dod --verbose` goes from 41 stable-tagged components with 27 in debt, to 40 with 26, and reports no stale entry. `pnpm tsc`, `oxlint`, `oxfmt --check` and `pnpm vitest --project=unit run src/kits` (73 files, 847 tests) are all green, as is the full pre-commit suite.

