### PR TITLE
feat(F0Checkbox): stabilizing checkbox, adding description prop

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -15,7 +15,6 @@
     "Avatars/AvatarTeam",
     "BigNumber",
     "Charts/RadarChart",
-    "Checkbox",
     "DatePicker",
     "EmptyState",
     "Filters/FilterPicker",

--- a/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
+++ b/packages/react/src/components/F0Checkbox/F0Checkbox.tsx
@@ -9,6 +9,13 @@ interface CheckboxProps extends DataAttributes {
   title?: string
 
   /**
+   * A secondary line of text rendered under the title, for context the title
+   * cannot carry on its own. Hidden along with the title when `hideLabel` is
+   * set, and exposed to assistive technology as the checkbox's description.
+   */
+  description?: string
+
+  /**
    * The id of the checkbox
    */
   id?: string
@@ -73,6 +80,7 @@ interface CheckboxProps extends DataAttributes {
 
 function _F0Checkbox({
   title,
+  description,
   onCheckedChange,
   id,
   disabled,
@@ -89,6 +97,7 @@ function _F0Checkbox({
   return (
     <CheckboxRoot
       title={title}
+      description={description}
       onCheckedChange={onCheckedChange}
       id={id}
       disabled={disabled}

--- a/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.mdx
+++ b/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.mdx
@@ -22,13 +22,26 @@ indeterminate.
 
 ## Anatomy
 
-A checkbox is composed of the selection control itself plus a `title` label.
-Always provide a meaningful `title` so the control is clearly labelled, both
-visually and for assistive technology. The component is controlled — provide
-`checked` and update it from the `onCheckedChange` callback.
+A checkbox is composed of the selection control itself plus a `title` label, and
+optionally a `description` under it. Always provide a meaningful `title` so the
+control is clearly labelled, both visually and for assistive technology. The
+component is controlled — provide `checked` and update it from the
+`onCheckedChange` callback.
 
 <Canvas of={CheckboxStories.Default} />
 <Controls of={CheckboxStories.Default} />
+
+### Description
+
+Use `description` for context the title cannot carry on its own: what the option
+actually does, or what happens once it is ticked. Keep the `title` short enough
+to scan and let the description do the explaining, and do not restate the title.
+
+The description sits inside the label, so clicking it toggles the checkbox. It
+is exposed as the checkbox's accessible description rather than part of its
+name, so assistive technology announces the title first.
+
+<Canvas of={CheckboxStories.WithDescription} />
 
 ## States
 

--- a/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.mdx
+++ b/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.mdx
@@ -1,5 +1,7 @@
 import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
 import * as CheckboxStories from "./F0Checkbox.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import { F0Checkbox } from "../F0Checkbox"
 
 <Meta of={CheckboxStories} />
 
@@ -86,3 +88,32 @@ keyboard navigation.
   on or off takes effect immediately, rather than being captured as a form value
 - **Mutually exclusive options**: Use a radio button when only one option can be
   selected at a time
+
+### Do's and don'ts
+
+<DoDonts
+  do={{
+    description:
+      "Let the title name the option in the affirmative, and put the consequence in description.",
+    guidelines: [
+      "Sentence case, no trailing period, and no question mark",
+      "Use description for what happens once it is ticked, not a restatement of the title",
+    ],
+    children: (
+      <F0Checkbox
+        title="Share usage data"
+        description="Helps us decide which reports are worth keeping."
+        checked
+      />
+    ),
+  }}
+  dont={{
+    description:
+      "Don't phrase the title as a question, and don't negate it: a negative title makes the ticked state a double negative.",
+    guidelines: [
+      'A question leaves ticked and unticked equally plausible as "yes"',
+      'Turn "Don\'t send reminders" into "Send reminders" and let the box carry the negation',
+    ],
+    children: <F0Checkbox title="Don't send reminders" checked={false} />,
+  }}
+/>

--- a/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
+++ b/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
@@ -22,6 +22,10 @@ const meta = {
       control: "text",
       description: "The title of the checkbox",
     },
+    description: {
+      control: "text",
+      description: "A secondary line of text rendered under the title",
+    },
     id: {
       control: "text",
       description: "The id of the checkbox",
@@ -92,6 +96,35 @@ export const WithDataTestId: Story = {
   },
 }
 
+export const WithDescription: Story = {
+  args: {
+    title: "Share usage data",
+    description: "Helps us understand which features are worth keeping.",
+  },
+  render: (args) => {
+    const [checked, setChecked] = useState(false)
+    return (
+      <F0Checkbox {...args} checked={checked} onCheckedChange={setChecked} />
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const checkbox = canvas.getByRole("checkbox")
+    const description = canvas.getByText(
+      "Helps us understand which features are worth keeping."
+    )
+
+    // The description is the checkbox's accessible description, not part of its
+    // name, so the title alone still names the control.
+    await expect(checkbox).toHaveAttribute("aria-label", "Share usage data")
+    await expect(checkbox).toHaveAttribute(
+      "aria-describedby",
+      description.getAttribute("id")
+    )
+  },
+}
+
 export const Disabled: Story = {
   args: {
     title: "Disabled checkbox",
@@ -140,6 +173,21 @@ export const Snapshot: Story = {
       <F0Checkbox title="Indeterminate" indeterminate />
       <F0Checkbox title="Disabled" disabled />
       <F0Checkbox title="Disabled checked" disabled checked={true} />
+      <F0Checkbox
+        title="With description"
+        description="A second line of context under the title."
+        checked={false}
+      />
+      <F0Checkbox
+        title="With description, checked"
+        description="A second line of context under the title."
+        checked={true}
+      />
+      <F0Checkbox
+        title="With description, disabled"
+        description="A second line of context under the title."
+        disabled
+      />
     </div>
   ),
 }

--- a/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
+++ b/packages/react/src/components/F0Checkbox/__stories__/F0Checkbox.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   tags: ["stable", "!autodocs"],
   title: "Checkbox",
   parameters: {
+    a11y: { test: "error" },
     layout: "centered",
     docs: {
       description: {

--- a/packages/react/src/components/F0Checkbox/__test__/F0Checkbox.test.tsx
+++ b/packages/react/src/components/F0Checkbox/__test__/F0Checkbox.test.tsx
@@ -9,7 +9,7 @@ describe("F0Checkbox", () => {
     render(<F0Checkbox id="custom-id" title="Custom checkbox" />)
 
     const checkbox = screen.getByRole("checkbox")
-    const label = screen.getByText("Custom checkbox")
+    const label = screen.getByText("Custom checkbox").closest("label")
 
     expect(checkbox).toHaveAttribute("id", "custom-id")
     expect(label).toHaveAttribute("for", "custom-id")
@@ -155,6 +155,75 @@ describe("F0Checkbox", () => {
     ).filter((className) => className.includes("hover:"))
 
     expect(hoverClasses).toEqual([])
+  })
+
+  describe("description", () => {
+    it("renders the description under the title", () => {
+      render(
+        <F0Checkbox title="Share usage data" description="Helps us improve." />
+      )
+
+      expect(screen.getByText("Share usage data")).toBeInTheDocument()
+      expect(screen.getByText("Helps us improve.")).toBeInTheDocument()
+    })
+
+    // The description must not leak into the accessible name — a screen reader
+    // should announce "Share usage data, checkbox" and only then the
+    // description, the same as a native `aria-describedby` pairing.
+    it("exposes the description through aria-describedby, not the name", () => {
+      render(
+        <F0Checkbox title="Share usage data" description="Helps us improve." />
+      )
+
+      const checkbox = screen.getByRole("checkbox")
+      const description = screen.getByText("Helps us improve.")
+
+      expect(checkbox).toHaveAttribute("aria-label", "Share usage data")
+      expect(checkbox).toHaveAttribute(
+        "aria-describedby",
+        description.getAttribute("id")
+      )
+    })
+
+    it("has no aria-describedby when there is no description", () => {
+      render(<F0Checkbox title="Share usage data" />)
+
+      expect(screen.getByRole("checkbox")).not.toHaveAttribute(
+        "aria-describedby"
+      )
+    })
+
+    it("hides the description along with the label when hideLabel is set", () => {
+      render(
+        <F0Checkbox
+          title="Share usage data"
+          description="Helps us improve."
+          hideLabel
+        />
+      )
+
+      expect(screen.queryByText("Helps us improve.")).not.toBeInTheDocument()
+      expect(screen.getByRole("checkbox")).not.toHaveAttribute(
+        "aria-describedby"
+      )
+    })
+
+    it("toggles when the description is clicked", async () => {
+      const user = userEvent.setup()
+      const onCheckedChange = vi.fn()
+
+      render(
+        <F0Checkbox
+          title="Share usage data"
+          description="Helps us improve."
+          onCheckedChange={onCheckedChange}
+        />
+      )
+
+      await user.click(screen.getByText("Helps us improve."))
+
+      expect(onCheckedChange).toHaveBeenCalledWith(true)
+    })
   })
 
   it("generates unique id when not provided", () => {

--- a/packages/react/src/ui/Text/Text.tsx
+++ b/packages/react/src/ui/Text/Text.tsx
@@ -71,6 +71,12 @@ export interface TextProps
    * @default false
    */
   required?: boolean
+
+  /**
+   * The id of the control this text labels. Only meaningful together with
+   * `as="label"`; `React.HTMLAttributes` does not carry it.
+   */
+  htmlFor?: string
 }
 
 /**

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -75,7 +75,7 @@ const Checkbox = React.forwardRef<
           <label
             htmlFor={checkboxId}
             className={cn(
-              "flex flex-col pl-1 hover:cursor-pointer",
+              "flex flex-col pl-2 hover:cursor-pointer",
               // With a description the row aligns to the top rather than the
               // centre, so the title has to line up with the *visible* 20px
               // square, which `after:top-0.5` paints 2px below the top of the

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -5,6 +5,7 @@ import { useId } from "react"
 import { F0Icon } from "../components/F0Icon"
 import { Check, Minus } from "../icons/app"
 import { cn, focusRing } from "../lib/utils"
+import { Text } from "./Text"
 
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
@@ -56,19 +57,18 @@ const Checkbox = React.forwardRef<
           </AnimatePresence>
         </CheckboxPrimitive.Root>
         {props.title && !hideLabel ? (
-          <label
+          <Text
+            as="label"
+            variant="label"
             htmlFor={checkboxId}
+            content={props.title}
+            required={required}
             className={cn(
-              "flex items-center justify-center pl-2.5 text-current hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-50",
+              "flex items-center justify-center gap-0.5 pl-2 hover:cursor-pointer",
               disabled &&
                 "cursor-not-allowed opacity-50 hover:cursor-not-allowed"
             )}
-          >
-            {props.title}
-            {required ? (
-              <span className="ml-0.5 text-f1-foreground-critical">*</span>
-            ) : null}
-          </label>
+          />
         ) : null}
       </div>
     )

--- a/packages/react/src/ui/checkbox.tsx
+++ b/packages/react/src/ui/checkbox.tsx
@@ -13,24 +13,39 @@ const Checkbox = React.forwardRef<
     indeterminate?: boolean
     hideLabel?: boolean
     required?: boolean
+    description?: string
   }
 >(
   (
-    { className, indeterminate, disabled, hideLabel, required, ...props },
+    {
+      className,
+      indeterminate,
+      disabled,
+      hideLabel,
+      required,
+      description,
+      ...props
+    },
     ref
   ) => {
     // Generate a unique ID if one isn't provided
     const uniqueId = useId()
     const checkboxId = props.id || uniqueId
+    const descriptionId = `${checkboxId}-description`
+    const showLabel = !hideLabel && !!(props.title || description)
 
     return (
-      <div className="flex items-center">
+      <div className={cn("flex", description ? "items-start" : "items-center")}>
         <CheckboxPrimitive.Root
           {...props}
           ref={ref}
           id={checkboxId}
           name={props.name || checkboxId}
           aria-label={props.title}
+          aria-describedby={
+            props["aria-describedby"] ??
+            (showLabel && description ? descriptionId : undefined)
+          }
           className={cn(
             "relative h-6 w-6 shrink-0 rounded-sm text-f1-foreground-selected data-[state=checked]:text-f1-foreground-inverse",
             "after:absolute after:left-0.5 after:top-0.5 after:z-[1] after:h-5 after:w-5 after:rounded-xs after:border after:border-solid after:border-f1-border after:transition-[background-color] after:content-[''] data-[state=checked]:after:bg-f1-background-selected-bold",
@@ -56,19 +71,38 @@ const Checkbox = React.forwardRef<
             </CheckboxPrimitive.Indicator>
           </AnimatePresence>
         </CheckboxPrimitive.Root>
-        {props.title && !hideLabel ? (
-          <Text
-            as="label"
-            variant="label"
+        {showLabel ? (
+          <label
             htmlFor={checkboxId}
-            content={props.title}
-            required={required}
             className={cn(
-              "flex items-center justify-center gap-0.5 pl-2 hover:cursor-pointer",
+              "flex flex-col pl-1 hover:cursor-pointer",
+              // With a description the row aligns to the top rather than the
+              // centre, so the title has to line up with the *visible* 20px
+              // square, which `after:top-0.5` paints 2px below the top of the
+              // 24px hit area. Keep this in sync with that inset.
+              description && "pt-0.5",
               disabled &&
                 "cursor-not-allowed opacity-50 hover:cursor-not-allowed"
             )}
-          />
+          >
+            {props.title ? (
+              <Text
+                as="span"
+                variant="label"
+                content={props.title}
+                required={required}
+                className="flex items-center gap-0.5"
+              />
+            ) : null}
+            {description ? (
+              <Text
+                as="span"
+                id={descriptionId}
+                variant="description"
+                content={description}
+              />
+            ) : null}
+          </label>
         ) : null}
       </div>
     )


### PR DESCRIPTION
Checkbox was tagged `stable` but sat below the stable bar: its label was hand-rolled markup that ignored the type scale, and it had no way to explain an option beyond its title. This brings the label onto `F0Text`, adds a `description` prop, and closes the last two Definition-of-Done requirements, so Checkbox now genuinely clears the bar it claimed.

## Before
<img width="709" height="94" alt="image" src="https://github.com/user-attachments/assets/d4838a05-7632-4bd5-b98c-3e39d32a5fd8" />

## After
<img width="675" height="91" alt="image" src="https://github.com/user-attachments/assets/96c902b1-68ef-4448-9229-b548fe0decd6" />
<img width="680" height="94" alt="image" src="https://github.com/user-attachments/assets/63e4387d-3b94-4880-8676-ac4a67aa27c5" />


## The label is an F0Text label

It was a bare `<label>` rendering its text at whatever weight and colour it inherited, so it read lighter than every other label in the system. It now goes through the same `Text` component that backs `F0Text variant="label"`.

| | before | after |
|---|---|---|
| weight | inherited (400) | `font-medium` (500) |
| size | inherited | `text-base` (14px) |
| colour | `text-current` | `text-f1-foreground` |
| left padding | `pl-2.5` (10px) | `pl-2` (8px) |

The required asterisk now comes from `Text`'s own `required` prop instead of a hand-rolled `<span>`, matching how form labels render it everywhere else.

## New: `description`

A second line under the title, styled as `F0Text variant="description"`.

```tsx
<F0Checkbox
  title="Share usage data"
  description="Helps us decide which reports are worth keeping."
  checked={checked}
  onCheckedChange={setChecked}
/>
```

Three things worth knowing about how it behaves:

- **It is inside the `<label>`**, so clicking the description toggles the checkbox.
- **It reaches assistive tech through `aria-describedby`, not the label text**, so it never leaks into the checkbox's accessible name. A screen reader still announces "Share usage data, checkbox" and only then the description. A consumer-supplied `aria-describedby` wins.
- **`hideLabel` hides it along with the title**, and drops the `aria-describedby` with it.

With a description the row aligns to the top instead of the centre, and the label takes a 2px top offset so the title lines up with the *visible* 20px square rather than the top of the 24px hit area (`after:top-0.5`). Measured in the browser: title box and visible square share the same top and centre to the pixel.

## Two decisions to sanity-check

**`Text` rather than the public `F0Text`.** `F0Text` omits `className`, and the label needs its own layout and disabled classes; `ui/checkbox.tsx` already reaches into `components/F0Icon`, so importing the sibling `ui/Text` is in keeping with the file. Same component and same variants either way, so the two cannot drift. One deliberate difference: `F0Text` defaults `markdown` to `true`, and going through `Text` leaves it off, so an existing checkbox whose title contains `*` or `_` keeps rendering as literal text instead of turning into emphasis.

**`TextProps` gains `htmlFor`.** `as="label"` was already an allowed tag on `Text` (and on the public `F0Text`), but `React.HTMLAttributes` does not carry `htmlFor`, so a `Text` could not actually label a control. Added as a documented optional prop; additive.

## Definition of Done

Two mechanically-checked stable requirements were unmet, and both are now closed:

- **Do's and don'ts** in the docs, one of the criteria for the "good" doc tier. The pair covers the mistake the component invites now that `description` exists: a title phrased as a question, or negated, so ticking the box reads as a double negative.
- **Blocking axe.** The stories move off the global `test: "todo"` default to `a11y: { test: "error" }`, so a WCAG 2.0-2.2 A/AA violation in any Checkbox story fails CI instead of warning into the job summary.

Those were the last two gaps, so Checkbox comes off `.scripts/stable-dod-debt.json`. The ratchet fails if a listed component starts passing, which is what makes that permanent.

## Retroactive impact

Any checkbox with a visible title gets a heavier label. Inside f0 that is a short list, because almost every internal consumer passes `hideLabel` (row, table, filter and select-all checkboxes are all icon-only): `F0Form` checkbox fields and the survey checkbox questions built on them, `F0QuestionCard`, and a few stories.

**The colour change is the one to look at on review.** A checkbox on a non-default background used to inherit its label colour and now pins to `f1-foreground`. I found no such usage in f0, but a consumer could have one.

`F0Switch` has byte-identical bare-label markup and the same `pl-2.5` (`ui/switch.tsx`). Deliberately left alone to keep this scoped to Checkbox, so the two are inconsistent until a follow-up. Happy to extend it here if you would rather they move together.

## Testing

- Full unit suite green. `F0Checkbox.test.tsx` gains 5 description tests: renders, the `aria-describedby` pairing, absent without a description, hidden by `hideLabel`, and click-to-toggle. One existing assertion updated, since the title is now a `<span>` inside the `<label>` and the `for` check reads `getByText(...).closest("label")`.
- `pnpm test-storybook` against a local Storybook: 7 Checkbox stories pass with axe **blocking**, including the new `WithDescription` and its play function asserting the `aria-label` / `aria-describedby` split.
- `pnpm check:stable-dod`: ratchet holds, Checkbox among the components meeting the full DoD.
- `pnpm tsc`, `pnpm lint`, `pnpm format` clean.
- Geometry verified in the browser rather than by eye: 8px gap on every row, and exact top/centre alignment on the description rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
