### PR TITLE
feat(F0Dialog): optional dismiss control on the notification variant

### DIFF
--- a/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
@@ -23,12 +23,6 @@ const meta: Meta<typeof DialogNotificationInternal> = {
       options: dialogNotificationTypes,
       table: { defaultValue: { summary: "info" } },
     },
-    dismissable: {
-      description:
-        'Renders a dismiss (X) control in the top-right corner, so the dialog does not have to spend a button on "Cancel".',
-      control: "boolean",
-      table: { defaultValue: { summary: "false" } },
-    },
     ...getDialogAlikeArgTypes({
       componentName: "dialog",
       include: [
@@ -38,6 +32,7 @@ const meta: Meta<typeof DialogNotificationInternal> = {
         "secondaryAction",
         "isOpen",
         "onClose",
+        "dismissable",
       ],
     }),
   },
@@ -104,6 +99,7 @@ export const Warning: Story = {
     type: "warning",
     title: "Warning",
     description: "Proceed with caution.",
+    isOpen: false,
   },
 }
 

--- a/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
@@ -23,6 +23,12 @@ const meta: Meta<typeof DialogNotificationInternal> = {
       options: dialogNotificationTypes,
       table: { defaultValue: { summary: "info" } },
     },
+    dismissable: {
+      description:
+        'Renders a dismiss (X) control in the top-right corner, so the dialog does not have to spend a button on "Cancel".',
+      control: "boolean",
+      table: { defaultValue: { summary: "false" } },
+    },
     ...getDialogAlikeArgTypes({
       componentName: "dialog",
       include: [
@@ -107,5 +113,28 @@ export const Positive: Story = {
     type: "positive",
     title: "Success",
     description: "Operation completed successfully.",
+  },
+}
+
+/**
+ * With `dismissable`, the notification gets the same close control every other dialog has, so it no
+ * longer needs to spend a button on "Cancel" — the two remaining actions are the real choices.
+ */
+export const Dismissable: Story = {
+  args: {
+    isOpen: true,
+    type: "warning",
+    title: "Unsaved changes",
+    description:
+      "You have unsaved changes. Save them before leaving, or discard them.",
+    dismissable: true,
+    primaryAction: {
+      label: "Save & leave",
+      onClick: () => {},
+    },
+    secondaryAction: {
+      label: "Discard & leave",
+      onClick: () => {},
+    },
   },
 }

--- a/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__stories__/DialogNotification.stories.tsx
@@ -111,26 +111,3 @@ export const Positive: Story = {
     description: "Operation completed successfully.",
   },
 }
-
-/**
- * With `dismissable`, the notification gets the same close control every other dialog has, so it no
- * longer needs to spend a button on "Cancel" — the two remaining actions are the real choices.
- */
-export const Dismissable: Story = {
-  args: {
-    isOpen: true,
-    type: "warning",
-    title: "Unsaved changes",
-    description:
-      "You have unsaved changes. Save them before leaving, or discard them.",
-    dismissable: true,
-    primaryAction: {
-      label: "Save & leave",
-      onClick: () => {},
-    },
-    secondaryAction: {
-      label: "Discard & leave",
-      onClick: () => {},
-    },
-  },
-}

--- a/packages/react/src/components/dialog-alike/F0Dialog/internal/DialogInternal.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/internal/DialogInternal.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect, useMemo, useState } from "react"
 import { Content } from "../../common/Content"
 import { Footer } from "../../common/Footer"
 import { Header } from "../../common/Header"
+import { NotificationCloseButton } from "../../common/NotificationCloseButton"
 import { DialogWrapper } from "../../common/Wrapper"
 import { DialogInternalProps } from "./internal-types"
 
@@ -25,6 +26,7 @@ export const DialogInternal: FC<DialogInternalProps> = ({
   variant = "default",
   type = "default",
   container,
+  dismissable = false,
 }) => {
   const [localIsOpen, setLocalIsOpen] = useState(isOpen)
 
@@ -35,6 +37,9 @@ export const DialogInternal: FC<DialogInternalProps> = ({
   const _memoizedDialogLayout = useMemo(() => {
     return (
       <>
+        {variant === "notification" && dismissable ? (
+          <NotificationCloseButton disabled={disableClose} />
+        ) : null}
         {variant !== "notification" ? (
           <Header
             title={title}
@@ -74,6 +79,7 @@ export const DialogInternal: FC<DialogInternalProps> = ({
     secondaryAction,
     variant,
     type,
+    dismissable,
   ])
 
   return (

--- a/packages/react/src/components/dialog-alike/F0Dialog/internal/DialogNotification.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/internal/DialogNotification.tsx
@@ -22,6 +22,12 @@ type F0DialogNotificationProps = {
    * @default undefined
    */
   secondaryAction?: F0DialogAction | F0DialogAction[]
+  /**
+   * Renders the dismiss (X) control in the top-right corner, so the dialog does not need to spend
+   * a button on "Cancel".
+   * @default false
+   */
+  dismissable?: boolean
 }
 
 export const DialogNotificationInternal = ({
@@ -32,6 +38,7 @@ export const DialogNotificationInternal = ({
   description,
   primaryAction,
   secondaryAction,
+  dismissable = false,
 }: F0DialogNotificationProps) => {
   return (
     <DialogInternal
@@ -42,6 +49,7 @@ export const DialogNotificationInternal = ({
       primaryAction={primaryAction}
       secondaryAction={secondaryAction}
       type={type === "critical" ? "critical" : "default"}
+      dismissable={dismissable}
       modal
     >
       <div className="flex flex-col gap-4 py-2">

--- a/packages/react/src/components/dialog-alike/F0Dialog/internal/internal-types.ts
+++ b/packages/react/src/components/dialog-alike/F0Dialog/internal/internal-types.ts
@@ -17,4 +17,11 @@ export type DialogInternalProps = DialogAlikeInternalProps & {
    * @private
    */
   variant?: DialogVariant
+
+  /**
+   * Renders a dismiss (X) control in the notification variant's top-right corner. Ignored by the
+   * default variant, whose `Header` already carries one.
+   * @default false
+   */
+  dismissable?: boolean
 }

--- a/packages/react/src/components/dialog-alike/common/NotificationCloseButton.tsx
+++ b/packages/react/src/components/dialog-alike/common/NotificationCloseButton.tsx
@@ -1,0 +1,44 @@
+import { ButtonInternal } from "@/components/F0Button/internal"
+import CrossIcon from "@/icons/app/Cross"
+import { useI18n } from "@/lib/providers/i18n"
+import { useDialogWrapperContext } from "./DialogWrapperProvider"
+
+type NotificationCloseButtonProps = {
+  /**
+   * Disables the close button, matching the `Header`'s own `disableClose`.
+   * @internal
+   */
+  disabled?: boolean
+}
+
+/**
+ * The notification dialog's dismiss control.
+ *
+ * The notification variant renders no `Header` — its title and description sit in the body under
+ * the alert avatar — so it cannot borrow the header's close button. Without one, the only way out
+ * of a notification is an explicit "Cancel" action, which costs a button for something every other
+ * dialog expresses with an X. This is that X: anchored to the panel's top-right corner and wired to
+ * the same `onClose` the header button uses, so dismissing resolves the dialog exactly like the
+ * escape key does on a non-modal one.
+ */
+export const NotificationCloseButton = ({
+  disabled,
+}: NotificationCloseButtonProps) => {
+  const translations = useI18n()
+  const { onClose } = useDialogWrapperContext()
+
+  return (
+    <div className="relative">
+      <div className="absolute right-3 top-3 z-10">
+        <ButtonInternal
+          variant="outline"
+          icon={CrossIcon}
+          disabled={disabled}
+          onClick={onClose}
+          label={translations.actions.close}
+          hideLabel
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/components/dialog-alike/common/__stories__/argsTypes.ts
+++ b/packages/react/src/components/dialog-alike/common/__stories__/argsTypes.ts
@@ -53,6 +53,11 @@ export const getDialogAlikeArgTypes = ({
       control: "boolean",
       table: { defaultValue: { summary: "false" } },
     },
+    dismissable: {
+      description: `Renders a dismiss (X) control in the ${componentName}'s top-right corner, so it does not have to spend a button on "Cancel". Only the notification variant needs it — the default variant's header already carries one.`,
+      control: "boolean",
+      table: { defaultValue: { summary: "false" } },
+    },
     otherActions: {
       description: "Other actions to display in the header",
       control: "object",

--- a/packages/react/src/lib/providers/dialogs-alike/components/DialogsAlike.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/components/DialogsAlike.tsx
@@ -201,6 +201,7 @@ export const DialogsAlike = ({ items }: DialogsAlikeProps) => {
               onClose={item.onCloseDialog}
               primaryAction={item.actions.primary[0]}
               secondaryAction={item.actions.secondary}
+              dismissable={item.dismissable}
             />
           ) : item.variant === "drawer" ? (
             <DrawerInternal

--- a/packages/react/src/lib/providers/dialogs-alike/components/__tests__/Dialogs.test.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/components/__tests__/Dialogs.test.tsx
@@ -69,6 +69,7 @@ const MockDialogNotificationInternal = vi.hoisted(() => {
       data-description={props.description}
       data-type={props.type}
       data-is-open={props.isOpen}
+      data-dismissable={String(!!props.dismissable)}
     >
       <button data-testid="notification-close-button" onClick={props.onClose}>
         Close
@@ -273,6 +274,51 @@ describe("DialogsAlike", () => {
       )
       expect(dialog).toHaveAttribute("data-type", "warning")
       expect(dialog).toHaveAttribute("data-is-open", "true")
+    })
+
+    it("should forward dismissable to DialogNotificationInternal", () => {
+      const dialogs: DialogDefinitionInternal[] = [
+        {
+          id: "dialog-notif-dismissable",
+          title: "Unsaved changes",
+          description: "Save them before leaving, or discard them.",
+          variant: "notification",
+          type: "warning",
+          dismissable: true,
+          content: <div>Content</div>,
+          actions: { primary: { label: "Save", value: true } },
+          onCloseDialog: vi.fn(),
+          onClickAction: vi.fn(),
+        },
+      ]
+
+      zeroRender(<DialogsAlike items={dialogs} />)
+
+      expect(
+        screen.getByTestId("f0-dialog-notification-internal")
+      ).toHaveAttribute("data-dismissable", "true")
+    })
+
+    it("defaults dismissable to false, so existing notifications keep no close control", () => {
+      const dialogs: DialogDefinitionInternal[] = [
+        {
+          id: "dialog-notif-plain",
+          title: "Heads up",
+          description: "Something happened.",
+          variant: "notification",
+          type: "info",
+          content: <div>Content</div>,
+          actions: { primary: { label: "Ok", value: true } },
+          onCloseDialog: vi.fn(),
+          onClickAction: vi.fn(),
+        },
+      ]
+
+      zeroRender(<DialogsAlike items={dialogs} />)
+
+      expect(
+        screen.getByTestId("f0-dialog-notification-internal")
+      ).toHaveAttribute("data-dismissable", "false")
     })
 
     it("should render dialog content", () => {

--- a/packages/react/src/lib/providers/dialogs-alike/imperative.tsx
+++ b/packages/react/src/lib/providers/dialogs-alike/imperative.tsx
@@ -47,8 +47,14 @@ const makeActionHandler =
     dialogsAlikeStore.removeItem(id)
   }
 
+// `Optional<…>` is built on `Omit`, which does not distribute over a union — it collapses
+// `DialogDefinitionInternal` to the keys both variants share, dropping notification-only ones. So
+// `dismissable` is re-declared here rather than being widened onto the public `DialogDefinition`,
+// where the default variant would advertise a prop its own `Header` already covers.
 const openDialogInternal = (
-  definition: Optional<DialogDefinitionInternal, "id">
+  definition: Optional<DialogDefinitionInternal, "id"> & {
+    dismissable?: boolean
+  }
 ): Promise<DialogActionValue> => {
   return new Promise((resolve) => {
     const id = definition.id || nanoid()
@@ -137,6 +143,7 @@ const notification = (
     title: options.title,
     content: <></>,
     actions: options.actions,
+    dismissable: options.dismissable,
   })
 
 // Notification dialog with confirm + cancel actions (defaults to Ok/Cancel).

--- a/packages/react/src/lib/providers/dialogs-alike/types.ts
+++ b/packages/react/src/lib/providers/dialogs-alike/types.ts
@@ -96,6 +96,7 @@ export type DialogDefinitionInternal =
   | (Omit<DialogDefinition, "modal" | "module"> & {
       variant: "notification"
       type: DialogNotificationType
+      dismissable?: boolean
     })
 
 // =============================================================================
@@ -145,6 +146,12 @@ export type NotificationDialogBaseOptions = Optional<
 > & {
   msg: string
   type?: DialogNotificationType
+  /**
+   * Renders a dismiss (X) control in the dialog's top-right corner. Lets a notification offer a
+   * way out without spending a button on "Cancel".
+   * @default false
+   */
+  dismissable?: boolean
 }
 
 export type NotificationDialogOptions = NotificationDialogBaseOptions & {


### PR DESCRIPTION
## 🚪 Why?

The notification variant renders no header, so it has no close X. That forced "I misclicked, do nothing" to become a third button labelled **Cancel**, sitting beside two consequential ones.

<img width="1266" height="797" alt="image" src="https://github.com/user-attachments/assets/19d4e7b0-15ad-46e8-bc6a-4a5da6b2c0a7" />

In device management those two are expensive: **Save & leave** pushes a configuration profile, automation or software scope to employees' devices; **Discard & leave** throws away authored work. A look-alike third button next to them is exactly how the wrong one gets clicked.

<img width="559" height="312" alt="image" src="https://github.com/user-attachments/assets/03dc68aa-eb00-40e2-8b10-d68c0db0a2ab" />


## 🔑 What?

Adds an opt-in `dismissable` flag that renders the X in the notification's top-right corner, so the button row holds only the real choices. It is wired to the same `onClose` the header's button uses, so dismissing resolves the promise with `undefined` exactly as before — callers need no new handling.

The flag is threaded through `DialogNotification`, the `dialogs-alike` provider and `NotificationDialogBaseOptions`, so `dialogs.notification()`, `alert()` and `confirmation()` all accept it, and it is documented alongside `modal` in the shared control set rather than as a story of its own.

Additive and backwards compatible: it defaults to `false`, and unset the new component never mounts, so existing notifications render identical DOM. 107 dialog tests pass unchanged, plus two new ones covering the forwarding and the default.
