### PR TITLE
refactor(lint): render conditional JSX children with ternaries

### DIFF
--- a/packages/react/.oxlint-plugins/README.md
+++ b/packages/react/.oxlint-plugins/README.md
@@ -25,11 +25,18 @@ code first.
 
 ## External JS plugins
 
-`.oxlintrc.json` also loads two published ESLint plugins the same way:
+`.oxlintrc.json` also loads three published ESLint plugins the same way:
 `eslint-plugin-sonarjs` (the `recommended` set, minus rules listed as debt in
-the config) and `eslint-plugin-import` under the alias `import-js`, for the
-rules oxlint has no native version of. The same editor caveat below applies to
-them. Rules that need type information run without it under oxlint's JS plugin
+the config), `eslint-plugin-import` under the alias `import-js`, and
+`eslint-plugin-react` under the alias `react-js`, for the rules oxlint has no
+native version of. The aliases are needed because oxlint reserves the names
+`import` and `react` for its own plugins. The same editor caveat below applies
+to them.
+
+`f0-react/` is a local wrapper around `eslint-plugin-react`'s
+`jsx-no-leaked-render`. The upstream rule reports `&&` in attribute values as
+well as in children; the wrapper only reports children, where a leaked `0` or
+`""` actually renders. It is tested in `__tests__/f0-react.test.ts`. Rules that need type information run without it under oxlint's JS plugin
 bridge; the type-aware rules that do work come from oxlint's own `typescript`
 plugin with `--type-aware` (see the `lint` script).
 

--- a/packages/react/.oxlint-plugins/__tests__/f0-react.test.ts
+++ b/packages/react/.oxlint-plugins/__tests__/f0-react.test.ts
@@ -1,0 +1,86 @@
+import { execFileSync } from "node:child_process"
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+
+// Same approach as f0-security.test.ts: run the real oxlint binary, because
+// oxlint's JS-plugin AST is what the wrapped rule actually sees.
+const PLUGIN_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const PKG_DIR = resolve(PLUGIN_DIR, "..")
+const OXLINT = resolve(PKG_DIR, "node_modules/.bin/oxlint")
+
+let workspace: string
+let configPath: string
+
+beforeAll(() => {
+  workspace = mkdtempSync(join(tmpdir(), "f0-react-"))
+  configPath = join(workspace, ".oxlintrc.json")
+  writeFileSync(
+    configPath,
+    JSON.stringify({
+      jsPlugins: [join(PLUGIN_DIR, "f0-react", "index.js")],
+      rules: {
+        "f0-react/jsx-no-leaked-render": [
+          "error",
+          { validStrategies: ["ternary"] },
+        ],
+      },
+    })
+  )
+})
+
+afterAll(() => rmSync(workspace, { recursive: true, force: true }))
+
+const lint = (source: string): string[] => {
+  const file = join(workspace, "probe.tsx")
+  writeFileSync(file, source)
+  let output = ""
+  try {
+    output = execFileSync(
+      OXLINT,
+      ["--config", configPath, "--format", "default", file],
+      { cwd: PKG_DIR, encoding: "utf-8", stdio: ["ignore", "pipe", "pipe"] }
+    )
+  } catch (error) {
+    output = (error as { stdout?: string }).stdout ?? ""
+  }
+  return [...output.matchAll(/f0-react\(([a-z-]+)\)/g)].map((m) => m[1])
+}
+
+describe("jsx-no-leaked-render", () => {
+  it("flags && in element children", () => {
+    expect(
+      lint(`export const A = ({ n }) => <div>{n && <span>{n}</span>}</div>`)
+    ).toContain("jsx-no-leaked-render")
+  })
+
+  it("flags && in fragment children", () => {
+    expect(
+      lint(`export const A = ({ n }) => <>{n && <span>{n}</span>}</>`)
+    ).toContain("jsx-no-leaked-render")
+  })
+
+  it("flags a boolean-looking left side too, since it has no types", () => {
+    expect(
+      lint(`export const A = ({ open }) => <div>{open && <span>x</span>}</div>`)
+    ).toContain("jsx-no-leaked-render")
+  })
+
+  it("accepts a ternary with a null alternate", () => {
+    expect(
+      lint(
+        `export const A = ({ n }) => <div>{n ? <span>{n}</span> : null}</div>`
+      )
+    ).not.toContain("jsx-no-leaked-render")
+  })
+
+  it("leaves && in attribute values alone", () => {
+    expect(
+      lint(
+        `export const A = ({ open, disabled }) => <dialog open={open && !disabled} />`
+      )
+    ).not.toContain("jsx-no-leaked-render")
+  })
+})

--- a/packages/react/.oxlint-plugins/f0-react/index.js
+++ b/packages/react/.oxlint-plugins/f0-react/index.js
@@ -1,0 +1,30 @@
+/**
+ * f0-react — local oxlint JS plugin wrapping rules from eslint-plugin-react.
+ *
+ * `jsx-no-leaked-render` upstream matches every JSX expression container, so
+ * `open={isOpen && !disabled}` is reported like `{items.length && <List />}`.
+ * Only the second one leaks a value into the rendered output. This wrapper
+ * runs the upstream rule (same options, same autofix) on element and fragment
+ * children only, and leaves attribute values alone.
+ */
+import react from "eslint-plugin-react"
+
+const upstream = react.rules["jsx-no-leaked-render"]
+const SELECTOR = 'JSXExpressionContainer > LogicalExpression[operator="&&"]'
+
+export default {
+  meta: { name: "f0-react" },
+  rules: {
+    "jsx-no-leaked-render": {
+      meta: upstream.meta,
+      create(context) {
+        const listeners = upstream.create(context)
+        const onLogicalAnd = listeners[SELECTOR]
+        return {
+          [`JSXElement > ${SELECTOR}`]: onLogicalAnd,
+          [`JSXFragment > ${SELECTOR}`]: onLogicalAnd,
+        }
+      },
+    },
+  },
+}

--- a/packages/react/.oxlintrc.json
+++ b/packages/react/.oxlintrc.json
@@ -161,7 +161,6 @@
     "sonarjs/insecure-cookie": "error",
     "sonarjs/insecure-jwt-token": "error",
     "sonarjs/inverted-assertion-arguments": "error",
-    "sonarjs/jsx-no-leaked-render": "error",
     "sonarjs/label-position": "error",
     "sonarjs/max-switch-cases": "error",
     "sonarjs/memoize-cache-key": "error",
@@ -269,6 +268,14 @@
     "sonarjs/x-powered-by": "error",
     "sonarjs/xml-parser-xxe": "error",
 
+    // eslint-plugin-react, loaded as a JS plugin (`react-js`). It has no type
+    // information, so only the syntax-based rules are useful. `f0-react` wraps
+    // its jsx-no-leaked-render to check JSX children only, not attributes.
+    // Ternaries everywhere is the only leak-safe strategy without types.
+    "f0-react/jsx-no-leaked-render": ["error", { "validStrategies": ["ternary"] }],
+    "react-js/no-deprecated": "error",
+    "react-js/no-invalid-html-attribute": "error",
+
     // DEBT. Turn on once the code is fixed. Number = violations when this
     // was written. Do not add new violations.
     "typescript/no-non-null-assertion": "off", // 718
@@ -305,6 +312,10 @@
     "sonarjs/super-linear-regex": "off", // 10
     "sonarjs/void-use": "off", // 10
     "sonarjs/no-globals-shadowing": "off", // 6; story exports named Error
+    "react-js/no-unstable-nested-components": "off", // 25
+    "react-js/jsx-no-constructed-context-values": "off", // 35
+    "react-js/no-unused-prop-types": "off", // 34
+    "react-js/no-object-type-as-default-prop": "off", // 59
 
     // OXLINT BUGS (1.43). Re-check after each oxlint upgrade.
     "typescript/consistent-indexed-object-style": "off", // flags mapped types that use the key; the autofix rewrites them to Record<> and drops the key
@@ -327,7 +338,8 @@
     "sonarjs/no-selector-parameter": "off", // boolean parameters that switch behavior are allowed
     "sonarjs/no-unused-vars": "off", // duplicate of no-unused-vars
     "sonarjs/unused-import": "off", // duplicate of no-unused-vars
-    "sonarjs/no-duplicate-string": "off" // 1167 hits, mostly class name strings
+    "sonarjs/no-duplicate-string": "off", // 1167 hits, mostly class name strings
+    "sonarjs/jsx-no-leaked-render": "off" // needs type information, reports nothing under oxlint; f0-react/jsx-no-leaked-render replaces it
   },
   "env": {
     "builtin": true,
@@ -336,10 +348,15 @@
   "jsPlugins": [
     "eslint-plugin-react-refresh",
     "./.oxlint-plugins/f0-security/index.js",
+    "./.oxlint-plugins/f0-react/index.js",
     "eslint-plugin-sonarjs",
     {
       "name": "import-js",
       "specifier": "eslint-plugin-import"
+    },
+    {
+      "name": "react-js",
+      "specifier": "eslint-plugin-react"
     }
   ],
   "overrides": [

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -209,6 +209,7 @@
     "emoji-mart": "^5.6.0",
     "emojibase-data": "^16.0.3",
     "eslint-plugin-import": "^2.32.0",
+    "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-refresh": "^0.4.26",
     "eslint-plugin-sonarjs": "^4.2.0",
     "eslint-plugin-storybook": "^10.3.3",

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -166,7 +166,7 @@ export function A11yAuditResults({
   const c = TONE[tone]
   return (
     <div className="mt-2" aria-live="polite">
-      {state.status === "running" && (
+      {state.status === "running" ? (
         <div className="flex items-center gap-2">
           <svg
             className={`h-4 w-4 shrink-0 animate-spin motion-reduce:animate-none ${c.muted}`}
@@ -191,19 +191,19 @@ export function A11yAuditResults({
           </svg>
           <span>Checking the rendered stories…</span>
         </div>
-      )}
-      {state.status === "unavailable" && (
+      ) : null}
+      {state.status === "unavailable" ? (
         <p className="m-0">
           Live results are available on the Storybook docs page. See the story’s{" "}
           <strong>Accessibility</strong> tab for per-element detail.
         </p>
-      )}
-      {state.status === "done" && state.criteria.length === 0 && (
+      ) : null}
+      {state.status === "done" && state.criteria.length === 0 ? (
         <p className="m-0 text-f1-foreground-positive">
           No violations in the stories’ default state.
         </p>
-      )}
-      {state.status === "done" && state.criteria.length > 0 && (
+      ) : null}
+      {state.status === "done" && state.criteria.length > 0 ? (
         <div role="list" className="space-y-1">
           {state.criteria.map((crit) => (
             <div
@@ -216,12 +216,12 @@ export function A11yAuditResults({
               </span>
               <span>
                 <code className={c.strong}>{crit.ruleId}</code>
-                {crit.sc && (
+                {crit.sc ? (
                   <span className={c.muted}>
                     {" "}
                     · WCAG {crit.sc} {crit.level} ({crit.version})
                   </span>
-                )}
+                ) : null}
                 <span className={c.muted}>
                   {" "}
                   · {crit.description} · {crit.nodes}{" "}
@@ -231,14 +231,14 @@ export function A11yAuditResults({
             </div>
           ))}
         </div>
-      )}
-      {(state.status === "done" || state.status === "unavailable") && (
+      ) : null}
+      {state.status === "done" || state.status === "unavailable" ? (
         <p className={`mt-2 text-sm ${c.muted}`}>
           Checked in each story’s default state — violations behind interactions
           (open menus, dialogs) aren’t shown here. CI enforces the full set,
           including play-function states.
         </p>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/component-status/ComponentStability.tsx
+++ b/packages/react/src/component-status/ComponentStability.tsx
@@ -98,7 +98,7 @@ export function ComponentStability({
         {status.summary}
       </p>
 
-      {status.showChecklist && (
+      {status.showChecklist ? (
         // role="list" divs (not <ul>/<li>): Storybook docs injects a global
         // `#storybook-docs ul { margin-bottom: 24px !important }` that .sb-unstyled
         // doesn't neutralize and no utility class can outrank, so semantic-role
@@ -129,7 +129,7 @@ export function ComponentStability({
                   </div>
                   <div className="mt-0.5 text-base text-f1-foreground-secondary">
                     {req.detail}
-                    {req.criteria && req.criteria.length > 0 && (
+                    {req.criteria && req.criteria.length > 0 ? (
                       <div role="list" className="mt-1 space-y-0.5">
                         {req.criteria.map((criterion) => (
                           <div
@@ -147,14 +147,14 @@ export function ComponentStability({
                           </div>
                         ))}
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </div>
             )
           )}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -174,7 +174,7 @@ function StatusDetails({ status }: { status: ComponentStatus }) {
     <div className="text-f1-foreground-inverse">
       <p className="m-0 text-base opacity-90">{status.summary}</p>
 
-      {status.showChecklist && (
+      {status.showChecklist ? (
         <div role="list" className="mt-3 space-y-3">
           {status.requirements.map((req) =>
             req.key === "a11y" ? (
@@ -199,7 +199,7 @@ function StatusDetails({ status }: { status: ComponentStatus }) {
                   <div className="text-base">{req.label}</div>
                   <div className="mt-0.5 text-base opacity-75">
                     {req.detail}
-                    {req.criteria && req.criteria.length > 0 && (
+                    {req.criteria && req.criteria.length > 0 ? (
                       <div role="list" className="mt-1 space-y-0.5">
                         {req.criteria.map((criterion) => (
                           <div
@@ -217,14 +217,14 @@ function StatusDetails({ status }: { status: ComponentStatus }) {
                           </div>
                         ))}
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               </div>
             )
           )}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/CardSelectable/CardSelectable.tsx
+++ b/packages/react/src/components/CardSelectable/CardSelectable.tsx
@@ -40,7 +40,9 @@ function RadioIndicator({ checked }: { checked: boolean }) {
           : "border-2 border-solid border-f1-border bg-f1-background"
       )}
     >
-      {checked && <div className="h-2 w-2 rounded-full bg-f1-background" />}
+      {checked ? (
+        <div className="h-2 w-2 rounded-full bg-f1-background" />
+      ) : null}
     </div>
   )
 }
@@ -57,7 +59,7 @@ function CheckboxIndicator({ checked }: { checked: boolean }) {
           : "border border-solid border-f1-border bg-f1-background"
       )}
     >
-      {checked && <F0Icon icon={Check} size="sm" />}
+      {checked ? <F0Icon icon={Check} size="sm" /> : null}
     </div>
   )
 }
@@ -173,7 +175,7 @@ function _CardSelectable<T extends CardSelectableValue>({
           moreInfoLink && "pb-0"
         )}
       >
-        {item.avatar && <AvatarRender avatar={item.avatar} />}
+        {item.avatar ? <AvatarRender avatar={item.avatar} /> : null}
         <div className="flex min-w-0 flex-1 flex-col gap-2">
           <div className="flex flex-col gap-0.5">
             <span
@@ -183,35 +185,35 @@ function _CardSelectable<T extends CardSelectableValue>({
               )}
             >
               {item.title}
-              {item.required && (
+              {item.required ? (
                 <span className="ml-0.5 text-f1-foreground-critical">*</span>
-              )}
+              ) : null}
             </span>
-            {item.description && (
+            {item.description ? (
               <span className="text-base text-f1-foreground-secondary">
                 {item.description}
               </span>
-            )}
+            ) : null}
           </div>
         </div>
         {renderIndicator()}
       </div>
 
       {/* Outside the interactive header — see the `moreInfoLink` note above. */}
-      {moreInfoLink && (
+      {moreInfoLink ? (
         <div
           className={cn(
             "flex flex-row items-start gap-3 pt-2",
             grouped ? "px-4 pb-3" : compact ? "px-3 pb-3" : "px-4 pb-4"
           )}
         >
-          {item.avatar && (
+          {item.avatar ? (
             /* Invisible copy of the avatar keeps the link aligned with the
                title column without hardcoding the avatar's width. */
             <div aria-hidden="true" className="invisible">
               <AvatarRender avatar={item.avatar} />
             </div>
-          )}
+          ) : null}
           <F0Link
             href={moreInfoLink.href}
             target="_blank"
@@ -223,10 +225,10 @@ function _CardSelectable<T extends CardSelectableValue>({
             {moreInfoLink.label ?? forms.moreInformation}
           </F0Link>
         </div>
-      )}
+      ) : null}
 
       {/* Expandable content — outside the interactive area, attached below */}
-      {hasSelectedContent && (
+      {hasSelectedContent ? (
         <motion.div
           initial={false}
           animate={{
@@ -250,7 +252,7 @@ function _CardSelectable<T extends CardSelectableValue>({
             </div>
           </div>
         </motion.div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/F0Accordion/F0Accordion.tsx
+++ b/packages/react/src/components/F0Accordion/F0Accordion.tsx
@@ -53,9 +53,9 @@ const F0AccordionBase = forwardRef<HTMLDivElement, F0AccordionProps>(
       >
         {items.map((item, index) => (
           <Fragment key={item.id}>
-            {index > 0 && (
+            {index > 0 ? (
               <div className="h-px w-full bg-f1-border-secondary" />
-            )}
+            ) : null}
             <AccordionItem
               item={item}
               open={openIds.includes(item.id)}

--- a/packages/react/src/components/F0Accordion/F0AccordionSkeleton.tsx
+++ b/packages/react/src/components/F0Accordion/F0AccordionSkeleton.tsx
@@ -20,7 +20,9 @@ export const F0AccordionSkeleton = ({
     >
       {Array.from({ length: items }).map((_, index) => (
         <Fragment key={index}>
-          {index > 0 && <div className="h-px w-full bg-f1-border-secondary" />}
+          {index > 0 ? (
+            <div className="h-px w-full bg-f1-border-secondary" />
+          ) : null}
           <div className="flex items-center gap-3 px-4 py-3">
             <Skeleton className="h-4 flex-1 max-w-48" />
             <Skeleton className="ml-auto h-7 w-7 shrink-0 rounded" />

--- a/packages/react/src/components/F0Accordion/components/AccordionItem.tsx
+++ b/packages/react/src/components/F0Accordion/components/AccordionItem.tsx
@@ -49,7 +49,7 @@ export const AccordionItem = ({
             </button>
           </CollapsibleTrigger>
           <div className="flex items-center gap-2 py-3 pl-2 pr-4">
-            {hasActions && <AccordionActions actions={item.actions!} />}
+            {hasActions ? <AccordionActions actions={item.actions!} /> : null}
             <CollapsibleTrigger asChild>
               <F0Button
                 variant="outline"
@@ -62,7 +62,7 @@ export const AccordionItem = ({
           </div>
         </div>
         <AnimatePresence initial={false}>
-          {open && (
+          {open ? (
             <motion.div
               initial={{ height: 0, opacity: 0 }}
               animate={{ height: "auto", opacity: 1 }}
@@ -76,7 +76,7 @@ export const AccordionItem = ({
                 </div>
               </CollapsibleContent>
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
     </Collapsible>

--- a/packages/react/src/components/F0ActionBar/index.tsx
+++ b/packages/react/src/components/F0ActionBar/index.tsx
@@ -378,7 +378,7 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
 
     const actionBarContent = (
       <AnimatePresence>
-        {isOpen && (
+        {isOpen ? (
           <motion.div
             ref={containerRef}
             data-variant={variant}
@@ -411,12 +411,12 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
             )}
           >
             {leftContent}
-            {(!!label || (status && status !== "idle")) && (
+            {!!label || (status && status !== "idle") ? (
               <div className="ml-2 flex items-center gap-2">
-                {status && status !== "idle" && (
+                {status && status !== "idle" ? (
                   <StatusIcon status={status} isLight={isLight} />
-                )}
-                {!!label && (
+                ) : null}
+                {label ? (
                   <span
                     className={cn(
                       "font-medium",
@@ -427,9 +427,9 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
                   >
                     {label}
                   </span>
-                )}
+                ) : null}
               </div>
-            )}
+            ) : null}
             <div>
               <div
                 className={cn(
@@ -475,9 +475,9 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
                 )}
               >
                 <Fragment key="desktop-actions">
-                  {dropdownActions.length > 0 && (
+                  {dropdownActions.length > 0 ? (
                     <Dropdown items={dropdownActions} />
-                  )}
+                  ) : null}
                   {visibleSecondaryActions
                     .slice()
                     .reverse()
@@ -522,7 +522,7 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
               </div>
             </div>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
     )
 

--- a/packages/react/src/components/F0Alert/F0Alert.tsx
+++ b/packages/react/src/components/F0Alert/F0Alert.tsx
@@ -100,16 +100,16 @@ const _F0Alert = ({
               </div>
               <div className="flex flex-col gap-0.5">
                 <p className={titleVariants({ variant })}>{title}</p>
-                {description && (
+                {description ? (
                   <p className="text-base text-f1-foreground-secondary">
                     {description}
                   </p>
-                )}
+                ) : null}
               </div>
             </div>
-            {(action || link) && (
+            {action || link ? (
               <div className="flex flex-shrink-0 flex-row items-center gap-3 pl-8 @xs:pl-0">
-                {link && (
+                {link ? (
                   <F0Link
                     href={link.href}
                     target="_blank"
@@ -118,8 +118,8 @@ const _F0Alert = ({
                   >
                     {link.label}
                   </F0Link>
-                )}
-                {action && (
+                ) : null}
+                {action ? (
                   <F0Button
                     label={action.label}
                     variant="outline"
@@ -128,15 +128,15 @@ const _F0Alert = ({
                     disabled={action.disabled}
                     type="button"
                   />
-                )}
+                ) : null}
               </div>
-            )}
+            ) : null}
           </div>
-          {onClose && (
+          {onClose ? (
             <div className="flex-shrink-0 self-start @xs:self-center">
               <CloseButton onClose={onClose} />
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayer.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayer.tsx
@@ -87,14 +87,14 @@ const F0AudioPlayerBase = forwardRef<HTMLDivElement, F0AudioPlayerProps>(
         />
 
         {/* Inline audio-language picker when several dubbed tracks are given. */}
-        {audioLang.languages.length > 1 && audioLang.activeLocale && (
+        {audioLang.languages.length > 1 && audioLang.activeLocale ? (
           <LanguageSelect
             value={audioLang.activeLocale}
             options={audioLang.languages}
             onChange={changeAudioLanguage}
             kind={i18n.audioPlayer.audio}
           />
-        )}
+        ) : null}
       </div>
     )
   }

--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -321,19 +321,19 @@ const F0AudioPlayerCardBase = forwardRef<
             <span className="truncate text-base font-medium text-f1-foreground">
               {title}
             </span>
-            {subtitle && (
+            {subtitle ? (
               <span className="truncate text-base text-f1-foreground-secondary">
                 {subtitle}
               </span>
-            )}
+            ) : null}
           </div>
         </div>
-        {(hasDetails ||
-          controller.playbackRates.length > 0 ||
-          audioLang.languages.length > 1 ||
-          actions) && (
+        {hasDetails ||
+        controller.playbackRates.length > 0 ||
+        audioLang.languages.length > 1 ||
+        actions ? (
           <div className="flex shrink-0 items-center gap-2">
-            {hasDetails && (
+            {hasDetails ? (
               <F0Button
                 variant="outline"
                 size="sm"
@@ -341,10 +341,10 @@ const F0AudioPlayerCardBase = forwardRef<
                 onClick={() => setExpanded(!isExpanded)}
                 aria-expanded={isExpanded}
               />
-            )}
-            {(controller.playbackRates.length > 0 ||
-              audioLang.languages.length > 1 ||
-              actions) && (
+            ) : null}
+            {controller.playbackRates.length > 0 ||
+            audioLang.languages.length > 1 ||
+            actions ? (
               <PlaybackMenu
                 playbackRate={controller.playbackRate}
                 playbackRates={controller.playbackRates}
@@ -355,9 +355,9 @@ const F0AudioPlayerCardBase = forwardRef<
                 audioLanguage={audioLang.activeLocale}
                 onAudioLanguageChange={changeAudioLanguage}
               />
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
       </div>
 
       <div className="flex w-full items-center gap-2">
@@ -376,7 +376,7 @@ const F0AudioPlayerCardBase = forwardRef<
         />
       </div>
 
-      {hasDetails && (
+      {hasDetails ? (
         <motion.div
           role="region"
           aria-label={singleTab ? singleTab.label : i18n.audioPlayer.details}
@@ -395,7 +395,7 @@ const F0AudioPlayerCardBase = forwardRef<
         >
           {/* Language picker when the content is provided in several languages;
               a single selection drives both tabs. */}
-          {languages.length > 1 && activeLocale && (
+          {languages.length > 1 && activeLocale ? (
             <div className="flex justify-end pb-2.5">
               <LanguageSelect
                 value={activeLocale}
@@ -404,9 +404,9 @@ const F0AudioPlayerCardBase = forwardRef<
                 kind={i18n.audioPlayer.language}
               />
             </div>
-          )}
+          ) : null}
           {/* One tab has nothing to switch between — show the content alone. */}
-          {!singleTab && (
+          {!singleTab ? (
             <F0SegmentedControl
               fullWidth
               ariaLabel={i18n.audioPlayer.details}
@@ -417,7 +417,7 @@ const F0AudioPlayerCardBase = forwardRef<
                 label: tab.label,
               }))}
             />
-          )}
+          ) : null}
           <div className={singleTab ? undefined : "pt-2.5"}>
             <ScrollArea
               viewportRef={viewportRef}
@@ -434,7 +434,7 @@ const F0AudioPlayerCardBase = forwardRef<
             </ScrollArea>
           </div>
         </motion.div>
-      )}
+      ) : null}
     </div>
   )
 })

--- a/packages/react/src/components/F0AudioPlayer/components/AudioScrubber.tsx
+++ b/packages/react/src/components/F0AudioPlayer/components/AudioScrubber.tsx
@@ -98,7 +98,7 @@ export const AudioScrubber = ({
           style={{ width: `${percent}%` }}
         />
       </SliderTrack>
-      {!isDisabled && (
+      {!isDisabled ? (
         <span
           aria-hidden
           style={{ left: knobLeft }}
@@ -108,7 +108,7 @@ export const AudioScrubber = ({
             "group-has-[:focus-visible]:ring-1 group-has-[:focus-visible]:ring-f1-special-ring group-has-[:focus-visible]:ring-offset-1"
           )}
         />
-      )}
+      ) : null}
 
       <SliderThumb
         aria-label={i18n.audioPlayer.seek}

--- a/packages/react/src/components/F0AudioPlayer/components/LanguageSelect.tsx
+++ b/packages/react/src/components/F0AudioPlayer/components/LanguageSelect.tsx
@@ -106,11 +106,11 @@ export function LanguageSelect({
                 setOpen(false)
               }}
             >
-              {isActive && (
+              {isActive ? (
                 <span className="absolute left-2.5 inline-flex items-center">
                   <Check />
                 </span>
-              )}
+              ) : null}
               {languageLabel(option)}
             </button>
           )

--- a/packages/react/src/components/F0AudioPlayer/components/PlaybackMenu.tsx
+++ b/packages/react/src/components/F0AudioPlayer/components/PlaybackMenu.tsx
@@ -56,7 +56,7 @@ export const PlaybackMenu = ({
         align="end"
         className="flex min-w-44 flex-col gap-0.5"
       >
-        {showSpeed && (
+        {showSpeed ? (
           <>
             <DropdownMenuLabel className="text-f1-foreground-secondary">
               {i18n.audioPlayer.playbackSpeed}
@@ -74,19 +74,19 @@ export const PlaybackMenu = ({
                   )}
                 >
                   <span className="relative">{rate}x</span>
-                  {selected && (
+                  {selected ? (
                     <span className="relative flex text-f1-icon-selected">
                       <F0Icon icon={CheckCircle} size="md" />
                     </span>
-                  )}
+                  ) : null}
                 </DropdownMenuItem>
               )
             })}
           </>
-        )}
-        {showAudioLanguages && (
+        ) : null}
+        {showAudioLanguages ? (
           <>
-            {showSpeed && <DropdownMenuSeparator />}
+            {showSpeed ? <DropdownMenuSeparator /> : null}
             <DropdownMenuLabel className="text-f1-foreground-secondary">
               {i18n.audioPlayer.audio}
             </DropdownMenuLabel>
@@ -103,19 +103,19 @@ export const PlaybackMenu = ({
                   )}
                 >
                   <span className="relative">{languageLabel(option)}</span>
-                  {selected && (
+                  {selected ? (
                     <span className="relative flex text-f1-icon-selected">
                       <F0Icon icon={CheckCircle} size="md" />
                     </span>
-                  )}
+                  ) : null}
                 </DropdownMenuItem>
               )
             })}
           </>
-        )}
-        {extraItems.length > 0 && (
+        ) : null}
+        {extraItems.length > 0 ? (
           <>
-            {(showSpeed || showAudioLanguages) && <DropdownMenuSeparator />}
+            {showSpeed || showAudioLanguages ? <DropdownMenuSeparator /> : null}
             {extraItems.map((action) => (
               <DropdownMenuItem
                 key={action.label}
@@ -127,7 +127,7 @@ export const PlaybackMenu = ({
                     : "text-f1-foreground"
                 )}
               >
-                {action.icon && (
+                {action.icon ? (
                   <span
                     className={cn(
                       "relative flex",
@@ -136,12 +136,12 @@ export const PlaybackMenu = ({
                   >
                     <F0Icon icon={action.icon} size="md" />
                   </span>
-                )}
+                ) : null}
                 <span className="relative">{action.label}</span>
               </DropdownMenuItem>
             ))}
           </>
-        )}
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/packages/react/src/components/F0AudioPlayer/components/TranscriptCueList.tsx
+++ b/packages/react/src/components/F0AudioPlayer/components/TranscriptCueList.tsx
@@ -93,7 +93,9 @@ export const TranscriptCueList = memo(function TranscriptCueList({
 
   return (
     <>
-      {onSeek && <p className="sr-only">{i18n.audioPlayer.transcriptHint}</p>}
+      {onSeek ? (
+        <p className="sr-only">{i18n.audioPlayer.transcriptHint}</p>
+      ) : null}
       <ol className="flex list-none flex-col gap-1 p-0">
         {cues.map((cue, index) => (
           <CueRow

--- a/packages/react/src/components/F0BigNumber/F0BigNumber.tsx
+++ b/packages/react/src/components/F0BigNumber/F0BigNumber.tsx
@@ -56,17 +56,17 @@ const F0BigNumberCmp = ({ label, ...props }: BigNumberProps) => {
 
   return (
     <div className="flex flex-col gap-2">
-      {label && <div>{label}</div>}
+      {label ? <div>{label}</div> : null}
       <div className="flex flex-row flex-wrap items-center gap-2">
         <span className="font-bold text-2xl">{formattedValue}</span>
-        {comparisonValue !== undefined && (
+        {comparisonValue !== undefined ? (
           <F0TagBalance
             percentage={trendPercentage}
             amount={comparison}
             invertStatus={trendConfig.invertStatus}
             hint={props.comparisonHint}
           />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/components/F0Button/internal.tsx
+++ b/packages/react/src/components/F0Button/internal.tsx
@@ -173,15 +173,15 @@ const ButtonInternal = forwardRef<
             (iconPosition === "right" ? "-mr-[3px]" : "-ml-[3px]")
         )}
       >
-        {iconPosition === "left" && iconNode}
-        {emoji && (
+        {iconPosition === "left" ? iconNode : null}
+        {emoji ? (
           <EmojiImage
             emoji={emoji}
             mode={emojiMode}
             size={size === "sm" ? "sm" : "md"}
             alt={""}
           />
-        )}
+        ) : null}
         {!shouldHideLabel ? (
           <OneEllipsis
             className={cn(
@@ -207,9 +207,9 @@ const ButtonInternal = forwardRef<
         ) : (
           <span className="sr-only">{buttonLabel}</span>
         )}
-        {iconPosition === "right" && iconNode}
+        {iconPosition === "right" ? iconNode : null}
         {append}{" "}
-        {hasCounter && (
+        {hasCounter ? (
           <span
             className={cn(
               "ml-1 inline-flex items-center",
@@ -220,7 +220,7 @@ const ButtonInternal = forwardRef<
           >
             <Counter value={counterValue} size={counterSize} type="default" />
           </span>
-        )}
+        ) : null}
       </div>
     </Action>
   )

--- a/packages/react/src/components/F0ButtonDropdown/__tests__/F0ButtonDropdown.test.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/__tests__/F0ButtonDropdown.test.tsx
@@ -27,11 +27,13 @@ vi.mock("@/ui/Action", () => ({
         data-tooltip={tooltip ? JSON.stringify(tooltip) : undefined}
         {...props}
       >
-        {prepend && <div data-testid="action-prepend">{prepend}</div>}
+        {prepend ? <div data-testid="action-prepend">{prepend}</div> : null}
         <span data-testid="action-label">{children}</span>
-        {append && <div data-testid="action-append-inline">{append}</div>}
+        {append ? <div data-testid="action-append-inline">{append}</div> : null}
       </button>
-      {appendOutside && <div data-testid="action-append">{appendOutside}</div>}
+      {appendOutside ? (
+        <div data-testid="action-append">{appendOutside}</div>
+      ) : null}
     </>
   ),
 }))

--- a/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
+++ b/packages/react/src/components/F0ButtonToggle/internal/F0ButtonToggle.internal.tsx
@@ -265,7 +265,7 @@ export const F0ButtonToggleInternal = forwardRef<
           </div>
         </AnimatePresence>
 
-        {variant === "expanded" && (
+        {variant === "expanded" ? (
           <AnimatePresence initial={false}>
             <span
               className={cn(
@@ -276,7 +276,7 @@ export const F0ButtonToggleInternal = forwardRef<
               {localLabel}
             </span>
           </AnimatePresence>
-        )}
+        ) : null}
       </TogglePrimitive.Root>
     )
 

--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -284,7 +284,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
         data-testid="card"
         ref={alert && alert.visible !== false ? undefined : ref}
       >
-        {link && !disableOverlayLink && (
+        {link && !disableOverlayLink ? (
           <F0Link
             href={link}
             variant="unstyled"
@@ -294,9 +294,9 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
           >
             &nbsp;
           </F0Link>
-        )}
+        ) : null}
 
-        {image && (
+        {image ? (
           <div
             className={cn(
               // pointer-events-none lets clicks on the image fall through to the
@@ -316,23 +316,23 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
             )}
           >
             {blurredBackground &&
-              (imageFit === "contain" ||
-                imageFit === "fit-width" ||
-                imageFit === "fit-height" ||
-                imageFit === "scale-down") && (
-                <div
-                  className="absolute inset-0 z-0 rounded-md"
-                  style={{
-                    backgroundImage: `url(${image})`,
-                    backgroundSize: "cover",
-                    backgroundPosition: "center",
-                    filter: "blur(20px)",
-                    opacity: 0.4,
-                    transform: "scale(1.1)",
-                  }}
-                  aria-hidden="true"
-                />
-              )}
+            (imageFit === "contain" ||
+              imageFit === "fit-width" ||
+              imageFit === "fit-height" ||
+              imageFit === "scale-down") ? (
+              <div
+                className="absolute inset-0 z-0 rounded-md"
+                style={{
+                  backgroundImage: `url(${image})`,
+                  backgroundSize: "cover",
+                  backgroundPosition: "center",
+                  filter: "blur(20px)",
+                  opacity: 0.4,
+                  transform: "scale(1.1)",
+                }}
+                aria-hidden="true"
+              />
+            ) : null}
             <Image
               src={image}
               alt={title}
@@ -348,7 +348,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
               overlay
             />
           </div>
-        )}
+        ) : null}
 
         <div
           className={cn(
@@ -403,13 +403,13 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
                 compact && "flex-row items-center gap-2"
               )}
             >
-              {avatar && (
+              {avatar ? (
                 <CardAvatar
                   avatar={avatar}
                   overlay={!!image}
                   compact={compact}
                 />
-              )}
+              ) : null}
               <div className={cn("flex flex-col gap-0")}>
                 <CardTitle
                   className={cn(
@@ -419,7 +419,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
                 >
                   {title}
                 </CardTitle>
-                {description && (
+                {description ? (
                   <CardSubtitle
                     className={cn("text-base text-f1-foreground-secondary")}
                   >
@@ -427,10 +427,10 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
                       {description}
                     </OneEllipsis>
                   </CardSubtitle>
-                )}
+                ) : null}
               </div>
             </CardHeader>
-            {!image && (
+            {!image ? (
               <CardOptions
                 otherActions={otherActions}
                 selectable={selectable}
@@ -439,9 +439,9 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
                 bookmark={bookmark}
                 title={title}
               />
-            )}
+            ) : null}
           </div>
-          {metadata && (
+          {metadata ? (
             // Metadata is display-only, so it navigates with the rest of the card:
             // clicks bubble up to the body handler above. It sits above the overlay
             // link (z-10) so its icon tooltips stay hoverable.
@@ -456,8 +456,8 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
                 <CardMetadata key={index} metadata={item} />
               ))}
             </div>
-          )}
-          {children && (
+          ) : null}
+          {children ? (
             // Children can be interactive, so this region swallows clicks
             // (stopPropagation) and only re-enables pointer events on the
             // interactive elements inside it — keeping them from navigating the
@@ -468,7 +468,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
             >
               {children}
             </CardContent>
-          )}
+          ) : null}
         </div>
         <CardActions
           primaryAction={primaryAction}

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -783,14 +783,14 @@ export const WithDismissibleAlert: Story = {
             onDismiss: () => setVisible(false),
           }}
         />
-        {!visible && (
+        {!visible ? (
           <button
             className="self-start text-sm text-f1-foreground-secondary underline"
             onClick={() => setVisible(true)}
           >
             Restore alert
           </button>
-        )}
+        ) : null}
       </div>
     )
   },
@@ -816,7 +816,7 @@ export const WithAlertAction: Story = {
             },
           }}
         />
-        {actioned && (
+        {actioned ? (
           <button
             type="button"
             className="self-start text-sm text-f1-foreground-secondary underline"
@@ -824,7 +824,7 @@ export const WithAlertAction: Story = {
           >
             Reset action
           </button>
-        )}
+        ) : null}
       </div>
     )
   },

--- a/packages/react/src/components/F0Card/__stories__/DraggableStoryCard.tsx
+++ b/packages/react/src/components/F0Card/__stories__/DraggableStoryCard.tsx
@@ -58,17 +58,17 @@ export function DraggableStoryCard({
 
   return (
     <div ref={ref} className="relative w-full py-2">
-      {overEdge === "top" && (
+      {overEdge === "top" ? (
         <div className="absolute inset-x-0 top-0 z-10 mt-[-2px] h-[4px] bg-f1-border-hover" />
-      )}
+      ) : null}
       <DraggableF0Card
         title={title}
         description={description}
         drag={{ id, type: "list-card" }}
       />
-      {overEdge === "bottom" && (
+      {overEdge === "bottom" ? (
         <div className="absolute inset-x-0 bottom-0 z-10 mb-[-2px] h-[4px] bg-f1-border-hover" />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/F0Card/components/CardActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardActions.tsx
@@ -69,7 +69,7 @@ export function CardActions({
       // (used when the card is interactive via onClick instead of a link).
       onClick={(e) => e.stopPropagation()}
     >
-      {secondaryActions && (
+      {secondaryActions ? (
         <div className="flex w-full flex-col gap-md sm:flex-row [&_a]:justify-center sm:[&_a]:justify-start [&_button]:w-full sm:[&_button]:w-fit [&_div]:w-full [&_div]:justify-center sm:[&_div]:w-fit">
           {Array.isArray(secondaryActions) ? (
             secondaryActions.map((action, index) => (
@@ -98,9 +98,9 @@ export function CardActions({
             </F0Link>
           )}
         </div>
-      )}
+      ) : null}
 
-      {primaryAction && (
+      {primaryAction ? (
         <div className="w-full sm:w-fit [&_button]:w-full sm:[&_button]:w-fit [&_div]:w-full [&_div]:justify-center">
           <F0Button
             label={primaryAction.label}
@@ -114,7 +114,7 @@ export function CardActions({
             data-testid="primary-button"
           />
         </div>
-      )}
+      ) : null}
     </CardFooter>
   )
 

--- a/packages/react/src/components/F0Card/components/CardMetadata.tsx
+++ b/packages/react/src/components/F0Card/components/CardMetadata.tsx
@@ -37,9 +37,9 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
   if (!renderer) {
     return (
       <div className="flex h-8 items-center gap-1.5">
-        {"icon" in metadata && metadata.icon && (
+        {"icon" in metadata && metadata.icon ? (
           <F0Icon icon={metadata.icon} color="default" size="md" />
-        )}
+        ) : null}
         <span>Unsupported property type: {type}</span>
       </div>
     )
@@ -52,13 +52,13 @@ export function CardMetadata({ metadata }: CardMetadataProps) {
 
   return (
     <div className="flex h-8 items-center gap-1.5">
-      {"icon" in metadata && metadata.icon && (
+      {"icon" in metadata && metadata.icon ? (
         <div className="pointer-events-auto flex items-center">
           <Tooltip label={metadata.property.label}>
             <F0Icon icon={metadata.icon} color="default" size="md" />
           </Tooltip>
         </div>
-      )}
+      ) : null}
       {typedRenderer(value, { visualization: "card" })}
     </div>
   )

--- a/packages/react/src/components/F0Card/components/CardOptions.tsx
+++ b/packages/react/src/components/F0Card/components/CardOptions.tsx
@@ -73,7 +73,7 @@ export function CardOptions({
           "pointer-events-auto absolute right-2 top-2 rounded-sm bg-f1-background/60 p-1 shadow-md backdrop-blur-sm"
       )}
     >
-      {hasOtherActions && (
+      {hasOtherActions ? (
         <div className="flex items-center justify-center">
           <Dropdown items={otherActions} open={isOpen} onOpenChange={setIsOpen}>
             <ButtonInternal
@@ -89,8 +89,8 @@ export function CardOptions({
             />
           </Dropdown>
         </div>
-      )}
-      {selectable && (
+      ) : null}
+      {selectable ? (
         <div className="flex items-center justify-center">
           <F0Checkbox
             title={title}
@@ -100,8 +100,8 @@ export function CardOptions({
             stopPropagation
           />
         </div>
-      )}
-      {bookmark && (
+      ) : null}
+      {bookmark ? (
         <div className="flex items-center justify-center">
           <ButtonInternal
             label={bookmark.label ?? title ?? translations.actions.save}
@@ -118,7 +118,7 @@ export function CardOptions({
             }}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/F0ChipList/index.tsx
+++ b/packages/react/src/components/F0ChipList/index.tsx
@@ -70,12 +70,12 @@ const _F0ChipList = ({
         return <Chip key={index} {...chip} />
       })}
 
-      {showCounter && (
+      {showCounter ? (
         <ChipCounter
           count={remainingCount}
           list={initialRemainingCount ? undefined : remainingChips}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/F0DurationInput/F0DurationInput.tsx
+++ b/packages/react/src/components/F0DurationInput/F0DurationInput.tsx
@@ -335,7 +335,7 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
           disabled && "cursor-not-allowed"
         )}
       >
-        {showLabel && (
+        {showLabel ? (
           <Label
             label={label}
             required={required}
@@ -343,7 +343,7 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
             className="min-w-0 flex-1"
             disabled={disabled}
           />
-        )}
+        ) : null}
         <div
           id={id}
           data-testid="input-field-wrapper"
@@ -381,14 +381,14 @@ export const F0DurationInput = forwardRef<HTMLDivElement, F0DurationInputProps>(
 
             return (
               <Fragment key={unit}>
-                {index > 0 && (
+                {index > 0 ? (
                   <F0Icon
                     icon={Bullet}
                     size="xs"
                     color="default"
                     aria-hidden="true"
                   />
-                )}
+                ) : null}
                 <input
                   ref={setInputRef(unit)}
                   id={`${baseId}-${unit}`}

--- a/packages/react/src/components/F0FileItem/F0FileItem.tsx
+++ b/packages/react/src/components/F0FileItem/F0FileItem.tsx
@@ -94,8 +94,8 @@ const _F0FileItem = forwardRef<HTMLDivElement, F0FileItemProps>(
         >
           {file.name}
         </OneEllipsis>
-        {hasActions &&
-          (singleAction ? (
+        {hasActions ? (
+          singleAction ? (
             <F0Button
               label={singleAction.label}
               size={buttonSizeMap[size]}
@@ -111,7 +111,8 @@ const _F0FileItem = forwardRef<HTMLDivElement, F0FileItemProps>(
               icon={Ellipsis}
               size={buttonSizeMap[size]}
             />
-          ))}
+          )
+        ) : null}
       </div>
     )
   }

--- a/packages/react/src/components/F0InputField/F0InputField.tsx
+++ b/packages/react/src/components/F0InputField/F0InputField.tsx
@@ -425,7 +425,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
         )}
         ref={ref}
       >
-        {((!hideLabel && label) || (maxLength && !hideMaxLength)) && (
+        {(!hideLabel && label) || (maxLength && !hideMaxLength) ? (
           <div
             className={cn(
               "flex max-w-full items-center",
@@ -436,7 +436,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
               className={cn("flex min-w-0 flex-1 flex-row gap-4")}
               data-testid="input-field-top"
             >
-              {!hideLabel && label && (
+              {!hideLabel && label ? (
                 <Label
                   label={label}
                   required={required}
@@ -445,15 +445,15 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                   className="min-w-0 flex-1"
                   disabled={disabled}
                 />
-              )}
-              {maxLength && !hideMaxLength && !noEdit && (
+              ) : null}
+              {maxLength && !hideMaxLength && !noEdit ? (
                 <div className="text-right text-f1-foreground-secondary">
                   {lengthProvider(localValue)}/{maxLength}
                 </div>
-              )}
+              ) : null}
             </div>
           </div>
-        )}
+        ) : null}
         <div
           className={cn(
             "relative h-fit transition-all",
@@ -480,7 +480,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
             className="pointer-events-auto relative flex h-full w-full min-w-0 flex-1"
             onClick={handleClickContent}
           >
-            {(icon || avatar) && (
+            {icon || avatar ? (
               <div
                 data-slot="icon"
                 className={cn(
@@ -488,16 +488,16 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                   size === "md" && "left-3 top-[9px]"
                 )}
               >
-                {icon && (
+                {icon ? (
                   <F0Icon
                     onClick={handleClickContent}
                     icon={icon}
                     color="default"
                   />
-                )}
-                {avatar && <F0Avatar avatar={avatar} size="xs" />}
+                ) : null}
+                {avatar ? <F0Avatar avatar={avatar} size="xs" /> : null}
               </div>
-            )}
+            ) : null}
             <div
               onClick={handleClickChildren}
               className="w-full min-w-0 flex-1"
@@ -559,7 +559,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
             >
               {placeholder}
             </div>
-            {(clearable || hasAppend || loading) && (
+            {clearable || hasAppend || loading ? (
               <div
                 className={cn(
                   "flex h-fit min-w-6 items-center gap-1.5 self-center pr-[3px]",
@@ -567,9 +567,9 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                   "relative"
                 )}
               >
-                {clearable && !noEdit && (
+                {clearable && !noEdit ? (
                   <AnimatePresence initial={!isEmpty(localValue)}>
-                    {!isEmpty(localValue) && (
+                    {!isEmpty(localValue) ? (
                       <motion.button
                         initial={{ opacity: 0 }}
                         animate={{ opacity: 1 }}
@@ -594,15 +594,15 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                           size="md"
                         />
                       </motion.button>
-                    )}
+                    ) : null}
                   </AnimatePresence>
-                )}
+                ) : null}
 
-                {hasAppend && (
+                {hasAppend ? (
                   <div className="flex min-h-6 min-w-6 items-center justify-center self-center">
                     {append}
-                    {appendTag && <AppendTag text={appendTag} />}
-                    {buttonToggle && (
+                    {appendTag ? <AppendTag text={appendTag} /> : null}
+                    {buttonToggle ? (
                       <F0ButtonToggle
                         label={buttonToggle.label}
                         icon={buttonToggle.icon}
@@ -611,12 +611,12 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                         onSelectedChange={buttonToggle.onChange}
                         size="sm"
                       />
-                    )}
+                    ) : null}
                   </div>
-                )}
+                ) : null}
 
                 <AnimatePresence>
-                  {loading && (
+                  {loading ? (
                     <div
                       className={cn(
                         "pointer-events-none flex h-6 w-6 items-center justify-center",
@@ -639,10 +639,10 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
                     >
                       <Spinner size="small" className="mt-[1px]" />
                     </div>
-                  )}
+                  ) : null}
                 </AnimatePresence>
               </div>
-            )}
+            ) : null}
           </div>
         </div>
         <InputMessages status={status} />

--- a/packages/react/src/components/F0InputField/components/InputMessages.tsx
+++ b/packages/react/src/components/F0InputField/components/InputMessages.tsx
@@ -46,12 +46,12 @@ const InputMessages = ({ status }: InputMessagesProps) => {
   return (
     messages.length > 0 && (
       <div className="flex gap-1">
-        {icon && (
+        {icon ? (
           <F0Icon
             icon={icon}
             color={statuses[status.type].iconColor || "currentColor"}
           />
-        )}
+        ) : null}
         <ul className="list-none">
           {messages.map((message) => (
             <li

--- a/packages/react/src/components/F0InputField/components/Label.tsx
+++ b/packages/react/src/components/F0InputField/components/Label.tsx
@@ -31,13 +31,13 @@ const Label = ({
       aria-label={label}
       aria-disabled={disabled}
     >
-      {icon && <F0Icon icon={icon} size="sm"></F0Icon>}
+      {icon ? <F0Icon icon={icon} size="sm"></F0Icon> : null}
       <OneEllipsis className="shrink-1 min-w-0">{label}</OneEllipsis>
-      {required && (
+      {required ? (
         <span className="text-f1-foreground-critical" aria-hidden="true">
           *
         </span>
-      )}
+      ) : null}
     </label>
   )
 }

--- a/packages/react/src/components/F0Link/F0Link.tsx
+++ b/packages/react/src/components/F0Link/F0Link.tsx
@@ -61,12 +61,12 @@ const _F0Link = forwardRef<HTMLAnchorElement, F0LinkProps>(function Link(
   return (
     <Action ref={ref} {...actionProps} variant={variant}>
       <span>{children}</span>
-      {external && (
+      {external ? (
         <>
           <F0Icon icon={ExternalLink} size="sm" aria-hidden={true} />
           <span className="sr-only"> (opens in new tab)</span>
         </>
-      )}
+      ) : null}
     </Action>
   )
 })

--- a/packages/react/src/components/F0NumberInput/internal.tsx
+++ b/packages/react/src/components/F0NumberInput/internal.tsx
@@ -123,11 +123,11 @@ function NumberRow({
       >
         {children}
       </div>
-      {extraContent && (
+      {extraContent ? (
         <span className="shrink-0 text-f1-foreground-secondary">
           {extraContent}
         </span>
-      )}
+      ) : null}
       {trailingAction}
     </div>
   )

--- a/packages/react/src/components/F0PdfViewer/F0PdfViewer.tsx
+++ b/packages/react/src/components/F0PdfViewer/F0PdfViewer.tsx
@@ -78,23 +78,23 @@ export const F0PdfViewerBase = forwardRef<HTMLDivElement, F0PdfViewerProps>(
         <Suspense
           fallback={<Skeleton className="h-full w-full rounded-none" />}
         >
-          {kind === "sheet" && (
+          {kind === "sheet" ? (
             <SheetViewer
               url={url}
               filename={filename}
               withCredentials={withCredentials}
               actions={actions}
             />
-          )}
-          {kind === "docx" && (
+          ) : null}
+          {kind === "docx" ? (
             <DocxViewer
               url={url}
               filename={filename}
               withCredentials={withCredentials}
               actions={actions}
             />
-          )}
-          {kind === "text" && (
+          ) : null}
+          {kind === "text" ? (
             <TextViewer
               url={url}
               name={filename ?? ""}
@@ -102,7 +102,7 @@ export const F0PdfViewerBase = forwardRef<HTMLDivElement, F0PdfViewerProps>(
               withCredentials={withCredentials}
               actions={actions}
             />
-          )}
+          ) : null}
         </Suspense>
       </div>
     )
@@ -364,7 +364,7 @@ const PdfViewerBase = forwardRef<
           actions={actions}
         />
 
-        {url && (
+        {url ? (
           <Document
             file={file}
             onLoadSuccess={onDocumentLoadSuccess}
@@ -376,50 +376,52 @@ const PdfViewerBase = forwardRef<
               />
             }
           >
-            {pdf &&
-              Array.from({ length: totalPages ?? 0 }).map((_, index) => {
-                const pageNumber =
-                  (pagesToDisplay.length > 0 ? pagesToDisplay[index] : index) +
-                  1
-                return (
-                  <div
-                    key={index}
-                    className="F0PdfViewer__page mx-auto w-fit px-4 pt-4 last:pb-4"
-                  >
-                    <Page
-                      className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary shadow-md"
-                      pageNumber={pageNumber}
-                      scale={scale}
-                      rotate={rotation}
-                      loading={
-                        <Skeleton
-                          style={{
-                            width: pageSkeletonWidth,
-                            height: pageSkeletonHeight,
-                          }}
-                        />
-                      }
-                      renderForms
-                      renderTextLayer
-                      inputRef={(reference) => {
-                        pageElements.current[index] = reference
-                      }}
-                      onLoadSuccess={(loadedPage) => {
-                        setPages((current) => {
-                          const next = [...current]
-                          next[index] = {
-                            originalWidth: loadedPage.originalWidth,
-                            originalHeight: loadedPage.originalHeight,
-                          }
-                          return next
-                        })
-                      }}
-                    />
-                  </div>
-                )
-              })}
+            {pdf
+              ? Array.from({ length: totalPages ?? 0 }).map((_, index) => {
+                  const pageNumber =
+                    (pagesToDisplay.length > 0
+                      ? pagesToDisplay[index]
+                      : index) + 1
+                  return (
+                    <div
+                      key={index}
+                      className="F0PdfViewer__page mx-auto w-fit px-4 pt-4 last:pb-4"
+                    >
+                      <Page
+                        className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary shadow-md"
+                        pageNumber={pageNumber}
+                        scale={scale}
+                        rotate={rotation}
+                        loading={
+                          <Skeleton
+                            style={{
+                              width: pageSkeletonWidth,
+                              height: pageSkeletonHeight,
+                            }}
+                          />
+                        }
+                        renderForms
+                        renderTextLayer
+                        inputRef={(reference) => {
+                          pageElements.current[index] = reference
+                        }}
+                        onLoadSuccess={(loadedPage) => {
+                          setPages((current) => {
+                            const next = [...current]
+                            next[index] = {
+                              originalWidth: loadedPage.originalWidth,
+                              originalHeight: loadedPage.originalHeight,
+                            }
+                            return next
+                          })
+                        }}
+                      />
+                    </div>
+                  )
+                })
+              : null}
           </Document>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/components/F0PdfViewer/components/DocumentToolbar.tsx
+++ b/packages/react/src/components/F0PdfViewer/components/DocumentToolbar.tsx
@@ -83,7 +83,7 @@ export const DocumentToolbar = ({
       <div className="flex min-w-0 flex-1 basis-0 flex-row items-center gap-2 overflow-x-auto">
         {children}
       </div>
-      {zoom && (
+      {zoom ? (
         <div className="flex shrink-0 flex-row items-center gap-2">
           <ToolbarButton
             label={pdfViewer.zoomOut}
@@ -103,7 +103,7 @@ export const DocumentToolbar = ({
             onChange={(value: FixedScale) => zoom.setScale(Number(value))}
           />
         </div>
-      )}
+      ) : null}
       <div className="flex flex-1 basis-0 flex-row items-center justify-end gap-2">
         <ToolbarButton
           label={pdfViewer.download}

--- a/packages/react/src/components/F0PdfViewer/components/DocxViewer.tsx
+++ b/packages/react/src/components/F0PdfViewer/components/DocxViewer.tsx
@@ -80,19 +80,19 @@ const DocxViewer = ({
         zoom={zoom}
       />
       <div className="relative min-h-0 grow overflow-auto bg-f1-background-secondary">
-        {state === "loading" && (
+        {state === "loading" ? (
           <Skeleton
             role="status"
             aria-busy={true}
             aria-label={i18n.pdfViewer.loading}
             className="absolute inset-0 h-full w-full rounded-none"
           />
-        )}
-        {state === "failed" && (
+        ) : null}
+        {state === "failed" ? (
           <div className="flex h-full w-full items-center justify-center bg-f1-background text-f1-foreground-secondary">
             {i18n.pdfViewer.previewFailed}
           </div>
-        )}
+        ) : null}
         {/* Always mounted: the render effect writes into it across url changes.
             CSS zoom reflows, so the scroll container tracks the zoomed pages. */}
         <div

--- a/packages/react/src/components/F0PdfViewer/components/PdfToolbar.tsx
+++ b/packages/react/src/components/F0PdfViewer/components/PdfToolbar.tsx
@@ -72,14 +72,14 @@ export const PdfToolbar = ({
       )}
     >
       <div className={groupClassName}>
-        {hasDocument && (
+        {hasDocument ? (
           <span
             aria-live="polite"
             className="whitespace-nowrap text-sm font-medium text-f1-foreground-secondary"
           >
             {currentPage} / {totalPages}
           </span>
-        )}
+        ) : null}
         <ToolbarButton
           label={pdfViewer.previousPage}
           onClick={onPreviousPage}
@@ -115,13 +115,13 @@ export const PdfToolbar = ({
       </div>
 
       <div className={groupClassName}>
-        {rotatable && (
+        {rotatable ? (
           <ToolbarButton
             label={pdfViewer.rotate}
             onClick={onRotate}
             icon={Reset}
           />
-        )}
+        ) : null}
         <ToolbarButton
           label={pdfViewer.print}
           onClick={onPrint}

--- a/packages/react/src/components/F0PdfViewer/components/SheetViewer.tsx
+++ b/packages/react/src/components/F0PdfViewer/components/SheetViewer.tsx
@@ -86,7 +86,7 @@ const SheetViewer = ({
       >
         {/* Sheet switcher — one toggle per workbook sheet. Radix single-type
             toggles emit "" when re-clicking the active one; keep it selected. */}
-        {sheets && sheets.length > 1 && (
+        {sheets && sheets.length > 1 ? (
           <ToggleGroup
             type="single"
             size="sm"
@@ -108,7 +108,7 @@ const SheetViewer = ({
               </ToggleGroupItem>
             ))}
           </ToggleGroup>
-        )}
+        ) : null}
       </DocumentToolbar>
       {failed ? (
         <div className="flex min-h-0 grow items-center justify-center text-f1-foreground-secondary">
@@ -163,13 +163,13 @@ const SheetViewer = ({
               </tbody>
             </table>
           </div>
-          {active.truncatedRows && (
+          {active.truncatedRows ? (
             <div className="shrink-0 border-0 border-t border-solid border-f1-border-secondary px-3 py-1.5 text-sm text-f1-foreground-secondary">
               {i18n.t("pdfViewer.showingFirstRows.other", {
                 count: VIEWER_MAX_ROWS,
               })}
             </div>
-          )}
+          ) : null}
         </>
       )}
     </div>

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -1212,7 +1212,7 @@ const F0SelectComponent = forwardRef(function Select<
             onFiltersOpenChange={setIsFiltersOpen}
             showPreview={showPreview}
           />
-          {multiple && !currentSearch && !isFiltersOpen && (
+          {multiple && !currentSearch && !isFiltersOpen ? (
             <SelectAll
               selectedCount={selectionMeta.selectedItemsCount}
               indeterminate={
@@ -1226,7 +1226,7 @@ const F0SelectComponent = forwardRef(function Select<
               items={getDisplayItemsForSelection}
               paddingTop={!showSearchBox && !localSource.filters}
             />
-          )}
+          ) : null}
         </>
       }
       right={
@@ -1315,7 +1315,7 @@ const F0SelectComponent = forwardRef(function Select<
             disabled && "cursor-not-allowed opacity-50"
           )}
         >
-          {label && !hideLabel && (
+          {label && !hideLabel ? (
             <Label
               label={label}
               required={required}
@@ -1323,7 +1323,7 @@ const F0SelectComponent = forwardRef(function Select<
               icon={labelIcon}
               disabled={disabled}
             />
-          )}
+          ) : null}
           {/* Select Container */}
           <div
             className={cn(
@@ -1431,10 +1431,12 @@ const F0SelectComponent = forwardRef(function Select<
                   e.preventDefault()
                 }}
               >
-                {(multiple
-                  ? localValue.length > 0 ||
-                    selectionMeta.selectedItemsCount > 0
-                  : !!localValue[0]) && (
+                {(
+                  multiple
+                    ? localValue.length > 0 ||
+                      selectionMeta.selectedItemsCount > 0
+                    : !!localValue[0]
+                ) ? (
                   <SelectedItems
                     multiple={multiple}
                     totalSelectedCount={
@@ -1455,13 +1457,13 @@ const F0SelectComponent = forwardRef(function Select<
                     // their icons for the rows regardless.
                     hideItemIcon={!!icon}
                   />
-                )}
+                ) : null}
               </button>
             </F0InputField>
           )}
         </SelectTrigger>
       )}
-      {openLocal && selectContent}
+      {openLocal ? selectContent : null}
     </SelectPrimitive>
   )
 

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -325,15 +325,17 @@ const meta: Meta = {
             {isMultiplePaginated ? (
               <>
                 <p>{getSelectionDisplay()}</p>
-                {selectionStatus && (
+                {selectionStatus ? (
                   <p>Total: {selectionStatus.selectedCount}</p>
-                )}
-                {getFiltersDisplay() && <p>Filters: {getFiltersDisplay()}</p>}
+                ) : null}
+                {getFiltersDisplay() ? (
+                  <p>Filters: {getFiltersDisplay()}</p>
+                ) : null}
               </>
             ) : (
               <>
                 Selected: {JSON.stringify(truncatedValue, null, 2)}
-                {args.multiple && ` - Total: ${localValue?.length ?? 0}`}
+                {args.multiple ? ` - Total: ${localValue?.length ?? 0}` : null}
               </>
             )}
           </div>

--- a/packages/react/src/components/F0Select/components/SelectBottomActions.tsx
+++ b/packages/react/src/components/F0Select/components/SelectBottomActions.tsx
@@ -45,21 +45,21 @@ export const SelectBottomActions = ({
           disabled={action.disabled}
         />
       ))}
-      {showCancelButton && (
+      {showCancelButton ? (
         <F0Button
           onClick={onCancel}
           label={i18n.filters.cancel}
           variant="ghost"
         />
-      )}
-      {showApplyButton && (
+      ) : null}
+      {showApplyButton ? (
         <div className={showCancelButton ? "" : "ml-auto"}>
           <F0Button
             onClick={onApply}
             label={applyLabel ?? i18n.select.applySelection}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/F0Select/components/SelectItem.tsx
+++ b/packages/react/src/components/F0Select/components/SelectItem.tsx
@@ -42,36 +42,36 @@ export const SelectItem = <T extends string, R>({
       <div
         className={`flex w-full gap-1.5 ${item.description ? "items-start" : "items-center"}`}
       >
-        {item.avatar && (
+        {item.avatar ? (
           <div className="flex shrink-0 items-center">
             <F0Avatar avatar={item.avatar} size="xs" />
           </div>
-        )}
-        {item.icon && (
+        ) : null}
+        {item.icon ? (
           <div className="flex shrink-0 items-center text-f1-icon">
             <F0Icon icon={item.icon} />
           </div>
-        )}
-        {!isStatusTag && (
+        ) : null}
+        {!isStatusTag ? (
           <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex min-w-0 items-baseline gap-1.5">
               <OneEllipsis lines={2} className="font-medium">
                 {item.label}
               </OneEllipsis>
-              {item.metadata && (
+              {item.metadata ? (
                 <span className="whitespace-nowrap text-f1-foreground-secondary">
                   {metadataText(item.metadata)}
                 </span>
-              )}
+              ) : null}
             </div>
-            {item.description && (
+            {item.description ? (
               <OneEllipsis lines={2} className="text-f1-foreground-secondary">
                 {item.description}
               </OneEllipsis>
-            )}
+            ) : null}
           </div>
-        )}
-        {item.tag && (
+        ) : null}
+        {item.tag ? (
           <div className={item.description ? "self-start" : "self-center"}>
             {typeof item.tag === "string" ? (
               <F0TagRaw text={item.tag} />
@@ -85,7 +85,7 @@ export const SelectItem = <T extends string, R>({
               <F0TagPerson name={item.tag.name} src={item.tag.src} />
             )}
           </div>
-        )}
+        ) : null}
       </div>
     </SelectItemPrimitive>
   )

--- a/packages/react/src/components/F0Select/components/SelectTopActions.tsx
+++ b/packages/react/src/components/F0Select/components/SelectTopActions.tsx
@@ -75,7 +75,7 @@ export const SelectTopActions = <R extends RecordType = RecordType>({
     <div className="flex flex-col">
       <div className="flex gap-2 p-2 border-0 border-b border-solid border-f1-border-secondary">
         <div className="flex flex-1 flex-row gap-2">
-          {showSearchBox && (
+          {showSearchBox ? (
             <div className="flex-1">
               <F0SearchInput
                 placeholder={searchBoxPlaceholder ?? i18n.toc.search}
@@ -86,8 +86,8 @@ export const SelectTopActions = <R extends RecordType = RecordType>({
                 clearable
               />
             </div>
-          )}
-          {filters && (
+          ) : null}
+          {filters ? (
             <OneFilterPicker
               filters={filters}
               value={currentFilters}
@@ -95,7 +95,7 @@ export const SelectTopActions = <R extends RecordType = RecordType>({
               mode={showPreview ? "inline" : asList ? "simple" : "compact"}
               onOpenChange={handleFiltersOpenChange}
             />
-          )}
+          ) : null}
         </div>
         <GroupingSelector
           hideLabel={true}
@@ -105,7 +105,7 @@ export const SelectTopActions = <R extends RecordType = RecordType>({
         />
       </div>
       <AnimatePresence>
-        {filters && hasActiveFilters(currentFilters) && (
+        {filters && hasActiveFilters(currentFilters) ? (
           <motion.div
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
@@ -118,7 +118,7 @@ export const SelectTopActions = <R extends RecordType = RecordType>({
               onFiltersChange={onFiltersChange}
             />
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
     </div>
   )

--- a/packages/react/src/components/F0Select/components/SelectedItems.tsx
+++ b/packages/react/src/components/F0Select/components/SelectedItems.tsx
@@ -141,16 +141,16 @@ export const SelectedItems = forwardRef<HTMLDivElement, SelectValueProps>(
 
     return (
       <div className="flex min-w-0 flex-1 justify-start gap-1.5" ref={ref}>
-        {selectedItem.avatar && (
+        {selectedItem.avatar ? (
           <div className="flex shrink-0 items-center">
             <F0Avatar avatar={selectedItem.avatar} size="xs" />
           </div>
-        )}
-        {selectedItem.icon && !hideItemIcon && (
+        ) : null}
+        {selectedItem.icon && !hideItemIcon ? (
           <div className="h-5 shrink-0 text-f1-icon">
             <F0Icon icon={selectedItem.icon} />
           </div>
-        )}
+        ) : null}
         <OneEllipsis tag="span" className="text-left text-f1-foreground">
           {/* `selectedLabel` when the item carries one: out here there is no
               group header or sibling to read the row's short label against. */}

--- a/packages/react/src/components/F0Select/components/SelectionPreview.tsx
+++ b/packages/react/src/components/F0Select/components/SelectionPreview.tsx
@@ -31,14 +31,14 @@ function PreviewItem<T extends string>({
   return (
     <div className="flex w-fit max-w-full min-w-0 items-center justify-between gap-1.5 rounded-md border border-solid border-f1-border-secondary p-1">
       <div className="flex min-w-0 flex-1 items-center gap-1.5">
-        {item.avatar && <F0Avatar avatar={item.avatar} size="xs" />}
-        {item.icon && (
+        {item.avatar ? <F0Avatar avatar={item.avatar} size="xs" /> : null}
+        {item.icon ? (
           <F0Icon
             icon={item.icon}
             size="sm"
             className="shrink-0 text-f1-icon"
           />
-        )}
+        ) : null}
         <OneEllipsis className="text-sm">{item.label}</OneEllipsis>
       </div>
       <button
@@ -130,11 +130,11 @@ export function SelectionPreview<T extends string>({
                   onDeselect={onDeselect}
                 />
               ))}
-              {isLoadingMore && (
+              {isLoadingMore ? (
                 <div className="flex items-center justify-center py-2">
                   <Spinner size="small" />
                 </div>
-              )}
+              ) : null}
             </div>
           </ScrollArea>
         </div>

--- a/packages/react/src/components/F0Slider/F0Slider.tsx
+++ b/packages/react/src/components/F0Slider/F0Slider.tsx
@@ -174,7 +174,7 @@ const F0SliderBase = forwardRef<HTMLDivElement, F0SliderProps>((props, ref) => {
         pointerInteractionRef.current = false
       }}
     >
-      {showLabel && (
+      {showLabel ? (
         <Label
           label={label}
           required={required}
@@ -182,7 +182,7 @@ const F0SliderBase = forwardRef<HTMLDivElement, F0SliderProps>((props, ref) => {
           id={labelId}
           disabled={disabled}
         />
-      )}
+      ) : null}
       <Slider
         value={[currentValue]}
         onValueChange={handleValueChange}
@@ -221,13 +221,13 @@ const F0SliderBase = forwardRef<HTMLDivElement, F0SliderProps>((props, ref) => {
           onFocus={() => setIsFocused(!pointerInteractionRef.current)}
           onBlur={() => setIsFocused(false)}
         />
-        {showTooltip !== "never" && (
+        {showTooltip !== "never" ? (
           <SliderTooltip
             visible={tooltipVisible}
             content={formatValue(currentValue)}
             style={{ left: `calc(${percent}% + ${thumbInBoundsOffset}px)` }}
           />
-        )}
+        ) : null}
       </Slider>
       <SliderRangeLabels minLabel={minLabel} maxLabel={maxLabel} />
       <div id={messagesId} role="status" aria-live="polite">

--- a/packages/react/src/components/F0Slider/F0SliderSkeleton.tsx
+++ b/packages/react/src/components/F0Slider/F0SliderSkeleton.tsx
@@ -13,7 +13,7 @@ const F0SliderSkeleton = ({ hideLabel = false }: F0SliderSkeletonProps) => {
       aria-busy="true"
       aria-live="polite"
     >
-      {!hideLabel && <Skeleton className="h-4 w-24 rounded-md" />}
+      {!hideLabel ? <Skeleton className="h-4 w-24 rounded-md" /> : null}
       <div className="flex items-center py-2">
         <Skeleton className="h-1.5 w-full rounded-full" />
       </div>

--- a/packages/react/src/components/F0Slider/components/SliderTooltip.tsx
+++ b/packages/react/src/components/F0Slider/components/SliderTooltip.tsx
@@ -19,7 +19,7 @@ export const SliderTooltip = ({
 
   return (
     <AnimatePresence>
-      {visible && (
+      {visible ? (
         <motion.div
           initial={{ opacity: 0, x: "-50%", y: 2 }}
           animate={{ opacity: 1, x: "-50%", y: 0 }}
@@ -36,7 +36,7 @@ export const SliderTooltip = ({
         >
           {content}
         </motion.div>
-      )}
+      ) : null}
     </AnimatePresence>
   )
 }

--- a/packages/react/src/components/F0VideoPlayer/components/Controls.tsx
+++ b/packages/react/src/components/F0VideoPlayer/components/Controls.tsx
@@ -190,7 +190,7 @@ export function Controls({
         containerRef={containerRef}
       />
 
-      {captionsInBar && (
+      {captionsInBar ? (
         // Filled glyph when captions are on, line glyph when off; `aria-pressed`
         // conveys the state to assistive tech (the label stays stable).
         <F0Button
@@ -202,9 +202,9 @@ export function Controls({
           aria-pressed={captionsOn}
           onClick={onToggleCaptions}
         />
-      )}
+      ) : null}
 
-      {audioDescriptionInBar && (
+      {audioDescriptionInBar ? (
         // Filled "AD" badge when on, line badge when off — the same on/off
         // language as captions, legible over video. `hideLabel` gives the
         // captions-style tooltip from the label; `aria-pressed` conveys state.
@@ -221,9 +221,9 @@ export function Controls({
           aria-pressed={audioDescriptionOn}
           onClick={onToggleAudioDescription}
         />
-      )}
+      ) : null}
 
-      {showSettings && (
+      {showSettings ? (
         <SettingsMenu
           containerRef={containerRef}
           audioLanguages={audioLanguages}
@@ -240,9 +240,9 @@ export function Controls({
           onAudioDescriptionLanguageChange={onAudioDescriptionLanguageChange}
           onAudioDescriptionOff={onAudioDescriptionOff}
         />
-      )}
+      ) : null}
 
-      {download && (
+      {download ? (
         <F0Button
           variant="ghost"
           size="sm"
@@ -251,7 +251,7 @@ export function Controls({
           label={download.label}
           onClick={download.onClick}
         />
-      )}
+      ) : null}
 
       <F0Button
         variant="ghost"

--- a/packages/react/src/components/F0VideoPlayer/components/PlaybackRateMenu.tsx
+++ b/packages/react/src/components/F0VideoPlayer/components/PlaybackRateMenu.tsx
@@ -104,11 +104,11 @@ export function PlaybackRateMenu({
                 setOpen(false)
               }}
             >
-              {isActive && (
+              {isActive ? (
                 <span className="absolute left-2.5 inline-flex items-center">
                   <Check />
                 </span>
-              )}
+              ) : null}
               {formatPlaybackRate(rate)}
             </button>
           )

--- a/packages/react/src/components/F0VideoPlayer/components/Seekbar.tsx
+++ b/packages/react/src/components/F0VideoPlayer/components/Seekbar.tsx
@@ -153,20 +153,20 @@ export function Seekbar({
         className="pointer-events-none absolute left-0 h-1 rounded-sm bg-f1-foreground"
         style={{ width: `${progressFraction * 100}%` }}
       />
-      {showMarker && (
+      {showMarker ? (
         <div
           className="pointer-events-none absolute z-[1] h-2.5 w-0.5 -translate-x-px bg-f1-foreground/95"
           style={{ left: `${markerFraction * 100}%` }}
           aria-hidden="true"
         />
-      )}
+      ) : null}
       <div
         className="pointer-events-none absolute z-[2] h-3 w-3 -translate-x-1/2 rounded-full bg-f1-foreground shadow-[0_0_4px_rgba(0,0,0,0.4)]"
         style={{ left: `${progressFraction * 100}%` }}
       />
-      {isHoveringBlocked && (
+      {isHoveringBlocked ? (
         <div className="absolute inset-0 cursor-not-allowed" />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/F0VideoPlayer/components/SettingsMenu.tsx
+++ b/packages/react/src/components/F0VideoPlayer/components/SettingsMenu.tsx
@@ -94,11 +94,11 @@ function LanguageSubmenu({
                 {languageLabel(option)}
               </DropdownMenuRadioItem>
             ))}
-            {toggleable && (
+            {toggleable ? (
               <DropdownMenuRadioItem value={OFF} className={ITEM_CLASS}>
                 {offLabel}
               </DropdownMenuRadioItem>
-            )}
+            ) : null}
           </DropdownMenuRadioGroup>
         </DropdownMenuSubContent>
       </DropdownMenuPortal>
@@ -180,7 +180,7 @@ export function SettingsMenu({
         align="end"
         className={CONTENT_CLASS}
       >
-        {audioLanguages.length > 1 && (
+        {audioLanguages.length > 1 ? (
           <LanguageSubmenu
             icon={Globe}
             label={t("videoPlayer.audio")}
@@ -190,8 +190,8 @@ export function SettingsMenu({
             onLanguageChange={onAudioLanguageChange}
             offLabel={offLabel}
           />
-        )}
-        {captionLanguages.length > 1 && (
+        ) : null}
+        {captionLanguages.length > 1 ? (
           <LanguageSubmenu
             icon={CaptionsLineIcon}
             label={t("videoPlayer.subtitles")}
@@ -203,8 +203,8 @@ export function SettingsMenu({
             onOff={onCaptionsOff}
             offLabel={offLabel}
           />
-        )}
-        {audioDescriptionLanguages.length > 1 && (
+        ) : null}
+        {audioDescriptionLanguages.length > 1 ? (
           <LanguageSubmenu
             icon={AudioDescriptionLineIcon}
             label={t("videoPlayer.audioDescription")}
@@ -216,7 +216,7 @@ export function SettingsMenu({
             onOff={onAudioDescriptionOff}
             offLabel={offLabel}
           />
-        )}
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/packages/react/src/components/F0VideoPlayer/internal.tsx
+++ b/packages/react/src/components/F0VideoPlayer/internal.tsx
@@ -299,29 +299,29 @@ export function F0VideoPlayerInternal({
         // immediately (otherwise the opacity gate would hide the poster too).
         style={{ opacity: video.videoLoaded || poster ? 1 : 0 }}
       >
-        {captions.trackSrc && (
+        {captions.trackSrc ? (
           <track
             kind="captions"
             src={captions.trackSrc}
             label={t("videoPlayer.captions")}
             default={false}
           />
-        )}
-        {audioDescription.trackSrc && (
+        ) : null}
+        {audioDescription.trackSrc ? (
           <track
             kind="descriptions"
             src={audioDescription.trackSrc}
             label={t("videoPlayer.audioDescription")}
             default={false}
           />
-        )}
+        ) : null}
       </video>
 
       {/* Center play affordance while paused, so a still frame / poster reads
           as a video without hovering to reveal the controls. Visual only
           (`aria-hidden`, not focusable): the labelled play control lives in the
           controls bar and Space toggles playback on the focused region. */}
-      {!video.isPlaying && (
+      {!video.isPlaying ? (
         <div
           aria-hidden
           data-video-play-overlay
@@ -336,14 +336,14 @@ export function F0VideoPlayerInternal({
             <F0Icon icon={SolidPlay} size="lg" color="#fff" />
           </button>
         </div>
-      )}
+      ) : null}
 
       {/* Description text shown as a caption for deaf/HoH viewers when captions
           are on — the visual counterpart of the spoken audio description. Drawn
           here (top, distinct italic style) since browsers don't render
           `kind="descriptions"` tracks; `aria-hidden` because screen-reader users
           get the spoken description instead. */}
-      {captions.showing && audioDescription.activeCue && (
+      {captions.showing && audioDescription.activeCue ? (
         <div
           aria-hidden
           className="dark pointer-events-none absolute inset-x-0 top-0 z-[2] flex justify-center p-3"
@@ -355,7 +355,7 @@ export function F0VideoPlayerInternal({
             {audioDescription.activeCue}
           </p>
         </div>
-      )}
+      ) : null}
 
       {/* Polite live region so play/pause via keyboard shortcuts is announced. */}
       <span className="sr-only" aria-live="polite">
@@ -364,7 +364,7 @@ export function F0VideoPlayerInternal({
 
       {/* Render the controls only once the video is ready — avoids focusable
           controls living inside an `aria-hidden` subtree before load. */}
-      {video.videoLoaded && (
+      {video.videoLoaded ? (
         <Controls
           isPlaying={video.isPlaying}
           currentTime={video.currentTime}
@@ -403,7 +403,7 @@ export function F0VideoPlayerInternal({
           onSeek={seek}
           download={download}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/OneCalendar/OneCalendar.stories.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.stories.tsx
@@ -74,7 +74,7 @@ function SelectedDateDisplay({ range }: { range: DateRange }) {
       <h4>Selected</h4>
       <p className="text-sm text-f1-foreground">
         {formatDate(range.from)}
-        {range.to && <> - {formatDate(range.to)}</>}
+        {range.to ? <> - {formatDate(range.to)}</> : null}
         <br />
         <span className="tabular-nums">
           ({range.from.toLocaleDateString()} - {range.to?.toLocaleDateString()})
@@ -117,7 +117,7 @@ export const MonthSingle: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -156,7 +156,7 @@ export const MonthRange: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -193,7 +193,7 @@ export const YearSingle: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -232,7 +232,7 @@ export const YearRange: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -273,7 +273,7 @@ export const DaySingle: Story = {
           defaultSelected={selectedRange?.from}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -315,7 +315,7 @@ export const DayRange: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -359,7 +359,7 @@ export const Week: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -405,7 +405,7 @@ export const QuarterSingle: Story = {
           defaultSelected={selectedDate}
           onSelect={handleSelect}
         />
-        {displayRange && <SelectedDateDisplay range={displayRange} />}
+        {displayRange ? <SelectedDateDisplay range={displayRange} /> : null}
       </div>
     )
   },
@@ -448,7 +448,7 @@ export const QuarterRange: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -494,7 +494,7 @@ export const HalfYearSingle: Story = {
           defaultSelected={selectedDate}
           onSelect={handleSelect}
         />
-        {displayRange && <SelectedDateDisplay range={displayRange} />}
+        {displayRange ? <SelectedDateDisplay range={displayRange} /> : null}
       </div>
     )
   },
@@ -536,7 +536,7 @@ export const HalfYearRange: Story = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -690,7 +690,7 @@ export const CompactMonthSingle: OneCalendarInternalStory = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -730,7 +730,7 @@ export const CompactMonthRange: OneCalendarInternalStory = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -775,7 +775,7 @@ export const CompactWeek: OneCalendarInternalStory = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -818,7 +818,7 @@ export const CompactDayRange: OneCalendarInternalStory = {
           defaultSelected={selectedRange}
           onSelect={handleSelect}
         />
-        {selectedRange && <SelectedDateDisplay range={selectedRange} />}
+        {selectedRange ? <SelectedDateDisplay range={selectedRange} /> : null}
       </div>
     )
   },
@@ -871,11 +871,11 @@ export const RegularVsCompact: Story = {
             onSelect={handleSelect}
           />
         </div>
-        {selectedRange && (
+        {selectedRange ? (
           <div className="mt-6">
             <SelectedDateDisplay range={selectedRange} />
           </div>
-        )}
+        ) : null}
       </div>
     )
   },

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -327,7 +327,7 @@ const OneCalendarInternal = ({
 
   return (
     <div className="flex flex-col">
-      {showInput && !granularity.hideDateInput && (
+      {showInput && !granularity.hideDateInput ? (
         <div className="mb-2 flex gap-2">
           <Input
             label={i18n.date.from}
@@ -347,7 +347,7 @@ const OneCalendarInternal = ({
             }}
             onChange={(value) => setInputValue({ ...inputValue, from: value })}
           />
-          {mode === "range" && (
+          {mode === "range" ? (
             <Input
               label={i18n.date.to}
               hideLabel
@@ -366,10 +366,10 @@ const OneCalendarInternal = ({
               }}
               onChange={(value) => setInputValue({ ...inputValue, to: value })}
             />
-          )}
+          ) : null}
         </div>
-      )}
-      {showNavigation && (
+      ) : null}
+      {showNavigation ? (
         <div
           className={cn(
             "flex items-center justify-between",
@@ -417,7 +417,7 @@ const OneCalendarInternal = ({
             />
           </div>
         </div>
-      )}
+      ) : null}
       <div className="relative">
         {granularity.render({
           mode,

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -167,7 +167,7 @@ export function CalendarHeaderDropdowns({
     // min-w-0 lets the header shrink this side instead of pushing the
     // prev/next arrows out of the container.
     <div className="flex min-w-0 items-center gap-1">
-      {showMonth && (
+      {showMonth ? (
         // Fixed width so the trigger (and the popover around it) doesn't
         // resize when switching between short and long month names. Compact
         // pairs a narrower trigger with short month labels: 5.5rem fits the
@@ -185,7 +185,7 @@ export function CalendarHeaderDropdowns({
             fitContentWidth
           />
         </div>
-      )}
+      ) : null}
       <div className={compact ? "w-[5.5rem]" : "w-[6rem]"}>
         <F0Select
           size="sm"

--- a/packages/react/src/components/OneCalendar/granularities/halfyear/HalfyearView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/halfyear/HalfyearView.tsx
@@ -236,14 +236,14 @@ export const HalfYearView = ({
                         "rounded-none bg-f1-background-selected after:opacity-0 after:transition-none first:rounded-l-md last:rounded-r-md hover:bg-f1-background-selected [&>span]:text-f1-foreground-selected"
                     )}
                   >
-                    {isStart && (
+                    {isStart ? (
                       <div className="absolute inset-y-0 right-0 z-0 w-1/2 bg-f1-background-selected" />
-                    )}
-                    {isEnd && (
+                    ) : null}
+                    {isEnd ? (
                       <div className="absolute inset-y-0 left-0 z-0 w-1/2 bg-f1-background-selected" />
-                    )}
+                    ) : null}
                     <span className="z-10 font-medium">H{halfYear}</span>
-                    {isCurrent && (
+                    {isCurrent ? (
                       <div
                         className={cn(
                           "absolute inset-x-0 bottom-1 z-20 mx-auto h-0.5 w-1.5 rounded-full bg-f1-background-selected-bold transition-colors duration-100",
@@ -256,7 +256,7 @@ export const HalfYearView = ({
                             "bg-f1-background-selected-bold"
                         )}
                       />
-                    )}
+                    ) : null}
                   </button>
                 )
               })}

--- a/packages/react/src/components/OneCalendar/granularities/month/MonthView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/month/MonthView.tsx
@@ -243,7 +243,7 @@ export function MonthView({
               )}
             >
               <span>{month.name}</span>
-              {isCurrent && (
+              {isCurrent ? (
                 <div
                   className={cn(
                     "absolute inset-x-0 z-20 mx-auto h-0.5 rounded-full bg-f1-background-selected-bold transition-colors duration-100",
@@ -257,7 +257,7 @@ export function MonthView({
                       "bg-f1-background-selected-bold"
                   )}
                 />
-              )}
+              ) : null}
             </button>
           )
         })}

--- a/packages/react/src/components/OneCalendar/granularities/periods/PeriodsView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/periods/PeriodsView.tsx
@@ -68,11 +68,11 @@ export function PeriodsView({
 
   return (
     <div className="flex flex-col gap-2">
-      {header && (
+      {header ? (
         <div className="px-2 font-medium text-f1-foreground-secondary">
           {header}
         </div>
-      )}
+      ) : null}
       <AnimatePresence
         mode="popLayout"
         initial={false}

--- a/packages/react/src/components/OneCalendar/granularities/quarter/QuarterView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/quarter/QuarterView.tsx
@@ -234,14 +234,14 @@ export const QuarterView = ({
                         "rounded-none bg-f1-background-selected after:opacity-0 after:transition-none first:rounded-l-md last:rounded-r-md hover:bg-f1-background-selected [&>span]:text-f1-foreground-selected"
                     )}
                   >
-                    {isStart && (
+                    {isStart ? (
                       <div className="absolute inset-y-0 right-0 z-0 w-1/2 bg-f1-background-selected" />
-                    )}
-                    {isEnd && (
+                    ) : null}
+                    {isEnd ? (
                       <div className="absolute inset-y-0 left-0 z-0 w-1/2 bg-f1-background-selected" />
-                    )}
+                    ) : null}
                     <span className="z-10 font-medium">Q{quarter}</span>
-                    {isCurrent && (
+                    {isCurrent ? (
                       <div
                         className={cn(
                           "absolute inset-x-0 bottom-1 z-20 mx-auto h-0.5 w-1.5 rounded-full bg-f1-background-selected-bold transition-colors duration-100",
@@ -254,7 +254,7 @@ export const QuarterView = ({
                             "bg-f1-background-selected-bold"
                         )}
                       />
-                    )}
+                    ) : null}
                   </button>
                 )
               })}

--- a/packages/react/src/components/OneCalendar/granularities/year/YearView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/year/YearView.tsx
@@ -203,7 +203,7 @@ export function YearView({
               )}
             >
               <span>{year}</span>
-              {isCurrent && (
+              {isCurrent ? (
                 <div
                   className={cn(
                     "absolute inset-x-0 bottom-1 z-20 mx-auto h-0.5 w-1.5 rounded-full bg-f1-background-selected-bold transition-colors duration-100",
@@ -216,7 +216,7 @@ export function YearView({
                       "bg-f1-background-selected-bold"
                   )}
                 />
-              )}
+              ) : null}
             </button>
           )
         })}

--- a/packages/react/src/components/OneChip/index.tsx
+++ b/packages/react/src/components/OneChip/index.tsx
@@ -76,9 +76,11 @@ const _Chip = ({
   const closeDescriptionId = useId()
   const content = (
     <>
-      {avatar && <F0Avatar avatar={avatar} size="xs" />}
+      {avatar ? <F0Avatar avatar={avatar} size="xs" /> : null}
       <div className="flex items-center gap-0.5">
-        {icon && <F0Icon icon={icon} size="sm" className="text-f1-icon" />}
+        {icon ? (
+          <F0Icon icon={icon} size="sm" className="text-f1-icon" />
+        ) : null}
         <span
           id={onClose ? closeDescriptionId : undefined}
           className={deactivated ? "text-f1-foreground/[0.61]" : undefined}
@@ -113,7 +115,7 @@ const _Chip = ({
       ) : (
         content
       )}
-      {onClose && (
+      {onClose ? (
         <button
           type="button"
           onClick={(e) => {
@@ -132,7 +134,7 @@ const _Chip = ({
         >
           <F0Icon icon={CrossedCircle} size="sm" />
         </button>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
+++ b/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
@@ -18,19 +18,23 @@ function _OneEmptyState({
       className="@container flex flex-col items-center justify-center gap-5 p-8"
       {...rest}
     >
-      {variant === "default" && <F0AvatarEmoji emoji={emoji!} size="lg" />}
-      {variant !== "default" && <F0AvatarAlert type={variant} size="lg" />}
+      {variant === "default" ? (
+        <F0AvatarEmoji emoji={emoji!} size="lg" />
+      ) : null}
+      {variant !== "default" ? (
+        <F0AvatarAlert type={variant} size="lg" />
+      ) : null}
       <div className="flex flex-col items-center justify-center gap-0.5">
         <p className="text-center text-lg font-medium text-f1-foreground">
           {title}
         </p>
-        {description && (
+        {description ? (
           <p className="max-w-96 text-center text-f1-foreground-secondary">
             {description}
           </p>
-        )}
+        ) : null}
       </div>
-      {actions && (
+      {actions ? (
         <div className="flex w-full max-w-full flex-col items-center justify-center gap-2 @sm:w-fit @sm:flex-row @sm:flex-wrap @sm:gap-3 [&>div]:w-full">
           {actions.map((action) => {
             if (action.type === "upsell") {
@@ -59,7 +63,7 @@ function _OneEmptyState({
             }
           })}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/RichText/F0NotesTextEditor/F0NotesTextEditor.tsx
+++ b/packages/react/src/components/RichText/F0NotesTextEditor/F0NotesTextEditor.tsx
@@ -363,7 +363,7 @@ const F0NotesTextEditorComponent = forwardRef<
       ref={containerRef}
       id={editorId}
     >
-      {showHeader && (
+      {showHeader ? (
         <Header
           primaryAction={primaryAction}
           secondaryActions={secondaryActions}
@@ -371,12 +371,12 @@ const F0NotesTextEditorComponent = forwardRef<
           otherActions={otherActions}
           status={status}
         />
-      )}
-      {error && (
+      ) : null}
+      {error ? (
         <ImageUploadError errorType={error} onDismiss={() => setError(null)} />
-      )}
+      ) : null}
       <AnimatePresence>
-        {enhance.error && !enhance.isLoading && (
+        {enhance.error && !enhance.isLoading ? (
           <motion.div
             key="enhance-error"
             initial={{ height: 0, opacity: 0, y: -20 }}
@@ -390,27 +390,27 @@ const F0NotesTextEditorComponent = forwardRef<
               onDismiss={enhance.clearError}
             />
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
       <ScrollArea className="notes-text-editor-scroll h-full gap-6">
-        {alert && (
+        {alert ? (
           <div className="mx-auto w-full max-w-[824px] sm:px-14 px-0">
             <F0Alert {...alert} />
           </div>
-        )}
-        {showTitle && (
+        ) : null}
+        {showTitle ? (
           <Title
             value={title}
             onChange={onTitleChange ? setTitle : undefined}
             placeholder={titlePlaceholder}
             disabled={!onTitleChange || readonly}
           />
-        )}
+        ) : null}
         <div
           className="notes-text-editor h-full"
           onClick={() => editor.commands.focus()}
         >
-          {!readonly && (
+          {!readonly ? (
             <DragHandle
               editor={editor}
               tippyOptions={tippyOptions}
@@ -437,7 +437,7 @@ const F0NotesTextEditorComponent = forwardRef<
                 </div>
               </div>
             </DragHandle>
-          )}
+          ) : null}
 
           <EditorContent
             editor={editor}
@@ -445,7 +445,7 @@ const F0NotesTextEditorComponent = forwardRef<
           />
         </div>
       </ScrollArea>
-      {!readonly && (
+      {!readonly ? (
         <EditorBubbleMenu
           editorId={editorId}
           editor={editor}
@@ -455,7 +455,7 @@ const F0NotesTextEditorComponent = forwardRef<
           plainHtmlMode={false}
           enhance={enhance}
         />
-      )}
+      ) : null}
     </div>
   )
 })
@@ -471,7 +471,7 @@ export const F0NotesTextEditorSkeleton = ({
       aria-busy="true"
       aria-live="polite"
     >
-      {withHeader && (
+      {withHeader ? (
         <div className="flex items-center justify-between border-b border-f1-border px-6 py-3">
           <div className="flex items-center gap-3">
             <Skeleton className="h-6 w-20 rounded-md" />
@@ -482,9 +482,9 @@ export const F0NotesTextEditorSkeleton = ({
             <Skeleton className="h-8 w-12 rounded-md" />
           </div>
         </div>
-      )}
+      ) : null}
 
-      {withToolbar && (
+      {withToolbar ? (
         <div className="absolute bottom-8 left-1/2 z-50 flex -translate-x-1/2 flex-row items-center gap-[9px] rounded-lg bg-f1-background p-2 shadow-md">
           <Skeleton className="h-8 w-8 rounded" />
           <div className="flex items-center gap-0.5">
@@ -507,13 +507,13 @@ export const F0NotesTextEditorSkeleton = ({
             <Skeleton className="h-8 w-8 rounded" />
           </div>
         </div>
-      )}
+      ) : null}
       <ScrollArea className="h-full gap-6">
-        {withTitle && (
+        {withTitle ? (
           <div className="mx-auto flex w-full max-w-[824px] flex-col px-14 pb-5 pt-5">
             <Skeleton className="h-8 w-80 rounded-md" />
           </div>
-        )}
+        ) : null}
 
         <div className="h-full">
           <div className="pb-28 [&>div]:mx-auto [&>div]:w-full [&>div]:max-w-[824px] [&>div]:px-14">

--- a/packages/react/src/components/RichText/F0NotesTextEditor/components/Header/index.tsx
+++ b/packages/react/src/components/RichText/F0NotesTextEditor/components/Header/index.tsx
@@ -92,11 +92,11 @@ const Header = ({
 
   return (
     <div className="flex flex-col">
-      {(allMetadata.length > 0 || hasActions) && (
+      {allMetadata.length > 0 || hasActions ? (
         <div className="flex flex-col items-start justify-between gap-2 sm:px-6 px-0 py-4 sm:flex-row sm:items-center">
-          {allMetadata.length > 0 && <Metadata items={allMetadata} />}
+          {allMetadata.length > 0 ? <Metadata items={allMetadata} /> : null}
           <div className="flex flex-shrink-0 flex-row items-center gap-2">
-            {hasOtherActions && <Dropdown items={visibleOtherActions} />}
+            {hasOtherActions ? <Dropdown items={visibleOtherActions} /> : null}
             {visibleSecondaryActions.map((action, index) =>
               isSecondaryDropdownAction(action) ? (
                 <F0ButtonDropdown
@@ -123,10 +123,10 @@ const Header = ({
               )
             )}
             {isPrimaryActionVisible &&
-              (hasSecondaryActions || hasOtherActions) && (
-                <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
-              )}
-            {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
+            (hasSecondaryActions || hasOtherActions) ? (
+              <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
+            ) : null}
+            {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) ? (
               <F0Button
                 label={primaryAction.label}
                 onClick={primaryAction.onClick}
@@ -135,21 +135,21 @@ const Header = ({
                 disabled={primaryAction.disabled}
                 tooltip={primaryAction.tooltip}
               />
-            )}
+            ) : null}
             {isPrimaryActionVisible &&
-              isPrimaryDropdownAction(primaryAction) && (
-                <F0ButtonDropdown
-                  items={primaryAction.items}
-                  onClick={primaryAction.onClick}
-                  variant="default"
-                  value={primaryAction.value}
-                  disabled={primaryAction.disabled}
-                  tooltip={primaryAction.tooltip}
-                />
-              )}
+            isPrimaryDropdownAction(primaryAction) ? (
+              <F0ButtonDropdown
+                items={primaryAction.items}
+                onClick={primaryAction.onClick}
+                variant="default"
+                value={primaryAction.value}
+                disabled={primaryAction.disabled}
+                tooltip={primaryAction.tooltip}
+              />
+            ) : null}
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/F0RichTextEditor.tsx
@@ -396,9 +396,9 @@ const F0RichTextEditorComponent = forwardRef<
             "border-f1-border-critical-bold bg-f1-background-critical bg-opacity-10"
         )}
       >
-        {isFullscreen && (
+        {isFullscreen ? (
           <div className="pointer-events-none fixed inset-0 z-40" />
-        )}
+        ) : null}
 
         <Head
           fullScreenMode={fullScreenMode}
@@ -447,7 +447,7 @@ const F0RichTextEditorComponent = forwardRef<
           <AnimatePresence>
             {/* The floating toolbar disappears the moment an enhance kicks off
                 (disableButtons covers loading, review and error). */}
-            {isFullscreen && isToolbarOpen && !enhance.disableButtons && (
+            {isFullscreen && isToolbarOpen && !enhance.disableButtons ? (
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -477,7 +477,7 @@ const F0RichTextEditorComponent = forwardRef<
                       icon={Cross}
                     />
                     <ToolbarDivider />
-                    {enhanceConfig && (
+                    {enhanceConfig ? (
                       <>
                         <EnhanceActivator
                           enhance={enhance}
@@ -487,7 +487,7 @@ const F0RichTextEditorComponent = forwardRef<
                         />
                         <ToolbarDivider />
                       </>
-                    )}
+                    ) : null}
                     <Toolbar
                       editor={editor}
                       isFullscreen={isFullscreen}
@@ -497,13 +497,13 @@ const F0RichTextEditorComponent = forwardRef<
                   </div>
                 </div>
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
 
           {/* In review the floating toolbar disappears entirely and the
               compact accept/discard menu takes its place. */}
           <AnimatePresence>
-            {isFullscreen && isToolbarOpen && enhance.isAcceptChangesOpen && (
+            {isFullscreen && isToolbarOpen && enhance.isAcceptChangesOpen ? (
               <motion.div
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -528,7 +528,7 @@ const F0RichTextEditorComponent = forwardRef<
                   />
                 </div>
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
         </div>
 
@@ -540,7 +540,7 @@ const F0RichTextEditorComponent = forwardRef<
           )}
         >
           <AnimatePresence>
-            {enhance.error && !enhance.isLoading && (
+            {enhance.error && !enhance.isLoading ? (
               <motion.div
                 key="accordion"
                 initial={{ height: 0, opacity: 0, y: -20 }}
@@ -554,11 +554,11 @@ const F0RichTextEditorComponent = forwardRef<
                   onDismiss={enhance.clearError}
                 />
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
 
           <AnimatePresence initial={false}>
-            {dictationError && (
+            {dictationError ? (
               <motion.div
                 key="dictation-error"
                 role="alert"
@@ -574,7 +574,7 @@ const F0RichTextEditorComponent = forwardRef<
                   dismissLabel={i18n.actions.close}
                 />
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
 
           <FileList

--- a/packages/react/src/components/RichText/F0RichTextEditor/components/FileList/index.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/components/FileList/index.tsx
@@ -56,7 +56,7 @@ const FileList = ({
         aria-label="Upload file"
       />
       <AnimatePresence>
-        {files.length > 0 && (
+        {files.length > 0 ? (
           <motion.div
             key="filelist-accordion"
             initial={{ height: 0, opacity: 0, y: -20 }}
@@ -81,7 +81,7 @@ const FileList = ({
               ))}
             </div>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
     </>
   )

--- a/packages/react/src/components/RichText/F0RichTextEditor/components/Footer/ActionsMenu/index.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/components/Footer/ActionsMenu/index.tsx
@@ -141,21 +141,22 @@ const SecondaryActionsButtons = ({
       })}
 
       {/* Render button actions - these might be hidden in little mode */}
-      {!shouldHideButtonActions &&
-        buttonActions.map((action, index) => (
-          <F0Button
-            key={`button-${index}`}
-            onClick={(e) => {
-              e.preventDefault()
-              action.onClick()
-            }}
-            variant={"variant" in action ? action.variant : "outline"}
-            size="md"
-            label={action.label}
-            disabled={disableButtons || action.disabled}
-            icon={"icon" in action ? action.icon : undefined}
-          />
-        ))}
+      {!shouldHideButtonActions
+        ? buttonActions.map((action, index) => (
+            <F0Button
+              key={`button-${index}`}
+              onClick={(e) => {
+                e.preventDefault()
+                action.onClick()
+              }}
+              variant={"variant" in action ? action.variant : "outline"}
+              size="md"
+              label={action.label}
+              disabled={disableButtons || action.disabled}
+              icon={"icon" in action ? action.icon : undefined}
+            />
+          ))
+        : null}
     </div>
   )
 }
@@ -237,7 +238,7 @@ const renderPrimaryActionContent = ({
           icon={sub.icon}
         />
       ))}
-      {primaryAction.subActions?.length && <ToolbarDivider />}
+      {primaryAction.subActions?.length ? <ToolbarDivider /> : null}
       <PrimaryActionButton
         primaryAction={primaryAction.action}
         disableButtons={disableButtons}
@@ -297,17 +298,19 @@ const ActionsMenu = ({
         disableButtons={disableButtons}
       />
 
-      {shouldShowDivider && <ToolbarDivider />}
+      {shouldShowDivider ? <ToolbarDivider /> : null}
 
-      {primaryAction &&
-        renderPrimaryActionContent({
-          primaryAction,
-          isFullscreen,
-          listOfActions,
-          handleOnClick: onActionClick,
-          disableButtons,
-          includeSecondaryInDropdown: shouldIncludeSecondaryInDropdown ?? false,
-        })}
+      {primaryAction
+        ? renderPrimaryActionContent({
+            primaryAction,
+            isFullscreen,
+            listOfActions,
+            handleOnClick: onActionClick,
+            disableButtons,
+            includeSecondaryInDropdown:
+              shouldIncludeSecondaryInDropdown ?? false,
+          })
+        : null}
     </div>
   )
 }

--- a/packages/react/src/components/RichText/F0RichTextEditor/components/Footer/index.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/components/Footer/index.tsx
@@ -126,7 +126,7 @@ const Footer = ({
       {/* Always second, right after the toolbar button: while transcribing
           this button shows the spinner exactly where the recording confirm
           (✓) button was. */}
-      {canRecord && (
+      {canRecord ? (
         <F0Button
           label={i18n.ai.recordAudio}
           hideLabel
@@ -139,9 +139,9 @@ const Footer = ({
           }}
           loading={recordingStatus === "transcribing"}
         />
-      )}
+      ) : null}
 
-      {canUseFiles && (
+      {canUseFiles ? (
         <F0Button
           icon={Paperclip}
           onClick={handleFileClick}
@@ -150,9 +150,9 @@ const Footer = ({
           variant="outline"
           disabled={disableButtons}
         />
-      )}
+      ) : null}
 
-      {enhance.config && !isFullscreen && (
+      {enhance.config && !isFullscreen ? (
         <EnhanceActivator
           enhance={enhance}
           disabled={disableButtons}
@@ -162,13 +162,13 @@ const Footer = ({
           onOpenChange={setEnhanceMenuOpen}
           hideReviewPanel
         />
-      )}
+      ) : null}
 
-      {maxCharacters && !useLittleMode && (
+      {maxCharacters && !useLittleMode ? (
         <p className="text-sm font-normal text-f1-foreground-secondary">
           {characterCount}/{maxCharacters}
         </p>
-      )}
+      ) : null}
     </>
   )
 
@@ -222,7 +222,7 @@ const Footer = ({
       {/* The footer content disappears while a footer-initiated enhance is in
           flight; during review the menu shows up in its place, spanning the
           whole footer width without a border. */}
-      {hideFooterContent && enhance.isAcceptChangesOpen && (
+      {hideFooterContent && enhance.isAcceptChangesOpen ? (
         <div className="absolute inset-x-0 inset-y-0 z-20 flex items-center">
           <AIEnhanceMenu
             onSelect={() => {}}
@@ -234,14 +234,14 @@ const Footer = ({
             onRetry={enhance.retryChanges}
           />
         </div>
-      )}
+      ) : null}
       <div
         className={cn(
           "relative flex flex-grow items-center gap-2",
           hideFooterContent && "invisible"
         )}
       >
-        {!isFullscreen && (
+        {!isFullscreen ? (
           <motion.div
             initial={{ width: 0 }}
             animate={{ width: isToolbarOpen ? "100%" : 0 }}
@@ -284,9 +284,9 @@ const Footer = ({
               />
             </div>
           </motion.div>
-        )}
+        ) : null}
 
-        {!isFullscreen && (
+        {!isFullscreen ? (
           <motion.div
             className="flex items-center gap-2"
             initial={{ opacity: 1 }}
@@ -302,14 +302,14 @@ const Footer = ({
             {renderToolbarButton()}
             {renderActionButtons()}
           </motion.div>
-        )}
+        ) : null}
 
-        {isFullscreen && (
+        {isFullscreen ? (
           <div className="flex items-center gap-2">
-            {!isToolbarOpen && renderToolbarButton()}
+            {!isToolbarOpen ? renderToolbarButton() : null}
             {renderActionButtons()}
           </div>
-        )}
+        ) : null}
       </div>
 
       <div className={cn("contents", hideFooterContent && "invisible")}>

--- a/packages/react/src/components/RichText/F0RichTextEditor/components/Head/index.tsx
+++ b/packages/react/src/components/RichText/F0RichTextEditor/components/Head/index.tsx
@@ -18,7 +18,7 @@ const Head = ({
 }: HeadProps) => {
   return (
     <>
-      {fullScreenMode && (
+      {fullScreenMode ? (
         <div className="absolute right-3 top-3 z-[1300]">
           <F0Button
             onClick={(e) => {
@@ -34,12 +34,12 @@ const Head = ({
             disabled={disableAllButtons}
           />
         </div>
-      )}
-      {isFullscreen && (
+      ) : null}
+      {isFullscreen ? (
         <div className="flex w-full items-start justify-center px-10 pt-24">
           <h1 className="font-bold w-full max-w-[824px] text-3xl">{title}</h1>
         </div>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/components/RichText/internal/BubbleMenu/index.tsx
+++ b/packages/react/src/components/RichText/internal/BubbleMenu/index.tsx
@@ -120,7 +120,7 @@ export const EditorBubbleMenu = memo(function EditorBubbleMenu({
         return true
       }}
     >
-      {!isToolbarOpen && (!enhanceActive || shouldKeepEnhanceVisible) && (
+      {!isToolbarOpen && (!enhanceActive || shouldKeepEnhanceVisible) ? (
         <div
           ref={bubbleMenuContainerRef}
           className={cn(
@@ -131,7 +131,7 @@ export const EditorBubbleMenu = memo(function EditorBubbleMenu({
             shouldKeepEnhanceVisible && "invisible"
           )}
         >
-          {enhance?.config && (
+          {enhance?.config ? (
             <>
               <EnhanceActivator
                 enhance={enhance}
@@ -143,7 +143,7 @@ export const EditorBubbleMenu = memo(function EditorBubbleMenu({
               />
               <ToolbarDivider />
             </>
-          )}
+          ) : null}
           <Toolbar
             editor={editor}
             disableButtons={disableButtons}
@@ -152,7 +152,7 @@ export const EditorBubbleMenu = memo(function EditorBubbleMenu({
             plainHtmlMode={plainHtmlMode}
           />
         </div>
-      )}
+      ) : null}
     </BubbleMenu>
   )
 })

--- a/packages/react/src/components/RichText/internal/Enhance/EnhanceActivator.tsx
+++ b/packages/react/src/components/RichText/internal/Enhance/EnhanceActivator.tsx
@@ -305,9 +305,9 @@ const EnhanceActivator = memo(function EnhanceActivator({
               only affordance: the menu stays hidden and reopens in review mode
               (unless the consumer renders its own review UI). */}
           {open &&
-            !isLoadingEnhance &&
-            !(hideReviewPanel && isAcceptChangesOpen) &&
-            (renderAsFixedLockedPanel ? (
+          !isLoadingEnhance &&
+          !(hideReviewPanel && isAcceptChangesOpen) ? (
+            renderAsFixedLockedPanel ? (
               <motion.div
                 initial={{ opacity: 0, scale: 0.95 }}
                 animate={{ opacity: 1, scale: 1 }}
@@ -356,7 +356,8 @@ const EnhanceActivator = memo(function EnhanceActivator({
                   <AIEnhanceMenu {...enhanceMenuProps} />
                 </motion.div>
               </Popover.Content>
-            ))}
+            )
+          ) : null}
         </AnimatePresence>
       </Popover.Portal>
     </Popover.Root>

--- a/packages/react/src/components/RichText/internal/Enhance/EnhanceMenu.tsx
+++ b/packages/react/src/components/RichText/internal/Enhance/EnhanceMenu.tsx
@@ -117,7 +117,7 @@ const AIEnhanceMenu = ({
               customInputRef.current?.focus()
             }}
           >
-            {isIdle && (
+            {isIdle ? (
               <>
                 <input
                   data-enhance-input="true"
@@ -155,8 +155,8 @@ const AIEnhanceMenu = ({
                   />
                 </div>
               </>
-            )}
-            {isLoading && (
+            ) : null}
+            {isLoading ? (
               <div
                 className={cn(
                   "relative z-20 flex h-8 min-w-0 flex-1 items-center gap-2 pl-2",
@@ -173,8 +173,8 @@ const AIEnhanceMenu = ({
                   onClick={onRetry}
                 />
               </div>
-            )}
-            {isReview && (
+            ) : null}
+            {isReview ? (
               <div
                 className={cn(
                   "relative z-20 flex items-center justify-between gap-2",
@@ -187,9 +187,9 @@ const AIEnhanceMenu = ({
                   label="Try again"
                   onClick={onRetry}
                 />
-                {useCompactReview && (
+                {useCompactReview ? (
                   <div className="h-4 w-px bg-f1-border rounded-full" />
-                )}
+                ) : null}
                 <div className="flex items-center gap-2">
                   <F0Button
                     variant="outline"
@@ -203,11 +203,11 @@ const AIEnhanceMenu = ({
                   />
                 </div>
               </div>
-            )}
+            ) : null}
           </motion.div>
         </DropdownMenuTrigger>
 
-        {showOptions && (
+        {showOptions ? (
           <DropdownMenuContent
             align="start"
             sideOffset={4}
@@ -229,9 +229,9 @@ const AIEnhanceMenu = ({
                   <DropdownMenuSub key={option.id}>
                     <DropdownMenuSubTrigger className="mx-1 px-2 data-[state=open]:rounded-sm data-[state=closed]:bg-transparent data-[state=open]:bg-f1-background-hover">
                       <div className="flex w-full flex-row items-center gap-2">
-                        {option.icon && (
+                        {option.icon ? (
                           <F0Icon icon={option.icon} color="default" />
-                        )}
+                        ) : null}
                         <span className="flex-1 text-base font-medium">
                           {option.label}
                         </span>
@@ -254,9 +254,9 @@ const AIEnhanceMenu = ({
                             }}
                           >
                             <div className="flex w-full flex-row items-center gap-2">
-                              {subOption.icon && (
+                              {subOption.icon ? (
                                 <F0Icon icon={subOption.icon} color="default" />
-                              )}
+                              ) : null}
                               <span className="flex-1">{subOption.label}</span>
                             </div>
                           </DropdownMenuItem>
@@ -276,16 +276,16 @@ const AIEnhanceMenu = ({
                   }}
                 >
                   <div className="flex w-full flex-row items-center gap-2">
-                    {option.icon && (
+                    {option.icon ? (
                       <F0Icon icon={option.icon} color="default" />
-                    )}
+                    ) : null}
                     <span className="flex-1">{option.label}</span>
                   </div>
                 </DropdownMenuItem>
               )
             })}
           </DropdownMenuContent>
-        )}
+        ) : null}
       </DropdownMenu>
     </div>
   )

--- a/packages/react/src/components/RichText/internal/Extensions/AIBlock/index.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/AIBlock/index.tsx
@@ -250,9 +250,9 @@ const AIButtonsSection = ({
   onButtonClick: (type: string) => void
 }) => (
   <div className="flex flex-col gap-2">
-    {config.title && (
+    {config.title ? (
       <div className="text-f1-foreground-secondary">{config.title}</div>
-    )}
+    ) : null}
     <div className="relative flex flex-row flex-wrap items-center gap-2">
       {config.buttons?.map((button, index) => (
         <F0Button

--- a/packages/react/src/components/RichText/internal/Extensions/Image/index.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Image/index.tsx
@@ -97,12 +97,12 @@ const ImageNodeView = ({
           draggable={false}
           className="block h-auto w-full rounded-md transition-all duration-150 ease-out"
         />
-        {uploading && (
+        {uploading ? (
           <div className="absolute inset-0 flex items-center justify-center rounded-lg bg-f1-background-secondary backdrop-blur-[2px] transition-opacity duration-200">
             <Spinner size="medium" />
           </div>
-        )}
-        {isEditable && !uploading && (
+        ) : null}
+        {isEditable && !uploading ? (
           <div className="absolute right-2 top-2 opacity-0 transition-opacity group-hover/image:opacity-100">
             <F0Button
               onClick={deleteNode}
@@ -112,8 +112,8 @@ const ImageNodeView = ({
               hideLabel
             />
           </div>
-        )}
-        {isEditable && !uploading && (
+        ) : null}
+        {isEditable && !uploading ? (
           <div
             className={cn(
               "absolute right-2 top-1/2 -translate-y-1/2 flex cursor-col-resize items-center justify-center",
@@ -127,7 +127,7 @@ const ImageNodeView = ({
             aria-label="Resize image"
             tabIndex={0}
           />
-        )}
+        ) : null}
       </div>
     </NodeViewWrapper>
   )

--- a/packages/react/src/components/RichText/internal/Extensions/MoodTracker/index.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/MoodTracker/index.tsx
@@ -116,7 +116,7 @@ export const MoodTrackerView: React.FC<NodeViewProps> = ({
           </div>
         </div>
 
-        {isOpen && (
+        {isOpen ? (
           <div className="text-f1-text-primary flex flex-col gap-2">
             {data.days.map((day, index) => (
               <div className="flex flex-row items-center gap-2" key={index}>
@@ -134,7 +134,7 @@ export const MoodTrackerView: React.FC<NodeViewProps> = ({
               </div>
             ))}
           </div>
-        )}
+        ) : null}
       </div>
       <NodeViewContent style={{ display: "none" }} />
     </NodeViewWrapper>

--- a/packages/react/src/components/RichText/internal/Extensions/SlashCommand/CommandList.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/SlashCommand/CommandList.tsx
@@ -141,13 +141,13 @@ const CommandList = forwardRef<CommandListHandle, CommandListProps>(
           <div key={groupIndex}>
             <div className="p-1">
               {/* Group title (only show if we have multiple groups and the group has a title) */}
-              {groups && group.title && (
+              {groups && group.title ? (
                 <div className="p-2">
                   <p className="text-sm font-medium tracking-wide text-f1-foreground-secondary">
                     {group.title}
                   </p>
                 </div>
-              )}
+              ) : null}
 
               {/* Group commands */}
               {group.commands.map((item, commandIndex) => {
@@ -184,11 +184,11 @@ const CommandList = forwardRef<CommandListHandle, CommandListProps>(
               })}
             </div>
             {/* Divider between groups (only show if not the last group and we have multiple groups) */}
-            {groups && groupIndex < commandsToRender.length - 1 && (
+            {groups && groupIndex < commandsToRender.length - 1 ? (
               <div className="py-1">
                 <div className="h-[1px] w-full bg-f1-border-secondary" />
               </div>
-            )}
+            ) : null}
           </div>
         ))}
       </div>

--- a/packages/react/src/components/RichText/internal/Extensions/Transcript/index.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Transcript/index.tsx
@@ -123,20 +123,20 @@ export const TranscriptView: React.FC<NodeViewProps> = ({
           </div>
         </div>
 
-        {isOpen && (
+        {isOpen ? (
           <div className="scrollbar-macos text-f1-text-primary flex max-h-[500px] flex-col gap-4 overflow-y-auto">
             {data.messages.map((message, index) => {
               const user = getUserById(message.userId)
               return (
                 <div key={index} className="flex flex-row gap-3">
-                  {user?.imageUrl && (
+                  {user?.imageUrl ? (
                     <F0AvatarPerson
                       size="xs"
                       src={user.imageUrl}
                       firstName={user.fullname}
                       lastName={""}
                     />
-                  )}
+                  ) : null}
                   <div className="flex flex-col">
                     <div className="flex items-baseline gap-2">
                       <span className="text-f1-text-primary font-medium">
@@ -152,7 +152,7 @@ export const TranscriptView: React.FC<NodeViewProps> = ({
               )
             })}
           </div>
-        )}
+        ) : null}
       </div>
       <NodeViewContent style={{ display: "none" }} />
     </NodeViewWrapper>

--- a/packages/react/src/components/RichText/internal/Extensions/VideoEmbed/index.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/VideoEmbed/index.tsx
@@ -87,7 +87,7 @@ const VideoEmbedNodeView = ({
             allowFullScreen
           />
         </div>
-        {isEditable && (
+        {isEditable ? (
           <div className="dark absolute right-2 top-2">
             <F0Button
               onClick={deleteNode}
@@ -98,7 +98,7 @@ const VideoEmbedNodeView = ({
               size="sm"
             />
           </div>
-        )}
+        ) : null}
       </div>
     </NodeViewWrapper>
   )

--- a/packages/react/src/components/RichText/internal/Toolbar/LinkPopup/index.tsx
+++ b/packages/react/src/components/RichText/internal/Toolbar/LinkPopup/index.tsx
@@ -108,7 +108,7 @@ export const LinkPopup = ({ editor, disabled }: LinkPopupProps) => {
           style={{ zIndex: 9999 }}
         >
           <AnimatePresence>
-            {openLinkPopover && (
+            {openLinkPopover ? (
               <motion.div
                 initial={{ opacity: 0, y: 10, scale: 0.95 }}
                 animate={{ opacity: 1, y: 0, scale: 1 }}
@@ -177,14 +177,14 @@ export const LinkPopup = ({ editor, disabled }: LinkPopupProps) => {
                       }}
                     />
 
-                    {editor.isActive("link") && (
+                    {editor.isActive("link") ? (
                       <F0Icon
                         size="md"
                         icon={CrossedCircle}
                         className="cursor-pointer text-f1-foreground-tertiary hover:text-f1-foreground-secondary"
                         onClick={handleDelete}
                       />
-                    )}
+                    ) : null}
 
                     <F0Button
                       variant="outline"
@@ -206,7 +206,7 @@ export const LinkPopup = ({ editor, disabled }: LinkPopupProps) => {
                   ></F0Button>
                 </div>
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
         </Popover.Content>
       </Popover.Portal>

--- a/packages/react/src/components/RichText/internal/Toolbar/ToolbarDropdown/index.tsx
+++ b/packages/react/src/components/RichText/internal/Toolbar/ToolbarDropdown/index.tsx
@@ -62,7 +62,7 @@ export const ToolbarDropdown = ({
           style={{ zIndex: 9999 }}
         >
           <AnimatePresence>
-            {open && (
+            {open ? (
               <motion.div
                 initial={{ opacity: 0, scale: 0.95, y: 5 }}
                 animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -100,7 +100,7 @@ export const ToolbarDropdown = ({
                   </Action>
                 ))}
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
         </Popover.Content>
       </Popover.Portal>

--- a/packages/react/src/components/RichText/internal/Toolbar/index.tsx
+++ b/packages/react/src/components/RichText/internal/Toolbar/index.tsx
@@ -36,7 +36,7 @@ const intersperse = (arr: ReactNode[], sep: ReactNode) =>
   arr.map((item, index) => (
     <Fragment key={`intersperse-${index}`}>
       {item}
-      {index < arr.length - 1 && sep}
+      {index < arr.length - 1 ? sep : null}
     </Fragment>
   ))
 

--- a/packages/react/src/components/avatars/F0AvatarFile/F0AvatarFile.tsx
+++ b/packages/react/src/components/avatars/F0AvatarFile/F0AvatarFile.tsx
@@ -43,12 +43,12 @@ const F0AvatarFile = forwardRef<ElementRef<typeof Avatar>, F0AvatarFileProps>(
       () =>
         badge ? (
           <>
-            {badge.type === "module" && (
+            {badge.type === "module" ? (
               <F0AvatarModule module={badge.module} size={moduleAvatarSize} />
-            )}
-            {badge.type !== "module" && (
+            ) : null}
+            {badge.type !== "module" ? (
               <Badge type={badge.type} icon={badge.icon} size={badgeSize} />
-            )}
+            ) : null}
           </>
         ) : null,
       [badge, badgeSize, moduleAvatarSize]
@@ -77,7 +77,7 @@ const F0AvatarFile = forwardRef<ElementRef<typeof Avatar>, F0AvatarFileProps>(
           >
             {fileType}
           </AvatarFallback>
-          {badge && (
+          {badge ? (
             <div className="absolute -bottom-0.5 -right-0.5">
               {badge.tooltip ? (
                 <Tooltip description={badge.tooltip}>
@@ -87,7 +87,7 @@ const F0AvatarFile = forwardRef<ElementRef<typeof Avatar>, F0AvatarFileProps>(
                 badgeContent
               )}
             </div>
-          )}
+          ) : null}
         </Avatar>
       </DataTestIdWrapper>
     )

--- a/packages/react/src/components/avatars/F0AvatarList/components/MaxCounter.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/components/MaxCounter.tsx
@@ -134,11 +134,11 @@ export const MaxCounter = ({
           <div className="truncate font-semibold">
             {getAvatarDisplayName(avatarType, avatar)}
           </div>
-          {description && (
+          {description ? (
             <div className="truncate text-sm text-current opacity-70">
               {description}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     )

--- a/packages/react/src/components/avatars/F0AvatarModule/F0AvatarModule.tsx
+++ b/packages/react/src/components/avatars/F0AvatarModule/F0AvatarModule.tsx
@@ -84,9 +84,9 @@ export function F0AvatarModule({
         </defs>
         <path d={squirclePath} fill={`url(#${gradientId})`} />
       </svg>
-      {IconComponent && (
+      {IconComponent ? (
         <IconComponent className={iconSizeVariants({ size })} />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
+++ b/packages/react/src/components/avatars/internal/BaseAvatar/BaseAvatar.tsx
@@ -83,12 +83,12 @@ export const BaseAvatar = forwardRef<HTMLDivElement, BaseAvatarProps>(
       () =>
         badge ? (
           <>
-            {badge.type === "module" && (
+            {badge.type === "module" ? (
               <F0AvatarModule module={badge.module} size={moduleAvatarSize} />
-            )}
-            {badge.type !== "module" && (
+            ) : null}
+            {badge.type !== "module" ? (
               <Badge type={badge.type} icon={badge.icon} size={badgeSize} />
-            )}
+            ) : null}
           </>
         ) : null,
       [badge, badgeSize, moduleAvatarSize]
@@ -156,9 +156,9 @@ export const BaseAvatar = forwardRef<HTMLDivElement, BaseAvatarProps>(
           </AvatarComponent>
         </div>
 
-        {badge && (
+        {badge ? (
           <div className="absolute -bottom-0.5 -right-0.5">{badgeContent}</div>
-        )}
+        ) : null}
       </div>
     )
 

--- a/packages/react/src/components/dialog-alike/F0Dialog/internal/DialogInternal.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/internal/DialogInternal.tsx
@@ -35,7 +35,7 @@ export const DialogInternal: FC<DialogInternalProps> = ({
   const _memoizedDialogLayout = useMemo(() => {
     return (
       <>
-        {variant !== "notification" && (
+        {variant !== "notification" ? (
           <Header
             title={title}
             description={description}
@@ -46,7 +46,7 @@ export const DialogInternal: FC<DialogInternalProps> = ({
             setActiveTabId={setActiveTabId}
             disableClose={disableClose}
           />
-        )}
+        ) : null}
         <Content disableContentPadding={disableContentPadding ?? false}>
           {children}
         </Content>

--- a/packages/react/src/components/dialog-alike/common/Content.tsx
+++ b/packages/react/src/components/dialog-alike/common/Content.tsx
@@ -92,8 +92,10 @@ export const Content = ({
       </ScrollArea>
 
       <AnimatePresence>
-        {!isAtTop && <ScrollShadow position="top" key="shadow-top" />}
-        {!isAtBottom && <ScrollShadow position="bottom" key="shadow-bottom" />}
+        {!isAtTop ? <ScrollShadow position="top" key="shadow-top" /> : null}
+        {!isAtBottom ? (
+          <ScrollShadow position="bottom" key="shadow-bottom" />
+        ) : null}
       </AnimatePresence>
     </div>
   )

--- a/packages/react/src/components/dialog-alike/common/Footer.tsx
+++ b/packages/react/src/components/dialog-alike/common/Footer.tsx
@@ -107,24 +107,25 @@ export const Footer = (props: FooterProps) => {
             : "justify-end"
         )}
       >
-        {secondaryActions.length > 0 &&
-          secondaryActions.map((action) => (
-            <ButtonInternal
-              key={action.value ?? action.label}
-              block={props.variant === "notification"}
-              label={action.label}
-              onClick={async () => {
-                await toPromise(action.onClick)
-                if (action.closeOnClick) {
-                  props.onClose()
-                }
-              }}
-              variant="outline"
-              icon={action.icon}
-              disabled={action.disabled}
-              loading={action.loading}
-            />
-          ))}
+        {secondaryActions.length > 0
+          ? secondaryActions.map((action) => (
+              <ButtonInternal
+                key={action.value ?? action.label}
+                block={props.variant === "notification"}
+                label={action.label}
+                onClick={async () => {
+                  await toPromise(action.onClick)
+                  if (action.closeOnClick) {
+                    props.onClose()
+                  }
+                }}
+                variant="outline"
+                icon={action.icon}
+                disabled={action.disabled}
+                loading={action.loading}
+              />
+            ))
+          : null}
         {renderPrimaryAction()}
       </div>
     </div>

--- a/packages/react/src/components/dialog-alike/common/Header.tsx
+++ b/packages/react/src/components/dialog-alike/common/Header.tsx
@@ -117,15 +117,15 @@ export const Header = ({
               </DialogTitle>
             )
           )}
-          {!!description && (
+          {description ? (
             <DrawerDescription className="text-base text-f1-foreground-secondary">
               {description}
             </DrawerDescription>
-          )}
+          ) : null}
         </div>
         <div className="flex flex-row gap-2">
           <Actions />
-          {otherActions && <Divider />}
+          {otherActions ? <Divider /> : null}
           <ButtonInternal
             variant="outline"
             icon={CrossIcon}
@@ -136,7 +136,7 @@ export const Header = ({
           />
         </div>
       </div>
-      {tabs && tabs.length > 0 && (
+      {tabs && tabs.length > 0 ? (
         <div className="-mx-2">
           <Tabs
             tabs={tabs}
@@ -144,7 +144,7 @@ export const Header = ({
             setActiveTabId={setActiveTabId}
           />
         </div>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
@@ -107,7 +107,7 @@ export const DialogContent = forwardRef<
 
     return (
       <DialogPortal container={container}>
-        {context.showOverlay && <DialogOverlay />}
+        {context.showOverlay ? <DialogOverlay /> : null}
         <DialogPrimitive.Content
           ref={ref}
           className={cn(

--- a/packages/react/src/components/tags/internal/BaseTag/index.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.tsx
@@ -79,7 +79,7 @@ export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
           )}
         >
           {left}
-          {!!text && !hideLabel && (
+          {!!text && !hideLabel ? (
             <OneEllipsis
               tag="span"
               lines={1}
@@ -89,22 +89,22 @@ export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
             >
               {text}
             </OneEllipsis>
-          )}
-          {additionalAccessibleText && (
+          ) : null}
+          {additionalAccessibleText ? (
             <span className="sr-only">{additionalAccessibleText}</span>
-          )}
+          ) : null}
           {right}
         </div>
-        {hint && (
+        {hint ? (
           <span className="text-base font-medium text-f1-foreground-secondary">
             {hint}
           </span>
-        )}
-        {info && (
+        ) : null}
+        {info ? (
           <Tooltip description={info}>
             <F0Icon icon={InfoCircleLine} size="md" />
           </Tooltip>
-        )}
+        ) : null}
       </div>
     )
   }

--- a/packages/react/src/deprecated/Dialog/index.tsx
+++ b/packages/react/src/deprecated/Dialog/index.tsx
@@ -73,7 +73,7 @@ const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
               </DialogDescription>
             </div>
           </DialogHeader>
-          {actions && (
+          {actions ? (
             <DialogFooter className="px-4 pb-4 pt-2">
               <div className="hidden sm:flex sm:flex-row sm:justify-between sm:gap-3 [&>div]:w-full">
                 <F0Button variant="outline" {...actions.secondary} />
@@ -91,7 +91,7 @@ const OneDialog = forwardRef<HTMLDivElement, DialogProps>(
                 />
               </div>
             </DialogFooter>
-          )}
+          ) : null}
         </DialogContent>
       </DialogPrimitive>
     )

--- a/packages/react/src/deprecated/EntitySelect/Content/MainContent/Searcher.tsx
+++ b/packages/react/src/deprecated/EntitySelect/Content/MainContent/Searcher.tsx
@@ -45,14 +45,14 @@ export const Searcher = ({
         value={search}
         onChange={(e) => onSearch(e.target.value)}
       />
-      {search && (
+      {search ? (
         <F0Icon
           icon={CrossedCircle}
           size="md"
           onClick={() => onSearch("")}
           className="cursor-pointer text-f1-icon-secondary"
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/deprecated/EntitySelect/Content/MainContent/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/Content/MainContent/index.tsx
@@ -457,7 +457,7 @@ export const MainContent: React.FC<MainContentProps> = ({
             goToLast={goToLast}
           />
         </div>
-        {groups && groups.length > 1 && (
+        {groups && groups.length > 1 ? (
           <div className="flex-1">
             <F0Select
               label="Group"
@@ -472,7 +472,7 @@ export const MainContent: React.FC<MainContentProps> = ({
               )}
             />
           </div>
-        )}
+        ) : null}
       </header>
       <section
         className={cn(
@@ -480,12 +480,12 @@ export const MainContent: React.FC<MainContentProps> = ({
           !showFooter ? "rounded-b-xl border-r-0" : ""
         )}
       >
-        {loading && (
+        {loading ? (
           <div className="flex h-full w-full flex-row items-center justify-center">
             <Spinner />
           </div>
-        )}
-        {!loading && !totalFilteredEntities && (
+        ) : null}
+        {!loading && !totalFilteredEntities ? (
           <div
             className="absolute flex w-full flex-col items-center justify-center gap-0.5 p-5"
             style={{
@@ -497,8 +497,8 @@ export const MainContent: React.FC<MainContentProps> = ({
               {notFoundSubtitle}
             </span>
           </div>
-        )}
-        {!loading && (!!totalFilteredEntities || onCreate) && (
+        ) : null}
+        {!loading && (!!totalFilteredEntities || onCreate) ? (
           <div className="h-full">
             {!groupView ? (
               <VirtualList
@@ -526,7 +526,7 @@ export const MainContent: React.FC<MainContentProps> = ({
               />
             )}
           </div>
-        )}
+        ) : null}
       </section>
       <Footer
         onSelectAll={onSelectAll}

--- a/packages/react/src/deprecated/EntitySelect/Content/SecondaryContent/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/Content/SecondaryContent/index.tsx
@@ -62,11 +62,11 @@ export const SecondaryContent = ({
   return (
     <div className="w-full flex-col rounded-r-xl">
       <div className="flex h-[48px] rounded-tr-xl border-0 border-b-[1px] border-solid border-f1-border-secondary bg-f1-background/30 p-3 backdrop-blur-2xl">
-        {selectedLabel && (
+        {selectedLabel ? (
           <span className="my-auto text-f1-foreground-secondary">
             {totalSelectedSubItems} {selectedLabel}
           </span>
-        )}
+        ) : null}
       </div>
       <div className="flex flex-col gap-3 rounded-br-xl bg-f1-background pb-0 pl-2">
         <VirtualList

--- a/packages/react/src/deprecated/EntitySelect/Content/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/Content/index.tsx
@@ -98,7 +98,7 @@ export const Content = ({
           onCreateLabel={onCreateLabel}
         />
       </div>
-      {isExpanded && (
+      {isExpanded ? (
         <div
           className="min-h-0"
           style={{
@@ -115,7 +115,7 @@ export const Content = ({
             hiddenAvatar={hiddenAvatar}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/deprecated/EntitySelect/ListItem/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/ListItem/index.tsx
@@ -120,7 +120,7 @@ export const ListItemSingleContent = ({
             : ""
         )}
       >
-        {!hiddenAvatar && (
+        {!hiddenAvatar ? (
           <F0AvatarPerson
             src={entity.avatar}
             firstName={firstName}
@@ -128,7 +128,7 @@ export const ListItemSingleContent = ({
             size="xs"
             deactivated={entity.deactivated}
           />
-        )}
+        ) : null}
 
         <div className="flex flex-1 flex-col">
           <div
@@ -157,13 +157,13 @@ export const ListItemSingleContent = ({
           )}
         />
 
-        {singleSelector && selected && (
+        {singleSelector && selected ? (
           <F0Icon
             className="text-f1-icon-selected"
             icon={CheckCircle}
             size="md"
           />
-        )}
+        ) : null}
       </label>
     </div>
   )
@@ -290,12 +290,12 @@ const EntitySelectListItem = ({
           }}
           className="flex flex-1 flex-row items-center gap-2 rounded border px-2 py-1.5 focus-within:outline focus-within:outline-1 focus-within:-outline-offset-1 focus-within:outline-f1-border-selected-bold hover:cursor-pointer hover:bg-f1-background-hover"
         >
-          {showGroupIcon && (
+          {showGroupIcon ? (
             <F0Icon
               icon={LogoAvatar}
               className="rounded-xs bg-f1-foreground-secondary text-f1-foreground-inverse"
             />
-          )}
+          ) : null}
           <div className="flex flex-grow flex-row items-center gap-2 break-all">
             <HighlightText
               semiBold
@@ -321,9 +321,9 @@ const EntitySelectListItem = ({
         </label>
       </div>
 
-      {!hideLine && !expanded && (
+      {!hideLine && !expanded ? (
         <div className="h-[1px] w-full bg-f1-border-secondary" />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
@@ -60,7 +60,7 @@ export const F0SegmentedControl = ({
             fullWidth && "w-full"
           )}
         >
-          {item.icon && <F0Icon icon={item.icon} size="md" />}
+          {item.icon ? <F0Icon icon={item.icon} size="md" /> : null}
           {hideLabels && item.icon ? (
             <span className="sr-only">{item.label}</span>
           ) : (

--- a/packages/react/src/experimental/AiPromotionChat/OneSwitch.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/OneSwitch.tsx
@@ -71,11 +71,11 @@ export const OneSwitch = ({
               </SwitchPrimitive.Root>
             </div>
           </TooltipTrigger>
-          {!open && (
+          {!open ? (
             <TooltipContent side="left" className="font-medium">
               {translations.ai.welcome}
             </TooltipContent>
-          )}
+          ) : null}
         </Tooltip>
       </TooltipProvider>
     </div>

--- a/packages/react/src/experimental/AiPromotionChat/components/ChatWindow.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/components/ChatWindow.tsx
@@ -18,7 +18,7 @@ export const SidebarWindow = ({ children }: { children?: ReactNode }) => {
 
   return (
     <AnimatePresence>
-      {open && (
+      {open ? (
         <motion.div
           key="chat-window"
           aria-hidden={!open}
@@ -54,7 +54,7 @@ export const SidebarWindow = ({ children }: { children?: ReactNode }) => {
             </motion.div>
           </div>
         </motion.div>
-      )}
+      ) : null}
     </AnimatePresence>
   )
 }

--- a/packages/react/src/experimental/AiPromotionChat/index.tsx
+++ b/packages/react/src/experimental/AiPromotionChat/index.tsx
@@ -102,14 +102,14 @@ const AiPromotionChatCmp = () => {
           </div>
 
           {/* Description */}
-          {description && (
+          {description ? (
             <p className="text-md text-f1-foreground-secondary">
               {description}
             </p>
-          )}
+          ) : null}
 
           {/* Benefits list */}
-          {benefits?.length && (
+          {benefits?.length ? (
             <ul className="flex flex-col gap-2">
               {benefits.map((benefit, index) => (
                 <li key={index} className="flex items-center gap-1">
@@ -120,10 +120,10 @@ const AiPromotionChatCmp = () => {
                 </li>
               ))}
             </ul>
-          )}
+          ) : null}
 
           {/* Actions */}
-          {actions?.length && (
+          {actions?.length ? (
             <div className="flex flex-col gap-3 pt-2">
               {actions.map((action, index) => (
                 <CustomButton
@@ -133,7 +133,7 @@ const AiPromotionChatCmp = () => {
                 />
               ))}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
 

--- a/packages/react/src/experimental/F0CardHorizontal/F0CardHorizontal.tsx
+++ b/packages/react/src/experimental/F0CardHorizontal/F0CardHorizontal.tsx
@@ -206,7 +206,7 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
         onClick={disabled ? undefined : onClick}
         data-testid="card"
       >
-        {link && !disableOverlayLink && (
+        {link && !disableOverlayLink ? (
           <F0Link
             href={link}
             variant="unstyled"
@@ -215,7 +215,7 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
           >
             &nbsp;
           </F0Link>
-        )}
+        ) : null}
 
         <div className={cardHorizontalClassName[stackAt]}>
           <div
@@ -229,7 +229,7 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
               avatar ? "items-start" : "items-center"
             )}
           >
-            {avatar && <CardAvatar avatar={avatar} size="lg" />}
+            {avatar ? <CardAvatar avatar={avatar} size="lg" /> : null}
             <div className="flex min-w-0 flex-col gap-0">
               <Text
                 variant="body"
@@ -239,7 +239,7 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
                   inactive && "text-f1-foreground-secondary line-through"
                 )}
               />
-              {description && (
+              {description ? (
                 <Text
                   variant="description"
                   content={description}
@@ -249,7 +249,7 @@ const F0CardHorizontalBase = forwardRef<HTMLDivElement, F0CardHorizontalProps>(
                     inactive && "line-through"
                   )}
                 />
-              )}
+              ) : null}
             </div>
           </div>
 

--- a/packages/react/src/experimental/F0FormEditableTable/F0FormEditableTable.tsx
+++ b/packages/react/src/experimental/F0FormEditableTable/F0FormEditableTable.tsx
@@ -266,7 +266,7 @@ function RowCells<R extends RecordType>({
   const customActions = rowActions?.(item, index) ?? []
   return (
     <>
-      {dragHandle !== undefined && (
+      {dragHandle !== undefined ? (
         <TableCell
           width={HANDLE_COL_WIDTH}
           sticky={{ left: 0 }}
@@ -279,7 +279,7 @@ function RowCells<R extends RecordType>({
             {dragHandle}
           </div>
         </TableCell>
-      )}
+      ) : null}
       {columns.map((column, cellIndex) => {
         const editType = column.editType?.(item)
         const isEditableCell =
@@ -322,14 +322,14 @@ function RowCells<R extends RecordType>({
           </TableCell>
         )
       })}
-      {hasActionsColumn && (
+      {hasActionsColumn ? (
         <TableCell
           width={actionsColWidth}
           sticky={{ right: 0 }}
           className={cn(CELL_CLASSES, ACTIONS_SHRINK_CLASSES)}
         >
           <div className="pointer-events-auto flex h-full items-center justify-center gap-2 px-2">
-            {showEdit && (
+            {showEdit ? (
               <F0Button
                 type="button"
                 variant="outline"
@@ -339,7 +339,7 @@ function RowCells<R extends RecordType>({
                 disabled={disabled}
                 onClick={() => onEditRow(item, index)}
               />
-            )}
+            ) : null}
             {customActions.map((action, actionIndex) => (
               <RowActionButton
                 key={action.id ?? `${action.label}-${actionIndex}`}
@@ -349,7 +349,7 @@ function RowCells<R extends RecordType>({
                 disabled={disabled}
               />
             ))}
-            {showRemove && (
+            {showRemove ? (
               // The critical variant inverts its icon on `group-hover`, which
               // the surrounding `.group` table row also triggers — turning the
               // icon white on mere row hover. Pin it to the critical color and
@@ -367,10 +367,10 @@ function RowCells<R extends RecordType>({
                   onClick={() => onRemoveRow(item, index)}
                 />
               </span>
-            )}
+            ) : null}
           </div>
         </TableCell>
-      )}
+      ) : null}
     </>
   )
 }
@@ -561,7 +561,7 @@ function F0FormEditableTableBase<R extends RecordType>({
     <OneTable>
       <TableHeader>
         <TableRow>
-          {sortableRows && (
+          {sortableRows ? (
             <TableHead
               width={HANDLE_COL_WIDTH}
               sticky={{ left: 0 }}
@@ -569,7 +569,7 @@ function F0FormEditableTableBase<R extends RecordType>({
             >
               <span className="sr-only">{reorderLabel}</span>
             </TableHead>
-          )}
+          ) : null}
           {columns.map((column, index) => (
             <TableHead
               key={column.id ?? `head-${index}`}
@@ -582,7 +582,7 @@ function F0FormEditableTableBase<R extends RecordType>({
               {column.label}
             </TableHead>
           ))}
-          {hasActionsColumn && (
+          {hasActionsColumn ? (
             <TableHead
               width={actionsColWidth}
               sticky={{ right: 0 }}
@@ -594,7 +594,7 @@ function F0FormEditableTableBase<R extends RecordType>({
             >
               <span className="sr-only">{actionsLabel}</span>
             </TableHead>
-          )}
+          ) : null}
         </TableRow>
       </TableHeader>
       <TableBody>
@@ -653,8 +653,8 @@ function F0FormEditableTableBase<R extends RecordType>({
           table
         )}
       </div>
-      {addRow &&
-        (addRow.disabled && addRow.disabledTooltip ? (
+      {addRow ? (
+        addRow.disabled && addRow.disabledTooltip ? (
           <TooltipProvider delayDuration={100}>
             <Tooltip>
               {/* A disabled button emits no hover events, so the span wrapper
@@ -690,7 +690,8 @@ function F0FormEditableTableBase<R extends RecordType>({
             onClick={addRow.onClick}
             disabled={addRow.disabled}
           />
-        ))}
+        )
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
@@ -112,7 +112,7 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
 
     const titleBlock = (
       <>
-        {headline && (
+        {headline ? (
           <Text
             variant="body"
             content={headline}
@@ -124,10 +124,10 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
               state === "cancelled" && "line-through"
             )}
           />
-        )}
-        {metaSegments.length > 0 && (
+        ) : null}
+        {metaSegments.length > 0 ? (
           <Text variant="description" content={metaSegments.join(" · ")} />
-        )}
+        ) : null}
       </>
     )
 
@@ -159,9 +159,9 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
             onClick={action.onClick}
           />
         ))}
-        {showsJoin && join && (
+        {showsJoin && join ? (
           <MeetingJoinButton join={join} disabled={joinDisabled} />
-        )}
+        ) : null}
       </>
     )
 
@@ -188,11 +188,11 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
               {attendeesBlock}
               {summaryBlock}
             </div>
-            {hasActions && (
+            {hasActions ? (
               <div className="flex shrink-0 flex-row items-center gap-2">
                 {actionsBlock}
               </div>
-            )}
+            ) : null}
           </div>
         ) : (
           <>
@@ -202,7 +202,7 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
             {summaryBlock}
 
             {/* Stretched over the card padding so the divider reaches both edges. */}
-            {(hasActions || showsStatusTag) && (
+            {hasActions || showsStatusTag ? (
               <div
                 className={cn(
                   "flex flex-row items-center gap-2",
@@ -213,13 +213,13 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
                 <div className="flex flex-1 flex-row items-center gap-2">
                   {statusTagBlock}
                 </div>
-                {hasActions && (
+                {hasActions ? (
                   <div className="flex flex-row items-center gap-2">
                     {actionsBlock}
                   </div>
-                )}
+                ) : null}
               </div>
-            )}
+            ) : null}
           </>
         )}
       </Card>

--- a/packages/react/src/experimental/F0ProgressSeries/F0ProgressSeries.tsx
+++ b/packages/react/src/experimental/F0ProgressSeries/F0ProgressSeries.tsx
@@ -190,14 +190,14 @@ function BarTrack({
               : "bg-f1-background-secondary"
           )}
         >
-          {!isEmpty && !bar.canceled && (
+          {!isEmpty && !bar.canceled ? (
             <BarFill pct={pct} color={bar.color ?? DEFAULT_COLOR} />
-          )}
+          ) : null}
         </div>
       </TooltipTrigger>
-      {!hideTooltip && (
+      {!hideTooltip ? (
         <TooltipContent className="text-sm">{tooltip}</TooltipContent>
-      )}
+      ) : null}
     </Tooltip>
   )
 }
@@ -219,10 +219,10 @@ function BarLabel({
 
   return (
     <div className={cn("flex items-center gap-1 truncate", textClass)}>
-      {label && <span className="text-f1-foreground">{label}</span>}
-      {caption && (
+      {label ? <span className="text-f1-foreground">{label}</span> : null}
+      {caption ? (
         <span className="text-f1-foreground-secondary">{caption}</span>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -290,24 +290,24 @@ const F0ProgressSeriesBase = forwardRef<HTMLDivElement, F0ProgressSeriesProps>(
             ))}
           </div>
 
-          {showLabelRow && (
+          {showLabelRow ? (
             <div className={cn("flex w-full", gapClass)} aria-hidden="true">
               {resolved.map((r, index) => (
                 <div
                   key={`${r.bar.label}-${index}`}
                   className="min-w-[3px] flex-1 overflow-hidden"
                 >
-                  {shown.has(index) && (
+                  {shown.has(index) ? (
                     <BarLabel
                       label={r.bar.label}
                       caption={r.caption}
                       textClass={LABEL_CLASS[size]}
                     />
-                  )}
+                  ) : null}
                 </div>
               ))}
             </div>
-          )}
+          ) : null}
         </TooltipProvider>
       </div>
     )

--- a/packages/react/src/experimental/F0VersionHistory/index.tsx
+++ b/packages/react/src/experimental/F0VersionHistory/index.tsx
@@ -29,13 +29,13 @@ function _F0VersionHistory({
 
       <ScrollArea className="h-full flex-1">
         <div className="flex flex-col gap-1">
-          {currentVersion && (
+          {currentVersion ? (
             <CurrentVersionIndicator
               title={currentVersion.title}
               onClick={currentVersion.onClick}
               isActive={activeVersionId === "current"}
             />
-          )}
+          ) : null}
           {versions.map((version) => (
             <VersionItem
               key={version.id}

--- a/packages/react/src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/F0PhoneInput.tsx
@@ -243,7 +243,7 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
           disabled && "cursor-not-allowed"
         )}
       >
-        {!hideLabel && label && (
+        {!hideLabel && label ? (
           <Label
             label={label}
             required={required}
@@ -252,7 +252,7 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
             className="min-w-0 flex-1"
             disabled={disabled}
           />
-        )}
+        ) : null}
         <div
           className={cn(
             "pointer-events-auto",
@@ -299,14 +299,14 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
             aria-invalid={effectiveStatus?.type === "error" || undefined}
             aria-busy={loading || undefined}
           />
-          {(showClear || loading) && (
+          {showClear || loading ? (
             <div
               className={cn(
                 "flex h-fit min-w-6 items-center gap-1.5 self-center pr-[3px]",
                 size === "md" && "pr-[7px]"
               )}
             >
-              {showClear && (
+              {showClear ? (
                 <button
                   className={cn(
                     "flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded-full p-0",
@@ -323,14 +323,14 @@ export const F0PhoneInput = forwardRef<HTMLInputElement, F0PhoneInputProps>(
                 >
                   <F0Icon icon={CrossedCircle} color="default" size="md" />
                 </button>
-              )}
-              {loading && (
+              ) : null}
+              {loading ? (
                 <div className="pointer-events-none flex h-6 w-6 items-center justify-center">
                   <Spinner size="small" className="mt-[1px]" />
                 </div>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
         <InputMessages status={effectiveStatus} />
       </div>

--- a/packages/react/src/experimental/Forms/F0PhoneInput/components/CountrySelect.tsx
+++ b/packages/react/src/experimental/Forms/F0PhoneInput/components/CountrySelect.tsx
@@ -134,11 +134,11 @@ export const CountrySelect = ({
           data-testid="phone-input-country-trigger"
         >
           <CountryFlag country={value} />
-          {value && (
+          {value ? (
             <span className="whitespace-nowrap text-f1-foreground">
               {dialCodeFor(value)}
             </span>
-          )}
+          ) : null}
           <span
             className={cn(
               "flex origin-center items-center transition-transform duration-200",

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
@@ -61,7 +61,7 @@ export const Description = ({ description }: { description: string }) => {
           {description}
         </div>
       </motion.div>
-      {(needsTruncation || isExpanded) && (
+      {needsTruncation || isExpanded ? (
         <button
           onClick={() => setIsExpanded((current) => !current)}
           className="relative w-fit font-medium text-f1-foreground after:absolute after:-bottom-0.5 after:left-0 after:right-0 after:h-[1.5px] after:bg-f1-border after:transition-all after:content-[''] hover:after:bg-f1-border-hover"
@@ -70,7 +70,7 @@ export const Description = ({ description }: { description: string }) => {
             ? translations.actions.showLess
             : translations.actions.showAll}
         </button>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -149,7 +149,7 @@ export function BaseHeader({
             !description && "md:items-center"
           )}
         >
-          {avatar && (
+          {avatar ? (
             <div className="flex items-start">
               <F0Avatar
                 avatar={{
@@ -160,7 +160,7 @@ export function BaseHeader({
                 size="xl"
               />
             </div>
-          )}
+          ) : null}
           <div className="flex flex-col gap-1">
             <span
               className={cn(
@@ -170,18 +170,18 @@ export function BaseHeader({
             >
               {title}
             </span>
-            {description && <Description description={description} />}
+            {description ? <Description description={description} /> : null}
           </div>
         </div>
 
-        {allMetadata.length > 0 && (
+        {allMetadata.length > 0 ? (
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 md:hidden">
             <Metadata items={allMetadata} rowGap={metadataRowGap} />
           </div>
-        )}
+        ) : null}
 
         <div className="flex w-full shrink-0 flex-col gap-x-2 gap-y-3 md:hidden">
-          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
+          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) ? (
             <div className="w-full md:hidden [&>*]:w-full">
               <F0Button
                 label={primaryAction.label}
@@ -194,8 +194,8 @@ export function BaseHeader({
                 loading={primaryAction.loading}
               />
             </div>
-          )}
-          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) && (
+          ) : null}
+          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) ? (
             <div className="w-full md:hidden [&>*]:w-full">
               <F0ButtonDropdown
                 items={primaryAction.items}
@@ -208,7 +208,7 @@ export function BaseHeader({
                 loading={primaryAction.loading}
               />
             </div>
-          )}
+          ) : null}
 
           {visibleSecondaryActions.map((action, index) => (
             <Fragment key={getSecondaryActionKey(action, index)}>
@@ -241,12 +241,12 @@ export function BaseHeader({
             </Fragment>
           ))}
 
-          {visibleOtherActions.length > 0 && (
+          {visibleOtherActions.length > 0 ? (
             <div className="w-full [&>*]:w-full [&_button]:w-full">
               <MobileDropdown items={visibleOtherActions} />
             </div>
-          )}
-          {onClose && (
+          ) : null}
+          {onClose ? (
             <div className="w-full md:hidden [&>*]:w-full">
               <F0Button
                 label={i18n.actions.close}
@@ -256,15 +256,15 @@ export function BaseHeader({
                 onClick={onClose}
               />
             </div>
-          )}
+          ) : null}
         </div>
 
         <div className="-m-1 hidden w-fit shrink-0 flex-wrap items-center gap-x-2 gap-y-2 p-1 md:flex md:overflow-x-auto">
-          {visibleOtherActions.length > 0 && (
+          {visibleOtherActions.length > 0 ? (
             <div>
               <Dropdown items={visibleOtherActions} />
             </div>
-          )}
+          ) : null}
           {visibleSecondaryActions.map((action, index) => (
             <Fragment key={getSecondaryActionKey(action, index)}>
               <div className="hidden md:block">
@@ -295,10 +295,10 @@ export function BaseHeader({
             </Fragment>
           ))}
           {isPrimaryActionVisible &&
-            (hasSecondaryActions || hasOtherActions) && (
-              <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
-            )}
-          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) && (
+          (hasSecondaryActions || hasOtherActions) ? (
+            <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
+          ) : null}
+          {isPrimaryActionVisible && isPrimaryActionButton(primaryAction) ? (
             <div className="hidden md:block">
               <F0Button
                 label={primaryAction.label}
@@ -310,8 +310,8 @@ export function BaseHeader({
                 loading={primaryAction.loading}
               />
             </div>
-          )}
-          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) && (
+          ) : null}
+          {isPrimaryActionVisible && isPrimaryDropdownAction(primaryAction) ? (
             <div className="hidden md:block">
               <F0ButtonDropdown
                 items={primaryAction.items}
@@ -324,8 +324,8 @@ export function BaseHeader({
                 loading={primaryAction.loading}
               />
             </div>
-          )}
-          {onClose && (
+          ) : null}
+          {onClose ? (
             <>
               <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
               <div className="hidden md:block">
@@ -338,14 +338,14 @@ export function BaseHeader({
                 />
               </div>
             </>
-          )}
+          ) : null}
         </div>
       </div>
-      {allMetadata.length > 0 && (
+      {allMetadata.length > 0 ? (
         <div className="hidden flex-wrap items-center gap-x-3 gap-y-1 md:block">
           <Metadata items={allMetadata} rowGap={metadataRowGap} />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/experimental/Information/Headers/Metadata/MetadataValue.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/MetadataValue.tsx
@@ -40,7 +40,7 @@ export function MetadataValue({
       return (
         <div className="flex items-center gap-1">
           <F0Avatar avatar={value.variant} size="xs" />
-          {value.text && <span>{value.text}</span>}
+          {value.text ? <span>{value.text}</span> : null}
         </div>
       )
 
@@ -63,11 +63,11 @@ export function MetadataValue({
       return collapse ? (
         <div className="flex items-center justify-center gap-1 font-medium">
           {value.data[0]}
-          {value.data.length > 1 && (
+          {value.data.length > 1 ? (
             <span className="tabular-nums text-f1-foreground-secondary">
               +{value.data.length - 1}
             </span>
-          )}
+          ) : null}
         </div>
       ) : (
         <div className="flex flex-col gap-1.5">
@@ -81,11 +81,11 @@ export function MetadataValue({
       return collapse ? (
         <div className="flex flex-wrap items-center justify-center gap-1 font-medium">
           <F0TagRaw text={value.tags[0]} />
-          {value.tags.length > 1 && (
+          {value.tags.length > 1 ? (
             <span className="tabular-nums text-f1-foreground-secondary">
               +{value.tags.length - 1}
             </span>
-          )}
+          ) : null}
         </div>
       ) : (
         <div
@@ -138,11 +138,11 @@ export function MetadataValue({
               aria-valuetext={value.label}
             />
           </div>
-          {value.label && (
+          {value.label ? (
             <span className="whitespace-nowrap text-sm font-medium">
               {value.label}
             </span>
-          )}
+          ) : null}
         </div>
       )
     }

--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -174,11 +174,11 @@ function MetadataItem({ item }: { item: MetadataItem }) {
 
   return (
     <div className="flex h-8 items-center gap-2">
-      {item.icon && (
+      {item.icon ? (
         <span className="flex shrink-0 items-center text-f1-foreground-secondary">
           <F0Icon icon={item.icon} size="md" />
         </span>
-      )}
+      ) : null}
       <div
         className={cn(
           "flex w-28 items-center gap-1 truncate text-f1-foreground-secondary md:w-fit",
@@ -186,7 +186,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
         )}
       >
         {item.label}
-        {item.info && (
+        {item.info ? (
           <div className="flex h-4 w-4 items-center text-f1-foreground-tertiary hover:cursor-help">
             <Tooltip
               label={item.info.title}
@@ -195,7 +195,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
               <F0Icon icon={InfoCircleLine} size="sm" />
             </Tooltip>
           </div>
-        )}
+        ) : null}
       </div>
       <div
         role="button"
@@ -215,7 +215,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
         >
           <MetadataValue item={item} collapse />
         </div>
-        {isAction && (
+        {isAction ? (
           <div className="w-full md:hidden">
             <MobileDropdown
               items={
@@ -229,9 +229,9 @@ function MetadataItem({ item }: { item: MetadataItem }) {
               <MetadataValue item={item} collapse />
             </MobileDropdown>
           </div>
-        )}
+        ) : null}
         <AnimatePresence>
-          {isActive && hasHover && (
+          {isActive && hasHover ? (
             <motion.div
               className={cn(
                 "absolute -left-1.5 -top-1.5 z-50 hidden max-h-[80vh] items-start justify-center gap-1.5 overflow-y-auto whitespace-nowrap rounded-sm bg-f1-background py-1 pl-1.5 shadow-md ring-1 ring-inset ring-f1-border-secondary md:flex",
@@ -251,7 +251,7 @@ function MetadataItem({ item }: { item: MetadataItem }) {
               >
                 <MetadataValue item={item} />
               </div>
-              {isAction && (
+              {isAction ? (
                 <motion.div
                   className="flex gap-1"
                   initial={{ x: -16 }}
@@ -287,9 +287,9 @@ function MetadataItem({ item }: { item: MetadataItem }) {
                     }
                   })}
                 </motion.div>
-              )}
+              ) : null}
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
     </div>
@@ -311,9 +311,9 @@ const _Metadata = memo(function Metadata({
       {cleanedItems.map((item, index) => (
         <Fragment key={`metadata-item-${index}`}>
           <MetadataItem item={item} />
-          {index < cleanedItems.length - 1 && (
+          {index < cleanedItems.length - 1 ? (
             <div className="hidden h-4 w-[1px] bg-f1-border md:block" />
-          )}
+          ) : null}
         </Fragment>
       ))}
     </div>

--- a/packages/react/src/experimental/Lists/DataList/ItemContainer.tsx
+++ b/packages/react/src/experimental/Lists/DataList/ItemContainer.tsx
@@ -56,12 +56,13 @@ export const ItemContainer = forwardRef<HTMLLIElement, ItemContainerProps>(
           action={action}
           className={cn("flex items-center gap-1.5 p-1.5", className)}
         >
-          {LeftIcon &&
-            (typeof LeftIcon === "function" ? (
+          {LeftIcon ? (
+            typeof LeftIcon === "function" ? (
               LeftIcon({})
             ) : (
               <F0Icon icon={LeftIcon} size="md" aria-hidden="true" />
-            ))}
+            )
+          ) : null}
           <div className="line-clamp-5 flex-1 whitespace-pre-line text-left">
             {text}
           </div>

--- a/packages/react/src/experimental/Lists/DataList/actions/CopyAction.tsx
+++ b/packages/react/src/experimental/Lists/DataList/actions/CopyAction.tsx
@@ -47,7 +47,7 @@ export const CopyAction = ({ text, children }: CopyActionProps) => {
       {children}
       <div className="relative h-5 w-5">
         <AnimatePresence mode="wait">
-          {!copied && (
+          {!copied ? (
             <motion.div
               key="copy-icon"
               initial={{ opacity: 0, scale: 0.8 }}
@@ -68,8 +68,8 @@ export const CopyAction = ({ text, children }: CopyActionProps) => {
                 )}
               />
             </motion.div>
-          )}
-          {copied && (
+          ) : null}
+          {copied ? (
             <motion.div
               key="check-icon"
               initial={{ opacity: 0, scale: 0.8 }}
@@ -90,7 +90,7 @@ export const CopyAction = ({ text, children }: CopyActionProps) => {
                 )}
               />
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
     </button>

--- a/packages/react/src/experimental/Lists/DataList/index.tsx
+++ b/packages/react/src/experimental/Lists/DataList/index.tsx
@@ -34,7 +34,7 @@ const _DataList = forwardRef<HTMLUListElement, DataListProps>(
             : "min-w-32"
         )}
       >
-        {label && (
+        {label ? (
           <p
             className={cn(
               "px-1.5 text-f1-foreground-secondary",
@@ -43,7 +43,7 @@ const _DataList = forwardRef<HTMLUListElement, DataListProps>(
           >
             {label}
           </p>
-        )}
+        ) : null}
         <ul className="flex flex-col justify-center gap-0.5" ref={ref}>
           {children}
         </ul>

--- a/packages/react/src/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.tsx
@@ -73,37 +73,44 @@ export interface DetailsItemType {
 
 const ItemContent: FC<{ content: DetailsItemContent }> = ({ content }) => (
   <>
-    {content.type === "weekdays" && (
+    {content.type === "weekdays" ? (
       <li className="list-none px-1.5 py-1">
         <Weekdays {...content} />
       </li>
-    )}
-    {content.type === "person" && <DataList.PersonItem {...content} />}
-    {content.type === "item" && <DataList.Item {...content} />}
-    {content.type === "team" && <DataList.TeamItem {...content} />}
-    {content.type === "company" && <DataList.CompanyItem {...content} />}
-    {content.type === "dot-tag" && <DataList.DotTagItem {...content} />}
-    {content.type === "alert-tag" && <DataList.AlertTagItem {...content} />}
-    {content.type === "balance-tag" && <DataList.BalanceTagItem {...content} />}
-    {content.type === "status-tag" && <DataList.StatusTagItem {...content} />}
-    {content.type === "raw-tag" && <DataList.RawTagItem {...content} />}
-    {content.type === "tag-list" && (
+    ) : null}
+    {content.type === "person" ? <DataList.PersonItem {...content} /> : null}
+    {content.type === "item" ? <DataList.Item {...content} /> : null}
+    {content.type === "team" ? <DataList.TeamItem {...content} /> : null}
+    {content.type === "company" ? <DataList.CompanyItem {...content} /> : null}
+    {content.type === "dot-tag" ? <DataList.DotTagItem {...content} /> : null}
+    {content.type === "alert-tag" ? (
+      <DataList.AlertTagItem {...content} />
+    ) : null}
+    {content.type === "balance-tag" ? (
+      <DataList.BalanceTagItem {...content} />
+    ) : null}
+    {content.type === "status-tag" ? (
+      <DataList.StatusTagItem {...content} />
+    ) : null}
+    {content.type === "raw-tag" ? <DataList.RawTagItem {...content} /> : null}
+    {content.type === "tag-list" ? (
       <DataList.TagListItem {...content.tagList} />
-    )}
-    {content.type === "avatar-list" && (
+    ) : null}
+    {content.type === "avatar-list" ? (
       <li className="list-none px-1.5 py-1">
         <F0AvatarList {...content.avatarList} />
       </li>
-    )}
-    {content.type === "file" &&
-      (() => {
-        const { type: _type, ...fileProps } = content
-        return (
-          <li className="list-none px-1.5 py-1">
-            <F0FileItem {...fileProps} />
-          </li>
-        )
-      })()}
+    ) : null}
+    {content.type === "file"
+      ? (() => {
+          const { type: _type, ...fileProps } = content
+          return (
+            <li className="list-none px-1.5 py-1">
+              <F0FileItem {...fileProps} />
+            </li>
+          )
+        })()
+      : null}
   </>
 )
 

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
@@ -45,11 +45,11 @@ const _DetailsItemsList = forwardRef<HTMLDivElement, DetailsItemsListProps>(
     return (
       <DataTestIdWrapper dataTestId={dataTestId}>
         <div ref={ref} className="flex flex-col gap-4">
-          {!!title && (
+          {title ? (
             <p className="mb-1 pl-1.5 text-sm font-semibold text-f1-foreground-secondary">
               {title.toLocaleUpperCase()}
             </p>
-          )}
+          ) : null}
           <div
             className={cn(
               "flex flex-col",
@@ -68,13 +68,13 @@ const _DetailsItemsList = forwardRef<HTMLDivElement, DetailsItemsListProps>(
                   isHorizontal={tableView}
                   verticalLayout={item.verticalLayout}
                 />
-                {tableView && index !== details.length - 1 && (
+                {tableView && index !== details.length - 1 ? (
                   <div className="h-[1px] w-full bg-f1-border-secondary" />
-                )}
+                ) : null}
               </React.Fragment>
             ))}
           </div>
-          {showSeeMore && <SeeMoreButton onClick={onClickSeeMore} />}
+          {showSeeMore ? <SeeMoreButton onClick={onClickSeeMore} /> : null}
         </div>
       </DataTestIdWrapper>
     )

--- a/packages/react/src/experimental/Lists/OnePersonListItem/index.tsx
+++ b/packages/react/src/experimental/Lists/OnePersonListItem/index.tsx
@@ -65,7 +65,7 @@ const BaseOnePersonListItem = React.forwardRef<
       <div className="flex flex-1 flex-col">
         <div className="flex flex-1 flex-row items-center gap-1">
           <span className="truncate font-medium">{`${person.firstName} ${person.lastName}`}</span>
-          {props.info && (
+          {props.info ? (
             <Tooltip label={props.info}>
               <F0Icon
                 icon={InfoCircle}
@@ -73,40 +73,40 @@ const BaseOnePersonListItem = React.forwardRef<
                 className="text-f1-icon-secondary"
               />
             </Tooltip>
-          )}
+          ) : null}
         </div>
-        {"bottomTags" in props && (
+        {"bottomTags" in props ? (
           <div className="-ml-1.5 flex flex-row items-center [&>div]:-mr-1">
             {props.bottomTags.map((tag, i) => (
               <>
                 <F0TagRaw key={tag.text} {...tag} />
-                {i < props.bottomTags.length - 1 && <span>·</span>}
+                {i < props.bottomTags.length - 1 ? <span>·</span> : null}
               </>
             ))}
           </div>
-        )}
-        {"description" in props && props.description && (
+        ) : null}
+        {"description" in props && props.description ? (
           <p className="truncate text-f1-foreground-secondary">
             {props.description}
           </p>
-        )}
+        ) : null}
       </div>
       <div className="flex flex-row items-center justify-between gap-2">
-        {"rightTag" in props && props.rightTag && (
+        {"rightTag" in props && props.rightTag ? (
           <F0TagDot {...props.rightTag} />
-        )}
-        {"actions" in props && (
+        ) : null}
+        {"actions" in props ? (
           <div className="flex flex-1 flex-row items-center justify-end gap-2">
-            {props.actions?.primary && (
+            {props.actions?.primary ? (
               <F0Button
                 variant="outline"
                 onClick={props.actions.primary.onClick}
                 label={props.actions.primary.label}
                 icon={props.actions.primary.icon}
               />
-            )}
+            ) : null}
 
-            {props.actions?.secondary && (
+            {props.actions?.secondary ? (
               <F0Button
                 variant="outline"
                 onClick={props.actions.secondary.onClick}
@@ -114,9 +114,9 @@ const BaseOnePersonListItem = React.forwardRef<
                 icon={props.actions.secondary.icon}
                 hideLabel
               />
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/experimental/Navigation/Carousel/DynamicCarousel/index.tsx
+++ b/packages/react/src/experimental/Navigation/Carousel/DynamicCarousel/index.tsx
@@ -123,7 +123,7 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
             )}
       </div>
 
-      {canScrollPrev && (
+      {canScrollPrev ? (
         <ButtonInternal
           size="lg"
           compact
@@ -137,9 +137,9 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
           label="Previous"
           hideLabel
         ></ButtonInternal>
-      )}
+      ) : null}
 
-      {canScrollNext && (
+      {canScrollNext ? (
         <ButtonInternal
           size="lg"
           variant={"outline"}
@@ -153,7 +153,7 @@ export const DynamicCarousel = ({ children }: PropsWithChildren) => {
           label="Next"
           hideLabel
         ></ButtonInternal>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/experimental/Navigation/Carousel/index.tsx
+++ b/packages/react/src/experimental/Navigation/Carousel/index.tsx
@@ -173,12 +173,12 @@ const _Carousel = ({
               )
             })}
           </CarouselContent>
-          {showArrows && !inRow && (
+          {showArrows && !inRow ? (
             <>
               <CarouselPrevious label={arrowLabels?.previous ?? "Previous"} />
               <CarouselNext label={arrowLabels?.next ?? "Next"} />
             </>
-          )}
+          ) : null}
         </div>
         {inRow ? (
           <CarouselControls labels={arrowLabels} showDots={showDots} />

--- a/packages/react/src/experimental/Navigation/Dropdown/DropdownItem.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/DropdownItem.tsx
@@ -5,17 +5,17 @@ import { DropdownItemObject } from "./internal"
 
 export const DropdownItemContent = ({ item }: { item: DropdownItemObject }) => (
   <>
-    {item.avatar && <F0Avatar avatar={item.avatar} size="xs" />}
-    {item.icon && (
+    {item.avatar ? <F0Avatar avatar={item.avatar} size="xs" /> : null}
+    {item.icon ? (
       <F0Icon
         icon={item.icon}
         size="md"
         className={cn("text-f1-icon", item.critical && "text-f1-icon-critical")}
       />
-    )}
+    ) : null}
     <div className="flex flex-col items-start">
       {item.label}
-      {item.description && (
+      {item.description ? (
         <div
           className={cn(
             "font-normal text-f1-foreground-secondary",
@@ -24,7 +24,7 @@ export const DropdownItemContent = ({ item }: { item: DropdownItemObject }) => (
         >
           {item.description}
         </div>
-      )}
+      ) : null}
     </div>
   </>
 )

--- a/packages/react/src/experimental/Navigation/Dropdown/index.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/index.tsx
@@ -126,7 +126,7 @@ const _MobileDropdown = ({ items, children, dataTestId }: DropdownProps) => {
                   }}
                   className="flex w-full cursor-pointer items-center gap-2 p-3"
                 >
-                  {item.icon && (
+                  {item.icon ? (
                     <span
                       className={cn(
                         "h-5 w-5 text-f1-icon",
@@ -135,7 +135,7 @@ const _MobileDropdown = ({ items, children, dataTestId }: DropdownProps) => {
                     >
                       <F0Icon icon={item.icon} size="md" />
                     </span>
-                  )}
+                  ) : null}
                   <span
                     className={cn(
                       "font-medium",

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/ItemDropDown.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/ItemDropDown.tsx
@@ -53,7 +53,9 @@ function renderAction(action: TOCItemAction, index: number) {
             }}
           >
             <div className="flex w-full flex-row items-center gap-2">
-              {action.icon && <F0Icon icon={action.icon} color="default" />}
+              {action.icon ? (
+                <F0Icon icon={action.icon} color="default" />
+              ) : null}
               <span className="flex-1">{action.label}</span>
               <Switch
                 title={action.label}
@@ -73,15 +75,17 @@ function renderAction(action: TOCItemAction, index: number) {
           <DropdownMenuSub>
             <DropdownMenuSubTrigger className="mx-1 px-2 data-[state=open]:rounded-sm data-[state=closed]:bg-transparent data-[state=open]:bg-f1-background-hover">
               <div className="flex w-full flex-row items-center gap-2">
-                {action.icon && <F0Icon icon={action.icon} color="default" />}
+                {action.icon ? (
+                  <F0Icon icon={action.icon} color="default" />
+                ) : null}
                 <span className="flex-1 text-base font-medium">
                   {action.label}
                 </span>
-                {action.selectedLabel && (
+                {action.selectedLabel ? (
                   <span className="mr-1 text-base text-f1-foreground-secondary">
                     {action.selectedLabel}
                   </span>
-                )}
+                ) : null}
               </div>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
@@ -109,9 +113,9 @@ function renderAction(action: TOCItemAction, index: number) {
       className={cn(item.critical && "text-f1-foreground-critical")}
     >
       <div className="flex w-full flex-row items-center gap-2">
-        {item.icon && <F0Icon icon={item.icon} />}
+        {item.icon ? <F0Icon icon={item.icon} /> : null}
         <span className="flex-1">{item.label}</span>
-        {item.selected && <F0Icon icon={Check} color="default" />}
+        {item.selected ? <F0Icon icon={Check} color="default" /> : null}
       </div>
     </DropdownMenuItem>
   )

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/PrimitiveItem.tsx
@@ -53,7 +53,7 @@ export function PrimitiveItem({
 
   return (
     <div className="flex w-full min-w-0 items-center">
-      {collapsible && (
+      {collapsible ? (
         <ButtonInternal
           compact
           size="sm"
@@ -70,7 +70,7 @@ export function PrimitiveItem({
           )}
           icon={ChevronDown}
         ></ButtonInternal>
-      )}
+      ) : null}
       <div
         className={cn(
           focusRing("focus:border-f1-border-focus"),
@@ -84,7 +84,7 @@ export function PrimitiveItem({
         onMouseEnter={() => setIsHovered(true)}
         onMouseLeave={() => setIsHovered(false)}
       >
-        {(sortable || icon) && (
+        {sortable || icon ? (
           <div className="absolute left-1.5 top-1/2 -translate-y-1/2">
             <AnimatePresence mode="wait">
               {showHandleIcon ? (
@@ -125,7 +125,7 @@ export function PrimitiveItem({
               )}
             </AnimatePresence>
           </div>
-        )}
+        ) : null}
         <OneEllipsis
           lines={1}
           className={cn(
@@ -137,7 +137,7 @@ export function PrimitiveItem({
         </OneEllipsis>
 
         <AnimatePresence>
-          {(shouldShowCounter || shouldShowDropdown) && (
+          {shouldShowCounter || shouldShowDropdown ? (
             <motion.div
               key="actions-container"
               initial={{ opacity: 0, scale: 0.8 }}
@@ -178,20 +178,20 @@ export function PrimitiveItem({
                       }}
                       className="flex items-center justify-center"
                     >
-                      {otherActions && (
+                      {otherActions ? (
                         <ItemDropDown
                           otherActions={otherActions}
                           open={open}
                           setOpen={setOpen}
                           disabled={disabled}
                         />
-                      )}
+                      ) : null}
                     </motion.div>
                   )
                 )}
               </AnimatePresence>
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
       {children}

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/StaticItemSectionHeader.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/ItemSectionHeader/StaticItemSectionHeader.tsx
@@ -48,11 +48,11 @@ export function StaticItemSectionHeader({
         currentParentId={currentParentId}
         draggedItemId={draggedItemId}
       />
-      {children && (
+      {children ? (
         <div className="ml-[18px] min-w-0 border-0 border-l border-solid border-f1-border-secondary pl-4">
           {children}
         </div>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/TOCFooter/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/TOCFooter/index.tsx
@@ -32,7 +32,7 @@ export function TOCFooter({ actions }: TOCFooterProps) {
           >
             {action.label}
           </OneEllipsis>
-          {action.icon && <F0Icon icon={action.icon} color="secondary" />}
+          {action.icon ? <F0Icon icon={action.icon} color="secondary" /> : null}
         </div>
       ))}
     </div>

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
@@ -104,7 +104,7 @@ function renderTOCItem(
   return (
     <>
       {/* Placeholder before item — instant, pointer-events-none to avoid layout thrashing */}
-      {showPlaceholderBefore && (
+      {showPlaceholderBefore ? (
         <div
           className={cn(
             "pointer-events-none h-10 rounded border-2 border-dashed border-f1-border-secondary bg-f1-background-hover/40",
@@ -112,7 +112,7 @@ function renderTOCItem(
             "mb-0.5"
           )}
         />
-      )}
+      ) : null}
       {Component === Item ? (
         <Item
           key={item.id}
@@ -149,7 +149,7 @@ function renderTOCItem(
           currentParentId={currentParentId}
           draggedItemId={draggedItemId}
         >
-          {item.children && (Component === ItemSectionHeader || isExpanded) && (
+          {item.children && (Component === ItemSectionHeader || isExpanded) ? (
             <div
               className={cn(
                 "flex flex-col",
@@ -185,21 +185,21 @@ function renderTOCItem(
               })}
               {/* Placeholder when dragging inside and section is empty or collapsed */}
               {isDragOver &&
-                dragOverPosition === "inside" &&
-                canDropInside &&
-                (!isExpanded || item.children.length === 0) && (
-                  <div className="flex h-9 items-center justify-center rounded-md bg-f1-background-hover/30 text-xs text-f1-foreground-secondary">
-                    Drop here
-                  </div>
-                )}
+              dragOverPosition === "inside" &&
+              canDropInside &&
+              (!isExpanded || item.children.length === 0) ? (
+                <div className="flex h-9 items-center justify-center rounded-md bg-f1-background-hover/30 text-xs text-f1-foreground-secondary">
+                  Drop here
+                </div>
+              ) : null}
             </div>
-          )}
+          ) : null}
         </Component>
       )}
       {/* Placeholder after item — instant, pointer-events-none to avoid layout thrashing */}
-      {showPlaceholderAfter && (
+      {showPlaceholderAfter ? (
         <div className="pointer-events-none my-0.5 h-10 rounded border-2 border-dashed border-f1-border-secondary bg-f1-background-hover/40" />
-      )}
+      ) : null}
     </>
   )
 }
@@ -897,9 +897,9 @@ function TOCContent({
       aria-label={title}
       ref={containerRef}
     >
-      {(title || showSearchBox) && (
+      {title || showSearchBox ? (
         <div className="shrink-0 bg-f1-background pb-2 pl-5 pr-4 pt-5">
-          {showSearchBox && (
+          {showSearchBox ? (
             <div className="mb-4">
               <F0SearchInput
                 placeholder={searchPlaceholder ?? i18n.toc.search}
@@ -908,9 +908,9 @@ function TOCContent({
                 clearable
               />
             </div>
-          )}
+          ) : null}
 
-          {title && (
+          {title ? (
             <OneEllipsis
               lines={1}
               tag="h2"
@@ -918,9 +918,9 @@ function TOCContent({
             >
               {title}
             </OneEllipsis>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
       {(() => {
         const displayItems = sortable ? filteredSortableItems : filteredItems
         const firstItem = displayItems[0]
@@ -929,7 +929,7 @@ function TOCContent({
 
         const listContent = (
           <>
-            {sortable && firstItem && (
+            {sortable && firstItem ? (
               <EdgeDropZone
                 targetItemId={firstItem.id}
                 position="before"
@@ -938,7 +938,7 @@ function TOCContent({
                 onDrop={handleDrop}
                 visible={hasDrag}
               />
-            )}
+            ) : null}
             {displayItems.map((item) =>
               renderTOCItem(
                 item,
@@ -962,7 +962,7 @@ function TOCContent({
                 justDroppedItemId
               )
             )}
-            {sortable && lastItem && (
+            {sortable && lastItem ? (
               <EdgeDropZone
                 targetItemId={lastItem.id}
                 position="after"
@@ -971,7 +971,7 @@ function TOCContent({
                 onDrop={handleDrop}
                 visible={hasDrag}
               />
-            )}
+            ) : null}
           </>
         )
 

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/index.tsx
@@ -112,7 +112,7 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
           </BreadcrumbItem>
         ))}
       </ol>
-      {state && state.headItem && (
+      {state && state.headItem ? (
         <BreadcrumbList>
           <BreadcrumbItem
             isOnly={state.isOnly}
@@ -127,7 +127,7 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
             this triggers resize observer and starts an infinite loop.
             The only way to make this transactional is to rerender all tail breadcrumbs together with the collapsed element
           */}
-          {hasCollapsedElements && (
+          {hasCollapsedElements ? (
             <>
               <CollapsedBreadcrumbItem
                 key="collapsed-items"
@@ -144,8 +144,8 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
                 </BreadcrumbItem>
               ))}
             </>
-          )}
-          {!hasCollapsedElements && (
+          ) : null}
+          {!hasCollapsedElements ? (
             <>
               {state.tailItems.map((item, index) => (
                 <BreadcrumbItem
@@ -158,9 +158,9 @@ export function Breadcrumbs({ breadcrumbs, append }: BreadcrumbsProps) {
                 </BreadcrumbItem>
               ))}
             </>
-          )}
+          ) : null}
         </BreadcrumbList>
-      )}
+      ) : null}
     </Breadcrumb>
   )
 }

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
@@ -40,7 +40,7 @@ vi.mock("../BreadcrumbSelect", async (importOriginal) => {
   const BreadcrumbSelect: typeof actual.BreadcrumbSelect = (props) => (
     <>
       <actual.BreadcrumbSelect {...props} />
-      {driver.selection && (
+      {driver.selection ? (
         <button
           aria-label="pick"
           onClick={() =>
@@ -54,8 +54,8 @@ vi.mock("../BreadcrumbSelect", async (importOriginal) => {
             )
           }
         />
-      )}
-      {driver.filtersChange && (
+      ) : null}
+      {driver.filtersChange ? (
         <button
           aria-label="set-filters"
           onClick={() =>
@@ -66,7 +66,7 @@ vi.mock("../BreadcrumbSelect", async (importOriginal) => {
             )
           }
         />
-      )}
+      ) : null}
     </>
   )
   return { ...actual, BreadcrumbSelect }

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.tsx
@@ -129,7 +129,7 @@ export function BreadcrumbCollectionSelect({
         showSearchBox={item.searchbox}
         onFiltersChange={stableOnFiltersChange}
       />
-      {pendingHref && (
+      {pendingHref ? (
         <Link
           href={pendingHref}
           ref={navRef}
@@ -137,7 +137,7 @@ export function BreadcrumbCollectionSelect({
           aria-hidden
           className="hidden"
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
@@ -29,7 +29,7 @@ const BreadcrumbItem = forwardRef<
   PropsWithChildren<BreadcrumbItemProps>
 >(({ item, isLast, isOnly = false, isFirst = false, children }, ref) => (
   <ShadBreadcrumbItem key={getBreadcrumbKey(item)} ref={ref}>
-    {!isFirst && <BreadcrumbSeparator />}
+    {!isFirst ? <BreadcrumbSeparator /> : null}
     <BreadcrumbContent
       item={item}
       isLast={isLast}
@@ -65,11 +65,11 @@ const BreadcrumbContent = forwardRef<HTMLDivElement, BreadcrumbItemProps>(
         transition={{ duration: 0.15 }}
       >
         {!isLoading &&
-          "module" in item &&
-          item.module &&
-          (isOnly || isFirst) && (
-            <F0AvatarModule module={item.module} size={isOnly ? "md" : "xs"} />
-          )}
+        "module" in item &&
+        item.module &&
+        (isOnly || isFirst) ? (
+          <F0AvatarModule module={item.module} size={isOnly ? "md" : "xs"} />
+        ) : null}
         <span className="truncate">
           {!isLoading && "label" in item ? item.label : ""}
         </span>

--- a/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageHeader/index.tsx
@@ -131,7 +131,7 @@ export function PageHeader({
     >
       <div className="flex flex-grow items-center">
         <AnimatePresence>
-          {!embedded && sidebarState !== "locked" && (
+          {!embedded && sidebarState !== "locked" ? (
             <motion.div
               initial={{ opacity: 0, width: 0 }}
               animate={{ opacity: 1, width: "auto" }}
@@ -147,7 +147,7 @@ export function PageHeader({
                 />
               </div>
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
         <div
           className={cn(
@@ -155,7 +155,7 @@ export function PageHeader({
             canGoBack && "justify-center"
           )}
         >
-          {embedded && canGoBack && (
+          {embedded && canGoBack ? (
             <div className="absolute left-4">
               <F0Button
                 variant="ghost"
@@ -165,7 +165,7 @@ export function PageHeader({
                 onClick={() => window.history.back()}
               />
             </div>
-          )}
+          ) : null}
           {canGoBack || hasNavigation ? (
             <div className="text-lg font-semibold text-f1-foreground">
               {"loading" in lastBreadcrumb ? (
@@ -192,7 +192,7 @@ export function PageHeader({
         </div>
       </div>
       <div className="flex items-center gap-3">
-        {!embedded && hasStatus && (
+        {!embedded && hasStatus ? (
           <div>
             {statusTag.tooltip ? (
               <Tooltip label={statusTag.tooltip}>
@@ -208,42 +208,44 @@ export function PageHeader({
               <F0TagStatus text={statusTag.text} variant={statusTag.variant} />
             )}
           </div>
-        )}
+        ) : null}
         {!embedded &&
-          hasStatus &&
-          (effectiveNavigation || hasActions || hasProductUpdates) && (
-            <div className="h-4 w-px bg-f1-border-secondary" />
-          )}
-        {effectiveNavigation && <PageNavigation {...effectiveNavigation} />}
-        {effectiveNavigation && hasActions && (
+        hasStatus &&
+        (effectiveNavigation || hasActions || hasProductUpdates) ? (
           <div className="h-4 w-px bg-f1-border-secondary" />
-        )}
-        {(hasProductUpdates || hasActions) && (
+        ) : null}
+        {effectiveNavigation ? (
+          <PageNavigation {...effectiveNavigation} />
+        ) : null}
+        {effectiveNavigation && hasActions ? (
+          <div className="h-4 w-px bg-f1-border-secondary" />
+        ) : null}
+        {hasProductUpdates || hasActions ? (
           <div className="flex items-center gap-2">
-            {hasProductUpdates && (
+            {hasProductUpdates ? (
               <div className="items-right flex gap-2">
                 <ProductUpdates
                   {...productUpdates}
                   currentModule={module.name}
                 />
               </div>
-            )}
-            {hasActions && (
+            ) : null}
+            {hasActions ? (
               <div className="items-right flex gap-2">
                 {actions.map((action, index) => (
                   <PageAction key={index} action={action} />
                 ))}
               </div>
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
         <div className="flex items-center gap-3">
-          {!hideOneSwitch && (
+          {!hideOneSwitch ? (
             <F0OneSwitch
               tooltip={oneSwitchTooltip}
               autoOpen={oneSwitchAutoOpen}
             />
-          )}
+          ) : null}
           <OnePromotionSwitch />
         </div>
       </div>

--- a/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/PageNavigation/index.tsx
@@ -71,11 +71,11 @@ function PageNavigationLink({
 export function PageNavigation({ previous, next, counter }: NavigationProps) {
   return (
     <div className="flex items-center gap-3">
-      {counter && (
+      {counter ? (
         <span className="text-sm text-f1-foreground-secondary">
           {counter.current}/{counter.total}
         </span>
-      )}
+      ) : null}
       <div className="flex items-center gap-2">
         <PageNavigationLink
           icon={ChevronLeft}

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -151,20 +151,20 @@ const ProductUpdates = ({
           style={{ maxHeight: "min(90vh, 760px)" }}
         >
           <Header title={label} url={updatesPageUrl} onClick={onHeaderClick} />
-          {state === "fetching" && <ProductUpdatesSkeleton />}
+          {state === "fetching" ? <ProductUpdatesSkeleton /> : null}
           <div className="scrollbar-macos flex-1 overflow-y-auto">
-            {state === "idle" && updates !== null && updates.length === 0 && (
+            {state === "idle" && updates !== null && updates.length === 0 ? (
               <div className="p-2 pt-0">
                 <NoUpdates {...emptyScreen} buttonUrl={updatesPageUrl} />
               </div>
-            )}
-            {state === "idle" && updates !== null && updates.length > 0 && (
+            ) : null}
+            {state === "idle" && updates !== null && updates.length > 0 ? (
               <div className="px-1">
                 <FeaturedDropdownItem
                   {...featuredUpdate}
                   onClick={onItemClick}
                 />
-                {updates.length > 1 && (
+                {updates.length > 1 ? (
                   <>
                     <div className="pb-1">
                       {restUpdates.map((update, index) => (
@@ -176,10 +176,10 @@ const ProductUpdates = ({
                       ))}
                     </div>
                   </>
-                )}
+                ) : null}
               </div>
-            )}
-            {state === "error" && (
+            ) : null}
+            {state === "error" ? (
               <div className="p-2 pt-0">
                 <ErrorScreen
                   {...errorScreen}
@@ -188,16 +188,16 @@ const ProductUpdates = ({
                   }}
                 />
               </div>
-            )}
+            ) : null}
           </div>
-          {state === "idle" && crossSelling && crossSelling.isVisible && (
+          {state === "idle" && crossSelling && crossSelling.isVisible ? (
             <DiscoverMoreProducts
               isVisible={crossSelling.isVisible}
               onClose={crossSelling.onClose}
               crossSelling={crossSelling}
               onDropdownClose={() => setOpen(false)}
             />
-          )}
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenuPortal>
     </DropdownMenu>
@@ -259,7 +259,7 @@ const FeaturedDropdownItem = ({
                 {updated}
               </p>
             </div>
-            {unread && <UnreadDot className="mt-1.5" />}
+            {unread ? <UnreadDot className="mt-1.5" /> : null}
           </div>
         </div>
       </Link>
@@ -295,7 +295,7 @@ const DropdownItem = ({
               {updated}
             </p>
           </div>
-          {unread && <UnreadDot className="mt-1.5" />}
+          {unread ? <UnreadDot className="mt-1.5" /> : null}
         </div>
       </Link>
     </DropdownMenuItem>
@@ -470,7 +470,7 @@ const DiscoverMoreProducts = ({
               {crossSelling?.sectionTitle}
             </p>
 
-            {onClose && (
+            {onClose ? (
               <div className="relative z-10 h-6 w-6">
                 <F0Button
                   variant="ghost"
@@ -481,7 +481,7 @@ const DiscoverMoreProducts = ({
                   label="Close"
                 />
               </div>
-            )}
+            ) : null}
           </div>
 
           <Carousel

--- a/packages/react/src/experimental/OneTable/Table/index.tsx
+++ b/packages/react/src/experimental/OneTable/Table/index.tsx
@@ -58,7 +58,7 @@ function TableBase({ children, loading = false }: TableProps) {
           {children}
         </TableRoot>
         <AnimatePresence>
-          {loading && (
+          {loading ? (
             <motion.div
               className="absolute inset-0 flex cursor-progress items-center justify-center"
               initial={{ opacity: 0 }}
@@ -67,7 +67,7 @@ function TableBase({ children, loading = false }: TableProps) {
             >
               <Spinner />
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
     </TableContext.Provider>

--- a/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
@@ -189,8 +189,8 @@ export const NestedCell = ({
               }
             }}
           >
-            {firstCellWithChildren &&
-              (nestedRowProps?.expanded ? (
+            {firstCellWithChildren ? (
+              nestedRowProps?.expanded ? (
                 <ChevronDown
                   className="pointer-events-none shrink-0"
                   size={CHEVRON_SIZE}
@@ -200,7 +200,8 @@ export const NestedCell = ({
                   className="pointer-events-none shrink-0"
                   size={CHEVRON_SIZE}
                 />
-              ))}
+              )
+            ) : null}
           </div>
           <div
             className={cn(

--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -176,8 +176,7 @@ export function TableCell({
       }}
     >
       <AnimatePresence>
-        {((isStickyLeft && isScrolled) ||
-          (isStickyRight && isScrolledRight)) && (
+        {(isStickyLeft && isScrolled) || (isStickyRight && isScrolledRight) ? (
           <motion.div
             key="cell-shadow-gradient"
             className={cn(
@@ -189,18 +188,18 @@ export function TableCell({
             animate={{ opacity: 0.1 }}
             exit={{ opacity: 0 }}
           />
-        )}
+        ) : null}
       </AnimatePresence>
 
-      {firstCell && nestedRowProps?.tableWithChildren && (
+      {firstCell && nestedRowProps?.tableWithChildren ? (
         <TreeConnector
           firstCell={firstCell}
           nestedRowProps={nestedRowProps}
           fromVisualization={fromVisualization}
         />
-      )}
+      ) : null}
 
-      {loading && (
+      {loading ? (
         <div
           style={{ ...firstCellMarginLeft }}
           className={cn(
@@ -212,9 +211,9 @@ export function TableCell({
         >
           <Skeleton className="h-4 w-full" />
         </div>
-      )}
+      ) : null}
 
-      {!loading && (
+      {!loading ? (
         <>
           <div
             className={cn(
@@ -254,7 +253,7 @@ export function TableCell({
               </div>
             )}
           </div>
-          {href && (
+          {href ? (
             <Link
               ref={linkRef}
               href={href}
@@ -263,8 +262,8 @@ export function TableCell({
             >
               <span className="sr-only">{actions.view}</span>
             </Link>
-          )}
-          {onClick && (
+          ) : null}
+          {onClick ? (
             <button
               type="button"
               onClick={(e) => {
@@ -283,9 +282,9 @@ export function TableCell({
             >
               <span className="sr-only">{actions.view}</span>
             </button>
-          )}
+          ) : null}
         </>
-      )}
+      ) : null}
     </TableCellRoot>
   )
 }

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -166,9 +166,9 @@ export function TableHead({
             {children}
           </div>
         )}
-        {hasContent && (
+        {hasContent ? (
           <div className="flex items-center">
-            {info && (
+            {info ? (
               <div
                 className="flex h-6 w-6 items-center justify-center text-f1-foreground-secondary"
                 // Reading the column's help text is not asking to sort by it.
@@ -180,8 +180,8 @@ export function TableHead({
                   label={typeof children === "string" ? children : undefined}
                 />
               </div>
-            )}
-            {onSortClick && (
+            ) : null}
+            {onSortClick ? (
               <motion.button
                 className={cn(
                   "relative h-5 w-5 rounded-xs p-1 text-f1-foreground-secondary opacity-0 transition-all focus-within:opacity-100 hover:bg-f1-background-hover group-hover:opacity-100",
@@ -208,7 +208,7 @@ export function TableHead({
                   >
                     <F0Icon icon={ArrowDown} size="xs" />
                   </motion.div>
-                  {sortState === "none" && (
+                  {sortState === "none" ? (
                     <motion.div
                       key="sort-arrow-secondary"
                       className="absolute left-1 top-1 flex h-3 w-3 items-center justify-center"
@@ -222,12 +222,12 @@ export function TableHead({
                     >
                       <F0Icon icon={ArrowDown} size="xs" />
                     </motion.div>
-                  )}
+                  ) : null}
                 </AnimatePresence>
               </motion.button>
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
       </div>
     </>
   )
@@ -278,8 +278,7 @@ export function TableHead({
     >
       <div className="absolute inset-x-0 top-0 z-[1] h-px w-full bg-f1-border-secondary" />
       <AnimatePresence>
-        {((isStickyLeft && isScrolled) ||
-          (isStickyRight && isScrolledRight)) && (
+        {(isStickyLeft && isScrolled) || (isStickyRight && isScrolledRight) ? (
           <motion.div
             key="shadow-gradient"
             className={cn(
@@ -291,9 +290,9 @@ export function TableHead({
             animate={{ opacity: 0.1 }}
             exit={{ opacity: 0 }}
           />
-        )}
+        ) : null}
       </AnimatePresence>
-      {!hidden && content}
+      {!hidden ? content : null}
     </TableHeadRoot>
   )
 }

--- a/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/CoachmarkProvider.tsx
@@ -216,9 +216,9 @@ export const CoachmarkProvider = ({
 
   return (
     <>
-      {isRenderer && item && (
+      {isRenderer && item ? (
         <ActiveCoachmark key={item.id} item={item} container={container} />
-      )}
+      ) : null}
       {children}
     </>
   )

--- a/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/F0Coachmark.tsx
@@ -231,7 +231,7 @@ const CoachmarkPanel = ({
       {/* Under the panel and over everything else. Rendered from here rather
           than by the provider so the two always agree on which element is lit:
           the panel points at `target`, and so does the hole. */}
-      {overlay && (
+      {overlay ? (
         <CoachmarkSpotlight
           target={target}
           container={container}
@@ -240,7 +240,7 @@ const CoachmarkPanel = ({
             onOutsideInteraction?.()
           }}
         />
-      )}
+      ) : null}
       <PopoverContent
         ref={contentRef}
         container={container}
@@ -351,7 +351,7 @@ const CoachmarkPanel = ({
                 className="flex-shrink-0"
               />
             </div>
-            {description && (
+            {description ? (
               // One level down from the title, which keeps the panel's own
               // colour. Same pairing F0Toast uses for title vs description.
               <p
@@ -360,16 +360,16 @@ const CoachmarkPanel = ({
               >
                 {description}
               </p>
-            )}
+            ) : null}
           </div>
           {/* `ml-auto` on the action rather than `justify-end` on the row, so
               the action stays right aligned whether or not a step is present. */}
           <div className="flex flex-row items-center gap-3">
-            {step && (
+            {step ? (
               <p className="text-f1-foreground-inverse-secondary">
                 {step.current}/{step.total}
               </p>
-            )}
+            ) : null}
             <ButtonInternal
               variant="outline"
               label={label}
@@ -378,7 +378,7 @@ const CoachmarkPanel = ({
             />
           </div>
         </div>
-        {arrow && !centred && (
+        {arrow && !centred ? (
           <PopoverArrow asChild width={ARROW_WIDTH} height={ARROW_HEIGHT}>
             {/* The fill uses the panel's own surface tokens, alpha included, so
                 both composite over the same backdrop to the same colour. It is
@@ -392,7 +392,7 @@ const CoachmarkPanel = ({
               />
             </svg>
           </PopoverArrow>
-        )}
+        ) : null}
       </PopoverContent>
     </Popover>
   )

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.stories.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__stories__/F0Coachmark.stories.tsx
@@ -33,14 +33,14 @@ const AnchoredCoachmark = ({
       <span ref={setTarget} className="inline-flex">
         <F0Button variant="outline" label={anchorLabel} />
       </span>
-      {target && (
+      {target ? (
         <F0Coachmark
           {...props}
           target={target}
           onAction={() => undefined}
           onClose={() => undefined}
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/F0Coachmark.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/F0Coachmark.test.tsx
@@ -18,7 +18,7 @@ const Harness = (props: PanelProps) => {
   return (
     <>
       <button ref={setTarget}>Filters</button>
-      {target && <F0Coachmark {...props} target={target} />}
+      {target ? <F0Coachmark {...props} target={target} /> : null}
     </>
   )
 }

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/coachmarks.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/coachmarks.test.tsx
@@ -141,7 +141,7 @@ describe("coachmarks API", () => {
         return (
           <CoachmarkProvider>
             <button onClick={() => setMounted(true)}>Mount target</button>
-            {mounted && <button id="late">Late</button>}
+            {mounted ? <button id="late">Late</button> : null}
           </CoachmarkProvider>
         )
       }
@@ -169,7 +169,7 @@ describe("coachmarks API", () => {
             <button onClick={() => setMounted((value) => !value)}>
               Toggle target
             </button>
-            {mounted && <button id="toggling">Toggling</button>}
+            {mounted ? <button id="toggling">Toggling</button> : null}
           </CoachmarkProvider>
         )
       }

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -163,13 +163,15 @@ export function TooltipInternal({
           >
             <div className="flex flex-col gap-0.5">
               <div className="flex items-center gap-2">
-                {label && <p className="font-semibold">{label}</p>}
-                {shortcut && <Shortcut keys={shortcut} variant="inverse" />}
+                {label ? <p className="font-semibold">{label}</p> : null}
+                {shortcut ? (
+                  <Shortcut keys={shortcut} variant="inverse" />
+                ) : null}
               </div>
-              {description && (
+              {description ? (
                 <p className="font-normal">{description.toString()}</p>
-              )}
-              {items && items.length > 0 && (
+              ) : null}
+              {items && items.length > 0 ? (
                 <ul className="m-0 flex list-disc flex-col gap-0.5 pl-4 font-normal">
                   {items.map((item, index) => (
                     <li
@@ -180,13 +182,13 @@ export function TooltipInternal({
                       ) : (
                         <>
                           <span className="font-semibold">{item.title}</span>
-                          {item.description && <> {item.description}</>}
+                          {item.description ? <> {item.description}</> : null}
                         </>
                       )}
                     </li>
                   ))}
                 </ul>
-              )}
+              ) : null}
             </div>
           </TooltipContent>
         </TooltipPrimitive>

--- a/packages/react/src/experimental/Widgets/ChartWidgetEmptyState/index.tsx
+++ b/packages/react/src/experimental/Widgets/ChartWidgetEmptyState/index.tsx
@@ -69,23 +69,25 @@ const _ChartWidgetEmptyState = forwardRef<HTMLDivElement, Props>(
               bgClassName
             )}
           >
-            {type === "bar-chart" && (
+            {type === "bar-chart" ? (
               <div className="absolute bottom-1 left-4 right-4">
                 <EmptyBarChart className="w-full" />
               </div>
-            )}
-            {type === "line-chart" && <EmptyLineChart className="w-full" />}
+            ) : null}
+            {type === "line-chart" ? (
+              <EmptyLineChart className="w-full" />
+            ) : null}
           </div>
           <div className="relative flex min-h-28 flex-1 flex-col items-start gap-5">
             <p className="flex w-3/4 text-xl font-semibold">{content}</p>
-            {buttonLabel && (
+            {buttonLabel ? (
               <F0Button
                 label={buttonLabel}
                 icon={buttonIcon}
                 variant={buttonVariant}
                 onClick={buttonAction}
               />
-            )}
+            ) : null}
           </div>
         </CardContent>
       </Card>

--- a/packages/react/src/experimental/Widgets/Charts/ChartContainer.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/ChartContainer.tsx
@@ -17,7 +17,9 @@ export const ChartContainer = Object.assign(
   >(function ChartContainer({ chart, summaries, ...props }, ref) {
     return (
       <Widget ref={ref} {...props} summaries={summaries}>
-        {chart && <div className="min-h-52 min-w-52 grow pt-2">{chart}</div>}
+        {chart ? (
+          <div className="min-h-52 min-w-52 grow pt-2">{chart}</div>
+        ) : null}
       </Widget>
     )
   }),

--- a/packages/react/src/experimental/Widgets/Content/CalendarEvent/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/CalendarEvent/index.tsx
@@ -84,7 +84,7 @@ export const CalendarEvent = forwardRef<HTMLDivElement, CalendarEventProps>(
         ref={ref}
         className="relative flex flex-row items-stretch gap-2.5 overflow-hidden rounded-sm p-2"
       >
-        {!noBackground && (
+        {!noBackground ? (
           <>
             <div
               className="absolute bottom-0 left-0 right-0 top-0 opacity-5"
@@ -99,7 +99,7 @@ export const CalendarEvent = forwardRef<HTMLDivElement, CalendarEventProps>(
               }}
             />
           </>
-        )}
+        ) : null}
 
         <div
           className="min-h-10 min-w-1 rounded-2xs"
@@ -122,21 +122,21 @@ export const CalendarEvent = forwardRef<HTMLDivElement, CalendarEventProps>(
         <div className="z-10 flex flex-1 flex-col gap-2">
           <div className="flex flex-row items-start gap-2.5">
             <div className="flex flex-1 flex-col gap-0.5">
-              {!!label && (
+              {label ? (
                 <p className="line-clamp-1 text-sm text-f1-foreground-secondary">
                   {label}
                 </p>
-              )}
+              ) : null}
               <p className="line-clamp-3 font-medium text-f1-foreground">
                 {title}
-                {!!subtitle && (
+                {subtitle ? (
                   <span className="pl-1 font-normal text-f1-foreground-secondary">{`· ${subtitle}`}</span>
-                )}
+                ) : null}
               </p>
               <p className="text-f1-foreground-secondary">{description}</p>
             </div>
             <div className="flex flex-row items-center">
-              {fromDate && (
+              {fromDate ? (
                 <>
                   <F0AvatarDate date={fromDate} />
                   <F0Icon
@@ -145,16 +145,16 @@ export const CalendarEvent = forwardRef<HTMLDivElement, CalendarEventProps>(
                     className="text-f1-foreground-tertiary"
                   />
                 </>
-              )}
-              {toDate && <F0AvatarDate date={toDate} />}
+              ) : null}
+              {toDate ? <F0AvatarDate date={toDate} /> : null}
             </div>
           </div>
-          {(leftTags || rightTags) && (
+          {leftTags || rightTags ? (
             <div className="flex flex-row items-center justify-between">
-              {leftTags && <Tags tags={leftTags} />}
-              {rightTags && <Tags tags={rightTags} right />}
+              {leftTags ? <Tags tags={leftTags} /> : null}
+              {rightTags ? <Tags tags={rightTags} right /> : null}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     )

--- a/packages/react/src/experimental/Widgets/Content/ListItems/WidgetAvatarsListItem/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ListItems/WidgetAvatarsListItem/index.tsx
@@ -72,8 +72,12 @@ export function WidgetAvatarsListItem({
       withEmoji={"emoji" in props && !!props.emoji}
       withPointerCursor={withPointerCursor}
     >
-      {"alert" in props && props.alert && <F0AvatarAlert type={props.alert} />}
-      {"emoji" in props && props.emoji && <F0AvatarEmoji emoji={props.emoji} />}
+      {"alert" in props && props.alert ? (
+        <F0AvatarAlert type={props.alert} />
+      ) : null}
+      {"emoji" in props && props.emoji ? (
+        <F0AvatarEmoji emoji={props.emoji} />
+      ) : null}
       <div className="flex-1">
         <p className="line-clamp-1 font-medium">{title}</p>
         <p className="line-clamp-1 text-f1-foreground-secondary">{subtitle}</p>

--- a/packages/react/src/experimental/Widgets/Content/ListItems/WidgetSimpleListItem/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ListItems/WidgetSimpleListItem/index.tsx
@@ -64,26 +64,26 @@ export function WidgetSimpleListItem({
   return (
     <Wrapper onClick={handleOnClick} className={className}>
       <div className="flex flex-1 flex-row items-start gap-1">
-        {icon && (
+        {icon ? (
           <F0Icon
             icon={icon}
             size="md"
             className={cn("mt-0.5", iconClassName)}
           />
-        )}
+        ) : null}
         <p className="mt-0.5 line-clamp-2 font-medium">{title}</p>
-        {rightIcon && (
+        {rightIcon ? (
           <F0Icon
             icon={rightIcon}
             size="md"
             className={cn("mt-0.5", rightIconClassName)}
           />
-        )}
+        ) : null}
       </div>
       <div className="flex flex-row items-center gap-2">
-        {alert && <F0TagAlert {...alert} />}
-        {rawTag && <F0TagRaw {...rawTag} />}
-        {!!count && <Counter value={count} />}
+        {alert ? <F0TagAlert {...alert} /> : null}
+        {rawTag ? <F0TagRaw {...rawTag} /> : null}
+        {count ? <Counter value={count} /> : null}
       </div>
     </Wrapper>
   )

--- a/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/TwoColumnsList/index.tsx
@@ -31,11 +31,11 @@ export const TwoColumnsList = forwardRef<HTMLDivElement, TwoColumnsListType>(
   function TwoColumnsList({ title, titleValue, titleTooltip, list }, ref) {
     return (
       <div ref={ref} className="flex flex-col gap-2">
-        {title && (
+        {title ? (
           <div className="flex items-center justify-between gap-2 font-medium">
             <div className="flex items-center gap-1">
               <div>{title}</div>
-              {titleTooltip && (
+              {titleTooltip ? (
                 <div className="flex h-4 w-4 items-center text-f1-foreground-tertiary hover:cursor-help">
                   <Tooltip
                     label={titleTooltip.label}
@@ -44,11 +44,11 @@ export const TwoColumnsList = forwardRef<HTMLDivElement, TwoColumnsListType>(
                     <F0Icon icon={InfoCircleLine} size="sm" />
                   </Tooltip>
                 </div>
-              )}
+              ) : null}
             </div>
-            {titleValue && <div>{titleValue}</div>}
+            {titleValue ? <div>{titleValue}</div> : null}
           </div>
-        )}
+        ) : null}
         {list.map((item) => (
           <Item key={item.title} title={item.title} info={item.info} />
         ))}

--- a/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
@@ -11,7 +11,7 @@ const renderWidget = () => {
     <Widget>
       <></>
       <Fragment></Fragment>
-      {showHiddenChild() && <p>asd</p>}
+      {showHiddenChild() ? <p>asd</p> : null}
       {null}
       {undefined}
       <p>1</p>
@@ -19,7 +19,7 @@ const renderWidget = () => {
       <p>3</p>
       <></>
       <Fragment></Fragment>
-      {showHiddenChild() && <p>asd</p>}
+      {showHiddenChild() ? <p>asd</p> : null}
       {null}
       {undefined}
     </Widget>

--- a/packages/react/src/experimental/Widgets/Widget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.tsx
@@ -376,11 +376,11 @@ const Container = forwardRef<
         )}
         ref={composedRef}
       >
-        {header && (
+        {header ? (
           <CardHeader className="-mr-1 -mt-1">
             <div className="flex w-full flex-1 flex-col gap-4">
               <div className="flex flex-1 flex-row flex-nowrap items-center justify-between gap-2">
-                {draggable && (
+                {draggable ? (
                   <div
                     className="-ml-1 flex h-6 w-6 shrink-0 items-center justify-center text-f1-icon-secondary hover:cursor-grab"
                     onMouseDown={onDragStart}
@@ -388,28 +388,28 @@ const Container = forwardRef<
                   >
                     <F0Icon icon={Handle} size="xs" />
                   </div>
-                )}
+                ) : null}
                 {/* `min-w-0` rather than `truncate`: the ellipsis belongs to the
                   TITLE, which carries its own (see `WidgetTitle`), and an
                   `overflow: hidden` here clipped the linked title's hover
                   background where it bleeds past the content box. */}
                 <div className="flex min-h-6 min-w-0 grow flex-row items-center gap-1">
-                  {header.title && (
+                  {header.title ? (
                     <WidgetTitle
                       title={header.title}
                       link={header.link}
                       isWide={isWide}
                     />
-                  )}
-                  {header.subtitle && (
+                  ) : null}
+                  {header.subtitle ? (
                     <div className="flex flex-row items-center gap-1">
-                      {!header.link && <InlineDot />}
+                      {!header.link ? <InlineDot /> : null}
                       <CardSubtitle className="truncate">
                         {header.subtitle}
                       </CardSubtitle>
                     </div>
-                  )}
-                  {header.info && (
+                  ) : null}
+                  {header.info ? (
                     <Tooltip label={header.info}>
                       <F0Icon
                         icon={InfoCircleLine}
@@ -417,28 +417,28 @@ const Container = forwardRef<
                         className="text-f1-foreground-secondary"
                       />
                     </Tooltip>
-                  )}
-                  {header.count && (
+                  ) : null}
+                  {header.count ? (
                     <div className="ml-0.5">
                       <Counter value={header.count} />
                     </div>
-                  )}
+                  ) : null}
                 </div>
                 <div className="flex flex-row items-center gap-3">
-                  {alert && <F0TagAlert text={alert} level="critical" />}
-                  {status && (
+                  {alert ? <F0TagAlert text={alert} level="critical" /> : null}
+                  {status ? (
                     <F0TagStatus text={status.text} variant={status.variant} />
-                  )}
+                  ) : null}
                   {headerControls}
-                  {AIButton && (
+                  {AIButton ? (
                     <AIButtonComponent
                       size="sm"
                       label={t.ai.ask}
                       onClick={AIButton}
                       icon={OneIcon}
                     />
-                  )}
-                  {actions && (
+                  ) : null}
+                  {actions ? (
                     <DropdownInternal items={actions} align="end">
                       <F0Button
                         icon={Ellipsis}
@@ -448,17 +448,17 @@ const Container = forwardRef<
                         hideLabel
                       />
                     </DropdownInternal>
-                  )}
+                  ) : null}
                   {/* No link here: it is the TITLE (see `WidgetTitle`). This
                     corner belongs to the overflow menu. */}
                 </div>
               </div>
-              {header.comment && (
+              {header.comment ? (
                 <div className="flex flex-row items-center gap-3 overflow-visible">
                   <PrivateBox>
                     <CardComment>{header.comment}</CardComment>
                   </PrivateBox>
-                  {!!header.canBeBlurred && (
+                  {header.canBeBlurred ? (
                     <span>
                       <F0Button
                         icon={privacyModeEnabled ? EyeInvisible : EyeVisible}
@@ -469,14 +469,14 @@ const Container = forwardRef<
                         size="sm"
                       />
                     </span>
-                  )}
+                  ) : null}
                 </div>
-              )}
+              ) : null}
             </div>
           </CardHeader>
-        )}
+        ) : null}
         <CardContent className="flex h-full flex-col gap-4">
-          {summaries && (
+          {summaries ? (
             <div className="flex flex-row">
               {summaries.map((summary, index) => (
                 <div key={index} className="grow">
@@ -484,34 +484,34 @@ const Container = forwardRef<
                     {summary.label}
                   </div>
                   <div className="flex flex-row items-end gap-0.5 text-2xl font-semibold">
-                    {!!summary.prefixUnit && (
+                    {summary.prefixUnit ? (
                       <div className="text-lg font-medium">
                         {summary.prefixUnit}
                       </div>
-                    )}
+                    ) : null}
                     {summary.value}
-                    {!!summary.postfixUnit && (
+                    {summary.postfixUnit ? (
                       <div className="text-lg font-medium">
                         {summary.postfixUnit}
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 </div>
               ))}
             </div>
-          )}
+          ) : null}
           {React.Children.toArray(children)
             .filter(isRealNode)
             .map((child, index) => {
               return (
                 <React.Fragment key={index}>
-                  {index > 0 && <Separator bare />}
+                  {index > 0 ? <Separator bare /> : null}
                   {child}
                 </React.Fragment>
               )
             })}
         </CardContent>
-        {footerActions.length > 0 && (
+        {footerActions.length > 0 ? (
           <CardFooter className={cn("gap-2", footerClassName)}>
             {footerActions.map((footerAction, index) => (
               /* Both are DEFAULTS, not decisions: each action is spread after
@@ -534,7 +534,7 @@ const Container = forwardRef<
               />
             ))}
           </CardFooter>
-        )}
+        ) : null}
       </Card>
     </WidgetIsWideContext.Provider>
   )
@@ -584,7 +584,9 @@ const Skeleton = forwardRef<HTMLDivElement, WidgetSkeletonProps>(
             ) : (
               <SkeletonPrimitive className="h-4 w-full max-w-16" />
             )}
-            {header?.subtitle && <CardSubtitle>{header.subtitle}</CardSubtitle>}
+            {header?.subtitle ? (
+              <CardSubtitle>{header.subtitle}</CardSubtitle>
+            ) : null}
           </div>
         </CardHeader>
         <CardContent

--- a/packages/react/src/hooks/datasource/__stories__/examples.stories.tsx
+++ b/packages/react/src/hooks/datasource/__stories__/examples.stories.tsx
@@ -265,7 +265,7 @@ const GroupedExample = () => {
               </span>
             </button>
 
-            {openGroups[group.key] && (
+            {openGroups[group.key] ? (
               <div
                 style={{
                   padding: "12px",
@@ -309,7 +309,7 @@ const GroupedExample = () => {
                   </div>
                 ))}
               </div>
-            )}
+            ) : null}
           </div>
         ))}
       </div>
@@ -387,7 +387,7 @@ const SelectableExample = () => {
           </strong>
         </label>
 
-        {selectedItems.size > 0 && (
+        {selectedItems.size > 0 ? (
           <div style={{ marginTop: "8px", display: "flex", gap: "8px" }}>
             <button
               onClick={() => {
@@ -422,7 +422,7 @@ const SelectableExample = () => {
               Export Selected
             </button>
           </div>
-        )}
+        ) : null}
       </div>
 
       <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
@@ -464,7 +464,7 @@ const SelectableExample = () => {
               >
                 {user.status}
               </span>
-              {!user.canBeSelected && (
+              {!user.canBeSelected ? (
                 <span
                   style={{
                     marginLeft: "8px",
@@ -474,7 +474,7 @@ const SelectableExample = () => {
                 >
                   (Cannot be selected)
                 </span>
-              )}
+              ) : null}
             </div>
           </div>
         ))}
@@ -610,7 +610,7 @@ const CompleteExample = () => {
           </div>
         </div>
 
-        {selectedItems.size > 0 && (
+        {selectedItems.size > 0 ? (
           <div style={{ display: "flex", gap: "8px" }}>
             <button
               onClick={() => {
@@ -645,7 +645,7 @@ const CompleteExample = () => {
               Export Selected
             </button>
           </div>
-        )}
+        ) : null}
       </div>
 
       {/* Groups */}
@@ -726,7 +726,7 @@ const CompleteExample = () => {
                 </div>
               </div>
 
-              {openGroups[group.key] && (
+              {openGroups[group.key] ? (
                 <div
                   style={{
                     padding: "12px",
@@ -777,7 +777,7 @@ const CompleteExample = () => {
                         >
                           {user.status}
                         </span>
-                        {!user.canBeSelected && (
+                        {!user.canBeSelected ? (
                           <span
                             style={{
                               marginLeft: "8px",
@@ -787,12 +787,12 @@ const CompleteExample = () => {
                           >
                             (Cannot be selected)
                           </span>
-                        )}
+                        ) : null}
                       </div>
                     </div>
                   ))}
                 </div>
-              )}
+              ) : null}
             </div>
           )
         })}

--- a/packages/react/src/hooks/datasource/itemNeighbors/__stories__/useItemNeighbors.stories.tsx
+++ b/packages/react/src/hooks/datasource/itemNeighbors/__stories__/useItemNeighbors.stories.tsx
@@ -131,8 +131,9 @@ const DetailPanel = ({ withCapability }: { withCapability: boolean }) => {
           </div>
           <div className="text-sm text-f1-foreground-secondary">
             {activeEmployee?.department}
-            {neighbors?.position !== undefined &&
-              ` — ${neighbors.position} of ${neighbors.total}`}
+            {neighbors?.position !== undefined
+              ? ` — ${neighbors.position} of ${neighbors.total}`
+              : null}
           </div>
         </div>
         <div className="flex gap-2">

--- a/packages/react/src/hooks/datasource/useDataSourceItemNavigation/__stories__/useDataSourceItemNavigation.stories.tsx
+++ b/packages/react/src/hooks/datasource/useDataSourceItemNavigation/__stories__/useDataSourceItemNavigation.stories.tsx
@@ -179,26 +179,26 @@ const PageBasedDemo = () => {
         <button disabled={!hasNext || isNavigating} onClick={goToNext}>
           Next →
         </button>
-        {isNavigating && <span style={{ color: "#888" }}>Loading…</span>}
+        {isNavigating ? <span style={{ color: "#888" }}>Loading…</span> : null}
       </div>
 
-      {(previousItemUrl || nextItemUrl) && (
+      {previousItemUrl || nextItemUrl ? (
         <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
-          {previousItemUrl && (
+          {previousItemUrl ? (
             <span>
               ← <a href={previousItemUrl}>{previousItemUrl}</a>
             </span>
-          )}
-          {previousItemUrl && nextItemUrl && " | "}
-          {nextItemUrl && (
+          ) : null}
+          {previousItemUrl && nextItemUrl ? " | " : null}
+          {nextItemUrl ? (
             <span>
               <a href={nextItemUrl}>{nextItemUrl}</a> →
             </span>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
 
-      {activeItem && (
+      {activeItem ? (
         <div
           style={{
             padding: 12,
@@ -211,14 +211,14 @@ const PageBasedDemo = () => {
           <strong>Active:</strong> {(activeItem as Item).name} —{" "}
           {(activeItem as Item).department} ({(activeItem as Item).email})
         </div>
-      )}
+      ) : null}
 
-      {paginationInfo?.type === "pages" && (
+      {paginationInfo?.type === "pages" ? (
         <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
           Page {paginationInfo.currentPage} of {paginationInfo.pagesCount} •{" "}
           {paginationInfo.total} total items
         </div>
-      )}
+      ) : null}
 
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
         {isLoading && data.records.length === 0 ? (
@@ -386,26 +386,26 @@ const InfiniteScrollDemo = () => {
         <button disabled={!hasNext || isNavigating} onClick={goToNext}>
           Next →
         </button>
-        {isNavigating && <span style={{ color: "#888" }}>Loading…</span>}
+        {isNavigating ? <span style={{ color: "#888" }}>Loading…</span> : null}
       </div>
 
-      {(previousItemUrl || nextItemUrl) && (
+      {previousItemUrl || nextItemUrl ? (
         <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
-          {previousItemUrl && (
+          {previousItemUrl ? (
             <span>
               ← <a href={previousItemUrl}>{previousItemUrl}</a>
             </span>
-          )}
-          {previousItemUrl && nextItemUrl && " | "}
-          {nextItemUrl && (
+          ) : null}
+          {previousItemUrl && nextItemUrl ? " | " : null}
+          {nextItemUrl ? (
             <span>
               <a href={nextItemUrl}>{nextItemUrl}</a> →
             </span>
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
 
-      {activeItem && (
+      {activeItem ? (
         <div
           style={{
             padding: 12,
@@ -418,13 +418,13 @@ const InfiniteScrollDemo = () => {
           <strong>Active:</strong> {(activeItem as Item).name} —{" "}
           {(activeItem as Item).department} ({(activeItem as Item).email})
         </div>
-      )}
+      ) : null}
 
       <div style={{ marginBottom: 8, fontSize: "0.85em", color: "#666" }}>
         {data.records.length} items loaded
-        {paginationInfo?.type === "infinite-scroll" &&
-          paginationInfo.hasMore &&
-          " • More available"}
+        {paginationInfo?.type === "infinite-scroll" && paginationInfo.hasMore
+          ? " • More available"
+          : null}
       </div>
 
       <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>

--- a/packages/react/src/hooks/toast/ToastProvider.tsx
+++ b/packages/react/src/hooks/toast/ToastProvider.tsx
@@ -371,7 +371,7 @@ const ToastsContainer = ({
       style={anchorStyle}
     >
       <AnimatePresence>
-        {hasItems && (
+        {hasItems ? (
           <div key="toast-panel" className="flex w-full flex-col p-6 sm:w-96">
             {/* Stacked Toasts at the Top */}
             <div ref={stackedContainerRef}>
@@ -426,7 +426,7 @@ const ToastsContainer = ({
               </AnimatePresence>
             </div>
           </div>
-        )}
+        ) : null}
       </AnimatePresence>
     </div>
   )
@@ -495,15 +495,16 @@ export const ToastProvider = ({
   return (
     <>
       {isRenderer &&
-        isMounted &&
-        typeof document !== "undefined" &&
-        portalTarget != null &&
-        createPortal(
-          <Fragment key={portalKey}>
-            <ToastsContainer items={items} />
-          </Fragment>,
-          portalTarget
-        )}
+      isMounted &&
+      typeof document !== "undefined" &&
+      portalTarget != null
+        ? createPortal(
+            <Fragment key={portalKey}>
+              <ToastsContainer items={items} />
+            </Fragment>,
+            portalTarget
+          )
+        : null}
       {children}
     </>
   )

--- a/packages/react/src/kits/Charts/AreaChart/index.tsx
+++ b/packages/react/src/kits/Charts/AreaChart/index.tsx
@@ -123,26 +123,26 @@ export const BaseAreaChart = <K extends LineChartConfig>(
             x2="100%"
             y2="0"
           >
-            {(blurArea === "l" || blurArea === "lr") && (
+            {blurArea === "l" || blurArea === "lr" ? (
               <>
                 <stop offset="0%" stopColor="black" stopOpacity="0"></stop>
                 <stop offset="1%" stopColor="white" stopOpacity="0.1"></stop>
                 <stop offset="7%" stopColor="white" stopOpacity="1"></stop>
               </>
-            )}
-            {(blurArea === "r" || blurArea === "lr") && (
+            ) : null}
+            {blurArea === "r" || blurArea === "lr" ? (
               <>
                 <stop offset="93%" stopColor="white" stopOpacity="1"></stop>
                 <stop offset="99%" stopColor="white" stopOpacity="0.1"></stop>
                 <stop offset="100%" stopColor="black" stopOpacity="0"></stop>
               </>
-            )}
-            {!blurArea && (
+            ) : null}
+            {!blurArea ? (
               <>
                 <stop offset="0%" stopColor="white" stopOpacity="1"></stop>
                 <stop offset="100%" stopColor="white" stopOpacity="1"></stop>
               </>
-            )}
+            ) : null}
           </linearGradient>
           <mask
             id={`${chartId}-transparent-edges`}
@@ -191,7 +191,7 @@ export const BaseAreaChart = <K extends LineChartConfig>(
           {...cartesianGridProps()}
           mask={`url(#${chartId}-transparent-edges)`}
         />
-        {isXAxisVisible && (
+        {isXAxisVisible ? (
           <XAxis
             dataKey="x"
             tickLine={false}
@@ -203,8 +203,8 @@ export const BaseAreaChart = <K extends LineChartConfig>(
             interval={0}
             tick={ChartAreaBoundedTick}
           />
-        )}
-        {isYAxisVisible && (
+        ) : null}
+        {isYAxisVisible ? (
           <YAxis
             tickLine={false}
             axisLine={false}
@@ -219,8 +219,8 @@ export const BaseAreaChart = <K extends LineChartConfig>(
             domain={yAxis?.domain}
             width={yAxisWidth}
           />
-        )}
-        {showTooltip && (
+        ) : null}
+        {showTooltip ? (
           <ChartTooltip
             {...chartTooltipProps()}
             content={
@@ -230,7 +230,7 @@ export const BaseAreaChart = <K extends LineChartConfig>(
               />
             }
           />
-        )}
+        ) : null}
         {areas.map((area, index) => (
           <Area
             isAnimationActive={false}
@@ -249,12 +249,12 @@ export const BaseAreaChart = <K extends LineChartConfig>(
             strokeDasharray={dataConfig[area].dashed ? "4 4" : undefined}
           />
         ))}
-        {Object.keys(dataConfig).length > 1 && (
+        {Object.keys(dataConfig).length > 1 ? (
           <ChartLegend
             className="flex justify-start"
             content={<ChartLegendContent />}
           />
-        )}
+        ) : null}
       </AreaChartPrimitive>
     </ChartContainer>
   )

--- a/packages/react/src/kits/Charts/BarChart/index.tsx
+++ b/packages/react/src/kits/Charts/BarChart/index.tsx
@@ -122,15 +122,15 @@ const _BarChart = <K extends ChartConfig>(
           onClick(chartData)
         }}
       >
-        {!hideTooltip && (
+        {!hideTooltip ? (
           <ChartTooltip
             {...chartTooltipProps()}
             content={
               <ChartTooltipContent yAxisFormatter={yAxis.tickFormatter} />
             }
           />
-        )}
-        {!hideGrid && <CartesianGrid {...cartesianGridProps()} />}
+        ) : null}
+        {!hideGrid ? <CartesianGrid {...cartesianGridProps()} /> : null}
         <YAxis
           {...yAxisProps(yAxis)}
           tick
@@ -168,7 +168,7 @@ const _BarChart = <K extends ChartConfig>(
                       >
                         {payload.value}
                       </text>
-                      {!!value && (
+                      {value ? (
                         <text
                           x={0}
                           y={0}
@@ -178,7 +178,7 @@ const _BarChart = <K extends ChartConfig>(
                         >
                           {normalizedValue}
                         </text>
-                      )}
+                      ) : null}
                     </g>
                   )
                 }
@@ -206,7 +206,7 @@ const _BarChart = <K extends ChartConfig>(
             radius={type === "stacked-by-sign" ? [4, 4, 0, 0] : 4}
             maxBarSize={32}
           >
-            {label && (
+            {label ? (
               <LabelList
                 key={`label-${key}`}
                 position="top"
@@ -214,10 +214,10 @@ const _BarChart = <K extends ChartConfig>(
                 className="fill-f1-foreground"
                 fontSize={12}
               />
-            )}
+            ) : null}
           </Bar>
         ))}
-        {legend && (
+        {legend ? (
           <ChartLegend
             content={<ChartLegendContent nameKey="label" />}
             align={"center"}
@@ -225,7 +225,7 @@ const _BarChart = <K extends ChartConfig>(
             layout="vertical"
             className={"flex-row items-start gap-4 pr-3 pt-2"}
           />
-        )}
+        ) : null}
       </BarChartPrimitive>
     </ChartContainer>
   )

--- a/packages/react/src/kits/Charts/CategoryBarChart/index.tsx
+++ b/packages/react/src/kits/Charts/CategoryBarChart/index.tsx
@@ -71,15 +71,15 @@ const _CategoryBarChart = (
               ))}
             </div>
           </TooltipTrigger>
-          {!hideTooltip && tooltipItems.length > 0 && (
+          {!hideTooltip && tooltipItems.length > 0 ? (
             <CategoryBarTooltipContent
               items={tooltipItems}
               activeKey={activeKey}
             />
-          )}
+          ) : null}
         </Tooltip>
       </div>
-      {legend && (
+      {legend ? (
         <div
           className="mt-2 flex w-full flex-wrap gap-x-2.5 gap-y-0.5"
           role="list"
@@ -104,7 +104,7 @@ const _CategoryBarChart = (
             )
           })}
         </div>
-      )}
+      ) : null}
     </TooltipProvider>
   )
 }

--- a/packages/react/src/kits/Charts/ComboChart/index.tsx
+++ b/packages/react/src/kits/Charts/ComboChart/index.tsx
@@ -273,17 +273,17 @@ const _ComboChart = <K extends ChartConfig>(
           onClick(chartData)
         }}
       >
-        {!hideTooltip && (
+        {!hideTooltip ? (
           <ChartTooltip
             {...chartTooltipProps()}
             content={
               <ChartTooltipContent yAxisFormatter={yAxis.tickFormatter} />
             }
           />
-        )}
-        {!hideGrid && <CartesianGrid {...cartesianGridProps()} />}
+        ) : null}
+        {!hideGrid ? <CartesianGrid {...cartesianGridProps()} /> : null}
 
-        {leftAxisCharts.length > 0 && (
+        {leftAxisCharts.length > 0 ? (
           <YAxis
             {...yAxisProps(yAxis)}
             tick
@@ -306,9 +306,9 @@ const _ComboChart = <K extends ChartConfig>(
                 : undefined
             }
           />
-        )}
+        ) : null}
 
-        {rightAxisCharts.length > 0 && (
+        {rightAxisCharts.length > 0 ? (
           <YAxis
             {...yAxisProps(yAxis)}
             yAxisId="right"
@@ -335,7 +335,7 @@ const _ComboChart = <K extends ChartConfig>(
                 : undefined
             }
           />
-        )}
+        ) : null}
         <XAxis
           {...xAxisProps(xAxis)}
           hide={xAxis?.hide}
@@ -367,7 +367,7 @@ const _ComboChart = <K extends ChartConfig>(
                       >
                         {payload.value}
                       </text>
-                      {!!value && (
+                      {value ? (
                         <text
                           x={0}
                           y={0}
@@ -377,7 +377,7 @@ const _ComboChart = <K extends ChartConfig>(
                         >
                           {normalizedValue}
                         </text>
-                      )}
+                      ) : null}
                     </g>
                   )
                 }
@@ -470,7 +470,7 @@ const _ComboChart = <K extends ChartConfig>(
             shape={createScatter(String(category))}
           />
         ))}
-        {legend && (
+        {legend ? (
           <ChartLegend
             content={<ChartLegendContent nameKey="label" />}
             align={"center"}
@@ -478,7 +478,7 @@ const _ComboChart = <K extends ChartConfig>(
             layout="vertical"
             className={"flex-row items-start gap-4 pr-3 pt-2"}
           />
-        )}
+        ) : null}
       </ComposedChart>
     </ChartContainer>
   )

--- a/packages/react/src/kits/Charts/LineChart/index.tsx
+++ b/packages/react/src/kits/Charts/LineChart/index.tsx
@@ -63,22 +63,22 @@ export const _LineChart = <K extends LineChartConfig>(
         data={preparedData}
         margin={{ left: yAxis && !yAxis.hide ? 0 : 12, right: 12 }}
       >
-        {!hideGrid && <CartesianGrid {...cartesianGridProps()} />}
-        {!xAxis?.hide && <XAxis {...xAxisProps(xAxis)} />}
-        {!yAxis?.hide && (
+        {!hideGrid ? <CartesianGrid {...cartesianGridProps()} /> : null}
+        {!xAxis?.hide ? <XAxis {...xAxisProps(xAxis)} /> : null}
+        {!yAxis?.hide ? (
           <YAxis
             {...yAxisProps(yAxis)}
             width={yAxis.width ?? maxLabelWidth + 20}
           />
-        )}
-        {!hideTooltip && (
+        ) : null}
+        {!hideTooltip ? (
           <ChartTooltip
             {...chartTooltipProps()}
             content={
               <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
             }
           />
-        )}
+        ) : null}
         {lines.map((line, index) => (
           <Line
             key={line}

--- a/packages/react/src/kits/Charts/PieChart/index.tsx
+++ b/packages/react/src/kits/Charts/PieChart/index.tsx
@@ -57,12 +57,12 @@ export const _PieChart = (
       style={{ height: 380 }}
     >
       <PieChartPrimitive accessibilityLayer margin={{ left: 0, right: 0 }}>
-        {sum !== 0 && (
+        {sum !== 0 ? (
           <ChartTooltip
             isAnimationActive={false}
             content={<ChartTooltipContent yAxisFormatter={tickFormatter} />}
           />
-        )}
+        ) : null}
         <Pie
           isAnimationActive={false}
           nameKey={"label"}

--- a/packages/react/src/kits/Charts/ProgressChart/index.tsx
+++ b/packages/react/src/kits/Charts/ProgressChart/index.tsx
@@ -32,9 +32,9 @@ const _ProgressBar = <K extends ChartConfig>(
           aria-label={`${percentage.toFixed(1)}%`}
         />
       </div>
-      {label && (
+      {label ? (
         <div className="flex-shrink-0 text-sm font-medium">{label}</div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/Charts/RadarChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadarChart/index.tsx
@@ -146,7 +146,7 @@ const _RadarChart = <K extends ChartConfig>(
               />
             ))}
 
-          {series.length > 1 && (
+          {series.length > 1 ? (
             <ChartLegend
               iconType="star"
               content={
@@ -157,7 +157,7 @@ const _RadarChart = <K extends ChartConfig>(
                 />
               }
             />
-          )}
+          ) : null}
         </RadarChartPrimitive>
       </ChartContainer>
     </DataTestIdWrapper>

--- a/packages/react/src/kits/Charts/RadialProgressChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadialProgressChart/index.tsx
@@ -47,7 +47,7 @@ export function RadialProgressChart({
           strokeLinecap="round"
         />
       </svg>
-      {overview && (
+      {overview ? (
         <div className="absolute inset-0 flex translate-y-0.5 flex-col items-center justify-center">
           <span className="text-sm text-f1-foreground-secondary">
             {overview.label}
@@ -56,7 +56,7 @@ export function RadialProgressChart({
             {overview.number}
           </span>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
@@ -106,21 +106,21 @@ const _VBarChart = <K extends ChartConfig>(
           right: label || showRatio ? 100 : 0,
         }}
       >
-        {!hideTooltip && (
+        {!hideTooltip ? (
           <ChartTooltip
             {...chartTooltipProps(true)}
             content={
               <ChartTooltipContent yAxisFormatter={yAxis?.tickFormatter} />
             }
           />
-        )}
-        {!hideGrid && (
+        ) : null}
+        {!hideGrid ? (
           <CartesianGrid
             {...cartesianGridProps()}
             vertical={true}
             horizontal={false}
           />
-        )}
+        ) : null}
         <XAxis {...xAxisProps} hide={xAxis?.hide} />
         <YAxis
           {...yAxisProps}
@@ -144,7 +144,7 @@ const _VBarChart = <K extends ChartConfig>(
                 radius={4}
                 maxBarSize={24}
               >
-                {(label || showRatio) && (
+                {label || showRatio ? (
                   <LabelList
                     key={`label-{${key}}`}
                     position="right"
@@ -162,7 +162,7 @@ const _VBarChart = <K extends ChartConfig>(
                       ) : undefined
                     }
                   />
-                )}
+                ) : null}
               </Bar>
             </>
           )
@@ -198,7 +198,7 @@ const CustomLabel = ({
 
   return (
     <g transform={`translate(${gx},${gy + 4})`}>
-      {showLabel && (
+      {showLabel ? (
         <text
           x={0}
           textAnchor="start"
@@ -206,7 +206,7 @@ const CustomLabel = ({
         >
           {firstText}
         </text>
-      )}
+      ) : null}
       {
         <text
           x={showLabel ? firstTextWidth + 8 : 0}

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
@@ -31,11 +31,11 @@ const _DataChartEmptyState = forwardRef<
     >
       <div className="relative flex flex-col items-center gap-1 px-6 text-center">
         <p className="text-lg font-medium text-f1-foreground">{content}</p>
-        {description && (
+        {description ? (
           <p className="text-md max-w-sm text-f1-foreground-secondary">
             {description}
           </p>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -48,7 +48,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
 
   return (
     <div className="relative h-full w-full">
-      {showLabels && (
+      {showLabels ? (
         <div
           className={`pointer-events-none absolute inset-0 z-10 flex ${isHorizontal ? "" : "flex-col"}`}
         >
@@ -91,7 +91,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
                       >
                         {formattedValue}
                       </OneEllipsis>
-                      {pct && <Tag tag={{ type: "raw", text: pct }} />}
+                      {pct ? <Tag tag={{ type: "raw", text: pct }} /> : null}
                     </div>
                   ) : (
                     <>
@@ -101,7 +101,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
                       >
                         {formattedValue}
                       </OneEllipsis>
-                      {pct && <Tag tag={{ type: "raw", text: pct }} />}
+                      {pct ? <Tag tag={{ type: "raw", text: pct }} /> : null}
                     </>
                   )}
                 </div>
@@ -109,7 +109,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
             )
           })}
         </div>
-      )}
+      ) : null}
 
       <div ref={ref} className="h-full w-full" />
     </div>

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
@@ -32,11 +32,11 @@ export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
         ref={ref}
         className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
       />
-      {size === "sm" && (
+      {size === "sm" ? (
         <div className="absolute inset-0 flex items-center justify-center bg-f1-background p-3 text-center text-sm font-medium text-f1-foreground-tertiary">
           {i18n.dataChart.heatmapNotSupported}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/F0DataChart/skeletons.tsx
+++ b/packages/react/src/kits/F0DataChart/skeletons.tsx
@@ -52,7 +52,7 @@ function AxisSkeleton({
         </div>
 
         {/* Legend */}
-        {showLegend && (
+        {showLegend ? (
           <div className="flex items-center justify-center gap-4 pt-3">
             <div className="flex items-center gap-1.5">
               <Skeleton className="size-2.5 rounded-full" />
@@ -63,7 +63,7 @@ function AxisSkeleton({
               <Skeleton className="h-2.5 w-12 rounded-sm" />
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     )
   }
@@ -97,7 +97,7 @@ function AxisSkeleton({
       </div>
 
       {/* Legend */}
-      {showLegend && (
+      {showLegend ? (
         <div className="flex items-center justify-center gap-4 pt-3">
           <div className="flex items-center gap-1.5">
             <Skeleton className="size-2.5 rounded-full" />
@@ -108,7 +108,7 @@ function AxisSkeleton({
             <Skeleton className="h-2.5 w-12 rounded-sm" />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -294,7 +294,7 @@ export function LineChartSkeleton({
           preserveAspectRatio="none"
           className="h-full w-full"
         >
-          {showArea && (
+          {showArea ? (
             <defs>
               <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
                 <stop
@@ -306,8 +306,8 @@ export function LineChartSkeleton({
                 <stop offset="100%" stopColor="currentColor" stopOpacity="0" />
               </linearGradient>
             </defs>
-          )}
-          {showArea && <path d={fillD} fill={`url(#${gradientId})`} />}
+          ) : null}
+          {showArea ? <path d={fillD} fill={`url(#${gradientId})`} /> : null}
           <path
             d={pathD}
             fill="none"
@@ -318,18 +318,19 @@ export function LineChartSkeleton({
             className="text-f1-foreground-secondary"
           />
         </svg>
-        {showDots &&
-          DOT_POINTS.map(([x, y]) => (
-            <Skeleton
-              key={`${x}-${y}`}
-              className="absolute size-2 rounded-full"
-              style={{
-                left: `${(x / 200) * 100}%`,
-                top: `${(y / 80) * 100}%`,
-                transform: "translate(-50%, -50%)",
-              }}
-            />
-          ))}
+        {showDots
+          ? DOT_POINTS.map(([x, y]) => (
+              <Skeleton
+                key={`${x}-${y}`}
+                className="absolute size-2 rounded-full"
+                style={{
+                  left: `${(x / 200) * 100}%`,
+                  top: `${(y / 80) * 100}%`,
+                  transform: "translate(-50%, -50%)",
+                }}
+              />
+            ))
+          : null}
       </div>
     </AxisSkeleton>
   )
@@ -473,14 +474,14 @@ export function FunnelChartSkeleton({
         </div>
 
         {/* Legend */}
-        {showLegend && (
+        {showLegend ? (
           <div className="flex items-center justify-center gap-4 pt-1.5">
             <div className="flex items-center gap-1.5">
               <Skeleton className="size-2.5 rounded-full" />
               <Skeleton className="h-2.5 w-14 rounded-sm" />
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     )
   }
@@ -528,14 +529,14 @@ export function FunnelChartSkeleton({
       </div>
 
       {/* Legend */}
-      {showLegend && (
+      {showLegend ? (
         <div className="flex items-center justify-center gap-4 pt-1.5">
           <div className="flex items-center gap-1.5">
             <Skeleton className="size-2.5 rounded-full" />
             <Skeleton className="h-2.5 w-14 rounded-sm" />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -616,14 +617,14 @@ export function PieChartSkeleton({
             className="text-f1-background"
           />
           {/* Inner circle for donut */}
-          {innerR > 0 && (
+          {innerR > 0 ? (
             <circle cx="50" cy="50" r={innerR} className="fill-f1-background" />
-          )}
+          ) : null}
         </svg>
       </div>
 
       {/* Legend */}
-      {showLegend && (
+      {showLegend ? (
         <div className="flex items-center justify-center gap-4 pt-3">
           <div className="flex items-center gap-1.5">
             <Skeleton className="size-2.5 rounded-full" />
@@ -638,7 +639,7 @@ export function PieChartSkeleton({
             <Skeleton className="h-2.5 w-8 rounded-sm" />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -728,7 +729,7 @@ export function RadarChartSkeleton({
       </div>
 
       {/* Legend */}
-      {showLegend && (
+      {showLegend ? (
         <div className="flex items-center justify-center gap-4 pt-3">
           <div className="flex items-center gap-1.5">
             <Skeleton className="size-2.5 rounded-full" />
@@ -739,7 +740,7 @@ export function RadarChartSkeleton({
             <Skeleton className="h-2.5 w-12 rounded-sm" />
           </div>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
+++ b/packages/react/src/kits/ai/Banners/BaseBanner/index.tsx
@@ -88,16 +88,16 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
             )}
           >
             <h3 className="font-bold text-xl text-f1-foreground">{title}</h3>
-            {subtitle && (
+            {subtitle ? (
               <p className="text-base text-f1-foreground-secondary">
                 {subtitle}
               </p>
-            )}
+            ) : null}
           </div>
 
           {/* Actions */}
           <div className="flex gap-3">
-            {primaryAction && (
+            {primaryAction ? (
               <F0Button
                 onClick={primaryAction.onClick}
                 label={primaryAction.label}
@@ -105,8 +105,8 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
                 size="md"
                 icon={primaryAction.icon}
               />
-            )}
-            {secondaryAction && (
+            ) : null}
+            {secondaryAction ? (
               <F0Button
                 onClick={secondaryAction.onClick}
                 label={secondaryAction.label}
@@ -114,13 +114,13 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
                 size="md"
                 icon={secondaryAction.icon}
               />
-            )}
+            ) : null}
             {children}
           </div>
         </div>
 
         {/* Close button */}
-        {onClose && (
+        {onClose ? (
           <div className="absolute right-2 top-2 z-10">
             <F0Button
               variant="ghost"
@@ -131,7 +131,7 @@ const BaseBannerComponent = forwardRef<HTMLDivElement, BaseBannerProps>(
               label="Close"
             />
           </div>
-        )}
+        ) : null}
       </div>
     ) : null
   }

--- a/packages/react/src/kits/ai/Banners/F0AiBanner/AiBannerInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0AiBanner/AiBannerInternal.tsx
@@ -22,7 +22,7 @@ export const AiBannerInternal = forwardRef<
     >
       <div className="flex flex-row items-center justify-between px-4 py-2">
         <OneEllipsis className="font-medium">{title}</OneEllipsis>
-        {onClose && (
+        {onClose ? (
           <F0Button
             variant="ghost"
             icon={Cross}
@@ -31,7 +31,7 @@ export const AiBannerInternal = forwardRef<
             onClick={onClose}
             label="Close"
           />
-        )}
+        ) : null}
       </div>
 
       <div className="flex flex-col gap-[1px]">
@@ -45,30 +45,30 @@ export const AiBannerInternal = forwardRef<
         >
           <F0RichTextDisplay content={content} />
         </div>
-        {(secondaryAction || primaryAction) && (
+        {secondaryAction || primaryAction ? (
           <div className="flex flex-row items-center justify-between gap-3 rounded-b-[13.25px] bg-f1-background px-4 py-3">
             <div>
-              {secondaryAction && (
+              {secondaryAction ? (
                 <F0Button
                   label={secondaryAction.label}
                   onClick={secondaryAction.onClick}
                   variant="outline"
                   icon={secondaryAction.icon}
                 />
-              )}
+              ) : null}
             </div>
             <div>
-              {primaryAction && (
+              {primaryAction ? (
                 <F0Button
                   label={primaryAction.label}
                   onClick={primaryAction.onClick}
                   variant="outline"
                   icon={primaryAction.icon}
                 />
-              )}
+              ) : null}
             </div>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )
@@ -98,12 +98,12 @@ export const AiBannerSkeleton = ({ compact }: AiBannerSkeletonProps) => {
             <Skeleton className="h-4 w-1/2 rounded-md" />
           </div>
         </div>
-        {!compact && (
+        {!compact ? (
           <div className="flex flex-row items-center justify-between gap-3 rounded-b-[13.25px] bg-f1-background px-4 py-3">
             <Skeleton className="h-8 w-24 rounded-md" />
             <Skeleton className="h-8 w-28 rounded-md" />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/kits/ai/Banners/F0Callout/CalloutInternal.tsx
+++ b/packages/react/src/kits/ai/Banners/F0Callout/CalloutInternal.tsx
@@ -62,16 +62,16 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
               variantTitleColors[variant]
             )}
           >
-            {variantIcons[variant] && (
+            {variantIcons[variant] ? (
               <F0Icon icon={variantIcons[variant]} size="sm" aria-hidden />
-            )}
+            ) : null}
             <OneEllipsis
               className={variantTitleColors[variant] || "font-medium"}
             >
               {title}
             </OneEllipsis>
           </div>
-          {onClose && (
+          {onClose ? (
             <F0Button
               variant="ghost"
               icon={Cross}
@@ -80,7 +80,7 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
               onClick={onClose}
               label="Close"
             />
-          )}
+          ) : null}
         </div>
 
         <div className="flex flex-col gap-[1px]">
@@ -92,7 +92,7 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
           >
             {children}
           </div>
-          {hasActions && (
+          {hasActions ? (
             <div className="flex flex-row items-center justify-between gap-3 rounded-b-[13.25px] bg-f1-background px-4 py-3">
               {actions.map((action, index) => (
                 <div key={index}>
@@ -105,7 +105,7 @@ export const CalloutInternal = forwardRef<HTMLDivElement, CalloutInternalProps>(
                 </div>
               ))}
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     )
@@ -139,12 +139,12 @@ export const CalloutSkeleton = ({
             <Skeleton className="h-4 w-1/2 rounded-md" />
           </div>
         </div>
-        {!compact && (
+        {!compact ? (
           <div className="flex flex-row items-center justify-between gap-3 rounded-b-[13.25px] bg-f1-background px-4 py-3">
             <Skeleton className="h-8 w-24 rounded-md" />
             <Skeleton className="h-8 w-28 rounded-md" />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/kits/ai/F0ActionItem/F0ActionItem.tsx
+++ b/packages/react/src/kits/ai/F0ActionItem/F0ActionItem.tsx
@@ -30,7 +30,7 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
     <div className="flex w-full items-start gap-1 text-f1-foreground-secondary">
       <div className="flex h-5 w-6 shrink-0 items-center justify-start">
         <AnimatePresence mode="wait">
-          {inProgress && (
+          {inProgress ? (
             <motion.div
               key="inProgress"
               className="flex h-5 w-5 shrink-0 items-center justify-center"
@@ -43,13 +43,13 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
                 icon={DottedCircle}
               />
             </motion.div>
-          )}
-          {(executing || writing) && (
+          ) : null}
+          {executing || writing ? (
             <div className="flex h-5 w-5 shrink-0 items-center justify-center">
               <ChatSpinner variant={executing ? "default" : "continuous"} />
             </div>
-          )}
-          {completed && (
+          ) : null}
+          {completed ? (
             <motion.div
               key="completed"
               {...ICON_MOTION}
@@ -63,10 +63,10 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
                 icon={OutlineCircle}
               />
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
-      {title && (
+      {title ? (
         <p
           className={cn(
             "text-pretty leading-5",
@@ -75,7 +75,7 @@ export const F0ActionItem = ({ title, status, inGroup }: F0ActionItemProps) => {
         >
           {title}
         </p>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/F0AiChat.tsx
@@ -223,11 +223,11 @@ const F0AiChatComponent = ({
             {input}
           </motion.div>
         </div>
-        {overlay && (
+        {overlay ? (
           <div className="absolute inset-0 z-30 flex items-center justify-center bg-f1-background-overlay p-4">
             {overlay}
           </div>
-        )}
+        ) : null}
       </div>
     )
   }

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/_mock/MockConnectedChatHeader.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/_mock/MockConnectedChatHeader.tsx
@@ -99,7 +99,7 @@ export const MockConnectedChatHeader = ({
         credits={credits}
         employeeCredits={employeeCredits}
       />
-      {isHistoryOpen && historyEnabled && (
+      {isHistoryOpen && historyEnabled ? (
         <MockChatHistoryDialog
           fetchThreads={fetchThreads}
           deleteThread={deleteThread}
@@ -107,7 +107,7 @@ export const MockConnectedChatHeader = ({
           onSelectThread={handleSelectThread}
           onNewChat={handleNewChat}
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.widgetDrop.test.tsx
@@ -55,11 +55,11 @@ const Probe = ({
         Start Pong
       </button>
       <span data-testid="quote">{pendingQuote?.text ?? ""}</span>
-      {onCaptureQuote && (
+      {onCaptureQuote ? (
         <button type="button" onClick={() => onCaptureQuote(pendingQuote)}>
           Capture pending quote
         </button>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -255,7 +255,7 @@ export const SidebarWindow = ({
 
   return (
     <AnimatePresence>
-      {isVisible && (
+      {isVisible ? (
         <motion.div
           key="chat-wrapper"
           className={cn(
@@ -299,7 +299,7 @@ export const SidebarWindow = ({
         >
           {/* Resize seam: inner (left) edge for a right-docked panel, inner
               (right) edge for a left-docked one — so it renders after the card. */}
-          {resizable && !fullscreen && !isSmallScreen && !isLeft && (
+          {resizable && !fullscreen && !isSmallScreen && !isLeft ? (
             <ResizeHandle
               onResize={handleResize}
               onReset={resetChatWidth}
@@ -308,7 +308,7 @@ export const SidebarWindow = ({
               isCanvasMode={isCanvasMode}
               side="right"
             />
-          )}
+          ) : null}
           <div
             ref={widgetDropZoneRef}
             aria-hidden={!isVisible}
@@ -341,7 +341,7 @@ export const SidebarWindow = ({
             </div>
             {/* `canDrop` gates only the file drop — quoting a dragged widget
                 needs no upload handler, so it renders on its own. */}
-            {(canDrop || (canAcceptWidgetDrop && dragQuote !== null)) && (
+            {canDrop || (canAcceptWidgetDrop && dragQuote !== null) ? (
               <DropOverlay
                 visible={(canDrop && fileDragOver) || dragQuote !== null}
                 mode={dragQuote !== null ? "discuss" : "files"}
@@ -355,10 +355,10 @@ export const SidebarWindow = ({
                     : undefined
                 }
               />
-            )}
-            {activeGame === "pong" && <F0AiPong onClose={closeGame} />}
+            ) : null}
+            {activeGame === "pong" ? <F0AiPong onClose={closeGame} /> : null}
           </div>
-          {resizable && !fullscreen && !isSmallScreen && isLeft && (
+          {resizable && !fullscreen && !isSmallScreen && isLeft ? (
             <ResizeHandle
               onResize={handleResize}
               onReset={resetChatWidth}
@@ -367,9 +367,9 @@ export const SidebarWindow = ({
               isCanvasMode={isCanvasMode}
               side="left"
             />
-          )}
+          ) : null}
         </motion.div>
-      )}
+      ) : null}
     </AnimatePresence>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChat/components/markdownRenderers/entityRef/components/EntityRefDetails.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/markdownRenderers/entityRef/components/EntityRefDetails.tsx
@@ -18,9 +18,9 @@ export function EntityRefDetails({ rows }: EntityRefDetailsProps) {
     <div className="flex flex-col gap-2">
       {rows.map((row, index) => (
         <div key={row.label ?? index} className="flex flex-col">
-          {row.label && (
+          {row.label ? (
             <p className="text-f1-foreground-secondary">{row.label}</p>
-          )}
+          ) : null}
           <div className="flex items-center gap-1.5 font-medium text-f1-foreground">
             {row.value}
           </div>

--- a/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
@@ -160,7 +160,7 @@ export const F0AiChatHeader = ({
         )}
       >
         <div className="flex min-w-0 flex-1 items-center">
-          {!lockVisualizationMode && (
+          {!lockVisualizationMode ? (
             <Action
               variant="ghost"
               size="md"
@@ -174,7 +174,7 @@ export const F0AiChatHeader = ({
                 <F0Icon icon={ChevronDown} color="default" size="md" />
               </div>
             </Action>
-          )}
+          ) : null}
         </div>
         <motion.div
           className="flex shrink-0 items-center"
@@ -211,7 +211,7 @@ export const F0AiChatHeader = ({
           ease: "easeOut",
         }}
       >
-        {hasMessages && !lockVisualizationMode && (
+        {hasMessages && !lockVisualizationMode ? (
           <ButtonInternal
             variant="ghost"
             hideLabel
@@ -219,7 +219,7 @@ export const F0AiChatHeader = ({
             icon={New}
             onClick={onNewChat}
           />
-        )}
+        ) : null}
         <CreditsPopoverPicker
           credits={credits}
           employeeCredits={employeeCredits}

--- a/packages/react/src/kits/ai/F0AiChatHeader/components/CreditsPopover.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/components/CreditsPopover.tsx
@@ -76,7 +76,7 @@ export function CreditsPopover({ credits, trigger }: CreditsPopoverProps) {
         collisionPadding={12}
         className="flex w-[324px] flex-col gap-3 rounded-md border border-solid border-f1-border-secondary p-3"
       >
-        {hasHeader && (
+        {hasHeader ? (
           <div className="flex min-w-0 max-w-full flex-1 items-center gap-2 overflow-hidden text-left text-lg text-f1-foreground">
             <F0AvatarCompany
               name={credits.companyName ?? ""}
@@ -87,20 +87,20 @@ export function CreditsPopover({ credits, trigger }: CreditsPopoverProps) {
               <OneEllipsis tag="span" className="font-medium">
                 {credits.companyName ?? ""}
               </OneEllipsis>
-              {credits.planName && (
+              {credits.planName ? (
                 <OneEllipsis
                   tag="span"
                   className="text-sm font-medium text-f1-foreground-secondary"
                 >
                   {credits.planName}
                 </OneEllipsis>
-              )}
+              ) : null}
             </div>
           </div>
-        )}
+        ) : null}
         <div className="flex flex-col rounded border border-solid border-f1-border-secondary">
           <div className="flex flex-col gap-2 p-3">
-            {loading && (
+            {loading ? (
               <div className="flex flex-col gap-2">
                 <div className="flex justify-between">
                   <div className="h-5 w-16 animate-pulse rounded bg-f1-background-secondary" />
@@ -112,13 +112,13 @@ export function CreditsPopover({ credits, trigger }: CreditsPopoverProps) {
                   <div className="h-3 w-28 animate-pulse rounded bg-f1-background-secondary" />
                 </div>
               </div>
-            )}
-            {error && (
+            ) : null}
+            {error ? (
               <span className="text-sm text-f1-foreground-secondary">
                 {i18n.t("ai.credits.creditsError")}
               </span>
-            )}
-            {!loading && !error && data && (
+            ) : null}
+            {!loading && !error && data ? (
               <>
                 <div className="flex justify-between">
                   <span className="text-base font-medium text-f1-foreground">
@@ -162,9 +162,9 @@ export function CreditsPopover({ credits, trigger }: CreditsPopoverProps) {
                   </span>
                 </div>
               </>
-            )}
+            ) : null}
           </div>
-          {credits.upgradePlanUrl && (
+          {credits.upgradePlanUrl ? (
             <div className="flex items-center justify-between border-0 border-t border-solid border-f1-border-secondary p-3">
               <span>{i18n.t("ai.credits.needMoreCredits")}</span>
               <F0Button
@@ -174,7 +174,7 @@ export function CreditsPopover({ credits, trigger }: CreditsPopoverProps) {
                 icon={Upsell}
               />
             </div>
-          )}
+          ) : null}
         </div>
       </PopoverContent>
     </Popover>

--- a/packages/react/src/kits/ai/F0AiChatHeader/components/EmployeeCreditsPopover.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/components/EmployeeCreditsPopover.tsx
@@ -101,7 +101,7 @@ export function EmployeeCreditsPopover({
         collisionPadding={12}
         className="flex w-[324px] flex-col gap-3 rounded-md border border-solid border-f1-border-secondary p-3"
       >
-        {hasHeader && (
+        {hasHeader ? (
           <div className="flex min-w-0 max-w-full flex-1 items-center gap-2 overflow-hidden text-left text-lg text-f1-foreground">
             <F0AvatarCompany
               name={employeeCredits.companyName ?? ""}
@@ -112,20 +112,20 @@ export function EmployeeCreditsPopover({
               <OneEllipsis tag="span" className="font-medium">
                 {employeeCredits.companyName ?? ""}
               </OneEllipsis>
-              {employeeCredits.planName && (
+              {employeeCredits.planName ? (
                 <OneEllipsis
                   tag="span"
                   className="text-sm font-medium text-f1-foreground-secondary"
                 >
                   {employeeCredits.planName}
                 </OneEllipsis>
-              )}
+              ) : null}
             </div>
           </div>
-        )}
+        ) : null}
         <div className="flex flex-col rounded border border-solid border-f1-border-secondary">
           <div className="flex flex-col gap-2 p-3">
-            {loading && (
+            {loading ? (
               <div
                 className="flex flex-col gap-2"
                 aria-busy="true"
@@ -141,13 +141,13 @@ export function EmployeeCreditsPopover({
                   <div className="h-3 w-28 animate-pulse rounded bg-f1-background-secondary" />
                 </div>
               </div>
-            )}
-            {error && (
+            ) : null}
+            {error ? (
               <span className="text-sm text-f1-foreground-secondary">
                 {i18n.t("ai.credits.creditsError")}
               </span>
-            )}
-            {!loading && !error && data && (
+            ) : null}
+            {!loading && !error && data ? (
               <div className="flex flex-col gap-2">
                 <div className="flex justify-between">
                   <span className="text-base font-medium text-f1-foreground">
@@ -189,7 +189,7 @@ export function EmployeeCreditsPopover({
                   </span>
                 </div>
               </div>
-            )}
+            ) : null}
           </div>
         </div>
       </PopoverContent>

--- a/packages/react/src/kits/ai/F0AiChatHistory/F0AiChatHistory.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHistory/F0AiChatHistory.tsx
@@ -164,22 +164,22 @@ export const F0AiChatHistory = ({
               </div>
             </Action>
 
-            {isLoading && <ThreadListSkeleton />}
+            {isLoading ? <ThreadListSkeleton /> : null}
 
-            {!isLoading && error && (
+            {!isLoading && error ? (
               <p className="py-8 text-center text-base text-f1-foreground-tertiary">
                 {error}
               </p>
-            )}
+            ) : null}
 
-            {!isLoading && !error && !hasResults && (
+            {!isLoading && !error && !hasResults ? (
               <p className="py-8 text-center text-base text-f1-foreground-tertiary">
                 {translations.ai.noPreviousChats}
               </p>
-            )}
+            ) : null}
 
             {/* Pinned group */}
-            {!isLoading && !error && pinnedThreads.length > 0 && (
+            {!isLoading && !error && pinnedThreads.length > 0 ? (
               <CollapsibleGroup
                 label={translations.ai.pinnedChats}
                 threads={pinnedThreads}
@@ -189,23 +189,23 @@ export const F0AiChatHistory = ({
                 onUnpin={onUnpinThread}
                 onDelete={handleDelete}
               />
-            )}
+            ) : null}
 
             {/* Date groups (unpinned threads) */}
-            {!isLoading &&
-              !error &&
-              groups.map((group) => (
-                <CollapsibleGroup
-                  key={group.key}
-                  label={groupLabels[group.key]}
-                  threads={group.threads}
-                  pinnedIds={pinnedIds}
-                  onSelect={handleSelectThread}
-                  onPin={onPinThread}
-                  onUnpin={onUnpinThread}
-                  onDelete={handleDelete}
-                />
-              ))}
+            {!isLoading && !error
+              ? groups.map((group) => (
+                  <CollapsibleGroup
+                    key={group.key}
+                    label={groupLabels[group.key]}
+                    threads={group.threads}
+                    pinnedIds={pinnedIds}
+                    onSelect={handleSelectThread}
+                    onPin={onPinThread}
+                    onUnpin={onUnpinThread}
+                    onDelete={handleDelete}
+                  />
+                ))
+              : null}
           </div>
         </div>
       </div>

--- a/packages/react/src/kits/ai/F0AiChatHistory/components/CollapsibleGroup.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHistory/components/CollapsibleGroup.tsx
@@ -59,7 +59,7 @@ export function CollapsibleGroup({
           size="xs"
         />
       </div>
-      {expanded && (
+      {expanded ? (
         <div className="flex flex-col">
           {threads.map((thread) => (
             <ThreadItem
@@ -73,7 +73,7 @@ export function CollapsibleGroup({
             />
           ))}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChatHistory/components/ThreadItem.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHistory/components/ThreadItem.tsx
@@ -100,14 +100,14 @@ export function ThreadItem({
         className="flex w-full min-w-0 items-center gap-1"
         onClick={() => onSelect(thread.id, thread.title)}
       >
-        {thread.icon && (
+        {thread.icon ? (
           <F0Icon
             icon={thread.icon}
             size="sm"
             className="mr-1 shrink-0 text-f1-icon"
             aria-hidden
           />
-        )}
+        ) : null}
         <OneEllipsis lines={1} className="py-0.5 text-left font-medium">
           {thread.title}
         </OneEllipsis>
@@ -116,11 +116,11 @@ export function ThreadItem({
           {formattedDate}
         </span>
       </div>
-      {thread.trailingLabel && (
+      {thread.trailingLabel ? (
         <span className="hidden shrink-0 pr-1 text-sm font-medium text-f1-foreground-tertiary group-focus-within:inline group-hover:inline">
           {thread.trailingLabel}
         </span>
-      )}
+      ) : null}
       {isPending ? (
         // While saving, the spinner sits where the actions button is and stays
         // visible off-hover so the row reads as "working".

--- a/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/F0AiChatTextArea.tsx
@@ -573,7 +573,7 @@ export const F0AiChatTextArea = ({
       {...(fullscreen ? composerReveal : {})}
     >
       <div className="flex w-full max-w-content flex-col gap-2">
-        {suggestionsRow && !suggestionsInside && (
+        {suggestionsRow && !suggestionsInside ? (
           <div>
             {/* The row above the composer has no bar to collapse — it IS the
                 thing that opens, so the reveal is its own height. Composers that
@@ -581,7 +581,7 @@ export const F0AiChatTextArea = ({
                 nothing for a layout to trip over. */}
             {welcomeScreenSuggestionsCollapsedByDefault ? (
               <AnimatePresence initial={false}>
-                {composerOpen && (
+                {composerOpen ? (
                   <motion.div
                     key="welcome-suggestions"
                     className="overflow-hidden"
@@ -592,13 +592,13 @@ export const F0AiChatTextArea = ({
                   >
                     {suggestionsRow}
                   </motion.div>
-                )}
+                ) : null}
               </AnimatePresence>
             ) : (
               suggestionsRow
             )}
           </div>
-        )}
+        ) : null}
         <CreditWarningWrapper creditWarning={creditWarning}>
           <form
             aria-busy={inProgress}
@@ -701,15 +701,15 @@ export const F0AiChatTextArea = ({
                     ease: [0.4, 0, 0.2, 1],
                   }}
                 >
-                  {pendingQuote && (
+                  {pendingQuote ? (
                     <PendingQuoteChip
                       quote={pendingQuote}
                       onRemove={() => onPendingQuoteChange?.(null)}
                     />
-                  )}
+                  ) : null}
 
                   <AnimatePresence initial={false}>
-                    {transientError && (
+                    {transientError ? (
                       <motion.div
                         key="transient-error"
                         role="alert"
@@ -737,7 +737,7 @@ export const F0AiChatTextArea = ({
                           </p>
                         </div>
                       </motion.div>
-                    )}
+                    ) : null}
                   </AnimatePresence>
 
                   <AttachedFilesList
@@ -777,11 +777,11 @@ export const F0AiChatTextArea = ({
                         Spins while a response streams — F0OneIcon's own
                         affordance for exactly this, and the only moving part the
                         composer has to say the AI is working. */}
-                    {inlineComposerBar && (
+                    {inlineComposerBar ? (
                       <div className="flex shrink-0 self-center pl-3">
                         <F0OneIcon size="sm" spin={inProgress} />
                       </div>
-                    )}
+                    ) : null}
                     <TextareaField
                       textareaRef={textareaRef}
                       highlightRef={highlightRef}
@@ -809,7 +809,7 @@ export const F0AiChatTextArea = ({
                         taller than the line, visibly high against the top
                         border. Grown past one line the same 10px keeps it on the
                         last line. */}
-                    {barCollapsed && (
+                    {barCollapsed ? (
                       // `preventDefault` ON MOUSEDOWN IS LOAD-BEARING, and the
                       // bug it fixes is worth spelling out: taking focus is the
                       // browser's DEFAULT ACTION for mousedown, focus is what
@@ -828,14 +828,14 @@ export const F0AiChatTextArea = ({
                         className="flex shrink-0 items-center gap-2 pb-[10px] pl-2"
                         onMouseDown={(event) => event.preventDefault()}
                       >
-                        {canRecord && (
+                        {canRecord ? (
                           <DictationButton
                             inProgress={inProgress}
                             recordingStatus={recorder.status}
                             onStartRecording={handleStartRecording}
                             size="sm"
                           />
-                        )}
+                        ) : null}
                         <SubmitButton
                           inProgress={inProgress}
                           hasDataToSend={hasDataToSend}
@@ -844,7 +844,7 @@ export const F0AiChatTextArea = ({
                           size="sm"
                         />
                       </div>
-                    )}
+                    ) : null}
                   </div>
 
                   {/* THE CONTROL ROW, and whether it is there at all. The
@@ -862,7 +862,7 @@ export const F0AiChatTextArea = ({
                       (its focus-ring room) is not clipped with it. */}
                   {barCollapsible ? (
                     <AnimatePresence initial={false}>
-                      {!barCollapsed && (
+                      {!barCollapsed ? (
                         <motion.div
                           key="action-row"
                           className="overflow-hidden"
@@ -873,7 +873,7 @@ export const F0AiChatTextArea = ({
                         >
                           {actionRow}
                         </motion.div>
-                      )}
+                      ) : null}
                     </AnimatePresence>
                   ) : (
                     actionRow
@@ -885,17 +885,17 @@ export const F0AiChatTextArea = ({
         </CreditWarningWrapper>
       </div>
 
-      {showWelcomeCards && (
+      {showWelcomeCards ? (
         <div className="w-full max-w-content pt-2">
           <WelcomeScreenCardsRow cards={welcomeScreenCards} />
         </div>
-      )}
+      ) : null}
 
-      {footer && isWelcomeScreen && fullscreen && (
+      {footer && isWelcomeScreen && fullscreen ? (
         <div className="w-full py-4 mx-auto flex max-w-content justify-center">
           {footer}
         </div>
-      )}
+      ) : null}
 
       <AnimatePresence mode="wait" initial={false}>
         {isClarifying ? (
@@ -961,7 +961,7 @@ export const F0AiChatTextArea = ({
                 </OneEllipsis>
               )}
 
-              {disclaimer.link && disclaimer.linkText && (
+              {disclaimer.link && disclaimer.linkText ? (
                 <Link
                   href={disclaimer.link}
                   target="_blank"
@@ -970,7 +970,7 @@ export const F0AiChatTextArea = ({
                 >
                   {disclaimer.linkText}
                 </Link>
-              )}
+              ) : null}
             </motion.div>
           )
         )}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -430,14 +430,14 @@ const Wrapper = ({
         fullscreen={fullscreen}
         padding={padding}
       />
-      {submissions.length > 0 && (
+      {submissions.length > 0 ? (
         <div className="rounded-md border border-f1-border p-3 text-sm">
           <div className="font-medium pb-2">Last submission</div>
           <pre className="text-xs whitespace-pre-wrap">
             {JSON.stringify(submissions[submissions.length - 1], null, 2)}
           </pre>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.focusBridge.test.tsx
@@ -39,14 +39,14 @@ const FocusHarness = () => {
       <button type="button" onClick={() => setIsClarifying(false)}>
         Restore composer
       </button>
-      {showInput && (
+      {showInput ? (
         <F0AiChatTextArea
           onSubmit={vi.fn()}
           clarifyingUI={
             isClarifying ? <div>Choose a reporting period</div> : undefined
           }
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/ActionBar.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/ActionBar.tsx
@@ -99,7 +99,7 @@ export const ActionBar = ({
     // `justify-between`, which would strand a lone send button on the left the
     // moment the row has nothing else in it.
     <div className="flex shrink-0 items-center gap-2 p-3">
-      {(onUploadFiles || toolbarStart) && (
+      {onUploadFiles || toolbarStart ? (
         <div
           className={cn(
             "flex items-center gap-2",
@@ -109,7 +109,7 @@ export const ActionBar = ({
             center ? "shrink-0" : "min-w-0"
           )}
         >
-          {onUploadFiles && (
+          {onUploadFiles ? (
             <>
               <ButtonInternal
                 label={translation.ai.attachFile}
@@ -136,8 +136,8 @@ export const ActionBar = ({
                 onChange={handleFileSelect}
               />
             </>
-          )}
-          {toolbarStart && (
+          ) : null}
+          {toolbarStart ? (
             // Host controls keep their own focus instead of bubbling to the
             // form's click handler, which intentionally focuses the textarea.
             <div
@@ -146,18 +146,18 @@ export const ActionBar = ({
             >
               {toolbarStart}
             </div>
-          )}
+          ) : null}
         </div>
-      )}
-      {center && <div className="min-w-0 flex-1">{center}</div>}
+      ) : null}
+      {center ? <div className="min-w-0 flex-1">{center}</div> : null}
       <div className="ml-auto flex shrink-0 items-center gap-2">
-        {canRecord && (
+        {canRecord ? (
           <DictationButton
             inProgress={inProgress}
             recordingStatus={recordingStatus}
             onStartRecording={onStartRecording}
           />
-        )}
+        ) : null}
         <SubmitButton
           inProgress={inProgress}
           hasDataToSend={hasDataToSend}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/CreditWarningWrapper.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/CreditWarningWrapper.tsx
@@ -45,7 +45,7 @@ export const CreditWarningWrapper = ({
           {config.text}
         </p>
         <div className="flex shrink-0 items-center gap-1">
-          {creditWarning.onGetCredits && (
+          {creditWarning.onGetCredits ? (
             <F0Button
               label={translation.ai.creditWarning.getCredits ?? ""}
               size="sm"
@@ -54,8 +54,8 @@ export const CreditWarningWrapper = ({
               tooltip={translation.ai.creditWarning.getCredits ?? ""}
               onClick={creditWarning.onGetCredits}
             />
-          )}
-          {creditWarning.onDismiss && (
+          ) : null}
+          {creditWarning.onDismiss ? (
             <F0Button
               label={translation.ai.creditWarning.dismiss ?? ""}
               size="sm"
@@ -64,7 +64,7 @@ export const CreditWarningWrapper = ({
               hideLabel
               onClick={creditWarning.onDismiss}
             />
-          )}
+          ) : null}
         </div>
       </div>
       {children}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/TextareaField.tsx
@@ -51,7 +51,7 @@ export const TextareaField = ({
       >
         {inputValue.endsWith("\n") ? inputValue + "_" : inputValue}
       </div>
-      {hasOverlay && (
+      {hasOverlay ? (
         <div
           ref={highlightRef}
           aria-hidden={true}
@@ -85,8 +85,8 @@ export const TextareaField = ({
             )
           )}
         </div>
-      )}
-      {!inputValue && !multiplePlaceholders && (
+      ) : null}
+      {!inputValue && !multiplePlaceholders ? (
         <p
           className={cn(
             "col-start-1 row-start-1",
@@ -101,7 +101,7 @@ export const TextareaField = ({
             ? placeholders[0]
             : resolvedDefaultPlaceholder}
         </p>
-      )}
+      ) : null}
       <textarea
         aria-label={resolvedDefaultPlaceholder}
         autoFocus={false}
@@ -143,14 +143,14 @@ export const TextareaField = ({
               : "caret-transparent")
         )}
       />
-      {multiplePlaceholders && (
+      {multiplePlaceholders ? (
         <TypewriterPlaceholder
           placeholders={placeholders}
           defaultPlaceholder={resolvedDefaultPlaceholder}
           inputValue={inputValue}
           inProgress={inProgress ?? false}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/TypewriterPlaceholder.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/TypewriterPlaceholder.tsx
@@ -146,9 +146,9 @@ export const TypewriterPlaceholder = ({
           )}
         >
           {displayedPlaceholder}
-          {isTyping && !shouldReduceMotion && (
+          {isTyping && !shouldReduceMotion ? (
             <span className="f0-chat-cursor-blink">|</span>
-          )}
+          ) : null}
         </div>
       </motion.div>
     </AnimatePresence>

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -213,7 +213,7 @@ export const WelcomeScreenSuggestionsRow = ({
           </div>
         </PopoverAnchor>
       </div>
-      {activeGroup && (
+      {activeGroup ? (
         <PopoverContent
           side={side}
           align="start"
@@ -271,7 +271,7 @@ export const WelcomeScreenSuggestionsRow = ({
             ))}
           </div>
         </PopoverContent>
-      )}
+      ) : null}
     </Popover>
   )
 }

--- a/packages/react/src/kits/ai/F0AiInsightCard/__tests__/F0AiInsightCard.test.tsx
+++ b/packages/react/src/kits/ai/F0AiInsightCard/__tests__/F0AiInsightCard.test.tsx
@@ -41,7 +41,9 @@ vi.mock("@/ui/OverflowList", () => ({
     return (
       <div data-testid="overflow-list-mock">
         {visible.map((item, i) => renderListItem(item, i))}
-        {overflowCount > 0 && renderOverflowIndicator?.(overflowCount, false)}
+        {overflowCount > 0
+          ? renderOverflowIndicator?.(overflowCount, false)
+          : null}
       </div>
     )
   },

--- a/packages/react/src/kits/ai/F0AiInsightCard/components/CardHeader.tsx
+++ b/packages/react/src/kits/ai/F0AiInsightCard/components/CardHeader.tsx
@@ -21,13 +21,13 @@ export const CardHeader = ({
 
   return (
     <>
-      {description && (
+      {description ? (
         <span className={cn(descriptionVariants(), "truncate")}>
           {description}
         </span>
-      )}
+      ) : null}
       <AnimatePresence>
-        {onAskOne && isRevealed && (
+        {onAskOne && isRevealed ? (
           <motion.div
             className="absolute bottom-4 left-4 z-10"
             initial={{ opacity: 0 }}
@@ -47,7 +47,7 @@ export const CardHeader = ({
               }}
             />
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
     </>
   )

--- a/packages/react/src/kits/ai/F0AiInsightCard/components/CardMetadata.tsx
+++ b/packages/react/src/kits/ai/F0AiInsightCard/components/CardMetadata.tsx
@@ -54,7 +54,7 @@ export const CardMetadata = (props: CardMetadataProps) => {
         animate={{ opacity: shouldFadeContent ? 0 : 1 }}
         transition={fadeTransition}
       >
-        {content === "person" && (
+        {content === "person" ? (
           <div className="flex items-center gap-1">
             <F0AvatarPerson
               firstName={props.avatar.firstName}
@@ -62,49 +62,55 @@ export const CardMetadata = (props: CardMetadataProps) => {
               src={props.avatar.src}
               size="xs"
             />
-            {label && <span className={cn(labelVariants())}>{label}</span>}
+            {label ? (
+              <span className={cn(labelVariants())}>{label}</span>
+            ) : null}
           </div>
-        )}
+        ) : null}
 
-        {content === "people" && (
+        {content === "people" ? (
           <F0AvatarList
             type="person"
             avatars={props.avatars}
             size="md"
             max={3}
           />
-        )}
+        ) : null}
 
-        {content === "team" && (
+        {content === "team" ? (
           <div className="flex items-center gap-1">
             <F0AvatarTeam
               name={props.avatar.name}
               src={props.avatar.src}
               size="xs"
             />
-            {label && <span className={cn(labelVariants())}>{label}</span>}
+            {label ? (
+              <span className={cn(labelVariants())}>{label}</span>
+            ) : null}
           </div>
-        )}
+        ) : null}
 
-        {content === "company" && (
+        {content === "company" ? (
           <div className="flex items-center gap-1">
             <F0AvatarCompany
               name={props.avatar.name}
               src={props.avatar.src}
               size="xs"
             />
-            {label && <span className={cn(labelVariants())}>{label}</span>}
+            {label ? (
+              <span className={cn(labelVariants())}>{label}</span>
+            ) : null}
           </div>
-        )}
+        ) : null}
 
-        {content === "alert" && (
+        {content === "alert" ? (
           <F0TagAlert text={props.alertLabel} level={props.level} />
-        )}
+        ) : null}
 
-        {content === "balance" && <BalanceTag balance={props.balance} />}
+        {content === "balance" ? <BalanceTag balance={props.balance} /> : null}
       </motion.div>
 
-      {label && !hiddenBottomLabelTypes.has(content) && (
+      {label && !hiddenBottomLabelTypes.has(content) ? (
         <motion.span
           className={cn(labelVariants())}
           animate={{ opacity: shouldFadeContent ? 0 : 1 }}
@@ -112,7 +118,7 @@ export const CardMetadata = (props: CardMetadataProps) => {
         >
           {label}
         </motion.span>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0AiInsightCard/internal.tsx
+++ b/packages/react/src/kits/ai/F0AiInsightCard/internal.tsx
@@ -52,7 +52,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
 
     return (
       <div className="relative">
-        {selected && (
+        {selected ? (
           <>
             <div
               data-testid="selected-border"
@@ -73,7 +73,7 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
               )}
             />
           </>
-        )}
+        ) : null}
         <div
           ref={ref}
           role={onClick ? "button" : undefined}

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/F0AiMessagesContainer.tsx
@@ -248,29 +248,31 @@ const Messages = ({
         {turn.userMessages.map((message, index) =>
           renderUserMessage(message, index)
         )}
-        {turn.thinking && turn.thinking.titles.length > 0 && (
+        {turn.thinking && turn.thinking.titles.length > 0 ? (
           <Thinking
             titles={turn.thinking.titles}
             title={translations.ai.thoughtsGroupTitle}
             inProgress={turn.thinking.inProgress}
             isWriting={turn.thinking.isWriting}
           />
-        )}
+        ) : null}
         {turn.assistantMessages.map((message, index) =>
           renderAssistantMessage(message, index)
         )}
-        {turn.endIndicator === "thinking" && (
+        {turn.endIndicator === "thinking" ? (
           <F0ActionItem title={translations.ai.thinking} status="executing" />
-        )}
-        {turn.endIndicator === "activity" && <F0ActionItem status="writing" />}
-        {turn.feedback && (
+        ) : null}
+        {turn.endIndicator === "activity" ? (
+          <F0ActionItem status="writing" />
+        ) : null}
+        {turn.feedback ? (
           <TurnFeedback
             content={turn.feedback.content}
             targetMessage={turn.feedback.targetMessage}
             onCopy={onCopy}
           />
-        )}
-        {isLastTurn && <ActiveFormCard />}
+        ) : null}
+        {isLastTurn ? <ActiveFormCard /> : null}
       </div>
     )
   }
@@ -299,8 +301,8 @@ const Messages = ({
                 "w-full max-w-content"
               )}
             >
-              {isLoadingThread && <MessagesSkeleton />}
-              {showWelcomeBlock && (
+              {isLoadingThread ? <MessagesSkeleton /> : null}
+              {showWelcomeBlock ? (
                 <WelcomeScreen
                   messages={welcomeMessages}
                   caption={initialMessageCaption}
@@ -309,9 +311,10 @@ const Messages = ({
                   onClick={onWelcomeClick}
                   fullscreen={fullscreen}
                 />
-              )}
-              {!isLoadingThread &&
-                turns.map((turn, turnIndex) => renderTurn(turn, turnIndex))}
+              ) : null}
+              {!isLoadingThread
+                ? turns.map((turn, turnIndex) => renderTurn(turn, turnIndex))
+                : null}
               {interrupt}
             </div>
 
@@ -322,7 +325,7 @@ const Messages = ({
             </footer>
 
             <AnimatePresence>
-              {showScrollBtn && (
+              {showScrollBtn ? (
                 <motion.div
                   className="sticky bottom-2 z-10 flex justify-center"
                   initial={{ opacity: 0, scale: 0.8 }}
@@ -340,27 +343,27 @@ const Messages = ({
                     />
                   </div>
                 </motion.div>
-              )}
+              ) : null}
             </AnimatePresence>
           </div>
         </div>
 
-        {!noShadows && !showWelcomeBlock && (
+        {!noShadows && !showWelcomeBlock ? (
           <>
             <ScrollShadow position="top" key="shadow-top" />
             <ScrollShadow position="bottom" key="shadow-bottom" />
           </>
-        )}
+        ) : null}
       </div>
 
-      {modal.isOpen && (
+      {modal.isOpen ? (
         <FeedbackModal
           onSubmit={handleSubmit}
           onClose={handleClose}
           reactionType={modal.currentReaction}
           message={modal.currentMessage}
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/components/AssistantMessage.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/components/AssistantMessage.tsx
@@ -95,15 +95,15 @@ export const AssistantMessage = ({
   return (
     <ToolCallIdContext.Provider value={toolCallId}>
       <div className="relative isolate flex w-full flex-col items-start justify-center">
-        {message && content && (
+        {message && content ? (
           <div
             ref={contentRef}
             className="w-full max-w-full [&>div]:flex [&>div]:flex-col [&>div]:gap-1"
           >
             {(renderMarkdown ?? defaultMarkdownFallback)(content)}
           </div>
-        )}
-        {!!subComponent && <div className="w-full">{subComponent}</div>}
+        ) : null}
+        {subComponent ? <div className="w-full">{subComponent}</div> : null}
         <ReplyPopover
           anchor={anchor}
           onReply={(text) => {

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/components/CollapsibleMessage.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/components/CollapsibleMessage.tsx
@@ -72,7 +72,7 @@ export const CollapsibleMessage = ({
         <div className="min-h-6 flex items-center">
           <span>{title}</span>
         </div>
-        {!lockOpen && <F0Icon icon={ChevronRight} />}
+        {!lockOpen ? <F0Icon icon={ChevronRight} /> : null}
       </CollapsibleTrigger>
       <CollapsibleContent forceMount className="data-[state=open]:mt-3">
         <motion.div

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/components/FormCard.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/components/FormCard.tsx
@@ -278,7 +278,7 @@ export function FormCard({
         showButton: isActive,
       }}
     >
-      {visibleFields.length > 0 && !isActive && (
+      {visibleFields.length > 0 && !isActive ? (
         <div className="-mx-3 flex w-full flex-col overflow-hidden pb-1">
           <DetailsItemsList
             details={visibleFields.map((field) => ({
@@ -291,7 +291,7 @@ export function FormCard({
             tableView
           />
         </div>
-      )}
+      ) : null}
     </F0CanvasCard>
   )
 }

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/components/Thinking.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/components/Thinking.tsx
@@ -52,12 +52,12 @@ export const Thinking = ({
               status={itemStatus(index)}
               inGroup
             />
-            {index < titles.length - 1 && (
+            {index < titles.length - 1 ? (
               <div
                 aria-hidden
                 className="absolute -bottom-3 left-2 ml-px top-5 w-px bg-f1-border-secondary rounded"
               />
-            )}
+            ) : null}
           </div>
         ))}
       </div>

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/components/UserMessage.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/components/UserMessage.tsx
@@ -163,11 +163,11 @@ export const UserMessage = ({
       ref={ref}
       className="my-4 flex w-full flex-col items-end gap-2 first:mt-0 last:mb-0"
     >
-      {quoteText && (
+      {quoteText ? (
         <ReplyQuoteBlock text={quoteText} renderMarkdown={renderMarkdown} />
-      )}
+      ) : null}
 
-      {uploadedFiles.length > 0 && (
+      {uploadedFiles.length > 0 ? (
         <div className="flex max-w-[90%] flex-wrap justify-end gap-1.5">
           {uploadedFiles.map((file, index) => (
             <F0FileItem
@@ -177,15 +177,15 @@ export const UserMessage = ({
             />
           ))}
         </div>
-      )}
-      {hasVisibleText && (
+      ) : null}
+      {hasVisibleText ? (
         <div
           ref={bubbleRef}
           className="w-fit max-w-[90%] self-end whitespace-pre-wrap rounded-xl bg-f1-background-tertiary px-4 py-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-1"
         >
           {(renderMarkdown ?? defaultMarkdownFallback)(content)}
         </div>
-      )}
+      ) : null}
       <ReplyPopover
         anchor={anchor}
         onReply={(text) => {

--- a/packages/react/src/kits/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
+++ b/packages/react/src/kits/ai/F0AiMessagesContainer/components/WelcomeScreen.tsx
@@ -141,7 +141,7 @@ export const WelcomeScreen = ({
       )}
     >
       <div className="flex flex-col items-center">
-        {cta && (
+        {cta ? (
           <ButtonInternal
             variant="neutral"
             size="sm"
@@ -150,12 +150,12 @@ export const WelcomeScreen = ({
             icon={cta.icon}
             onClick={cta.onClick}
           />
-        )}
-        {caption && (
+        ) : null}
+        {caption ? (
           <p className="animate-in fade-in-0 text-center text-2xl font-semibold leading-[28px] text-f1-foreground-secondary duration-500">
             {caption}
           </p>
-        )}
+        ) : null}
         {/* aria-label is prohibited on a plain paragraph role, so only the
             interactive (button) case is named by it; the sr-only span names
             the static case with the full, stable phrase instead of the
@@ -182,11 +182,11 @@ export const WelcomeScreen = ({
           </span>
           <span className="sr-only">{current}</span>
         </p>
-        {subtitle && (
+        {subtitle ? (
           <p className="animate-in fade-in-0 mt-3 text-center text-base leading-snug text-f1-foreground-secondary duration-500">
             {subtitle}
           </p>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/kits/ai/F0AiPong/F0AiPong.tsx
+++ b/packages/react/src/kits/ai/F0AiPong/F0AiPong.tsx
@@ -630,7 +630,7 @@ export const F0AiPong = ({ onClose }: F0AiPongProps) => {
             </div>
 
             {/* Goal indicator — bottom half when player scores, top half when AI scores */}
-            {phase === "scored" && lastScorer && (
+            {phase === "scored" && lastScorer ? (
               <div
                 className={cn(
                   "pointer-events-none absolute left-4 flex items-center",
@@ -641,16 +641,16 @@ export const F0AiPong = ({ onClose }: F0AiPongProps) => {
                   {translations.ai.pong.goal}
                 </span>
               </div>
-            )}
+            ) : null}
 
             {/* Game over overlay */}
-            {phase === "gameover" && endMessage && (
+            {phase === "gameover" && endMessage ? (
               <div className="pointer-events-none absolute inset-0 z-40 flex items-center justify-center bg-f1-special-page/60 backdrop-blur-sm">
                 <span className="text-2xl font-semibold text-f1-foreground">
                   {endMessage}
                 </span>
               </div>
-            )}
+            ) : null}
 
             {/* Confetti canvas */}
             <canvas

--- a/packages/react/src/kits/ai/F0AiProcessingOverlay/F0AiProcessingOverlay.tsx
+++ b/packages/react/src/kits/ai/F0AiProcessingOverlay/F0AiProcessingOverlay.tsx
@@ -121,7 +121,7 @@ export const F0AiProcessingOverlay = memo(function F0AiProcessingOverlay({
   return (
     <div className={cn("relative flex flex-1 flex-col", className)}>
       <AnimatePresence>
-        {active && (
+        {active ? (
           // Zero-height sticky anchor pinned to the top of the scroll viewport,
           // with the pill pushed to ~half the viewport height. This keeps the
           // pill centred in the visible area regardless of how tall the blurred
@@ -139,7 +139,7 @@ export const F0AiProcessingOverlay = memo(function F0AiProcessingOverlay({
               />
             </div>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
       <motion.div
         className={cn("flex flex-1 flex-col", active && "pointer-events-none")}

--- a/packages/react/src/kits/ai/F0AiProposalCard/F0AiProposalCard.tsx
+++ b/packages/react/src/kits/ai/F0AiProposalCard/F0AiProposalCard.tsx
@@ -70,16 +70,16 @@ export function F0AiProposalCard(props: F0AiProposalCardProps) {
       {...dataAttributes}
     >
       <div className="flex items-center gap-3 px-4 py-3">
-        {module && <F0AvatarModule module={module} size="md" />}
+        {module ? <F0AvatarModule module={module} size="md" /> : null}
         <div className="min-w-0 flex-1">
           <h2 className="truncate text-lg font-semibold text-f1-foreground">
             {heading}
           </h2>
-          {subtitle && (
+          {subtitle ? (
             <p className="truncate text-base text-f1-foreground-secondary">
               {subtitle}
             </p>
-          )}
+          ) : null}
         </div>
       </div>
 
@@ -96,7 +96,7 @@ export function F0AiProposalCard(props: F0AiProposalCardProps) {
           )}
         >
           {visibleDescription}
-          {shouldTruncate && !expanded && (
+          {shouldTruncate && !expanded ? (
             <>
               {" "}
               <button
@@ -112,11 +112,11 @@ export function F0AiProposalCard(props: F0AiProposalCardProps) {
                 {seeMoreLabel}
               </button>
             </>
-          )}
+          ) : null}
         </p>
       </div>
 
-      {actions && (
+      {actions ? (
         <div className="flex items-center justify-end gap-3 border-0 border-t border-solid border-f1-border-secondary px-4 py-3">
           <F0Button
             type="button"
@@ -125,7 +125,7 @@ export function F0AiProposalCard(props: F0AiProposalCardProps) {
             onClick={actions.onPrimaryAction}
           />
         </div>
-      )}
+      ) : null}
     </section>
   )
 }

--- a/packages/react/src/kits/ai/F0CanvasPanel/F0CanvasPanel.tsx
+++ b/packages/react/src/kits/ai/F0CanvasPanel/F0CanvasPanel.tsx
@@ -97,7 +97,7 @@ export function F0CanvasPanel({
 
   return (
     <AnimatePresence>
-      {content && (
+      {content ? (
         <motion.div
           className={cn(
             // No overflow on the outer wrappers so the inner card's
@@ -151,7 +151,7 @@ export function F0CanvasPanel({
             </motion.div>
           </div>
         </motion.div>
-      )}
+      ) : null}
     </AnimatePresence>
   )
 }

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/ConfirmFooter.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/ConfirmFooter.tsx
@@ -25,7 +25,7 @@ export const ConfirmFooter = ({
   return (
     <div className="flex items-center justify-end gap-3 p-3">
       <div className="flex items-center">
-        {showSkip && onSkip && (
+        {showSkip && onSkip ? (
           <F0Button
             variant="outline"
             type="button"
@@ -33,7 +33,7 @@ export const ConfirmFooter = ({
             onClick={onSkip}
             disabled={submitDisabled}
           />
-        )}
+        ) : null}
       </div>
       <F0Button
         disabled={!canProceed || submitDisabled}

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
@@ -160,7 +160,7 @@ export const OptionsList = ({
         </motion.div>
       ))}
 
-      {allowCustomAnswer && (
+      {allowCustomAnswer ? (
         <motion.div {...rowEnter(options.length)}>
           <CustomAnswerRow
             mode={mode}
@@ -176,7 +176,7 @@ export const OptionsList = ({
             onConfirm={onConfirm}
           />
         </motion.div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/RadioIndicator.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/RadioIndicator.tsx
@@ -14,7 +14,9 @@ export const RadioIndicator = ({ isSelected }: RadioIndicatorProps) => {
           : "border-2 border-solid border-f1-border bg-f1-background"
       )}
     >
-      {isSelected && <div className="h-2 w-2 rounded-full bg-f1-background" />}
+      {isSelected ? (
+        <div className="h-2 w-2 rounded-full bg-f1-background" />
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/StepHeader.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/StepHeader.tsx
@@ -43,7 +43,7 @@ export const StepHeader = ({
         {question}
       </OneEllipsis>
 
-      {stepLabel && (
+      {stepLabel ? (
         <div className="flex shrink-0 items-center gap-0.5">
           <F0Button
             variant="ghost"
@@ -78,7 +78,7 @@ export const StepHeader = ({
             icon={ChevronRight}
           />
         </div>
-      )}
+      ) : null}
       <F0Button
         variant="ghost"
         size="sm"

--- a/packages/react/src/kits/ai/F0OneSwitch/F0OneSwitch.tsx
+++ b/packages/react/src/kits/ai/F0OneSwitch/F0OneSwitch.tsx
@@ -108,14 +108,14 @@ export const F0OneSwitch = ({
               </SwitchPrimitive.Root>
             </div>
           </TooltipTrigger>
-          {!open && (
+          {!open ? (
             <TooltipContent
               side="left"
               className={cn("font-medium", autoOpen && "z-[100]")}
             >
               {tooltipText}
             </TooltipContent>
-          )}
+          ) : null}
         </Tooltip>
       </TooltipProvider>
     </div>

--- a/packages/react/src/kits/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/kits/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -90,26 +90,26 @@ export function F0CanvasCard({
       onClick={handleCardClick}
     >
       <div className="flex w-full min-w-0 flex-row items-center gap-3">
-        {avatar?.type === "module" && (
+        {avatar?.type === "module" ? (
           <F0AvatarModule module={avatar.module} size="md" />
-        )}
-        {avatar?.type === "file" && (
+        ) : null}
+        {avatar?.type === "file" ? (
           <F0AvatarFile file={avatar.file} size="lg" />
-        )}
-        {avatar?.type === "icon" && (
+        ) : null}
+        {avatar?.type === "icon" ? (
           <F0AvatarIcon icon={avatar.icon} size="md" />
-        )}
+        ) : null}
         <div className="flex min-w-0 flex-1 flex-col">
           <OneEllipsis className="text-lg font-semibold text-f1-foreground">
             {title}
           </OneEllipsis>
-          {description && (
+          {description ? (
             <OneEllipsis className="text-base text-f1-foreground-secondary">
               {description}
             </OneEllipsis>
-          )}
+          ) : null}
         </div>
-        {action.type === "open" && action.showButton !== false && (
+        {action.type === "open" && action.showButton !== false ? (
           <F0Button
             variant="outline"
             size="md"
@@ -120,8 +120,8 @@ export function F0CanvasCard({
             }
             onClick={isActive ? action.onClose : action.onOpen}
           />
-        )}
-        {action.type === "custom" && (
+        ) : null}
+        {action.type === "custom" ? (
           <F0Button
             variant="outline"
             size="md"
@@ -130,7 +130,7 @@ export function F0CanvasCard({
             hideLabel={action.hideLabel}
             onClick={action.onClick}
           />
-        )}
+        ) : null}
       </div>
       {children}
     </div>

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
@@ -303,10 +303,10 @@ function SurveyAnsweringFormDialog({
             isStepped && !isFullscreen && "min-h-[600px]"
           )}
         >
-          {showTableOfContent && (
+          {showTableOfContent ? (
             <TableOfContent elements={elements} onChange={noop} answering />
-          )}
-          {showStepperProgress && (
+          ) : null}
+          {showStepperProgress ? (
             <div className="absolute left-0 right-0 top-0 [&>div>div>div]:h-1 [&>div>div>div]:rounded-none">
               <ProgressBarCell
                 label="Value"
@@ -314,7 +314,7 @@ function SurveyAnsweringFormDialog({
                 hideLabel
               />
             </div>
-          )}
+          ) : null}
           <div
             className={cn(
               "mx-auto flex w-full flex-1 justify-center flex-col @lg:w-[750px] max-w-full pt-0",
@@ -350,19 +350,19 @@ function SurveyAnsweringFormDialog({
                 />
               </F0Box>
             ) : null}
-            {showSectionHeader && (
+            {showSectionHeader ? (
               <div className="py-1 pl-5">
                 <span className="text-lg font-semibold text-f1-foreground">
                   {stepper.currentQuestion?.sectionTitle}
                 </span>
-                {stepper.currentQuestion?.sectionDescription && (
+                {stepper.currentQuestion?.sectionDescription ? (
                   <p className="text-f1-foreground-secondary">
                     {stepper.currentQuestion?.sectionDescription}
                   </p>
-                )}
+                ) : null}
               </div>
-            )}
-            {hasQuestions && !loading && (
+            ) : null}
+            {hasQuestions && !loading ? (
               <F0Form
                 key={isStepped ? stepper.currentStep : undefined}
                 formRef={formRef}
@@ -376,7 +376,7 @@ function SurveyAnsweringFormDialog({
                 errorTriggerMode={errorTriggerMode}
                 sections={sections}
               />
-            )}
+            ) : null}
           </div>
         </div>
       </SurveyFormBuilderProvider>
@@ -438,7 +438,7 @@ function SurveyAnsweringFormInline({
       datasets={datasets}
     >
       <div className="mx-auto flex w-full max-w-3xl flex-col">
-        {!hideResourceHeader && (
+        {!hideResourceHeader ? (
           <div className="mb-6">
             <F0ResourceHeader
               title={title}
@@ -446,7 +446,7 @@ function SurveyAnsweringFormInline({
               {...resourceHeader}
             />
           </div>
-        )}
+        ) : null}
         {loading ? (
           <SurveyAllQuestionsLoadingSkeleton />
         ) : !hasQuestions ? (

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/components/SelectQuestionField.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/components/SelectQuestionField.tsx
@@ -30,7 +30,9 @@ function RadioIndicator({ checked }: { checked: boolean }) {
           : "border border-solid border-f1-border bg-f1-background"
       )}
     >
-      {checked && <div className="h-2 w-2 rounded-full bg-f1-background" />}
+      {checked ? (
+        <div className="h-2 w-2 rounded-full bg-f1-background" />
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/components/skeletons/SurveyAnsweringFormLoadingSkeletons.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/components/skeletons/SurveyAnsweringFormLoadingSkeletons.tsx
@@ -14,12 +14,12 @@ function SkeletonQuestionCard({
     <div className="flex flex-col gap-4 rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-4">
       <div className="flex flex-col gap-2">
         <Skeleton className="h-5 rounded-sm" style={{ width: titleWidth }} />
-        {descriptionWidth && (
+        {descriptionWidth ? (
           <Skeleton
             className="h-4 rounded-sm"
             style={{ width: descriptionWidth }}
           />
-        )}
+        ) : null}
       </div>
       {answer}
     </div>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/AddButton/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/AddButton/index.tsx
@@ -88,7 +88,7 @@ export const AddButton = () => {
               </div>
             </DropdownMenuItem>
           ))}
-          {datasetKeys.length > 0 && (
+          {datasetKeys.length > 0 ? (
             <>
               <DropdownMenuSeparator />
               {datasetKeys.map((dk) => {
@@ -101,7 +101,9 @@ export const AddButton = () => {
                   <DropdownMenuSub key={dk}>
                     <DropdownMenuSubTrigger className="mx-1 px-2 data-[state=open]:rounded-sm data-[state=closed]:bg-transparent data-[state=open]:bg-f1-background-hover">
                       <div className="flex w-full flex-row items-center gap-2">
-                        {entry && <F0Icon icon={entry.icon} color="default" />}
+                        {entry ? (
+                          <F0Icon icon={entry.icon} color="default" />
+                        ) : null}
                         <span className="flex-1 text-base font-medium">
                           {entry?.label ?? dk}
                         </span>
@@ -109,7 +111,7 @@ export const AddButton = () => {
                     </DropdownMenuSubTrigger>
                     <DropdownMenuPortal>
                       <DropdownMenuSubContent>
-                        {isQuestionTypeAllowed("dropdown-single") && (
+                        {isQuestionTypeAllowed("dropdown-single") ? (
                           <DropdownMenuItem
                             onClick={() =>
                               handleAddNewQuestion("dropdown-single", dk)
@@ -122,8 +124,8 @@ export const AddButton = () => {
                               </span>
                             </div>
                           </DropdownMenuItem>
-                        )}
-                        {isQuestionTypeAllowed("dropdown-multi") && (
+                        ) : null}
+                        {isQuestionTypeAllowed("dropdown-multi") ? (
                           <DropdownMenuItem
                             onClick={() =>
                               handleAddNewQuestion("dropdown-multi", dk)
@@ -136,14 +138,14 @@ export const AddButton = () => {
                               </span>
                             </div>
                           </DropdownMenuItem>
-                        )}
+                        ) : null}
                       </DropdownMenuSubContent>
                     </DropdownMenuPortal>
                   </DropdownMenuSub>
                 )
               })}
             </>
-          )}
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/QuestionItem.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/QuestionItem.tsx
@@ -70,9 +70,8 @@ export const QuestionItem = ({
             isDragging && "cursor-grabbing"
           )}
         >
-          {!disabled &&
-            !answering &&
-            (questionLocked ? (
+          {!disabled && !answering ? (
+            questionLocked ? (
               // Blocked question: drop the drag affordance but keep the handle's
               // gutter so the card stays the same width and alignment as the
               // editable questions around it.
@@ -91,7 +90,8 @@ export const QuestionItem = ({
               >
                 <F0Icon icon={Handle} size="sm" />
               </div>
-            ))}
+            )
+          ) : null}
           <QuestionComponent
             {...({
               ...item.question,
@@ -99,7 +99,7 @@ export const QuestionItem = ({
           />
         </div>
       </div>
-      {showEndOfSection && <EndOfSectionDivider />}
+      {showEndOfSection ? <EndOfSectionDivider /> : null}
     </Reorder.Item>
   )
 }

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/SectionHeaderItem.tsx
@@ -58,9 +58,8 @@ export const SectionHeaderItem = ({
               isDragging && "cursor-grabbing"
             )}
           >
-            {!disabled &&
-              !answering &&
-              (item.section.locked ? (
+            {!disabled && !answering ? (
+              item.section.locked ? (
                 // Blocked section: drop the drag affordance but keep the
                 // handle's gutter so the header stays aligned with the
                 // editable rows around it.
@@ -77,19 +76,20 @@ export const SectionHeaderItem = ({
                 >
                   <F0Icon icon={Handle} size="sm" />
                 </div>
-              ))}
+              )
+            ) : null}
             <SectionComponent {...item.section} hideQuestions />
           </div>
 
           {isDraggingThisSection &&
-            (item.section.questions ?? []).length > 0 && (
-              <div className="flex flex-col gap-4 w-full mt-4 ml-7">
-                {(item.section.questions ?? []).map((q) => (
-                  <QuestionComponent key={q.id} {...(q as QuestionProps)} />
-                ))}
-                <EndOfSectionDivider />
-              </div>
-            )}
+          (item.section.questions ?? []).length > 0 ? (
+            <div className="flex flex-col gap-4 w-full mt-4 ml-7">
+              {(item.section.questions ?? []).map((q) => (
+                <QuestionComponent key={q.id} {...(q as QuestionProps)} />
+              ))}
+              <EndOfSectionDivider />
+            </div>
+          ) : null}
         </div>
       </div>
     </Reorder.Item>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
@@ -157,9 +157,9 @@ const _SurveyFormBuilder = ({
     >
       <DragProvider>
         <DragSelectGuard>
-          {showTableOfContent && (
+          {showTableOfContent ? (
             <TableOfContent elements={elements} onChange={onChange} />
-          )}
+          ) : null}
           <div className="relative flex flex-1 flex-col">
             <motion.div
               className={cn(
@@ -278,9 +278,9 @@ const _SurveyFormBuilder = ({
                   })()}
                 </div>
               </Reorder.Group>
-              {shouldShowAddButton && <AddButton />}
+              {shouldShowAddButton ? <AddButton /> : null}
             </motion.div>
-            {applyingChanges && (
+            {applyingChanges ? (
               <motion.div
                 className="sticky bottom-1/2 left-0 z-50 flex w-full items-center justify-center"
                 initial={{ opacity: 0, scale: 0.95 }}
@@ -289,7 +289,7 @@ const _SurveyFormBuilder = ({
               >
                 <ApplyingChangesTag />
               </motion.div>
-            )}
+            ) : null}
           </div>
         </DragSelectGuard>
       </DragProvider>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/ActionsMenu/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/ActionsMenu/index.tsx
@@ -115,11 +115,11 @@ const QuestionTypeMenuItem = ({
         <div className="flex w-full flex-row items-center gap-2">
           <F0Icon icon={Hub} color="default" />
           <span className="flex-1 text-base font-medium">{label}</span>
-          {!!selectedOptionLabel && (
+          {selectedOptionLabel ? (
             <span className="mr-1 text-base text-f1-foreground-secondary">
               {selectedOptionLabel}
             </span>
-          )}
+          ) : null}
         </div>
       </DropdownMenuSubTrigger>
       <DropdownMenuPortal>
@@ -136,7 +136,7 @@ const QuestionTypeMenuItem = ({
                     <div className="flex w-full flex-row items-center gap-2 text-base font-medium">
                       <F0Icon icon={questionType.icon} color="default" />
                       <span className="flex-1">{questionType.label}</span>
-                      {currentRatingType && (
+                      {currentRatingType ? (
                         <span className="mr-1 text-base text-f1-foreground-secondary">
                           {
                             RATING_OPTIONS.find(
@@ -144,7 +144,7 @@ const QuestionTypeMenuItem = ({
                             )?.label
                           }
                         </span>
-                      )}
+                      ) : null}
                     </div>
                   </DropdownMenuSubTrigger>
                   <DropdownMenuPortal>
@@ -156,9 +156,9 @@ const QuestionTypeMenuItem = ({
                         >
                           <div className="flex w-full flex-row items-center gap-2 pl-2">
                             <span className="flex-1">{ratingOption.label}</span>
-                            {currentRatingType === ratingOption.value && (
+                            {currentRatingType === ratingOption.value ? (
                               <F0Icon icon={Check} color="default" />
-                            )}
+                            ) : null}
                           </div>
                         </DropdownMenuItem>
                       ))}
@@ -176,12 +176,12 @@ const QuestionTypeMenuItem = ({
                 <div className="flex w-full flex-row items-center gap-2">
                   <F0Icon icon={questionType.icon} color="default" />
                   <span className="flex-1">{questionType.label}</span>
-                  {isSelected && <F0Icon icon={Check} color="default" />}
+                  {isSelected ? <F0Icon icon={Check} color="default" /> : null}
                 </div>
               </DropdownMenuItem>
             )
           })}
-          {datasetKeys.length > 0 && (
+          {datasetKeys.length > 0 ? (
             <>
               <DropdownMenuSeparator />
               {datasetKeys.map((dk) => {
@@ -195,20 +195,20 @@ const QuestionTypeMenuItem = ({
                   <DropdownMenuSub key={dk}>
                     <DropdownMenuSubTrigger className="mx-1 px-2 data-[state=open]:rounded-sm data-[state=closed]:bg-transparent data-[state=open]:bg-f1-background-hover">
                       <div className="flex w-full flex-row items-center gap-2">
-                        {singleEntry && (
+                        {singleEntry ? (
                           <F0Icon icon={singleEntry.icon} color="default" />
-                        )}
+                        ) : null}
                         <span className="flex-1 text-base font-medium">
                           {singleEntry?.label ?? dk}
                         </span>
-                        {currentDatasetKey === dk && (
+                        {currentDatasetKey === dk ? (
                           <F0Icon icon={Check} color="default" />
-                        )}
+                        ) : null}
                       </div>
                     </DropdownMenuSubTrigger>
                     <DropdownMenuPortal>
                       <DropdownMenuSubContent>
-                        {isQuestionTypeAllowed("dropdown-single") && (
+                        {isQuestionTypeAllowed("dropdown-single") ? (
                           <DropdownMenuItem
                             onClick={() =>
                               onSelectQuestionType("dropdown-single", dk)
@@ -220,13 +220,13 @@ const QuestionTypeMenuItem = ({
                                 {t("surveyFormBuilder.labels.singleSelection")}
                               </span>
                               {currentDatasetKey === dk &&
-                                value === "dropdown-single" && (
-                                  <F0Icon icon={Check} color="default" />
-                                )}
+                              value === "dropdown-single" ? (
+                                <F0Icon icon={Check} color="default" />
+                              ) : null}
                             </div>
                           </DropdownMenuItem>
-                        )}
-                        {isQuestionTypeAllowed("dropdown-multi") && (
+                        ) : null}
+                        {isQuestionTypeAllowed("dropdown-multi") ? (
                           <DropdownMenuItem
                             onClick={() =>
                               onSelectQuestionType("dropdown-multi", dk)
@@ -238,19 +238,19 @@ const QuestionTypeMenuItem = ({
                                 {t("surveyFormBuilder.labels.multiSelection")}
                               </span>
                               {currentDatasetKey === dk &&
-                                value === "dropdown-multi" && (
-                                  <F0Icon icon={Check} color="default" />
-                                )}
+                              value === "dropdown-multi" ? (
+                                <F0Icon icon={Check} color="default" />
+                              ) : null}
                             </div>
                           </DropdownMenuItem>
-                        )}
+                        ) : null}
                       </DropdownMenuSubContent>
                     </DropdownMenuPortal>
                   </DropdownMenuSub>
                 )
               })}
             </>
-          )}
+          ) : null}
         </DropdownMenuSubContent>
       </DropdownMenuPortal>
     </DropdownMenuSub>
@@ -364,7 +364,7 @@ export function ActionsMenu({
         <DropdownMenuLabel className="p-4 pb-2 font-medium text-f1-foreground-secondary">
           {t("surveyFormBuilder.labels.questionOptions")}
         </DropdownMenuLabel>
-        {showRequired && (
+        {showRequired ? (
           <DropdownMenuGroup>
             <ToggleItem
               label={t("surveyFormBuilder.labels.required")}
@@ -373,8 +373,8 @@ export function ActionsMenu({
               onChange={handleChangeRequired}
             />
           </DropdownMenuGroup>
-        )}
-        {showMultiSelect && (
+        ) : null}
+        {showMultiSelect ? (
           <DropdownMenuGroup>
             <ToggleItem
               label={t("surveyFormBuilder.labels.allowMultiSelection")}
@@ -383,8 +383,8 @@ export function ActionsMenu({
               onChange={handleToggleMultiSelect}
             />
           </DropdownMenuGroup>
-        )}
-        {showAllowCreate && (
+        ) : null}
+        {showAllowCreate ? (
           <DropdownMenuGroup>
             <ToggleItem
               label={t("surveyFormBuilder.labels.allowCreate")}
@@ -393,8 +393,8 @@ export function ActionsMenu({
               onChange={handleToggleAllowCreate}
             />
           </DropdownMenuGroup>
-        )}
-        {showQuestionType && (
+        ) : null}
+        {showQuestionType ? (
           <DropdownMenuGroup>
             <QuestionTypeMenuItem
               label={t("surveyFormBuilder.labels.questionType")}
@@ -407,31 +407,33 @@ export function ActionsMenu({
               onSelectRatingType={handleSelectRatingType}
             />
           </DropdownMenuGroup>
-        )}
+        ) : null}
         {(showRequired ||
           showMultiSelect ||
           showAllowCreate ||
           showQuestionType) &&
-          (showDuplicate || showDelete) && <DropdownMenuSeparator />}
-        {(showDuplicate || showDelete) && (
+        (showDuplicate || showDelete) ? (
+          <DropdownMenuSeparator />
+        ) : null}
+        {showDuplicate || showDelete ? (
           <DropdownMenuGroup>
-            {showDuplicate && (
+            {showDuplicate ? (
               <SimpleItem
                 label={t("surveyFormBuilder.actions.duplicateQuestion")}
                 icon={LayersFront}
                 onClick={handleDuplicate}
               />
-            )}
-            {showDelete && (
+            ) : null}
+            {showDelete ? (
               <SimpleItem
                 label={t("surveyFormBuilder.actions.deleteQuestion")}
                 icon={Delete}
                 onClick={handleDelete}
                 critical
               />
-            )}
+            ) : null}
           </DropdownMenuGroup>
-        )}
+        ) : null}
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -224,9 +224,9 @@ export const BaseQuestion = ({
             {answering ? (
               <div className="w-full whitespace-pre-wrap break-words px-2 py-1 text-lg font-semibold text-f1-foreground">
                 {title || titlePlaceholder}
-                {required && (
+                {required ? (
                   <span className="text-f1-foreground-critical"> *</span>
-                )}
+                ) : null}
               </div>
             ) : (
               <>
@@ -245,7 +245,7 @@ export const BaseQuestion = ({
                 />
                 <div className="textarea-overlay pointer-events-none absolute left-0 top-0 h-full w-full whitespace-pre-wrap break-words px-2 py-1 text-lg font-semibold">
                   <span className="opacity-0">{title || titlePlaceholder}</span>
-                  {required && (
+                  {required ? (
                     <span
                       className={cn(
                         "text-f1-foreground-critical",
@@ -255,12 +255,12 @@ export const BaseQuestion = ({
                       {" "}
                       *
                     </span>
-                  )}
+                  ) : null}
                 </div>
               </>
             )}
           </FrozenFieldNotice>
-          {!answering && locked && (
+          {!answering && locked ? (
             // Blocked question: a static lock sits where the actions "⋯" menu
             // would be, signalling the card is predefined and can't be edited.
             // Hovering just the lock (not the whole card) reveals why.
@@ -301,8 +301,8 @@ export const BaseQuestion = ({
                 />
               )}
             </div>
-          )}
-          {!disabled && !answering && !locked && (
+          ) : null}
+          {!disabled && !answering && !locked ? (
             <div
               className={cn(
                 "opacity-0 group-hover/question:opacity-100",
@@ -320,7 +320,7 @@ export const BaseQuestion = ({
                 hiddenActions={hiddenActions}
               />
             </div>
-          )}
+          ) : null}
         </div>
         {answering ? (
           description ? (
@@ -350,7 +350,7 @@ export const BaseQuestion = ({
         ) : null}
       </div>
       {children}
-      {answering && (
+      {answering ? (
         <FormMessage
           className="-mt-2"
           fallback={
@@ -359,8 +359,8 @@ export const BaseQuestion = ({
               : t("forms.validation.invalidType")
           }
         />
-      )}
-      {!disabled && !answering && !locked && (
+      ) : null}
+      {!disabled && !answering && !locked ? (
         <div
           className={cn(
             "absolute bottom-0 left-1/2 translate-x-[-50%] translate-y-[50%] bg-f1-background opacity-0 group-hover/question:opacity-100",
@@ -381,7 +381,7 @@ export const BaseQuestion = ({
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="center" className="w-80">
-              {!isWithinSection && (
+              {!isWithinSection ? (
                 <>
                   <DropdownMenuItem onClick={handleAddNewSection}>
                     <div className="flex w-full flex-row items-center gap-2">
@@ -393,7 +393,7 @@ export const BaseQuestion = ({
                   </DropdownMenuItem>
                   <DropdownMenuSeparator />
                 </>
-              )}
+              ) : null}
               {regularTypes.map((qt) => (
                 <DropdownMenuItem
                   key={qt.questionType}
@@ -407,7 +407,7 @@ export const BaseQuestion = ({
                   </div>
                 </DropdownMenuItem>
               ))}
-              {datasetKeys.length > 0 && (
+              {datasetKeys.length > 0 ? (
                 <>
                   <DropdownMenuSeparator />
                   {datasetKeys.map((dk) => {
@@ -420,9 +420,9 @@ export const BaseQuestion = ({
                       <DropdownMenuSub key={dk}>
                         <DropdownMenuSubTrigger className="mx-1 px-2 data-[state=open]:rounded-sm data-[state=closed]:bg-transparent data-[state=open]:bg-f1-background-hover">
                           <div className="flex w-full flex-row items-center gap-2">
-                            {entry && (
+                            {entry ? (
                               <F0Icon icon={entry.icon} color="default" />
-                            )}
+                            ) : null}
                             <span className="flex-1 text-base font-medium">
                               {entry?.label ?? dk}
                             </span>
@@ -430,7 +430,7 @@ export const BaseQuestion = ({
                         </DropdownMenuSubTrigger>
                         <DropdownMenuPortal>
                           <DropdownMenuSubContent>
-                            {isQuestionTypeAllowed("dropdown-single") && (
+                            {isQuestionTypeAllowed("dropdown-single") ? (
                               <DropdownMenuItem
                                 onClick={() =>
                                   handleAddNewQuestion("dropdown-single", dk)
@@ -445,8 +445,8 @@ export const BaseQuestion = ({
                                   </span>
                                 </div>
                               </DropdownMenuItem>
-                            )}
-                            {isQuestionTypeAllowed("dropdown-multi") && (
+                            ) : null}
+                            {isQuestionTypeAllowed("dropdown-multi") ? (
                               <DropdownMenuItem
                                 onClick={() =>
                                   handleAddNewQuestion("dropdown-multi", dk)
@@ -461,18 +461,18 @@ export const BaseQuestion = ({
                                   </span>
                                 </div>
                               </DropdownMenuItem>
-                            )}
+                            ) : null}
                           </DropdownMenuSubContent>
                         </DropdownMenuPortal>
                       </DropdownMenuSub>
                     )
                   })}
                 </>
-              )}
+              ) : null}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
-      )}
+      ) : null}
     </div>
   )
 

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/SelectOption/index.tsx
@@ -26,7 +26,9 @@ function RadioIndicator({
         disabled && "opacity-50"
       )}
     >
-      {checked && <div className="h-2 w-2 rounded-full bg-f1-background" />}
+      {checked ? (
+        <div className="h-2 w-2 rounded-full bg-f1-background" />
+      ) : null}
     </div>
   )
 }
@@ -169,11 +171,11 @@ export const SelectOption = ({
         ) : (
           <p className="flex-1 font-medium">{label}</p>
         )}
-        {!disabled && !answering && correct && (
+        {!disabled && !answering && correct ? (
           <span className="text-sm font-medium text-f1-foreground-positive">
             {t("surveyFormBuilder.selectQuestion.correct")}
           </span>
-        )}
+        ) : null}
         {!disabled && !answering && !locked ? (
           <div className="hidden flex-row items-center gap-1 group-hover:inline-block">
             <F0Button

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
@@ -207,7 +207,7 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
             })}
           </Reorder.Group>
         </DragProvider>
-        {!disabled && !answering && !questionLocked && (
+        {!disabled && !answering && !questionLocked ? (
           <div className="opacity-70">
             <F0Button
               label={t("surveyFormBuilder.selectQuestion.addOption")}
@@ -216,7 +216,7 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
               onClick={handleAddOption}
             />
           </div>
-        )}
+        ) : null}
       </div>
     </BaseQuestion>
   )

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Section/Item/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Section/Item/index.tsx
@@ -51,7 +51,7 @@ export const Item = ({ question }: ItemProps) => {
         )}
         style={{ marginLeft: disabled || answering ? 0 : -27 }}
       >
-        {!disabled && !answering && (
+        {!disabled && !answering ? (
           <div
             className={cn(
               "mt-2 flex aspect-square w-6 scale-75 items-center opacity-0 hover:opacity-40 group-hover/question-element:opacity-40",
@@ -66,7 +66,7 @@ export const Item = ({ question }: ItemProps) => {
           >
             <F0Icon icon={Handle} size="sm" />
           </div>
-        )}
+        ) : null}
         <Question
           {...({
             ...question,

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Section/index.tsx
@@ -131,11 +131,11 @@ export const Section = ({
         locked && !answering ? "cursor-not-allowed" : "bg-f1-background"
       )}
     >
-      {(showTitle || showDescription || (locked && !answering)) && (
+      {showTitle || showDescription || (locked && !answering) ? (
         <div className="py-1 pl-5 pr-3">
-          {(showTitle || (locked && !answering)) && (
+          {showTitle || (locked && !answering) ? (
             <div className="flex flex-row items-center gap-2">
-              {showTitle && (
+              {showTitle ? (
                 <input
                   ref={titleRef}
                   type="text"
@@ -149,15 +149,15 @@ export const Section = ({
                     inputDisabled && "cursor-not-allowed"
                   )}
                 />
-              )}
-              {lockedTag && (
+              ) : null}
+              {lockedTag ? (
                 <div className="ml-auto flex shrink-0 items-center">
                   <Tooltip description={lockedNoticeText} instant>
                     <span className="inline-flex">{lockedTag}</span>
                   </Tooltip>
                 </div>
-              )}
-              {!disabled && !answering && !locked && (
+              ) : null}
+              {!disabled && !answering && !locked ? (
                 <div
                   className={cn(
                     "opacity-0 group-hover/section:opacity-100",
@@ -181,10 +181,10 @@ export const Section = ({
                     />
                   </Dropdown>
                 </div>
-              )}
+              ) : null}
             </div>
-          )}
-          {showDescription && !(locked && !answering) && (
+          ) : null}
+          {showDescription && !(locked && !answering) ? (
             <textarea
               value={description}
               aria-label={t("surveyFormBuilder.labels.description")}
@@ -199,10 +199,10 @@ export const Section = ({
                 inputDisabled && "cursor-not-allowed"
               )}
             />
-          )}
+          ) : null}
         </div>
-      )}
-      {!hideQuestions && (
+      ) : null}
+      {!hideQuestions ? (
         <>
           <DragProvider>
             <Reorder.Group
@@ -218,7 +218,7 @@ export const Section = ({
               </div>
             </Reorder.Group>
           </DragProvider>
-          {!answering && (
+          {!answering ? (
             <div className="mt-8 flex flex-row items-center gap-4">
               <div className="h-px flex-1 bg-f1-border-secondary" />
               <span className="text-base font-medium text-f1-foreground-secondary">
@@ -226,9 +226,9 @@ export const Section = ({
               </span>
               <div className="h-px flex-1 bg-f1-border-secondary" />
             </div>
-          )}
+          ) : null}
         </>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/kits/surveys/SurveySampleQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveySampleQuestion/index.tsx
@@ -59,7 +59,7 @@ function RatingScale({
           />
         ))}
       </F0Box>
-      {(minLabel || maxLabel) && (
+      {minLabel || maxLabel ? (
         <F0Box display="flex" justifyContent="between" alignItems="center">
           <span className="text-xs text-f1-foreground-secondary">
             {minLabel}
@@ -68,7 +68,7 @@ function RatingScale({
             {maxLabel}
           </span>
         </F0Box>
-      )}
+      ) : null}
     </F0Box>
   )
 }

--- a/packages/react/src/layouts/Layout/blocks/Block/Block.tsx
+++ b/packages/react/src/layouts/Layout/blocks/Block/Block.tsx
@@ -108,17 +108,17 @@ export const Block = forwardRef<HTMLDivElement, BlockProps>(
         data-drag-id={dragId}
         {...props}
       >
-        {showActionsBar && (
+        {showActionsBar ? (
           <div className="absolute right-0 top-0 flex items-center justify-end gap-2 p-4">
-            {!!primaryAction && primaryAction}
-            {actionsDropdownItems.length > 0 && (
+            {primaryAction ? primaryAction : null}
+            {actionsDropdownItems.length > 0 ? (
               <Dropdown
                 items={actionsToLayoutBlockActionItems(actions)}
                 data-testid="actions-dropdown"
               />
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
         <div data-testid="content">{children}</div>
       </div>
     )

--- a/packages/react/src/layouts/Layout/blocks/BlockContent.tsx
+++ b/packages/react/src/layouts/Layout/blocks/BlockContent.tsx
@@ -39,9 +39,9 @@ const PageLayoutContentBlockComponent = ({
           {title}
         </TitleTag>
 
-        {description && (
+        {description ? (
           <p className="text-sm text-f1-foreground-secondary">{description}</p>
-        )}
+        ) : null}
       </div>
 
       <div className="flex-1">{children}</div>

--- a/packages/react/src/layouts/Layout/pages/Page.tsx
+++ b/packages/react/src/layouts/Layout/pages/Page.tsx
@@ -44,7 +44,7 @@ const Page = forwardRef<HTMLDivElement, PageProps>(function Page(
             "border-t border-solid border-t-f1-border-secondary sm:border-t-0"
           )}
         >
-          {header && (
+          {header ? (
             <header
               className={cn(
                 stickyHeader && "sticky top-0 z-30 bg-f1-background"
@@ -52,11 +52,11 @@ const Page = forwardRef<HTMLDivElement, PageProps>(function Page(
             >
               {header}
             </header>
-          )}
+          ) : null}
           <div className="flex-1">{mainContent}</div>
         </main>
 
-        {aside && (
+        {aside ? (
           <aside
             className={cn(
               "min-w-30 sm:basis-1/4 md:max-w-80",
@@ -66,7 +66,7 @@ const Page = forwardRef<HTMLDivElement, PageProps>(function Page(
           >
             {aside}
           </aside>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/lib/F0Box/__stories__/F0Box.stories.tsx
+++ b/packages/react/src/lib/F0Box/__stories__/F0Box.stories.tsx
@@ -341,9 +341,9 @@ const Label = ({
 }) => (
   <div className="flex flex-col gap-1 pb-2">
     <span className="text-lg font-semibold text-f1-foreground">{children}</span>
-    {subtitle && (
+    {subtitle ? (
       <span className="text-base text-f1-foreground-secondary">{subtitle}</span>
-    )}
+    ) : null}
   </div>
 )
 

--- a/packages/react/src/lib/F0GridStack/components/grid-stack-render.tsx
+++ b/packages/react/src/lib/F0GridStack/components/grid-stack-render.tsx
@@ -19,7 +19,7 @@ export function GridStackRender() {
 
         return (
           <GridStackWidgetContext.Provider key={id} value={{ widget: { id } }}>
-            {content && createPortal(content, widgetContainer)}
+            {content ? createPortal(content, widgetContainer) : null}
           </GridStackWidgetContext.Provider>
         )
       })}

--- a/packages/react/src/lib/InfoHint/InfoHint.tsx
+++ b/packages/react/src/lib/InfoHint/InfoHint.tsx
@@ -69,7 +69,7 @@ function StructuredHint({
           <p className="text-f1-foreground-inverse-secondary">
             {info.description}
           </p>
-          {info.link && (
+          {info.link ? (
             <button
               type="button"
               onClick={() => {
@@ -83,7 +83,7 @@ function StructuredHint({
             >
               {info.link.label}
             </button>
-          )}
+          ) : null}
         </div>
       </HoverCardContent>
     </HoverCard>

--- a/packages/react/src/lib/providers/dialogs-alike/DialogsAlikeLayoutProvider.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/DialogsAlikeLayoutProvider.tsx
@@ -62,9 +62,9 @@ export const DialogsAlikeLayoutProvider = ({
 
   return (
     <>
-      {isRenderer &&
-        typeof document !== "undefined" &&
-        createPortal(<DialogsAlike items={items} />, document.body)}
+      {isRenderer && typeof document !== "undefined"
+        ? createPortal(<DialogsAlike items={items} />, document.body)
+        : null}
       {children}
     </>
   )

--- a/packages/react/src/lib/providers/dialogs-alike/components/__tests__/Dialogs.test.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/components/__tests__/Dialogs.test.tsx
@@ -73,7 +73,7 @@ const MockDialogNotificationInternal = vi.hoisted(() => {
       <button data-testid="notification-close-button" onClick={props.onClose}>
         Close
       </button>
-      {props.primaryAction && (
+      {props.primaryAction ? (
         <button
           data-testid="notification-primary-action"
           onClick={props.primaryAction.onClick}
@@ -81,7 +81,7 @@ const MockDialogNotificationInternal = vi.hoisted(() => {
         >
           {props.primaryAction.label}
         </button>
-      )}
+      ) : null}
       {props.secondaryAction?.map((action: any, index: number) => (
         <button
           key={`notification-secondary-${index}`}

--- a/packages/react/src/lib/providers/form-overlays/FormOverlaysProvider.tsx
+++ b/packages/react/src/lib/providers/form-overlays/FormOverlaysProvider.tsx
@@ -57,9 +57,9 @@ export const FormOverlaysProvider = ({
 
   return (
     <>
-      {isRenderer &&
-        typeof document !== "undefined" &&
-        createPortal(<FormOverlays items={items} />, document.body)}
+      {isRenderer && typeof document !== "undefined"
+        ? createPortal(<FormOverlays items={items} />, document.body)
+        : null}
       {children}
     </>
   )

--- a/packages/react/src/lib/storybook-utils/do-donts.tsx
+++ b/packages/react/src/lib/storybook-utils/do-donts.tsx
@@ -36,15 +36,15 @@ export const DoDonts: FC<DoDontsProps> = ({
       <div className="w-fit">
         <F0TagStatus text="Do" variant="positive" />
       </div>
-      {doExample.children && (
+      {doExample.children ? (
         <div className="[&>div]:m-0 [&_.docs-story]:rounded-none [&_.docs-story]:border-0 [&_.docs-story]:bg-transparent [&_.docs-story]:p-0 [&_.docs-story]:shadow-none">
           {doExample.children}
         </div>
-      )}
+      ) : null}
       <p className="!m-0 text-f1-foreground-secondary">
         {doExample.description}
       </p>
-      {doExample.guidelines && (
+      {doExample.guidelines ? (
         <ul className="!my-0 !list-inside !list-disc !pl-2">
           {doExample.guidelines.map((guideline) => (
             <li key={guideline} className="!leading-snug">
@@ -52,22 +52,22 @@ export const DoDonts: FC<DoDontsProps> = ({
             </li>
           ))}
         </ul>
-      )}
+      ) : null}
     </div>
 
     <div className="flex flex-col gap-4 rounded-lg bg-f1-background-tertiary p-5">
       <div className="w-fit">
         <F0TagStatus text="Don't" variant="critical" />
       </div>
-      {dontExample.children && (
+      {dontExample.children ? (
         <div className="[&>div]:m-0 [&_.docs-story]:rounded-none [&_.docs-story]:border-0 [&_.docs-story]:bg-transparent [&_.docs-story]:p-0 [&_.docs-story]:shadow-none">
           {dontExample.children}
         </div>
-      )}
+      ) : null}
       <p className="!m-0 text-f1-foreground-secondary">
         {dontExample.description}
       </p>
-      {dontExample.guidelines && (
+      {dontExample.guidelines ? (
         <ul className="!my-0 !list-inside !list-disc !pl-2">
           {dontExample.guidelines.map((guideline) => (
             <li key={guideline} className="!leading-snug">
@@ -75,7 +75,7 @@ export const DoDonts: FC<DoDontsProps> = ({
             </li>
           ))}
         </ul>
-      )}
+      ) : null}
     </div>
   </div>
 )

--- a/packages/react/src/lib/xray.tsx
+++ b/packages/react/src/lib/xray.tsx
@@ -61,31 +61,31 @@ export const XRayProvider: React.FC<{ children: ReactNode }> = ({
   return (
     <XRayContext.Provider value={{ enabled, enable, disable, filter }}>
       {children}
-      {enabled &&
-        typeof document !== "undefined" &&
-        createPortal(
-          <div className="bg-white fixed right-2 top-2 z-50 flex flex-col space-y-2 rounded-2xs border-solid border-f1-border p-4 opacity-80 shadow-md">
-            <div className="text-md z-50 font-semibold">XRay</div>
-            <div className="flex flex-col space-y-2">
-              {componentTypes.map((type) => (
-                <label className="block" key={type}>
-                  <input
-                    onChange={(event) =>
-                      event.target.checked
-                        ? setFilter([...filter, type])
-                        : setFilter(filter.filter((f) => f !== type))
-                    }
-                    type="checkbox"
-                    checked={filter.includes(type)}
-                    className="mr-2"
-                  />
-                  {type}
-                </label>
-              ))}
-            </div>
-          </div>,
-          document?.body
-        )}
+      {enabled && typeof document !== "undefined"
+        ? createPortal(
+            <div className="bg-white fixed right-2 top-2 z-50 flex flex-col space-y-2 rounded-2xs border-solid border-f1-border p-4 opacity-80 shadow-md">
+              <div className="text-md z-50 font-semibold">XRay</div>
+              <div className="flex flex-col space-y-2">
+                {componentTypes.map((type) => (
+                  <label className="block" key={type}>
+                    <input
+                      onChange={(event) =>
+                        event.target.checked
+                          ? setFilter([...filter, type])
+                          : setFilter(filter.filter((f) => f !== type))
+                      }
+                      type="checkbox"
+                      checked={filter.includes(type)}
+                      className="mr-2"
+                    />
+                    {type}
+                  </label>
+                ))}
+              </div>
+            </div>,
+            document?.body
+          )
+        : null}
     </XRayContext.Provider>
   )
 }

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1392,9 +1392,9 @@ const ConversationsSidebarInner = ({
           />
           {/* Search lives with the tabs in the (fixed) header so it stays put
               while the body scrolls. Only the Home tab uses it. */}
-          {tab === "home" && (
+          {tab === "home" ? (
             <SearchBar placeholder="Search..." onClick={() => {}} />
-          )}
+          ) : null}
         </>
       }
       body={

--- a/packages/react/src/patterns/ApplicationFrame/index.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.tsx
@@ -309,7 +309,7 @@ function ApplicationFrameContent({
           <div className="relative isolate flex h-full">
             {/* Sidebar backdrop */}
             <AnimatePresence>
-              {sidebarState === "unlocked" && (
+              {sidebarState === "unlocked" ? (
                 <motion.nav
                   className={cn(
                     "fixed inset-0 z-20 bg-f1-background-inverse",
@@ -321,7 +321,7 @@ function ApplicationFrameContent({
                   transition={{ duration: shouldReduceMotion ? 0 : 0.2 }}
                   onClick={() => toggleSidebar()}
                 />
-              )}
+              ) : null}
             </AnimatePresence>
 
             {/* Sidebar */}
@@ -405,7 +405,7 @@ function ApplicationFrameContent({
 
               {/* Chat */}
               {/* Canvas dashboard panel */}
-              {ai?.enabled && isCanvasMode && canvasContent && (
+              {ai?.enabled && isCanvasMode && canvasContent ? (
                 <motion.div
                   className={cn(
                     // z-[21] sits above the chat wrapper (z-20 in canvas
@@ -444,87 +444,93 @@ function ApplicationFrameContent({
                     side={panelSide}
                   />
                 </motion.div>
-              )}
+              ) : null}
 
-              {ai?.enabled &&
-                (() => {
-                  // One absolutely-positioned container per docked window. A
-                  // single side (the default) keeps today's lone container;
-                  // split mode adds a second one on the other edge for hosted
-                  // content, both sitting under the main content (z-0), which
-                  // covers/uncovers them as its padding moves.
-                  const panelContainer = (
-                    side: "left" | "right",
-                    isActivePanel: boolean,
-                    content: React.ReactNode
-                  ) => (
-                    <motion.div
-                      key={`panel-${side}`}
-                      className={cn(
-                        "pointer-events-none",
-                        "[&_.copilotKitSidebarContentWrapper]:relative [&_.copilotKitSidebarContentWrapper]:h-full [&_.copilotKitSidebarContentWrapper]:w-full",
-                        isSmallViewport
-                          ? "fixed inset-0 z-[30]"
-                          : cn(
-                              "absolute top-0 bottom-0",
-                              side === "left" ? "left-0" : "right-0",
-                              // In canvas mode the chat wrapper must sit above
-                              // the CanvasPanel (z-[15]) so the ResizeHandle's
-                              // hit-area (which extends a few pixels over the
-                              // canvas side of the seam) can receive hover
-                              // events — otherwise the canvas captures them
-                              // and the handle never lights up.
-                              isInFullscreenTransition || isCanvasMode
-                                ? "z-20"
-                                : "z-0",
-                              // Left seam for the panel — owned by the frame because
-                              // it depends on the sidebar. The panel's left edge needs
-                              // a gap only when it's left-docked or filling the screen;
-                              // and never when the sidebar is active (locked), since
-                              // the sidebar already provides the gap (same rule as the
-                              // main content). md:-gated so mobile fullscreen is full-bleed.
-                              sidebarState !== "locked" &&
-                                (side === "left" || isInFullscreenTransition) &&
-                                "md:pl-1"
-                            )
-                      )}
-                      animate={{
-                        width:
-                          isSmallViewport ||
-                          (isAiChatFullscreen && isActivePanel)
-                            ? "100%"
-                            : reservedChatWidth,
-                      }}
-                      transition={chatContainerTransition}
-                      onAnimationComplete={() => {
-                        if (isFullscreenExitTransitionActive && isActivePanel) {
-                          setIsFullscreenExitTransitionActive(false)
-                        }
-                      }}
-                    >
-                      {content}
-                    </motion.div>
-                  )
-
-                  return (
-                    <>
-                      {panelContainer(
-                        panelSide,
-                        !isSplitPanel || !hasPanelContent,
-                        <F0AiChat />
-                      )}
-                      {isSplitPanel &&
-                        panelContainer(
-                          panelContentSide,
-                          hasPanelContent,
-                          <HostedPanelWindow />
+              {ai?.enabled
+                ? (() => {
+                    // One absolutely-positioned container per docked window. A
+                    // single side (the default) keeps today's lone container;
+                    // split mode adds a second one on the other edge for hosted
+                    // content, both sitting under the main content (z-0), which
+                    // covers/uncovers them as its padding moves.
+                    const panelContainer = (
+                      side: "left" | "right",
+                      isActivePanel: boolean,
+                      content: React.ReactNode
+                    ) => (
+                      <motion.div
+                        key={`panel-${side}`}
+                        className={cn(
+                          "pointer-events-none",
+                          "[&_.copilotKitSidebarContentWrapper]:relative [&_.copilotKitSidebarContentWrapper]:h-full [&_.copilotKitSidebarContentWrapper]:w-full",
+                          isSmallViewport
+                            ? "fixed inset-0 z-[30]"
+                            : cn(
+                                "absolute top-0 bottom-0",
+                                side === "left" ? "left-0" : "right-0",
+                                // In canvas mode the chat wrapper must sit above
+                                // the CanvasPanel (z-[15]) so the ResizeHandle's
+                                // hit-area (which extends a few pixels over the
+                                // canvas side of the seam) can receive hover
+                                // events — otherwise the canvas captures them
+                                // and the handle never lights up.
+                                isInFullscreenTransition || isCanvasMode
+                                  ? "z-20"
+                                  : "z-0",
+                                // Left seam for the panel — owned by the frame because
+                                // it depends on the sidebar. The panel's left edge needs
+                                // a gap only when it's left-docked or filling the screen;
+                                // and never when the sidebar is active (locked), since
+                                // the sidebar already provides the gap (same rule as the
+                                // main content). md:-gated so mobile fullscreen is full-bleed.
+                                sidebarState !== "locked" &&
+                                  (side === "left" ||
+                                    isInFullscreenTransition) &&
+                                  "md:pl-1"
+                              )
                         )}
-                    </>
-                  )
-                })()}
+                        animate={{
+                          width:
+                            isSmallViewport ||
+                            (isAiChatFullscreen && isActivePanel)
+                              ? "100%"
+                              : reservedChatWidth,
+                        }}
+                        transition={chatContainerTransition}
+                        onAnimationComplete={() => {
+                          if (
+                            isFullscreenExitTransitionActive &&
+                            isActivePanel
+                          ) {
+                            setIsFullscreenExitTransitionActive(false)
+                          }
+                        }}
+                      >
+                        {content}
+                      </motion.div>
+                    )
+
+                    return (
+                      <>
+                        {panelContainer(
+                          panelSide,
+                          !isSplitPanel || !hasPanelContent,
+                          <F0AiChat />
+                        )}
+                        {isSplitPanel
+                          ? panelContainer(
+                              panelContentSide,
+                              hasPanelContent,
+                              <HostedPanelWindow />
+                            )
+                          : null}
+                      </>
+                    )
+                  })()
+                : null}
             </motion.div>
 
-            {aiPromotion?.enabled && <AiPromotionChat />}
+            {aiPromotion?.enabled ? <AiPromotionChat /> : null}
           </div>
         </LayoutGroup>
       </div>

--- a/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
+++ b/packages/react/src/patterns/Cocreation/__stories__/creation-with-ai.stories.tsx
@@ -3052,7 +3052,7 @@ function FlowContent({
               href: "/cocreation",
             }}
           />
-          {visualizationMode !== "fullscreen" && (
+          {visualizationMode !== "fullscreen" ? (
             <ClickableTabs
               tabs={[
                 { label: config.navTabLabel, id: config.id },
@@ -3061,7 +3061,7 @@ function FlowContent({
               activeTabId={activeTabId}
               setActiveTabId={setActiveTabId}
             />
-          )}
+          ) : null}
         </>
       }
     >
@@ -3187,7 +3187,9 @@ function CreationWithAIFlow({
               {/* Feeds the survey welcome cards into the chat via
                   `welcomeScreenCards`; renders nothing itself. "cards" entry
                   flow (Engagement) only — "guidedType" (Training) has none. */}
-              {config.entryMode === "cards" && <SurveyWelcomeCardsRegistrar />}
+              {config.entryMode === "cards" ? (
+                <SurveyWelcomeCardsRegistrar />
+              ) : null}
               <FlowContent phase={phase} setPhase={setPhase} />
             </ApplicationFrame>
           </TemplatesReturnProvider>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/F0AnalyticsDashboard.tsx
@@ -124,7 +124,7 @@ export const F0AnalyticsDashboard = <
     <div
       className={cn("flex flex-col gap-5 pb-10", fillHeight && "h-full pb-0")}
     >
-      {(filters || filtersLoading || enableExport || navigationFilters) && (
+      {filters || filtersLoading || enableExport || navigationFilters ? (
         <div className="flex items-center justify-between gap-4 px-5">
           <div className="w-full">
             {filters ? (
@@ -139,22 +139,22 @@ export const F0AnalyticsDashboard = <
             ) : null}
           </div>
           <div className="flex shrink-0 items-center gap-2">
-            {navigationFilters && (
+            {navigationFilters ? (
               <NavigationFilters
                 navigationFilters={navigationFilters}
                 currentNavigationFilters={currentNavigationFilters}
                 onChangeNavigationFilters={setCurrentNavigationFilters}
               />
-            )}
-            {enableExport && (
+            ) : null}
+            {enableExport ? (
               <ExportDropdown
                 onExportExcel={exportAsExcel}
                 isExporting={isExporting}
               />
-            )}
+            ) : null}
           </div>
         </div>
-      )}
+      ) : null}
       <div
         className={cn(
           "px-5",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.askAi.test.tsx
@@ -107,11 +107,11 @@ const ChatProbe = ({
         data-open={String(open)}
       />
       <textarea ref={inputRef} aria-label="Chat question" />
-      {onCapture && (
+      {onCapture ? (
         <button type="button" onClick={() => onCapture(pendingQuote)}>
           Capture pending quote
         </button>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardItem.test.tsx
@@ -196,11 +196,11 @@ describe("DashboardItem — description action", () => {
             data-quote={pendingQuote?.text ?? ""}
             data-open={String(open)}
           />
-          {onCapture && (
+          {onCapture ? (
             <button type="button" onClick={() => onCapture(pendingQuote)}>
               Capture pending quote
             </button>
-          )}
+          ) : null}
         </>
       )
     }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/AccessiblePointActions.tsx
@@ -196,7 +196,7 @@ export function AccessiblePointActions({
             focusChatInput()
           }}
         >
-          {hasPrevious && (
+          {hasPrevious ? (
             <DropdownMenuItem
               onSelect={(event) => {
                 event.preventDefault()
@@ -205,7 +205,7 @@ export function AccessiblePointActions({
             >
               {previousLabel}
             </DropdownMenuItem>
-          )}
+          ) : null}
           {pageActions.map((action) => (
             <DropdownMenuItem
               key={action.key}
@@ -230,7 +230,7 @@ export function AccessiblePointActions({
               {action.getLabel()}
             </DropdownMenuItem>
           ))}
-          {hasNext && (
+          {hasNext ? (
             <DropdownMenuItem
               onSelect={(event) => {
                 event.preventDefault()
@@ -239,7 +239,7 @@ export function AccessiblePointActions({
             >
               {nextLabel}
             </DropdownMenuItem>
-          )}
+          ) : null}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -647,7 +647,9 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
           <div key={ri} className="relative">
             {/* Drop line before this row. The first row also gets one so an
                 item can be reordered to the very top (afterRowIdx -1). */}
-            {canDrag && <RowGapDropZone active={!!isNewRowTarget(ri - 1)} />}
+            {canDrag ? (
+              <RowGapDropZone active={!!isNewRowTarget(ri - 1)} />
+            ) : null}
             <div
               data-dashboard-row=""
               className={cn(
@@ -713,7 +715,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
               })}
             </div>
             {/* Row resize handle — only in edit mode */}
-            {canDrag && (
+            {canDrag ? (
               <div
                 className="group/resize absolute -bottom-3.5 mx-auto flex h-3 w-full items-center justify-center hover:cursor-ns-resize"
                 onMouseDown={(e) => {
@@ -748,20 +750,20 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
               >
                 <div className="h-1 w-16 rounded-full bg-transparent transition-colors group-hover/resize:bg-f1-foreground-tertiary" />
               </div>
-            )}
+            ) : null}
           </div>
         )
       })}
 
       {/* Drop line after the last row — reorder to the very bottom */}
-      {canDrag && (
+      {canDrag ? (
         <RowGapDropZone active={!!isNewRowTarget(displayRows.length - 1)} />
-      )}
+      ) : null}
 
       {/* Floating ghost that tracks the cursor during a pointer drag. Its
           position is written imperatively in the pointermove handler so the
           grid doesn't re-render on every mouse move. */}
-      {dragId && (
+      {dragId ? (
         <div
           ref={ghostRef}
           className="pointer-events-none fixed left-0 top-0 z-50 max-w-xs truncate rounded-lg border border-solid border-f1-border-secondary bg-f1-background px-3 py-2 text-sm font-medium text-f1-foreground shadow-lg"
@@ -769,7 +771,7 @@ export function DashboardGrid<Filters extends FiltersDefinition>({
         >
           {itemMap.get(dragId)?.title ?? ""}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -861,7 +863,7 @@ function RowItem({
 
   return (
     <>
-      {showIndicatorBefore && <DropIndicator />}
+      {showIndicatorBefore ? <DropIndicator /> : null}
       <div
         ref={itemRef}
         data-card-id={id}
@@ -870,7 +872,7 @@ function RowItem({
           isDragging && "opacity-40 scale-[0.97]"
         )}
       >
-        {canDrag && (
+        {canDrag ? (
           // Pointer-based drag (not native HTML5 DnD): a `pointerdown` on the
           // grip starts a document-tracked gesture. Native drag was unusable
           // here — its ghost never tracked the cursor over a chart canvas, and
@@ -884,10 +886,10 @@ function RowItem({
           >
             <F0Icon icon={Handle} size="xs" />
           </div>
-        )}
+        ) : null}
         {children}
       </div>
-      {showIndicatorAfter && <DropIndicator />}
+      {showIndicatorAfter ? <DropIndicator /> : null}
     </>
   )
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -258,27 +258,27 @@ export function DashboardItem({
               <h3 className="text-base font-medium text-f1-foreground">
                 {title}
               </h3>
-              {info && (
+              {info ? (
                 <div className="flex shrink-0 items-center text-f1-foreground-secondary">
                   <InfoHint info={info} />
                 </div>
-              )}
+              ) : null}
             </div>
-            {description && (
+            {description ? (
               <p className="text-base text-f1-foreground-secondary">
                 {description}
               </p>
-            )}
+            ) : null}
           </div>
-          {(itemFilters || hasAskOne) && (
+          {itemFilters || hasAskOne ? (
             <div className={actionsClassName}>
-              {itemFilters && (
+              {itemFilters ? (
                 <DashboardItemFilters
                   {...itemFilters}
                   onOpenChange={setIsFiltersOpen}
                 />
-              )}
-              {hasAskOne && (
+              ) : null}
+              {hasAskOne ? (
                 <DropdownMenu
                   open={isDropdownOpen}
                   onOpenChange={handleDropdownOpenChange}
@@ -305,9 +305,9 @@ export function DashboardItem({
                     {askOneMenuItem}
                   </DropdownMenuContent>
                 </DropdownMenu>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
         <div className="min-h-0 flex-1 overflow-auto">
           <OneEmptyState
@@ -358,24 +358,24 @@ export function DashboardItem({
             >
               {title}
             </OneEllipsis>
-            {info && (
+            {info ? (
               <div className="flex shrink-0 items-center text-f1-foreground-secondary">
                 <InfoHint info={info} />
               </div>
-            )}
+            ) : null}
           </div>
-          {(description || descriptionAction) && (
+          {description || descriptionAction ? (
             // Baseline-aligned row so the link sits on the description's own
             // line; the text keeps its own truncation, the link never shrinks.
             <div className="flex items-baseline gap-1">
-              {description && (
+              {description ? (
                 <OneEllipsis className="text-base text-f1-foreground-secondary">
                   {description}
                 </OneEllipsis>
-              )}
-              {descriptionAction && (
+              ) : null}
+              {descriptionAction ? (
                 <>
-                  {description && (
+                  {description ? (
                     // Separator, not content: hidden from the accessibility tree
                     // so the description and the action read as two things rather
                     // than one sentence with a stray character in it.
@@ -385,7 +385,7 @@ export function DashboardItem({
                     >
                       ·
                     </span>
-                  )}
+                  ) : null}
                   <button
                     type="button"
                     onClick={descriptionAction.onClick}
@@ -394,18 +394,18 @@ export function DashboardItem({
                     {descriptionAction.label}
                   </button>
                 </>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
         <div className={actionsClassName}>
-          {itemFilters && (
+          {itemFilters ? (
             <DashboardItemFilters
               {...itemFilters}
               onOpenChange={setIsFiltersOpen}
             />
-          )}
-          {hasFullscreen && (
+          ) : null}
+          {hasFullscreen ? (
             <ButtonInternal
               label={
                 isFullscreen
@@ -419,8 +419,8 @@ export function DashboardItem({
               compact
               onClick={() => onFullscreenChange?.(!isFullscreen)}
             />
-          )}
-          {showMenu && (
+          ) : null}
+          {showMenu ? (
             <DropdownMenu
               open={isDropdownOpen}
               onOpenChange={handleDropdownOpenChange}
@@ -451,7 +451,7 @@ export function DashboardItem({
                   </div>
                 ) : (
                   <>
-                    {hasChartTypes && (
+                    {hasChartTypes ? (
                       <div className="mb-1 flex flex-col items-start gap-2 border-0 border-b border-solid border-f1-border-secondary p-3">
                         <OneEllipsis className="text-base font-medium text-f1-foreground-tertiary">
                           {translations.ai.dashboardItem.chartType}
@@ -476,8 +476,8 @@ export function DashboardItem({
                           fullWidth
                         />
                       </div>
-                    )}
-                    {hasExplanation && (
+                    ) : null}
+                    {hasExplanation ? (
                       <DropdownMenuGroup>
                         <DropdownMenuItem
                           onSelect={(e) => {
@@ -493,11 +493,11 @@ export function DashboardItem({
                           </div>
                         </DropdownMenuItem>
                       </DropdownMenuGroup>
-                    )}
+                    ) : null}
 
                     {askOneMenuItem}
 
-                    {hasDownloads && (
+                    {hasDownloads ? (
                       <DropdownMenuGroup>
                         <DropdownMenuSub>
                           <DropdownMenuSubTrigger className="mx-1 rounded-sm px-2">
@@ -516,9 +516,9 @@ export function DashboardItem({
                                   onClick={action.onClick}
                                 >
                                   <div className="flex w-full flex-row items-center gap-2">
-                                    {action.icon && (
+                                    {action.icon ? (
                                       <F0Icon icon={action.icon} />
-                                    )}
+                                    ) : null}
                                     <span className="flex-1">
                                       {action.label}
                                     </span>
@@ -529,8 +529,8 @@ export function DashboardItem({
                           </DropdownMenuPortal>
                         </DropdownMenuSub>
                       </DropdownMenuGroup>
-                    )}
-                    {hasDelete && (
+                    ) : null}
+                    {hasDelete ? (
                       <DropdownMenuGroup>
                         <DropdownMenuItem
                           onClick={() => {
@@ -549,12 +549,12 @@ export function DashboardItem({
                           </div>
                         </DropdownMenuItem>
                       </DropdownMenuGroup>
-                    )}
+                    ) : null}
                   </>
                 )}
               </DropdownMenuContent>
             </DropdownMenu>
-          )}
+          ) : null}
         </div>
       </div>
       <div className={cn("flex-1", !fitContent && "min-h-0")}>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItemFilters.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItemFilters.tsx
@@ -213,11 +213,11 @@ export function DashboardItemFilters<
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         />
       </PopoverTrigger>
-      {appliedCount && (
+      {appliedCount ? (
         <span id={`${id}-status`} className="sr-only">
           {appliedFilterLabel} ({appliedCount})
         </span>
-      )}
+      ) : null}
       <PopoverContent
         ref={contentRef}
         aria-label={i18n.filters.label}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -140,7 +140,7 @@ export function MetricValue({
         <span className="whitespace-nowrap text-3xl font-semibold leading-none tracking-tight text-f1-foreground">
           {value}
         </span>
-        {trend && trend.direction !== "flat" && (
+        {trend && trend.direction !== "flat" ? (
           <div className="flex shrink-0 items-center">
             {trend.direction === "up" ? (
               <F0Icon
@@ -173,7 +173,7 @@ export function MetricValue({
               {trend.percent.toFixed(1)}%
             </span>
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )
@@ -222,7 +222,7 @@ export function MetricItem<Filters extends FiltersDefinition>({
       onAskAiTarget={onAskAiTarget}
       itemId={item.id}
     >
-      {data && (
+      {data ? (
         <MetricValue
           value={
             item.valueFormatter
@@ -231,7 +231,7 @@ export function MetricItem<Filters extends FiltersDefinition>({
           }
           trend={trend}
         />
-      )}
+      ) : null}
     </DashboardItem>
   )
 }

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogContent.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogContent.tsx
@@ -93,8 +93,10 @@ export const F0DialogContent = ({
       </ScrollArea>
 
       <AnimatePresence>
-        {!isAtTop && <ScrollShadow position="top" key="shadow-top" />}
-        {!isAtBottom && <ScrollShadow position="bottom" key="shadow-bottom" />}
+        {!isAtTop ? <ScrollShadow position="top" key="shadow-top" /> : null}
+        {!isAtBottom ? (
+          <ScrollShadow position="bottom" key="shadow-bottom" />
+        ) : null}
       </AnimatePresence>
     </div>
   )

--- a/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
+++ b/packages/react/src/patterns/F0Dialog/components/F0DialogHeader.tsx
@@ -146,8 +146,8 @@ export const F0DialogHeader = ({
 
     return (
       <>
-        {controls.expand &&
-          (controls.expand.url !== undefined ? (
+        {controls.expand ? (
+          controls.expand.url !== undefined ? (
             <ButtonInternal
               variant="outline"
               icon={Maximize}
@@ -161,9 +161,12 @@ export const F0DialogHeader = ({
               onClick={controls.expand.onClick}
               label={controls.expand.label}
             />
-          ))}
-        {controls.expand && controls.navigation && <Divider />}
-        {controls.navigation && <PageNavigation {...controls.navigation} />}
+          )
+        ) : null}
+        {controls.expand && controls.navigation ? <Divider /> : null}
+        {controls.navigation ? (
+          <PageNavigation {...controls.navigation} />
+        ) : null}
       </>
     )
   }
@@ -210,7 +213,7 @@ export const F0DialogHeader = ({
         )}
       >
         <div className="flex flex-row items-center gap-3">
-          {(module || title || !!description) && (
+          {module || title || !!description ? (
             <div className="flex flex-col gap-1">
               {module ? (
                 <Module />
@@ -221,19 +224,19 @@ export const F0DialogHeader = ({
                   </DialogTitle>
                 )
               )}
-              {!!description && (
+              {description ? (
                 <DrawerDescription className="text-base text-f1-foreground-secondary">
                   {description}
                 </DrawerDescription>
-              )}
+              ) : null}
             </div>
-          )}
+          ) : null}
         </div>
         <div className="flex flex-row items-center gap-2">
-          {navigation && <PageNavigation {...navigation} />}
+          {navigation ? <PageNavigation {...navigation} /> : null}
           <Status />
           <Actions />
-          {(navigation || otherActions) && <Divider />}
+          {navigation || otherActions ? <Divider /> : null}
           <CloseButton />
         </div>
       </div>

--- a/packages/react/src/patterns/F0FilterPickerContent/internal.tsx
+++ b/packages/react/src/patterns/F0FilterPickerContent/internal.tsx
@@ -46,7 +46,7 @@ export function FilterPickerInternal<Filters extends FiltersDefinition>({
           onFilterSelect={onFilterSelect}
           onClickApplyFilters={onApply}
         />
-        {selectedFilterKey && (
+        {selectedFilterKey ? (
           <div className="min-w-[340px] flex-1">
             <FilterContent
               selectedFilterKey={selectedFilterKey}
@@ -55,23 +55,23 @@ export function FilterPickerInternal<Filters extends FiltersDefinition>({
               onFilterChange={onFilterChange}
             />
           </div>
-        )}
+        ) : null}
       </div>
       {showApplyButton || onClear ? (
         <div className="flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2">
-          {onClear && (
+          {onClear ? (
             <F0Button
               onClick={onClear}
               label={i18n.collections.emptyStates.noResults.clearFilters}
               variant="outline"
             />
-          )}
-          {showApplyButton && (
+          ) : null}
+          {showApplyButton ? (
             <F0Button
               onClick={onApply}
               label={applyButtonLabel ?? i18n.filters.applyFilters}
             />
-          )}
+          ) : null}
         </div>
       ) : null}
     </div>

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -1354,26 +1354,24 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       })}
 
       {/* Root error message */}
-      {rootError && (
+      {rootError ? (
         <p className="mt-4 text-base font-medium text-f1-foreground-critical">
           {rootError.message}
         </p>
-      )}
+      ) : null}
 
       {/* Default submit button */}
-      {!isActionBar &&
-        showSubmitButton &&
-        (!showSubmitWhenDirty || isDirty) && (
-          <div className="mt-4 flex justify-end">
-            <F0Button
-              type="submit"
-              label={submitLabel}
-              icon={submitIcon}
-              loading={isSubmitting}
-              disabled={hasErrors || isFormLoading || hasPendingUploads}
-            />
-          </div>
-        )}
+      {!isActionBar && showSubmitButton && (!showSubmitWhenDirty || isDirty) ? (
+        <div className="mt-4 flex justify-end">
+          <F0Button
+            type="submit"
+            label={submitLabel}
+            icon={submitIcon}
+            loading={isSubmitting}
+            disabled={hasErrors || isFormLoading || hasPendingUploads}
+          />
+        </div>
+      ) : null}
     </form>
   )
 
@@ -1405,7 +1403,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
           </div>
         )}
 
-        {!hideActionBar && (
+        {!hideActionBar ? (
           <FormActionBar
             ref={actionBarRef}
             isActionBar={isActionBar}
@@ -1427,7 +1425,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             goToPreviousError={goToPreviousError}
             goToNextError={goToNextError}
           />
-        )}
+        ) : null}
       </FormProvider>
     </F0FormContext.Provider>
   )

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -2505,9 +2505,9 @@ export const CustomField: Story = {
               </option>
             ))}
           </select>
-          {error && (
+          {error ? (
             <span className="text-sm text-f1-foreground-critical">{error}</span>
-          )}
+          ) : null}
         </div>
       )
     }
@@ -2556,9 +2556,9 @@ export const CustomField: Story = {
               </button>
             ))}
           </div>
-          {error && (
+          {error ? (
             <span className="text-sm text-f1-foreground-critical">{error}</span>
-          )}
+          ) : null}
         </div>
       )
     }
@@ -3539,9 +3539,9 @@ export const FormInDialog: Story = {
     return (
       <div className="flex flex-col items-start gap-3">
         <F0Button label="Add Team Member" icon={Plus} onClick={handleAdd} />
-        {lastResult && (
+        {lastResult ? (
           <p className="text-sm text-f1-foreground-secondary">{lastResult}</p>
-        )}
+        ) : null}
       </div>
     )
   },

--- a/packages/react/src/patterns/F0Form/__tests__/F0AiFormRegistryAvailableDefinitions.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0AiFormRegistryAvailableDefinitions.test.tsx
@@ -907,14 +907,14 @@ describe("F0AiFormRegistryProvider availableFormDefinitions", () => {
               capturedRegistry = r
             }}
           />
-          {showForm && (
+          {showForm ? (
             <F0Form
               name="canvas-form"
               schema={formSchema}
               defaultValues={{ name: "Alice", email: "alice@test.com" }}
               onSubmit={async () => ({ success: true })}
             />
-          )}
+          ) : null}
         </F0AiFormRegistryProvider>
       )
     }

--- a/packages/react/src/patterns/F0Form/components/ActionBar.tsx
+++ b/packages/react/src/patterns/F0Form/components/ActionBar.tsx
@@ -80,7 +80,7 @@ export const FormActionBar = forwardRef<F0ActionBarRef, FormActionBarProps>(
                         )}
                   </span>
                 </div>
-                {errorCount > 1 && (
+                {errorCount > 1 ? (
                   <div className="flex items-center gap-2">
                     <F0Button
                       icon={ChevronUp}
@@ -97,7 +97,7 @@ export const FormActionBar = forwardRef<F0ActionBarRef, FormActionBarProps>(
                       hideLabel
                     />
                   </div>
-                )}
+                ) : null}
               </div>
             ) : undefined
           }

--- a/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
+++ b/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
@@ -292,7 +292,7 @@ export function F0FormSection<TSchema extends F0FormSchema>({
             )}
           >
             <SectionHeader title={title} description={description ?? ""} />
-            {sectionConfig?.action && (
+            {sectionConfig?.action ? (
               <F0Button
                 label={sectionConfig.action.label}
                 icon={sectionConfig.action.icon}
@@ -301,7 +301,7 @@ export function F0FormSection<TSchema extends F0FormSchema>({
                 variant="outline"
                 size="md"
               />
-            )}
+            ) : null}
           </div>
 
           <div className={`flex flex-col ${FIELD_GAP}`}>
@@ -358,13 +358,13 @@ export function F0FormSection<TSchema extends F0FormSchema>({
             })}
           </div>
 
-          {rootError && (
+          {rootError ? (
             <p className="mt-4 text-base font-medium text-f1-foreground-critical">
               {rootError.message}
             </p>
-          )}
+          ) : null}
 
-          {!hideSubmitButton && (!showSubmitWhenDirty || isDirty) && (
+          {!hideSubmitButton && (!showSubmitWhenDirty || isDirty) ? (
             <div className="mt-4 flex justify-end">
               <F0Button
                 type="submit"
@@ -374,7 +374,7 @@ export function F0FormSection<TSchema extends F0FormSchema>({
                 disabled={hasErrors || isFormLoading}
               />
             </div>
-          )}
+          ) : null}
         </form>
       </FormProvider>
     </F0FormContext.Provider>

--- a/packages/react/src/patterns/F0Form/components/SectionRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/components/SectionRenderer.tsx
@@ -55,7 +55,7 @@ export function SectionRenderer({ section }: SectionRendererProps) {
         )}
       >
         <SectionHeader title={title} description={description ?? ""} />
-        {action && (
+        {action ? (
           <F0Button
             label={action.label}
             icon={action.icon}
@@ -64,7 +64,7 @@ export function SectionRenderer({ section }: SectionRendererProps) {
             variant="outline"
             size="md"
           />
-        )}
+        ) : null}
       </div>
       <div className={`flex flex-col ${FIELD_GAP}`}>
         {groupedItems.map((item, index) => {

--- a/packages/react/src/patterns/F0Form/components/SwitchGroupRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/components/SwitchGroupRenderer.tsx
@@ -280,7 +280,7 @@ export function SwitchGroupRenderer({
           <F0Alert key={fieldId} {...props} variant={props.variant ?? "info"} />
         ))}
       </div>
-      {groupErrors.length > 0 && (
+      {groupErrors.length > 0 ? (
         <div className="flex flex-col gap-1">
           {groupErrors.map((error) => (
             <FormFieldPrimitive
@@ -295,7 +295,7 @@ export function SwitchGroupRenderer({
             />
           ))}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/F0Form/fields/FieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/FieldRenderer.tsx
@@ -215,7 +215,7 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
       {...(isAutosubmit || field.autoSave ? { disabled: false } : {})}
       render={({ field: formField, fieldState }) => (
         <FormItem id={anchorId} className="scroll-mt-4">
-          {showLabel && (
+          {showLabel ? (
             /* No `htmlFor`: it used to be `field.id`, which matches no element
                in the DOM — the rendered input gets its own id from
                `F0InputField` (`props.id ?? useId()`), and the field renderers
@@ -227,11 +227,11 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
                not focus the input — tracked separately. */
             <label className="text-base font-medium leading-normal text-f1-foreground-secondary">
               {field.label}
-              {isRequired && (
+              {isRequired ? (
                 <span className="ml-0.5 text-f1-foreground-critical">*</span>
-              )}
+              ) : null}
             </label>
-          )}
+          ) : null}
           <FormControl>
             {renderFieldContent({
               field,
@@ -244,10 +244,10 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
               renderCustomField,
             })}
           </FormControl>
-          {field.helpText && (
+          {field.helpText ? (
             <FormDescription>{field.helpText}</FormDescription>
-          )}
-          {"moreInfoLink" in field && field.moreInfoLink && (
+          ) : null}
+          {"moreInfoLink" in field && field.moreInfoLink ? (
             <F0Link
               href={field.moreInfoLink.href}
               target="_blank"
@@ -255,7 +255,7 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
             >
               {field.moreInfoLink.label ?? forms.moreInformation}
             </F0Link>
-          )}
+          ) : null}
           {(() => {
             const alertProps = resolveFieldAlert(
               field.alert,
@@ -269,13 +269,13 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
               <F0Alert {...alertProps} variant={alertProps.variant ?? "info"} />
             )
           })()}
-          {showFormMessage && !fieldState.error && (
+          {showFormMessage && !fieldState.error ? (
             <InputMessages status={field.status} />
-          )}
+          ) : null}
           {/* A critical alert already conveys the message via the F0Alert above,
               so suppress the redundant FormMessage text (the input still shows
               error styling because fieldState.error is set). */}
-          {showFormMessage && fieldState.error?.type !== "alertCritical" && (
+          {showFormMessage && fieldState.error?.type !== "alertCritical" ? (
             <FormMessage
               fallback={
                 isRequired
@@ -283,7 +283,7 @@ export function FieldRenderer({ field, sectionId }: FieldRendererProps) {
                   : forms.validation.invalidType
               }
             />
-          )}
+          ) : null}
         </FormItem>
       )}
     />

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
@@ -906,11 +906,11 @@ export function EntitiesListFieldRenderer({
           FieldRenderer.tsx. */}
       <label className="text-base font-medium leading-normal text-f1-foreground-secondary">
         {field.label}
-        {isRequired && (
+        {isRequired ? (
           <span className="ml-0.5 text-f1-foreground-critical">*</span>
-        )}
+        ) : null}
       </label>
-      {addConfig && <AddButton config={addConfig} />}
+      {addConfig ? <AddButton config={addConfig} /> : null}
     </div>
   )
 
@@ -955,11 +955,11 @@ export function EntitiesListFieldRenderer({
           viewLabel={translations.view}
         />
 
-        {rootError && (
+        {rootError ? (
           <p className="text-sm font-medium text-f1-foreground-critical">
             {rootError}
           </p>
-        )}
+        ) : null}
       </div>
     )
   }
@@ -1000,11 +1000,11 @@ export function EntitiesListFieldRenderer({
         disabled={isDisabled || removingKeys.size > 0}
       />
 
-      {rootError && (
+      {rootError ? (
         <p className="text-sm font-medium text-f1-foreground-critical">
           {rootError}
         </p>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/F0Form/fields/file/FileAttachment.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileAttachment.tsx
@@ -136,14 +136,14 @@ export function FileAttachment({
         <span className="truncate text-sm font-medium text-f1-foreground">
           {fileName}
         </span>
-        {subtitleText && (
+        {subtitleText ? (
           <span className="text-sm text-f1-foreground-secondary">
             {subtitleText}
           </span>
-        )}
+        ) : null}
       </div>
 
-      {!disabled && (
+      {!disabled ? (
         <F0Button
           variant="outline"
           size="sm"
@@ -152,7 +152,7 @@ export function FileAttachment({
           icon={Cross}
           hideLabel
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -517,13 +517,13 @@ export function FileFieldRenderer({
 
   return (
     <div className="flex flex-col gap-4">
-      {isLoadingInitialFiles && !hasFiles && (
+      {isLoadingInitialFiles && !hasFiles ? (
         <div className="flex animate-pulse flex-col gap-2 rounded-xl border border-dashed border-f1-border px-4 py-10">
           <div className="mx-auto h-8 w-8 rounded-full bg-f1-background-secondary" />
           <div className="mx-auto h-4 w-32 rounded bg-f1-background-secondary" />
         </div>
-      )}
-      {!isLoadingInitialFiles && showDropzone && (
+      ) : null}
+      {!isLoadingInitialFiles && showDropzone ? (
         <div
           role="button"
           tabIndex={field.disabled ? -1 : 0}
@@ -549,17 +549,17 @@ export function FileFieldRenderer({
             <span className="text-center text-base font-medium text-f1-foreground">
               {dropzoneText}
             </span>
-            {acceptedTypesLabel && (
+            {acceptedTypesLabel ? (
               <span className="text-center text-base text-f1-foreground-secondary">
                 {translations.acceptedTypes.replace(
                   "{{types}}",
                   acceptedTypesLabel
                 )}
               </span>
-            )}
+            ) : null}
           </div>
         </div>
-      )}
+      ) : null}
 
       <input
         ref={fileInputRef}
@@ -573,16 +573,16 @@ export function FileFieldRenderer({
         tabIndex={-1}
       />
 
-      {validationError && (
+      {validationError ? (
         <div className="-mt-2 flex items-center gap-1">
           <F0Icon icon={AlertCircle} color="critical" />
           <p className="text-base font-medium text-f1-foreground-critical">
             {validationError}
           </p>
         </div>
-      )}
+      ) : null}
 
-      {entries.length > 0 && (
+      {entries.length > 0 ? (
         <div className="flex flex-col">
           {entries.map((entry, index) => {
             const total = entries.length
@@ -618,7 +618,7 @@ export function FileFieldRenderer({
             )
           })}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/F0FormField/F0FormField.tsx
+++ b/packages/react/src/patterns/F0FormField/F0FormField.tsx
@@ -64,17 +64,17 @@ export function F0FormField({
 
   return (
     <div className="space-y-2" id={id}>
-      {showLabel && (
+      {showLabel ? (
         <label
           htmlFor={field.id}
           className="text-base font-medium leading-normal text-f1-foreground-secondary"
         >
           {field.label}
-          {isRequired && (
+          {isRequired ? (
             <span className="ml-0.5 text-f1-foreground-critical">*</span>
-          )}
+          ) : null}
         </label>
-      )}
+      ) : null}
       {renderFieldInput({
         field: resolvedField,
         formField,
@@ -85,11 +85,11 @@ export function F0FormField({
         initialFiles: fileInitialFiles,
         fieldStatus: resolvedStatus,
       })}
-      {field.helpText && (
+      {field.helpText ? (
         <p className="text-base text-f1-foreground-secondary">
           {field.helpText}
         </p>
-      )}
+      ) : null}
       <InputMessages status={resolvedStatus} />
     </div>
   )

--- a/packages/react/src/patterns/F0Graph/F0GraphSkeleton.tsx
+++ b/packages/react/src/patterns/F0Graph/F0GraphSkeleton.tsx
@@ -114,10 +114,10 @@ export const F0GraphSkeleton = ({
   >
     <div className="flex flex-col items-center gap-2">
       <SkeletonNodeCard />
-      {showTags && <SkeletonTagPill />}
+      {showTags ? <SkeletonTagPill /> : null}
     </div>
 
-    {childrenCount > 0 && (
+    {childrenCount > 0 ? (
       <>
         <SkeletonConnectors childrenCount={childrenCount} />
 
@@ -125,12 +125,12 @@ export const F0GraphSkeleton = ({
           {Array.from({ length: childrenCount }).map((_, index) => (
             <div key={index} className="flex flex-col items-center gap-2">
               <SkeletonNodeCard />
-              {showTags && <SkeletonTagPill />}
+              {showTags ? <SkeletonTagPill /> : null}
               <SkeletonExpander />
             </div>
           ))}
         </div>
       </>
-    )}
+    ) : null}
   </div>
 )

--- a/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
+++ b/packages/react/src/patterns/F0Graph/__stories__/F0Graph.stories.tsx
@@ -782,7 +782,7 @@ function ClickToFocusWithSidePanelDemo() {
         }}
         onPaneClick={() => setSelected(null)}
       />
-      {selected && (
+      {selected ? (
         <div
           className="absolute right-0 top-0 z-20 flex h-full flex-col gap-2 border-l border-f1-border bg-f1-background p-6 shadow-lg"
           style={{ width: PANEL_WIDTH }}
@@ -799,7 +799,7 @@ function ClickToFocusWithSidePanelDemo() {
             onClick={() => setSelected(null)}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/F0Graph/components/F0GraphControls/F0GraphControls.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphControls/F0GraphControls.tsx
@@ -15,7 +15,7 @@ export const F0GraphControls = forwardRef<HTMLDivElement, F0GraphControlsProps>(
         aria-label={i18n.graph.controls.navigation}
         className="flex flex-col items-center gap-2"
       >
-        {onFocusUser && (
+        {onFocusUser ? (
           <F0Button
             variant="outline"
             size="md"
@@ -24,7 +24,7 @@ export const F0GraphControls = forwardRef<HTMLDivElement, F0GraphControlsProps>(
             hideLabel
             onClick={onFocusUser}
           />
-        )}
+        ) : null}
 
         <F0Button
           variant="outline"

--- a/packages/react/src/patterns/F0Graph/components/F0GraphEdge/F0GraphEdge.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphEdge/F0GraphEdge.tsx
@@ -91,7 +91,7 @@ export function F0GraphEdgeBase({
 
   return (
     <>
-      {showDot && (
+      {showDot ? (
         <defs>
           <marker
             id={`${MARKER_ID}-${edgeProps.id}`}
@@ -109,7 +109,7 @@ export function F0GraphEdgeBase({
             />
           </marker>
         </defs>
-      )}
+      ) : null}
       <BaseEdge
         id={edgeProps.id}
         path={edgePath}

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNode.tsx
@@ -416,12 +416,12 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
                           width: isCompact ? 120 : 96,
                         }}
                       />
-                      {!isCompact && !isDot && (
+                      {!isCompact && !isDot ? (
                         <Skeleton
                           className="rounded-xs"
                           style={{ height: 12, width: 64 }}
                         />
-                      )}
+                      ) : null}
                     </div>
                   ) : (
                     <>
@@ -435,7 +435,7 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
                       >
                         {title}
                       </p>
-                      {!isCompact && !isDot && subtitle && (
+                      {!isCompact && !isDot && subtitle ? (
                         <p
                           className="w-full truncate tracking-[-0.07px] text-f1-foreground-secondary"
                           style={{
@@ -446,7 +446,7 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
                         >
                           {subtitle}
                         </p>
-                      )}
+                      ) : null}
                     </>
                   )}
                 </motion.div>
@@ -455,7 +455,7 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
           </div>
         </div>
 
-        {isDetail && actions && (
+        {isDetail && actions ? (
           <NodeToolbar
             nodeId={nodeId}
             isVisible={state === "selected"}
@@ -465,7 +465,7 @@ const F0GraphNodeBase = forwardRef<HTMLDivElement, F0GraphNodeProps>(
           >
             <div className="flex items-center gap-1">{actions}</div>
           </NodeToolbar>
-        )}
+        ) : null}
 
         {tagRow("max-w-[256px]")}
       </div>

--- a/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNodeStackedRow.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphNode/F0GraphNodeStackedRow.tsx
@@ -95,11 +95,13 @@ export const F0GraphNodeStackedRow = ({
             className="shrink-0 rounded-full"
             style={{ width: STACKED_NODE_AVATAR, height: STACKED_NODE_AVATAR }}
           />
-          {titleType && <Skeleton className="h-3 w-24 flex-1 rounded-xs" />}
+          {titleType ? (
+            <Skeleton className="h-3 w-24 flex-1 rounded-xs" />
+          ) : null}
         </>
       ) : (
         <>
-          {avatar && (
+          {avatar ? (
             <div
               className={cn(
                 "flex shrink-0 items-center justify-center",
@@ -120,23 +122,23 @@ export const F0GraphNodeStackedRow = ({
             >
               <F0Avatar size="md" avatar={avatar} />
             </div>
-          )}
+          ) : null}
           {/* Dropped entirely at dot zoom rather than faded: the card has no
               text there either, and a row that keeps it would be the only
               legible label on a canvas of dots. */}
-          {titleType && (
+          {titleType ? (
             <p
               className="min-w-0 flex-1 truncate font-medium tracking-[-0.07px] text-f1-foreground"
               style={titleType}
             >
               {title}
             </p>
-          )}
+          ) : null}
         </>
       )}
       {/* Trailing content follows the title: it is a detail-level affordance,
           and at dot zoom there is no text for it to sit beside. */}
-      {trailing && titleType && (
+      {trailing && titleType ? (
         // Its own affordance: clicking a small action must not also select and
         // fly to the node. Two paths would select it — the row's `onClick`,
         // stopped here, and the canvas `pointerup` handler, which fires
@@ -148,7 +150,7 @@ export const F0GraphNodeStackedRow = ({
         >
           {trailing}
         </div>
-      )}
+      ) : null}
     </div>
   )
 

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -1010,19 +1010,19 @@ export function F0GraphView<T = unknown>(
                       </ReactFlow>
                     </div>
 
-                    {canvasActions && (
+                    {canvasActions ? (
                       <div className="absolute left-6 top-3 z-10 flex flex-col gap-2 rounded-md backdrop-blur-[140px]">
                         {canvasActions}
                       </div>
-                    )}
+                    ) : null}
 
-                    {canvasFooterActions && (
+                    {canvasFooterActions ? (
                       <div className="absolute bottom-6 right-6 z-10 flex flex-col items-end gap-2">
                         {canvasFooterActions}
                       </div>
-                    )}
+                    ) : null}
 
-                    {showControls && (
+                    {showControls ? (
                       <div className="absolute bottom-6 left-6 z-10">
                         <F0GraphControls
                           onZoomIn={handleZoomIn}
@@ -1043,7 +1043,7 @@ export function F0GraphView<T = unknown>(
                           labels={controlLabels}
                         />
                       </div>
-                    )}
+                    ) : null}
                   </div>
                 </F0GraphStackHoverContext.Provider>
               </F0GraphSelectionContext.Provider>

--- a/packages/react/src/patterns/F0Map/F0Map.tsx
+++ b/packages/react/src/patterns/F0Map/F0Map.tsx
@@ -559,7 +559,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
           {/* Bottom of the overlay stack: a GL circle under the lines and under
               every DOM marker. The sr-only span keeps the announcement the
               canvas can't provide. */}
-          {!webglFailed && mapInstance && currentLocation && (
+          {!webglFailed && mapInstance && currentLocation ? (
             <>
               <CurrentLocationLayer
                 map={mapInstance}
@@ -567,8 +567,8 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
               />
               <span className="sr-only">{i18n.map.currentLocation}</span>
             </>
-          )}
-          {!webglFailed && mapInstance && hasLines && (
+          ) : null}
+          {!webglFailed && mapInstance && hasLines ? (
             <F0MapVectorLayer
               map={mapInstance}
               routes={routes}
@@ -577,8 +577,8 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
               onRouteClick={onRouteClick}
               onArcClick={onArcClick}
             />
-          )}
-          {!webglFailed && mapInstance && markers.length > 0 && (
+          ) : null}
+          {!webglFailed && mapInstance && markers.length > 0 ? (
             <F0MapMarkersLayer
               map={mapInstance}
               points={markers}
@@ -586,8 +586,8 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
               highlightedId={highlightedId}
               onSelect={selectMarker}
             />
-          )}
-          {!webglFailed && mapInstance && showControls && interactive && (
+          ) : null}
+          {!webglFailed && mapInstance && showControls && interactive ? (
             <div
               className={cn(
                 "absolute z-10",
@@ -602,9 +602,9 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
                 labels={controlLabels}
               />
             </div>
-          )}
+          ) : null}
 
-          {tileError && !webglFailed && (
+          {tileError && !webglFailed ? (
             <div className="absolute inset-x-0 top-0 z-30 flex items-center justify-between gap-3 border-b border-solid border-f1-border-secondary bg-f1-background px-4 py-2 text-sm text-f1-foreground">
               <span>{i18n.map.loadError}</span>
               <button
@@ -622,7 +622,7 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
                 {i18n.map.retry}
               </button>
             </div>
-          )}
+          ) : null}
 
           {/* Screen-reader text alternative (always in the DOM), and the visible
               fallback when the map can't render. */}

--- a/packages/react/src/patterns/F0Map/components/F0MapControls/F0MapControls.tsx
+++ b/packages/react/src/patterns/F0Map/components/F0MapControls/F0MapControls.tsx
@@ -46,57 +46,59 @@ export const F0MapControls = forwardRef<HTMLDivElement, F0MapControlsProps>(
           aria-label={i18n.map.navigation}
           className="flex flex-col items-center gap-2"
         >
-          {hasTopGroup &&
-            card(
-              <>
-                {onFit && (
-                  <F0Button
-                    variant="ghost"
-                    size="md"
-                    label={labels?.fit ?? i18n.map.controls.fit}
-                    icon={FitView}
-                    hideLabel
-                    onClick={onFit}
-                  />
-                )}
-                {onLocate && (
-                  <F0Button
-                    variant="ghost"
-                    size="md"
-                    label={labels?.locate ?? i18n.map.controls.locate}
-                    icon={Target}
-                    hideLabel
-                    onClick={onLocate}
-                  />
-                )}
-              </>
-            )}
+          {hasTopGroup
+            ? card(
+                <>
+                  {onFit ? (
+                    <F0Button
+                      variant="ghost"
+                      size="md"
+                      label={labels?.fit ?? i18n.map.controls.fit}
+                      icon={FitView}
+                      hideLabel
+                      onClick={onFit}
+                    />
+                  ) : null}
+                  {onLocate ? (
+                    <F0Button
+                      variant="ghost"
+                      size="md"
+                      label={labels?.locate ?? i18n.map.controls.locate}
+                      icon={Target}
+                      hideLabel
+                      onClick={onLocate}
+                    />
+                  ) : null}
+                </>
+              )
+            : null}
 
-          {hasZoomGroup &&
-            card(
-              <>
-                {onZoomIn && (
-                  <F0Button
-                    variant="ghost"
-                    size="md"
-                    label={labels?.zoomIn ?? i18n.map.controls.zoomIn}
-                    icon={Add}
-                    hideLabel
-                    onClick={onZoomIn}
-                  />
-                )}
-                {onZoomOut && (
-                  <F0Button
-                    variant="ghost"
-                    size="md"
-                    label={labels?.zoomOut ?? i18n.map.controls.zoomOut}
-                    icon={Minus}
-                    hideLabel
-                    onClick={onZoomOut}
-                  />
-                )}
-              </>
-            )}
+          {hasZoomGroup
+            ? card(
+                <>
+                  {onZoomIn ? (
+                    <F0Button
+                      variant="ghost"
+                      size="md"
+                      label={labels?.zoomIn ?? i18n.map.controls.zoomIn}
+                      icon={Add}
+                      hideLabel
+                      onClick={onZoomIn}
+                    />
+                  ) : null}
+                  {onZoomOut ? (
+                    <F0Button
+                      variant="ghost"
+                      size="md"
+                      label={labels?.zoomOut ?? i18n.map.controls.zoomOut}
+                      icon={Minus}
+                      hideLabel
+                      onClick={onZoomOut}
+                    />
+                  ) : null}
+                </>
+              )
+            : null}
         </div>
       </DataTestIdWrapper>
     )

--- a/packages/react/src/patterns/F0Map/components/F0MapList/F0MapList.tsx
+++ b/packages/react/src/patterns/F0Map/components/F0MapList/F0MapList.tsx
@@ -76,11 +76,11 @@ export const F0MapList = forwardRef<HTMLElement, F0MapListProps>(
             className
           )}
         >
-          {visible && (
+          {visible ? (
             <h2 className="text-f1-foreground mb-2 text-base font-medium">
               {listLabel}
             </h2>
-          )}
+          ) : null}
           <ul className={visible ? "flex flex-col gap-0.5" : undefined}>
             {points.map((p) => (
               <li key={p.id}>

--- a/packages/react/src/patterns/F0Map/components/internal/BaseMapMarker/BaseMapMarker.tsx
+++ b/packages/react/src/patterns/F0Map/components/internal/BaseMapMarker/BaseMapMarker.tsx
@@ -437,7 +437,7 @@ const BaseMapMarkerBase = forwardRef<HTMLButtonElement, BaseMapMarkerProps>(
     // the tip is only slightly rounded.
     const caret = (
       <AnimatePresence>
-        {selected && (
+        {selected ? (
           <motion.svg
             key="caret"
             width={m.caretW}
@@ -473,7 +473,7 @@ const BaseMapMarkerBase = forwardRef<HTMLButtonElement, BaseMapMarkerProps>(
           >
             <path d="M0 0h16c-4.2 3-6.6 6.9-7.4 11.7a0.62 0.62 0 0 1-1.2 0C6.6 6.9 4.2 3 0 0Z" />
           </motion.svg>
-        )}
+        ) : null}
       </AnimatePresence>
     )
 

--- a/packages/react/src/patterns/F0Map/components/internal/F0MapCluster/F0MapCluster.tsx
+++ b/packages/react/src/patterns/F0Map/components/internal/F0MapCluster/F0MapCluster.tsx
@@ -129,32 +129,33 @@ const F0MapClusterBase = forwardRef<HTMLDivElement, F0MapClusterProps>(
           ))}
           {/* Overflow counter: f0's avatar-list "+N" circle (secondary surface,
               secondary foreground, fully rounded), in the last slot. */}
-          {hasCounter &&
-            (() => {
-              const [cx, cy] = positions[heads.length] ?? [0, 0]
-              return (
-                <span
-                  className={cn(
-                    "absolute left-0 top-0 flex h-6 min-w-6 items-center justify-center overflow-hidden rounded-full px-1.5",
-                    "border border-solid border-f1-border-secondary",
-                    // White-90 base with the translucent hover layer on top.
-                    "text-f1-foreground-secondary text-sm font-medium leading-none"
-                  )}
-                  style={{
-                    zIndex: MAX_AVATARS_WITH_COUNTER,
-                    backgroundColor: "hsl(var(--white-90))",
-                    transform: `translate(${cx * spread}px, ${cy * spread}px) translate(-50%, -50%) scale(${scale})`,
-                    transition: `transform 240ms ${EASE}`,
-                  }}
-                >
+          {hasCounter
+            ? (() => {
+                const [cx, cy] = positions[heads.length] ?? [0, 0]
+                return (
                   <span
-                    aria-hidden
-                    className="absolute inset-0 bg-f1-background-hover"
-                  />
-                  <span className="relative">{overflowLabel}</span>
-                </span>
-              )
-            })()}
+                    className={cn(
+                      "absolute left-0 top-0 flex h-6 min-w-6 items-center justify-center overflow-hidden rounded-full px-1.5",
+                      "border border-solid border-f1-border-secondary",
+                      // White-90 base with the translucent hover layer on top.
+                      "text-f1-foreground-secondary text-sm font-medium leading-none"
+                    )}
+                    style={{
+                      zIndex: MAX_AVATARS_WITH_COUNTER,
+                      backgroundColor: "hsl(var(--white-90))",
+                      transform: `translate(${cx * spread}px, ${cy * spread}px) translate(-50%, -50%) scale(${scale})`,
+                      transition: `transform 240ms ${EASE}`,
+                    }}
+                  >
+                    <span
+                      aria-hidden
+                      className="absolute inset-0 bg-f1-background-hover"
+                    />
+                    <span className="relative">{overflowLabel}</span>
+                  </span>
+                )
+              })()
+            : null}
         </div>
       </DataTestIdWrapper>
     )

--- a/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
+++ b/packages/react/src/patterns/F0WizardForm/__stories__/F0WizardForm.stories.tsx
@@ -218,9 +218,9 @@ function OpenFormWizardStory() {
     >
       <div className="flex flex-1 flex-col items-center justify-center gap-3">
         <F0Button label="Open wizard" onClick={handleOpen} />
-        {lastResult && (
+        {lastResult ? (
           <p className="text-f1-foreground-secondary">{lastResult}</p>
-        )}
+        ) : null}
       </div>
     </ApplicationFrame>
   )

--- a/packages/react/src/patterns/Navigation/Page/index.tsx
+++ b/packages/react/src/patterns/Navigation/Page/index.tsx
@@ -16,7 +16,7 @@ function _Page({ children, header, embedded = false }: PageProps) {
         !embedded && "xs:rounded-xl"
       )}
     >
-      {header && <div className="flex flex-col">{header}</div>}
+      {header ? <div className="flex flex-col">{header}</div> : null}
       <div className="isolate flex w-full flex-1 flex-col overflow-auto [&>*]:flex-1">
         {children}
       </div>

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatBlankState.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatBlankState.tsx
@@ -40,13 +40,13 @@ function _SidebarChatBlankState({
     >
       <div className="flex flex-col gap-0.5">
         <p className="text-base font-medium text-f1-foreground">{title}</p>
-        {description && (
+        {description ? (
           <p className="text-base text-f1-foreground-secondary">
             {description}
           </p>
-        )}
+        ) : null}
       </div>
-      {actions && actions.length > 0 && (
+      {actions && actions.length > 0 ? (
         <div className="flex flex-col items-center gap-2">
           {actions.map((action) => (
             <ButtonInternal
@@ -59,7 +59,7 @@ function _SidebarChatBlankState({
             />
           ))}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatItem.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatItem.tsx
@@ -132,13 +132,13 @@ export const SidebarChatItem = ({
             ) : (
               <F0Avatar size="xs" avatar={chat.avatar} />
             )}
-            {presence && (
+            {presence ? (
               <PresenceDot
                 presence={presence}
                 isActive={isActive}
                 label={i18n.chat.online}
               />
-            )}
+            ) : null}
           </div>
         ) : null}
 
@@ -158,7 +158,7 @@ export const SidebarChatItem = ({
         >
           {chat.label}
         </OneEllipsis>
-        {(statuses.length > 0 || chat.unreadCount) && (
+        {statuses.length > 0 || chat.unreadCount ? (
           <div
             className={cn(
               "gap-1 flex items-center justify-center transition-opacity",
@@ -189,14 +189,14 @@ export const SidebarChatItem = ({
               />
             ) : null}
           </div>
-        )}
+        ) : null}
       </button>
       {/* Hover (or focus) reveals a pin/unpin button, sitting where the unread
           badge / status is — a sibling of the row button so it isn't a nested
           <button>. While a pin/unpin is saving, a spinner takes its place and
           stays visible off-hover. */}
-      {chat.onTogglePin &&
-        (chat.pinPending ? (
+      {chat.onTogglePin ? (
+        chat.pinPending ? (
           <div
             className="absolute right-1.5 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center"
             aria-label={chat.pinned ? i18n.chat.unpin : i18n.chat.pin}
@@ -222,7 +222,8 @@ export const SidebarChatItem = ({
               }}
             />
           </div>
-        ))}
+        )
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatList.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatList.tsx
@@ -133,46 +133,48 @@ export const SidebarChatList = ({
           }
         />
       </div>
-      {portalRoots.above &&
-        createPortal(
-          above.count > 0 && (
-            <div className="pointer-events-none absolute inset-x-0 top-2 z-[60] flex justify-center">
-              <div className="flex rounded bg-f1-background">
-                <ButtonInternal
-                  type="button"
-                  variant="outline"
-                  size="md"
-                  className="pointer-events-auto shadow-md"
-                  icon={ArrowUp}
-                  label={getUnreadLabel(above.count)}
-                  aria-label={getDirectionalLabel("above", above.count)}
-                  onClick={(event) => jump("above", event.currentTarget)}
-                />
+      {portalRoots.above
+        ? createPortal(
+            above.count > 0 && (
+              <div className="pointer-events-none absolute inset-x-0 top-2 z-[60] flex justify-center">
+                <div className="flex rounded bg-f1-background">
+                  <ButtonInternal
+                    type="button"
+                    variant="outline"
+                    size="md"
+                    className="pointer-events-auto shadow-md"
+                    icon={ArrowUp}
+                    label={getUnreadLabel(above.count)}
+                    aria-label={getDirectionalLabel("above", above.count)}
+                    onClick={(event) => jump("above", event.currentTarget)}
+                  />
+                </div>
               </div>
-            </div>
-          ),
-          portalRoots.above
-        )}
-      {portalRoots.below &&
-        createPortal(
-          below.count > 0 && (
-            <div className="pointer-events-none absolute inset-x-0 bottom-2 z-[60] flex justify-center">
-              <div className="flex rounded bg-f1-background">
-                <ButtonInternal
-                  type="button"
-                  variant="outline"
-                  size="md"
-                  className="pointer-events-auto shadow-md"
-                  icon={ArrowDown}
-                  label={getUnreadLabel(below.count)}
-                  aria-label={getDirectionalLabel("below", below.count)}
-                  onClick={(event) => jump("below", event.currentTarget)}
-                />
+            ),
+            portalRoots.above
+          )
+        : null}
+      {portalRoots.below
+        ? createPortal(
+            below.count > 0 && (
+              <div className="pointer-events-none absolute inset-x-0 bottom-2 z-[60] flex justify-center">
+                <div className="flex rounded bg-f1-background">
+                  <ButtonInternal
+                    type="button"
+                    variant="outline"
+                    size="md"
+                    className="pointer-events-auto shadow-md"
+                    icon={ArrowDown}
+                    label={getUnreadLabel(below.count)}
+                    aria-label={getDirectionalLabel("below", below.count)}
+                    onClick={(event) => jump("below", event.currentTarget)}
+                  />
+                </div>
               </div>
-            </div>
-          ),
-          portalRoots.below
-        )}
+            ),
+            portalRoots.below
+          )
+        : null}
     </>
   )
 }

--- a/packages/react/src/patterns/Navigation/Sidebar/CollapsibleSection/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/CollapsibleSection/index.tsx
@@ -90,9 +90,9 @@ export const SidebarCollapsibleSection = ({
               <F0Icon icon={ChevronDown} size="xs" />
             </motion.div>
             {/* Surfaces hidden unreads at the far right while collapsed. */}
-            {!isOpen && collapsedBadge && (
+            {!isOpen && collapsedBadge ? (
               <span className="ml-auto">{collapsedBadge}</span>
-            )}
+            ) : null}
           </button>
         </div>
         <CollapsibleContent forceMount className="mt-0.5 flex flex-col gap-1">

--- a/packages/react/src/patterns/Navigation/Sidebar/Footer/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Footer/index.tsx
@@ -54,7 +54,7 @@ export function SidebarFooter({
           </button>
         </Dropdown>
       </div>
-      {showActivityButton && (
+      {showActivityButton ? (
         <Tooltip label={i18n.notifications} shortcut={activityButtonShortcut}>
           <div className="relative">
             <F0Button
@@ -64,14 +64,14 @@ export function SidebarFooter({
               variant="ghost"
               hideLabel
             />
-            {hasActivityUpdates && (
+            {hasActivityUpdates ? (
               <div className="absolute -right-1 -top-1 rounded-full bg-f1-background">
                 <Badge type="highlight" size="sm" icon={CircleIcon} />
               </div>
-            )}
+            ) : null}
           </div>
         </Tooltip>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/Navigation/Sidebar/Menu/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Menu/index.tsx
@@ -79,12 +79,14 @@ const MenuItemContent = ({
         />
         <span>{item.label}</span>
       </div>
-      {(item.tag || item.badge) && (
+      {item.tag || item.badge ? (
         <div className="flex flex-shrink-0 items-center gap-1.5">
-          {item.tag && <F0TagRaw text={item.tag} />}
-          {item.badge && <Counter value={item.badge} size="sm" type="bold" />}
+          {item.tag ? <F0TagRaw text={item.tag} /> : null}
+          {item.badge ? (
+            <Counter value={item.badge} size="sm" type="bold" />
+          ) : null}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }
@@ -626,7 +628,7 @@ function MenuContent({
         isDragging && "cursor-grabbing [&_*]:cursor-grabbing"
       )}
     >
-      {hasRoot && (
+      {hasRoot ? (
         <div className="flex w-full flex-col gap-3 bg-transparent px-3">
           {nonSortableItems
             .filter((category) => category.isRoot)
@@ -638,9 +640,9 @@ function MenuContent({
               />
             ))}
         </div>
-      )}
+      ) : null}
 
-      {hasFavorites && (
+      {hasFavorites ? (
         <div className="mt-3 flex w-full flex-col gap-3 bg-transparent px-3">
           <SidebarCollapsibleSection title={t.favorites.favorites}>
             <div ref={favoritesRef}>
@@ -661,9 +663,9 @@ function MenuContent({
             </div>
           </SidebarCollapsibleSection>
         </div>
-      )}
+      ) : null}
 
-      {hasNonSortableItems && (
+      {hasNonSortableItems ? (
         <div className="mt-3 flex w-full flex-col gap-3 bg-transparent px-3">
           {nonSortableItems
             .filter((category) => !category.isRoot)
@@ -675,9 +677,9 @@ function MenuContent({
               />
             ))}
         </div>
-      )}
+      ) : null}
 
-      {hasSortableItems && (
+      {hasSortableItems ? (
         <div
           className={cn(
             "mt-3 flex w-full flex-col gap-3 bg-transparent px-3 [&_li]:list-none"
@@ -700,7 +702,7 @@ function MenuContent({
             </Reorder.Group>
           )}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/Navigation/Sidebar/Sidebar.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Sidebar.tsx
@@ -114,7 +114,7 @@ function _Sidebar({
       transition={transition}
     >
       <header className="flex-shrink-0">{header}</header>
-      {body && (
+      {body ? (
         <nav className="relative flex-grow overflow-y-hidden">
           <ScrollArea className="h-full">
             <div
@@ -133,15 +133,15 @@ function _Sidebar({
           </ScrollArea>
 
           <AnimatePresence>
-            {!isAtTop && (
+            {!isAtTop ? (
               <ScrollShadow position="top" key="shadow-scroll-top" />
-            )}
-            {!isAtBottom && (
+            ) : null}
+            {!isAtBottom ? (
               <ScrollShadow position="bottom" key="shadow-scroll-bottom" />
-            )}
+            ) : null}
           </AnimatePresence>
         </nav>
-      )}
+      ) : null}
       <footer className="flex-shrink-0">{renderFooter()}</footer>
     </motion.aside>
   )

--- a/packages/react/src/patterns/Navigation/Sidebar/TabPanel/SidebarTabPanel.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/TabPanel/SidebarTabPanel.tsx
@@ -58,9 +58,9 @@ const SidebarTabPanelActionButton = ({
       focusRing("focus-visible:ring-inset")
     )}
   >
-    {action.icon && (
+    {action.icon ? (
       <F0Icon icon={action.icon} size="md" className="text-f1-icon" />
-    )}
+    ) : null}
     <span className="line-clamp-1">{action.label}</span>
   </button>
 )
@@ -111,14 +111,14 @@ export const SidebarTabPanel = ({
       data-sidebar-tab-panel-searching={isSearching}
     >
       {/* Search always sits at the very top of the panel. */}
-      {searchPlaceholder !== undefined && (
+      {searchPlaceholder !== undefined ? (
         <SidebarTabPanelSearch
           value={query}
           onChange={setQuery}
           placeholder={searchPlaceholder}
         />
-      )}
-      {actions && actions.length > 0 && (
+      ) : null}
+      {actions && actions.length > 0 ? (
         <div className="flex flex-col gap-0.5">
           {actions.map((action) => {
             const button = <SidebarTabPanelActionButton action={action} />
@@ -129,16 +129,16 @@ export const SidebarTabPanel = ({
             )
           })}
         </div>
-      )}
-      {showSkeleton && skeleton}
-      {!showSkeleton && !hasAnyItems && emptyState}
-      {noResults && (
+      ) : null}
+      {showSkeleton ? skeleton : null}
+      {!showSkeleton && !hasAnyItems ? emptyState : null}
+      {noResults ? (
         <p className="px-1.5 py-2 text-base text-f1-foreground-secondary">
           {noResultsLabel}
         </p>
-      )}
-      {!showSkeleton &&
-        (animateItems ? (
+      ) : null}
+      {!showSkeleton ? (
+        animateItems ? (
           // Layout-animated lists. A `LayoutGroup` lets the collapsible groups
           // remeasure together, so a row leaving one group and joining another
           // (pin/unpin) stays in sync as positions shift.
@@ -235,7 +235,8 @@ export const SidebarTabPanel = ({
               </SidebarCollapsibleSection>
             </div>
           ))
-        ))}
+        )
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/Navigation/Sidebar/Tabs/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Tabs/index.tsx
@@ -123,7 +123,7 @@ const TabButton = ({
           Toggled (no fade) so it appears/disappears directly — shown only once
           the pill has settled (see `showAura`) so it never flashes mid-transition.
           The slower spin comes from the inline animation-duration (keyframe is 2s). */}
-      {showAura && (
+      {showAura ? (
         <span
           aria-hidden="true"
           className="pointer-events-none absolute inset-0 rounded"
@@ -134,16 +134,16 @@ const TabButton = ({
           />
           <span className="absolute inset-0 rounded bg-f1-background" />
         </span>
-      )}
+      ) : null}
       {/* The sliding active background — one element shared across tabs. */}
-      {isActive && (
+      {isActive ? (
         <motion.span
           layoutId="sidebar-tab-active-pill"
           transition={transition}
           aria-hidden="true"
           className="absolute inset-0 rounded bg-f1-background-inverse-secondary ring-1 ring-inset ring-f1-border dark:bg-f1-background"
         />
-      )}
+      ) : null}
       <div className="main flex h-8 min-w-0 items-center justify-center">
         {/* Icon inherits the span's colour (F0Icon ignores a passed className),
             so an inactive tab only darkens its icon on hover — no background. */}
@@ -180,7 +180,7 @@ const TabButton = ({
         </span>
       </div>
 
-      {tab.badge && <UnreadDot />}
+      {tab.badge ? <UnreadDot /> : null}
     </button>
   )
 }

--- a/packages/react/src/patterns/Navigation/Tabs/index.tsx
+++ b/packages/react/src/patterns/Navigation/Tabs/index.tsx
@@ -87,13 +87,13 @@ export const BaseTabs: React.FC<TabsProps> = ({
               asChild
             >
               <Link role="link" {...props}>
-                {props.variant === "upsell" && (
+                {props.variant === "upsell" ? (
                   <F0Icon
                     icon={Upsell}
                     size="md"
                     className="mr-1 text-[hsl(var(--promote-50))]"
                   />
-                )}
+                ) : null}
                 {label}
               </Link>
             </TabNavigationLink>

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -1656,26 +1656,26 @@ const OneDataCollectionComp = <
           layout === "standard" && !tmpFullWidth ? "calc(100% + 46px)" : "100%", // To counteract the -mx-[23px] from the layout,
       }}
     >
-      {showTopToolbar && (
+      {showTopToolbar ? (
         <div className="border-f1-border-primary px-page flex gap-4">
-          {totalItemSummaryPosition === "top" && (
+          {totalItemSummaryPosition === "top" ? (
             <TotalItemsSummary
               isReady={!showTotalItemSummarySkeleton}
               totalItemSummaryResult={totalItemSummaryResult}
             />
-          )}
+          ) : null}
           <div className="flex flex-1 flex-shrink justify-end">
-            {navigationFiltersPosition === "top" && (
+            {navigationFiltersPosition === "top" ? (
               <NavigationFiltersComponent
                 navigationFilters={navigationFilters}
                 currentNavigationFilters={currentNavigationFilters}
                 onChangeNavigationFilters={setCurrentNavigationFilters}
               />
-            )}
+            ) : null}
           </div>
         </div>
-      )}
-      {showBottomToolbar && (
+      ) : null}
+      {showBottomToolbar ? (
         <div
           ref={toolbarRef}
           className={cn(
@@ -1684,14 +1684,14 @@ const OneDataCollectionComp = <
             tmpFullWidth && "px-0"
           )}
         >
-          {totalItemSummaryPosition === "bottom" && (
+          {totalItemSummaryPosition === "bottom" ? (
             <div ref={headerSummaryRef} className="flex items-center">
               <TotalItemsSummary
                 isReady={!showTotalItemSummarySkeleton}
                 totalItemSummaryResult={totalItemSummaryResult}
               />
             </div>
-          )}
+          ) : null}
           <div className="flex-1">
             <OneFilterPicker
               filters={effectiveFilters}
@@ -1708,7 +1708,7 @@ const OneDataCollectionComp = <
               onPresetAction={onPresetAction}
             >
               <div ref={headerActionsRef} className="flex items-center gap-2">
-                {isLoading && (
+                {isLoading ? (
                   <motion.div
                     className="flex h-8 w-8 items-center justify-center"
                     initial={{ opacity: 0 }}
@@ -1719,8 +1719,8 @@ const OneDataCollectionComp = <
                   >
                     <Spinner size="small" />
                   </motion.div>
-                )}
-                {search && (
+                ) : null}
+                {search ? (
                   <Search
                     onChange={setCurrentSearch}
                     value={currentSearch}
@@ -1731,16 +1731,16 @@ const OneDataCollectionComp = <
                     loadingMore={searchPreview.loadingMore}
                     onLoadMore={searchPreview.onLoadMore}
                   />
-                )}
-                {visualizations && visualizations.length > 1 && (
+                ) : null}
+                {visualizations && visualizations.length > 1 ? (
                   <VisualizationSwitcher
                     visualizations={visualizations}
                     currentVisualization={currentVisualization}
                     onVisualizationChange={setCurrentVisualization}
                     hideLabels={collapseHeaderActions}
                   />
-                )}
-                {shouldShowSettings && (
+                ) : null}
+                {shouldShowSettings ? (
                   <Settings
                     visualizations={visualizations}
                     currentVisualization={currentVisualization}
@@ -1752,12 +1752,12 @@ const OneDataCollectionComp = <
                     defaultSortings={defaultSortings.current}
                     onSortingsChange={setCurrentSortings}
                   />
-                )}
-                {hasCollectionsActions && (
+                ) : null}
+                {hasCollectionsActions ? (
                   <>
-                    {elementsRightActions && (
+                    {elementsRightActions ? (
                       <div className="mx-1 h-4 w-px bg-f1-background-secondary-hover" />
-                    )}
+                    ) : null}
                     <CollectionActions
                       primaryActions={primaryActionItems}
                       primaryActionsLabel={primaryActionsLabel}
@@ -1766,19 +1766,19 @@ const OneDataCollectionComp = <
                       upsellAction={upsellActionItem}
                     />
                   </>
-                )}
-                {navigationFiltersPosition === "bottom" && (
+                ) : null}
+                {navigationFiltersPosition === "bottom" ? (
                   <NavigationFiltersComponent
                     navigationFilters={navigationFilters}
                     currentNavigationFilters={currentNavigationFilters}
                     onChangeNavigationFilters={setCurrentNavigationFilters}
                   />
-                )}
+                ) : null}
               </div>
             </OneFilterPicker>
           </div>
         </div>
-      )}
+      ) : null}
       {/* Visualization renderer must be always mounted to react (load data) even if empty state is shown */}
       <div
         ref={vizContainerRef}
@@ -1789,7 +1789,7 @@ const OneDataCollectionComp = <
       >
         {/* With perPage "auto", defer mounting one frame until the container
             is measured, so the first fetch already uses the resolved size */}
-        {(!autoPerPageEnabled || autoPerPage !== undefined) && (
+        {!autoPerPageEnabled || autoPerPage !== undefined ? (
           <VisualizationRenderer
             visualization={visualizations[currentVisualization]}
             source={effectiveSource}
@@ -1799,7 +1799,7 @@ const OneDataCollectionComp = <
             tmpFullWidth={tmpFullWidth}
             searchSelectionNonce={searchPreview.selectionNonce}
           />
-        )}
+        ) : null}
       </div>
       {emptyState ? (
         <div className="flex flex-1 flex-col items-center justify-center">
@@ -1812,7 +1812,7 @@ const OneDataCollectionComp = <
         </div>
       ) : (
         <>
-          {bulkActions && (
+          {bulkActions ? (
             <ActionBar
               ref={actionBarRef}
               isOpen={
@@ -1842,7 +1842,7 @@ const OneDataCollectionComp = <
               isAllItemsSelected={isAllItemsSelected}
               totalItems={totalItems}
             />
-          )}
+          ) : null}
         </>
       )}
       <PresetFormDialog
@@ -1887,23 +1887,24 @@ const OneDataCollectionComp = <
           )
           .map((preset) => preset.label)}
       />
-      {typeof document !== "undefined" &&
-        createPortal(
-          // Portal next to the preset dialog (same container it uses) inside a
-          // stacking context above its overlay (z-50), so the confirmation
-          // paints on top of the overlay it's triggered from. The z-index is
-          // set inline (not a Tailwind arbitrary class) so it always applies
-          // regardless of the consumer's CSS build.
-          <div style={{ position: "relative", zIndex: 9999 }}>
-            <F0ActionBar
-              isOpen={shareCopied}
-              variant="light"
-              status="success"
-              label={i18n.collections.presets.copiedToClipboard}
-            />
-          </div>,
-          document.getElementById("content") ?? document.body
-        )}
+      {typeof document !== "undefined"
+        ? createPortal(
+            // Portal next to the preset dialog (same container it uses) inside a
+            // stacking context above its overlay (z-50), so the confirmation
+            // paints on top of the overlay it's triggered from. The z-index is
+            // set inline (not a Tailwind arbitrary class) so it always applies
+            // regardless of the consumer's CSS build.
+            <div style={{ position: "relative", zIndex: 9999 }}>
+              <F0ActionBar
+                isOpen={shareCopied}
+                variant="light"
+                status="success"
+                label={i18n.collections.presets.copiedToClipboard}
+              />
+            </div>,
+            document.getElementById("content") ?? document.body
+          )
+        : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/SortAndHideSettings.tsx
@@ -130,7 +130,7 @@ export const SortAndHideSettings = ({
 
   return (
     <div className="relative -mr-2 flex flex-col gap-2">
-      {onAddColumn && (
+      {onAddColumn ? (
         <div className="flex">
           <ButtonInternal
             variant="ghost"
@@ -140,7 +140,7 @@ export const SortAndHideSettings = ({
             onClick={onAddColumn}
           />
         </div>
-      )}
+      ) : null}
       {/*
         Cap the scrollable viewport (not the ScrollArea root) at ~8 rows.
         Radix's viewport is `height: 100%`, which does not resolve against a
@@ -164,7 +164,7 @@ export const SortAndHideSettings = ({
           allowSorting={allowSorting}
           allowHiding={allowHiding}
         />
-        {showToggleAll && (
+        {showToggleAll ? (
           <div className="sticky bottom-0 flex justify-between bg-f1-background/80 p-2 pl-0 backdrop-blur-sm">
             <F0Button
               variant="outline"
@@ -179,7 +179,7 @@ export const SortAndHideSettings = ({
               onClick={() => toggleAll(false)}
             />
           </div>
-        )}
+        ) : null}
       </ScrollArea>
     </div>
   )

--- a/packages/react/src/patterns/OneDataCollection/Settings/components/GroupingSelector.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/GroupingSelector.tsx
@@ -90,7 +90,7 @@ export const GroupingSelector = <
             }
           />
         </div>
-        {currentGrouping?.field && (
+        {currentGrouping?.field ? (
           <F0Button
             hideLabel
             label={i18n.collections.grouping.toggleDirection}
@@ -103,7 +103,7 @@ export const GroupingSelector = <
               })
             }
           />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/patterns/OneDataCollection/Settings/components/SortingSelector.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/SortingSelector.tsx
@@ -67,7 +67,7 @@ export const SortingSelector = <Sortings extends SortingsDefinition>({
           />
         </div>
 
-        {displaySortings.field !== EmptySortingValue && (
+        {displaySortings.field !== EmptySortingValue ? (
           <div>
             <F0Button
               hideLabel
@@ -82,7 +82,7 @@ export const SortingSelector = <Sortings extends SortingsDefinition>({
               }
             />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/by-view/by-view.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/by-view/by-view.stories.tsx
@@ -274,7 +274,9 @@ function CrudByViewScenario({
           onClick: () => setPreviewedResource(null),
         }}
       >
-        {previewedResource && <CrudContentPlaceholder minHeight="min-h-56" />}
+        {previewedResource ? (
+          <CrudContentPlaceholder minHeight="min-h-56" />
+        ) : null}
       </F0Dialog>
       <F0Dialog
         isOpen={editingResource !== null}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.stories.tsx
@@ -253,7 +253,9 @@ function CardDeleteScenario() {
           onClick: () => setPreviewedResource(null),
         }}
       >
-        {previewedResource && <CrudContentPlaceholder minHeight="min-h-56" />}
+        {previewedResource ? (
+          <CrudContentPlaceholder minHeight="min-h-56" />
+        ) : null}
       </F0Dialog>
       <F0Dialog
         isOpen={selectedResource !== null}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -149,7 +149,9 @@ function DefaultDialogScenario() {
           onClick: () => setSelectedResource(null),
         }}
       >
-        {selectedResource && <CrudContentPlaceholder minHeight="min-h-56" />}
+        {selectedResource ? (
+          <CrudContentPlaceholder minHeight="min-h-56" />
+        ) : null}
       </F0Dialog>
     </CrudPatternLayout>
   )
@@ -192,7 +194,9 @@ function VisualizationDialogScenario({
           onClick: () => setSelectedResource(null),
         }}
       >
-        {selectedResource && <CrudContentPlaceholder minHeight="min-h-56" />}
+        {selectedResource ? (
+          <CrudContentPlaceholder minHeight="min-h-56" />
+        ) : null}
       </F0Dialog>
     </CrudPatternLayout>
   )
@@ -275,7 +279,7 @@ function RightDialogScenario({
           onClick: () => setSelectedResource(null),
         }}
       >
-        {selectedResource && <ResourceDialogPreview />}
+        {selectedResource ? <ResourceDialogPreview /> : null}
       </F0Dialog>
     </CrudPatternLayout>
   )
@@ -328,7 +332,7 @@ function RightDialogToPageScenario() {
           onClick: () => setSurface("page"),
         }}
       >
-        {selectedResource && <ResourceDialogPreview />}
+        {selectedResource ? <ResourceDialogPreview /> : null}
       </F0Dialog>
     </CrudPatternLayout>
   )

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.stories.tsx
@@ -100,11 +100,11 @@ function RightPositionDialogScenario({
           onClick: () => setPreviewedResource(null),
         }}
       >
-        {previewedResource && (
+        {previewedResource ? (
           <div className="flex h-full flex-col p-4">
             <CrudContentPlaceholder minHeight="h-[calc(95dvh-12.5rem)]" />
           </div>
-        )}
+        ) : null}
       </F0Dialog>
       <F0Dialog
         isOpen={selectedResource !== null}
@@ -126,7 +126,7 @@ function RightPositionDialogScenario({
         }}
         disableContentPadding
       >
-        {selectedResource && (
+        {selectedResource ? (
           <ResourceFormF0
             key={selectedResource.id}
             mode="update"
@@ -134,7 +134,7 @@ function RightPositionDialogScenario({
             formRef={formRef}
             onSuccess={() => setSelectedResource(null)}
           />
-        )}
+        ) : null}
       </F0Dialog>
     </CrudPatternLayout>
   )
@@ -201,7 +201,9 @@ function UpdateWithSameFormScenario() {
           onClick: () => setPreviewedResource(null),
         }}
       >
-        {previewedResource && <CrudContentPlaceholder minHeight="min-h-56" />}
+        {previewedResource ? (
+          <CrudContentPlaceholder minHeight="min-h-56" />
+        ) : null}
       </F0Dialog>
       <F0Dialog
         isOpen={selectedResource !== null}
@@ -356,7 +358,9 @@ function CardActionsUpdateScenario() {
           onClick: () => setPreviewedResource(null),
         }}
       >
-        {previewedResource && <CrudContentPlaceholder minHeight="min-h-56" />}
+        {previewedResource ? (
+          <CrudContentPlaceholder minHeight="min-h-56" />
+        ) : null}
       </F0Dialog>
       <F0Dialog
         isOpen={selectedResource !== null}

--- a/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/filters/per-visualization-filters.stories.tsx
@@ -649,7 +649,7 @@ const PersistenceHarness = () => {
         </details>
       </div>
 
-      {mounted && <PersistenceCollection />}
+      {mounted ? <PersistenceCollection /> : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/performance/row-commits.stories.tsx
@@ -172,7 +172,7 @@ const Harness = ({
         however many rows are already loaded, not grow with them.
       </p>
 
-      {readout.length > 0 && (
+      {readout.length > 0 ? (
         <table className="w-fit border-collapse text-left">
           <thead>
             <tr className="text-f1-foreground-secondary">
@@ -191,7 +191,7 @@ const Harness = ({
             ))}
           </tbody>
         </table>
-      )}
+      ) : null}
 
       <OneDataCollection
         source={source}

--- a/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
@@ -150,8 +150,8 @@ export const OneDataCollectionActionBar = forwardRef<
     }
     return (
       <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center">
-        {warningMessage && <WarningAlert message={warningMessage} />}
-        {!!displayedSelectedNumber && (
+        {warningMessage ? <WarningAlert message={warningMessage} /> : null}
+        {displayedSelectedNumber ? (
           <div className="dark flex h-8 w-full items-center justify-between gap-3 px-2 sm:h-auto sm:w-fit sm:justify-start sm:pl-2 sm:pr-0">
             {showAllItemsSelected ? (
               <span className="font-medium tabular-nums text-f1-foreground">
@@ -182,7 +182,7 @@ export const OneDataCollectionActionBar = forwardRef<
               size="sm"
             />
           </div>
-        )}
+        ) : null}
       </div>
     )
   }, [

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -153,7 +153,7 @@ export const CollectionActions = ({
         )
       })}
 
-      {upsellAction && (
+      {upsellAction ? (
         <F0Button
           size="md"
           variant={upsellAction.variant ?? "outlinePromote"}
@@ -162,9 +162,9 @@ export const CollectionActions = ({
           onClick={upsellAction.onClick}
           disabled={upsellAction.disabled}
         />
-      )}
+      ) : null}
 
-      {dropdownItems.length > 0 && (
+      {dropdownItems.length > 0 ? (
         <Dropdown
           items={dropdownItems}
           align="end"
@@ -179,7 +179,7 @@ export const CollectionActions = ({
             pressed={open}
           />
         </Dropdown>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/components/NavigationFilters/NavigationFilters.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/NavigationFilters/NavigationFilters.tsx
@@ -24,24 +24,25 @@ export const NavigationFilters = <
 }: NavigationFiltersProps<NavigationFilters>) => {
   return (
     <>
-      {navigationFilters &&
-        Object.entries(navigationFilters).map(([key, filter]) => {
-          const filterDef = navigationFilterTypes[filter.type]
-          return (
-            <React.Fragment key={key}>
-              {filterDef.render({
-                filter: filter,
-                value: currentNavigationFilters[key]!,
-                onChange: (value) => {
-                  onChangeNavigationFilters({
-                    ...currentNavigationFilters,
-                    [key]: value,
-                  })
-                },
-              })}
-            </React.Fragment>
-          )
-        })}
+      {navigationFilters
+        ? Object.entries(navigationFilters).map(([key, filter]) => {
+            const filterDef = navigationFilterTypes[filter.type]
+            return (
+              <React.Fragment key={key}>
+                {filterDef.render({
+                  filter: filter,
+                  value: currentNavigationFilters[key]!,
+                  onChange: (value) => {
+                    onChangeNavigationFilters({
+                      ...currentNavigationFilters,
+                      [key]: value,
+                    })
+                  },
+                })}
+              </React.Fragment>
+            )
+          })
+        : null}
     </>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/components/PagesPagination/PagesPagination.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/PagesPagination/PagesPagination.tsx
@@ -29,11 +29,12 @@ export const PagesPagination = ({
       )}
     >
       <span className="shrink-0 text-f1-foreground-secondary">
-        {paginationInfo.total > 0 &&
-          `${(paginationInfo.currentPage - 1) * paginationInfo.perPage + 1}-${Math.min(
-            paginationInfo.currentPage * paginationInfo.perPage,
-            paginationInfo.total
-          )} ${t.collections.visualizations.pagination.of} ${paginationInfo.total}`}
+        {paginationInfo.total > 0
+          ? `${(paginationInfo.currentPage - 1) * paginationInfo.perPage + 1}-${Math.min(
+              paginationInfo.currentPage * paginationInfo.perPage,
+              paginationInfo.total
+            )} ${t.collections.visualizations.pagination.of} ${paginationInfo.total}`
+          : null}
       </span>
       <div className="flex items-center">
         <OnePagination

--- a/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
@@ -280,7 +280,7 @@ export const Search = ({
                   >
                     <IconComponent loading={loading || resultsLoading} />
                   </motion.div>
-                  {value && (
+                  {value ? (
                     <div className="flex h-7 w-full items-center justify-between gap-1.5 overflow-hidden pr-1.5">
                       <motion.div
                         layout
@@ -313,7 +313,7 @@ export const Search = ({
                         />
                       </motion.div>
                     </div>
-                  )}
+                  ) : null}
                 </motion.div>
               </motion.div>
             )}

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__stories__/useDataCollectionItemNavigation.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__stories__/useDataCollectionItemNavigation.stories.tsx
@@ -168,7 +168,7 @@ const UserDetail = ({
           <div className="flex items-center gap-2">
             {/* PageHeader renders this same thing from the provided context;
                 shown standalone here to keep the story focused */}
-            {navigation && <PageNavigation {...navigation} />}
+            {navigation ? <PageNavigation {...navigation} /> : null}
             <F0Button
               variant="outline"
               size="sm"
@@ -227,10 +227,10 @@ const DetailNavigationDemo = () => {
             direct-link scenario.
           </span>
         </div>
-        {activeUserId && (
+        {activeUserId ? (
           <UserDetail userId={activeUserId} onNavigate={setActiveUserId} />
-        )}
-        {listMounted && <UserList onOpenUser={setActiveUserId} />}
+        ) : null}
+        {listMounted ? <UserList onOpenUser={setActiveUserId} /> : null}
       </div>
     </DataCollectionStorageProvider>
   )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -450,56 +450,57 @@ export const CardCollection = <
           </CardGrid>
         ) : (
           <>
-            {data?.type === "grouped" &&
-              data.groups.map((group) => {
-                return (
-                  <>
-                    <GroupHeader
-                      label={group.label}
-                      itemCount={group.itemCount}
-                      onOpenChange={(open) => setGroupOpen(group.key, open)}
-                      open={openGroups[group.key]}
-                      selectable={!!source.selectable}
-                      showOpenChange={collapsible}
-                      select={
-                        groupAllSelectedStatus[group.key]?.checked
-                          ? true
-                          : groupAllSelectedStatus[group.key]?.indeterminate
-                            ? "indeterminate"
-                            : false
-                      }
-                      onSelectChange={(checked) =>
-                        handleSelectGroupChange(group, checked)
-                      }
-                      className="px-page pb-2 pt-4"
-                    />
-                    <AnimatePresence>
-                      {(!collapsible || openGroups[group.key]) && (
-                        <GroupCards
-                          key={group.key}
-                          source={source}
-                          items={group.records}
-                          selectedItems={selectedItems}
-                          handleSelectItemChange={handleSelectItemChange}
-                          title={title}
-                          cardProperties={cardProperties}
-                          description={description}
-                          avatar={avatar}
-                          image={image}
-                          imageFit={imageFit}
-                          imageSize={imageSize}
-                          imageAspectRatio={imageAspectRatio}
-                          blurredBackground={blurredBackground}
-                          compact={compact}
-                          tmpFullWidth={tmpFullWidth}
-                        />
-                      )}
-                    </AnimatePresence>
-                  </>
-                )
-              })}
+            {data?.type === "grouped"
+              ? data.groups.map((group) => {
+                  return (
+                    <>
+                      <GroupHeader
+                        label={group.label}
+                        itemCount={group.itemCount}
+                        onOpenChange={(open) => setGroupOpen(group.key, open)}
+                        open={openGroups[group.key]}
+                        selectable={!!source.selectable}
+                        showOpenChange={collapsible}
+                        select={
+                          groupAllSelectedStatus[group.key]?.checked
+                            ? true
+                            : groupAllSelectedStatus[group.key]?.indeterminate
+                              ? "indeterminate"
+                              : false
+                        }
+                        onSelectChange={(checked) =>
+                          handleSelectGroupChange(group, checked)
+                        }
+                        className="px-page pb-2 pt-4"
+                      />
+                      <AnimatePresence>
+                        {!collapsible || openGroups[group.key] ? (
+                          <GroupCards
+                            key={group.key}
+                            source={source}
+                            items={group.records}
+                            selectedItems={selectedItems}
+                            handleSelectItemChange={handleSelectItemChange}
+                            title={title}
+                            cardProperties={cardProperties}
+                            description={description}
+                            avatar={avatar}
+                            image={image}
+                            imageFit={imageFit}
+                            imageSize={imageSize}
+                            imageAspectRatio={imageAspectRatio}
+                            blurredBackground={blurredBackground}
+                            compact={compact}
+                            tmpFullWidth={tmpFullWidth}
+                          />
+                        ) : null}
+                      </AnimatePresence>
+                    </>
+                  )
+                })
+              : null}
 
-            {data?.type === "flat" && (
+            {data?.type === "flat" ? (
               <GroupCards
                 source={source}
                 items={data.records}
@@ -517,7 +518,7 @@ export const CardCollection = <
                 compact={compact}
                 tmpFullWidth={tmpFullWidth}
               />
-            )}
+            ) : null}
           </>
         )}
       </div>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/BaseCell.tsx
@@ -85,9 +85,9 @@ export function BaseCell({
       )}
     >
       <ErrorTooltip message={error}>
-        {hintPosition === "left" && hintIcon}
+        {hintPosition === "left" ? hintIcon : null}
         <div className="min-w-0 flex-1">{children}</div>
-        {hintPosition === "right" && hintIcon}
+        {hintPosition === "right" ? hintIcon : null}
       </ErrorTooltip>
     </div>
   )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ErrorTooltip.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ErrorTooltip.tsx
@@ -44,7 +44,7 @@ export function ErrorTooltip({ message, children }: ErrorTooltipProps) {
               {children}
             </div>
           </TooltipTrigger>
-          {message && (
+          {message ? (
             <TooltipContent
               side="top"
               className="border-black/10 flex items-center gap-1 bg-[#fff] shadow-md"
@@ -54,7 +54,7 @@ export function ErrorTooltip({ message, children }: ErrorTooltipProps) {
                 {message}
               </span>
             </TooltipContent>
-          )}
+          ) : null}
         </Tooltip>
       </TooltipProvider>
     </div>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/NumberCell.tsx
@@ -81,7 +81,7 @@ export function NumberCell<R extends RecordType>({
           )}
           style={{ width }}
         >
-          {unitsBefore && unitsSpan}
+          {unitsBefore ? unitsSpan : null}
           <F0NumberInput
             label={editableColumn.label}
             hideLabel
@@ -98,7 +98,7 @@ export function NumberCell<R extends RecordType>({
             step={config?.step}
             maxDecimals={config?.maxDecimals}
           />
-          {!unitsBefore && unitsSpan}
+          {!unitsBefore ? unitsSpan : null}
         </div>
       </div>
     </BaseCell>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
@@ -128,24 +128,24 @@ export function ReadOnlyCellContent<R extends RecordType>({
       )}
     >
       <span className="flex min-w-0 items-center gap-1.5">
-        {leadingIcon && (
+        {leadingIcon ? (
           <span className="flex h-5 w-5 shrink-0 items-center justify-center">
             <F0Icon icon={leadingIcon} color={iconColor} />
           </span>
-        )}
-        {unitsBefore && unit}
+        ) : null}
+        {unitsBefore ? unit : null}
         <span className="min-w-0 truncate">
           {formattedDate ??
             multiSelectLabel ??
             renderProperty(item, editableColumn, "editableTable", i18n)}
         </span>
-        {!unitsBefore && unit}
+        {!unitsBefore ? unit : null}
       </span>
-      {isSelect && (
+      {isSelect ? (
         <span className="flex shrink-0 items-center">
           <Arrow open={false} size="sm" />
         </span>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -534,7 +534,7 @@ export const KanbanCollection = <
                     onOpenChange={(open) => setGroupOpen(board.key, open)}
                   />
                   <AnimatePresence>
-                    {(!collapsible || openGroups[board.key]) && (
+                    {!collapsible || openGroups[board.key] ? (
                       <motion.div
                         initial={{ height: 0, opacity: 0 }}
                         animate={{ height: "auto", opacity: 1 }}
@@ -560,7 +560,7 @@ export const KanbanCollection = <
                           loading={kanbanLoading}
                         />
                       </motion.div>
-                    )}
+                    ) : null}
                   </AnimatePresence>
                 </div>
               )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/ItemTeaser.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/ItemTeaser.tsx
@@ -10,7 +10,7 @@ export type ItemTeaserProps = {
 export const ItemTeaser = ({ title, avatar, description }: ItemTeaserProps) => {
   return (
     <article className="flex w-[calc(100%-72px)] min-w-40 flex-col items-start gap-3 md:w-full md:flex-row md:items-center md:gap-2">
-      {avatar && <F0Avatar avatar={avatar} size="md" />}
+      {avatar ? <F0Avatar avatar={avatar} size="md" /> : null}
       <div className="flex flex-1 flex-col gap-0.5">
         <header>
           <h3>
@@ -20,18 +20,18 @@ export const ItemTeaser = ({ title, avatar, description }: ItemTeaserProps) => {
           </h3>
         </header>
         <aside>
-          {description && description.length > 0 && (
+          {description && description.length > 0 ? (
             <div className="flex w-full flex-col text-base font-normal text-f1-foreground-secondary md:flex-row md:gap-1">
               {description.map((item, index) => (
                 <div key={index} className="flex min-w-0 gap-1">
                   <OneEllipsis>{item}</OneEllipsis>
-                  {index < description.length - 1 && (
+                  {index < description.length - 1 ? (
                     <span className="hidden md:inline"> · </span>
-                  )}
+                  ) : null}
                 </div>
               ))}
             </div>
-          )}
+          ) : null}
         </aside>
       </div>
     </article>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/ListSkeleton.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/ListSkeleton.tsx
@@ -77,11 +77,11 @@ export const ListSkeleton = <
           className="relative flex w-full flex-col justify-between gap-4 p-3 transition-colors md:flex-row md:pl-3 md:pr-4"
         >
           <div className="flex flex-1 flex-row items-center gap-2">
-            {source.selectable && (
+            {source.selectable ? (
               <div className="z-10 hidden items-center justify-end md:flex">
                 <Skeleton className="h-4 w-4" />
               </div>
-            )}
+            ) : null}
             <article className="flex w-[calc(100%-72px)] min-w-40 flex-col items-start gap-3 md:w-full md:flex-row md:items-center md:gap-2">
               <Skeleton className="h-8 w-8 rounded-full" />
               <div className="flex flex-1 flex-col gap-1">
@@ -106,12 +106,12 @@ export const ListSkeleton = <
               </div>
             ))}
           </div>
-          {source.itemActions && (
+          {source.itemActions ? (
             <div className="absolute right-3 top-3 flex h-8 w-8 items-center justify-center md:hidden">
               <Skeleton className="h-6 w-6" />
             </div>
-          )}
-          {source.selectable && (
+          ) : null}
+          {source.selectable ? (
             <div
               className={cn(
                 "absolute right-3 top-3 flex h-8 w-8 items-center justify-center md:hidden",
@@ -120,7 +120,7 @@ export const ListSkeleton = <
             >
               <Skeleton className="h-4 w-4" />
             </div>
-          )}
+          ) : null}
         </div>
       ))}
     </div>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -115,7 +115,7 @@ export const Row = <
         className="pointer-events-auto absolute inset-0"
       ></div>
       <div className="pointer-events-none flex flex-1 flex-row items-center gap-2">
-        {source.selectable && id !== undefined && (
+        {source.selectable && id !== undefined ? (
           // z-10 is needed here to prevent the checkbox from not being selectable when itemHref is provided
           <div
             className={cn(
@@ -134,8 +134,8 @@ export const Row = <
               hideLabel
             />
           </div>
-        )}
-        {itemHref && (
+        ) : null}
+        {itemHref ? (
           <F0Link
             href={itemHref}
             className="pointer-events-auto absolute inset-0 block"
@@ -145,7 +145,7 @@ export const Row = <
           >
             <span className="sr-only">{actions.view}</span>
           </F0Link>
-        )}
+        ) : null}
         <ItemTeaser
           title={itemDef.title}
           avatar={itemDef.avatar}
@@ -171,7 +171,7 @@ export const Row = <
             )
           })}
       </div>
-      {source.itemActions && (
+      {source.itemActions ? (
         <>
           <ItemActionsRowContainer
             dropDownOpen={dropDownOpen}
@@ -184,16 +184,16 @@ export const Row = <
             />
           </ItemActionsRowContainer>
 
-          {hasMobileItemActions && (
+          {hasMobileItemActions ? (
             <ItemActionsMobile
               className="absolute -right-px bottom-0 top-0 z-20 items-center justify-end gap-2 py-2 pl-20 pr-3 md:hidden"
               items={mobileDropdownItemActions}
               onOpenChange={handleDropDownOpenChange}
             />
-          )}
+          ) : null}
         </>
-      )}
-      {source.selectable && id !== undefined && (
+      ) : null}
+      {source.selectable && id !== undefined ? (
         <div
           className={cn(
             "pointer-events-auto absolute right-3 top-3 flex h-8 w-8 items-center justify-center md:hidden",
@@ -209,7 +209,7 @@ export const Row = <
             hideLabel
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/index.tsx
@@ -185,62 +185,63 @@ export const ListCollection = <
         aria-busy={showFullscreenLoading ? "true" : undefined}
       >
         <div className="min-h-0 flex-1 overflow-auto pb-3">
-          {data.type === "grouped" &&
-            data.groups.map((group, index) => {
-              const itemCount = group.itemCount
-              return (
-                <div
-                  className="flex flex-col gap-0 pt-2 first:pt-0"
-                  key={`group-header-${group.key}`}
-                >
-                  <GroupHeader
+          {data.type === "grouped"
+            ? data.groups.map((group, index) => {
+                const itemCount = group.itemCount
+                return (
+                  <div
+                    className="flex flex-col gap-0 pt-2 first:pt-0"
                     key={`group-header-${group.key}`}
-                    className="cursor-pointer select-none rounded-md px-3.5 py-3 transition-colors hover:bg-f1-background-hover"
-                    selectable={!!source.selectable}
-                    select={
-                      groupAllSelectedStatus[group.key]?.checked
-                        ? true
-                        : groupAllSelectedStatus[group.key]?.indeterminate
-                          ? "indeterminate"
-                          : false
-                    }
-                    onSelectChange={(checked) =>
-                      handleSelectGroupChange(group, checked)
-                    }
-                    showOpenChange={collapsible}
-                    label={group.label}
-                    itemCount={itemCount}
-                    open={openGroups[group.key]}
-                    onOpenChange={(open) => setGroupOpen(group.key, open)}
-                  />
-                  <AnimatePresence>
-                    {(!collapsible || openGroups[group.key]) && (
-                      <motion.div
-                        initial={{ height: 0, opacity: 0 }}
-                        animate={{ height: "auto", opacity: 1 }}
-                        exit={{ height: 0, opacity: 0 }}
-                        transition={{ duration: 0.1, ease: "easeInOut" }}
-                        className="mt-0.5"
-                      >
-                        <ListGroup
-                          key={`list-group-${group.key}`}
-                          source={source}
-                          items={group.records}
-                          selectedItems={selectedItems}
-                          handleSelectItemChange={handleSelectItemChange}
-                          fields={fields}
-                          itemDefinition={itemDefinition}
-                          isLoadingMore={
-                            isLoadingMore && index === data.groups.length - 1
-                          }
-                        />
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </div>
-              )
-            })}
-          {data?.type === "flat" && (
+                  >
+                    <GroupHeader
+                      key={`group-header-${group.key}`}
+                      className="cursor-pointer select-none rounded-md px-3.5 py-3 transition-colors hover:bg-f1-background-hover"
+                      selectable={!!source.selectable}
+                      select={
+                        groupAllSelectedStatus[group.key]?.checked
+                          ? true
+                          : groupAllSelectedStatus[group.key]?.indeterminate
+                            ? "indeterminate"
+                            : false
+                      }
+                      onSelectChange={(checked) =>
+                        handleSelectGroupChange(group, checked)
+                      }
+                      showOpenChange={collapsible}
+                      label={group.label}
+                      itemCount={itemCount}
+                      open={openGroups[group.key]}
+                      onOpenChange={(open) => setGroupOpen(group.key, open)}
+                    />
+                    <AnimatePresence>
+                      {!collapsible || openGroups[group.key] ? (
+                        <motion.div
+                          initial={{ height: 0, opacity: 0 }}
+                          animate={{ height: "auto", opacity: 1 }}
+                          exit={{ height: 0, opacity: 0 }}
+                          transition={{ duration: 0.1, ease: "easeInOut" }}
+                          className="mt-0.5"
+                        >
+                          <ListGroup
+                            key={`list-group-${group.key}`}
+                            source={source}
+                            items={group.records}
+                            selectedItems={selectedItems}
+                            handleSelectItemChange={handleSelectItemChange}
+                            fields={fields}
+                            itemDefinition={itemDefinition}
+                            isLoadingMore={
+                              isLoadingMore && index === data.groups.length - 1
+                            }
+                          />
+                        </motion.div>
+                      ) : null}
+                    </AnimatePresence>
+                  </div>
+                )
+              })
+            : null}
+          {data?.type === "flat" ? (
             <ListGroup
               source={source}
               items={data.records}
@@ -250,19 +251,19 @@ export const ListCollection = <
               itemDefinition={itemDefinition}
               isLoadingMore={isLoadingMore}
             />
-          )}
+          ) : null}
           {/* Show skeleton items when loading more data */}
-          {isInfiniteScrollPagination(paginationInfo) && isLoadingMore && (
+          {isInfiniteScrollPagination(paginationInfo) && isLoadingMore ? (
             <ListSkeleton source={source} fields={fields} count={5} />
-          )}
+          ) : null}
           {isInfiniteScrollPagination(paginationInfo) &&
-            paginationInfo.hasMore && (
-              <div
-                ref={loadingIndicatorRef}
-                className="w-full"
-                aria-hidden="true"
-              />
-            )}
+          paginationInfo.hasMore ? (
+            <div
+              ref={loadingIndicatorRef}
+              className="w-full"
+              aria-hidden="true"
+            />
+          ) : null}
         </div>
       </div>
       <PagesPagination paginationInfo={paginationInfo} setPage={setPage} />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -531,7 +531,7 @@ export const TableCollection = <
             <TableHeader sticky={true}>
               {headerGroups ? (
                 <TableRow>
-                  {source.selectable && (
+                  {source.selectable ? (
                     <TableHead
                       align="left"
                       sticky={{ left: 0 }}
@@ -543,7 +543,7 @@ export const TableCollection = <
                     >
                       <div className="ml-3.5 flex w-full items-center justify-start" />
                     </TableHead>
-                  )}
+                  ) : null}
                   {headerGroups.map((entry, entryIndex) => {
                     // A collapsible group is clickable, so it keeps the cell's
                     // hover highlight — the same one a sortable column header
@@ -643,8 +643,8 @@ export const TableCollection = <
                       </TableHead>
                     )
                   })}
-                  {showItemActions &&
-                    (isEditableTable ? (
+                  {showItemActions ? (
+                    isEditableTable ? (
                       <TableHead
                         key="actions"
                         width="fit"
@@ -667,11 +667,12 @@ export const TableCollection = <
                           <span />
                         </TableHead>
                       </>
-                    ))}
+                    )
+                  ) : null}
                 </TableRow>
               ) : null}
               <TableRow>
-                {source.selectable && (
+                {source.selectable ? (
                   <TableHead
                     width={checkColumnWidth}
                     sticky={{ left: 0 }}
@@ -682,7 +683,7 @@ export const TableCollection = <
                         : undefined
                     }
                   >
-                    {!selectAllDisabled && (
+                    {!selectAllDisabled ? (
                       <div className="ml-3.5 flex w-full items-center justify-start">
                         <F0Checkbox
                           checked={isAllSelected}
@@ -693,9 +694,9 @@ export const TableCollection = <
                           disabled={data?.records.length === 0}
                         />
                       </div>
-                    )}
+                    ) : null}
                   </TableHead>
-                )}
+                ) : null}
                 {columns.map(({ sorting, label, ...column }, index) => {
                   const headerGroup = headerGroups?.find(
                     (group) =>
@@ -749,8 +750,8 @@ export const TableCollection = <
                     </TableHead>
                   )
                 })}
-                {showItemActions &&
-                  (isEditableTable ? (
+                {showItemActions ? (
+                  isEditableTable ? (
                     <TableHead key="actions" width="fit" sticky={{ right: 0 }}>
                       <span className="sr-only">
                         {i18n.collections.actions.actions}
@@ -771,255 +772,264 @@ export const TableCollection = <
                         {i18n.collections.actions.actions}
                       </TableHead>
                     </>
-                  ))}
+                  )
+                ) : null}
               </TableRow>
               {hasSelection &&
-                source.selectable &&
-                !!source.allPagesSelection && (
-                  <TableRow>
-                    <th
-                      colSpan={1 + selectionHeaderColSpan}
-                      className="h-11 border-0 border-t border-solid border-f1-border-secondary bg-f1-background-secondary px-5"
-                    >
-                      <div className="flex items-center gap-3">
-                        <HighlightedCount
-                          text={
-                            allSelectedStatus.checked &&
-                            !allSelectedStatus.indeterminate
-                              ? t("status.selected.allItemsSelected", {
-                                  total: selectableTotal,
+              source.selectable &&
+              !!source.allPagesSelection ? (
+                <TableRow>
+                  <th
+                    colSpan={1 + selectionHeaderColSpan}
+                    className="h-11 border-0 border-t border-solid border-f1-border-secondary bg-f1-background-secondary px-5"
+                  >
+                    <div className="flex items-center gap-3">
+                      <HighlightedCount
+                        text={
+                          allSelectedStatus.checked &&
+                          !allSelectedStatus.indeterminate
+                            ? t("status.selected.allItemsSelected", {
+                                total: selectableTotal,
+                              })
+                            : allPageRowsSelected
+                              ? t("status.selected.allOnPage", {
+                                  count: allSelectedStatus.selectedCount,
                                 })
-                              : allPageRowsSelected
-                                ? t("status.selected.allOnPage", {
-                                    count: allSelectedStatus.selectedCount,
-                                  })
-                                : `${allSelectedStatus.selectedCount} ${selectedText}`
-                          }
-                          count={
-                            allSelectedStatus.checked &&
-                            !allSelectedStatus.indeterminate
-                              ? selectableTotal
-                              : allSelectedStatus.selectedCount
-                          }
+                              : `${allSelectedStatus.selectedCount} ${selectedText}`
+                        }
+                        count={
+                          allSelectedStatus.checked &&
+                          !allSelectedStatus.indeterminate
+                            ? selectableTotal
+                            : allSelectedStatus.selectedCount
+                        }
+                      />
+                      {showSelectAllOption ? (
+                        <F0Button
+                          variant="outline"
+                          label={t("status.selected.selectAllItems", {
+                            total: selectableTotal,
+                          })}
+                          onClick={() => handleSelectAllItems(true)}
+                          size="sm"
                         />
-                        {showSelectAllOption && (
-                          <F0Button
-                            variant="outline"
-                            label={t("status.selected.selectAllItems", {
-                              total: selectableTotal,
-                            })}
-                            onClick={() => handleSelectAllItems(true)}
-                            size="sm"
-                          />
-                        )}
-                      </div>
-                    </th>
-                  </TableRow>
-                )}
+                      ) : null}
+                    </div>
+                  </th>
+                </TableRow>
+              ) : null}
             </TableHeader>
             <TableBody>
-              {data?.type === "grouped" &&
-                data.groups.map((group, groupIndex) => {
-                  const itemCount = group.itemCount
-                  return (
-                    <Fragment key={`group-${group.key}`}>
-                      <TableRow key={`group-header-${group.key}`} sticky>
-                        {source.selectable && (
-                          <TableCell
-                            width={checkColumnWidth}
-                            sticky={{ left: 0 }}
-                          >
-                            <div className="pointer-events-auto ml-1.5 flex items-center justify-start">
-                              {/* A group checkbox selects the whole group. */}
-                              {!selectAllDisabled && (
-                                <F0Checkbox
-                                  checked={
-                                    !!statusToChecked(
-                                      groupAllSelectedStatus[group.key]
-                                    )
-                                  }
-                                  indeterminate={
-                                    statusToChecked(
-                                      groupAllSelectedStatus[group.key]
-                                    ) === "indeterminate"
-                                  }
-                                  title={i18n.actions.selectAll}
-                                  hideLabel
-                                  onCheckedChange={(checked) =>
-                                    handleSelectGroupChange(group, checked)
-                                  }
-                                />
-                              )}
-                            </div>
-                          </TableCell>
-                        )}
-                        <TableCell
-                          sticky={{
-                            left: source.selectable ? checkColumnWidth : 0,
-                          }}
-                          colSpan={frozenColumnsLeft || 1}
-                        >
-                          <GroupHeader
-                            selectable={false}
-                            showOpenChange={collapsible}
-                            label={group.label}
-                            itemCount={itemCount}
-                            open={openGroups[group.key]}
-                            onOpenChange={(open) =>
-                              setGroupOpen(group.key, open)
-                            }
-                          />
-                        </TableCell>
-                        {columns.length - (frozenColumnsLeft || 1) > 0 && (
-                          <TableCell
-                            colSpan={columns.length - (frozenColumnsLeft || 1)}
-                          >
-                            &nbsp;
-                          </TableCell>
-                        )}
-                      </TableRow>
-
-                      <AnimatePresence key={`group-animate-${groupIndex}`}>
-                        {MotionRow &&
-                          (!collapsible || openGroups[group.key]) &&
-                          group.records.map((item, index) => {
-                            const rowKey = `row-${groupIndex}-${getRowKey(item, index)}`
-                            const motionRow = (
-                              <MotionRow
-                                variants={rowAnimationVariants}
-                                initial={collapsible ? "hidden" : "visible"}
-                                animate="visible"
-                                exit="hidden"
-                                custom={index}
-                                key={rowKey}
-                                layout
-                                source={rowSource}
-                                liveSource={liveSourceFor(item)}
-                                item={item}
-                                index={index}
-                                groupIndex={groupIndex}
-                                onItemCheckedChange={stableSelectItemChange}
-                                isSelected={isItemSelected(item)}
-                                selectedItems={nestedSelectedItems(item)}
-                                columns={columns}
-                                frozenColumnsLeft={frozenColumnsLeft}
-                                checkColumnWidth={checkColumnWidth}
-                                referenceRowType={referenceRowType}
-                                rowWrapper={RowWrapper}
-                                cellRenderer={cellRenderer}
-                                headerGroups={headerGroups}
-                                collapsingCellClasses={collapsingCellClasses}
-                                fromVisualization={fromVisualization}
-                                registerSelectable={selectionRegistry.register}
-                                unregisterSelectable={
-                                  selectionRegistry.unregister
-                                }
-                              />
-                            )
-                            if (RowWrapper) {
-                              return (
-                                <RowWrapper
-                                  key={rowKey}
-                                  item={item}
-                                  index={index}
-                                >
-                                  {motionRow}
-                                </RowWrapper>
-                              )
-                            }
-
-                            return motionRow
-                          })}
-                      </AnimatePresence>
-                    </Fragment>
-                  )
-                })}
-              {data?.type === "flat" &&
-                // Deliberately not wrapped in `AnimatePresence`: a row that
-                // leaves the dataset (deleted, filtered out, re-sorted away)
-                // must unmount on the same render. An exit transition keeps it
-                // mounted — still in the DOM, still in the selection registry —
-                // for as long as it runs, so a removed row goes on answering
-                // queries and shifting row/checkbox positions. Enter and flash
-                // don't need presence tracking; `initial`/`animate` cover them.
-                data.records.map((item, index) => {
-                  const rowKey = `row-${getRowKey(item, index)}`
-                  const isNew = addedRowKeys.has(rowKey)
-                  const motionRow = (
-                    <MotionRow
-                      variants={rowAnimationVariants}
-                      // Only a genuinely-inserted row plays the enter
-                      // animation; rows arriving via pagination or the initial
-                      // load appear in place, without movement.
-                      initial={isNew ? "hidden" : false}
-                      animate="visible"
-                      custom={index}
-                      key={rowKey}
-                      layout
-                      isNew={isNew}
-                      groupIndex={0}
-                      source={rowSource}
-                      liveSource={liveSourceFor(item)}
-                      item={item}
-                      index={index}
-                      onItemCheckedChange={stableSelectItemChange}
-                      isSelected={isItemSelected(item)}
-                      selectedItems={nestedSelectedItems(item)}
-                      columns={columns}
-                      frozenColumnsLeft={frozenColumnsLeft}
-                      checkColumnWidth={checkColumnWidth}
-                      tableWithChildren={tableWithChildren}
-                      referenceRowType={referenceRowType}
-                      boldRootRows={boldRootRows}
-                      rowWrapper={RowWrapper}
-                      cellRenderer={cellRenderer}
-                      fromVisualization={fromVisualization}
-                      headerGroups={headerGroups}
-                      collapsingCellClasses={collapsingCellClasses}
-                      registerSelectable={selectionRegistry.register}
-                      unregisterSelectable={selectionRegistry.unregister}
-                    />
-                  )
-                  if (RowWrapper) {
+              {data?.type === "grouped"
+                ? data.groups.map((group, groupIndex) => {
+                    const itemCount = group.itemCount
                     return (
-                      <RowWrapper key={rowKey} item={item} index={index}>
-                        {motionRow}
-                      </RowWrapper>
-                    )
-                  }
+                      <Fragment key={`group-${group.key}`}>
+                        <TableRow key={`group-header-${group.key}`} sticky>
+                          {source.selectable ? (
+                            <TableCell
+                              width={checkColumnWidth}
+                              sticky={{ left: 0 }}
+                            >
+                              <div className="pointer-events-auto ml-1.5 flex items-center justify-start">
+                                {/* A group checkbox selects the whole group. */}
+                                {!selectAllDisabled ? (
+                                  <F0Checkbox
+                                    checked={
+                                      !!statusToChecked(
+                                        groupAllSelectedStatus[group.key]
+                                      )
+                                    }
+                                    indeterminate={
+                                      statusToChecked(
+                                        groupAllSelectedStatus[group.key]
+                                      ) === "indeterminate"
+                                    }
+                                    title={i18n.actions.selectAll}
+                                    hideLabel
+                                    onCheckedChange={(checked) =>
+                                      handleSelectGroupChange(group, checked)
+                                    }
+                                  />
+                                ) : null}
+                              </div>
+                            </TableCell>
+                          ) : null}
+                          <TableCell
+                            sticky={{
+                              left: source.selectable ? checkColumnWidth : 0,
+                            }}
+                            colSpan={frozenColumnsLeft || 1}
+                          >
+                            <GroupHeader
+                              selectable={false}
+                              showOpenChange={collapsible}
+                              label={group.label}
+                              itemCount={itemCount}
+                              open={openGroups[group.key]}
+                              onOpenChange={(open) =>
+                                setGroupOpen(group.key, open)
+                              }
+                            />
+                          </TableCell>
+                          {columns.length - (frozenColumnsLeft || 1) > 0 ? (
+                            <TableCell
+                              colSpan={
+                                columns.length - (frozenColumnsLeft || 1)
+                              }
+                            >
+                              &nbsp;
+                            </TableCell>
+                          ) : null}
+                        </TableRow>
 
-                  return motionRow
-                })}
-              {paginationInfo?.type === "infinite-scroll" &&
-                isLoadingMore &&
-                Array.from({ length: 5 }).map((_, rowIndex) => (
-                  <TableRow key={`skeleton-row-${rowIndex}`}>
-                    {Array.from({ length: skeletonColumns }).map(
-                      (_, colIndex) => (
-                        <TableCell
-                          key={`skeleton-cell-${rowIndex}-${colIndex}`}
-                        >
-                          <Skeleton className="h-4 w-full" />
-                        </TableCell>
+                        <AnimatePresence key={`group-animate-${groupIndex}`}>
+                          {!collapsible || openGroups[group.key]
+                            ? group.records.map((item, index) => {
+                                const rowKey = `row-${groupIndex}-${getRowKey(item, index)}`
+                                const motionRow = (
+                                  <MotionRow
+                                    variants={rowAnimationVariants}
+                                    initial={collapsible ? "hidden" : "visible"}
+                                    animate="visible"
+                                    exit="hidden"
+                                    custom={index}
+                                    key={rowKey}
+                                    layout
+                                    source={rowSource}
+                                    liveSource={liveSourceFor(item)}
+                                    item={item}
+                                    index={index}
+                                    groupIndex={groupIndex}
+                                    onItemCheckedChange={stableSelectItemChange}
+                                    isSelected={isItemSelected(item)}
+                                    selectedItems={nestedSelectedItems(item)}
+                                    columns={columns}
+                                    frozenColumnsLeft={frozenColumnsLeft}
+                                    checkColumnWidth={checkColumnWidth}
+                                    referenceRowType={referenceRowType}
+                                    rowWrapper={RowWrapper}
+                                    cellRenderer={cellRenderer}
+                                    headerGroups={headerGroups}
+                                    collapsingCellClasses={
+                                      collapsingCellClasses
+                                    }
+                                    fromVisualization={fromVisualization}
+                                    registerSelectable={
+                                      selectionRegistry.register
+                                    }
+                                    unregisterSelectable={
+                                      selectionRegistry.unregister
+                                    }
+                                  />
+                                )
+                                if (RowWrapper) {
+                                  return (
+                                    <RowWrapper
+                                      key={rowKey}
+                                      item={item}
+                                      index={index}
+                                    >
+                                      {motionRow}
+                                    </RowWrapper>
+                                  )
+                                }
+
+                                return motionRow
+                              })
+                            : null}
+                        </AnimatePresence>
+                      </Fragment>
+                    )
+                  })
+                : null}
+              {/* Deliberately not wrapped in `AnimatePresence`: a row that
+                  leaves the dataset (deleted, filtered out, re-sorted away)
+                  must unmount on the same render. An exit transition keeps it
+                  mounted — still in the DOM, still in the selection registry —
+                  for as long as it runs, so a removed row goes on answering
+                  queries and shifting row/checkbox positions. Enter and flash
+                  don't need presence tracking; `initial`/`animate` cover them. */}
+              {data?.type === "flat"
+                ? data.records.map((item, index) => {
+                    const rowKey = `row-${getRowKey(item, index)}`
+                    const isNew = addedRowKeys.has(rowKey)
+                    const motionRow = (
+                      <MotionRow
+                        variants={rowAnimationVariants}
+                        // Only a genuinely-inserted row plays the enter
+                        // animation; rows arriving via pagination or the initial
+                        // load appear in place, without movement.
+                        initial={isNew ? "hidden" : false}
+                        animate="visible"
+                        custom={index}
+                        key={rowKey}
+                        layout
+                        isNew={isNew}
+                        groupIndex={0}
+                        source={rowSource}
+                        liveSource={liveSourceFor(item)}
+                        item={item}
+                        index={index}
+                        onItemCheckedChange={stableSelectItemChange}
+                        isSelected={isItemSelected(item)}
+                        selectedItems={nestedSelectedItems(item)}
+                        columns={columns}
+                        frozenColumnsLeft={frozenColumnsLeft}
+                        checkColumnWidth={checkColumnWidth}
+                        tableWithChildren={tableWithChildren}
+                        referenceRowType={referenceRowType}
+                        boldRootRows={boldRootRows}
+                        rowWrapper={RowWrapper}
+                        cellRenderer={cellRenderer}
+                        fromVisualization={fromVisualization}
+                        headerGroups={headerGroups}
+                        collapsingCellClasses={collapsingCellClasses}
+                        registerSelectable={selectionRegistry.register}
+                        unregisterSelectable={selectionRegistry.unregister}
+                      />
+                    )
+                    if (RowWrapper) {
+                      return (
+                        <RowWrapper key={rowKey} item={item} index={index}>
+                          {motionRow}
+                        </RowWrapper>
                       )
-                    )}
-                  </TableRow>
-                ))}
+                    }
+
+                    return motionRow
+                  })
+                : null}
+              {paginationInfo?.type === "infinite-scroll" && isLoadingMore
+                ? Array.from({ length: 5 }).map((_, rowIndex) => (
+                    <TableRow key={`skeleton-row-${rowIndex}`}>
+                      {Array.from({ length: skeletonColumns }).map(
+                        (_, colIndex) => (
+                          <TableCell
+                            key={`skeleton-cell-${rowIndex}-${colIndex}`}
+                          >
+                            <Skeleton className="h-4 w-full" />
+                          </TableCell>
+                        )
+                      )}
+                    </TableRow>
+                  ))
+                : null}
               {isInfiniteScrollPagination(paginationInfo) &&
-                paginationInfo.hasMore && (
-                  <tr>
-                    <td
-                      colSpan={
-                        columns.length +
-                        (source.selectable ? 1 : 0) +
-                        (showItemActions ? 1 : 0)
-                      }
-                      ref={loadingIndicatorRef}
-                      className="h-10"
-                      aria-hidden="true"
-                    ></td>
-                  </tr>
-                )}
+              paginationInfo.hasMore ? (
+                <tr>
+                  <td
+                    colSpan={
+                      columns.length +
+                      (source.selectable ? 1 : 0) +
+                      (showItemActions ? 1 : 0)
+                    }
+                    ref={loadingIndicatorRef}
+                    className="h-10"
+                    aria-hidden="true"
+                  ></td>
+                </tr>
+              ) : null}
             </TableBody>
             {(() => {
               const actions = normalizeAddRowActions(addRow?.addRowActions?.())
@@ -1030,7 +1040,7 @@ export const TableCollection = <
 
               return (
                 <TableFooter>
-                  {summaryData && (
+                  {summaryData ? (
                     <TableRow
                       className={cn(
                         summaryData.sticky &&
@@ -1038,18 +1048,18 @@ export const TableCollection = <
                         "font-medium"
                       )}
                     >
-                      {source.selectable && (
+                      {source.selectable ? (
                         <TableCell
                           width={checkColumnWidth}
                           sticky={{ left: 0 }}
                         >
-                          {summaryData.label && (
+                          {summaryData.label ? (
                             <div className="font-medium text-f1-foreground-secondary">
                               {summaryData.label}
                             </div>
-                          )}
+                          ) : null}
                         </TableCell>
-                      )}
+                      ) : null}
                       {columns.map((column, cellIndex) => (
                         <TableCell
                           key={`summary-${String(column.label)}`}
@@ -1121,8 +1131,8 @@ export const TableCollection = <
                           )}
                         </TableCell>
                       ))}
-                      {showItemActions &&
-                        (isEditableTable ? (
+                      {showItemActions ? (
+                        isEditableTable ? (
                           <TableCell
                             key="summary-actions"
                             sticky={{ right: 0 }}
@@ -1143,10 +1153,11 @@ export const TableCollection = <
                               {""}
                             </TableCell>
                           </>
-                        ))}
+                        )
+                      ) : null}
                     </TableRow>
-                  )}
-                  {actions.length > 0 && (
+                  ) : null}
+                  {actions.length > 0 ? (
                     <TableRow>
                       <TableCell
                         colSpan={
@@ -1210,7 +1221,7 @@ export const TableCollection = <
                         </div>
                       </TableCell>
                     </TableRow>
-                  )}
+                  ) : null}
                 </TableFooter>
               )
             })()}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -293,136 +293,137 @@ const NestedRowContent = <
         fromVisualization={props.fromVisualization}
       />
 
-      {shouldShowChildren &&
-        children.map((child, childIndex) => {
-          const childItem = child as R
-          const childHasChildren = props.source.itemsWithChildren?.(childItem)
-          const isFirstChild = childIndex === 0
-          const isLastChildInLevel = childIndex === children.length - 1
+      {shouldShowChildren
+        ? children.map((child, childIndex) => {
+            const childItem = child as R
+            const childHasChildren = props.source.itemsWithChildren?.(childItem)
+            const isFirstChild = childIndex === 0
+            const isLastChildInLevel = childIndex === children.length - 1
 
-          const depth = (props.nestedRowProps?.depth ?? 0) + 1
+            const depth = (props.nestedRowProps?.depth ?? 0) + 1
 
-          /**
-           * Get the appropriate ref for connector height calculations
-           *
-           * We only need refs for the first and last children to calculate
-           * the connector line height. Other children don't need refs.
-           *
-           * Special case: If there's a "Load More" button, the last child
-           * doesn't get the ref because the LoadMore component will be the
-           * actual last element.
-           */
-          const getChildRef = () => {
-            if (isFirstChild) {
-              return (el: HTMLTableRowElement | null) => {
-                setFirstChildRef(el)
+            /**
+             * Get the appropriate ref for connector height calculations
+             *
+             * We only need refs for the first and last children to calculate
+             * the connector line height. Other children don't need refs.
+             *
+             * Special case: If there's a "Load More" button, the last child
+             * doesn't get the ref because the LoadMore component will be the
+             * actual last element.
+             */
+            const getChildRef = () => {
+              if (isFirstChild) {
+                return (el: HTMLTableRowElement | null) => {
+                  setFirstChildRef(el)
+                }
+              } else if (
+                isLastChildInLevel &&
+                !shouldShowLoadMore &&
+                !hasAddRowActions
+              ) {
+                return (el: HTMLTableRowElement | null) => {
+                  setLastChildRef(el)
+                }
               }
-            } else if (
-              isLastChildInLevel &&
-              !shouldShowLoadMore &&
-              !hasAddRowActions
-            ) {
-              return (el: HTMLTableRowElement | null) => {
-                setLastChildRef(el)
-              }
+              return undefined
             }
-            return undefined
-          }
 
-          /**
-           * Determine if this child is the last visible element in the tree
-           *
-           * A child is the "last in tree" only if:
-           * 1. It's the last child in its current level
-           * 2. Its parent is also the last in the tree (isLastChild from props)
-           * 3. There's no LoadMore button (which would add more elements)
-           *
-           * This ensures the border "bubbles down" to the deepest last visible element
-           */
-          const childIsLastInTree =
-            isLastChildInLevel && isLastChild && !shouldShowLoadMore
+            /**
+             * Determine if this child is the last visible element in the tree
+             *
+             * A child is the "last in tree" only if:
+             * 1. It's the last child in its current level
+             * 2. Its parent is also the last in the tree (isLastChild from props)
+             * 3. There's no LoadMore button (which would add more elements)
+             *
+             * This ensures the border "bubbles down" to the deepest last visible element
+             */
+            const childIsLastInTree =
+              isLastChildInLevel && isLastChild && !shouldShowLoadMore
 
-          const RowWrapper = props.rowWrapper
+            const RowWrapper = props.rowWrapper
 
-          // Recursive case: Child has its own children
-          if (childHasChildren) {
-            const nestedChild = (
-              <NestedRow
-                {...props}
-                key={`nested-row-${props.groupIndex}-${child.id}-${props.index}-${childIndex}`}
-                index={childIndex}
-                item={childItem}
-                isSelected={isChildSelected(childItem)}
-                tableWithChildren={props.tableWithChildren}
-                ref={getChildRef()}
-                nestedRowProps={{
-                  ...props.nestedRowProps,
-                  parentHasChildren: true,
-                  depth: depth,
-                  isLastChild: childIsLastInTree,
-                }}
-                fromVisualization={props.fromVisualization}
-              />
-            )
-
-            if (RowWrapper) {
-              return (
-                <RowWrapper
+            // Recursive case: Child has its own children
+            if (childHasChildren) {
+              const nestedChild = (
+                <NestedRow
+                  {...props}
                   key={`nested-row-${props.groupIndex}-${child.id}-${props.index}-${childIndex}`}
-                  item={childItem}
                   index={childIndex}
-                >
-                  {nestedChild}
-                </RowWrapper>
+                  item={childItem}
+                  isSelected={isChildSelected(childItem)}
+                  tableWithChildren={props.tableWithChildren}
+                  ref={getChildRef()}
+                  nestedRowProps={{
+                    ...props.nestedRowProps,
+                    parentHasChildren: true,
+                    depth: depth,
+                    isLastChild: childIsLastInTree,
+                  }}
+                  fromVisualization={props.fromVisualization}
+                />
               )
-            }
 
-            return nestedChild
-          } else {
-            // Base case: Leaf node with no children
-            // For leaf nodes, border is shown only if it's the last visible element in the tree
-            const leafShouldHideBorder =
-              !childIsLastInTree && isTableVisualization
+              if (RowWrapper) {
+                return (
+                  <RowWrapper
+                    key={`nested-row-${props.groupIndex}-${child.id}-${props.index}-${childIndex}`}
+                    item={childItem}
+                    index={childIndex}
+                  >
+                    {nestedChild}
+                  </RowWrapper>
+                )
+              }
 
-            const leafChild = (
-              <Row
-                {...props}
-                key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
-                index={childIndex}
-                item={childItem}
-                isSelected={isChildSelected(childItem)}
-                noBorder={leafShouldHideBorder}
-                ref={getChildRef()}
-                nestedRowProps={{
-                  ...props.nestedRowProps,
-                  depth: (props.nestedRowProps?.depth ?? 0) + 1,
-                  parentHasChildren: true,
-                  nestedVariant: childrenType,
-                  onExpand: handleExpand,
-                  isLastChild: childIsLastInTree,
-                }}
-                fromVisualization={props.fromVisualization}
-                tableWithChildren={props.tableWithChildren}
-              />
-            )
+              return nestedChild
+            } else {
+              // Base case: Leaf node with no children
+              // For leaf nodes, border is shown only if it's the last visible element in the tree
+              const leafShouldHideBorder =
+                !childIsLastInTree && isTableVisualization
 
-            if (RowWrapper) {
-              return (
-                <RowWrapper
+              const leafChild = (
+                <Row
+                  {...props}
                   key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
-                  item={childItem}
                   index={childIndex}
-                >
-                  {leafChild}
-                </RowWrapper>
+                  item={childItem}
+                  isSelected={isChildSelected(childItem)}
+                  noBorder={leafShouldHideBorder}
+                  ref={getChildRef()}
+                  nestedRowProps={{
+                    ...props.nestedRowProps,
+                    depth: (props.nestedRowProps?.depth ?? 0) + 1,
+                    parentHasChildren: true,
+                    nestedVariant: childrenType,
+                    onExpand: handleExpand,
+                    isLastChild: childIsLastInTree,
+                  }}
+                  fromVisualization={props.fromVisualization}
+                  tableWithChildren={props.tableWithChildren}
+                />
               )
+
+              if (RowWrapper) {
+                return (
+                  <RowWrapper
+                    key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
+                    item={childItem}
+                    index={childIndex}
+                  >
+                    {leafChild}
+                  </RowWrapper>
+                )
+              }
+
+              return leafChild
             }
+          })
+        : null}
 
-            return leafChild
-          }
-        })}
-
-      {shouldShowLoading && (
+      {shouldShowLoading ? (
         <RowLoading
           {...props}
           rowRef={internalRowRef}
@@ -434,9 +435,9 @@ const NestedRowContent = <
           ref={setLastChildRef}
           shouldHideBorder={!isLastChild}
         />
-      )}
+      ) : null}
 
-      {shouldShowLoadMore && !isLoading && (
+      {shouldShowLoadMore && !isLoading ? (
         <LoadMoreRow
           {...props}
           disableHover={true}
@@ -450,9 +451,9 @@ const NestedRowContent = <
             isLastChild,
           }}
         />
-      )}
+      ) : null}
 
-      {hasAddRowActions && (
+      {hasAddRowActions ? (
         <AddRowRow
           {...props}
           disableHover={true}
@@ -471,11 +472,11 @@ const NestedRowContent = <
             nestedVariant: childrenType,
           }}
         />
-      )}
+      ) : null}
 
       {/* Invisible sentinel row used by useStickyParentRow to detect when
           all children have been scrolled past and the parent should unstick. */}
-      {open && (
+      {open ? (
         <tr aria-hidden="true" className="h-0 border-none p-0">
           <td
             ref={sentinelRef}
@@ -487,7 +488,7 @@ const NestedRowContent = <
             className="h-0 border-none p-0"
           />
         </tr>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -372,7 +372,7 @@ const RowComponentInner = <
         referenceTypeClasses[referenceRowType]
       )}
     >
-      {source.selectable && (
+      {source.selectable ? (
         <TableCell
           width={checkColumnWidth}
           sticky={{ left: 0 }}
@@ -385,7 +385,7 @@ const RowComponentInner = <
           )}
           referenceRowType={referenceRowType}
         >
-          {id !== undefined && (
+          {id !== undefined ? (
             <div
               className={cn(
                 "pointer-events-auto ml-3.5 flex h-full items-center justify-start",
@@ -402,9 +402,9 @@ const RowComponentInner = <
                 hideLabel
               />
             </div>
-          )}
+          ) : null}
         </TableCell>
-      )}
+      ) : null}
 
       {columns.map((column, cellIndex) => {
         const headerGroup = headerGroups?.find((group) => {
@@ -475,10 +475,10 @@ const RowComponentInner = <
       })}
 
       {hasItemActions &&
-        !loading &&
-        !nestedRowProps?.onLoadMoreChildren &&
-        !nestedRowProps?.onAddRow &&
-        (fromVisualization === "editableTable" ? (
+      !loading &&
+      !nestedRowProps?.onLoadMoreChildren &&
+      !nestedRowProps?.onAddRow ? (
+        fromVisualization === "editableTable" ? (
           <TableCell
             key={`table-cell-${groupIndex}-${index}-actions`}
             sticky={{ right: 0 }}
@@ -510,7 +510,7 @@ const RowComponentInner = <
               </ItemActionsRowContainer>
             </td>
             {/** Mobile item actions */}
-            {hasMobileItemActions && (
+            {hasMobileItemActions ? (
               <TableCell
                 key={`table-cell-${groupIndex}-${index}-actions`}
                 width={68}
@@ -526,9 +526,10 @@ const RowComponentInner = <
                   onOpenChange={handleDropDownOpenChange}
                 />
               </TableCell>
-            )}
+            ) : null}
           </>
-        ))}
+        )
+      ) : null}
     </TableRow>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/SortAndHideList/SortAndHideList.tsx
@@ -105,7 +105,7 @@ const Item = ({
 
   const content = (
     <div className={classes}>
-      {(allowSorting || item.showLockState) && (
+      {allowSorting || item.showLockState ? (
         <div
           className={cn(
             "flex shrink-0 items-center justify-center text-f1-icon",
@@ -149,7 +149,7 @@ const Item = ({
             <F0Icon icon={LockLocked} size="sm" />
           )}
         </div>
-      )}
+      ) : null}
       <span
         className={cn(
           "flex-1 min-w-0",
@@ -158,13 +158,13 @@ const Item = ({
       >
         <OneEllipsis>{item.label}</OneEllipsis>
       </span>
-      {(showLock || showRemove) && (
+      {showLock || showRemove ? (
         <div
           data-column-actions
           className="shrink-0 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
         >
           <div className="flex items-center">
-            {showLock && (
+            {showLock ? (
               <span
                 onKeyDown={trackKeyboardActivation}
                 onPointerDown={() => {
@@ -189,8 +189,8 @@ const Item = ({
                   }}
                 />
               </span>
-            )}
-            {showRemove && (
+            ) : null}
+            {showRemove ? (
               <ButtonInternal
                 variant="ghost"
                 size="sm"
@@ -200,12 +200,12 @@ const Item = ({
                 label={i18n.collections.table.settings.removeColumn}
                 onClick={() => onRemove?.(item)}
               />
-            )}
+            ) : null}
           </div>
         </div>
-      )}
-      {allowHiding &&
-        (item.disabledReason ? (
+      ) : null}
+      {allowHiding ? (
+        item.disabledReason ? (
           // Locked by the caller (e.g. no permission): forced OFF + disabled,
           // with the reason in a tooltip. The switch is wrapped in a span so the
           // tooltip still triggers on hover — a disabled control fires no pointer
@@ -228,7 +228,8 @@ const Item = ({
             hideLabel
             disabled={!item.canHide || locked}
           />
-        ))}
+        )
+      ) : null}
     </div>
   )
 

--- a/packages/react/src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/components/DateNavigatorTrigger.tsx
@@ -169,7 +169,7 @@ const DateNavigatorTrigger = forwardRef<
             navigation ? "justify-between" : "justify-center"
           )}
         >
-          {navigation && (
+          {navigation ? (
             <F0Button
               size="sm"
               variant="ghost"
@@ -179,7 +179,7 @@ const DateNavigatorTrigger = forwardRef<
               disabled={!nextPrev?.prev}
               onClick={() => handleNavigation(nextPrev?.prev ?? false)}
             />
-          )}
+          ) : null}
           <ButtonInternal
             fontSize="md"
             size="sm"
@@ -190,7 +190,7 @@ const DateNavigatorTrigger = forwardRef<
             style={{ minWidth: granularity?.toStringMaxWidth() }}
             className={cn(highlighted && "bg-f1-background-secondary-hover")}
           />
-          {navigation && (
+          {navigation ? (
             <F0Button
               variant="ghost"
               icon={ChevronRight}
@@ -201,9 +201,9 @@ const DateNavigatorTrigger = forwardRef<
               disabled={!nextPrev?.next}
               onClick={() => handleNavigation(nextPrev?.next ?? false)}
             />
-          )}
+          ) : null}
         </div>
-        {!hideGoToCurrent && currentDate && (
+        {!hideGoToCurrent && currentDate ? (
           <div className="border-l-solid flex-shrink-0 border-[#f00]">
             <F0Button
               fontSize="md"
@@ -217,7 +217,7 @@ const DateNavigatorTrigger = forwardRef<
               onClick={handleClickCurrentDate}
             />
           </div>
-        )}
+        ) : null}
       </div>
     )
   }

--- a/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
@@ -248,11 +248,11 @@ const FiltersControls = () => {
         mode={mode}
         displayCounter={displayCounter}
       />
-      {!!presets?.length && (
+      {presets?.length ? (
         <div className="flex items-center">
           <div className="mx-2 h-4 w-px bg-f1-background-secondary-hover" />
         </div>
-      )}
+      ) : null}
     </>
   )
 }
@@ -386,21 +386,21 @@ const _OneFilterPicker = <Definition extends FiltersDefinition>(
             !rootProps.filters && "justify-end"
           )}
         >
-          {rootProps.filters && (
+          {rootProps.filters ? (
             <div className="flex min-w-0 flex-1 gap-1">
               <FiltersControls />
               <FiltersPresets />
             </div>
-          )}
-          {rootProps.children && (
+          ) : null}
+          {rootProps.children ? (
             <div className="flex shrink-0 items-center gap-2">
               {rootProps.children}
             </div>
-          )}
+          ) : null}
         </div>
-        {(!rootProps.mode || rootProps.mode === "default") && (
+        {!rootProps.mode || rootProps.mode === "default" ? (
           <FiltersChipsList />
-        )}
+        ) : null}
       </FiltersRoot>
     </DataTestIdWrapper>
   )

--- a/packages/react/src/patterns/OneFilterPicker/__stories__/OneFilterPicker.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/__stories__/OneFilterPicker.stories.tsx
@@ -543,12 +543,12 @@ const LargeAsyncOptionsComponent = (props: { cache: boolean }) => {
         This example loads a large list of countries asynchronously. Open the
         Countries filter and use the search field to filter the options.
       </p>
-      {props.cache && (
+      {props.cache ? (
         <p>
           The options are cached so that the same options are not loaded again
           when the filter is opened.
         </p>
-      )}
+      ) : null}
       <OneFilterPickerComponent
         filters={largeAsyncDefinition}
         value={filters}

--- a/packages/react/src/patterns/OneFilterPicker/components/FilterList.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FilterList.tsx
@@ -89,9 +89,9 @@ export function FilterList<Definition extends FiltersDefinition>({
           "flex flex-1 h-full w-full flex-col min-h-0 max-h-full gap-1 overflow-x-hidden p-2"
         )}
       >
-        {isCompactMode && (
+        {isCompactMode ? (
           <div className="-mx-2 mb-1 h-px border-0 border-t border-solid border-f1-border-secondary" />
-        )}
+        ) : null}
         <ListScrollArea className="flex-1 min-h-0 max-h-full">
           <div className="flex flex-col gap-1">
             {Object.entries(definition).map(([key, filter]) => {
@@ -139,7 +139,7 @@ export function FilterList<Definition extends FiltersDefinition>({
                       {filter.label}
                     </OneEllipsis>
                     <AnimatePresence>
-                      {isActive && (
+                      {isActive ? (
                         <motion.span
                           className="h-2 w-2 shrink-0 rounded-full bg-f1-background-selected-bold"
                           initial={
@@ -154,11 +154,11 @@ export function FilterList<Definition extends FiltersDefinition>({
                               : { opacity: 0, scale: 0.7 }
                           }
                         />
-                      )}
+                      ) : null}
                     </AnimatePresence>
-                    {isCompactMode && <F0Icon icon={ChevronRight} />}
+                    {isCompactMode ? <F0Icon icon={ChevronRight} /> : null}
                   </div>
-                  {isActive && (
+                  {isActive ? (
                     <span
                       id={`${activeDescriptionId}-${key}`}
                       className="sr-only"
@@ -167,20 +167,20 @@ export function FilterList<Definition extends FiltersDefinition>({
                         filters: filter.label,
                       })}
                     </span>
-                  )}
+                  ) : null}
                 </button>
               )
             })}
           </div>
         </ListScrollArea>
-        {isCompactMode && (
+        {isCompactMode ? (
           <div className="-mx-2 flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2">
             <F0Button
               onClick={onClickApplyFilters}
               label={i18n.filters.applyFilters}
             />
           </div>
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersChipsList.tsx
@@ -47,7 +47,7 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
   return (
     <div className="mt-2 flex items-center gap-2">
       <div className="flex flex-wrap items-center gap-2">
-        {resultCount !== undefined && hasVisibleChips && (
+        {resultCount !== undefined && hasVisibleChips ? (
           <F0TagRaw
             text={i18n.t(
               resultCount === 1
@@ -56,47 +56,48 @@ export function FiltersChipsList<Filters extends FiltersDefinition>({
               { count: resultCount }
             )}
           />
-        )}
+        ) : null}
         <AnimatePresence presenceAffectsLayout initial={false}>
-          {hasVisibleChips &&
-            activeFilterKeys.map((key) => {
-              const filterSchema = filters[key]
+          {hasVisibleChips
+            ? activeFilterKeys.map((key) => {
+                const filterSchema = filters[key]
 
-              if (!filters[key]) {
-                return null
-              }
+                if (!filters[key]) {
+                  return null
+                }
 
-              const currentValue = value?.[key as keyof Filters]
+                const currentValue = value?.[key as keyof Filters]
 
-              const filterType = getFilterType(filterSchema.type)
-              type FilterType =
-                FilterDefinitionsByType[typeof filterSchema.type]
+                const filterType = getFilterType(filterSchema.type)
+                type FilterType =
+                  FilterDefinitionsByType[typeof filterSchema.type]
 
-              const typedFilterType =
-                filterType as unknown as FilterTypeDefinition<
-                  FilterValue<FilterType>
-                >
+                const typedFilterType =
+                  filterType as unknown as FilterTypeDefinition<
+                    FilterValue<FilterType>
+                  >
 
-              if (
-                typedFilterType.isEmpty(currentValue, {
-                  schema: filterSchema as unknown as FilterTypeSchema,
-                  i18n,
-                })
-              ) {
-                return null
-              }
+                if (
+                  typedFilterType.isEmpty(currentValue, {
+                    schema: filterSchema as unknown as FilterTypeSchema,
+                    i18n,
+                  })
+                ) {
+                  return null
+                }
 
-              return (
-                <FilterChipButton
-                  key={`filter-${String(key)}`}
-                  filter={filterSchema}
-                  filterKey={String(key)}
-                  value={currentValue}
-                  onSelect={() => onFilterSelect(key)}
-                  onRemove={() => onFilterRemove(key)}
-                />
-              )
-            })}
+                return (
+                  <FilterChipButton
+                    key={`filter-${String(key)}`}
+                    filter={filterSchema}
+                    filterKey={String(key)}
+                    value={currentValue}
+                    onSelect={() => onFilterSelect(key)}
+                    onRemove={() => onFilterRemove(key)}
+                  />
+                )
+              })
+            : null}
         </AnimatePresence>
       </div>
 

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
@@ -280,12 +280,12 @@ export function FiltersControls<Filters extends FiltersDefinition>({
             tooltip={activeFiltersTooltip}
           />
 
-          {hasFiltersApplied && (
+          {hasFiltersApplied ? (
             <div className="absolute right-0 top-0 aspect-square w-2 rounded-full border border-solid border-f1-background bg-f1-background-selected-bold" />
-          )}
+          ) : null}
         </div>
         <AnimatePresence mode="popLayout" propagate={false}>
-          {isOpen && (
+          {isOpen ? (
             <motion.div
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
@@ -317,7 +317,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
                     }
                     onClickApplyFilters={handleApplyFilters}
                   />
-                  {selectedFilterKey && (
+                  {selectedFilterKey ? (
                     <div className="flex-1 min-w-0 overflow-hidden">
                       <FilterContent
                         selectedFilterKey={selectedFilterKey}
@@ -326,7 +326,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
                         onFilterChange={updateFilterValue}
                       />
                     </div>
-                  )}
+                  ) : null}
                 </div>
                 <div className="flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2 bg-f1-background">
                   <F0Button
@@ -336,7 +336,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
                 </div>
               </div>
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
     )
@@ -368,14 +368,14 @@ export function FiltersControls<Filters extends FiltersDefinition>({
 
     const ApplySelectionButton = (
       <>
-        {selectedFilterKey && (
+        {selectedFilterKey ? (
           <div className="sticky bottom-0 left-0 right-0 z-30 flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary p-2 bg-f1-background">
             <F0Button
               onClick={handleApplyFiltersSelection}
               label={i18n.filters.applySelection}
             />
           </div>
-        )}
+        ) : null}
       </>
     )
 
@@ -404,12 +404,12 @@ export function FiltersControls<Filters extends FiltersDefinition>({
             tooltip={activeFiltersTooltip}
           />
 
-          {hasFiltersApplied && (
+          {hasFiltersApplied ? (
             <div className="absolute right-0 top-0 aspect-square w-2 rounded-full border border-solid border-f1-background bg-f1-background-selected-bold" />
-          )}
+          ) : null}
         </div>
         <AnimatePresence mode="popLayout" propagate={false}>
-          {isOpen && (
+          {isOpen ? (
             <motion.div
               initial={{ opacity: 0, y: 8 }}
               animate={{ opacity: 1, y: 0 }}
@@ -462,7 +462,7 @@ export function FiltersControls<Filters extends FiltersDefinition>({
                 {ApplySelectionButton}
               </div>
             </motion.div>
-          )}
+          ) : null}
         </AnimatePresence>
       </div>
     )

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersPresets.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersPresets.tsx
@@ -246,7 +246,7 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
         data-visible={true}
       >
         {preset.label}
-        {presetNumber !== undefined && (
+        {presetNumber !== undefined ? (
           <Await
             resolve={presetNumber}
             fallback={<Skeleton className="h-4 w-6" />}
@@ -260,7 +260,7 @@ export const FiltersPresets = <Filters extends FiltersDefinition>({
               )
             }
           </Await>
-        )}
+        ) : null}
       </button>
     )
   }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/DateFilter/DateFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/DateFilter/DateFilter.tsx
@@ -55,7 +55,7 @@ export function DateFilter({
           showInput
         />
       </div>
-      {!isCompactMode && (
+      {!isCompactMode ? (
         <div className="sticky bottom-0 left-0 right-0 z-20 flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary bg-f1-background/80 p-2 backdrop-blur-[8px]">
           <F0Button
             variant="ghost"
@@ -65,7 +65,7 @@ export function DateFilter({
             size="sm"
           />
         </div>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/InFilter.tsx
@@ -296,7 +296,7 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
       role="group"
       aria-label={schema.label}
     >
-      {showSearch && (
+      {showSearch ? (
         <div className="rounded-tr-xl p-2">
           <F0SearchInput
             placeholder={i18n.filters.inFilter.searchPlaceholder}
@@ -305,7 +305,7 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
             clearable
           />
         </div>
-      )}
+      ) : null}
       <div
         className={cn(
           "flex w-full items-center justify-between gap-1 pb-1",
@@ -335,11 +335,11 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
         onScrollBottom={handleScrollBottom}
         scrollMargin={50}
       >
-        {filteredOptions.length === 0 && !isLoading && (
+        {filteredOptions.length === 0 && !isLoading ? (
           <div className="flex w-full items-center justify-center py-4 text-sm text-f1-foreground-secondary">
             {i18n.select.noResults}
           </div>
-        )}
+        ) : null}
         {hasAnyChildren
           ? filteredOptions.map((option) => (
               <InFilterOptionRow
@@ -365,11 +365,11 @@ export function InFilter<T extends string, R extends RecordType = RecordType>({
                 isCompactMode={isCompactMode}
               />
             ))}
-        {isLoading && (
+        {isLoading ? (
           <div className="flex w-full items-center justify-center py-4">
             <Spinner size="small" />
           </div>
-        )}
+        ) : null}
       </ScrollArea>
     </div>
   )

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/components/InFilterOptionRow.tsx
@@ -88,7 +88,7 @@ export function InFilterOptionRow<T extends string>({
         className="flex flex-row items-center overflow-hidden min-w-0"
         style={{ paddingLeft: `${depth * 24}px` }}
       >
-        {hasChildren && (
+        {hasChildren ? (
           <div className="relative shrink-0">
             <F0Button
               variant="ghost"
@@ -104,14 +104,14 @@ export function InFilterOptionRow<T extends string>({
               aria-expanded={effectiveExpanded}
               hideLabel
             />
-            {hasDescendantSelected && !effectiveExpanded && (
+            {hasDescendantSelected && !effectiveExpanded ? (
               <span
                 aria-hidden="true"
                 className="absolute -right-px -top-px h-2 w-2 rounded-full bg-f1-background-selected-bold"
               />
-            )}
+            ) : null}
           </div>
-        )}
+        ) : null}
         <div
           className={cn(
             "flex min-w-0 flex-1 cursor-pointer appearance-none items-center gap-1 rounded p-1.5 font-medium transition-colors hover:bg-f1-background-secondary",
@@ -134,7 +134,7 @@ export function InFilterOptionRow<T extends string>({
           </div>
         </div>
       </div>
-      {effectiveExpanded && option.children && (
+      {effectiveExpanded && option.children ? (
         <div>
           {option.children.options
             .filter(
@@ -161,7 +161,7 @@ export function InFilterOptionRow<T extends string>({
               )
             })}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter.tsx
@@ -217,7 +217,7 @@ export function NumberFilter({
               }
             />
           </div>
-          {localValue?.mode === "range" && (
+          {localValue?.mode === "range" ? (
             <div className="min-w-1/2 flex-1">
               <NumberInputInternal
                 label={
@@ -246,17 +246,17 @@ export function NumberFilter({
                 }
               />
             </div>
-          )}
+          ) : null}
         </div>
-        {showModeSwitch && (
+        {showModeSwitch ? (
           <Switch
             title={i18n.filters.number.rangeTitle}
             checked={localValue?.mode === "range"}
             onCheckedChange={handleModeChange}
           />
-        )}
+        ) : null}
       </div>
-      {!isCompactMode && (
+      {!isCompactMode ? (
         <div className="sticky bottom-0 left-0 right-0 z-20 flex items-center justify-end gap-2 border border-solid border-transparent border-t-f1-border-secondary bg-f1-background/80 p-2 backdrop-blur-[8px]">
           <F0Button
             variant="ghost"
@@ -266,7 +266,7 @@ export function NumberFilter({
             size="sm"
           />
         </div>
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/patterns/SectionHeader/index.tsx
+++ b/packages/react/src/patterns/SectionHeader/index.tsx
@@ -63,15 +63,15 @@ const _SectionHeader = ({
           <h2 className="text-lg font-semibold text-f1-foreground">{title}</h2>
           <p className="text-f1-foreground-secondary">{description}</p>
         </div>
-        {link && (
+        {link ? (
           <div className="w-fit">
             <F0Link href={link.href} target="_blank">
               {link.label}
             </F0Link>
           </div>
-        )}
+        ) : null}
       </div>
-      {action && (
+      {action ? (
         <>
           <div className="hidden md:block">
             <F0Button
@@ -92,7 +92,7 @@ const _SectionHeader = ({
             />
           </div>
         </>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/Selector/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/Selector/index.tsx
@@ -18,7 +18,7 @@ function Selector({
       className="flex cursor-default flex-row items-center gap-1 rounded-xs px-1 py-0.5 hover:bg-f1-background-hover"
       onClick={onClick}
     >
-      {icon && <F0Icon icon={icon} className="text-f1-icon" />}
+      {icon ? <F0Icon icon={icon} className="text-f1-icon" /> : null}
       <span
         className={cn(
           "font-medium",

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/Skeleton.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/Skeleton.tsx
@@ -40,7 +40,9 @@ export function ClockInControlsSkeleton({
           <Skeleton className="h-7 w-28" />
           <Skeleton className="h-7 w-12" />
         </div>
-        {canSeeGraph && <Skeleton className="h-1.5 w-full rounded-full" />}
+        {canSeeGraph ? (
+          <Skeleton className="h-1.5 w-full rounded-full" />
+        ) : null}
         <div className="flex flex-row justify-between gap-2">
           <Skeleton className="h-5 w-12" />
           <Skeleton className="h-5 w-24" />
@@ -53,9 +55,9 @@ export function ClockInControlsSkeleton({
             <Skeleton className="h-8 w-full rounded-md" />
           ) : null}
           <div className="flex flex-row items-center gap-2">
-            {(canShowLocation || canShowProject) && (
+            {canShowLocation || canShowProject ? (
               <Skeleton className="h-8 min-w-0 flex-1 rounded-md" />
-            )}
+            ) : null}
             <Skeleton className="ml-auto h-8 w-24 shrink-0 rounded-md" />
           </div>
         </div>
@@ -81,12 +83,14 @@ export function ClockInControlsSkeleton({
               <Skeleton className="h-8 w-28 rounded-md" />
             </div>
           </div>
-          {canSeeGraph && (
+          {canSeeGraph ? (
             <Skeleton className="h-40 w-40 shrink-0 rounded-full" />
-          )}
+          ) : null}
         </div>
         <div className="mt-6 flex flex-row justify-center @xs:justify-start">
-          {canShowLocation && <Skeleton className="h-6 w-32 rounded-md" />}
+          {canShowLocation ? (
+            <Skeleton className="h-6 w-32 rounded-md" />
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
+++ b/packages/react/src/sds/Home/ClockIn/ClockInControls/index.tsx
@@ -74,7 +74,7 @@ const StatusPulse = ({ color }: { color: string }) => {
 
   return (
     <div className="relative aspect-square h-4 shrink-0 self-center">
-      {!reducedMotion && (
+      {!reducedMotion ? (
         <motion.div
           className="absolute inset-0 rounded-full opacity-20"
           style={{ backgroundColor: color }}
@@ -82,7 +82,7 @@ const StatusPulse = ({ color }: { color: string }) => {
           animate={{ scale: 1.6, opacity: 0 }}
           transition={{ duration: 1.5, repeat: Infinity, repeatDelay: 1 }}
         />
-      )}
+      ) : null}
       <div
         className="absolute inset-[3px] rounded-full"
         style={{ backgroundColor: color }}
@@ -409,7 +409,7 @@ export function ClockInControls({
   // layout, so a variant re-places them rather than redefining them.
   const controls = (
     <>
-      {status === "clocked-out" && (
+      {status === "clocked-out" ? (
         // The nudge off the right edge is the DEFAULT layout's: it balances the
         // lone button against the ring beside it. The bar variant pins its
         // controls to the tile's edge, where that margin would be a gap.
@@ -420,11 +420,11 @@ export function ClockInControls({
             icon={SolidPlay}
           />
         </div>
-      )}
+      ) : null}
 
-      {status === "clocked-in" && (
+      {status === "clocked-in" ? (
         <>
-          {canShowBreakButton && (
+          {canShowBreakButton ? (
             <>
               {breakTypeOptions.length > 1 && onChangeBreakTypeId ? (
                 <F0Select
@@ -455,7 +455,7 @@ export function ClockInControls({
                 />
               )}
             </>
-          )}
+          ) : null}
           <F0Button
             onClick={onClockOut}
             label={labels.clockOut}
@@ -463,12 +463,12 @@ export function ClockInControls({
             icon={SolidStop}
           />
         </>
-      )}
-      {status === "break" &&
+      ) : null}
+      {status === "break" ? (
         // The PROMOTED action is the primary button, labelled; the other is an
         // icon-only outline beside it. Which one is promoted depends on where the
         // day stands — see `promotedOnBreak`.
-        (promotedOnBreak === "clock-out" ? (
+        promotedOnBreak === "clock-out" ? (
           <>
             <F0Button
               onClick={onClockIn}
@@ -498,7 +498,8 @@ export function ClockInControls({
               icon={SolidPlay}
             />
           </>
-        ))}
+        )
+      ) : null}
     </>
   )
 
@@ -521,8 +522,8 @@ export function ClockInControls({
 
   const contextTags = (
     <>
-      {canShowLocation && locationControl}
-      {canShowProject && projectControl}
+      {canShowLocation ? locationControl : null}
+      {canShowProject ? projectControl : null}
       {breakTag}
     </>
   )
@@ -611,7 +612,7 @@ export function ClockInControls({
                 can run long ("Lunch break — canteen, second shift"), so it
                 truncates; `OneEllipsis` mounts a tooltip only when it actually
                 clips, and the status keeps the room it needs first. */}
-            {canShowBreakTypeName && breakTypeName && (
+            {canShowBreakTypeName && breakTypeName ? (
               <>
                 <span
                   aria-hidden
@@ -626,7 +627,7 @@ export function ClockInControls({
                   {breakTypeName}
                 </OneEllipsis>
               </>
-            )}
+            ) : null}
           </div>
           <span className="shrink-0 text-xl font-semibold tabular-nums text-f1-foreground">
             {time}
@@ -634,22 +635,22 @@ export function ClockInControls({
         </div>
         {/* The same graph the default variant draws, in its rail geometry — so
             the day is normalized and coloured in exactly one place. */}
-        {canSeeGraph && (
+        {canSeeGraph ? (
           <ClockInGraph
             variant="horizontal-bar"
             data={data}
             trackedMinutes={trackedMinutes}
             remainingMinutes={canSeeRemainingTime ? remainingMinutes : 0}
           />
-        )}
+        ) : null}
         {/* The bar's two ends, labelled: when the day started, and what is left
             of it — the same remaining/overtime string the default variant puts
             under its status, so no new label is needed to translate. */}
         <div className="flex flex-row items-center justify-between gap-2 text-f1-foreground-secondary">
           <span className="tabular-nums">{primaryLabel}</span>
-          {subtitle && (
+          {subtitle ? (
             <span className="line-clamp-1 tabular-nums">{subtitle}</span>
-          )}
+          ) : null}
         </div>
         {/* THE FOOTER SPENDS LINES ON WHAT IS THERE: a picker on the actions'
             line, and a second one — the project — on a line above it. Two pickers
@@ -684,24 +685,24 @@ export function ClockInControls({
                 </span>
                 <StatusPulse color={statusColor} />
               </div>
-              {subtitle && (
+              {subtitle ? (
                 <p className="line-clamp-1 text-f1-foreground-secondary">
                   {subtitle}
                 </p>
-              )}
+              ) : null}
             </div>
 
             <div className="flex justify-center gap-2 @xs:justify-start">
               {controls}
             </div>
           </div>
-          {canSeeGraph && (
+          {canSeeGraph ? (
             <ClockInGraph
               data={data}
               trackedMinutes={trackedMinutes}
               remainingMinutes={canSeeRemainingTime ? remainingMinutes : 0}
             />
-          )}
+          ) : null}
         </div>
         <div className="mt-6 flex flex-row flex-wrap items-center justify-center gap-2 @xs:justify-start">
           {contextTags}

--- a/packages/react/src/sds/Home/Communities/Celebration/components/avatar.tsx
+++ b/packages/react/src/sds/Home/Communities/Celebration/components/avatar.tsx
@@ -37,12 +37,12 @@ export function CelebrationAvatar({
           : ""
       )}
     >
-      {src && (
+      {src ? (
         <div
           className="absolute inset-0 bg-cover bg-center bg-no-repeat opacity-10"
           style={{ backgroundImage: `url("${src}")` }}
         />
-      )}
+      ) : null}
       <div className="relative flex h-full w-full items-center justify-center overflow-hidden rounded-md backdrop-blur">
         <div className="relative h-fit w-fit">
           <div
@@ -62,7 +62,7 @@ export function CelebrationAvatar({
               size="2xl"
             />
           </div>
-          {canReact && (
+          {canReact ? (
             <div
               ref={pickerRef}
               className={cn(
@@ -77,7 +77,7 @@ export function CelebrationAvatar({
                 variant="neutral"
               />
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/CommunityPost/index.tsx
@@ -342,13 +342,13 @@ export const BaseCommunityPost = ({
                 title={act.label ?? ""}
               />
             ))}
-            {dropdownItems?.length && (
+            {dropdownItems?.length ? (
               <Dropdown
                 items={dropdownItems}
                 icon={EllipsisHorizontal}
                 size="sm"
               />
-            )}
+            ) : null}
           </div>
           <div className="md:hidden">
             <Dropdown
@@ -376,7 +376,7 @@ export const BaseCommunityPost = ({
         >
           {title}
         </p>
-        {description && (
+        {description ? (
           <>
             <PostDescription
               ref={descriptionRef}
@@ -387,20 +387,20 @@ export const BaseCommunityPost = ({
               className={cn(descriptionExpanded && focusRing())}
             />
             {descriptionExpandable &&
-              !noDescriptionClamp &&
-              isDescriptionOverflowing &&
-              !descriptionExpanded && (
-                <ExpandDescriptionButton
-                  describedBy={titleId}
-                  controls={descriptionId}
-                  expanded={descriptionExpanded}
-                  onClick={handleExpandDescription}
-                />
-              )}
+            !noDescriptionClamp &&
+            isDescriptionOverflowing &&
+            !descriptionExpanded ? (
+              <ExpandDescriptionButton
+                describedBy={titleId}
+                controls={descriptionId}
+                expanded={descriptionExpanded}
+                onClick={handleExpandDescription}
+              />
+            ) : null}
           </>
-        )}
+        ) : null}
       </div>
-      {mediaUrl && !event && (
+      {mediaUrl && !event ? (
         // FILLS THE POST, UP TO THE READING COLUMN. The old 480px cap dated
         // from when the avatar's gutter took a chunk of the card and the media
         // sat in what was left; with the body starting at the card's own edge it
@@ -441,14 +441,14 @@ export const BaseCommunityPost = ({
             </>
           )}
         </div>
-      )}
-      {event && (
+      ) : null}
+      {event ? (
         <div className="w-full @[744px]:max-w-content">
           <PostEvent {...event} />
         </div>
-      )}
+      ) : null}
       <p className="text-f1-foreground-secondary">{countersDisplay}</p>
-      {!noReactionsButton && (
+      {!noReactionsButton ? (
         <Reactions
           items={reactions?.items ?? []}
           onInteraction={reactions?.onInteraction}
@@ -458,7 +458,7 @@ export const BaseCommunityPost = ({
             icon: CommentIcon,
           }}
         />
-      )}
+      ) : null}
     </div>
   )
 }
@@ -488,16 +488,16 @@ export const CommunityPostSkeleton = ({
       <div className="mt-3">
         <PostDescription.Skeleton />
       </div>
-      {withImage && !withEvent && (
+      {withImage && !withEvent ? (
         <div className="mt-3 aspect-video w-full overflow-hidden rounded-xl md:w-2/3">
           <Skeleton className="h-full w-full rounded-2xs" />
         </div>
-      )}
-      {withEvent && (
+      ) : null}
+      {withEvent ? (
         <div className="mt-3 w-full md:w-2/3">
           <PostEvent.Skeleton />
         </div>
-      )}
+      ) : null}
       <div className="mt-3 flex flex-row items-center gap-1 py-1">
         <Skeleton className="h-2.5 w-14 rounded-2xs" />
         <Skeleton className="h-2.5 w-14 rounded-2xs" />

--- a/packages/react/src/sds/Home/Communities/Post/PostEvent/index.tsx
+++ b/packages/react/src/sds/Home/Communities/Post/PostEvent/index.tsx
@@ -33,7 +33,7 @@ export const BasePostEvent = ({
 
   return (
     <div className="flex w-full flex-col gap-1 rounded-xl border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary p-1 shadow dark:bg-f1-background-tertiary">
-      {mediaUrl && (
+      {mediaUrl ? (
         <div className="relative aspect-video w-full overflow-hidden rounded-md">
           {isVideo(mediaUrl) ? (
             <video
@@ -55,7 +55,7 @@ export const BasePostEvent = ({
             </>
           )}
         </div>
-      )}
+      ) : null}
       <CalendarEvent
         title={title}
         description={description}

--- a/packages/react/src/sds/Home/DaytimePage/index.tsx
+++ b/packages/react/src/sds/Home/DaytimePage/index.tsx
@@ -65,10 +65,10 @@ function _DaytimePage({
       } bg-f1-special-page shadow`}
     >
       <div className={daytimePageVariants({ period })} />
-      {header && (
+      {header ? (
         <div className="flex flex-row items-center justify-between pr-6 @container">
           <div className="flex flex-row items-center gap-2 px-5 py-4 @5xl:px-page">
-            {(isSmallScreen || sidebarState === "hidden") && (
+            {isSmallScreen || sidebarState === "hidden" ? (
               <F0Button
                 variant="ghost"
                 onClick={() => toggleSidebar()}
@@ -76,7 +76,7 @@ function _DaytimePage({
                 icon={Menu}
                 hideLabel
               />
-            )}
+            ) : null}
             <div
               className={cn(
                 "flex flex-row items-center",
@@ -115,7 +115,7 @@ function _DaytimePage({
                   {header.title}
                 </p>
 
-                {header.description && (
+                {header.description ? (
                   <p
                     className={cn(
                       isSmallScreen ? "text-md" : "text-lg",
@@ -124,16 +124,16 @@ function _DaytimePage({
                   >
                     {header.description}
                   </p>
-                )}
+                ) : null}
               </div>
             </div>
           </div>
           <div>
-            {!hideOneSwitch && <F0OneSwitch />}
+            {!hideOneSwitch ? <F0OneSwitch /> : null}
             <OnePromotionSwitch />
           </div>
         </div>
-      )}
+      ) : null}
       <div
         className={cn(
           "isolate flex w-full flex-1 flex-col overflow-y-auto overflow-x-hidden [&>*]:flex-1",

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -1204,12 +1204,12 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
                 the top-right controls, after the rail's own collapse button. It
                 draws NOTHING unless the AI chat context is enabled, so a Home
                 without One keeps the row it had. */}
-            {!hideOneSwitch && (
+            {!hideOneSwitch ? (
               <F0OneSwitch
                 tooltip={oneSwitchTooltip}
                 autoOpen={oneSwitchAutoOpen}
               />
-            )}
+            ) : null}
           </div>
         </HomeEntrance>
         {/* Main column: its own scroll region, no mask — a reading column should

--- a/packages/react/src/sds/Profile/CategoryBarSection/index.tsx
+++ b/packages/react/src/sds/Profile/CategoryBarSection/index.tsx
@@ -34,7 +34,7 @@ export function CategoryBarSection({
           hideTooltip={hideTooltip}
         />
       </div>
-      {!!helpText && (
+      {helpText ? (
         <div className={legend ? "mt-1" : "mt-2"}>
           <span
             className={cn(
@@ -45,7 +45,7 @@ export function CategoryBarSection({
             {helpText}
           </span>
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/UpsellingKit/ProductBlankslate/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductBlankslate/index.tsx
@@ -83,29 +83,29 @@ const _ProductBlankslate = forwardRef<HTMLDivElement, ProductBlankslateProps>(
           <div className="flex flex-col gap-5">
             <div className="flex flex-col gap-2">
               <div className="flex flex-row items-center gap-2">
-                {module && <F0AvatarModule module={module} />}
-                {moduleName && (
+                {module ? <F0AvatarModule module={module} /> : null}
+                {moduleName ? (
                   <p className="text-base font-medium text-f1-foreground">
                     {moduleName}
                   </p>
-                )}
+                ) : null}
               </div>
-              {(tag || promoTag) && (
+              {tag || promoTag ? (
                 <div className="flex justify-start gap-2">
-                  {tag && <F0TagRaw icon={tag.icon} text={tag.label} />}
-                  {promoTag && (
+                  {tag ? <F0TagRaw icon={tag.icon} text={tag.label} /> : null}
+                  {promoTag ? (
                     <F0TagStatus
                       variant={promoTag.variant || "positive"}
                       text={promoTag.label}
                     />
-                  )}
+                  ) : null}
                 </div>
-              )}
+              ) : null}
               <h2 className="font-bold text-xl text-f1-foreground">{title}</h2>
             </div>
             <Benefits benefits={benefits} />
           </div>
-          {actions && <div className="flex gap-3">{actions}</div>}
+          {actions ? <div className="flex gap-3">{actions}</div> : null}
         </div>
       </div>
     )

--- a/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
@@ -115,7 +115,7 @@ function _ProductCard({
                 </div>
               </>
 
-              {dismissable && (
+              {dismissable ? (
                 <div className="h-6 w-6">
                   <F0Button
                     variant="ghost"
@@ -126,7 +126,7 @@ function _ProductCard({
                     label="Close"
                   />
                 </div>
-              )}
+              ) : null}
             </div>
           </div>
         </div>

--- a/packages/react/src/sds/UpsellingKit/ProductModal/components/CustomModal.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductModal/components/CustomModal.tsx
@@ -43,7 +43,7 @@ export function CustomModal({
       >
         <div className="flex flex-row items-center justify-between px-4 py-4">
           <DialogTitle className="flex flex-row items-center gap-2 text-lg font-semibold text-f1-foreground">
-            {module && <F0AvatarModule module={module} size="md" />}
+            {module ? <F0AvatarModule module={module} size="md" /> : null}
             {title}
           </DialogTitle>
           <ButtonInternal

--- a/packages/react/src/sds/UpsellingKit/ProductModal/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductModal/index.tsx
@@ -130,7 +130,7 @@ function _ProductModal({
             promoTag={promoTag}
             actions={
               <div className="flex gap-3">
-                {primaryAction && (
+                {primaryAction ? (
                   <F0Button
                     variant={primaryAction.variant}
                     label={isLoading ? loadingState.label : primaryAction.label}
@@ -139,8 +139,8 @@ function _ProductModal({
                     loading={primaryAction.loading}
                     size={primaryAction.size}
                   />
-                )}
-                {secondaryAction && (
+                ) : null}
+                {secondaryAction ? (
                   <F0Button
                     onClick={secondaryAction.onClick}
                     label={secondaryAction.label}
@@ -148,14 +148,14 @@ function _ProductModal({
                     size={secondaryAction.size}
                     icon={secondaryAction.icon}
                   />
-                )}
+                ) : null}
               </div>
             }
           />
         </div>
       </CustomModal>
 
-      {responseStatus && showResponseDialog && (
+      {responseStatus && showResponseDialog ? (
         <UpsellRequestResponseDialog
           open={true}
           onClose={() => {
@@ -169,7 +169,7 @@ function _ProductModal({
           closeLabel={closeLabel}
           portalContainer={portalContainer}
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/sds/UpsellingKit/ProductWidget/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductWidget/index.tsx
@@ -79,7 +79,7 @@ function _ProductWidget({
       {!isDismissed ? (
         <Card style={{ width }} className="relative bg-f1-background p-1">
           <CardContent>
-            {dismissible && (
+            {dismissible ? (
               <div className="absolute right-2 top-2 z-10">
                 <F0Button
                   variant="ghost"
@@ -90,11 +90,11 @@ function _ProductWidget({
                   label="Close"
                 />
               </div>
-            )}
+            ) : null}
             <div>
               <div>
-                {mediaUrl &&
-                  (isVideo ? (
+                {mediaUrl ? (
+                  isVideo ? (
                     <video
                       src={mediaUrl}
                       autoPlay
@@ -109,7 +109,8 @@ function _ProductWidget({
                       alt={title}
                       className="h-full w-full rounded-md"
                     />
-                  ))}
+                  )
+                ) : null}
               </div>
               <div className="flex flex-col gap-[2px] p-3">
                 <Label className="text-lg font-medium">{title}</Label>
@@ -119,7 +120,7 @@ function _ProductWidget({
               </div>
             </div>
           </CardContent>
-          {actions && (
+          {actions ? (
             <CardFooter className="p-3">
               {actions.map((action) =>
                 action.type === "upsell" ? (
@@ -147,7 +148,7 @@ function _ProductWidget({
                 )
               )}
             </CardFooter>
-          )}
+          ) : null}
         </Card>
       ) : null}
     </>

--- a/packages/react/src/sds/UpsellingKit/UpsellRequestResponseDialog/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellRequestResponseDialog/index.tsx
@@ -107,7 +107,7 @@ const DialogActions = ({
         onClick={onClose}
         size={isSmallScreen ? "lg" : undefined}
       />
-      {showSecondButton && (
+      {showSecondButton ? (
         <F0Button
           variant="promote"
           label={successButtonLabel}
@@ -117,7 +117,7 @@ const DialogActions = ({
           }}
           size={isSmallScreen ? "lg" : undefined}
         />
-      )}
+      ) : null}
     </>
   )
 

--- a/packages/react/src/sds/UpsellingKit/UpsellingAlert/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingAlert/index.tsx
@@ -102,18 +102,18 @@ function _UpsellingAlert({
                 description ? "items-start" : "items-center"
               )}
             >
-              {icon && (
+              {icon ? (
                 <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-sm border border-solid text-f1-icon-promote [background:hsl(var(--promote-50)/0.1)] [border-color:hsl(var(--promote-50)/0.1)]">
                   <F0Icon icon={icon} size="sm" />
                 </div>
-              )}
+              ) : null}
               <div className="flex flex-col gap-0.5">
                 <p className="font-medium text-f1-foreground">{title}</p>
-                {description && (
+                {description ? (
                   <p className="text-base text-f1-foreground-secondary">
                     {description}
                   </p>
-                )}
+                ) : null}
               </div>
             </div>
             <div className={cn("flex flex-shrink-0 @xs:pl-0", icon && "pl-8")}>
@@ -131,7 +131,7 @@ function _UpsellingAlert({
               />
             </div>
           </div>
-          {onDismiss && (
+          {onDismiss ? (
             <div
               className={cn(
                 "flex-shrink-0 self-start",
@@ -140,7 +140,7 @@ function _UpsellingAlert({
             >
               <DismissButton onDismiss={onDismiss} />
             </div>
-          )}
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingBanner/index.tsx
@@ -79,9 +79,12 @@ const _UpsellingBanner = forwardRef<HTMLDivElement, UpsellingBannerProps>(
         primaryAction={basePrimaryAction}
         secondaryAction={baseSecondaryAction}
       >
-        {primaryAction?.variant === "promote" && renderAction(primaryAction)}
-        {secondaryAction?.variant === "promote" &&
-          renderAction(secondaryAction)}
+        {primaryAction?.variant === "promote"
+          ? renderAction(primaryAction)
+          : null}
+        {secondaryAction?.variant === "promote"
+          ? renderAction(secondaryAction)
+          : null}
       </BaseBanner>
     )
   }

--- a/packages/react/src/sds/UpsellingKit/UpsellingButton/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingButton/index.tsx
@@ -118,7 +118,7 @@ function _UpsellingButton({
         loading={isLoading}
         {...props}
       />
-      {showConfirmation && responseStatus && (
+      {showConfirmation && responseStatus ? (
         <UpsellRequestResponseDialog
           open={true}
           onClose={handleModalClose}
@@ -129,7 +129,7 @@ function _UpsellingButton({
           closeLabel={closeLabel}
           portalContainer={portalContainer}
         />
-      )}
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/sds/UpsellingKit/UpsellingPopover/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingPopover/index.tsx
@@ -131,19 +131,19 @@ function _UpsellingPopover({
       </Popover>
 
       {currentAction?.type === "upsell" &&
-        currentAction.showConfirmation &&
-        responseStatus && (
-          <UpsellRequestResponseDialog
-            open={true}
-            onClose={handleModalClose}
-            success={responseStatus === "success"}
-            errorMessage={currentAction.errorMessage}
-            successMessage={currentAction.successMessage}
-            nextSteps={currentAction.nextSteps}
-            closeLabel={currentAction.closeLabel}
-            portalContainer={null}
-          />
-        )}
+      currentAction.showConfirmation &&
+      responseStatus ? (
+        <UpsellRequestResponseDialog
+          open={true}
+          onClose={handleModalClose}
+          success={responseStatus === "success"}
+          errorMessage={currentAction.errorMessage}
+          successMessage={currentAction.successMessage}
+          nextSteps={currentAction.nextSteps}
+          closeLabel={currentAction.closeLabel}
+          portalContainer={null}
+        />
+      ) : null}
     </>
   )
 }

--- a/packages/react/src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx
+++ b/packages/react/src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx
@@ -104,7 +104,7 @@ export const F0QuestionCardMultiStep = ({
       </CardContent>
       <CardFooter className="-mx-4 -mb-4 mt-4 flex items-center justify-between rounded-b-xl border-0 border-t border-t-f1-border bg-f1-background-secondary px-4 py-3">
         <div className="flex min-w-[7.5rem] items-center justify-start gap-1">
-          {showPagination && (
+          {showPagination ? (
             <>
               <button
                 type="button"
@@ -128,10 +128,10 @@ export const F0QuestionCardMultiStep = ({
                 <F0Icon icon={ChevronRight} size="sm" />
               </button>
             </>
-          )}
+          ) : null}
         </div>
         <div className="flex items-center gap-2">
-          {showSkip && (
+          {showSkip ? (
             <F0Button
               type="button"
               variant="ghost"
@@ -141,7 +141,7 @@ export const F0QuestionCardMultiStep = ({
               }
               onClick={onSkip}
             />
-          )}
+          ) : null}
           <F0Button
             type="button"
             variant="outline"

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatVideoAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatVideoAttachment.test.tsx
@@ -50,21 +50,21 @@ vi.mock("@/components/F0VideoPlayer", () => ({
       data-silent={silent}
     >
       <video data-testid="mock-video-media">
-        {content?.captions && (
+        {content?.captions ? (
           <track
             data-testid="mock-video-captions"
             kind="captions"
             src="captions.vtt"
           />
-        )}
+        ) : null}
       </video>
       <button type="button">Play</button>
       <button type="button">Enter fullscreen</button>
-      {download && (
+      {download ? (
         <button type="button" onClick={download.onClick}>
           {download.label}
         </button>
-      )}
+      ) : null}
     </div>
   ),
 }))

--- a/packages/react/src/sds/chat/F0Chat/components/ChatBubble.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatBubble.tsx
@@ -215,14 +215,14 @@ const ChatBubbleImpl = ({
           messageSurfaceColorClass(message.author, isMine)
         )}
       >
-        {message.replyTo && (
+        {message.replyTo ? (
           <ReplyQuote
             reply={message.replyTo}
             isMine={isMine}
             isFirstOfRun={isFirstOfRun}
           />
-        )}
-        {message.linkPreviews && message.linkPreviews.length > 0 && (
+        ) : null}
+        {message.linkPreviews && message.linkPreviews.length > 0 ? (
           <ChatLinkPreview
             previews={message.linkPreviews}
             isMine={isMine}
@@ -230,9 +230,9 @@ const ChatBubbleImpl = ({
             // keep it fully rounded there.
             isFirstOfRun={message.replyTo ? true : isFirstOfRun}
           />
-        )}
+        ) : null}
         <div className="relative px-3.5 py-2.5">
-          {author && (
+          {author ? (
             <ChatUserHoverCard user={author}>
               {/* WhatsApp-style: tint the sender name to match their avatar colour. */}
               <span
@@ -244,7 +244,7 @@ const ChatBubbleImpl = ({
                 {author.name}
               </span>
             </ChatUserHoverCard>
-          )}
+          ) : null}
           {/* The body is the one part of a message a double-click must NOT
               quote: the browser selects a word there instead. The marker is
               read by SELF_HANDLING_DESCENDANTS in ChatMessageItem. An inline

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -1115,7 +1115,7 @@ export const ChatComposer = (): ReactNode => {
           {/* Composer error. Upload/voice failures fade out; validation errors
               may persist until the next corrective attachment attempt. */}
           <AnimatePresence initial={false}>
-            {transientError && (
+            {transientError ? (
               <motion.div
                 key="transient-error"
                 role="alert"
@@ -1143,13 +1143,13 @@ export const ChatComposer = (): ReactNode => {
                   </p>
                 </div>
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
 
           {/* Pending files render from local object URLs immediately. Their
               uniform image-sized thumbnails keep the composer compact. */}
           <AnimatePresence initial={false}>
-            {attachments.length > 0 && (
+            {attachments.length > 0 ? (
               <motion.div
                 key="attachments-row"
                 className="overflow-hidden"
@@ -1221,7 +1221,7 @@ export const ChatComposer = (): ReactNode => {
                   </AnimatePresence>
                 </div>
               </motion.div>
-            )}
+            ) : null}
           </AnimatePresence>
 
           {/* The textarea stays during recording: it shows "Listening…" and
@@ -1343,7 +1343,7 @@ export const ChatComposer = (): ReactNode => {
                     />
                   </div>
                   <div className="flex items-center gap-1">
-                    {canRecord && (
+                    {canRecord ? (
                       <ButtonInternal
                         variant="outline"
                         size="md"
@@ -1364,7 +1364,7 @@ export const ChatComposer = (): ReactNode => {
                           isSendingVoiceNote
                         }
                       />
-                    )}
+                    ) : null}
                     {/* The send button fades on ACTIVATION (boundary flip of
                         canSend — first character, attachment ready) and on the
                         edit-mode icon swap; never per keystroke. */}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
@@ -80,7 +80,7 @@ const ChatComposerAttachmentPreviewContent = ({
             onClick={removeAction.onClick}
           />
         </div>
-        {uploading && <PreviewProgress />}
+        {uploading ? <PreviewProgress /> : null}
         <figcaption className="sr-only">{attachment.name}</figcaption>
       </figure>
     )
@@ -131,7 +131,7 @@ const ChatComposerAttachmentPreviewContent = ({
               onClick={removeAction.onClick}
             />
           </div>
-          {uploading && <PreviewProgress />}
+          {uploading ? <PreviewProgress /> : null}
           <figcaption className="sr-only">{attachment.name}</figcaption>
         </figure>
       )
@@ -153,7 +153,7 @@ const ChatComposerAttachmentPreviewContent = ({
             previewDisabled={uploading}
             compact
           />
-          {uploading && <PreviewProgress />}
+          {uploading ? <PreviewProgress /> : null}
         </div>
       )
     }
@@ -181,7 +181,7 @@ const ChatComposerAttachmentPreviewContent = ({
             onClick={removeAction.onClick}
           />
         </div>
-        {uploading && <PreviewProgress />}
+        {uploading ? <PreviewProgress /> : null}
         <span className="sr-only">{attachment.name}</span>
       </div>
     )
@@ -209,7 +209,7 @@ const ChatComposerAttachmentPreviewContent = ({
             onClick={removeAction.onClick}
           />
         </div>
-        {uploading && <PreviewProgress />}
+        {uploading ? <PreviewProgress /> : null}
       </div>
     )
   }
@@ -231,7 +231,7 @@ const ChatComposerAttachmentPreviewContent = ({
           onClick={removeAction.onClick}
         />
       </div>
-      {uploading && <PreviewProgress />}
+      {uploading ? <PreviewProgress /> : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
@@ -136,7 +136,7 @@ export const ChatDocumentAttachmentCard = ({
       style={{ width: cardWidth }}
       data-testid="chat-document-attachment"
     >
-      {!compact && (
+      {!compact ? (
         <div className="flex items-center gap-2 px-2 py-2">
           <F0AvatarFile
             file={{ name: file.name, type: file.mimeType ?? "" }}
@@ -145,7 +145,7 @@ export const ChatDocumentAttachmentCard = ({
           <ClampText className="grow text-sm font-medium text-f1-foreground">
             {file.name}
           </ClampText>
-          {action && (
+          {action ? (
             <ButtonInternal
               variant="ghost"
               size="sm"
@@ -154,9 +154,9 @@ export const ChatDocumentAttachmentCard = ({
               label={action.label}
               onClick={action.onClick}
             />
-          )}
+          ) : null}
         </div>
-      )}
+      ) : null}
       <button
         type="button"
         onClick={() => {
@@ -194,40 +194,40 @@ export const ChatDocumentAttachmentCard = ({
           data-testid="chat-document-snapshot"
         >
           <Suspense fallback={null}>
-            {kind === "pdf" && (
+            {kind === "pdf" ? (
               <ChatPdfThumbnail
                 url={file.url}
                 width={cardWidth - 2}
                 onError={() => setFailed(true)}
                 onRendered={() => setRendered(true)}
               />
-            )}
-            {kind === "sheet" && (
+            ) : null}
+            {kind === "sheet" ? (
               <ChatSheetThumbnail
                 url={file.url}
                 onError={() => setFailed(true)}
                 onRendered={() => setRendered(true)}
               />
-            )}
-            {kind === "docx" && (
+            ) : null}
+            {kind === "docx" ? (
               <ChatDocxThumbnail
                 url={file.url}
                 width={cardWidth - 2}
                 onError={() => setFailed(true)}
                 onRendered={() => setRendered(true)}
               />
-            )}
-            {kind === "text" && (
+            ) : null}
+            {kind === "text" ? (
               <ChatTextThumbnail
                 url={file.url}
                 onError={() => setFailed(true)}
                 onRendered={() => setRendered(true)}
               />
-            )}
+            ) : null}
           </Suspense>
         </div>
       </button>
-      {compact && action && (
+      {compact && action ? (
         <>
           <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
             <ButtonInternal
@@ -241,7 +241,7 @@ export const ChatDocumentAttachmentCard = ({
           </div>
           <span className="sr-only">{file.name}</span>
         </>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatDocumentPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatDocumentPreview.tsx
@@ -46,7 +46,7 @@ export const ChatDocumentPreview = (): ReactNode => {
         }
       }}
     >
-      {file && kind && (
+      {file && kind ? (
         <DialogContent
           container={portalTarget}
           className="h-full w-full max-w-none rounded-none bg-transparent p-0 shadow-none"
@@ -91,7 +91,7 @@ export const ChatDocumentPreview = (): ReactNode => {
             </div>
           </div>
         </DialogContent>
-      )}
+      ) : null}
     </Dialog>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatEditChip.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatEditChip.tsx
@@ -22,7 +22,7 @@ export const ChatEditChip = ({
   return (
     <div className="p-1">
       <div className="flex items-stretch gap-2 overflow-hidden rounded-[10px] bg-f1-background-tertiary py-1.5 pl-2 pr-1.5">
-        {thumbnailUrl && (
+        {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
             alt=""
@@ -30,7 +30,7 @@ export const ChatEditChip = ({
             decoding="async"
             className="h-9 w-9 shrink-0 self-center rounded-sm object-cover"
           />
-        )}
+        ) : null}
         <div className="min-w-0 flex-1 gap-0.5 p-1">
           {/* Mention-info pill (matches the @-mention chip styling) so the chip
               reads as a mention-like indicator that you're editing. */}
@@ -39,7 +39,7 @@ export const ChatEditChip = ({
             {i18n.chat.editing}
           </span>
           <span className="mt-0.5 flex min-w-0 items-center gap-1 text-f1-foreground-secondary">
-            {icon && <F0Icon icon={icon} size="xs" color="default" />}
+            {icon ? <F0Icon icon={icon} size="xs" color="default" /> : null}
             <OneEllipsis className="min-w-0 text-base" lines={1}>
               {label}
             </OneEllipsis>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatHeader.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatHeader.tsx
@@ -124,12 +124,12 @@ export const ChatHeader = ({
         ) : (
           <F0Avatar size="sm" avatar={channel.avatar} />
         )}
-        {showPresence && (
+        {showPresence ? (
           <PresenceDot
             online={channel.presence === "online"}
             label={i18n.chat.online}
           />
-        )}
+        ) : null}
       </div>
       <span className="truncate text-base font-medium text-f1-foreground">
         {channel.title}
@@ -176,7 +176,7 @@ export const ChatHeader = ({
             ))}
             {/* Search + the host's menu actions live behind the ellipsis menu,
                 which only exists while it holds something. */}
-            {menuItems.length > 0 && (
+            {menuItems.length > 0 ? (
               <Dropdown items={menuItems} align="end" label={i18n.chat.options}>
                 <ButtonInternal
                   variant="ghost"
@@ -185,8 +185,8 @@ export const ChatHeader = ({
                   icon={Ellipsis}
                 />
               </Dropdown>
-            )}
-            {onToggleFullscreen && !isSmallScreen && (
+            ) : null}
+            {onToggleFullscreen && !isSmallScreen ? (
               <ButtonInternal
                 variant="ghost"
                 hideLabel
@@ -196,8 +196,8 @@ export const ChatHeader = ({
                 icon={isFullscreen ? Minimize : Maximize}
                 onClick={onToggleFullscreen}
               />
-            )}
-            {onClose && (
+            ) : null}
+            {onClose ? (
               <ButtonInternal
                 variant="ghost"
                 hideLabel
@@ -205,7 +205,7 @@ export const ChatHeader = ({
                 icon={Cross}
                 onClick={onClose}
               />
-            )}
+            ) : null}
           </div>
         </>
       )}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatImagePreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatImagePreview.tsx
@@ -103,7 +103,7 @@ export const ChatImagePreview = (): ReactNode => {
         }
       }}
     >
-      {current && (
+      {current ? (
         <DialogContent
           container={portalTarget}
           className="h-full w-full max-w-none rounded-none bg-transparent p-0 shadow-none"
@@ -170,7 +170,7 @@ export const ChatImagePreview = (): ReactNode => {
           </div>
 
           {/* Bottom band: paging + counter (only with several images). */}
-          {multiple && (
+          {multiple ? (
             <div className="pointer-events-none absolute inset-x-0 bottom-0 flex items-center justify-center gap-2 p-3">
               <PreviewControl
                 icon={ChevronLeft}
@@ -186,9 +186,9 @@ export const ChatImagePreview = (): ReactNode => {
                 onClick={() => go(1)}
               />
             </div>
-          )}
+          ) : null}
         </DialogContent>
-      )}
+      ) : null}
     </Dialog>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatImageTile.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatImageTile.tsx
@@ -55,7 +55,7 @@ export const ChatImageTile = ({
       aria-label={label}
       data-testid="chat-image-attachment"
     >
-      {image.blurUrl && !loaded && (
+      {image.blurUrl && !loaded ? (
         // Scaled up so the blur's soft edges fall outside the cell instead of
         // fading into the tint at the border.
         <img
@@ -65,7 +65,7 @@ export const ChatImageTile = ({
           className="absolute inset-0 h-full w-full scale-105 object-cover blur-md"
           data-testid="chat-image-blur"
         />
-      )}
+      ) : null}
       <FadeInImage
         src={image.thumbnailUrl ?? image.url}
         alt={image.name}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatLinkPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatLinkPreview.tsx
@@ -44,12 +44,12 @@ const PreviewTexts = ({
   compact: boolean
 }): ReactNode => (
   <div className="flex min-w-0 flex-col gap-0.5 p-2.5">
-    {preview.title && (
+    {preview.title ? (
       <ClampText className="text-base font-medium text-f1-foreground">
         {preview.title}
       </ClampText>
-    )}
-    {preview.description && (
+    ) : null}
+    {preview.description ? (
       <span
         className={cn(
           "text-sm text-f1-foreground-secondary",
@@ -58,7 +58,7 @@ const PreviewTexts = ({
       >
         {preview.description}
       </span>
-    )}
+    ) : null}
     <ClampText className="text-sm text-f1-foreground">
       {hostOf(preview.url)}
     </ClampText>
@@ -104,7 +104,7 @@ export const ChatLinkPreview = ({
             index === previews.length - 1
           )}
         >
-          {!compact && preview.imageUrl && (
+          {!compact && preview.imageUrl ? (
             <FadeInImage
               src={preview.imageUrl}
               alt=""
@@ -113,7 +113,7 @@ export const ChatLinkPreview = ({
               // the transcript mid-conversation.
               className="h-40 w-full bg-f1-background-secondary object-cover"
             />
-          )}
+          ) : null}
           <PreviewTexts preview={preview} compact={compact} />
         </a>
       ))}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
@@ -150,19 +150,20 @@ export function ChatMentionPopover({
         )
       })}
 
-      {showMemberSkeleton &&
-        Array.from({ length: 3 }, (_, i) => (
-          <div
-            key={`skeleton-${i}`}
-            className="flex items-center gap-2 p-2"
-            aria-hidden="true"
-          >
-            <Skeleton className="size-5 shrink-0 rounded-full" />
-            <Skeleton
-              className={cn("h-4 rounded", i === 1 ? "w-24" : "w-32")}
-            />
-          </div>
-        ))}
+      {showMemberSkeleton
+        ? Array.from({ length: 3 }, (_, i) => (
+            <div
+              key={`skeleton-${i}`}
+              className="flex items-center gap-2 p-2"
+              aria-hidden="true"
+            >
+              <Skeleton className="size-5 shrink-0 rounded-full" />
+              <Skeleton
+                className={cn("h-4 rounded", i === 1 ? "w-24" : "w-32")}
+              />
+            </div>
+          ))
+        : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageActions.tsx
@@ -214,7 +214,7 @@ export const ChatMessageActions = ({
           />
         ) : (
           <>
-            {canReact && (
+            {canReact ? (
               <>
                 <div className="flex items-center justify-between p-2">
                   {QUICK_EMOJIS.map((emoji) => (
@@ -239,10 +239,10 @@ export const ChatMessageActions = ({
                 </div>
                 <div className="h-px bg-f1-border-secondary" />
               </>
-            )}
-            {(canViewInfo || canReply || canCopy) && (
+            ) : null}
+            {canViewInfo || canReply || canCopy ? (
               <div className="flex flex-col gap-0 p-1">
-                {canViewInfo && (
+                {canViewInfo ? (
                   <MenuItem
                     icon={AlertCircleLine}
                     label={i18n.chat.info}
@@ -258,10 +258,10 @@ export const ChatMessageActions = ({
                       />
                     }
                   />
-                )}
+                ) : null}
                 {/* Gated on `canReply`, which follows `canSend`: without a
                     composer this used to focus a node that isn't mounted. */}
-                {canReply && (
+                {canReply ? (
                   <MenuItem
                     icon={Reply}
                     label={i18n.chat.reply}
@@ -270,8 +270,8 @@ export const ChatMessageActions = ({
                       startReply(message)
                     })}
                   />
-                )}
-                {canCopy && (
+                ) : null}
+                {canCopy ? (
                   <MenuItem
                     icon={Files}
                     label={i18n.actions.copy}
@@ -284,34 +284,34 @@ export const ChatMessageActions = ({
                         .catch(() => {})
                     })}
                   />
-                )}
+                ) : null}
               </div>
-            )}
-            {(canEdit || canDelete) && (
+            ) : null}
+            {canEdit || canDelete ? (
               <>
                 {/* Only a separator when there IS something above to separate
                     from — a moderator-only menu opens straight on Delete. */}
-                {(canReact || canViewInfo || canReply || canCopy) && (
+                {canReact || canViewInfo || canReply || canCopy ? (
                   <div className="h-px bg-f1-border-secondary" />
-                )}
+                ) : null}
                 <div className="flex flex-col gap-0 p-1">
-                  {canEdit && (
+                  {canEdit ? (
                     <MenuItem
                       icon={Pencil}
                       label={i18n.chat.edit}
                       onClick={runAndClose(() => startEdit(message))}
                     />
-                  )}
-                  {canDelete && (
+                  ) : null}
+                  {canDelete ? (
                     <MenuItem
                       icon={Delete}
                       label={i18n.actions.delete}
                       onClick={runAndClose(() => deleteMessage(message.id))}
                     />
-                  )}
+                  ) : null}
                 </div>
               </>
-            )}
+            ) : null}
           </>
         )}
       </PopoverContent>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
@@ -186,7 +186,7 @@ export const ChatMessageAttachments = ({
         isMine ? "items-end" : "items-start"
       )}
     >
-      {images.length > 0 && (
+      {images.length > 0 ? (
         // The mosaic clips its own cells, so the cells carry no radius — the
         // interior seams stay square like WhatsApp's. The hairline lives on the
         // container for the same reason mobile puts it there: a mostly-white
@@ -239,7 +239,7 @@ export const ChatMessageAttachments = ({
             )
           })}
         </div>
-      )}
+      ) : null}
       {videoFiles.map((file, i) => (
         <ChatVideoAttachment
           key={`${file.url}-${i}`}
@@ -287,7 +287,7 @@ export const ChatMessageAttachments = ({
       {cards.map((card, i) => (
         <ChatCardAttachment key={`${card.title}-${i}`} card={card} />
       ))}
-      {plainFiles.length > 0 && (
+      {plainFiles.length > 0 ? (
         // Files flow side by side and wrap, instead of stacking vertically.
         <div className={cn("flex flex-wrap gap-1", isMine && "justify-end")}>
           {plainFiles.map((file, i) => (
@@ -308,10 +308,10 @@ export const ChatMessageAttachments = ({
             />
           ))}
         </div>
-      )}
-      {metaHost === "below" && (
+      ) : null}
+      {metaHost === "below" ? (
         <ChatMessageMeta message={message} placement="below" />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
@@ -17,11 +17,11 @@ const InfoRow = ({
 }): ReactNode => (
   <div className="flex flex-col items-start">
     <span className="text-base font-medium text-f1-foreground">{label}</span>
-    {value && (
+    {value ? (
       <span className="text-base font-normal text-f1-foreground-secondary">
         {value}
       </span>
-    )}
+    ) : null}
   </div>
 )
 
@@ -106,11 +106,11 @@ export const ChatMessageInfoView = ({
             label={i18n.chat.delivered}
             value={formatSeparator(new Date(message.createdAt), now, labels)}
           />
-          {message.isMine &&
-            (isGroup ? (
+          {message.isMine ? (
+            isGroup ? (
               <div className="flex flex-col gap-2">
                 <InfoRow label={readByLabel} />
-                {message.readBy && message.readBy.length > 0 && (
+                {message.readBy && message.readBy.length > 0 ? (
                   <ul
                     aria-label={readByLabel}
                     className="m-0 flex list-none flex-col gap-1 p-0"
@@ -122,7 +122,7 @@ export const ChatMessageInfoView = ({
                       </li>
                     ))}
                   </ul>
-                )}
+                ) : null}
               </div>
             ) : (
               message.readAt && (
@@ -131,7 +131,8 @@ export const ChatMessageInfoView = ({
                   value={formatSeparator(new Date(message.readAt), now, labels)}
                 />
               )
-            ))}
+            )
+          ) : null}
         </div>
       </div>
     </div>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageItem.tsx
@@ -225,7 +225,7 @@ export const ChatMessageItem = ({
       {/* Attachments + bubble are one message column on the message's side, so
           a text-less (files-only) message still aligns + gets hover actions.
           items-end keeps the avatar gutter level with the bottom of it. */}
-      {hasContent && (
+      {hasContent ? (
         <div
           className={cn(
             // 4px here + the outer surface's own 2px of padding stand the
@@ -273,7 +273,7 @@ export const ChatMessageItem = ({
               onDoubleClick={handleDoubleClick}
               data-testid="chat-message-surface"
             >
-              {hasAttachments && (
+              {hasAttachments ? (
                 <ChatMessageAttachments
                   message={message}
                   isMine={isMine}
@@ -281,8 +281,8 @@ export const ChatMessageItem = ({
                   isLastOfRun={isLastOfRun}
                   hasAvatar={hasAvatar}
                 />
-              )}
-              {hasBubble && (
+              ) : null}
+              {hasBubble ? (
                 <ChatBubble
                   message={message}
                   isMine={isMine}
@@ -296,16 +296,16 @@ export const ChatMessageItem = ({
                   isLastOfRun={isLastOfRun}
                   hasAvatar={hasAvatar}
                 />
-              )}
+              ) : null}
             </div>
             {/* Sending indicator for own messages, in the slot next to the
                 bubble (the row is flex-row-reverse for mine, so it reads to
                 the bubble's left). Adding/removing it never shifts the bubble
                 (right-anchored) nor the row height — stable measurements for
                 the virtualizer. */}
-            {isMine && message.status === "sending" && (
+            {isMine && message.status === "sending" ? (
               <SendingClock sentAt={message.createdAt} />
-            )}
+            ) : null}
             {/* Deleted tombstones have nothing to act on, and an in-flight
                 (sending) message can't be acted on yet either — only the clock
                 shows until it settles. The menu stays visible while open (not
@@ -315,69 +315,69 @@ export const ChatMessageItem = ({
                 ignores `hasActions`: retrying and discarding a local echo are
                 never permissions. */}
             {!message.deleted &&
-              message.status !== "sending" &&
-              (hasActions || message.status === "failed") && (
-                <div
-                  ref={actionsWrapperRef}
-                  className={cn(
-                    message.status === "failed"
-                      ? "opacity-100"
-                      : "opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100",
-                    actionsOpen && "opacity-100"
-                  )}
-                >
-                  {message.status === "failed" ? (
-                    // The alert fades in on a live failure (the branch switch
-                    // remounts it, so `initial` applies) — never on a
-                    // scroll-back of an old failure.
-                    <motion.div
-                      initial={
-                        wasFailedAtMountRef.current || reducedMotion
-                          ? false
-                          : { opacity: 0, scale: 0.9 }
-                      }
-                      animate={{ opacity: 1, scale: 1 }}
-                      transition={microEnterTransition}
-                    >
-                      <ChatMessageActions
-                        message={message}
-                        isMine={isMine}
-                        open={actionsOpen}
-                        onOpenChange={setActionsOpen}
-                      />
-                    </motion.div>
-                  ) : actionsArmed ? (
+            message.status !== "sending" &&
+            (hasActions || message.status === "failed") ? (
+              <div
+                ref={actionsWrapperRef}
+                className={cn(
+                  message.status === "failed"
+                    ? "opacity-100"
+                    : "opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100",
+                  actionsOpen && "opacity-100"
+                )}
+              >
+                {message.status === "failed" ? (
+                  // The alert fades in on a live failure (the branch switch
+                  // remounts it, so `initial` applies) — never on a
+                  // scroll-back of an old failure.
+                  <motion.div
+                    initial={
+                      wasFailedAtMountRef.current || reducedMotion
+                        ? false
+                        : { opacity: 0, scale: 0.9 }
+                    }
+                    animate={{ opacity: 1, scale: 1 }}
+                    transition={microEnterTransition}
+                  >
                     <ChatMessageActions
                       message={message}
                       isMine={isMine}
                       open={actionsOpen}
                       onOpenChange={setActionsOpen}
                     />
-                  ) : (
-                    // Same trigger the popover renders, minus the popover and
-                    // tooltip machinery — indistinguishable until interaction.
-                    // Activating it (click, tap, Enter) arms AND opens, so the
-                    // very first interaction behaves exactly like the real one.
-                    <ButtonInternal
-                      variant="outline"
-                      hideLabel
-                      noAutoTooltip
-                      label={i18n.chat.moreActions}
-                      icon={Ellipsis}
-                      pressed={false}
-                      onClick={() => {
-                        armActions()
-                        setActionsOpen(true)
-                      }}
-                    />
-                  )}
-                </div>
-              )}
+                  </motion.div>
+                ) : actionsArmed ? (
+                  <ChatMessageActions
+                    message={message}
+                    isMine={isMine}
+                    open={actionsOpen}
+                    onOpenChange={setActionsOpen}
+                  />
+                ) : (
+                  // Same trigger the popover renders, minus the popover and
+                  // tooltip machinery — indistinguishable until interaction.
+                  // Activating it (click, tap, Enter) arms AND opens, so the
+                  // very first interaction behaves exactly like the real one.
+                  <ButtonInternal
+                    variant="outline"
+                    hideLabel
+                    noAutoTooltip
+                    label={i18n.chat.moreActions}
+                    icon={Ellipsis}
+                    pressed={false}
+                    onClick={() => {
+                      armActions()
+                      setActionsOpen(true)
+                    }}
+                  />
+                )}
+              </div>
+            ) : null}
           </div>
         </div>
-      )}
+      ) : null}
       <AnimatePresence initial={false}>
-        {hasReactions && (
+        {hasReactions ? (
           // Reactions grow the row in (height + fade) when the first one lands
           // on a visible message, and collapse it back out when the last one is
           // removed — never a pop. The transcript's slide layer absorbs the
@@ -400,7 +400,7 @@ export const ChatMessageItem = ({
               <ChatMessageReactions message={message} isMine={isMine} />
             </div>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
     </div>
   )

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageReactions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageReactions.tsx
@@ -98,14 +98,14 @@ export const ChatMessageReactions = ({
           </motion.span>
         ))}
       </AnimatePresence>
-      {canReact && (
+      {canReact ? (
         <ChatEmojiPickerButton
           size="md"
           variant="outline"
           label={i18n.chat.react}
           onSelect={(emoji) => react(emoji, "inlinePicker")}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageRowRenderer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageRowRenderer.tsx
@@ -173,7 +173,9 @@ const ChatMessageRowRendererComponent = ({
     const showFooterGutter = isGroup && !row.message.isMine
     return (
       <div className={cn("flex w-full gap-1.5", spacing)}>
-        {showFooterGutter && <span aria-hidden className="size-5 shrink-0" />}
+        {showFooterGutter ? (
+          <span aria-hidden className="size-5 shrink-0" />
+        ) : null}
         <div className="min-w-0 flex-1">
           <MessageStatus message={row.message} isGroup={isGroup} />
         </div>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageSkeleton.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageSkeleton.tsx
@@ -13,7 +13,7 @@ const SkeletonRun = ({
   <div
     className={cn("flex w-full items-end gap-2", mine && "flex-row-reverse")}
   >
-    {!mine && <Skeleton className="size-6 shrink-0 rounded-full" />}
+    {!mine ? <Skeleton className="size-6 shrink-0 rounded-full" /> : null}
     <div
       className={cn("flex flex-col gap-1", mine ? "items-end" : "items-start")}
     >

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageStatusIcon.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageStatusIcon.tsx
@@ -32,14 +32,14 @@ export const SendingClock = ({ sentAt }: { sentAt: string }): ReactNode => {
       )}
       data-testid="chat-sending-clock"
     >
-      {visible && (
+      {visible ? (
         <F0Button
           variant="ghost"
           hideLabel
           label={formatClock(new Date(sentAt))}
           icon={Clock}
         />
-      )}
+      ) : null}
     </span>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessagesContainer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessagesContainer.tsx
@@ -634,7 +634,7 @@ export const ChatMessagesContainer = (): ReactNode => {
         )}
       />
 
-      {ready && (
+      {ready ? (
         <ChatViewportOverlays
           atTop={atTop}
           scrolledUp={scrolledUp}
@@ -647,7 +647,7 @@ export const ChatMessagesContainer = (): ReactNode => {
           reducedMotion={reducedMotion}
           onJumpToBottom={jumpToBottom}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatReplyChip.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatReplyChip.tsx
@@ -22,7 +22,7 @@ export const ChatReplyChip = ({
   return (
     <div className="p-1">
       <div className="flex items-stretch gap-2 overflow-hidden rounded-[10px] bg-f1-background-tertiary py-1.5 pl-2 pr-1.5">
-        {thumbnailUrl && (
+        {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
             alt=""
@@ -30,7 +30,7 @@ export const ChatReplyChip = ({
             decoding="async"
             className="h-9 w-9 shrink-0 self-center rounded-sm object-cover"
           />
-        )}
+        ) : null}
         <div className="min-w-0 flex-1 gap-0.5 p-1">
           <OneEllipsis
             className={cn(
@@ -41,7 +41,7 @@ export const ChatReplyChip = ({
             {message.isMine ? i18n.chat.you : message.author.name}
           </OneEllipsis>
           <span className="flex min-w-0 items-center gap-1 text-f1-foreground-secondary">
-            {icon && <F0Icon icon={icon} size="xs" color="default" />}
+            {icon ? <F0Icon icon={icon} size="xs" color="default" /> : null}
             <OneEllipsis className="min-w-0 text-base" lines={1}>
               {label}
             </OneEllipsis>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatStates.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatStates.tsx
@@ -28,7 +28,7 @@ export const ChatError = (): ReactNode => {
       <div className="flex flex-col items-center gap-3">
         <span>{i18n.chat.error}</span>
         {/* Recovery action — only when the host can actually retry the load. */}
-        {reconnect && (
+        {reconnect ? (
           <ButtonInternal
             variant="outline"
             size="sm"
@@ -36,7 +36,7 @@ export const ChatError = (): ReactNode => {
             icon={ArrowCycle}
             onClick={() => void reconnect()}
           />
-        )}
+        ) : null}
       </div>
     </Centered>
   )

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -77,7 +77,7 @@ export const ChatTextareaField = ({
         {value.endsWith("\n") ? value + "_" : value || " "}
       </div>
 
-      {hasOverlay && (
+      {hasOverlay ? (
         <div
           ref={highlightRef}
           aria-hidden
@@ -120,7 +120,7 @@ export const ChatTextareaField = ({
             )
           )}
         </div>
-      )}
+      ) : null}
 
       <textarea
         ref={textareaRef}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTypingBubble.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTypingBubble.tsx
@@ -106,8 +106,8 @@ export const ChatTypingBubble = ({
       animate={leaving ? { opacity: 0 } : { opacity: 1 }}
       transition={{ duration: 0.14, ease: EASE_OUT_SWIFT }}
     >
-      {isGroup &&
-        (users.length > 1 ? (
+      {isGroup ? (
+        users.length > 1 ? (
           // Several people typing: stacked avatar list, capped at 3 with a +N.
           <F0AvatarList
             type="person"
@@ -127,7 +127,8 @@ export const ChatTypingBubble = ({
               }
             }
           />
-        ))}
+        )
+      ) : null}
       {/* The point only belongs where the avatar is — in a DM there's nothing
           beside the bubble for it to aim at (see `bubbleCornerClass`). */}
       <div

--- a/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
@@ -124,7 +124,7 @@ export const ChatVideoAttachment = ({
         >
           <SolidPlay className="size-6" />
         </span>
-        {sizeLabel && (
+        {sizeLabel ? (
           <span
             className={cn(
               "absolute bottom-2 left-2 rounded-full px-2 py-0.5 text-sm font-medium text-f1-foreground-inverse",
@@ -134,7 +134,7 @@ export const ChatVideoAttachment = ({
           >
             {sizeLabel}
           </span>
-        )}
+        ) : null}
       </div>
 
       <div
@@ -160,11 +160,11 @@ export const ChatVideoAttachment = ({
 
       {/* Above the player shell so the time stays readable over the poster, and
           hidden on hover so it never fights the player's own bottom controls. */}
-      {meta && (
+      {meta ? (
         <span className="pointer-events-none absolute inset-0 z-20 opacity-100 transition-opacity duration-150 group-hover/video:opacity-0 motion-reduce:transition-none">
           {meta}
         </span>
-      )}
+      ) : null}
 
       <figcaption className="sr-only">{file.name}</figcaption>
     </figure>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatViewportOverlays.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatViewportOverlays.tsx
@@ -39,36 +39,38 @@ export const ChatViewportOverlays = ({
   return (
     <>
       <AnimatePresence>
-        {!atTop && <ScrollShadow position="top" key="chat-header-shadow" />}
+        {!atTop ? (
+          <ScrollShadow position="top" key="chat-header-shadow" />
+        ) : null}
       </AnimatePresence>
 
       <AnimatePresence>
         {scrolledUp &&
-          (!atTop || hasMoreOlder || loadingOlder) &&
-          stickyDate && (
-            <motion.div
-              className="pointer-events-none absolute inset-x-0 top-2 flex justify-center"
-              initial={{ opacity: 0, y: -4 }}
-              animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={{ duration: transitionDuration }}
+        (!atTop || hasMoreOlder || loadingOlder) &&
+        stickyDate ? (
+          <motion.div
+            className="pointer-events-none absolute inset-x-0 top-2 flex justify-center"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -4 }}
+            transition={{ duration: transitionDuration }}
+          >
+            <div
+              className="z-50"
+              aria-label={loadingOlder ? i18n.chat.loadingOlder : undefined}
             >
-              <div
-                className="z-50"
-                aria-label={loadingOlder ? i18n.chat.loadingOlder : undefined}
-              >
-                <DateTimeSeparator
-                  at={stickyDate}
-                  withTime
-                  loading={loadingOlder}
-                />
-              </div>
-            </motion.div>
-          )}
+              <DateTimeSeparator
+                at={stickyDate}
+                withTime
+                loading={loadingOlder}
+              />
+            </div>
+          </motion.div>
+        ) : null}
       </AnimatePresence>
 
       <AnimatePresence>
-        {showJumpButton && (
+        {showJumpButton ? (
           <motion.div
             data-testid="chat-jump-overlay"
             className="pointer-events-none absolute inset-x-0 flex justify-center"
@@ -116,7 +118,7 @@ export const ChatViewportOverlays = ({
               />
             </motion.div>
           </motion.div>
-        )}
+        ) : null}
       </AnimatePresence>
     </>
   )

--- a/packages/react/src/sds/chat/F0Chat/components/DateTimeSeparator.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/DateTimeSeparator.tsx
@@ -42,7 +42,7 @@ export const DateTimeSeparator = ({
       data-testid="chat-date-separator"
     >
       <span className="flex items-center gap-1.5 rounded-full border border-solid border-f1-border-secondary bg-f1-background px-2.5 py-0.5 backdrop-blur">
-        {loading && <Spinner size="small" className="h-3.5 w-3.5" />}
+        {loading ? <Spinner size="small" className="h-3.5 w-3.5" /> : null}
         <span className="text-sm font-normal text-f1-foreground-secondary">
           {label}
         </span>

--- a/packages/react/src/sds/chat/F0Chat/components/ReplyQuote.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ReplyQuote.tsx
@@ -62,7 +62,7 @@ export const ReplyQuote = ({
               : "rounded-tl-xs"
         )}
       >
-        {thumbnailUrl && (
+        {thumbnailUrl ? (
           <img
             src={thumbnailUrl}
             alt=""
@@ -70,7 +70,7 @@ export const ReplyQuote = ({
             decoding="async"
             className="ml-2.5 h-9 w-9 shrink-0 self-center rounded-sm object-cover"
           />
-        )}
+        ) : null}
         <div className="flex min-w-0 flex-1 flex-col gap-0.5 p-2.5">
           <ClampText
             className={cn(
@@ -81,7 +81,7 @@ export const ReplyQuote = ({
             {senderName}
           </ClampText>
           <span className="flex min-w-0 items-center gap-1 text-f1-foreground-secondary">
-            {icon && <F0Icon icon={icon} size="sm" color="default" />}
+            {icon ? <F0Icon icon={icon} size="sm" color="default" /> : null}
             <ClampText className="min-w-0 text-base">{label}</ClampText>
           </span>
         </div>

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useComposerOverlayLayout.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useComposerOverlayLayout.test.tsx
@@ -12,7 +12,7 @@ const ComposerLayoutHarness = ({ enabled }: { enabled: boolean }) => {
 
   return (
     <div ref={shellRef} data-testid="shell">
-      {enabled && <div ref={composerOverlayRef}>Composer</div>}
+      {enabled ? <div ref={composerOverlayRef}>Composer</div> : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/mocks/useDemoHeaderActions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/mocks/useDemoHeaderActions.tsx
@@ -86,7 +86,7 @@ export function useDemoHeaderActions(
           value={draftName}
           onChange={setDraftName}
         />
-        {members.length > 0 && (
+        {members.length > 0 ? (
           <div className="flex flex-col gap-2">
             <span className="text-sm font-medium text-f1-foreground-secondary">
               {channel.memberCount ?? members.length} members
@@ -105,7 +105,7 @@ export function useDemoHeaderActions(
               ))}
             </div>
           </div>
-        )}
+        ) : null}
         <p className="text-sm text-f1-foreground-secondary">
           The host owns this dialog: the header action only fires a callback
           with the channel, and the app decides what to open (here, an F0Dialog

--- a/packages/react/src/sds/inbox/Activity/ActivityItem/index.tsx
+++ b/packages/react/src/sds/inbox/Activity/ActivityItem/index.tsx
@@ -76,9 +76,9 @@ export const BaseActivityItem = ({
         </div>
       </div>
       <div className="ml-1">
-        {isUnread && (
+        {isUnread ? (
           <div className="mt-1.5 size-2 rounded-full bg-f1-icon-accent" />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/sds/inbox/Activity/ActivityItemList/index.tsx
+++ b/packages/react/src/sds/inbox/Activity/ActivityItemList/index.tsx
@@ -80,13 +80,14 @@ export const BaseActivityItemList = ({
             onClickItem={onClickItem}
             onItemVisible={handleItemVisible}
           />
-          {index !== groups.length - 1 && <Separator />}
+          {index !== groups.length - 1 ? <Separator /> : null}
         </React.Fragment>
       ))}
-      {loadingMoreItems &&
-        new Array(MORE_ITEMS_LOADING_COUNT)
-          .fill(null)
-          .map((_, index) => <ActivityItem.Skeleton key={index} />)}
+      {loadingMoreItems
+        ? new Array(MORE_ITEMS_LOADING_COUNT)
+            .fill(null)
+            .map((_, index) => <ActivityItem.Skeleton key={index} />)
+        : null}
     </div>
   )
 }

--- a/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/ApprovalStep/index.tsx
@@ -123,11 +123,11 @@ const ApprovalStep: FC<ApprovalStepProps> = ({
       <div className="w-full">
         <F0AvatarList avatars={avatars} layout="fill" type="person" size="md" />
       </div>
-      {approvalDate && (
+      {approvalDate ? (
         <p className="text-sm text-f1-foreground-secondary">
           {format(approvalDate, "PP", { locale })}
         </p>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/inbox/OneApprovalHistory/index.tsx
+++ b/packages/react/src/sds/inbox/OneApprovalHistory/index.tsx
@@ -34,9 +34,9 @@ const _OneApprovalHistory: FC<OneApprovalHistoryProps> = ({ steps }) => {
               >
                 <span>{index + 1}</span>
               </div>
-              {index !== steps.length - 1 && (
+              {index !== steps.length - 1 ? (
                 <div className="h-[96px] w-px bg-f1-border-secondary" />
-              )}
+              ) : null}
             </div>
           ))}
         </div>
@@ -50,9 +50,9 @@ const _OneApprovalHistory: FC<OneApprovalHistoryProps> = ({ steps }) => {
                 approvers={step.approvers}
                 approvalDate={step.approvalDate}
               />
-              {index !== steps.length - 1 && (
+              {index !== steps.length - 1 ? (
                 <div className="h-px w-full bg-f1-border-secondary" />
-              )}
+              ) : null}
             </Fragment>
           ))}
         </div>

--- a/packages/react/src/sds/social/Reactions/index.tsx
+++ b/packages/react/src/sds/social/Reactions/index.tsx
@@ -18,7 +18,7 @@ export interface ReactionsProps {
 function _Reactions({ items, onInteraction, locale, action }: ReactionsProps) {
   return (
     <div className="flex flex-wrap gap-2">
-      {action && (
+      {action ? (
         <F0Button
           label={action.label}
           icon={action.icon}
@@ -26,7 +26,7 @@ function _Reactions({ items, onInteraction, locale, action }: ReactionsProps) {
           variant="outline"
           hideLabel
         />
-      )}
+      ) : null}
       <Picker onSelect={onInteraction} locale={locale} />
       {items.map((item) => (
         <Reaction

--- a/packages/react/src/sds/timeline/components/Actions.tsx
+++ b/packages/react/src/sds/timeline/components/Actions.tsx
@@ -16,7 +16,7 @@ export const Actions = ({
 
   return (
     <div className="flex flex-col gap-2 xs:flex-row xs:items-center [&>*]:w-full [&>*]:xs:w-auto">
-      {hasOther && <Dropdown items={otherActions} size="md" />}
+      {hasOther ? <Dropdown items={otherActions} size="md" /> : null}
       {secondaryActions?.map((action, index) => (
         <F0Button
           key={`${action.label}-${index}`}
@@ -29,10 +29,10 @@ export const Actions = ({
           loading={action.loading}
         />
       ))}
-      {primaryAction && (hasOther || hasSecondary) && (
+      {primaryAction && (hasOther || hasSecondary) ? (
         <div className="mx-1 hidden h-4 w-px bg-f1-background-secondary-hover xs:block" />
-      )}
-      {primaryAction && (
+      ) : null}
+      {primaryAction ? (
         <F0Button
           label={primaryAction.label}
           icon={primaryAction.icon}
@@ -42,7 +42,7 @@ export const Actions = ({
           disabled={primaryAction.disabled}
           loading={primaryAction.loading}
         />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/timeline/components/MultitaskHeader.tsx
+++ b/packages/react/src/sds/timeline/components/MultitaskHeader.tsx
@@ -23,12 +23,12 @@ export const MultitaskHeader = ({
           onOpenChange={() => onExpandToggle()}
           showOpenChange
         />
-        {completedCount !== undefined && (
+        {completedCount !== undefined ? (
           <F0TagStatus
             text={`${completedCount}/${taskCount}`}
             variant={status === "completed" ? "positive" : "warning"}
           />
-        )}
+        ) : null}
       </div>
     </>
   )

--- a/packages/react/src/sds/timeline/components/MultitaskRow.tsx
+++ b/packages/react/src/sds/timeline/components/MultitaskRow.tsx
@@ -27,7 +27,7 @@ export const MultitaskRow = ({
       <div className="flex min-h-8 items-center gap-2">
         <MultitaskHeader props={props} />
       </div>
-      {expanded && (
+      {expanded ? (
         <div className="flex flex-col pl-4">
           {items.map((item, index: number) =>
             isNestedtaskItem(item) ? (
@@ -51,7 +51,7 @@ export const MultitaskRow = ({
             )
           )}
         </div>
-      )}
+      ) : null}
     </TimelineRowLayout>
   )
 }

--- a/packages/react/src/sds/timeline/components/NestedtaskHeader.tsx
+++ b/packages/react/src/sds/timeline/components/NestedtaskHeader.tsx
@@ -54,9 +54,9 @@ export const NestedtaskHeader = ({
             >
               {title}
             </span>
-            {description && (
+            {description ? (
               <F0Text content={description} variant="description" as="span" />
-            )}
+            ) : null}
             <F0Icon
               icon={expanded ? ChevronUp : ChevronDown}
               size="xs"
@@ -73,12 +73,12 @@ export const NestedtaskHeader = ({
             >
               {title}
             </span>
-            {description && (
+            {description ? (
               <F0Text content={description} variant="description" as="span" />
-            )}
+            ) : null}
           </div>
         )}
-        {completedCount !== undefined && taskCount !== undefined && (
+        {completedCount !== undefined && taskCount !== undefined ? (
           <div
             className="flex items-center gap-2"
             aria-label={`${completedCount} of ${taskCount} completed`}
@@ -96,7 +96,7 @@ export const NestedtaskHeader = ({
               {completedCount}/{taskCount}
             </span>
           </div>
-        )}
+        ) : null}
       </div>
     </>
   )

--- a/packages/react/src/sds/timeline/components/NestedtaskRow.tsx
+++ b/packages/react/src/sds/timeline/components/NestedtaskRow.tsx
@@ -26,7 +26,9 @@ const NestedItem = ({ props }: { props: F0TimelineRowTaskProps }) => {
       >
         {title}
       </h4>
-      {description && <F0Text content={description} variant="description" />}
+      {description ? (
+        <F0Text content={description} variant="description" />
+      ) : null}
     </div>
   )
 }
@@ -63,12 +65,12 @@ export const NestedtaskRow = ({
       <div className="flex min-h-8 items-center gap-3">
         <NestedtaskHeader props={props} contentId={contentId} />
       </div>
-      {metadata && hasMetadata && (
+      {metadata && hasMetadata ? (
         <div className="pl-9">
           <Metadata items={metadata} />
         </div>
-      )}
-      {isExpanded && (
+      ) : null}
+      {isExpanded ? (
         <div id={contentId} role="region" className="flex flex-col gap-0 pl-4">
           {content !== undefined
             ? content
@@ -76,8 +78,8 @@ export const NestedtaskRow = ({
                 <NestedItem key={`${item.title}-${index}`} props={item} />
               ))}
         </div>
-      )}
-      {hasActions && (
+      ) : null}
+      {hasActions ? (
         <div className="pl-9">
           <Actions
             primaryAction={primaryAction}
@@ -85,7 +87,7 @@ export const NestedtaskRow = ({
             otherActions={otherActions}
           />
         </div>
-      )}
+      ) : null}
     </TimelineRowLayout>
   )
 }

--- a/packages/react/src/sds/timeline/components/TaskDetails.tsx
+++ b/packages/react/src/sds/timeline/components/TaskDetails.tsx
@@ -13,13 +13,13 @@ export const TaskDetails = ({ props }: { props: F0TimelineRowTaskProps }) => {
 
   return (
     <div className="pl-9">
-      {metadata && hasMetadata && (
+      {metadata && hasMetadata ? (
         <div className="mb-3">
           <Metadata items={metadata} />
         </div>
-      )}
+      ) : null}
 
-      {hasActions && (
+      {hasActions ? (
         <div className="mb-3">
           <Actions
             primaryAction={primaryAction}
@@ -27,7 +27,7 @@ export const TaskDetails = ({ props }: { props: F0TimelineRowTaskProps }) => {
             otherActions={otherActions}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/sds/timeline/components/TaskHeader.tsx
+++ b/packages/react/src/sds/timeline/components/TaskHeader.tsx
@@ -22,12 +22,14 @@ export const TaskHeader = ({ props }: { props: F0TimelineRowTaskProps }) => {
         >
           {title}
         </h4>
-        {description && <F0Text content={description} variant="description" />}
+        {description ? (
+          <F0Text content={description} variant="description" />
+        ) : null}
       </div>
       <div className="flex justify-end items-center gap-3 pl-9">
-        {status === "completed" && metadata && hasMetadata && (
+        {status === "completed" && metadata && hasMetadata ? (
           <Metadata items={metadata} />
-        )}
+        ) : null}
       </div>
     </div>
   )

--- a/packages/react/src/sds/timeline/components/TaskRow.tsx
+++ b/packages/react/src/sds/timeline/components/TaskRow.tsx
@@ -11,7 +11,7 @@ export const TaskRow = ({ props }: { props: F0TimelineRowTaskProps }) => {
       <div className="flex min-h-8 items-center gap-2">
         <TaskHeader props={props} />
       </div>
-      {status !== "completed" && <TaskDetails props={props} />}
+      {status !== "completed" ? <TaskDetails props={props} /> : null}
     </TimelineRowLayout>
   )
 }

--- a/packages/react/src/sds/timeline/components/TimelineRowLayout.tsx
+++ b/packages/react/src/sds/timeline/components/TimelineRowLayout.tsx
@@ -23,7 +23,7 @@ export const TimelineRowLayout = ({
   children: ReactNode
 }) => (
   <div className="flex gap-4">
-    {!hideStatus && (
+    {!hideStatus ? (
       <div className="flex flex-col items-center">
         <div
           className="h-8 flex flex-col justify-center"
@@ -31,9 +31,9 @@ export const TimelineRowLayout = ({
         >
           {statusIcons[status]}
         </div>
-        {!isLast && <F0TimelineConnector status={status} />}
+        {!isLast ? <F0TimelineConnector status={status} /> : null}
       </div>
-    )}
+    ) : null}
     <div className="flex flex-1 flex-col gap-3 pb-5">{children}</div>
   </div>
 )

--- a/packages/react/src/ui/Action/Action.tsx
+++ b/packages/react/src/ui/Action/Action.tsx
@@ -88,7 +88,7 @@ export const Action = React.forwardRef<
         {append}
       </div>
       <AnimatePresence>
-        {loading && (
+        {loading ? (
           <>
             {isLinkStyled(localVariant) ? (
               <Skeleton className="absolute inset-0 my-auto h-full w-full" />
@@ -112,7 +112,7 @@ export const Action = React.forwardRef<
               </div>
             )}
           </>
-        )}
+        ) : null}
       </AnimatePresence>
     </>
   )

--- a/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
+++ b/packages/react/src/ui/ButtonGroup/ButtonGroup.tsx
@@ -343,10 +343,10 @@ function ButtonGroupStacked({
 
   return (
     <>
-      {otherActions.length > 0 && <MobileDropdown items={otherActions} />}
+      {otherActions.length > 0 ? <MobileDropdown items={otherActions} /> : null}
       {stackedSecondaries}
-      {secondaryLink && renderSecondaryLink(secondaryLink, size)}
-      {primaryAction && renderPrimaryNode(primaryAction, size)}
+      {secondaryLink ? renderSecondaryLink(secondaryLink, size) : null}
+      {primaryAction ? renderPrimaryNode(primaryAction, size) : null}
     </>
   )
 }
@@ -472,7 +472,7 @@ function ButtonGroupRow({
       >
         {/* Hidden measurement copy, used to compute the visible/overflow split.
             Skipped when the group can't overflow — nothing is ever measured away. */}
-        {canOverflow && (
+        {canOverflow ? (
           <div
             ref={measurementContainerRef}
             aria-hidden="true"
@@ -482,13 +482,13 @@ function ButtonGroupRow({
               renderActionButton(action, size, "outline")
             )}
           </div>
-        )}
+        ) : null}
 
-        {menuItems.length > 0 && (
+        {menuItems.length > 0 ? (
           <div ref={customOverflowIndicatorRef}>
             <Dropdown items={menuItems} icon={Ellipsis} size={size} />
           </div>
-        )}
+        ) : null}
 
         {cleanedTokens.map((token) =>
           token.kind === "sep" ? (
@@ -498,13 +498,13 @@ function ButtonGroupRow({
           )
         )}
 
-        {secondaryLink && renderSecondaryLink(secondaryLink, size)}
+        {secondaryLink ? renderSecondaryLink(secondaryLink, size) : null}
       </div>
 
       {splitSecondaries.map((action) =>
         renderSplitButton(action, size, "outline")
       )}
-      {dividerBeforePinned && <ButtonGroupSeparator />}
+      {dividerBeforePinned ? <ButtonGroupSeparator /> : null}
       {primaryNode}
     </>
   )

--- a/packages/react/src/ui/Card/Card.tsx
+++ b/packages/react/src/ui/Card/Card.tsx
@@ -50,11 +50,11 @@ const Card = React.forwardRef<
         }
       }}
     >
-      {href && !disabled && (
+      {href && !disabled ? (
         <Link href={href} className="absolute inset-0 block" tabIndex={0}>
           <span className="sr-only">{actions.view}</span>
         </Link>
-      )}
+      ) : null}
       {children}
     </div>
   )

--- a/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
+++ b/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
@@ -312,9 +312,9 @@ export function DatePickerPopup({
           />
         ) : (
           <div className="flex gap-4">
-            {(presets.length > 0 || granularityOptions.length > 1) && (
+            {presets.length > 0 || granularityOptions.length > 1 ? (
               <div>
-                {presets.length > 0 && (
+                {presets.length > 0 ? (
                   <F0Button
                     icon={ChevronLeft}
                     variant="neutral"
@@ -323,17 +323,17 @@ export function DatePickerPopup({
                     label="Back"
                     onClick={handleBackToPresets}
                   />
-                )}
-                {granularityOptions.length > 1 && (
+                ) : null}
+                {granularityOptions.length > 1 ? (
                   <GranularitySelector
                     granularities={granularityOptions}
                     value={localGranularity}
                     onChange={handleSelectGranularity}
                     definitions={definitions}
                   />
-                )}
+                ) : null}
               </div>
-            )}
+            ) : null}
             <div className="min-w-[300px] flex-1">
               <OneCalendar
                 showInput={!hideCalendarInput}
@@ -347,7 +347,7 @@ export function DatePickerPopup({
                 selectOnCellOnly={selectOnCellOnly}
                 periods={periods}
               />
-              {compareToOptions.length > 0 && (
+              {compareToOptions.length > 0 ? (
                 <div className="mt-4 flex flex-col gap-2">
                   <div className="text-gray-500 text-sm">
                     {i18n.date.compareTo}
@@ -365,7 +365,7 @@ export function DatePickerPopup({
                     value={selectedCompareTo}
                   />
                 </div>
-              )}
+              ) : null}
             </div>
           </div>
         )}

--- a/packages/react/src/ui/GroupHeader/GroupHeader.tsx
+++ b/packages/react/src/ui/GroupHeader/GroupHeader.tsx
@@ -90,8 +90,8 @@ export const GroupHeader = ({
         onKeyDown: handleKeyDown,
       })}
     >
-      {chevronPosition === "leading" && chevron}
-      {selectable && (
+      {chevronPosition === "leading" ? chevron : null}
+      {selectable ? (
         <F0Checkbox
           checked={!!select}
           indeterminate={select === "indeterminate"}
@@ -100,7 +100,7 @@ export const GroupHeader = ({
           onCheckedChange={(checked) => onSelectChange?.(checked)}
           stopPropagation
         />
-      )}
+      ) : null}
       <Await resolve={label} fallback={<Skeleton className="h-4 w-24" />}>
         {(label) => (
           <h6 className="text-base font-semibold text-f1-foreground">
@@ -111,7 +111,7 @@ export const GroupHeader = ({
       <Await resolve={itemCount} fallback={<Skeleton className="h-4 w-5" />}>
         {(count) => count !== undefined && <Counter value={count} />}
       </Await>
-      {chevronPosition === "trailing" && chevron}
+      {chevronPosition === "trailing" ? chevron : null}
     </div>
   )
 }

--- a/packages/react/src/ui/Kanban/components/KanbanCard.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanCard.tsx
@@ -128,7 +128,7 @@ export function KanbanCard<T = unknown>({
       onClick={handleClick}
     >
       <CardInternal {...props} disableOverlayLink={draggable} />
-      {props.link && (
+      {props.link ? (
         <F0Link
           ref={linkRef}
           href={props.link}
@@ -140,8 +140,8 @@ export function KanbanCard<T = unknown>({
         >
           &nbsp;
         </F0Link>
-      )}
-      {showIndicator && (forcedEdge ?? overEdge) && (
+      ) : null}
+      {showIndicator && (forcedEdge ?? overEdge) ? (
         <>
           {(() => {
             const activeEdge = (forcedEdge ?? overEdge) as "top" | "bottom"
@@ -158,7 +158,7 @@ export function KanbanCard<T = unknown>({
             )
           })()}
         </>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/ui/Lane/Lane.tsx
+++ b/packages/react/src/ui/Lane/Lane.tsx
@@ -114,12 +114,12 @@ export function Lane<Record extends RecordType>({
                     )
                   })
                 )}
-                {(loadingMore || hasMore) && (
+                {loadingMore || hasMore ? (
                   <LoadingSkeleton ref={loadingIndicatorRef} />
-                )}
+                ) : null}
               </div>
             </ScrollArea>
-            {loadingMore && (
+            {loadingMore ? (
               <AnimatePresence>
                 <motion.div
                   className="absolute inset-0 m-auto flex w-10 cursor-progress items-center justify-center"
@@ -130,11 +130,11 @@ export function Lane<Record extends RecordType>({
                   <Spinner />
                 </motion.div>
               </AnimatePresence>
-            )}
+            ) : null}
           </>
         )}
       </div>
-      {showFooterAction && (
+      {showFooterAction ? (
         <div className="pointer-events-none absolute inset-x-1 bottom-1.5 z-20 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
           <ButtonInternal
             variant="ghost"
@@ -146,7 +146,7 @@ export function Lane<Record extends RecordType>({
             onClick={onFooterAction}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/ui/Lane/components/LaneHeader.tsx
+++ b/packages/react/src/ui/Lane/components/LaneHeader.tsx
@@ -29,7 +29,7 @@ export const LaneHeader = ({
         <F0TagStatus text={label} variant={variant || "neutral"} />
       )}
       <Counter size="md" type="default" value={count} />
-      {showPrimary && (
+      {showPrimary ? (
         <div className="ml-auto flex items-center gap-1 pr-1">
           <F0Button
             variant="ghost"
@@ -40,7 +40,7 @@ export const LaneHeader = ({
             onClick={onPrimaryAction}
           />
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/ui/Lane/components/LoadingSkeleton.tsx
+++ b/packages/react/src/ui/Lane/components/LoadingSkeleton.tsx
@@ -17,10 +17,11 @@ export const LoadingSkeleton = forwardRef<HTMLDivElement, LoadingSkeletonProps>(
   ({ showPlaceholders = true, count = 3 }, ref) => {
     return (
       <div ref={ref} className="space-y-1" aria-hidden={!showPlaceholders}>
-        {showPlaceholders &&
-          Array.from({ length: count }).map((_, i) => (
-            <F0Card.Skeleton compact key={i} />
-          ))}
+        {showPlaceholders
+          ? Array.from({ length: count }).map((_, i) => (
+              <F0Card.Skeleton compact key={i} />
+            ))
+          : null}
       </div>
     )
   }

--- a/packages/react/src/ui/Omnibutton/index.tsx
+++ b/packages/react/src/ui/Omnibutton/index.tsx
@@ -50,9 +50,9 @@ function _OmniButton({ label, options, hasNewUpdate }: OmniButtonProps) {
           aria-label={label}
         >
           <F0Icon icon={Question} size="sm" />
-          {hasNewUpdate && (
+          {hasNewUpdate ? (
             <div className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-f1-background-critical-bold ring-2 ring-f1-background-critical" />
-          )}
+          ) : null}
         </button>
       </Dropdown>
     </div>

--- a/packages/react/src/ui/OnePagination/index.tsx
+++ b/packages/react/src/ui/OnePagination/index.tsx
@@ -146,7 +146,7 @@ function _OnePagination({
   return (
     <PaginationRoot>
       <PaginationContent role="navigation" aria-label={ariaLabel}>
-        {showControls && (
+        {showControls ? (
           <PaginationItem>
             <PaginationPrevious
               aria-disabled={currentPage === 1 || disabled}
@@ -165,39 +165,40 @@ function _OnePagination({
               }}
             />
           </PaginationItem>
-        )}
+        ) : null}
 
-        {!isIndeterminate &&
-          getPageNumbers.map((page, index) => (
-            <PaginationItem
-              key={index}
-              className={cn(
-                "hidden sm:flex",
-                page === currentPage && "flex",
-                disabled && "pointer-events-none opacity-50"
-              )}
-            >
-              {page === "..." ? (
-                <PaginationEllipsis />
-              ) : (
-                <PaginationLink
-                  aria-current={page === currentPage ? "page" : undefined}
-                  isActive={page === currentPage}
-                  onClick={() => handlePageChange(page as number)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") {
-                      handlePageChange(page as number)
-                    }
-                  }}
-                  tabIndex={0}
-                >
-                  {page}
-                </PaginationLink>
-              )}
-            </PaginationItem>
-          ))}
+        {!isIndeterminate
+          ? getPageNumbers.map((page, index) => (
+              <PaginationItem
+                key={index}
+                className={cn(
+                  "hidden sm:flex",
+                  page === currentPage && "flex",
+                  disabled && "pointer-events-none opacity-50"
+                )}
+              >
+                {page === "..." ? (
+                  <PaginationEllipsis />
+                ) : (
+                  <PaginationLink
+                    aria-current={page === currentPage ? "page" : undefined}
+                    isActive={page === currentPage}
+                    onClick={() => handlePageChange(page as number)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") {
+                        handlePageChange(page as number)
+                      }
+                    }}
+                    tabIndex={0}
+                  >
+                    {page}
+                  </PaginationLink>
+                )}
+              </PaginationItem>
+            ))
+          : null}
 
-        {showControls && (
+        {showControls ? (
           <PaginationItem>
             <PaginationNext
               aria-disabled={
@@ -230,7 +231,7 @@ function _OnePagination({
               }}
             />
           </PaginationItem>
-        )}
+        ) : null}
       </PaginationContent>
     </PaginationRoot>
   )

--- a/packages/react/src/ui/OnePreset/index.tsx
+++ b/packages/react/src/ui/OnePreset/index.tsx
@@ -72,7 +72,7 @@ const _Preset = ({
         onChange={() => onClick?.()}
       />
       <span className="min-w-0 truncate">{label}</span>
-      {number !== undefined && (
+      {number !== undefined ? (
         <Await resolve={number} fallback={<Skeleton className="h-4 w-4" />}>
           {(number) =>
             number !== undefined && (
@@ -83,10 +83,10 @@ const _Preset = ({
             )
           }
         </Await>
-      )}
-      {hasActions && (
+      ) : null}
+      {hasActions ? (
         <AnimatePresence initial={false}>
-          {showActions && (
+          {showActions ? (
             <motion.span
               key="preset-actions"
               className="-my-0.5 -ml-1.5 -mr-1 flex items-center gap-0.5 overflow-hidden"
@@ -95,7 +95,7 @@ const _Preset = ({
               exit={{ opacity: 0, width: 0 }}
               transition={{ duration: 0.15, ease: "easeOut" }}
             >
-              {onEdit && (
+              {onEdit ? (
                 <F0Button
                   variant="ghost"
                   size="sm"
@@ -104,11 +104,11 @@ const _Preset = ({
                   icon={Pencil}
                   onClick={actionHandler(onEdit)}
                 />
-              )}
+              ) : null}
             </motion.span>
-          )}
+          ) : null}
         </AnimatePresence>
-      )}
+      ) : null}
     </motion.label>
   )
 

--- a/packages/react/src/ui/OverflowList/OverflowIndicator/index.tsx
+++ b/packages/react/src/ui/OverflowList/OverflowIndicator/index.tsx
@@ -28,7 +28,7 @@ const OverflowIndicator: FC<OverflowIndicatorProps> = ({
       )}
     >
       <span>
-        {count < totalItemsCount && "+"}
+        {count < totalItemsCount ? "+" : null}
         {count}
       </span>
       <span>{i18n.actions.more}</span>

--- a/packages/react/src/ui/OverflowList/index.stories.tsx
+++ b/packages/react/src/ui/OverflowList/index.stories.tsx
@@ -215,7 +215,9 @@ export const Presets: Story = {
       return (
         <div className="flex justify-between rounded p-2 transition-colors hover:cursor-pointer hover:bg-f1-background-hover">
           <span className="font-medium">{preset.name}</span>
-          {preset.number && <Counter value={preset.number} type="default" />}
+          {preset.number ? (
+            <Counter value={preset.number} type="default" />
+          ) : null}
         </div>
       )
     },

--- a/packages/react/src/ui/OverflowList/index.tsx
+++ b/packages/react/src/ui/OverflowList/index.tsx
@@ -155,7 +155,7 @@ const OverflowList = function OverflowList<T>({
         marginLeft: gap < 0 ? `${-gap}px` : undefined,
       }}
     >
-      {!itemsWidth && (
+      {!itemsWidth ? (
         <div
           ref={measurementContainerRef}
           aria-hidden="true"
@@ -180,7 +180,7 @@ const OverflowList = function OverflowList<T>({
             </div>
           ))}
         </div>
-      )}
+      ) : null}
 
       <div
         className={cn(
@@ -199,24 +199,25 @@ const OverflowList = function OverflowList<T>({
         }}
         data-testid="overflow-visible-container"
       >
-        {isInitialized &&
-          visibleItems.map((item, index) => (
-            <div
-              key={`item-${index}`}
-              className="transition-all duration-150"
-              data-testid="overflow-visible-item"
-              style={{
-                marginLeft: gap < 0 ? `${gap}px` : undefined,
-              }}
-            >
-              {renderListItem(item, index, true)}
-            </div>
-          ))}
+        {isInitialized
+          ? visibleItems.map((item, index) => (
+              <div
+                key={`item-${index}`}
+                className="transition-all duration-150"
+                data-testid="overflow-visible-item"
+                style={{
+                  marginLeft: gap < 0 ? `${gap}px` : undefined,
+                }}
+              >
+                {renderListItem(item, index, true)}
+              </div>
+            ))
+          : null}
 
         {placeholderElements}
       </div>
 
-      {showOverflow && (
+      {showOverflow ? (
         <>
           {overflowIndicatorWithPopover ? (
             <Popover open={isOpen} onOpenChange={handleOpenChange}>
@@ -252,7 +253,7 @@ const OverflowList = function OverflowList<T>({
             </div>
           )}
         </>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -452,9 +452,9 @@ const SelectContent = forwardRef<
               : undefined
           }
         >
-          {asList && !props.right && (
+          {asList && !props.right ? (
             <div className="flex-shrink-0">{props.top}</div>
-          )}
+          ) : null}
           <div className="flex min-h-0 flex-1 flex-row overflow-hidden">
             <div
               className={cn(
@@ -462,8 +462,8 @@ const SelectContent = forwardRef<
                 asList && "flex flex-col overflow-hidden flex-1 min-h-0"
               )}
             >
-              {(!asList || props.right) && props.top}
-              {showLoadingIndicator && loadingNewContent && (
+              {!asList || props.right ? props.top : null}
+              {showLoadingIndicator && loadingNewContent ? (
                 <div
                   className="absolute inset-0 flex cursor-progress items-center justify-center"
                   aria-live="polite"
@@ -471,7 +471,7 @@ const SelectContent = forwardRef<
                 >
                   <Spinner />
                 </div>
-              )}
+              ) : null}
               <ScrollArea
                 viewportRef={parentRef}
                 className={cn(
@@ -519,11 +519,11 @@ const SelectContent = forwardRef<
           </div>
           {(isEmpty && emptyAction) || bottom ? (
             <div className="shrink-0">
-              {isEmpty && emptyAction && (
+              {isEmpty && emptyAction ? (
                 <div className="w-full border-0 border-t border-solid border-f1-border-secondary p-2">
                   {emptyAction}
                 </div>
-              )}
+              ) : null}
               {bottom}
             </div>
           ) : null}
@@ -541,7 +541,7 @@ const SelectContent = forwardRef<
             Only render when NOT using a custom portal container to avoid
             conflicts with modal focus management.
           */}
-          {open && !effectivePortalContainer && (
+          {open && !effectivePortalContainer ? (
             <div
               className="pointer-events-auto fixed inset-0 z-40"
               onClick={(e) => {
@@ -549,7 +549,7 @@ const SelectContent = forwardRef<
                 e.stopPropagation()
               }}
             />
-          )}
+          ) : null}
           {content}
         </>
       </SelectPrimitive.Portal>

--- a/packages/react/src/ui/Toast/F0Toast.tsx
+++ b/packages/react/src/ui/Toast/F0Toast.tsx
@@ -221,7 +221,7 @@ const F0Toast = forwardRef<HTMLDivElement, F0ToastProps>(
           )}
 
           <div className="flex flex-1 flex-col gap-1">
-            {title && (
+            {title ? (
               <p
                 className={titleVariants({
                   variant,
@@ -230,17 +230,17 @@ const F0Toast = forwardRef<HTMLDivElement, F0ToastProps>(
               >
                 {title}
               </p>
-            )}
-            {description && (
+            ) : null}
+            {description ? (
               <p className="line-clamp-3 text-base text-f1-foreground-inverse-secondary">
                 {description}
               </p>
-            )}
+            ) : null}
           </div>
 
           {/* Action(s) — inline on the trailing edge (never below the text).
               Link sits to the LEFT of the primary button (button is trailing). */}
-          {!isLoading && hasActions && (
+          {!isLoading && hasActions ? (
             <div className="dark flex flex-shrink-0 flex-row flex-wrap items-center gap-3">
               {linkActions.map((linkAction) => (
                 <div
@@ -263,13 +263,13 @@ const F0Toast = forwardRef<HTMLDivElement, F0ToastProps>(
                 />
               ))}
             </div>
-          )}
+          ) : null}
 
           {/* Close — the manual dismiss. Hidden when the action is the only
               control AND the toast auto-dismisses (so the ✕ isn't adjacent to the
               action). But a toast that WON'T auto-dismiss (persistent) always
               keeps the ✕, even with an action, so it's never a dead-end. */}
-          {onClose && !isLoading && (!hasActions || !willAutoDismiss) && (
+          {onClose && !isLoading && (!hasActions || !willAutoDismiss) ? (
             <div className="dark flex-shrink-0">
               <F0Button
                 variant="outline"
@@ -280,11 +280,11 @@ const F0Toast = forwardRef<HTMLDivElement, F0ToastProps>(
                 label={i18n.actions.close}
               />
             </div>
-          )}
+          ) : null}
         </div>
 
         {/* Progress Bar */}
-        {!isLoading && duration && duration > 0 && (
+        {!isLoading && duration && duration > 0 ? (
           <div className="absolute bottom-0 left-0 right-0 h-[3px] w-full overflow-hidden rounded-b-lg">
             <div
               className={cn("h-full w-full", progressBarColor)}
@@ -294,7 +294,7 @@ const F0Toast = forwardRef<HTMLDivElement, F0ToastProps>(
               }}
             />
           </div>
-        )}
+        ) : null}
       </div>
     )
   }

--- a/packages/react/src/ui/Toast/__stories__/F0Toast.stories.tsx
+++ b/packages/react/src/ui/Toast/__stories__/F0Toast.stories.tsx
@@ -58,15 +58,15 @@ const meta: Meta<typeof F0Toast> = {
       return (
         <div className="flex flex-col items-start gap-4 p-4">
           <div className="h-10">
-            {!isOpen && (
+            {!isOpen ? (
               <F0Button label="Open Toast" onClick={() => setIsOpen(true)} />
-            )}
+            ) : null}
           </div>
-          {isOpen && (
+          {isOpen ? (
             <Story
               args={{ ...context.args, onClose: () => setIsOpen(false) }}
             />
-          )}
+          ) : null}
         </div>
       )
     },

--- a/packages/react/src/ui/__tests__/form.test.tsx
+++ b/packages/react/src/ui/__tests__/form.test.tsx
@@ -37,8 +37,10 @@ function Harness({
             <FormControl>
               <input aria-label="Field" {...field} />
             </FormControl>
-            {description && <FormDescription>{description}</FormDescription>}
-            {message && <FormMessage>{message}</FormMessage>}
+            {description ? (
+              <FormDescription>{description}</FormDescription>
+            ) : null}
+            {message ? <FormMessage>{message}</FormMessage> : null}
           </FormItem>
         )}
       />

--- a/packages/react/src/ui/chart.tsx
+++ b/packages/react/src/ui/chart.tsx
@@ -326,13 +326,13 @@ const ChartTooltipContent = React.forwardRef<
                           {itemConfig?.label || item.name}
                         </span>
                       </div>
-                      {item.value && (
+                      {item.value ? (
                         <span className="font-mono font-medium tabular-nums text-f1-foreground">
                           {yAxisFormatter
                             ? yAxisFormatter(String(item.value))
                             : item.value.toLocaleString()}
                         </span>
-                      )}
+                      ) : null}
                     </div>
                   </>
                 )}

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -55,7 +55,7 @@ const Checkbox = React.forwardRef<
             </CheckboxPrimitive.Indicator>
           </AnimatePresence>
         </CheckboxPrimitive.Root>
-        {props.title && !hideLabel && (
+        {props.title && !hideLabel ? (
           <label
             htmlFor={checkboxId}
             className={cn(
@@ -65,11 +65,11 @@ const Checkbox = React.forwardRef<
             )}
           >
             {props.title}
-            {required && (
+            {required ? (
               <span className="ml-0.5 text-f1-foreground-critical">*</span>
-            )}
+            ) : null}
           </label>
-        )}
+        ) : null}
       </div>
     )
   }

--- a/packages/react/src/ui/indicator.tsx
+++ b/packages/react/src/ui/indicator.tsx
@@ -21,16 +21,16 @@ export const Indicator = forwardRef<HTMLDivElement, IndicatorProps>(
           >
             {label}
           </p>
-          {"icon" in props && props.icon && (
+          {"icon" in props && props.icon ? (
             <span className={cn("flex", color)}>
               <F0Icon icon={props.icon} />
             </span>
-          )}
-          {"emoji" in props && props.emoji && (
+          ) : null}
+          {"emoji" in props && props.emoji ? (
             <span className={cn("flex", color)}>
               <EmojiImage emoji={props.emoji} size="md" />
             </span>
-          )}
+          ) : null}
         </div>
       </div>
     )

--- a/packages/react/src/ui/scrollarea.tsx
+++ b/packages/react/src/ui/scrollarea.tsx
@@ -128,9 +128,9 @@ const ScrollBar = forwardRef<
     )}
     {...props}
   >
-    {showBar && (
+    {showBar ? (
       <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-f1-background-inverse opacity-30 transition-opacity group-hover/scrollbar:opacity-50" />
-    )}
+    ) : null}
   </ScrollAreaPrimitive.ScrollAreaScrollbar>
 ))
 ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName

--- a/packages/react/src/ui/switch.tsx
+++ b/packages/react/src/ui/switch.tsx
@@ -61,7 +61,7 @@ const Switch = React.forwardRef<
           )}
         />
       </SwitchPrimitive.Root>
-      {props.title && !hideLabel && (
+      {props.title && !hideLabel ? (
         <label
           htmlFor={switchId}
           className={cn(
@@ -71,11 +71,11 @@ const Switch = React.forwardRef<
           )}
         >
           {props.title}
-          {required && (
+          {required ? (
             <span className="ml-0.5 text-f1-foreground-critical">*</span>
-          )}
+          ) : null}
         </label>
-      )}
+      ) : null}
     </div>
   )
 })

--- a/packages/react/src/ui/tab-navigation.tsx
+++ b/packages/react/src/ui/tab-navigation.tsx
@@ -128,7 +128,7 @@ const _TabNavigationLink = React.forwardRef<
             )}
           >
             {children}
-            {active && !secondary && (
+            {active && !secondary ? (
               <motion.div
                 layoutId="underline"
                 className="absolute inset-x-0 -bottom-3 h-px bg-f1-background-inverse"
@@ -138,7 +138,7 @@ const _TabNavigationLink = React.forwardRef<
                   duration: 0.5,
                 }}
               />
-            )}
+            ) : null}
           </span>
         ))}
       </NavigationMenuPrimitives.Link>

--- a/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
+++ b/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
@@ -146,7 +146,7 @@ function BarWithTooltip({
               />
             ) : isUnder ? (
               <>
-                {heightValuePx > 0 && (
+                {heightValuePx > 0 ? (
                   <div
                     style={{
                       width: BAR_WIDTH_PX,
@@ -155,8 +155,8 @@ function BarWithTooltip({
                       borderRadius: heightNeutralPx > 0 ? "2px 2px 0 0" : 2,
                     }}
                   />
-                )}
-                {heightNeutralPx > 0 && (
+                ) : null}
+                {heightNeutralPx > 0 ? (
                   <div
                     className="bg-f1-border-secondary"
                     style={{
@@ -165,7 +165,7 @@ function BarWithTooltip({
                       borderRadius: heightValuePx > 0 ? "0 0 2px 2px" : 2,
                     }}
                   />
-                )}
+                ) : null}
               </>
             ) : isOver && heightOvertimePx > 0 ? (
               <>
@@ -188,7 +188,7 @@ function BarWithTooltip({
               </>
             ) : (
               <>
-                {heightValuePx > 0 && (
+                {heightValuePx > 0 ? (
                   <div
                     style={{
                       width: BAR_WIDTH_PX,
@@ -197,8 +197,8 @@ function BarWithTooltip({
                       borderRadius: heightNeutralPx > 0 ? "2px 2px 0 0" : 2,
                     }}
                   />
-                )}
-                {heightNeutralPx > 0 && (
+                ) : null}
+                {heightNeutralPx > 0 ? (
                   <div
                     className="bg-f1-border-secondary"
                     style={{
@@ -207,7 +207,7 @@ function BarWithTooltip({
                       borderRadius: heightValuePx > 0 ? "0 0 2px 2px" : 2,
                     }}
                   />
-                )}
+                ) : null}
               </>
             )}
           </div>

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
@@ -191,12 +191,12 @@ function CategoryBar({
             </div>
           </div>
         </TooltipTrigger>
-        {!hideTooltip && tooltipItems.length > 0 && (
+        {!hideTooltip && tooltipItems.length > 0 ? (
           <CategoryBarTooltipContent
             items={tooltipItems}
             activeKey={activeKey}
           />
-        )}
+        ) : null}
       </Tooltip>
     </TooltipProvider>
   )

--- a/packages/react/src/ui/value-display/types/compound/compound.tsx
+++ b/packages/react/src/ui/value-display/types/compound/compound.tsx
@@ -160,13 +160,13 @@ const formatNumberParts = ({
 const FormattedNumberContent = ({ parts }: { parts: FormattedNumberParts }) => {
   return (
     <>
-      {parts.unitsPosition === "left" && parts.units && (
+      {parts.unitsPosition === "left" && parts.units ? (
         <span>{parts.units.toString()}</span>
-      )}
+      ) : null}
       {parts.value}
-      {parts.unitsPosition === "right" && parts.units && (
+      {parts.unitsPosition === "right" && parts.units ? (
         <span>{parts.units.toString()}</span>
-      )}
+      ) : null}
     </>
   )
 }
@@ -281,13 +281,13 @@ export const CompoundCell = (
 
         return (
           <Fragment key={`${segment.type}-${index}`}>
-            {index > 0 && (
+            {index > 0 ? (
               <span
                 className={cn(toneClassByValue.secondary, "whitespace-pre")}
               >
                 {separator}
               </span>
-            )}
+            ) : null}
             <span
               className={cn(
                 toneClassByValue[tone],

--- a/packages/react/src/ui/value-display/types/number/number.tsx
+++ b/packages/react/src/ui/value-display/types/number/number.tsx
@@ -48,15 +48,15 @@ export const NumberCell = (
         shouldShowPlaceholderStyling && "text-f1-foreground-secondary"
       )}
     >
-      {number.unitsPosition === "left" && number.units && (
+      {number.unitsPosition === "left" && number.units ? (
         <Units units={number.units} />
-      )}
+      ) : null}
       {number.decimalPlaces !== undefined
         ? number.number?.toFixed(number.decimalPlaces)
         : (number.number?.toString() ?? "")}
-      {number.unitsPosition === "right" && number.units && (
+      {number.unitsPosition === "right" && number.units ? (
         <Units units={number.units} />
-      )}
+      ) : null}
     </div>
   )
 }

--- a/packages/react/src/ui/value-display/types/progressBar/progressBar.tsx
+++ b/packages/react/src/ui/value-display/types/progressBar/progressBar.tsx
@@ -69,11 +69,11 @@ export const ProgressBarCell = (
           className="w-full"
         />
       </div>
-      {!hideLabel && (
+      {!hideLabel ? (
         <div className="flex-shrink-0 text-sm font-medium text-f1-foreground">
           {label}
         </div>
-      )}
+      ) : null}
     </div>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -677,6 +677,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(eslint@9.39.2(jiti@2.6.1))
+      eslint-plugin-react:
+        specifier: ^7.37.5
+        version: 7.37.5(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react-refresh:
         specifier: ^0.4.26
         version: 0.4.26(eslint@9.39.2(jiti@2.6.1))
@@ -14286,7 +14289,7 @@ snapshots:
       getenv: 2.0.0
       glob: 13.0.6
       resolve-from: 5.0.0
-      semver: 7.7.3
+      semver: 7.8.5
       slash: 3.0.0
       slugify: 1.6.6
       xcode: 3.0.1
@@ -14329,7 +14332,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.1
-      semver: 7.7.3
+      semver: 7.8.5
       slugify: 1.6.6
       sucrase: 3.35.1
     transitivePeerDependencies:


### PR DESCRIPTION
Replaces `cond && <X />` with `cond ? <X /> : null` in JSX children and adds a lint rule that keeps it that way.

## Why

`{items.length && <List />}` renders `0` when the list is empty. `{name && <Tag />}` renders an empty string. The only value-safe form without knowing the type of the left side is a ternary with an explicit `null`.

## Why ternary everywhere, not only where the left side is a number or string

That would need type information. oxlint gives none of it to JS plugins, and it has no native version of this rule. `sonarjs/jsx-no-leaked-render` is the type-aware variant; under oxlint it silently reports nothing, so it is now turned off explicitly. The rule that does work is syntax only, so the codebase uses one form for every conditional child. Rules from the `react-js` plugin do not show in editors, only in `pnpm lint` and CI.

## What is in the PR

- `eslint-plugin-react` loaded as an oxlint JS plugin under the alias `react-js` (oxlint reserves the name `react`).
- `f0-react/jsx-no-leaked-render`: a local wrapper around the upstream rule that only checks JSX children. Upstream also reports attribute values like `open={isOpen && !disabled}`, where nothing leaks and `null` would break boolean props. Tested in `.oxlint-plugins/__tests__/f0-react.test.ts`.
- 1296 sites rewritten with a token-level codemod (the upstream autofix drops comments between `&& (` and the element, and there were 175 such comment lines). Formatting by oxfmt.
- One hand fix in `Table.tsx`: `MotionRow && ...` was a check on a component that is always defined; tsc rejects it as a ternary test.

## Rules

| Rule | Why |
| --- | --- |
| `f0-react/jsx-no-leaked-render` (`ternary`) | Stops `0` and `""` from rendering. See above. |
| `react-js/no-deprecated` | Flags React APIs that are removed in the next major. |
| `react-js/no-invalid-html-attribute` | Flags invalid values in `rel` and similar attributes. |
| `sonarjs/jsx-no-leaked-render` off | Needs types, reports nothing under oxlint. Replaced by the rule above. |

Added to the DEBT block, off until fixed: `react-js/no-unstable-nested-components` (25), `react-js/jsx-no-constructed-context-values` (35), `react-js/no-unused-prop-types` (34), `react-js/no-object-type-as-default-prop` (59).
