### PR TITLE
refactor(lint): enable oxlint's unicorn, oxc and promise rules

### DIFF
--- a/packages/react-native/.oxlintrc.json
+++ b/packages/react-native/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "import"],
+  "plugins": ["react", "typescript", "import", "unicorn", "oxc", "promise"],
   "categories": {
     "correctness": "error"
   },
@@ -14,6 +14,23 @@
     "no-regex-spaces": "error",
     "no-unexpected-multiline": "error",
     "preserve-caught-error": "error",
+
+    // oxlint's own rules from outside the `correctness` category, cherry-picked.
+    // `unicorn`, `oxc` and `promise` are also enabled as plugins above so their
+    // `correctness` rules run.
+    "eqeqeq": ["error", "always", { "null": "ignore" }], // `x == null` is the nullish check, keep it
+    "no-else-return": "error",
+    "no-unneeded-ternary": "error",
+    "no-useless-constructor": "error",
+    "no-await-in-loop": "error",
+    "radix": "error",
+    "react/jsx-no-useless-fragment": ["error", { "allowExpressions": true }], // `<>{children}</>` is how a ReactNode becomes an element
+    "react/no-unescaped-entities": "error",
+    "react/iframe-missing-sandbox": "error",
+    "import/no-empty-named-blocks": "error",
+    "oxc/no-accumulating-spread": "error",
+    "unicorn/prefer-set-has": "error",
+    "promise/always-return": ["error", { "ignoreLastCallback": true }], // a lost value only matters when the chain continues
 
     // typescript-eslint strict + stylistic, no type information needed.
     "typescript/no-dynamic-delete": "error",
@@ -37,7 +54,13 @@
     "import/no-duplicates": "error",
     "import/namespace": "error",
 
+    // DEBT. Turn on once the code is fixed. Number = violations when this
+    // was written. Do not add new violations.
+    "react/no-array-index-key": "off", // 3
+
     // OFF ON PURPOSE. Not planned to be enabled.
+    "typescript/ban-types": "off", // deprecated upstream; it bans `(string & {})`, which keeps autocomplete on open string unions. no-unsafe-function-type covers the useful part
+    "oxc/no-map-spread": "off", // wants Object.assign onto the mapped item, which mutates the input; props and state are immutable here. Its autofix also breaks code (oxlint 1.43)
     "import/default": "off", // false positives with CommonJS interop packages
     "import/no-named-as-default": "off", // false positives with CommonJS interop packages
     "import/no-named-as-default-member": "off" // false positives with CommonJS interop packages
@@ -88,7 +111,8 @@
         "**/__tests__/**"
       ],
       "rules": {
-        "no-console": "off"
+        "no-console": "off",
+        "no-await-in-loop": "off" // stories and tests step through flows one await at a time
       }
     },
     {

--- a/packages/react-native/src/components/F0Link/__tests__/F0Link.spec.tsx
+++ b/packages/react-native/src/components/F0Link/__tests__/F0Link.spec.tsx
@@ -147,6 +147,7 @@ describe("F0Link", () => {
   it("falls back to href in accessibilityLabel when text is not plain", () => {
     render(
       <F0Link href="https://factorialhr.com">
+        {/* oxlint-disable-next-line react/jsx-no-useless-fragment -- a child with no text is what this test covers */}
         <React.Fragment />
       </F0Link>
     )
@@ -158,6 +159,7 @@ describe("F0Link", () => {
   it("falls back to 'Link' in accessibilityLabel when there is no text or href", () => {
     render(
       <F0Link>
+        {/* oxlint-disable-next-line react/jsx-no-useless-fragment -- a child with no text is what this test covers */}
         <React.Fragment />
       </F0Link>
     )

--- a/packages/react/.oxlintrc.json
+++ b/packages/react/.oxlintrc.json
@@ -1,6 +1,6 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["react", "typescript", "vitest", "import"],
+  "plugins": ["react", "typescript", "vitest", "import", "unicorn", "oxc", "promise"],
   "categories": {
     "correctness": "error"
   },
@@ -22,6 +22,23 @@
     "no-regex-spaces": "error",
     "no-unexpected-multiline": "error",
     "preserve-caught-error": "error",
+
+    // oxlint's own rules from outside the `correctness` category, cherry-picked.
+    // `unicorn`, `oxc` and `promise` are also enabled as plugins above so their
+    // `correctness` rules run.
+    "eqeqeq": ["error", "always", { "null": "ignore" }], // `x == null` is the nullish check, keep it
+    "no-else-return": "error",
+    "no-unneeded-ternary": "error",
+    "no-useless-constructor": "error",
+    "no-await-in-loop": "error",
+    "radix": "error",
+    "react/jsx-no-useless-fragment": ["error", { "allowExpressions": true }], // `<>{children}</>` is how a ReactNode becomes an element
+    "react/no-unescaped-entities": "error",
+    "react/iframe-missing-sandbox": "error",
+    "import/no-empty-named-blocks": "error",
+    "oxc/no-accumulating-spread": "error",
+    "unicorn/prefer-set-has": "error",
+    "promise/always-return": ["error", { "ignoreLastCallback": true }], // a lost value only matters when the chain continues
 
     // typescript-eslint strict + stylistic, no type information needed.
     "typescript/no-extraneous-class": "error",
@@ -279,6 +296,7 @@
     // DEBT. Turn on once the code is fixed. Number = violations when this
     // was written. Do not add new violations.
     "typescript/no-non-null-assertion": "off", // 718
+    "react/no-array-index-key": "off", // 117
     "typescript/consistent-type-definitions": "off", // 984 interfaces vs 803 type literals, pick one first
     "typescript/no-explicit-any": "off", // 44; AGENTS.md forbids any, decide whether to enforce
     "typescript/no-floating-promises": "off", // 317
@@ -322,6 +340,8 @@
     "typescript/no-unnecessary-type-assertion": "off", // tsgolint (TS 7 semantics) reports assertions tsc 5.9 still needs; the autofix broke the build
 
     // OFF ON PURPOSE. Not planned to be enabled.
+    "typescript/ban-types": "off", // deprecated upstream; it bans `(string & {})`, which keeps autocomplete on open string unions. no-unsafe-function-type covers the useful part
+    "oxc/no-map-spread": "off", // wants Object.assign onto the mapped item, which mutates the input; props and state are immutable here. Its autofix also breaks code (oxlint 1.43)
     "typescript/no-namespace": "off", // namespaces are allowed
     "typescript/no-unsafe-assignment": "off", // too noisy around untyped third-party values
     "typescript/no-unsafe-argument": "off", // too noisy around untyped third-party values
@@ -397,7 +417,8 @@
         "**/__tests__/**"
       ],
       "rules": {
-        "no-console": "off"
+        "no-console": "off",
+        "no-await-in-loop": "off" // stories and tests step through flows one await at a time
       }
     },
     {

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -76,10 +76,10 @@ async function runAudit(): Promise<Criterion[]> {
   const targets = canvases.length > 0 ? canvases : []
 
   const byRule = new Map<string, Criterion>()
-  // Serialize: axe throws "Axe is already running" on concurrent runs.
   for (const node of targets) {
     let results: AxeResults
     try {
+      // oxlint-disable-next-line no-await-in-loop -- axe throws "Axe is already running" on concurrent runs
       results = await axe.run(node, {
         runOnly: { type: "tag", values: WCAG_TAGS },
       })

--- a/packages/react/src/components/CardSelectable/index.tsx
+++ b/packages/react/src/components/CardSelectable/index.tsx
@@ -51,10 +51,9 @@ function _CardSelectableContainer<T extends CardSelectableValue>(
     if (isMultiple) {
       const multiProps = props as CardSelectableMultipleProps<T>
       return (multiProps.value ?? []).includes(itemValue)
-    } else {
-      const singleProps = props as CardSelectableSingleProps<T>
-      return singleProps.value === itemValue
     }
+    const singleProps = props as CardSelectableSingleProps<T>
+    return singleProps.value === itemValue
   }
 
   // Determine the appropriate group role

--- a/packages/react/src/components/F0ActionBar/index.tsx
+++ b/packages/react/src/components/F0ActionBar/index.tsx
@@ -77,18 +77,16 @@ const normalizeItems = (
     if (items.every((item) => isActionGroup(item))) {
       // ActionBarGroup[]
       return items
-    } else {
-      // ActionType[]
-      return [
-        {
-          items: items,
-        },
-      ]
     }
-  } else {
-    // ActionBarGroup
-    return [items]
+    // ActionType[]
+    return [
+      {
+        items: items,
+      },
+    ]
   }
+  // ActionBarGroup
+  return [items]
 }
 
 export const actionBarStatuses = [
@@ -492,17 +490,15 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
                       />
                     ))}
                   {!singlePrimaryAction ? (
-                    <>
-                      <F0ButtonDropdown
-                        items={primaryActionsDropdownItems}
-                        onClick={(value) => {
-                          const action = getActionByValue(value)
-                          ;(action as ActionType)?.onClick?.()
-                        }}
-                        disabled={isInteractionDisabled || hasLoadingAction}
-                        loading={hasLoadingAction}
-                      />
-                    </>
+                    <F0ButtonDropdown
+                      items={primaryActionsDropdownItems}
+                      onClick={(value) => {
+                        const action = getActionByValue(value)
+                        ;(action as ActionType)?.onClick?.()
+                      }}
+                      disabled={isInteractionDisabled || hasLoadingAction}
+                      loading={hasLoadingAction}
+                    />
                   ) : (
                     <WithReason reason={singlePrimaryAction.tooltip}>
                       <F0Button

--- a/packages/react/src/components/F0BigNumber/__tests__/F0BigNumber.test.tsx
+++ b/packages/react/src/components/F0BigNumber/__tests__/F0BigNumber.test.tsx
@@ -89,7 +89,7 @@ describe("F0BigNumber", () => {
           numericValue: value.numericValue || { value: value.value },
           formatter: value.formatter || mockFormatter,
           formatterOptions: {
-            ...(options?.formatterOptions || {}),
+            ...options?.formatterOptions,
             ...value.formatterOptions,
           },
         }
@@ -115,10 +115,6 @@ describe("F0BigNumber", () => {
     // Mock Intl.NumberFormat - use class syntax to ensure it works as a constructor
     class MockNumberFormat {
       format = mockFormat
-
-      constructor() {
-        // Constructor can be empty, format is set as instance property
-      }
 
       static readonly supportedLocalesOf =
         OriginalIntl.NumberFormat.supportedLocalesOf

--- a/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
@@ -32,14 +32,12 @@ const normalizeItems = (
           items: items,
         },
       ]
-    } else {
-      // ButtonDropdownGroup[]
-      return items
     }
-  } else {
-    // ButtonDropdownGroup
-    return [items]
+    // ButtonDropdownGroup[]
+    return items
   }
+  // ButtonDropdownGroup
+  return [items]
 }
 
 export type F0DropdownButtonProps<T = string> = {

--- a/packages/react/src/components/F0DatePicker/components/DateInput.tsx
+++ b/packages/react/src/components/F0DatePicker/components/DateInput.tsx
@@ -101,31 +101,29 @@ const DateInput = forwardRef<HTMLInputElement, DateInputProps>(
     const placeholder = inputProps.placeholder ?? granularity.placeholder()
 
     return (
-      <>
-        <Input
-          {...inputProps}
-          placeholder={placeholder}
-          icon={showIcon ? getFieldInputIcon("date") : undefined}
-          ref={ref}
-          onFocus={() => onOpenChange?.(true)}
-          onClear={() => {
-            onClear?.()
-            setInputValue("")
-            handleNewValue("", granularity)
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              handleBlur()
-            }
-          }}
-          type="text"
-          onChange={handleChange}
-          error={error || inputProps.error}
-          onBlur={handleBlur}
-          value={inputValue}
-          onClickContent={() => onOpenChange?.(true)}
-        />
-      </>
+      <Input
+        {...inputProps}
+        placeholder={placeholder}
+        icon={showIcon ? getFieldInputIcon("date") : undefined}
+        ref={ref}
+        onFocus={() => onOpenChange?.(true)}
+        onClear={() => {
+          onClear?.()
+          setInputValue("")
+          handleNewValue("", granularity)
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            handleBlur()
+          }
+        }}
+        type="text"
+        onChange={handleChange}
+        error={error || inputProps.error}
+        onBlur={handleBlur}
+        value={inputValue}
+        onClickContent={() => onOpenChange?.(true)}
+      />
     )
   }
 )

--- a/packages/react/src/components/F0NumberInput/internal.tsx
+++ b/packages/react/src/components/F0NumberInput/internal.tsx
@@ -374,7 +374,10 @@ export const NumberInputInternal = forwardRef<
     // Otherwise (grouping off, or focused): reconcile the field only when
     // `value` changed externally, so in-progress typing isn't clobbered.
     const extractedData = extractNumber(fieldValue, { maxDecimals })
-    if (inputValue === undefined || inputValue == extractedData?.value) {
+    if (
+      inputValue === undefined ||
+      inputValue === (extractedData?.value ?? null)
+    ) {
       return
     }
     setFieldValue(

--- a/packages/react/src/components/F0PdfViewer/components/DocxViewer.tsx
+++ b/packages/react/src/components/F0PdfViewer/components/DocxViewer.tsx
@@ -42,20 +42,19 @@ const DocxViewer = ({
         }
         return response.blob()
       })
-      .then((blob) => {
+      .then(async (blob) => {
         if (cancelled) {
           return
         }
         // The wrapper brings docx-preview's page chrome (page background and
         // spacing between pages), matching what a Word preview looks like.
-        return renderAsync(blob, host, undefined, {
+        await renderAsync(blob, host, undefined, {
           inWrapper: true,
           breakPages: true,
-        }).then(() => {
-          if (!cancelled) {
-            setState("ready")
-          }
         })
+        if (!cancelled) {
+          setState("ready")
+        }
       })
       .catch(() => {
         if (!cancelled) {

--- a/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
+++ b/packages/react/src/components/F0Select/__stories__/F0Select.stories.tsx
@@ -712,25 +712,23 @@ export const WithSearchBox: Story = {
   },
   render: (args) => {
     return (
-      <>
-        <F0Select
-          showSearchBox
-          label="Select a theme"
-          onChange={fn()}
-          searchFn={(option, searchValue) => {
-            console.log("searchFn", option, searchValue)
-            return (
-              option.type === "separator" ||
-              !searchValue ||
-              option.label.toLowerCase().includes(searchValue.toLowerCase()) ||
-              option.description
-                ?.toLowerCase()
-                .includes(searchValue.toLowerCase())
-            )
-          }}
-          options={args.options}
-        />
-      </>
+      <F0Select
+        showSearchBox
+        label="Select a theme"
+        onChange={fn()}
+        searchFn={(option, searchValue) => {
+          console.log("searchFn", option, searchValue)
+          return (
+            option.type === "separator" ||
+            !searchValue ||
+            option.label.toLowerCase().includes(searchValue.toLowerCase()) ||
+            option.description
+              ?.toLowerCase()
+              .includes(searchValue.toLowerCase())
+          )
+        }}
+        options={args.options}
+      />
     )
   },
 }

--- a/packages/react/src/components/OneCalendar/granularities/halfyear/HalfyearView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/halfyear/HalfyearView.tsx
@@ -115,27 +115,26 @@ export const HalfYearView = ({
       const selectedMonth = selected.getMonth()
       const selectedHalfYear = getHalfYearFromMonth(selectedMonth)
       return selectedHalfYear === halfYear && selected.getFullYear() === year
-    } else {
-      // Range selection
-      const from = selected.from
-      const to = selected.to
+    }
+    // Range selection
+    const from = selected.from
+    const to = selected.to
 
-      if (from && to) {
-        // Check if any part of the half-year is within the selected range
-        const isWithinRange =
-          isWithinInterval(halfYearRange.from, { start: from, end: to }) ||
-          (!!halfYearRange.to &&
-            isWithinInterval(halfYearRange.to, { start: from, end: to })) ||
-          (isBefore(halfYearRange.from, from) &&
-            !!halfYearRange.to &&
-            isAfter(halfYearRange.to, to))
+    if (from && to) {
+      // Check if any part of the half-year is within the selected range
+      const isWithinRange =
+        isWithinInterval(halfYearRange.from, { start: from, end: to }) ||
+        (!!halfYearRange.to &&
+          isWithinInterval(halfYearRange.to, { start: from, end: to })) ||
+        (isBefore(halfYearRange.from, from) &&
+          !!halfYearRange.to &&
+          isAfter(halfYearRange.to, to))
 
-        return isWithinRange
-      } else if (from) {
-        // Check if the from date is in this half-year
-        const fromHalfYear = getHalfYearFromMonth(from.getMonth())
-        return fromHalfYear === halfYear && from.getFullYear() === year
-      }
+      return isWithinRange
+    } else if (from) {
+      // Check if the from date is in this half-year
+      const fromHalfYear = getHalfYearFromMonth(from.getMonth())
+      return fromHalfYear === halfYear && from.getFullYear() === year
     }
 
     return false

--- a/packages/react/src/components/OneCalendar/granularities/month/MonthView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/month/MonthView.tsx
@@ -118,19 +118,18 @@ export function MonthView({
       return (
         selected.getMonth() === monthIndex && selected.getFullYear() === year
       )
-    } else {
-      if (selected.from && selected.to) {
-        const current = new Date(year, monthIndex, 15)
-        return isWithinInterval(current, {
-          start: selected.from,
-          end: selected.to,
-        })
-      } else if (selected.from) {
-        return (
-          selected.from.getMonth() === monthIndex &&
-          selected.from.getFullYear() === year
-        )
-      }
+    }
+    if (selected.from && selected.to) {
+      const current = new Date(year, monthIndex, 15)
+      return isWithinInterval(current, {
+        start: selected.from,
+        end: selected.to,
+      })
+    } else if (selected.from) {
+      return (
+        selected.from.getMonth() === monthIndex &&
+        selected.from.getFullYear() === year
+      )
     }
 
     return false

--- a/packages/react/src/components/OneCalendar/granularities/quarter/QuarterView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/quarter/QuarterView.tsx
@@ -117,23 +117,22 @@ export const QuarterView = ({
       const selectedMonth = selected.getMonth()
       const selectedQuarter = getQuarterFromMonth(selectedMonth)
       return selectedQuarter === quarter && selected.getFullYear() === year
-    } else {
-      // Range selection
-      const from = selected.from
-      const to = selected.to
+    }
+    // Range selection
+    const from = selected.from
+    const to = selected.to
 
-      if (from && to) {
-        // Check if any part of the quarter is within the selected range
-        return (
-          isWithinInterval(quarterRange.from, { start: from, end: to }) ||
-          isWithinInterval(quarterRange.to, { start: from, end: to }) ||
-          (isBefore(quarterRange.from, from) && isAfter(quarterRange.to, to))
-        )
-      } else if (from) {
-        // Check if the from date is in this quarter
-        const fromQuarter = getQuarterFromMonth(from.getMonth())
-        return fromQuarter === quarter && from.getFullYear() === year
-      }
+    if (from && to) {
+      // Check if any part of the quarter is within the selected range
+      return (
+        isWithinInterval(quarterRange.from, { start: from, end: to }) ||
+        isWithinInterval(quarterRange.to, { start: from, end: to }) ||
+        (isBefore(quarterRange.from, from) && isAfter(quarterRange.to, to))
+      )
+    } else if (from) {
+      // Check if the from date is in this quarter
+      const fromQuarter = getQuarterFromMonth(from.getMonth())
+      return fromQuarter === quarter && from.getFullYear() === year
     }
 
     return false

--- a/packages/react/src/components/OneCalendar/granularities/year/YearView.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/year/YearView.tsx
@@ -98,17 +98,16 @@ export function YearView({
     if (!isDateRange(selected)) {
       // Single date selection
       return selected.getFullYear() === year
-    } else {
-      // Range selection
-      if (selected.from && selected.to) {
-        const current = new Date(year, 6, 1)
-        return isWithinInterval(current, {
-          start: selected.from,
-          end: selected.to,
-        })
-      } else if (selected.from) {
-        return selected.from.getFullYear() === year
-      }
+    }
+    // Range selection
+    if (selected.from && selected.to) {
+      const current = new Date(year, 6, 1)
+      return isWithinInterval(current, {
+        start: selected.from,
+        end: selected.to,
+      })
+    } else if (selected.from) {
+      return selected.from.getFullYear() === year
     }
 
     return false

--- a/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
+++ b/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
@@ -50,17 +50,16 @@ function _OneEmptyState({
                   closeLabel={action.closeLabel}
                 />
               )
-            } else {
-              return (
-                <F0Button
-                  key={action.label}
-                  label={action.label}
-                  variant={action.variant}
-                  onClick={action.onClick}
-                  icon={action.icon}
-                />
-              )
             }
+            return (
+              <F0Button
+                key={action.label}
+                label={action.label}
+                variant={action.variant}
+                onClick={action.onClick}
+                icon={action.icon}
+              />
+            )
           })}
         </div>
       ) : null}

--- a/packages/react/src/components/RichText/internal/Enhance/enhance.ts
+++ b/packages/react/src/components/RichText/internal/Enhance/enhance.ts
@@ -76,19 +76,18 @@ function applyEnhancedText(
       highlightFrom: 1,
       highlightTo: Math.max(1, docSize - 1),
     }
-  } else {
-    editor
-      .chain()
-      .focus()
-      .deleteRange({ from, to })
-      .insertContent(enhancedText)
-      .run()
-    // After insertion, cursor is at the end of inserted content
-    const highlightTo = editor.state.selection.to
-    return {
-      highlightFrom: from,
-      highlightTo,
-    }
+  }
+  editor
+    .chain()
+    .focus()
+    .deleteRange({ from, to })
+    .insertContent(enhancedText)
+    .run()
+  // After insertion, cursor is at the end of inserted content
+  const highlightTo = editor.state.selection.to
+  return {
+    highlightFrom: from,
+    highlightTo,
   }
 }
 

--- a/packages/react/src/components/RichText/internal/Extensions/Indent/index.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/Indent/index.tsx
@@ -13,7 +13,7 @@ const CLASS_PREFIX = "f0-indent-"
 
 // List nesting owns Tab and Shift-Tab inside a list; the indent shortcuts must
 // stand aside there rather than compete with it.
-const LIST_ITEM_TYPES = ["listItem", "taskItem"]
+const LIST_ITEM_TYPES = new Set(["listItem", "taskItem"])
 
 declare module "@tiptap/core" {
   interface Commands<ReturnType> {
@@ -169,7 +169,7 @@ export const IndentExtension = Extension.create<IndentOptions>({
       const { $from } = this.editor.state.selection
 
       for (let depth = $from.depth; depth > 0; depth -= 1) {
-        if (LIST_ITEM_TYPES.includes($from.node(depth).type.name)) {
+        if (LIST_ITEM_TYPES.has($from.node(depth).type.name)) {
           return false
         }
       }

--- a/packages/react/src/components/RichText/internal/Extensions/SlashCommand/AvailableCommands.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/SlashCommand/AvailableCommands.tsx
@@ -52,19 +52,17 @@ const getGroupedCommands = ({
       ? [
           {
             title: aiBlockConfig.title,
-            commands: [
-              ...aiBlockConfig.buttons.map((button) => ({
-                title: button.label,
-                command: (editor: Editor) => {
-                  editor
-                    .chain()
-                    .focus()
-                    .executeAIAction(button.type, aiBlockConfig)
-                    .run()
-                },
-                icon: button.icon,
-              })),
-            ],
+            commands: aiBlockConfig.buttons.map((button) => ({
+              title: button.label,
+              command: (editor: Editor) => {
+                editor
+                  .chain()
+                  .focus()
+                  .executeAIAction(button.type, aiBlockConfig)
+                  .run()
+              },
+              icon: button.icon,
+            })),
           },
         ]
       : []),

--- a/packages/react/src/components/RichText/internal/Extensions/VideoEmbed/index.tsx
+++ b/packages/react/src/components/RichText/internal/Extensions/VideoEmbed/index.tsx
@@ -79,6 +79,10 @@ const VideoEmbedNodeView = ({
         )}
       >
         <div className="relative w-full" style={{ paddingBottom: "56.25%" }}>
+          {/* No sandbox: the YouTube and Vimeo players need allow-scripts and
+              allow-same-origin together, which the rule rejects. `src` only
+              ever comes from parseVideoUrl, so it is one of those two hosts. */}
+          {/* oxlint-disable-next-line react/iframe-missing-sandbox */}
           <iframe
             src={src}
             title={`${provider} video`}

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogOverlay.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogOverlay.tsx
@@ -14,22 +14,20 @@ export const DialogOverlay = forwardRef<
   const modal = context.modal || context.showOverlay
 
   return (
-    <>
-      <DialogPrimitive.Root {...context} modal={modal}>
-        <div
-          data-state={context.open ? "open" : "closed"}
-          ref={ref}
-          className={cn(
-            "fixed inset-0 z-50 bg-f1-background-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-            "pointer-events-auto",
-            "transition-all duration-200",
-            className
-          )}
-          {...props}
-          style={{ pointerEvents: "auto", ...props.style }}
-        />
-      </DialogPrimitive.Root>
-    </>
+    <DialogPrimitive.Root {...context} modal={modal}>
+      <div
+        data-state={context.open ? "open" : "closed"}
+        ref={ref}
+        className={cn(
+          "fixed inset-0 z-50 bg-f1-background-overlay data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          "pointer-events-auto",
+          "transition-all duration-200",
+          className
+        )}
+        {...props}
+        style={{ pointerEvents: "auto", ...props.style }}
+      />
+    </DialogPrimitive.Root>
   )
 })
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName

--- a/packages/react/src/deprecated/EntitySelect/Content/SecondaryContent/index.tsx
+++ b/packages/react/src/deprecated/EntitySelect/Content/SecondaryContent/index.tsx
@@ -77,6 +77,7 @@ export const SecondaryContent = ({
           renderer={(vi) => {
             const current = flattenedList[vi.index]
             if (!current) {
+              // oxlint-disable-next-line react/jsx-no-useless-fragment -- the renderer must return an element
               return <></>
             }
             return (

--- a/packages/react/src/deprecated/EntitySelect/index.stories.tsx
+++ b/packages/react/src/deprecated/EntitySelect/index.stories.tsx
@@ -307,7 +307,7 @@ export const SingleSelector = {
         }
         selectedEntities={!selected ? [] : [selected]}
         onSelect={(selection) => {
-          if (selectedGroup != "all") {
+          if (selectedGroup !== "all") {
             const found = GROUP_DATA["all"].find(
               (el) => el.id === selection?.subItems?.[0]?.subId
             )
@@ -498,7 +498,7 @@ export const WithCustomTrigger = {
           selectedEntities={selected}
           onSelect={(selection: EntitySelectEntity[]) => {
             setSelected(selection)
-            if (selectedGroup != "all") {
+            if (selectedGroup !== "all") {
               let total = 0
               selection.forEach((el) => (total += el.subItems?.length ?? 0))
               setNumSelected(total)

--- a/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/index.tsx
@@ -270,21 +270,20 @@ function MetadataItem({ item }: { item: MetadataItem }) {
                           )}
                         />
                       )
-                    } else {
-                      return (
-                        <Tooltip label={action.label} key={`tooltip-${index}`}>
-                          <F0Button
-                            key={`action-${index}`}
-                            size="sm"
-                            variant="neutral"
-                            label={action.label}
-                            hideLabel
-                            icon={action.icon}
-                            onClick={action.onClick}
-                          />
-                        </Tooltip>
-                      )
                     }
+                    return (
+                      <Tooltip label={action.label} key={`tooltip-${index}`}>
+                        <F0Button
+                          key={`action-${index}`}
+                          size="sm"
+                          variant="neutral"
+                          label={action.label}
+                          hideLabel
+                          icon={action.icon}
+                          onClick={action.onClick}
+                        />
+                      </Tooltip>
+                    )
                   })}
                 </motion.div>
               ) : null}

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
@@ -42,11 +42,6 @@ function renderTOCItem(
   hideChildrenCounter?: boolean,
   expandedItems?: Set<string>,
   onToggleExpanded?: (id: string) => void,
-  onMoveItem?: (
-    itemId: string,
-    targetParentId: string | null,
-    targetIndex: number
-  ) => void,
   allItems?: TOCItem[],
   draggedItemId?: string | null,
   dragOverItemId?: string | null,
@@ -170,7 +165,6 @@ function renderTOCItem(
                   hideChildrenCounter,
                   expandedItems,
                   onToggleExpanded,
-                  onMoveItem,
                   allItems,
                   draggedItemId,
                   dragOverItemId,
@@ -949,7 +943,6 @@ function TOCContent({
                 hideChildrenCounter,
                 expandedItems,
                 handleToggleExpanded,
-                handleMoveItem,
                 sortableItems,
                 draggedItemId,
                 dragOverItemId,

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/utils.ts
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/utils.ts
@@ -203,17 +203,13 @@ export function wouldCreateCycle(
     return false
   }
 
-  function isDescendant(
-    items: TOCItem[],
-    ancestorId: string,
-    descendantId: string
-  ): boolean {
+  function isDescendant(items: TOCItem[], descendantId: string): boolean {
     for (const item of items) {
       if (item.id === descendantId) {
         return true
       }
       if (item.children) {
-        if (isDescendant(item.children, ancestorId, descendantId)) {
+        if (isDescendant(item.children, descendantId)) {
           return true
         }
       }
@@ -224,7 +220,7 @@ export function wouldCreateCycle(
   // Check if targetParentId is a descendant of itemId
   const itemWithChildren = findItemInTree(items, itemId)
   if (itemWithChildren?.item.children) {
-    return isDescendant(itemWithChildren.item.children, itemId, targetParentId)
+    return isDescendant(itemWithChildren.item.children, targetParentId)
   }
 
   return false

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbItem.tsx
@@ -82,22 +82,20 @@ const BreadcrumbContent = forwardRef<HTMLDivElement, BreadcrumbItemProps>(
       select: "type" in item &&
         item.type === "select" &&
         (item.options || item.source) && (
-          <>
-            <BreadcrumbSelect
-              label={item.label}
-              hideLabel
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              source={item.source as any}
-              options={item.options}
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any
-              mapOptions={item.mapOptions as any}
-              defaultItem={item.defaultItem}
-              clearable={false}
-              onChange={item.onChange}
-              value={item.value}
-              showSearchBox={item.searchbox}
-            />
-          </>
+          <BreadcrumbSelect
+            label={item.label}
+            hideLabel
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            source={item.source as any}
+            options={item.options}
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            mapOptions={item.mapOptions as any}
+            defaultItem={item.defaultItem}
+            clearable={false}
+            onChange={item.onChange}
+            value={item.value}
+            showSearchBox={item.searchbox}
+          />
         ),
       "collection-select": "type" in item &&
         item.type === "collection-select" && (

--- a/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
+++ b/packages/react/src/experimental/Navigation/Header/ProductUpdates/index.tsx
@@ -165,17 +165,15 @@ const ProductUpdates = ({
                   onClick={onItemClick}
                 />
                 {updates.length > 1 ? (
-                  <>
-                    <div className="pb-1">
-                      {restUpdates.map((update, index) => (
-                        <DropdownItem
-                          key={index}
-                          {...update}
-                          onClick={onItemClick}
-                        />
-                      ))}
-                    </div>
-                  </>
+                  <div className="pb-1">
+                    {restUpdates.map((update, index) => (
+                      <DropdownItem
+                        key={index}
+                        {...update}
+                        onClick={onItemClick}
+                      />
+                    ))}
+                  </div>
                 ) : null}
               </div>
             ) : null}

--- a/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/NestedCell/index.tsx
@@ -147,24 +147,22 @@ export const NestedCell = ({
           )}
         </div>
       ) : onLoadMoreChildren ? (
-        <>
-          <div
-            className={cn(
-              "pointer-events-auto cursor-pointer flex items-center w-full h-full border-0 border-r-[1px] border-solid border-f1-border-secondary"
-            )}
-          >
-            <F0Button
-              variant="ghost"
-              size="md"
-              icon={ArrowDown}
-              label={collections.table.seeMoreChildren}
-              onClick={(e) => {
-                e.stopPropagation()
-                onLoadMoreChildren?.()
-              }}
-            />
-          </div>
-        </>
+        <div
+          className={cn(
+            "pointer-events-auto cursor-pointer flex items-center w-full h-full border-0 border-r-[1px] border-solid border-f1-border-secondary"
+          )}
+        >
+          <F0Button
+            variant="ghost"
+            size="md"
+            icon={ArrowDown}
+            label={collections.table.seeMoreChildren}
+            onClick={(e) => {
+              e.stopPropagation()
+              onLoadMoreChildren?.()
+            }}
+          />
+        </div>
       ) : (
         <>
           <div
@@ -175,11 +173,9 @@ export const NestedCell = ({
             )}
             style={
               {
-                ...{
-                  "--chevron-parent-size": `${CHEVRON_PARENT_SIZE}px`,
-                  "--chevron-size": `${CHEVRON_SIZE}px`,
-                  "--spacing-factor": `${SPACING_FACTOR}px`,
-                },
+                "--chevron-parent-size": `${CHEVRON_PARENT_SIZE}px`,
+                "--chevron-size": `${CHEVRON_SIZE}px`,
+                "--spacing-factor": `${SPACING_FACTOR}px`,
               } as React.CSSProperties
             }
             onClick={(e) => {

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -147,60 +147,71 @@ export function TableHead({
       : undefined
 
   const content = (
-    <>
-      <div
-        className={cn(
-          "flex items-center whitespace-nowrap",
-          hasContent && "gap-1",
-          align === "right" && "flex-row-reverse"
-        )}
-      >
-        {typeof children === "string" ? (
-          <OneEllipsis className={cn(width !== "auto" && "overflow-hidden")}>
-            {children}
-          </OneEllipsis>
-        ) : (
-          <div
-            className={cn("truncate", width !== "auto" && "overflow-hidden")}
-          >
-            {children}
-          </div>
-        )}
-        {hasContent ? (
-          <div className="flex items-center">
-            {info ? (
-              <div
-                className="flex h-6 w-6 items-center justify-center text-f1-foreground-secondary"
-                // Reading the column's help text is not asking to sort by it.
-                onClick={(event) => event.stopPropagation()}
-              >
-                <InfoHint
-                  info={info}
-                  icon={infoIcon}
-                  label={typeof children === "string" ? children : undefined}
-                />
-              </div>
-            ) : null}
-            {onSortClick ? (
-              <motion.button
-                className={cn(
-                  "relative h-5 w-5 rounded-xs p-1 text-f1-foreground-secondary opacity-0 transition-all focus-within:opacity-100 hover:bg-f1-background-hover group-hover:opacity-100",
-                  focusRing()
-                )}
-                aria-label="Sort"
-                whileTap={{ scale: 0.8 }}
-                transition={{ duration: 0.1 }}
-              >
-                <AnimatePresence>
+    <div
+      className={cn(
+        "flex items-center whitespace-nowrap",
+        hasContent && "gap-1",
+        align === "right" && "flex-row-reverse"
+      )}
+    >
+      {typeof children === "string" ? (
+        <OneEllipsis className={cn(width !== "auto" && "overflow-hidden")}>
+          {children}
+        </OneEllipsis>
+      ) : (
+        <div className={cn("truncate", width !== "auto" && "overflow-hidden")}>
+          {children}
+        </div>
+      )}
+      {hasContent ? (
+        <div className="flex items-center">
+          {info ? (
+            <div
+              className="flex h-6 w-6 items-center justify-center text-f1-foreground-secondary"
+              // Reading the column's help text is not asking to sort by it.
+              onClick={(event) => event.stopPropagation()}
+            >
+              <InfoHint
+                info={info}
+                icon={infoIcon}
+                label={typeof children === "string" ? children : undefined}
+              />
+            </div>
+          ) : null}
+          {onSortClick ? (
+            <motion.button
+              className={cn(
+                "relative h-5 w-5 rounded-xs p-1 text-f1-foreground-secondary opacity-0 transition-all focus-within:opacity-100 hover:bg-f1-background-hover group-hover:opacity-100",
+                focusRing()
+              )}
+              aria-label="Sort"
+              whileTap={{ scale: 0.8 }}
+              transition={{ duration: 0.1 }}
+            >
+              <AnimatePresence>
+                <motion.div
+                  key="sort-arrow"
+                  className="absolute left-1 top-1 flex h-3 w-3 items-center justify-center"
+                  animate={{
+                    rotate: sortState === "desc" ? 0 : 180,
+                    x: sortState === "none" ? -3 : 0,
+                    y: sortState === "none" ? -1 : 0,
+                    scale: sortState === "none" ? 0.9 : 1,
+                  }}
+                  transition={{
+                    duration: 0.2,
+                    ease: [0.175, 0.885, 0.32, 1.275],
+                  }}
+                >
+                  <F0Icon icon={ArrowDown} size="xs" />
+                </motion.div>
+                {sortState === "none" ? (
                   <motion.div
-                    key="sort-arrow"
+                    key="sort-arrow-secondary"
                     className="absolute left-1 top-1 flex h-3 w-3 items-center justify-center"
-                    animate={{
-                      rotate: sortState === "desc" ? 0 : 180,
-                      x: sortState === "none" ? -3 : 0,
-                      y: sortState === "none" ? -1 : 0,
-                      scale: sortState === "none" ? 0.9 : 1,
-                    }}
+                    initial={{ opacity: 0, x: 0, y: 0, scale: 0.9 }}
+                    animate={{ opacity: 1, x: 3, y: 1, scale: 0.9 }}
+                    exit={{ opacity: 0, x: 0, y: 0, scale: 0.9 }}
                     transition={{
                       duration: 0.2,
                       ease: [0.175, 0.885, 0.32, 1.275],
@@ -208,28 +219,13 @@ export function TableHead({
                   >
                     <F0Icon icon={ArrowDown} size="xs" />
                   </motion.div>
-                  {sortState === "none" ? (
-                    <motion.div
-                      key="sort-arrow-secondary"
-                      className="absolute left-1 top-1 flex h-3 w-3 items-center justify-center"
-                      initial={{ opacity: 0, x: 0, y: 0, scale: 0.9 }}
-                      animate={{ opacity: 1, x: 3, y: 1, scale: 0.9 }}
-                      exit={{ opacity: 0, x: 0, y: 0, scale: 0.9 }}
-                      transition={{
-                        duration: 0.2,
-                        ease: [0.175, 0.885, 0.32, 1.275],
-                      }}
-                    >
-                      <F0Icon icon={ArrowDown} size="xs" />
-                    </motion.div>
-                  ) : null}
-                </AnimatePresence>
-              </motion.button>
-            ) : null}
-          </div>
-        ) : null}
-      </div>
-    </>
+                ) : null}
+              </AnimatePresence>
+            </motion.button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   )
 
   const colWidth = getColWidth(width)

--- a/packages/react/src/experimental/Overlays/Tooltip/__tests__/Tooltip.unslottableTrigger.test.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/__tests__/Tooltip.unslottableTrigger.test.tsx
@@ -17,6 +17,7 @@ describe("TooltipInternal with a trigger the Slot cannot clone onto", () => {
     const user = userEvent.setup()
     render(
       <TooltipInternal instant description="Scheduled to move on 2999-01-01">
+        {/* oxlint-disable-next-line react/jsx-no-useless-fragment -- a Fragment child is what this test covers */}
         <>
           <span>badge</span>
         </>

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -108,92 +108,88 @@ export function TooltipInternal({
     React.isValidElement(children) && children.type !== React.Fragment
 
   return (
-    <>
-      <TooltipProvider
-        delayDuration={openDelayMs}
-        disableHoverableContent={instant}
+    <TooltipProvider
+      delayDuration={openDelayMs}
+      disableHoverableContent={instant}
+    >
+      <TooltipPrimitive
+        open={hasContent && open}
+        onOpenChange={(nextOpen) => {
+          // We control when the tooltip opens so it doesn't show on mouse click
+          // focus/programmatic focus. Still allow Radix to request closing (e.g. escape).
+          if (!nextOpen) {
+            close()
+          }
+        }}
       >
-        <TooltipPrimitive
-          open={hasContent && open}
-          onOpenChange={(nextOpen) => {
-            // We control when the tooltip opens so it doesn't show on mouse click
-            // focus/programmatic focus. Still allow Radix to request closing (e.g. escape).
-            if (!nextOpen) {
+        <TooltipTrigger
+          asChild
+          className="pointer-events-auto"
+          onPointerEnter={(e) => {
+            if (e.pointerType === "touch") {
+              return
+            }
+            scheduleOpen()
+          }}
+          onPointerLeave={() => close()}
+          onPointerDown={() => close()}
+          onFocus={(e) => {
+            if (!hasContent) {
+              return
+            }
+            if (isFocusVisible(e.currentTarget)) {
+              onOpen?.()
+              setOpen(true)
+            } else {
+              // If focus comes from mouse/touch/programmatic focus, keep closed.
               close()
             }
           }}
+          onBlur={() => close()}
         >
-          <TooltipTrigger
-            asChild
-            className="pointer-events-auto"
-            onPointerEnter={(e) => {
-              if (e.pointerType === "touch") {
-                return
-              }
-              scheduleOpen()
-            }}
-            onPointerLeave={() => close()}
-            onPointerDown={() => close()}
-            onFocus={(e) => {
-              if (!hasContent) {
-                return
-              }
-              if (isFocusVisible(e.currentTarget)) {
-                onOpen?.()
-                setOpen(true)
-              } else {
-                // If focus comes from mouse/touch/programmatic focus, keep closed.
-                close()
-              }
-            }}
-            onBlur={() => close()}
-          >
-            {slottableTrigger ? (
-              stripNativeTitle(children)
-            ) : (
-              <span className="inline-flex h-fit w-fit">{children}</span>
-            )}
-          </TooltipTrigger>
-          <TooltipContent
-            className={cn(
-              "max-w-xs",
-              shortcut && "pr-1.5",
-              instant && "pointer-events-none"
-            )}
-          >
-            <div className="flex flex-col gap-0.5">
-              <div className="flex items-center gap-2">
-                {label ? <p className="font-semibold">{label}</p> : null}
-                {shortcut ? (
-                  <Shortcut keys={shortcut} variant="inverse" />
-                ) : null}
-              </div>
-              {description ? (
-                <p className="font-normal">{description.toString()}</p>
-              ) : null}
-              {items && items.length > 0 ? (
-                <ul className="m-0 flex list-disc flex-col gap-0.5 pl-4 font-normal">
-                  {items.map((item, index) => (
-                    <li
-                      key={`${index}-${typeof item === "string" ? item : item.title}`}
-                    >
-                      {typeof item === "string" ? (
-                        item
-                      ) : (
-                        <>
-                          <span className="font-semibold">{item.title}</span>
-                          {item.description ? <> {item.description}</> : null}
-                        </>
-                      )}
-                    </li>
-                  ))}
-                </ul>
-              ) : null}
+          {slottableTrigger ? (
+            stripNativeTitle(children)
+          ) : (
+            <span className="inline-flex h-fit w-fit">{children}</span>
+          )}
+        </TooltipTrigger>
+        <TooltipContent
+          className={cn(
+            "max-w-xs",
+            shortcut && "pr-1.5",
+            instant && "pointer-events-none"
+          )}
+        >
+          <div className="flex flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              {label ? <p className="font-semibold">{label}</p> : null}
+              {shortcut ? <Shortcut keys={shortcut} variant="inverse" /> : null}
             </div>
-          </TooltipContent>
-        </TooltipPrimitive>
-      </TooltipProvider>
-    </>
+            {description ? (
+              <p className="font-normal">{description.toString()}</p>
+            ) : null}
+            {items && items.length > 0 ? (
+              <ul className="m-0 flex list-disc flex-col gap-0.5 pl-4 font-normal">
+                {items.map((item, index) => (
+                  <li
+                    key={`${index}-${typeof item === "string" ? item : item.title}`}
+                  >
+                    {typeof item === "string" ? (
+                      item
+                    ) : (
+                      <>
+                        <span className="font-semibold">{item.title}</span>
+                        {item.description ? <> {item.description}</> : null}
+                      </>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        </TooltipContent>
+      </TooltipPrimitive>
+    </TooltipProvider>
   )
 }
 

--- a/packages/react/src/experimental/Widgets/Content/Lists/WidgetInboxList/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/Lists/WidgetInboxList/index.stories.tsx
@@ -27,7 +27,7 @@ type Story = StoryObj<WidgetInboxListProps>
 
 export const Default: Story = {
   args: {
-    items: new Array(12).fill(null).map(() => ({
+    items: Array.from({ length: 12 }, () => ({
       ...(DefaulWidgetInboxListItemStory.args as WidgetInboxListItemProps),
     })),
     onClickItem: () => {},
@@ -37,7 +37,7 @@ export const Default: Story = {
 export const WithLongTitles: Story = {
   args: {
     ...Default.args,
-    items: new Array(12).fill(null).map(() => ({
+    items: Array.from({ length: 12 }, () => ({
       ...(WithLongTitleWidgetInboxListItemStory.args as WidgetInboxListItemProps),
     })),
   },

--- a/packages/react/src/experimental/Widgets/Content/Lists/WidgetSimpleList/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Content/Lists/WidgetSimpleList/index.stories.tsx
@@ -26,7 +26,7 @@ type Story = StoryObj<WidgetSimpleListProps>
 
 export const Default: Story = {
   args: {
-    items: new Array(10).fill(null).map((_, i) => ({
+    items: Array.from({ length: 10 }, (_, i) => ({
       id: i,
       ...DefaultWidgetSimpleListItemStory.args,
       title: DefaultWidgetSimpleListItemStory.args?.title ?? "Example title",
@@ -38,7 +38,7 @@ export const Default: Story = {
 export const WithLongTitles: Story = {
   args: {
     ...Default.args,
-    items: new Array(10).fill(null).map((_, i) => ({
+    items: Array.from({ length: 10 }, (_, i) => ({
       id: i,
       ...WithLongTitleWidgetSimpleListItemStory.args,
       title:

--- a/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
+++ b/packages/react/src/experimental/Widgets/Widget/index.spec.tsx
@@ -1,3 +1,4 @@
+/* oxlint-disable react/jsx-no-useless-fragment -- empty fragments are part of the children under test */
 import { screen } from "@testing-library/react"
 import { Fragment } from "react"
 import { afterEach, describe, expect, test, vi } from "vitest"

--- a/packages/react/src/hooks/datasource/__stories__/examples.stories.tsx
+++ b/packages/react/src/hooks/datasource/__stories__/examples.stories.tsx
@@ -81,8 +81,8 @@ const createMockDataAdapter = () =>
 
       if (cursor) {
         filteredUsers = filteredUsers.slice(
-          parseInt(cursor),
-          parseInt(cursor) + (perPage ?? 10)
+          parseInt(cursor, 10),
+          parseInt(cursor, 10) + (perPage ?? 10)
         )
       }
 

--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -708,8 +708,8 @@ export function useData<
           // Use appropriate pagination type based on dataAdapter configuration
           return dataAdapter.fetchData({
             ...baseFetchOptions,
-            pagination: {
-              ...(dataAdapter.paginationType === "pages"
+            pagination:
+              dataAdapter.paginationType === "pages"
                 ? {
                     currentPage,
                     perPage: perPageValue,
@@ -719,8 +719,7 @@ export function useData<
                       cursor,
                       perPage: perPageValue,
                     }
-                  : {}),
-            },
+                  : {},
           }) as PromiseOrObservable<ResultType>
         }
 

--- a/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
+++ b/packages/react/src/kits/Charts/VerticalBarChart/index.tsx
@@ -130,41 +130,39 @@ const _VBarChart = <K extends ChartConfig>(
 
         {bars.map((key, index) => {
           return (
-            <>
-              <Bar
-                isAnimationActive={false}
-                layout="vertical"
-                key={`bar-${key}`}
-                dataKey={key}
-                fill={
-                  dataConfig[key].color
-                    ? getColor(dataConfig[key].color)
-                    : getCategoricalColor(index)
-                }
-                radius={4}
-                maxBarSize={24}
-              >
-                {label || showRatio ? (
-                  <LabelList
-                    key={`label-{${key}}`}
-                    position="right"
-                    offset={10}
-                    className="fill-f1-foreground"
-                    fontSize={12}
-                    formatter={valueFormatter}
-                    content={
-                      showRatio ? (
-                        <CustomLabel
-                          valueFormatter={valueFormatter}
-                          total={totalCategories[key]}
-                          showLabel={label}
-                        />
-                      ) : undefined
-                    }
-                  />
-                ) : null}
-              </Bar>
-            </>
+            <Bar
+              isAnimationActive={false}
+              layout="vertical"
+              key={`bar-${key}`}
+              dataKey={key}
+              fill={
+                dataConfig[key].color
+                  ? getColor(dataConfig[key].color)
+                  : getCategoricalColor(index)
+              }
+              radius={4}
+              maxBarSize={24}
+            >
+              {label || showRatio ? (
+                <LabelList
+                  key={`label-{${key}}`}
+                  position="right"
+                  offset={10}
+                  className="fill-f1-foreground"
+                  fontSize={12}
+                  formatter={valueFormatter}
+                  content={
+                    showRatio ? (
+                      <CustomLabel
+                        valueFormatter={valueFormatter}
+                        total={totalCategories[key]}
+                        showLabel={label}
+                      />
+                    ) : undefined
+                  }
+                />
+              ) : null}
+            </Bar>
           )
         })}
       </BarChartPrimitive>

--- a/packages/react/src/kits/ai/AIButton/AIButton.tsx
+++ b/packages/react/src/kits/ai/AIButton/AIButton.tsx
@@ -40,7 +40,7 @@ const AIButton = forwardRef<
       {...publicProps}
       variant="ai"
       ref={ref}
-      iconRotate={props.icon == AIIcons.One ? true : false}
+      iconRotate={props.icon === AIIcons.One}
     />
   )
 })

--- a/packages/react/src/kits/ai/F0ActionItem/components/ChatSpinner.tsx
+++ b/packages/react/src/kits/ai/F0ActionItem/components/ChatSpinner.tsx
@@ -52,7 +52,10 @@ const ChatSpinnerComponent = (
 
   // Stable placeholder array for the JSX: one <polygon> per pool slot. We pay
   // the React mount cost ONCE; per-frame updates go straight to the DOM.
-  const placeholders = useMemo(() => new Array(QUAD_POOL_SIZE).fill(0), [])
+  const placeholders = useMemo(
+    () => Array.from({ length: QUAD_POOL_SIZE }, () => 0),
+    []
+  )
 
   const setRefs = (el: HTMLDivElement | null) => {
     wrapperRef.current = el

--- a/packages/react/src/kits/ai/F0ActionItem/components/globeSpinMath.ts
+++ b/packages/react/src/kits/ai/F0ActionItem/components/globeSpinMath.ts
@@ -122,17 +122,13 @@ export function spinEase(t: number): number {
 // (~700 string allocations/frame saved). 256 levels is well below the eye's
 // gradient discrimination, so the LUT is visually lossless.
 const COLOR_LUT_SIZE = 256
-const COLOR_LUT: string[] = (() => {
-  const out: string[] = new Array(COLOR_LUT_SIZE)
-  for (let i = 0; i < COLOR_LUT_SIZE; i++) {
-    const t = i / (COLOR_LUT_SIZE - 1)
-    const r = Math.round(COLOR_A[0] + (COLOR_B[0] - COLOR_A[0]) * t)
-    const g = Math.round(COLOR_A[1] + (COLOR_B[1] - COLOR_A[1]) * t)
-    const b = Math.round(COLOR_A[2] + (COLOR_B[2] - COLOR_A[2]) * t)
-    out[i] = `rgb(${r},${g},${b})`
-  }
-  return out
-})()
+const COLOR_LUT: string[] = Array.from({ length: COLOR_LUT_SIZE }, (_, i) => {
+  const t = i / (COLOR_LUT_SIZE - 1)
+  const r = Math.round(COLOR_A[0] + (COLOR_B[0] - COLOR_A[0]) * t)
+  const g = Math.round(COLOR_A[1] + (COLOR_B[1] - COLOR_A[1]) * t)
+  const b = Math.round(COLOR_A[2] + (COLOR_B[2] - COLOR_A[2]) * t)
+  return `rgb(${r},${g},${b})`
+})
 
 function colorFor(t: number): string {
   // Clamp + quantize to LUT index. `t` is expected in [0, 1].
@@ -159,27 +155,25 @@ export const QUAD_POOL_SIZE = 4 * LAT_STEPS * SEGS // 960
 const LENS_EDGE: number[] = (() => {
   const a = LENS_C
   const r2 = LENS_R * LENS_R
-  const out = new Array<number>(SEGS + 1)
-  for (let si = 0; si <= SEGS; si++) {
+  return Array.from({ length: SEGS + 1 }, (_, si) => {
     const lon = (si / SEGS) * Math.PI * 2
     const k = Math.sin(lon) ** 2
     const c =
       k < 1e-9
         ? (a * a + 1 - r2) / (2 * a)
         : (a - Math.sqrt(a * a - k * (a * a + 1 - k - r2))) / k
-    out[si] = Math.acos(Math.max(-1, Math.min(1, c)))
-  }
-  return out
+    return Math.acos(Math.max(-1, Math.min(1, c)))
+  })
 })()
 
 // Azimuth trig, hoisted — it no longer depends on anything per-frame.
-const COS_LON: number[] = new Array(SEGS + 1)
-const SIN_LON: number[] = new Array(SEGS + 1)
-for (let si = 0; si <= SEGS; si++) {
-  const lon = (si / SEGS) * Math.PI * 2
-  COS_LON[si] = Math.cos(lon)
-  SIN_LON[si] = Math.sin(lon)
-}
+const lonAt = (si: number): number => (si / SEGS) * Math.PI * 2
+const COS_LON: number[] = Array.from({ length: SEGS + 1 }, (_, si) =>
+  Math.cos(lonAt(si))
+)
+const SIN_LON: number[] = Array.from({ length: SEGS + 1 }, (_, si) =>
+  Math.sin(lonAt(si))
+)
 
 // The four lenses are one patch repeated at 0/90/180/270° about the view axis,
 // which is what makes the resting mark four-fold symmetric like the logo.
@@ -195,14 +189,17 @@ const _capQs: Q[] = [
 const _compareAvgZ = (a: Quad, b: Quad): number => a.avgZ - b.avgZ
 
 export function createGlobeSpinState(): GlobeSpinState {
-  const quads: Quad[] = new Array(QUAD_POOL_SIZE)
-  for (let i = 0; i < QUAD_POOL_SIZE; i++) {
-    quads[i] = { points: "", color: "", avgZ: Infinity }
-  }
-  const grid: GridPoint[] = new Array(GRID_SIZE)
-  for (let i = 0; i < GRID_SIZE; i++) {
-    grid[i] = { x: 0, y: 0, z: 0, t: 0 }
-  }
+  const quads: Quad[] = Array.from({ length: QUAD_POOL_SIZE }, () => ({
+    points: "",
+    color: "",
+    avgZ: Infinity,
+  }))
+  const grid: GridPoint[] = Array.from({ length: GRID_SIZE }, () => ({
+    x: 0,
+    y: 0,
+    z: 0,
+    t: 0,
+  }))
   return { quads, grid }
 }
 

--- a/packages/react/src/kits/ai/F0AiChatTextArea/useFileAttachments.ts
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/useFileAttachments.ts
@@ -97,14 +97,14 @@ export function useFileAttachments(
         file,
         status: "uploading" as const,
       }))
-      const errorIds = newAttached.map((n) => n.id)
+      const errorIds = new Set(newAttached.map((n) => n.id))
 
       setAttachedFiles((prev) => [...prev, ...newAttached])
 
       const markBatchAsError = (errorMessage: string) =>
         setAttachedFiles((prev) =>
           prev.map((att) =>
-            errorIds.includes(att.id)
+            errorIds.has(att.id)
               ? { ...att, status: "error" as const, errorMessage }
               : att
           )

--- a/packages/react/src/kits/ai/F0AiMask/F0AiMask.ts
+++ b/packages/react/src/kits/ai/F0AiMask/F0AiMask.ts
@@ -100,7 +100,7 @@ function parseColor(colorStr: string): [number, number, number] {
     throw new Error(`Invalid color format: ${colorStr}`)
   }
   const [, r, g, b] = match
-  return [parseInt(r) / 255, parseInt(g) / 255, parseInt(b) / 255]
+  return [parseInt(r, 10) / 255, parseInt(g, 10) / 255, parseInt(b, 10) / 255]
 }
 
 export class F0AiMask {

--- a/packages/react/src/kits/ai/F0AuraVoiceAnimation/components/ReactShaderToy.tsx
+++ b/packages/react/src/kits/ai/F0AuraVoiceAnimation/components/ReactShaderToy.tsx
@@ -35,14 +35,14 @@ function isVectorListType(t: string, v: number[] | number): v is number[] {
   return (
     t.includes("v") &&
     Array.isArray(v) &&
-    v.length > Number.parseInt(t.charAt(0))
+    v.length > Number.parseInt(t.charAt(0), 10)
   )
 }
 function isVectorType(t: string, v: number[] | number): v is Vector4 {
   return (
     !t.includes("v") &&
     Array.isArray(v) &&
-    v.length > Number.parseInt(t.charAt(0))
+    v.length > Number.parseInt(t.charAt(0), 10)
   )
 }
 const processUniform = <T extends UniformType>(
@@ -753,13 +753,13 @@ export function ReactShaderToy({
         const tempObject: { arraySize?: string } = {}
         if (isMatrixType(type, value)) {
           const arrayLength = type.length
-          const val = Number.parseInt(type.charAt(arrayLength - 3))
+          const val = Number.parseInt(type.charAt(arrayLength - 3), 10)
           const numberOfMatrices = Math.floor(value.length / (val * val))
           if (value.length > val * val) {
             tempObject.arraySize = `[${numberOfMatrices}]`
           }
         } else if (isVectorListType(type, value)) {
-          tempObject.arraySize = `[${Math.floor(value.length / Number.parseInt(type.charAt(0)))}]`
+          tempObject.arraySize = `[${Math.floor(value.length / Number.parseInt(type.charAt(0), 10))}]`
         }
         uniformsRef.current[name] = {
           type: glslType,
@@ -794,9 +794,7 @@ export function ReactShaderToy({
           texturesArrRef.current[id] = new Texture(gl)
           return texturesArrRef.current[id]
             ?.load(texture)
-            .then((t: Texture) => {
-              setupChannelRes(t, id)
-            })
+            .then((t: Texture) => setupChannelRes(t, id))
         }
       )
       Promise.all(texturePromisesArr)

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
@@ -415,19 +415,17 @@ function buildFieldForQuestion(
             q.allowCreate && dataset.onCreate
               ? {
                   ...field,
-                  onCreate: (searchValue: string) => {
-                    return dataset.onCreate!(searchValue).then(
-                      (record) => {
-                        const option = dataset.mapOptions(record)
-                        ;(onChange as (value: unknown) => void)(option.value)
-                      },
-                      (err: unknown) => {
-                        console.warn(
-                          "[SurveyAnsweringForm] onCreate failed:",
-                          err
-                        )
-                      }
-                    )
+                  onCreate: async (searchValue: string) => {
+                    try {
+                      const record = await dataset.onCreate!(searchValue)
+                      const option = dataset.mapOptions(record)
+                      ;(onChange as (value: unknown) => void)(option.value)
+                    } catch (err) {
+                      console.warn(
+                        "[SurveyAnsweringForm] onCreate failed:",
+                        err
+                      )
+                    }
                   },
                 }
               : field

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.tsx
@@ -39,20 +39,18 @@ export const DropdownSingleQuestion = ({
 
   const handleCreate =
     answering && !isMulti && allowCreate && dataset.onCreate
-      ? (value: string) => {
-          return dataset.onCreate!(value).then(
-            (record) => {
-              const option = dataset.mapOptions(record)
-              onQuestionChange?.({
-                id: props.id,
-                type: "dropdown-single",
-                value: option.value,
-              })
-            },
-            (err: unknown) => {
-              console.warn("[SurveyFormBuilder] onCreate failed:", err)
-            }
-          )
+      ? async (value: string) => {
+          try {
+            const record = await dataset.onCreate!(value)
+            const option = dataset.mapOptions(record)
+            onQuestionChange?.({
+              id: props.id,
+              type: "dropdown-single",
+              value: option.value,
+            })
+          } catch (err) {
+            console.warn("[SurveyFormBuilder] onCreate failed:", err)
+          }
         }
       : undefined
 

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/lib.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/lib.ts
@@ -5,18 +5,18 @@ export type RatingOptionType = "1-5" | "1-10" | "0-10" | "emojis"
 export const getRatingOptions = (type: RatingOptionType) => {
   switch (type) {
     case "1-5":
-      return new Array(5).fill(0).map((_, index) => ({
+      return Array.from({ length: 5 }, (_, index) => ({
         value: index + 1,
         label: (index + 1).toString(),
       }))
     case "1-10":
-      return new Array(10).fill(0).map((_, index) => ({
+      return Array.from({ length: 10 }, (_, index) => ({
         value: index + 1,
         label: (index + 1).toString(),
       }))
     // Starts at 0, which makes it the standard eNPS scale.
     case "0-10":
-      return new Array(11).fill(0).map((_, index) => ({
+      return Array.from({ length: 11 }, (_, index) => ({
         value: index,
         label: index.toString(),
       }))

--- a/packages/react/src/layouts/Dashboard/__stories__/Dashboard.stories.tsx
+++ b/packages/react/src/layouts/Dashboard/__stories__/Dashboard.stories.tsx
@@ -128,77 +128,73 @@ const meta = {
       const [editMode, setEditMode] = useState(false)
 
       return (
-        <>
-          <div className="h-full w-full">
-            <Layout.Page
-              header={
-                <div className="flex items-center gap-2 p-4">
-                  <div className="mr-5">
-                    <F0Checkbox
-                      title="Edit mode"
-                      checked={editMode}
-                      onCheckedChange={(checked) => {
-                        setEditMode(checked)
-                      }}
-                    />
-                  </div>
-                  <F0Button
-                    label="Increment Global Counter"
-                    onClick={() => {
-                      setGlobalCounter((prev) => prev + 1)
+        <div className="h-full w-full">
+          <Layout.Page
+            header={
+              <div className="flex items-center gap-2 p-4">
+                <div className="mr-5">
+                  <F0Checkbox
+                    title="Edit mode"
+                    checked={editMode}
+                    onCheckedChange={(checked) => {
+                      setEditMode(checked)
                     }}
                   />
-                  <p>Global counter: {globalCounter}</p>
                 </div>
-              }
-              aside={
-                <>
-                  <ul className="flex list-none flex-col gap-2 p-4">
-                    <li>
-                      <F0Button
-                        label="Add text widget"
-                        onClick={() => handleAddWidget("text")}
-                      />
-                    </li>
-                    <li>
-                      <F0Button
-                        label="Add chart widget"
-                        onClick={() => handleAddWidget("chart")}
-                      />
-                    </li>
-                    <li>
-                      <F0Button
-                        label="Add table widget"
-                        onClick={() => handleAddWidget("table")}
-                      />
-                    </li>
-                    <li>
-                      <F0Button
-                        label="Add kpi widget"
-                        onClick={() => handleAddWidget("kpi")}
-                      />
-                    </li>
-                  </ul>
-                </>
-              }
-            >
-              <Story
-                args={{
-                  ...args,
-                  widgets,
-                  deps: { globalCounter },
-                  onChange: (updatedWidgets) => {
-                    console.log("widgets onChange stories", updatedWidgets)
-                    setWidgets(updatedWidgets as DashboardWidget[])
-                  },
-                  editMode: editMode,
-                }}
-              />
-            </Layout.Page>
+                <F0Button
+                  label="Increment Global Counter"
+                  onClick={() => {
+                    setGlobalCounter((prev) => prev + 1)
+                  }}
+                />
+                <p>Global counter: {globalCounter}</p>
+              </div>
+            }
+            aside={
+              <ul className="flex list-none flex-col gap-2 p-4">
+                <li>
+                  <F0Button
+                    label="Add text widget"
+                    onClick={() => handleAddWidget("text")}
+                  />
+                </li>
+                <li>
+                  <F0Button
+                    label="Add chart widget"
+                    onClick={() => handleAddWidget("chart")}
+                  />
+                </li>
+                <li>
+                  <F0Button
+                    label="Add table widget"
+                    onClick={() => handleAddWidget("table")}
+                  />
+                </li>
+                <li>
+                  <F0Button
+                    label="Add kpi widget"
+                    onClick={() => handleAddWidget("kpi")}
+                  />
+                </li>
+              </ul>
+            }
+          >
+            <Story
+              args={{
+                ...args,
+                widgets,
+                deps: { globalCounter },
+                onChange: (updatedWidgets) => {
+                  console.log("widgets onChange stories", updatedWidgets)
+                  setWidgets(updatedWidgets as DashboardWidget[])
+                },
+                editMode: editMode,
+              }}
+            />
+          </Layout.Page>
 
-            <pre className="mt-10 overflow-x-auto text-xs"></pre>
-          </div>
-        </>
+          <pre className="mt-10 overflow-x-auto text-xs"></pre>
+        </div>
       )
     },
   ],

--- a/packages/react/src/layouts/Layout/blocks/Block/Block.tsx
+++ b/packages/react/src/layouts/Layout/blocks/Block/Block.tsx
@@ -56,14 +56,12 @@ const normalizeActionItems = (
           items: items,
         },
       ]
-    } else {
-      // LayoutBlockActionGroup[] case
-      return items
     }
-  } else {
-    // LayoutBlockActionGroup case
-    return [items]
+    // LayoutBlockActionGroup[] case
+    return items
   }
+  // LayoutBlockActionGroup case
+  return [items]
 }
 
 export const Block = forwardRef<HTMLDivElement, BlockProps>(

--- a/packages/react/src/lib/Await/Await.tsx
+++ b/packages/react/src/lib/Await/Await.tsx
@@ -47,11 +47,10 @@ const _Await = <T,>({
       return () => {
         cancelled = true
       }
-    } else {
-      setResolvedValue(resolve)
-      setError(null)
-      setIsPending(false)
     }
+    setResolvedValue(resolve)
+    setError(null)
+    setIsPending(false)
   }, [resolve])
 
   if (isPending) {

--- a/packages/react/src/lib/F0GridStack/components/grid-stack-provider.tsx
+++ b/packages/react/src/lib/F0GridStack/components/grid-stack-provider.tsx
@@ -228,15 +228,17 @@ export function GridStackProvider({
     if (!Array.isArray(widgetsInGridstack)) {
       return
     }
-    const widgetsInGridstackIds = widgetsInGridstack.map((widget) => widget.id)
+    const widgetsInGridstackIds = new Set(
+      widgetsInGridstack.map((widget) => widget.id)
+    )
     const newWidgets = widgets || []
-    const newWidgetsIds = newWidgets.map((widget) => widget.id)
+    const newWidgetsIds = new Set(newWidgets.map((widget) => widget.id))
 
     /**
      * Add new widgets to gridstack
      */
     const widgetsToAdd = newWidgets.filter(
-      (widget) => !widgetsInGridstackIds.includes(widget.id!)
+      (widget) => !widgetsInGridstackIds.has(widget.id!)
     )
     if (widgetsToAdd.length > 0) {
       // Update ref synchronously BEFORE adding widgets to GridStack
@@ -287,7 +289,7 @@ export function GridStackProvider({
      * Remove widgets from gridstack that are not in the widgets array
      */
     const widgetsToRemove = widgetsInGridstack.filter(
-      (widget) => !newWidgetsIds.includes(widget.id!)
+      (widget) => !newWidgetsIds.has(widget.id!)
     )
     if (widgetsToRemove.length > 0) {
       const idsToRemove = widgetsToRemove.map((w) => w.id!).filter(Boolean)
@@ -392,7 +394,7 @@ export function GridStackProvider({
      * Update widgets DOM elements in gridstack that are in the widgets array
      */
     const widgetsToUpdate = newWidgets.filter((widget) =>
-      widgetsInGridstackIds.includes(widget.id!)
+      widgetsInGridstackIds.has(widget.id!)
     )
     if (widgetsToUpdate.length > 0) {
       const widgetsNeedingGridUpdate: {

--- a/packages/react/src/lib/F0GridStack/components/types.ts
+++ b/packages/react/src/lib/F0GridStack/components/types.ts
@@ -1,4 +1,6 @@
-// Import gridstack to ensure original types are loaded before augmentation
+// The empty import makes this file a module, so the block below augments
+// gridstack's types instead of replacing them.
+// oxlint-disable-next-line import/no-empty-named-blocks
 import type {} from "gridstack"
 
 declare module "gridstack" {

--- a/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
+++ b/packages/react/src/lib/OneEllipsis/OneEllipsis.tsx
@@ -36,7 +36,7 @@ const checkForEllipsis = (element: HTMLElement | null, lines: number) => {
   }
   if (lines > 1) {
     // For multi-line, check if content height exceeds line-clamp height
-    const lineHeight = parseInt(window.getComputedStyle(element).lineHeight)
+    const lineHeight = parseInt(window.getComputedStyle(element).lineHeight, 10)
     return element.scrollHeight > lineHeight * lines
   }
   // For single line, check if content width exceeds container width

--- a/packages/react/src/lib/VirtualList/index.tsx
+++ b/packages/react/src/lib/VirtualList/index.tsx
@@ -59,7 +59,7 @@ const _VirtualList = forwardRef<HTMLDivElement, VirtualListProps>(
               }}
             >
               {/* this is a protection in case the library sends null | undefined */}
-              {!vi ? <></> : renderer(vi)}
+              {!vi ? null : renderer(vi)}
             </div>
           ))}
         </div>

--- a/packages/react/src/lib/data-testid/index.tsx
+++ b/packages/react/src/lib/data-testid/index.tsx
@@ -1,7 +1,13 @@
 import React, { forwardRef, memo, type ReactNode } from "react"
 import { useRenderDataTestIdAttribute } from "../providers/user-platafform/UserPlatformProvider"
 
-const ignoredStaticProps = ["prototype", "length", "name", "$$typeof", "render"]
+const ignoredStaticProps = new Set([
+  "prototype",
+  "length",
+  "name",
+  "$$typeof",
+  "render",
+])
 /**
  * Copies all static properties from the source component to the target component.
  * This preserves marker properties like __isPageLayoutBlock and __isPageLayoutGroup.
@@ -16,7 +22,7 @@ const copyStaticProperties = (source: any, target: any): void => {
 
   for (const key of allKeys) {
     // Skip properties that should not be copied
-    if (ignoredStaticProps.includes(key as string)) {
+    if (ignoredStaticProps.has(key as string)) {
       continue
     }
 

--- a/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.stories.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/__stories__/dialog.stories.tsx
@@ -499,7 +499,10 @@ export const NonBlocking: Story = {
         description:
           'The primary action runs for 3s. Because it is nonBlocking, "Cancel" stays clickable while it runs.',
         content: (
-          <div>Click "Start", then notice "Cancel" is still enabled.</div>
+          <div>
+            Click &quot;Start&quot;, then notice &quot;Cancel&quot; is still
+            enabled.
+          </div>
         ),
         actions: {
           primary: {

--- a/packages/react/src/lib/providers/dialogs-alike/imperative.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/imperative.tsx
@@ -135,7 +135,7 @@ const notification = (
     description: options.msg,
     id: options.id || nanoid(),
     title: options.title,
-    content: <></>,
+    content: null,
     actions: options.actions,
   })
 

--- a/packages/react/src/lib/skeleton.tsx
+++ b/packages/react/src/lib/skeleton.tsx
@@ -30,10 +30,10 @@ export const Blend: React.FC<{
 }> = ({ orientation = "vertical", limit = 600, children }) => (
   <div
     style={{
-      maskImage: `linear-gradient(to ${orientation == "vertical" ? "bottom" : "right"}, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) calc(min(100% - ${limit}px, 100%)), rgba(0, 0, 0, 0) 100%)`,
+      maskImage: `linear-gradient(to ${orientation === "vertical" ? "bottom" : "right"}, rgba(0, 0, 0, 1) 0%, rgba(0, 0, 0, 1) calc(min(100% - ${limit}px, 100%)), rgba(0, 0, 0, 0) 100%)`,
     }}
     className={
-      orientation == "horizontal" ? "w-full overflow-hidden" : "w-auto"
+      orientation === "horizontal" ? "w-full overflow-hidden" : "w-auto"
     }
   >
     {children}

--- a/packages/react/src/lib/storybook-utils/ai-mocks.ts
+++ b/packages/react/src/lib/storybook-utils/ai-mocks.ts
@@ -29,6 +29,7 @@ export const makeMockTranscribe =
       if (signal?.aborted) {
         break
       }
+      // oxlint-disable-next-line no-await-in-loop -- words stream out one at a time with a delay between them
       await new Promise((r) => setTimeout(r, 60 + Math.random() * 100))
       acc = acc ? `${acc} ${word}` : word
       onPartial(acc)

--- a/packages/react/src/patterns/Cocreation/__stories__/standard-flow.stories.tsx
+++ b/packages/react/src/patterns/Cocreation/__stories__/standard-flow.stories.tsx
@@ -56,7 +56,7 @@ export const ResourceCards: Story = {
   tags: ["no-sidebar"],
   render: () => (
     <div className="mx-auto flex w-full max-w-[520px] flex-col gap-4">
-      <AssistantLine>I've created your survey.</AssistantLine>
+      <AssistantLine>I&apos;ve created your survey.</AssistantLine>
       {/* Superseded: faded + non-interactive, no action button. */}
       <div className="pointer-events-none opacity-50">
         <F0CardHorizontal
@@ -66,7 +66,7 @@ export const ResourceCards: Story = {
         />
       </div>
       <AssistantLine>
-        Done — I've added the question to your survey.
+        Done — I&apos;ve added the question to your survey.
       </AssistantLine>
       {/* Active (open in the canvas): the button reads "Close". */}
       <F0CardHorizontal
@@ -96,7 +96,7 @@ export const HilConversation: Story = {
   render: () => (
     <div className="mx-auto flex w-full max-w-[520px] flex-col gap-4">
       <AssistantLine>
-        Good idea — here's a change I'd suggest. Review it below.
+        Good idea — here&apos;s a change I&apos;d suggest. Review it below.
       </AssistantLine>
       <F0CardHorizontal
         title="Add an open-ended comment question"
@@ -104,7 +104,7 @@ export const HilConversation: Story = {
         status={{ icon: Check, variant: "positive", label: "Accepted" }}
       />
       <UserLine>Can you drop the demographics section?</UserLine>
-      <AssistantLine>Here's that change.</AssistantLine>
+      <AssistantLine>Here&apos;s that change.</AssistantLine>
       <F0CardHorizontal
         title="Remove the demographics section"
         description="Drops 4 questions"
@@ -112,7 +112,7 @@ export const HilConversation: Story = {
         inactive
       />
       <UserLine>Add a rating question instead.</UserLine>
-      <AssistantLine>Here's the change — apply it?</AssistantLine>
+      <AssistantLine>Here&apos;s the change — apply it?</AssistantLine>
       <F0CardHorizontal
         title="Add a 1–5 satisfaction rating"
         description="A new rating question before the comment"

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
@@ -121,6 +121,7 @@ async function fetchAllStateAwareRecords(
     const all: RecordType[] = []
     let currentPage = 1
     while (all.length < MAX_EXPORT_ROWS) {
+      // oxlint-disable-next-line no-await-in-loop -- the previous response says whether there is another page
       const response = (await resolvePromiseLike(
         fetchFn({
           ...baseParams,
@@ -143,6 +144,7 @@ async function fetchAllStateAwareRecords(
   const all: RecordType[] = []
   let cursor: string | null = null
   while (all.length < MAX_EXPORT_ROWS) {
+    // oxlint-disable-next-line no-await-in-loop -- the previous response says whether there is another page
     const response = (await resolvePromiseLike(
       fetchFn({
         ...baseParams,

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useDashboardExport.ts
@@ -50,29 +50,42 @@ async function buildMetricsSheet<Filters extends FiltersDefinition>(
     return null
   }
 
+  // Metrics are independent, so they are fetched in parallel. Rows keep the
+  // item order.
+  const results = await Promise.all(
+    metricItems.map(async (item) => {
+      try {
+        const data: DashboardMetricData = await item.fetchData(
+          getItemFilters(item, filters)
+        )
+        return { item, data }
+      } catch (err) {
+        console.warn(
+          `[useDashboardExport] Failed to export metric "${item.title}":`,
+          err
+        )
+        return null
+      }
+    })
+  )
+
   const rows: Record<string, unknown>[] = []
   let hasPrevious = false
 
-  for (const item of metricItems) {
-    try {
-      const data: DashboardMetricData = await item.fetchData(
-        getItemFilters(item, filters)
-      )
-      const row: Record<string, unknown> = {
-        Metric: item.title,
-        Value: data.value,
-      }
-      if (data.previousValue !== undefined) {
-        row["Previous Value"] = data.previousValue
-        hasPrevious = true
-      }
-      rows.push(row)
-    } catch (err) {
-      console.warn(
-        `[useDashboardExport] Failed to export metric "${item.title}":`,
-        err
-      )
+  for (const result of results) {
+    if (!result) {
+      continue
     }
+    const { item, data } = result
+    const row: Record<string, unknown> = {
+      Metric: item.title,
+      Value: data.value,
+    }
+    if (data.previousValue !== undefined) {
+      row["Previous Value"] = data.previousValue
+      hasPrevious = true
+    }
+    rows.push(row)
   }
 
   if (rows.length === 0) {

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -241,6 +241,7 @@ function toAvailableFormDefinition(
           // Call onSubmit for each section (matching per-section contract)
           const sectionIds = Object.keys(sectionSchemas)
           for (const sectionId of sectionIds) {
+            // oxlint-disable-next-line no-await-in-loop -- sections submit one after another, as the per-section form does
             await (
               originalOnSubmit as F0FormDefinitionPerSection<F0PerSectionSchema>["onSubmit"]
             )({

--- a/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
+++ b/packages/react/src/patterns/F0Form/testing/createF0FormTester.ts
@@ -169,7 +169,7 @@ export function createF0FormTester<TSchema extends F0FormSchema>(
   const validate = async (
     values?: Record<string, unknown>
   ): Promise<F0FormValidationResult> => {
-    const merged = { ...(defaultValues ?? {}), ...(values ?? {}) }
+    const merged = { ...defaultValues, ...values }
 
     // Build dynamic schema from raw merged values BEFORE null conversion,
     // matching the order used in createConditionalResolver.
@@ -215,7 +215,7 @@ export function createF0FormTester<TSchema extends F0FormSchema>(
     defaultValues
 
   const getVisibleFields = (values?: Record<string, unknown>): string[] => {
-    const merged = { ...(defaultValues ?? {}), ...(values ?? {}) }
+    const merged = { ...defaultValues, ...values }
     const objectSchema = unwrapToZodObject(schema)
     const visible: string[] = []
 
@@ -248,7 +248,7 @@ export function createF0FormTester<TSchema extends F0FormSchema>(
       return { success: false, errors: validation.errors }
     }
 
-    const merged = { ...(defaultValues ?? {}), ...(values ?? {}) }
+    const merged = { ...defaultValues, ...values }
     return onSubmit(merged as z.infer<TSchema>)
   }
 

--- a/packages/react/src/patterns/F0Graph/hooks/useExpandState.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useExpandState.ts
@@ -204,6 +204,7 @@ export function useExpandState<T>({
       // frontier from the result without waiting on React commits. Errors
       // are swallowed per-node so one failing branch does not abort the
       // cascade.
+      // oxlint-disable-next-line no-await-in-loop -- each level expands in parallel; the next frontier comes from its children
       const results = await Promise.all(
         frontier.map((id) =>
           lazyTreeRef.current

--- a/packages/react/src/patterns/F0Graph/hooks/useTreeBuilder.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/useTreeBuilder.ts
@@ -138,6 +138,8 @@ function buildTree<T>(nodes: GraphNode<T>[]): TreeBuilderResult<T> {
     inStack.delete(node.id)
   }
 
+  // detectCycles promotes cyclic children to roots while this runs, so iterate a copy.
+  // oxlint-disable-next-line unicorn/no-useless-spread
   for (const root of [...roots]) {
     detectCycles(root)
   }

--- a/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
+++ b/packages/react/src/patterns/F0Map/__tests__/F0Map.test.tsx
@@ -55,7 +55,7 @@ const mock = vi.hoisted(() => {
     once(type: string, cb: (e?: unknown) => void) {
       // Fire `load` on a microtask so the component's handler is registered.
       if (type === "load") {
-        void Promise.resolve().then(() => cb())
+        queueMicrotask(() => cb())
       }
       return this
     }

--- a/packages/react/src/patterns/F0Map/hooks/useClusters.ts
+++ b/packages/react/src/patterns/F0Map/hooks/useClusters.ts
@@ -77,7 +77,7 @@ export const useClusters = (
 
       // "Core" points nearly touch a neighbour (tight `radius`) — only these
       // seed a cluster, so isolated markers stay individual.
-      const core = new Array(n).fill(false)
+      const core = Array.from({ length: n }, () => false)
       for (let i = 0; i < n; i++) {
         for (let j = i + 1; j < n; j++) {
           if (dist2(i, j) <= markerR2) {

--- a/packages/react/src/patterns/F0Map/styles/buildStyles.mjs
+++ b/packages/react/src/patterns/F0Map/styles/buildStyles.mjs
@@ -425,7 +425,7 @@ const recolor = (style, theme) => {
   const f = saturatedFlavor(theme)
   const out = JSON.parse(JSON.stringify(style))
   out.name = `f0-${theme}`
-  out.metadata = { ...(out.metadata || {}), "f0:generated": true }
+  out.metadata = { ...out.metadata, "f0:generated": true }
 
   for (const layer of out.layers || []) {
     const lid = layer.id.toLowerCase()
@@ -435,7 +435,7 @@ const recolor = (style, theme) => {
     // (the boxed route numbers like "B-25"), and all basemap POI icons/labels
     // (metro, shops, etc.) - our own markers are the only points of interest.
     if (/ferry|shipping|shield|poi_/.test(lid)) {
-      layer.layout = { ...(layer.layout || {}), visibility: "none" }
+      layer.layout = { ...layer.layout, visibility: "none" }
       continue
     }
     // Base land: green when zoomed out (the world / regional view), fading to
@@ -448,7 +448,7 @@ const recolor = (style, theme) => {
     // park polygons still paint on top at those zooms.
     if (layer.type === "background") {
       layer.paint = {
-        ...(layer.paint || {}),
+        ...layer.paint,
         "background-color": [
           "interpolate",
           ["linear"],

--- a/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
+++ b/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
@@ -307,6 +307,7 @@ function F0WizardFormPerSection<T extends F0PerSectionSchema>({
       for (const sectionId of ids) {
         const sectionForm = sectionForms[sectionId]
         if (sectionForm) {
+          // oxlint-disable-next-line no-await-in-loop -- sections submit in order and a rejection stops the step
           await sectionForm.submit()
         }
       }

--- a/packages/react/src/patterns/Navigation/Sidebar/index.stories.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/index.stories.tsx
@@ -59,11 +59,7 @@ const meta: Meta<typeof Sidebar> = {
   },
   args: {
     header: <Header defaultSelected="1" />,
-    body: (
-      <>
-        <Menu {...SidebarMenuStories.Default.args} />
-      </>
-    ),
+    body: <Menu {...SidebarMenuStories.Default.args} />,
     footer: <SidebarFooter {...SidebarFooterStories.Default.args} />,
   } satisfies ComponentProps<typeof Sidebar>,
 }
@@ -75,11 +71,7 @@ type Story = StoryObj<typeof Sidebar>
 export const Default: Story = {
   args: {
     header: <Header defaultSelected="1" />,
-    body: (
-      <>
-        <Menu {...SidebarMenuStories.Default.args} />
-      </>
-    ),
+    body: <Menu {...SidebarMenuStories.Default.args} />,
     footer: <SidebarFooter {...SidebarFooterStories.Default.args} />,
   },
   decorators: [

--- a/packages/react/src/patterns/OneDataCollection/__tests__/useExportAction.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/useExportAction.test.tsx
@@ -358,7 +358,9 @@ describe("useExportAction", () => {
       const pageSize = 100
 
       const fetchData = vi.fn().mockImplementation(({ pagination }) => {
-        const cursorIndex = pagination.cursor ? parseInt(pagination.cursor) : 0
+        const cursorIndex = pagination.cursor
+          ? parseInt(pagination.cursor, 10)
+          : 0
         const pageRecords = allRecords.slice(
           cursorIndex,
           cursorIndex + pageSize

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/getFeatures.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/getFeatures.ts
@@ -4,7 +4,7 @@ import {
   DataCollectionStorageFeaturesDefinition,
 } from "./types"
 
-const ALL_FEATURES_TOKENS = ["*", "all"]
+const ALL_FEATURES_TOKENS = new Set(["*", "all"])
 
 /**
  * Calculate the features to use for the data collection storage
@@ -18,14 +18,14 @@ export const getFeatures = (
   if (!features) {
     return []
   }
-  if (features.some((feature) => ALL_FEATURES_TOKENS.includes(feature))) {
+  if (features.some((feature) => ALL_FEATURES_TOKENS.has(feature))) {
     dataCollectionStorageFeatures.forEach((feature) => {
       res.add(feature)
     })
   }
 
   features
-    .filter((feature) => !ALL_FEATURES_TOKENS.includes(feature))
+    .filter((feature) => !ALL_FEATURES_TOKENS.has(feature))
     .forEach((feature) => {
       if (feature.startsWith("!")) {
         res.delete(feature.slice(1) as DataCollectionStorageFeature)

--- a/packages/react/src/patterns/OneDataCollection/hooks/useExportAction.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useExportAction.ts
@@ -184,6 +184,7 @@ async function fetchAllRecords<
     let currentPage = 1
 
     while (allRecords.length < MAX_EXPORT_ROWS) {
+      // oxlint-disable-next-line no-await-in-loop -- the previous response says whether there is another page
       const result = await resolveResult(
         fetchFn({
           ...baseParams,
@@ -212,6 +213,7 @@ async function fetchAllRecords<
     let cursor: string | null = null
 
     while (allRecords.length < MAX_EXPORT_ROWS) {
+      // oxlint-disable-next-line no-await-in-loop -- the previous response says whether there is another page
       const result = await resolveResult(
         fetchFn({
           ...baseParams,

--- a/packages/react/src/patterns/OneDataCollection/hooks/useSelectableLanes/utils.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useSelectableLanes/utils.ts
@@ -14,23 +14,18 @@ export const mergeLanesSelectItemsStatus = <
   selectItemsStatus: Map<string, SelectedItemsDetailedStatus<R, Filters>>
 ): SelectedItemsDetailedStatus<R, Filters> => {
   const lanesStatus = Array.from(selectItemsStatus.values())
+  const groupsStatus: SelectedItemsDetailedStatus<R, Filters>["groupsStatus"] =
+    {}
+  const filters = {} as SelectedItemsDetailedStatus<R, Filters>["filters"]
+  for (const status of lanesStatus) {
+    Object.assign(groupsStatus, status.groupsStatus)
+    Object.assign(filters, status.filters)
+  }
   return {
     allSelected: lanesStatus.every((status) => status.allSelected),
     itemsStatus: lanesStatus.flatMap((status) => status.itemsStatus),
-    groupsStatus: lanesStatus.reduce(
-      (acc, status) => ({
-        ...acc,
-        ...status.groupsStatus,
-      }),
-      {}
-    ),
-    filters: lanesStatus.reduce(
-      (acc, status) => ({
-        ...acc,
-        ...status.filters,
-      }),
-      {}
-    ),
+    groupsStatus,
+    filters,
     selectedCount: lanesStatus.reduce(
       (acc, status) => acc + status.selectedCount,
       0

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
@@ -529,6 +529,7 @@ export function useDataCollectionTreeData<
           break
         }
 
+        // oxlint-disable-next-line no-await-in-loop -- each level loads in parallel; the next level comes from its results
         const results = await Promise.all(
           loadable.map((node) =>
             loadChildrenOf(node.id).then((children) => ({ children }))
@@ -766,6 +767,7 @@ export function useDataCollectionTreeData<
           break
         }
 
+        // oxlint-disable-next-line no-await-in-loop -- each level loads in parallel; the next level comes from its results
         const childArrays = await Promise.all(
           loadable.map((node) => loadChildrenOf(node.id))
         )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -407,9 +407,8 @@ export const TableCollection = <
           field: columnSorting,
           order: "desc",
         }
-      } else {
-        return null
       }
+      return null
     })
   }
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -378,48 +378,47 @@ const NestedRowContent = <
               }
 
               return nestedChild
-            } else {
-              // Base case: Leaf node with no children
-              // For leaf nodes, border is shown only if it's the last visible element in the tree
-              const leafShouldHideBorder =
-                !childIsLastInTree && isTableVisualization
-
-              const leafChild = (
-                <Row
-                  {...props}
-                  key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
-                  index={childIndex}
-                  item={childItem}
-                  isSelected={isChildSelected(childItem)}
-                  noBorder={leafShouldHideBorder}
-                  ref={getChildRef()}
-                  nestedRowProps={{
-                    ...props.nestedRowProps,
-                    depth: (props.nestedRowProps?.depth ?? 0) + 1,
-                    parentHasChildren: true,
-                    nestedVariant: childrenType,
-                    onExpand: handleExpand,
-                    isLastChild: childIsLastInTree,
-                  }}
-                  fromVisualization={props.fromVisualization}
-                  tableWithChildren={props.tableWithChildren}
-                />
-              )
-
-              if (RowWrapper) {
-                return (
-                  <RowWrapper
-                    key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
-                    item={childItem}
-                    index={childIndex}
-                  >
-                    {leafChild}
-                  </RowWrapper>
-                )
-              }
-
-              return leafChild
             }
+            // Base case: Leaf node with no children
+            // For leaf nodes, border is shown only if it's the last visible element in the tree
+            const leafShouldHideBorder =
+              !childIsLastInTree && isTableVisualization
+
+            const leafChild = (
+              <Row
+                {...props}
+                key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
+                index={childIndex}
+                item={childItem}
+                isSelected={isChildSelected(childItem)}
+                noBorder={leafShouldHideBorder}
+                ref={getChildRef()}
+                nestedRowProps={{
+                  ...props.nestedRowProps,
+                  depth: (props.nestedRowProps?.depth ?? 0) + 1,
+                  parentHasChildren: true,
+                  nestedVariant: childrenType,
+                  onExpand: handleExpand,
+                  isLastChild: childIsLastInTree,
+                }}
+                fromVisualization={props.fromVisualization}
+                tableWithChildren={props.tableWithChildren}
+              />
+            )
+
+            if (RowWrapper) {
+              return (
+                <RowWrapper
+                  key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
+                  item={childItem}
+                  index={childIndex}
+                >
+                  {leafChild}
+                </RowWrapper>
+              )
+            }
+
+            return leafChild
           })
         : null}
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
@@ -154,15 +154,15 @@ export const useColumns = <
     : frozenColumns || 1
   const columnsInSavedOrder = useMemo(() => {
     const leadingColumns = originalColumns.slice(0, nonEditableColumns)
-    const orderedColumns = [...originalColumns.slice(nonEditableColumns)].sort(
-      (a, b) => {
+    const orderedColumns = originalColumns
+      .slice(nonEditableColumns)
+      .sort((a, b) => {
         const aIndex = colsOrder.indexOf(getColumnId(a))
         const bIndex = colsOrder.indexOf(getColumnId(b))
         const aPos = aIndex === -1 ? colsOrder.length : aIndex
         const bPos = bIndex === -1 ? colsOrder.length : bIndex
         return aPos - bPos
-      }
-    )
+      })
 
     return [...leadingColumns, ...orderedColumns]
   }, [originalColumns, nonEditableColumns, colsOrder])

--- a/packages/react/src/patterns/OneFilterPicker/__stories__/mockData.ts
+++ b/packages/react/src/patterns/OneFilterPicker/__stories__/mockData.ts
@@ -274,7 +274,7 @@ const DataSourceFilterOptions: InFilterOptions<
         // Apply pagination
         const perPage = options.pagination?.perPage || 20
         const cursor = options.pagination?.cursor
-          ? parseInt(options.pagination.cursor)
+          ? parseInt(options.pagination.cursor, 10)
           : 0
         const startIndex = cursor
         const endIndex = startIndex + perPage

--- a/packages/react/src/patterns/OneFilterPicker/components/FilterChipButton.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FilterChipButton.tsx
@@ -87,14 +87,12 @@ export function FilterChipButton<Definition extends FiltersDefinition>({
       {isLoading ? (
         <Skeleton className="h-5 w-[100px]" />
       ) : (
-        <>
-          <Chip
-            variant="selected"
-            {...chipLabel}
-            onClose={onRemove}
-            onClick={onSelect}
-          />
-        </>
+        <Chip
+          variant="selected"
+          {...chipLabel}
+          onClose={onRemove}
+          onClick={onSelect}
+        />
       )}
     </motion.div>
   )

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
@@ -352,7 +352,7 @@ const dataSourceFilterOptions: InFilterOptions<string, MockUser> = {
     dataAdapter: {
       fetchData: async ({ pagination, search }) => {
         const { cursor, perPage = 10 } = pagination
-        const startIndex = cursor ? parseInt(cursor) : 0
+        const startIndex = cursor ? parseInt(cursor, 10) : 0
         const endIndex = startIndex + perPage
 
         const users = search

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter.tsx
@@ -128,7 +128,7 @@ export function NumberFilter({
         return {
           ...prev,
           [index]: {
-            ...(prev?.[index] ?? {}),
+            ...prev?.[index],
             value: inputValue ?? undefined,
           },
         }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/index.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/index.tsx
@@ -61,11 +61,10 @@ export const numberFilter: FilterTypeDefinition<
           return i18n.t("filters.number.lessThanOrEqualShort", {
             value: value?.to?.value,
           })
-        } else {
-          return i18n.t("filters.number.lessThanShort", {
-            value: value?.to?.value,
-          })
         }
+        return i18n.t("filters.number.lessThanShort", {
+          value: value?.to?.value,
+        })
       }
 
       if (value?.from?.value !== undefined) {
@@ -73,11 +72,10 @@ export const numberFilter: FilterTypeDefinition<
           return i18n.t("filters.number.greaterThanOrEqualShort", {
             value: value?.from?.value,
           })
-        } else {
-          return i18n.t("filters.number.greaterThanShort", {
-            value: value?.from?.value,
-          })
         }
+        return i18n.t("filters.number.greaterThanShort", {
+          value: value?.from?.value,
+        })
       }
     }
 

--- a/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.ts
+++ b/packages/react/src/sds/Home/ClockIn/ClockInGraph/helpers.ts
@@ -84,20 +84,16 @@ export const normalizeData = ({
         const context = { from: entry.from, to: entry.to, label: entry.label }
 
         if (entry.variant === "clocked-in" && overtimeOnly) {
-          return [
-            ...acc,
-            {
-              value:
-                totalEntryOvertimeSeconds / totalSecondsWithRemainingTime +
-                value,
-              color: CLOCK_IN_COLORS.overtime,
-              ...context,
-            },
-          ]
+          acc.push({
+            value:
+              totalEntryOvertimeSeconds / totalSecondsWithRemainingTime + value,
+            color: CLOCK_IN_COLORS.overtime,
+            ...context,
+          })
+          return acc
         }
 
-        return [
-          ...acc,
+        acc.push(
           {
             value: totalEntryOvertimeSeconds / totalSecondsWithRemainingTime,
             color: CLOCK_IN_COLORS.overtime,
@@ -107,8 +103,9 @@ export const normalizeData = ({
             value,
             color: CLOCK_IN_COLORS[entry.variant],
             ...context,
-          },
-        ]
+          }
+        )
+        return acc
       }, [])
       .reverse(),
     ...(leftEntry ? [leftEntry] : []),

--- a/packages/react/src/sds/Home/F0AvatarPulse/F0AvatarPulse.tsx
+++ b/packages/react/src/sds/Home/F0AvatarPulse/F0AvatarPulse.tsx
@@ -48,7 +48,7 @@ export const F0AvatarPulse = ({
 
   return (
     <div className="relative h-10 w-10">
-      <AnimatePresence mode="popLayout" initial={showWave ? true : false}>
+      <AnimatePresence mode="popLayout" initial={showWave}>
         {showWave ? (
           <motion.div
             className="relative h-10 w-10 rounded-full bg-f1-background-warning"

--- a/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.spec.tsx
@@ -1260,7 +1260,7 @@ describe("widgetChrome", () => {
       id: "communities",
       slots: [],
       action: { label: "Go to Communities" },
-      headerControls: <span>host's own</span>,
+      headerControls: <span>host&apos;s own</span>,
       headerActions: [{ label: "Write post" }],
       headerSelect: select,
       status: undefined,

--- a/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
+++ b/packages/react/src/sds/Home/WidgetContainer/dragGhost.ts
@@ -88,7 +88,7 @@ export const takePageSurface = (
   }
 }
 
-const TRANSPARENT = ["rgba(0, 0, 0, 0)", "transparent", ""]
+const TRANSPARENT = new Set(["rgba(0, 0, 0, 0)", "transparent", ""])
 
 const opaqueBackgroundOf = (from: Element): string | null => {
   if (typeof getComputedStyle !== "function") {
@@ -96,7 +96,7 @@ const opaqueBackgroundOf = (from: Element): string | null => {
   }
   for (let el: Element | null = from; el; el = el.parentElement) {
     const colour = getComputedStyle(el).backgroundColor
-    if (!TRANSPARENT.includes(colour)) {
+    if (!TRANSPARENT.has(colour)) {
       return colour
     }
   }

--- a/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/ProductCard/index.tsx
@@ -91,29 +91,22 @@ function _ProductCard({
               style={getCardStyles()}
               onClick={onClick}
             >
-              <>
-                {type === "one-campaign" ? (
-                  <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
-                    <F0Icon icon={One} size="lg" className="!h-8 !w-8" />
-                  </div>
-                ) : (
-                  <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
-                    <F0AvatarModule
-                      module={props.module as ModuleId}
-                      size="md"
-                    />
-                  </div>
-                )}
-
-                <div className="flex flex-1 flex-col">
-                  <div>
-                    <h3 className="text-lg font-medium">{title}</h3>
-                    <p className="text-f1-foreground-secondary">
-                      {description}
-                    </p>
-                  </div>
+              {type === "one-campaign" ? (
+                <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+                  <F0Icon icon={One} size="lg" className="!h-8 !w-8" />
                 </div>
-              </>
+              ) : (
+                <div className="relative flex h-8 w-8 shrink-0 items-center justify-center">
+                  <F0AvatarModule module={props.module as ModuleId} size="md" />
+                </div>
+              )}
+
+              <div className="flex flex-1 flex-col">
+                <div>
+                  <h3 className="text-lg font-medium">{title}</h3>
+                  <p className="text-f1-foreground-secondary">{description}</p>
+                </div>
+              </div>
 
               {dismissable ? (
                 <div className="h-6 w-6">

--- a/packages/react/src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx
+++ b/packages/react/src/sds/UpsellingKit/ai/F0QuestionCard/F0QuestionCard.tsx
@@ -50,7 +50,7 @@ export const F0QuestionCardMultiStep = ({
         // Build message from all selections
         const allSelectedLabels = Object.entries(selections)
           .map(([stepIndex, ids]) => {
-            const step = steps[parseInt(stepIndex)]
+            const step = steps[parseInt(stepIndex, 10)]
             return step.options
               .filter((o) => ids.includes(o.id))
               .map((o) => o.label)

--- a/packages/react/src/sds/chat/F0Chat/components/ChatDocxThumbnail.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatDocxThumbnail.tsx
@@ -45,26 +45,25 @@ const ChatDocxThumbnail = ({
         }
         return response.blob()
       })
-      .then((blob) => {
+      .then(async (blob) => {
         if (cancelled) {
           return
         }
         // No wrapper chrome for the snapshot — just the page content; the
         // card provides the white background and the crop.
-        return renderAsync(blob, host, undefined, {
+        await renderAsync(blob, host, undefined, {
           inWrapper: false,
           breakPages: false,
           ignoreLastRenderedPageBreak: true,
           renderHeaders: false,
           renderFooters: false,
-        }).then(() => {
-          if (cancelled) {
-            return
-          }
-          const naturalWidth = host.scrollWidth
-          setScale(naturalWidth > 0 ? Math.min(1, width / naturalWidth) : 1)
-          onRenderedRef.current()
         })
+        if (cancelled) {
+          return
+        }
+        const naturalWidth = host.scrollWidth
+        setScale(naturalWidth > 0 ? Math.min(1, width / naturalWidth) : 1)
+        onRenderedRef.current()
       })
       .catch(() => {
         if (!cancelled) {

--- a/packages/react/src/sds/inbox/Activity/ActivityItemList/index.stories.tsx
+++ b/packages/react/src/sds/inbox/Activity/ActivityItemList/index.stories.tsx
@@ -38,7 +38,7 @@ export default meta
 
 type Story = StoryObj<typeof ActivityItemList>
 
-const ITEMS = new Array(10).fill(null).map((_, index) => ({
+const ITEMS = Array.from({ length: 10 }, (_, index) => ({
   id: index.toString(),
   title: `Activity Item ${index + 1}`,
   description:

--- a/packages/react/src/sds/inbox/Activity/ActivityItemList/index.tsx
+++ b/packages/react/src/sds/inbox/Activity/ActivityItemList/index.tsx
@@ -49,13 +49,15 @@ export const BaseActivityItemList = ({
 
   const categorizedItems = categorizeItemsByDate(items, "createdAt")
 
-  const lastItemIds = Object.values(categorizedItems)
-    .slice()
-    .flatMap((items) => items.map((item) => item.id))
-    .slice(-onEndReachedItemsThreshold)
+  const lastItemIds = new Set(
+    Object.values(categorizedItems)
+      .slice()
+      .flatMap((items) => items.map((item) => item.id))
+      .slice(-onEndReachedItemsThreshold)
+  )
 
   const handleItemVisible = throttle((id: string) => {
-    if (lastItemIds.includes(id)) {
+    if (lastItemIds.has(id)) {
       onEndReached?.()
     }
   }, 1000)
@@ -84,9 +86,9 @@ export const BaseActivityItemList = ({
         </React.Fragment>
       ))}
       {loadingMoreItems
-        ? new Array(MORE_ITEMS_LOADING_COUNT)
-            .fill(null)
-            .map((_, index) => <ActivityItem.Skeleton key={index} />)
+        ? Array.from({ length: MORE_ITEMS_LOADING_COUNT }, (_, index) => (
+            <ActivityItem.Skeleton key={index} />
+          ))
         : null}
     </div>
   )

--- a/packages/react/src/ui/ButtonGroup/__stories__/ButtonGroup.behaviors.stories.tsx
+++ b/packages/react/src/ui/ButtonGroup/__stories__/ButtonGroup.behaviors.stories.tsx
@@ -382,7 +382,7 @@ export const OverflowMenu: Story = {
       {[560, 360, 240].map((w) => (
         <div key={w} className="flex flex-col gap-2">
           <span className="text-sm text-f1-foreground-secondary">
-            {w}px — buttons that don't fit collapse under the ellipsis
+            {w}px — buttons that don&apos;t fit collapse under the ellipsis
           </span>
           <div
             style={{ width: w }}

--- a/packages/react/src/ui/F0Wizard/hooks/useWizardNavigation.ts
+++ b/packages/react/src/ui/F0Wizard/hooks/useWizardNavigation.ts
@@ -78,6 +78,7 @@ export function useWizardNavigation({
           for (let i = currentStep; i < index; i++) {
             const step = stepsRef.current[i]
             if (step?.onNext) {
+              // oxlint-disable-next-line no-await-in-loop -- steps run onNext in order and a rejection stops the jump
               await step.onNext()
             }
           }

--- a/packages/react/src/ui/Select/__stories__/select.stories.tsx
+++ b/packages/react/src/ui/Select/__stories__/select.stories.tsx
@@ -44,25 +44,24 @@ const SelectWithHooks = ({
           {props.children}
         </Select>
       )
-    } else {
-      const [value, setValue] = useState<string | undefined>(
-        props.value as string | undefined
-      )
-      const handleChange = (value: string) => {
-        console.log("value", value)
-        setValue(value)
-        props.onValueChange(value)
-      }
-
-      return (
-        <Select
-          {...rest}
-          value={value}
-          onValueChange={handleChange}
-          multiple={false}
-        />
-      )
     }
+    const [value, setValue] = useState<string | undefined>(
+      props.value as string | undefined
+    )
+    const handleChange = (value: string) => {
+      console.log("value", value)
+      setValue(value)
+      props.onValueChange(value)
+    }
+
+    return (
+      <Select
+        {...rest}
+        value={value}
+        onValueChange={handleChange}
+        multiple={false}
+      />
+    )
   }
 
   const items = useMemo(

--- a/packages/react/src/ui/Select/components/radix-ui/select.tsx
+++ b/packages/react/src/ui/Select/components/radix-ui/select.tsx
@@ -26,8 +26,8 @@ import { RemoveScroll } from "react-remove-scroll"
 
 type Direction = "ltr" | "rtl"
 
-const OPEN_KEYS = [" ", "Enter", "ArrowUp", "ArrowDown"]
-const SELECTION_KEYS = [" ", "Enter"]
+const OPEN_KEYS = new Set([" ", "Enter", "ArrowUp", "ArrowDown"])
+const SELECTION_KEYS = new Set([" ", "Enter"])
 const SELECTED_ITEM_FALLBACK_DELAY = 50
 
 /* -------------------------------------------------------------------------------------------------
@@ -374,7 +374,7 @@ const SelectTrigger = React.forwardRef<
           if (isTypingAhead && event.key === " ") {
             return
           }
-          if (OPEN_KEYS.includes(event.key)) {
+          if (OPEN_KEYS.has(event.key)) {
             handleOpen()
             event.preventDefault()
           }
@@ -762,9 +762,11 @@ const SelectContentImpl = React.forwardRef<
     if (isPositioned && !hasFocusedOnOpenRef.current) {
       let cancelled = false
       let fallbackTimeout: ReturnType<typeof setTimeout> | undefined
-      const selectedValues = (
-        Array.isArray(context.value) ? context.value : [context.value]
-      ).filter((value): value is string => value !== undefined)
+      const selectedValues = new Set(
+        (Array.isArray(context.value) ? context.value : [context.value]).filter(
+          (value): value is string => value !== undefined
+        )
+      )
       const isPlaceholderValue =
         context.value === undefined || context.value === ""
       const selectedItemMatchesCurrentValue =
@@ -774,7 +776,7 @@ const SelectContentImpl = React.forwardRef<
             getItems().some(
               (item) =>
                 item.ref.current === selectedItem &&
-                selectedValues.includes(item.value)
+                selectedValues.has(item.value)
             )))
 
       const timeout = setTimeout(() => {
@@ -1419,7 +1421,9 @@ const SelectPopperPosition = React.forwardRef<
         // Ensure border-box for floating-ui calculations
         boxSizing: "border-box",
         ...popperProps.style,
-        // re-namespace exposed content custom properties
+        // re-namespace exposed content custom properties. The spread lets the
+        // custom properties past the CSSProperties type.
+        // oxlint-disable-next-line unicorn/no-useless-spread
         ...{
           "--radix-select-content-transform-origin":
             "var(--radix-popper-transform-origin)",
@@ -1750,7 +1754,7 @@ const SelectItem = React.forwardRef<SelectItemElement, SelectItemProps>(
               if (isTypingAhead && event.key === " ") {
                 return
               }
-              if (SELECTION_KEYS.includes(event.key)) {
+              if (SELECTION_KEYS.has(event.key)) {
                 handleSelect()
               }
               // prevent page scroll if using the space key to select an item
@@ -2208,7 +2212,7 @@ SelectBubbleInput.displayName = BUBBLE_INPUT_NAME
 
 function shouldShowPlaceholder(value?: string[] | string) {
   if (Array.isArray(value)) {
-    return value.length === 0 || value.every((v) => v === "")
+    return value.every((v) => v === "")
   }
   return value === "" || value === undefined
 }

--- a/packages/react/src/ui/value-display/types/delta/delta.tsx
+++ b/packages/react/src/ui/value-display/types/delta/delta.tsx
@@ -26,7 +26,7 @@ export const DeltaCell = (args: DeltaCellValue) => {
     <div className="flex items-center gap-1 pt-0.5">
       <F0Icon
         icon={icon}
-        color={status == "positive" ? "positive" : "critical"}
+        color={status === "positive" ? "positive" : "critical"}
       />
       <span className="text-f1-foreground font-normal">{args.label}</span>
     </div>


### PR DESCRIPTION
Turns on rules that oxlint ships itself but that were not running: the `unicorn`, `oxc` and `promise` plugins, plus a hand-picked set from outside the `correctness` category. Same rules in `packages/react` and `packages/react-native`.

## Why

The explicit `plugins` list in `.oxlintrc.json` had dropped two of oxlint's default plugins (`unicorn`, `oxc`), so their `correctness` rules never ran. The rest are cheap checks with a clear payoff: real bugs (`eqeqeq`, `radix`, `no-accumulating-spread`, `always-return`) or noise removal (`no-else-return`, `no-useless-fragment`).

## Rules

| Rule | Fixed | Why |
| --- | --- | --- |
| plugins `unicorn`, `oxc`, `promise` | 39 | Their `correctness` rules: `no-new-array`, `no-useless-fallback-in-spread`, `no-useless-spread`, `no-empty-file`, `only-used-in-recursion`, `no-callback-in-promise`. |
| `eqeqeq` (`null: ignore`) | 7 | `==` coerces types. `x == null` stays allowed: it is the idiomatic nullish check and TypeScript understands it. |
| `no-else-return` | 20 | An `else` after a `return` is one indentation level for nothing. |
| `radix` | 14 | `parseInt` without a radix guesses the base from the string. |
| `no-await-in-loop` | 13 | Awaiting inside a loop serialises work that could run in parallel. Every current site is deliberately sequential and says why in a disable comment. Off in stories and tests, which step through flows one await at a time. |
| `react/jsx-no-useless-fragment` (`allowExpressions`) | 26 | A fragment around one element is noise. `<>{children}</>` stays allowed, it is how a `ReactNode` becomes an element. |
| `react/no-unescaped-entities` | 12 | A stray `'` or `"` in JSX text is usually a typo in an expression. |
| `oxc/no-accumulating-spread` | 4 | `reduce` with `{ ...acc }` copies the accumulator on every step: quadratic. |
| `unicorn/prefer-set-has` | 11 | `array.includes` in a hot path is a linear scan. |
| `promise/always-return` (`ignoreLastCallback`) | 5 | A `.then` in the middle of a chain that returns nothing loses the value the next step needs. |
| `no-unneeded-ternary`, `no-useless-constructor`, `import/no-empty-named-blocks` | 2, 1, 1 | Small cleanups. |
| `react/iframe-missing-sandbox` | 1 | `sandbox` limits what an embedded page can do. The one existing iframe (video embed) keeps a disable comment: YouTube and Vimeo players need `allow-scripts` with `allow-same-origin`, a pair the rule rejects. |

Off on purpose, with the reason in the config:

- `oxc/no-map-spread`: the fix it wants is `Object.assign` onto the mapped item, which mutates the input. Props and state are immutable here. Its autofix also produced broken code.
- `typescript/ban-types`: deprecated upstream; it bans `(string & {})`, the idiom that keeps autocomplete on open string unions. `no-unsafe-function-type` covers the useful part.

Added to the DEBT block: `react/no-array-index-key` (117 in react, 3 in react-native).

## Behavior changes

- `useDashboardExport` fetches its metrics in parallel instead of one after another. Each metric keeps its own error handling and rows keep their order.
- Two empty files deleted, nothing imported them: `hooks/datasource/types/data.typings.ts` and `patterns/OneDataCollection/components/itemActions/index.ts`.
- `F0TableOfContent`: an internal render helper and `isDescendant` lose a parameter that was only passed to their own recursive call. No prop or export changes.

## Fixer notes

Two autofixes were reverted by hand: `import/no-empty-named-blocks` removed the `import type {} from "gridstack"` that makes `types.ts` a module augmentation, and `unicorn/no-useless-spread` flattened a spread that exists to get custom CSS properties past the `CSSProperties` type. Both sites now carry a disable comment with the reason.

Whole categories stay off: `style` has `no-magic-numbers` at 17887 hits, `restriction` has `explicit-function-return-type` at 5562.
