### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.88.3",
+  "packages/react": "6.88.4",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.88.4](https://github.com/factorialco/f0/compare/f0-react-v6.88.3...f0-react-v6.88.4) (2026-09-08)
+
+
+### Bug Fixes
+
+* **OneDataCollection:** drop the entry animation on card view cards ([#5410](https://github.com/factorialco/f0/issues/5410)) ([c54b926](https://github.com/factorialco/f0/commit/c54b9269ee87360271bb9eda765de7dfe203ff95))
+
 ## [6.88.3](https://github.com/factorialco/f0/compare/f0-react-v6.88.2...f0-react-v6.88.3) (2026-09-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.88.3",
+  "version": "6.88.4",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.88.4</summary>

## [6.88.4](https://github.com/factorialco/f0/compare/f0-react-v6.88.3...f0-react-v6.88.4) (2026-09-08)


### Bug Fixes

* **OneDataCollection:** drop the entry animation on card view cards ([#5410](https://github.com/factorialco/f0/issues/5410)) ([c54b926](https://github.com/factorialco/f0/commit/c54b9269ee87360271bb9eda765de7dfe203ff95))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).