### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.88.4",
+  "packages/react": "6.88.5",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.88.5](https://github.com/factorialco/f0/compare/f0-react-v6.88.4...f0-react-v6.88.5) (2026-09-08)
+
+
+### Bug Fixes
+
+* **F0InputField:** a placeholder never takes a second line ([#5452](https://github.com/factorialco/f0/issues/5452)) ([bdcda41](https://github.com/factorialco/f0/commit/bdcda41f6474b9618b9830cda55306727aa97ea3))
+
 ## [6.88.4](https://github.com/factorialco/f0/compare/f0-react-v6.88.3...f0-react-v6.88.4) (2026-09-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.88.4",
+  "version": "6.88.5",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.88.5</summary>

## [6.88.5](https://github.com/factorialco/f0/compare/f0-react-v6.88.4...f0-react-v6.88.5) (2026-09-08)


### Bug Fixes

* **F0InputField:** a placeholder never takes a second line ([#5452](https://github.com/factorialco/f0/issues/5452)) ([bdcda41](https://github.com/factorialco/f0/commit/bdcda41f6474b9618b9830cda55306727aa97ea3))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).