### PR TITLE
fix(F0InputField): a placeholder never takes a second line

### DIFF
--- a/packages/react/src/components/F0InputField/F0InputField.tsx
+++ b/packages/react/src/components/F0InputField/F0InputField.tsx
@@ -540,7 +540,11 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
             <div
               data-slot="placeholder"
               className={cn(
-                "pointer-events-none absolute left-0 top-[1px] z-10 flex flex-1 justify-start px-3 text-f1-foreground-secondary transition-opacity line-clamp-1",
+                // `line-clamp-1` used to sit here, but it sets `display` and
+                // loses to `flex`, so a placeholder longer than the field
+                // wrapped onto a second line and spilled out of it. The child
+                // truncates instead.
+                "pointer-events-none absolute inset-x-0 top-[1px] z-10 flex flex-1 justify-start overflow-hidden px-3 text-f1-foreground-secondary transition-opacity",
                 !canGrow && "bottom-0",
                 canGrow && "items-start",
                 (icon || avatar) && "pl-8",
@@ -557,7 +561,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
               aria-hidden="true"
               title={placeholder}
             >
-              {placeholder}
+              <span className="min-w-0 truncate">{placeholder}</span>
             </div>
             {clearable || hasAppend || loading ? (
               <div

--- a/packages/react/src/components/F0InputField/__tests__/F0InputField.test.tsx
+++ b/packages/react/src/components/F0InputField/__tests__/F0InputField.test.tsx
@@ -380,7 +380,9 @@ describe("F0InputField", () => {
       )
 
       // The placeholder div is still in the DOM but should have opacity-0
-      const placeholder = screen.getByText("Enter text")
+      const placeholder = screen
+        .getByText("Enter text")
+        .closest("[data-slot='placeholder']")
       expect(placeholder).toHaveClass("opacity-0")
     })
 
@@ -391,7 +393,9 @@ describe("F0InputField", () => {
         </F0InputField>
       )
 
-      const placeholder = screen.getByText("Enter text")
+      const placeholder = screen
+        .getByText("Enter text")
+        .closest("[data-slot='placeholder']")
       expect(placeholder).toHaveClass("opacity-0")
     })
 
@@ -402,8 +406,35 @@ describe("F0InputField", () => {
         </F0InputField>
       )
 
-      const placeholder = screen.getByText("Enter text")
+      const placeholder = screen
+        .getByText("Enter text")
+        .closest("[data-slot='placeholder']")
       expect(placeholder).toHaveClass("opacity-100")
+    })
+
+    it("keeps a placeholder on one line inside the field", () => {
+      render(
+        <F0InputField
+          label="Postal code"
+          placeholder="Enter a very long postal code that cannot possibly fit"
+          value=""
+        >
+          <input />
+        </F0InputField>
+      )
+
+      const slot = screen
+        .getByText("Enter a very long postal code that cannot possibly fit")
+        .closest("[data-slot='placeholder']")
+
+      // Spans the field and clips, rather than growing past it...
+      expect(slot).toHaveClass("inset-x-0")
+      expect(slot).toHaveClass("overflow-hidden")
+      // ...and the text truncates instead of wrapping onto a second line.
+      // `line-clamp-1` used to live on the slot, where `flex` overrode its
+      // `display`, so the clamp never applied.
+      expect(slot).not.toHaveClass("line-clamp-1")
+      expect(slot?.firstElementChild).toHaveClass("truncate")
     })
 
     it("should call onClickPlaceholder when placeholder is clicked", () => {
@@ -420,7 +451,9 @@ describe("F0InputField", () => {
         </F0InputField>
       )
 
-      const placeholder = screen.getByText("Enter text")
+      const placeholder = screen
+        .getByText("Enter text")
+        .closest("[data-slot='placeholder']")
       fireEvent.click(placeholder)
 
       expect(handleClickPlaceholder).toHaveBeenCalled()


### PR DESCRIPTION
## Description

A placeholder longer than its field wrapped onto a second line and grew out of the box. Found on `F0LocationInput`'s narrow parts (city, region, postal code in one row), but it affects every writable F0 input, since they all render their placeholder through `F0InputField`.

Two things were wrong in the placeholder slot:

- It carried `line-clamp-1`, which sets `display: -webkit-box` and loses to the `flex` next to it in the same class list, so the clamp never applied.
- It was pinned only on its left edge (`absolute left-0`, no right), so its width was shrink-to-fit. Forcing one line on its own would have spilled the text past the field rather than clipping it.

The slot now spans the field and clips (`inset-x-0` + `overflow-hidden`), and the text sits in a truncating child, so a long placeholder ends in an ellipsis at the field's edge.

Measured on a 139px-wide field with a deliberately over-long placeholder: the slot went from 406px wide and two lines to 139px and one, with the text truncated.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

Before: the placeholder text wrapped and overflowed the field's bottom edge. After: one line, ellipsis at the right edge, `title` still carries the full string on hover.

## Implementation details

- fix: the placeholder slot spans the field and clips; its text truncates in a child span
- test: a regression test asserting the slot spans and clips, no longer carries `line-clamp-1`, and that its child truncates
- test: three existing placeholder tests asserted the opacity classes on the element holding the text, which is now that child, so they read the `data-slot="placeholder"` container instead

Split out of #5408 so the primitive change can be reviewed on its own.