### PR TITLE
test(F0Select): de-flake the fallback focus test

### DIFF
--- a/packages/react/src/ui/Select/components/SelectContent.test.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.test.tsx
@@ -16,18 +16,16 @@ import { SelectTrigger } from "./SelectTrigger"
 function DeferredSelectItem({
   value,
   label,
-  delay = 20,
 }: {
   value: string
   label: string
-  delay?: number
 }) {
   const [isVisible, setIsVisible] = useState(false)
 
   useEffect(() => {
-    const timeout = setTimeout(() => setIsVisible(true), delay)
+    const timeout = setTimeout(() => setIsVisible(true), 20)
     return () => clearTimeout(timeout)
-  }, [delay])
+  }, [])
 
   return isVisible ? <SelectItem value={value}>{label}</SelectItem> : null
 }
@@ -50,18 +48,35 @@ describe("SelectContent", () => {
   })
 
   it("moves focus from its fallback to a selected option that mounts after the grace period", async () => {
-    render(
-      <Select open value="first" onValueChange={vi.fn()}>
-        <SelectTrigger aria-label="Choose an option">First</SelectTrigger>
-        <SelectContent>
-          <DeferredSelectItem value="first" label="First" delay={120} />
-          <SelectItem value="second">Second</SelectItem>
-        </SelectContent>
-      </Select>
+    // The selected option mounts on an explicit rerender, not a timer: the
+    // fallback focus asserted below only holds while that option is absent, and
+    // a timer racing the assertions loses that window on a loaded runner.
+    function SelectWithLateSelectedOption({
+      selectedMounted,
+    }: {
+      selectedMounted: boolean
+    }) {
+      return (
+        <Select open value="first" onValueChange={vi.fn()}>
+          <SelectTrigger aria-label="Choose an option">First</SelectTrigger>
+          <SelectContent>
+            {selectedMounted ? (
+              <SelectItem value="first">First</SelectItem>
+            ) : null}
+            <SelectItem value="second">Second</SelectItem>
+          </SelectContent>
+        </Select>
+      )
+    }
+
+    const { rerender } = render(
+      <SelectWithLateSelectedOption selectedMounted={false} />
     )
 
     const fallbackOption = screen.getByRole("option", { name: "Second" })
     await waitFor(() => expect(fallbackOption).toHaveFocus())
+
+    rerender(<SelectWithLateSelectedOption selectedMounted />)
 
     const selectedOption = await screen.findByRole("option", { name: "First" })
     await waitFor(() => expect(selectedOption).toHaveFocus())


### PR DESCRIPTION
## Description

De-flakes the `moves focus from its fallback to a selected option that mounts after the grace period` test in `SelectContent.test.tsx`. It asserted an intermediate focus state whose lifetime was bounded by two wall-clock timers, so a slow runner could step past that state before the first assertion ran. The selected option now mounts on an explicit `rerender` gated behind the fallback-focus assertion, which removes the timing dependency without weakening what the test covers.

## Implementation details

### What the old test asserted

The old test rendered the popup with the selected option (`"First"`) behind a 120ms `setTimeout` and the fallback option (`"Second"`) mounted right away, then asserted that `"Second"` held focus.

That holds only inside a window bounded by two timers. On open, `SelectContentImpl` finds no item matching `value="first"`, so it takes the `!selectedItemMatchesCurrentValue` branch, records the fallback, and schedules the 50ms `SELECTED_ITEM_FALLBACK_DELAY` timer that parks focus on the fallback. Once the test's own 120ms timer mounts `"First"`, the effect re-runs with a matching selected item and moves focus onto it.

So `"Second"` held focus between roughly 50ms and 120ms of real time.

### Why CI load broke it

On a loaded runner both timers had already fired before the first `expect(...).toHaveFocus()` ran. Focus sat on `"First"` (`data-state="checked"`, `data-highlighted`) and the assertion failed against the fallback. Nothing in the test ordered the two events. It only relied on that 70ms gap being wide enough, which is not a property a shared runner guarantees.

### Why the new form cannot race

The selected option no longer exists in the DOM until `rerender` puts it there, and that `rerender` runs only after `await waitFor(() => expect(fallbackOption).toHaveFocus())` has already observed the fallback state. Ordering is causal now instead of temporal. No amount of elapsed time can open the window, so no runner can skip past it. The 50ms grace period is still exercised, awaited rather than raced.

The file's `DeferredSelectItem` helper no longer needs its `delay` prop, since every remaining caller takes the default, so its 20ms is inlined.

### Verification

Twelve consecutive runs of the file pass, 9 tests each, as does the full `src/ui/Select` suite.

For red-green, adding `hasFocusedOnOpenRef.current = true` inside the fallback timer right after `selectedItem.focus()` makes this test the only failure in the file, 1 failed and 8 passed. No sibling test covers the move from fallback focus to a late-mounting selected option.