### PR TITLE
refactor(lint): enable the sonarjs debt rules

### DIFF
--- a/packages/react/.oxlintrc.json
+++ b/packages/react/.oxlintrc.json
@@ -296,7 +296,7 @@
     "sonarjs/parameterized-tests": "error",
     "sonarjs/void-use": "error",
     "sonarjs/no-globals-shadowing": "error",
-    "max-params": ["error", { "max": 4 }], // more than four positional arguments: pass an object
+    "max-params": ["error", { "max": 4 }], // five or more parameters: move all of them into one options object, do not mix positionals with an object
 
     // eslint-plugin-react, loaded as a JS plugin (`react-js`). It has no type
     // information, so only the syntax-based rules are useful. `f0-react` wraps

--- a/packages/react/.oxlintrc.json
+++ b/packages/react/.oxlintrc.json
@@ -285,6 +285,19 @@
     "sonarjs/x-powered-by": "error",
     "sonarjs/xml-parser-xxe": "error",
 
+    // sonarjs rules that were debt and are now fixed.
+    "sonarjs/no-nested-functions": ["error", { "threshold": 5 }], // the default of 4 has 110 hits, most of them JSX callbacks inside hooks
+    "sonarjs/no-identical-functions": "error", // off for stories and tests below, they repeat on purpose
+    "sonarjs/prefer-specific-assertions": "error",
+    "sonarjs/no-redundant-optional": "error",
+    "sonarjs/assertions-in-tests": "error",
+    "sonarjs/no-floating-point-equality": "error",
+    "sonarjs/use-type-alias": "error",
+    "sonarjs/parameterized-tests": "error",
+    "sonarjs/void-use": "error",
+    "sonarjs/no-globals-shadowing": "error",
+    "max-params": ["error", { "max": 4 }], // more than four positional arguments: pass an object
+
     // eslint-plugin-react, loaded as a JS plugin (`react-js`). It has no type
     // information, so only the syntax-based rules are useful. `f0-react` wraps
     // its jsx-no-leaked-render to check JSX children only, not attributes.
@@ -315,21 +328,8 @@
     "react/rules-of-hooks": "off", // 65 from the _Component naming convention, 414 from story render functions
     "import/named": "off", // nursery rule, false positives
     "import/export": "off", // nursery rule, false positives on export *
-    "sonarjs/cognitive-complexity": "off", // 143
-    "sonarjs/no-nested-functions": "off", // 110 at depth 4, 17 at depth 5
-    "sonarjs/prefer-specific-assertions": "off", // 75
-    "sonarjs/no-identical-functions": "off", // 51
-    "sonarjs/pseudo-random": "off", // 41; Math.random for ids and shuffles, not security
-    "sonarjs/no-redundant-optional": "off", // 35
-    "sonarjs/redundant-type-aliases": "off", // 31; public aliases like type ColId = string
+    "sonarjs/cognitive-complexity": "off", // 187 at the default threshold of 15; first rule of the lint ratchet (next PR)
     "sonarjs/todo-tag": "off", // 26; enabling bans TODO comments
-    "sonarjs/assertions-in-tests": "off", // 23
-    "sonarjs/no-floating-point-equality": "off", // 22
-    "sonarjs/use-type-alias": "off", // 21
-    "sonarjs/parameterized-tests": "off", // 12
-    "sonarjs/super-linear-regex": "off", // 10
-    "sonarjs/void-use": "off", // 10
-    "sonarjs/no-globals-shadowing": "off", // 6; story exports named Error
     "react-js/no-unstable-nested-components": "off", // 25
     "react-js/jsx-no-constructed-context-values": "off", // 35
     "react-js/no-unused-prop-types": "off", // 34
@@ -340,6 +340,9 @@
     "typescript/no-unnecessary-type-assertion": "off", // tsgolint (TS 7 semantics) reports assertions tsc 5.9 still needs; the autofix broke the build
 
     // OFF ON PURPOSE. Not planned to be enabled.
+    "sonarjs/pseudo-random": "off", // Math.random is used for ids and shuffles, never for security
+    "sonarjs/redundant-type-aliases": "off", // aliases like `type ColId = string` name intent, and most are exported
+    "sonarjs/super-linear-regex": "off", // the flagged regexes run on short strings we build ourselves
     "typescript/ban-types": "off", // deprecated upstream; it bans `(string & {})`, which keeps autocomplete on open string unions. no-unsafe-function-type covers the useful part
     "oxc/no-map-spread": "off", // wants Object.assign onto the mapped item, which mutates the input; props and state are immutable here. Its autofix also breaks code (oxlint 1.43)
     "typescript/no-namespace": "off", // namespaces are allowed
@@ -418,7 +421,8 @@
       ],
       "rules": {
         "no-console": "off",
-        "no-await-in-loop": "off" // stories and tests step through flows one await at a time
+        "no-await-in-loop": "off", // stories and tests step through flows one await at a time
+        "sonarjs/no-identical-functions": "off" // each story and test case reads on its own
       }
     },
     {

--- a/packages/react/src/components/F0Accordion/__stories__/F0Accordion.stories.tsx
+++ b/packages/react/src/components/F0Accordion/__stories__/F0Accordion.stories.tsx
@@ -129,7 +129,7 @@ export const WithSegmentedControlAndDropdown: Story = {
     const triggers = canvas.getAllByRole("button", {
       name: /^Expand |^Collapse /,
     })
-    expect(triggers.length).toBe(baseItems.length)
+    expect(triggers).toHaveLength(baseItems.length)
   },
 }
 

--- a/packages/react/src/components/F0ActionBar/index.tsx
+++ b/packages/react/src/components/F0ActionBar/index.tsx
@@ -271,7 +271,7 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
         }
 
         el.classList.remove(errorNavigateClassName, wiggleClassName)
-        void el.offsetWidth // Force reflow to restart animation
+        el.getBoundingClientRect() // Force reflow to restart animation
         el.classList.add(className)
 
         wiggleTimeoutRef.current = setTimeout(() => {
@@ -296,7 +296,7 @@ const _F0ActionBar = forwardRef<F0ActionBarRef, F0ActionBarProps>(
 
         setShowErrorStyles(false)
         el.classList.remove(errorNavigateClassName)
-        void el.offsetWidth
+        el.getBoundingClientRect() // Force reflow to restart animation
         el.classList.add(errorNavigateClassName)
 
         wiggleTimeoutRef.current = setTimeout(() => {

--- a/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
+++ b/packages/react/src/components/F0ButtonDropdown/F0ButtonDropdown.tsx
@@ -18,12 +18,15 @@ import {
   F0ButtonDropdownProps,
 } from "./types.ts"
 
+type ButtonDropdownItems =
+  | ButtonDropdownItem[]
+  | ButtonDropdownGroup[]
+  | ButtonDropdownGroup
+
 /**
  * Normalize the items to an array of DropdownButtonGroup
  */
-const normalizeItems = (
-  items: ButtonDropdownItem[] | ButtonDropdownGroup[] | ButtonDropdownGroup
-) => {
+const normalizeItems = (items: ButtonDropdownItems) => {
   if (Array.isArray(items)) {
     // ButtonDropdownItem[]
     if (items.every(isButtonDropdownItem)) {
@@ -75,7 +78,7 @@ const SplitMode = ({
 }: {
   onClick: (value: string, item: ButtonDropdownItem) => void
   value?: string
-  items: ButtonDropdownItem[] | ButtonDropdownGroup[] | ButtonDropdownGroup
+  items: ButtonDropdownItems
   size?: ButtonDropdownSize
   variant?: ButtonDropdownVariant
   disabled?: boolean
@@ -222,7 +225,7 @@ const DropdownMode = ({
   onClick: (value: string, item: ButtonDropdownItem) => void
   trigger?: string
   value?: string
-  items: ButtonDropdownItem[] | ButtonDropdownGroup[] | ButtonDropdownGroup
+  items: ButtonDropdownItems
   size?: ButtonDropdownSize
   variant?: ButtonDropdownVariant
   disabled?: boolean

--- a/packages/react/src/components/F0InputField/F0InputField.tsx
+++ b/packages/react/src/components/F0InputField/F0InputField.tsx
@@ -165,7 +165,7 @@ export type InputFieldProps<T> = {
   onClickPlaceholder?: () => void
   onClickChildren?: () => void
   onClickContent?: () => void
-  value?: T | undefined
+  value?: T
   onChange?: (value: T) => void
   size?: InputFieldSize
   /* @deprecated Use state (with type error)instead */

--- a/packages/react/src/components/F0InputField/__stories__/F0InputField.stories.tsx
+++ b/packages/react/src/components/F0InputField/__stories__/F0InputField.stories.tsx
@@ -205,7 +205,7 @@ export const Readonly: Story = {
   },
 }
 
-export const Error: Story = {
+const ErrorState: Story = {
   args: {
     ...Default.args,
     icon: Search,
@@ -390,3 +390,6 @@ export const Snapshot: Story = {
     )
   },
 }
+
+// Exported under the global's name so the story id stays `--error`.
+export { ErrorState as Error }

--- a/packages/react/src/components/F0NumberInput/internal/__tests__/extractNumber.test.ts
+++ b/packages/react/src/components/F0NumberInput/internal/__tests__/extractNumber.test.ts
@@ -109,24 +109,11 @@ describe("extractNumber", () => {
   })
 
   describe("decimal options", () => {
-    test("empty string", () => {
-      const input = ""
-      expect(extractNumber(input, decimalOptions)).toEqual({
-        formattedValue: input,
-        value: null,
-      })
-    })
-
-    test("lone decimal", () => {
-      const input = "."
-      expect(extractNumber(input, decimalOptions)).toEqual({
-        formattedValue: input,
-        value: null,
-      })
-    })
-
-    test("minus sign", () => {
-      const input = "-"
+    test.each([
+      { name: "empty string", input: "" },
+      { name: "lone decimal", input: "." },
+      { name: "minus sign", input: "-" },
+    ])("$name", ({ input }) => {
       expect(extractNumber(input, decimalOptions)).toEqual({
         formattedValue: input,
         value: null,

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -642,12 +642,11 @@ const F0SelectComponent = forwardRef(function Select<
     [handleSelectAllItems]
   )
 
-  const getMultiSelectionPayload = useCallback(() => {
-    const checkedItems = Array.from(selectedState.items.values() || []).filter(
-      (item) => item.checked
-    )
-
-    const extractOriginalItem = (
+  // Extract the original item from a record.
+  // For static options: the record IS the option, and option.item contains the original data.
+  // For datasource: the record is the original data, optionMapper creates the option.
+  const extractOriginalItem = useCallback(
+    (
       record: ActualRecordType | undefined
     ): ResolvedRecordType<R> | undefined => {
       if (!record) {
@@ -656,13 +655,19 @@ const F0SelectComponent = forwardRef(function Select<
       if (source) {
         return record as unknown as ResolvedRecordType<R>
       }
-
       const option = record as unknown as F0SelectItemObject<
         T,
         ResolvedRecordType<R>
       >
       return option.item
-    }
+    },
+    [source]
+  )
+
+  const getMultiSelectionPayload = useCallback(() => {
+    const checkedItems = Array.from(selectedState.items.values() || []).filter(
+      (item) => item.checked
+    )
 
     const records = checkedItems
       .map((item) => item.item)
@@ -693,7 +698,7 @@ const F0SelectComponent = forwardRef(function Select<
       originalItems,
       options,
     }
-  }, [optionMapper, selectedState.items, source])
+  }, [extractOriginalItem, optionMapper, selectedState.items, source])
 
   /**
    * Emit the value change. The type depends on the multiple prop and selectionMode.
@@ -716,27 +721,6 @@ const F0SelectComponent = forwardRef(function Select<
     // and clearing would trigger useSelectable to reset the selection
     if (!multiple && !openLocal && !asList) {
       setCurrentSearch(undefined)
-    }
-
-    // Helper to extract the original item from a record
-    // For static options: the record IS the option, and option.item contains the original data
-    // For datasource: the record is the original data, optionMapper creates the option
-    const extractOriginalItem = (
-      record: ActualRecordType | undefined
-    ): ResolvedRecordType<R> | undefined => {
-      if (!record) {
-        return undefined
-      }
-      if (source) {
-        // For datasource, the record itself is the original item
-        return record as unknown as ResolvedRecordType<R>
-      }
-      // For static options, extract the 'item' property from the option
-      const option = record as unknown as F0SelectItemObject<
-        T,
-        ResolvedRecordType<R>
-      >
-      return option.item
     }
 
     // TypeScript cannot infer the type of the onChange callback when it has generics,
@@ -819,6 +803,7 @@ const F0SelectComponent = forwardRef(function Select<
       }
     }
   }, [
+    extractOriginalItem,
     controlledInlineValue,
     getMultiSelectionPayload,
     hasDeferredApply,

--- a/packages/react/src/components/OneCalendar/OneCalendar.stories.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.stories.tsx
@@ -12,7 +12,7 @@ import {
 import MockDate from "mockdate"
 import { useState } from "react"
 import { OneCalendar, OneCalendarInternal } from "./OneCalendar"
-import { DateRange, WeekStartDay } from "./types"
+import { CalendarSelection, DateRange, WeekStartDay } from "./types"
 
 const mockDate = new Date(2025, 6, 30)
 const mockTodayDate = new Date(2025, 5, 30)
@@ -100,7 +100,7 @@ export const MonthSingle: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -139,7 +139,7 @@ export const MonthRange: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -176,7 +176,7 @@ export const YearSingle: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -215,7 +215,7 @@ export const YearRange: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -252,7 +252,7 @@ export const DaySingle: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -298,7 +298,7 @@ export const DayRange: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -342,7 +342,7 @@ export const Week: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         setSelectedRange(null)
         return
@@ -377,7 +377,7 @@ export const QuarterSingle: Story = {
       return new Date(now.getFullYear(), quarterStartMonth, 1)
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         setSelectedDate(null)
         return
@@ -431,7 +431,7 @@ export const QuarterRange: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         setSelectedRange(null)
         return
@@ -466,7 +466,7 @@ export const HalfYearSingle: Story = {
       return new Date(now.getFullYear(), halfYearStartMonth, 1)
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         setSelectedDate(null)
         return
@@ -519,7 +519,7 @@ export const HalfYearRange: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         setSelectedRange(null)
         return
@@ -673,7 +673,7 @@ export const CompactMonthSingle: OneCalendarInternalStory = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -713,7 +713,7 @@ export const CompactMonthRange: OneCalendarInternalStory = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -758,7 +758,7 @@ export const CompactWeek: OneCalendarInternalStory = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         setSelectedRange(null)
         return
@@ -801,7 +801,7 @@ export const CompactDayRange: OneCalendarInternalStory = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }
@@ -840,7 +840,7 @@ export const RegularVsCompact: Story = {
       }
     })
 
-    const handleSelect = (date: Date | DateRange | null) => {
+    const handleSelect = (date: CalendarSelection) => {
       if (!date) {
         return
       }

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -20,8 +20,8 @@ import {
 } from "./granularities"
 import {
   CalendarMode,
+  CalendarSelection,
   CalendarView,
-  DateRange,
   DateRangeString,
   WeekStartDay,
   WeekStartsOn,
@@ -33,9 +33,9 @@ const privateProps = ["compact"] as const
 interface OneCalendarInternalProps {
   mode: CalendarMode
   view: CalendarView
-  onSelect?: (date: Date | DateRange | null) => void
+  onSelect?: (date: CalendarSelection) => void
   defaultMonth?: Date
-  defaultSelected?: Date | DateRange | null
+  defaultSelected?: CalendarSelection
   showNavigation?: boolean
   showInput?: boolean
   minDate?: Date
@@ -108,9 +108,8 @@ const OneCalendarInternal = ({
 
   const [viewDate, setViewDate] = useState<Date>(effectiveDefaultMonth)
 
-  const [selected, setSelectedInternal] = useState<Date | DateRange | null>(
-    defaultSelected
-  )
+  const [selected, setSelectedInternal] =
+    useState<CalendarSelection>(defaultSelected)
 
   const [motionDirection, setMotionDirection] = useState(1)
 
@@ -123,7 +122,7 @@ const OneCalendarInternal = ({
   }, [view, effectiveWeekStartsOn, periods])
 
   const setSelected = useCallback(
-    (date: Date | DateRange | null) => {
+    (date: CalendarSelection) => {
       setSelectedInternal(date)
 
       // Set the input value
@@ -209,7 +208,7 @@ const OneCalendarInternal = ({
   }
 
   // Handle selection of a date
-  const handleSelect = (date: Date | DateRange | null) => {
+  const handleSelect = (date: CalendarSelection) => {
     if (!date) {
       return
     }

--- a/packages/react/src/components/OneCalendar/__tests__/formatDateToString.test.ts
+++ b/packages/react/src/components/OneCalendar/__tests__/formatDateToString.test.ts
@@ -11,22 +11,25 @@ describe("formatDateToString", () => {
     expect(result).toBe("2024-01-15")
   })
 
-  it("should format DateRange with different from and to dates using separator", () => {
-    const dateRange: DateRange = { from: fromDate, to: toDate }
+  it.each<{ name: string; dateRange: DateRange; expected: string }>([
+    {
+      name: "different from and to dates using separator",
+      dateRange: { from: fromDate, to: toDate },
+      expected: "2024-01-15 → 2024-01-31",
+    },
+    {
+      name: "same from and to dates without separator",
+      dateRange: { from: fromDate, to: fromDate },
+      expected: "2024-01-15",
+    },
+    {
+      name: "only from date",
+      dateRange: { from: fromDate },
+      expected: "2024-01-15",
+    },
+  ])("should format DateRange with $name", ({ dateRange, expected }) => {
     const result = formatDateToString(dateRange, "yyyy-MM-dd")
-    expect(result).toBe("2024-01-15 → 2024-01-31")
-  })
-
-  it("should format DateRange with same from and to dates without separator", () => {
-    const dateRange: DateRange = { from: fromDate, to: fromDate }
-    const result = formatDateToString(dateRange, "yyyy-MM-dd")
-    expect(result).toBe("2024-01-15")
-  })
-
-  it("should format DateRange with only from date", () => {
-    const dateRange: DateRange = { from: fromDate }
-    const result = formatDateToString(dateRange, "yyyy-MM-dd")
-    expect(result).toBe("2024-01-15")
+    expect(result).toBe(expected)
   })
 
   it("should return dash when date is undefined", () => {

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -77,9 +77,11 @@ export function buildYearOptions(
 export function buildMonthOptions(
   year: number,
   locale: string,
-  minDate?: Date,
-  maxDate?: Date,
-  format: "long" | "short" = "long"
+  {
+    minDate,
+    maxDate,
+    format = "long",
+  }: { minDate?: Date; maxDate?: Date; format?: "long" | "short" } = {}
 ): SelectOption[] {
   const formatter = new Intl.DateTimeFormat(locale, { month: format })
   return Array.from({ length: 12 }, (_, month) => {
@@ -145,13 +147,11 @@ export function CalendarHeaderDropdowns({
 
   const monthOptions = useMemo(
     () =>
-      buildMonthOptions(
-        viewDate.getFullYear(),
-        locale,
+      buildMonthOptions(viewDate.getFullYear(), locale, {
         minDate,
         maxDate,
-        compact ? "short" : "long"
-      ),
+        format: compact ? "short" : "long",
+      }),
     [locale, viewDate, minDate, maxDate, compact]
   )
 

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -74,15 +74,21 @@ export function buildYearOptions(
  * "short" format ("Sep", "sept.") so the trigger fits its narrower header at
  * a fixed width across locales.
  */
-export function buildMonthOptions(
-  year: number,
-  locale: string,
-  {
-    minDate,
-    maxDate,
-    format = "long",
-  }: { minDate?: Date; maxDate?: Date; format?: "long" | "short" } = {}
-): SelectOption[] {
+type BuildMonthOptionsOptions = {
+  year: number
+  locale: string
+  minDate?: Date
+  maxDate?: Date
+  format?: "long" | "short"
+}
+
+export function buildMonthOptions({
+  year,
+  locale,
+  minDate,
+  maxDate,
+  format = "long",
+}: BuildMonthOptionsOptions): SelectOption[] {
   const formatter = new Intl.DateTimeFormat(locale, { month: format })
   return Array.from({ length: 12 }, (_, month) => {
     const monthDate = new Date(year, month, 1)
@@ -147,7 +153,9 @@ export function CalendarHeaderDropdowns({
 
   const monthOptions = useMemo(
     () =>
-      buildMonthOptions(viewDate.getFullYear(), locale, {
+      buildMonthOptions({
+        year: viewDate.getFullYear(),
+        locale,
         minDate,
         maxDate,
         format: compact ? "short" : "long",

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -114,33 +114,19 @@ describe("buildMonthOptions", () => {
   })
 
   it("returns localized short month names for compact headers", () => {
-    const english = buildMonthOptions(
-      2026,
-      "en-US",
-      undefined,
-      undefined,
-      "short"
-    )
+    const english = buildMonthOptions(2026, "en-US", { format: "short" })
     expect(english[8].label).toBe("Sep")
 
-    const spanish = buildMonthOptions(
-      2026,
-      "es-ES",
-      undefined,
-      undefined,
-      "short"
-    )
+    const spanish = buildMonthOptions(2026, "es-ES", { format: "short" })
     expect(spanish[0].label.toLowerCase()).toContain("ene")
   })
 
   it("disables months that fall entirely outside min/max", () => {
     // Range is only June–August 2026.
-    const options = buildMonthOptions(
-      2026,
-      "en-US",
-      new Date(2026, 5, 1),
-      new Date(2026, 7, 31)
-    )
+    const options = buildMonthOptions(2026, "en-US", {
+      minDate: new Date(2026, 5, 1),
+      maxDate: new Date(2026, 7, 31),
+    })
 
     // January (0) is before the range, December (11) is after it.
     expect(options[0].disabled).toBe(true)
@@ -153,7 +139,9 @@ describe("buildMonthOptions", () => {
 
   it("keeps a partially-covered boundary month enabled", () => {
     // minDate mid-March: March is partially covered, so it stays enabled.
-    const options = buildMonthOptions(2026, "en-US", new Date(2026, 2, 15))
+    const options = buildMonthOptions(2026, "en-US", {
+      minDate: new Date(2026, 2, 15),
+    })
     expect(options[2].disabled).toBe(false)
     expect(options[1].disabled).toBe(true) // February fully before min
   })

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -100,7 +100,7 @@ describe("getYearBounds", () => {
 
 describe("buildMonthOptions", () => {
   it("returns 12 localized months, none disabled without bounds", () => {
-    const options = buildMonthOptions(2026, "en-US")
+    const options = buildMonthOptions({ year: 2026, locale: "en-US" })
 
     expect(options).toHaveLength(12)
     expect(options[0]).toMatchObject({ value: "0", label: "January" })
@@ -109,21 +109,31 @@ describe("buildMonthOptions", () => {
   })
 
   it("localizes month names", () => {
-    const options = buildMonthOptions(2026, "es-ES")
+    const options = buildMonthOptions({ year: 2026, locale: "es-ES" })
     expect(options[0].label.toLowerCase()).toBe("enero")
   })
 
   it("returns localized short month names for compact headers", () => {
-    const english = buildMonthOptions(2026, "en-US", { format: "short" })
+    const english = buildMonthOptions({
+      year: 2026,
+      locale: "en-US",
+      format: "short",
+    })
     expect(english[8].label).toBe("Sep")
 
-    const spanish = buildMonthOptions(2026, "es-ES", { format: "short" })
+    const spanish = buildMonthOptions({
+      year: 2026,
+      locale: "es-ES",
+      format: "short",
+    })
     expect(spanish[0].label.toLowerCase()).toContain("ene")
   })
 
   it("disables months that fall entirely outside min/max", () => {
     // Range is only June–August 2026.
-    const options = buildMonthOptions(2026, "en-US", {
+    const options = buildMonthOptions({
+      year: 2026,
+      locale: "en-US",
       minDate: new Date(2026, 5, 1),
       maxDate: new Date(2026, 7, 31),
     })
@@ -139,7 +149,9 @@ describe("buildMonthOptions", () => {
 
   it("keeps a partially-covered boundary month enabled", () => {
     // minDate mid-March: March is partially covered, so it stays enabled.
-    const options = buildMonthOptions(2026, "en-US", {
+    const options = buildMonthOptions({
+      year: 2026,
+      locale: "en-US",
       minDate: new Date(2026, 2, 15),
     })
     expect(options[2].disabled).toBe(false)

--- a/packages/react/src/components/OneCalendar/granularities/halfyear/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/halfyear/index.tsx
@@ -10,7 +10,11 @@ import {
   startOfMonth,
   startOfYear,
 } from "date-fns"
-import { DateRange, DateRangeComplete } from "../../types"
+import {
+  DateRange,
+  DateRangeComplete,
+  OptionalCalendarSelection,
+} from "../../types"
 import {
   isAfterOrEqual,
   isBeforeOrEqual,
@@ -34,7 +38,7 @@ const formatHalfYear = (date: Date) => {
   return `H${halfYear + 1}`
 }
 
-const toRangeString = (date: Date | DateRange | undefined | null) => {
+const toRangeString = (date: OptionalCalendarSelection) => {
   const dateRange = toHalfYearGranularityDateRange(date)
   if (!dateRange) {
     return {
@@ -60,7 +64,7 @@ const add = (date: DateRangeComplete, delta: number): DateRangeComplete => {
 }
 
 export function toHalfYearGranularityDateRange<
-  T extends Date | DateRange | undefined | null,
+  T extends OptionalCalendarSelection,
 >(date: T): T extends Date | DateRange ? DateRangeComplete : T {
   return toGranularityDateRange(
     date,
@@ -81,7 +85,7 @@ const isSameHalfYear = (date1: Date, date2: Date) => {
   return formatHalfYearFull(start.from) === formatHalfYearFull(end.from)
 }
 
-const formatHalfYearShort = (date: Date | DateRange | undefined | null) => {
+const formatHalfYearShort = (date: OptionalCalendarSelection) => {
   const dateRange = toRangeString(date)
   if (!dateRange) {
     return "-"
@@ -92,7 +96,7 @@ const formatHalfYearShort = (date: Date | DateRange | undefined | null) => {
   return `${from}${toPart}`
 }
 
-const formatHalfYearLong = (date: Date | DateRange | undefined | null) => {
+const formatHalfYearLong = (date: OptionalCalendarSelection) => {
   const dateRange = toHalfYearGranularityDateRange(date)
   if (!dateRange) {
     return ""

--- a/packages/react/src/components/OneCalendar/granularities/month/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/month/index.tsx
@@ -8,7 +8,11 @@ import {
   parse,
   startOfMonth,
 } from "date-fns"
-import { DateRange, DateRangeComplete } from "../../types"
+import {
+  DateRange,
+  DateRangeComplete,
+  OptionalCalendarSelection,
+} from "../../types"
 import {
   formatDateRange,
   formatDateToString,
@@ -25,7 +29,7 @@ import { MonthView } from "./MonthView"
 const MONTH_FORMAT = "MM/yyyy"
 
 export function toMonthGranularityDateRange<
-  T extends Date | DateRange | undefined | null,
+  T extends OptionalCalendarSelection,
 >(date: T): T extends Date | DateRange ? DateRangeComplete : T {
   return toGranularityDateRange(date, startOfMonth, endOfMonth)
 }
@@ -37,14 +41,11 @@ const add = (date: DateRangeComplete, delta: number): DateRangeComplete => {
   }
 }
 
-const formatMonthShort = (date: Date | DateRange | undefined | null) => {
+const formatMonthShort = (date: OptionalCalendarSelection) => {
   return formatDateToString(date, MONTH_FORMAT)
 }
 
-const formatMonthLong = (
-  date: Date | DateRange | undefined | null,
-  locale = "en-US"
-) => {
+const formatMonthLong = (date: OptionalCalendarSelection, locale = "en-US") => {
   const dateRange = toMonthGranularityDateRange(date)
   if (!dateRange) {
     return ""

--- a/packages/react/src/components/OneCalendar/granularities/quarter/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/quarter/index.tsx
@@ -7,7 +7,11 @@ import {
   isSameYear,
   startOfQuarter,
 } from "date-fns"
-import { DateRange, DateRangeComplete } from "../../types"
+import {
+  DateRange,
+  DateRangeComplete,
+  OptionalCalendarSelection,
+} from "../../types"
 import {
   formatDateRange,
   formatDateToString,
@@ -24,7 +28,7 @@ import { QuarterView } from "./QuarterView"
 const QUARTER_FORMAT = "'Q'Q yyyy"
 
 export function toQuarterGranularityDateRange<
-  T extends Date | DateRange | undefined | null,
+  T extends OptionalCalendarSelection,
 >(date: T): T extends Date | DateRange ? DateRangeComplete : T {
   return toGranularityDateRange(date, startOfQuarter, endOfQuarter)
 }
@@ -36,11 +40,11 @@ const add = (date: DateRangeComplete, delta: number): DateRangeComplete => {
   }
 }
 
-const formatQuarterShort = (date: Date | DateRange | undefined | null) => {
+const formatQuarterShort = (date: OptionalCalendarSelection) => {
   return formatDateToString(date, QUARTER_FORMAT)
 }
 
-const formatQuarterLong = (date: Date | DateRange | undefined | null) => {
+const formatQuarterLong = (date: OptionalCalendarSelection) => {
   const dateRange = toQuarterGranularityDateRange(date)
   if (!dateRange) {
     return ""

--- a/packages/react/src/components/OneCalendar/granularities/types.ts
+++ b/packages/react/src/components/OneCalendar/granularities/types.ts
@@ -2,10 +2,12 @@ import { ReactNode } from "react"
 import { TranslationsType } from "@/lib/providers/i18n"
 import {
   CalendarMode,
+  CalendarSelection,
   CalendarView,
   DateRange,
   DateRangeComplete,
   DateRangeString,
+  OptionalCalendarSelection,
   WeekStartsOn,
 } from "../types"
 
@@ -43,17 +45,17 @@ export interface GranularityDefinition {
   label: (viewDate: Date, i18n: TranslationsType, locale?: string) => ReactNode
   // Format the date to a date range with dates as string
   toRangeString: (
-    date: Date | DateRange | undefined | null,
+    date: OptionalCalendarSelection,
     i18n: TranslationsType,
     format?: DateStringFormat
   ) => DateRangeString
   // Convert the date to a date range (e.g for day granularity, this will be the start and end of the day)
-  toRange: <T extends Date | DateRange | undefined | null>(
+  toRange: <T extends OptionalCalendarSelection>(
     date: T
   ) => T extends Date | DateRange ? DateRangeComplete : T
   // Format the date to a string (e.g W12 2025 -> W13 2025)
   toString: (
-    date: Date | DateRange | undefined | null,
+    date: OptionalCalendarSelection,
     i18n: TranslationsType,
     format?: DateStringFormat,
     locale?: string
@@ -76,8 +78,8 @@ export interface GranularityDefinition {
   // Render the calendar view (this is only used in the Calendar component to render the view internally, in other component use the `calendarView` prop to pass it to the Calendar component)
   render: (renderProps: {
     mode: CalendarMode
-    selected: Date | DateRange | null
-    onSelect: (date: Date | DateRange | null) => void
+    selected: CalendarSelection
+    onSelect: (date: CalendarSelection) => void
     month: Date
     onMonthChange: (date: Date) => void
     motionDirection: number

--- a/packages/react/src/components/OneCalendar/granularities/week/index.tsx
+++ b/packages/react/src/components/OneCalendar/granularities/week/index.tsx
@@ -16,6 +16,7 @@ import {
 import {
   DateRange,
   DateRangeComplete,
+  OptionalCalendarSelection,
   WeekStartDay,
   WeekStartsOn,
 } from "../../types"
@@ -56,9 +57,7 @@ export const getIsSameWeek = (
     : isSameWeek(dateLeft, dateRight, { weekStartsOn })
 }
 
-export function toWeekGranularityDateRange<
-  T extends Date | DateRange | undefined | null,
->(
+export function toWeekGranularityDateRange<T extends OptionalCalendarSelection>(
   date: T,
   weekStartsOn: WeekStartsOn = WeekStartDay.Monday
 ): T extends Date | DateRange ? DateRangeComplete : T {

--- a/packages/react/src/components/OneCalendar/types.ts
+++ b/packages/react/src/components/OneCalendar/types.ts
@@ -22,6 +22,10 @@ export type DateRange = {
 
 export type DateRangeComplete = Required<DateRange>
 
+export type CalendarSelection = Date | DateRange | null
+
+export type OptionalCalendarSelection = CalendarSelection | undefined
+
 export type DateRangeString = {
   from: string
   to?: string

--- a/packages/react/src/components/OneCalendar/utils.ts
+++ b/packages/react/src/components/OneCalendar/utils.ts
@@ -2,7 +2,12 @@ import { format, isAfter, isBefore, isEqual, max, min } from "date-fns"
 import { Matcher } from "react-day-picker"
 import { GranularityDefinition } from "./granularities"
 import { rangeSeparator } from "./granularities/consts"
-import { DateRange, DateRangeComplete, DateRangeString } from "./types"
+import {
+  DateRange,
+  DateRangeComplete,
+  DateRangeString,
+  OptionalCalendarSelection,
+} from "./types"
 
 /**
  * Converts a date-fns format string to a human-readable placeholder pattern.
@@ -29,7 +34,7 @@ export const earliestDate = (a?: Date, b?: Date): Date | undefined =>
   a && b ? min([a, b]) : (a ?? b)
 
 export const toDateRange = (
-  value: Date | DateRange | undefined | null
+  value: OptionalCalendarSelection
 ): DateRange | undefined => {
   if (value instanceof Date) {
     return { from: value }
@@ -99,7 +104,7 @@ export const formatDate = (date: Date, formatStr: string): string => {
  * @returns
  */
 export const formatDateRange = (
-  date: Date | DateRange | undefined | null,
+  date: OptionalCalendarSelection,
   formatStr: string
 ): DateRangeString => {
   const dateRange = toDateRange(date)
@@ -120,7 +125,7 @@ export const formatDateRange = (
 }
 
 export const formatDateToString = (
-  date: Date | DateRange | undefined | null,
+  date: OptionalCalendarSelection,
   formatStr: string
 ): string => {
   const dateRange = formatDateRange(date, formatStr)
@@ -133,10 +138,8 @@ export const formatDateToString = (
   return `${from}${toPart}`
 }
 
-export function toGranularityDateRange<
-  T extends Date | DateRange | undefined | null,
->(
-  date: Date | DateRange | undefined | null,
+export function toGranularityDateRange<T extends OptionalCalendarSelection>(
+  date: OptionalCalendarSelection,
   fromFn: (date: Date) => Date,
   toFn: (date: Date) => Date
 ): T extends Date | DateRange ? DateRangeComplete : T {

--- a/packages/react/src/components/RichText/internal/Enhance/__tests__/useEnhance.test.tsx
+++ b/packages/react/src/components/RichText/internal/Enhance/__tests__/useEnhance.test.tsx
@@ -57,7 +57,7 @@ describe("useEnhance", () => {
       resolveEnhance({ success: true, text: "<p>Enhanced</p>" })
       await enhancePromise
     })
-    expect(editor.view.dom.querySelectorAll(".enhance-highlight").length).toBe(
+    expect(editor.view.dom.querySelectorAll(".enhance-highlight")).toHaveLength(
       0
     )
   })

--- a/packages/react/src/components/RichText/internal/Enhance/enhance.ts
+++ b/packages/react/src/components/RichText/internal/Enhance/enhance.ts
@@ -64,9 +64,11 @@ interface ApplyEnhancedTextResult {
 function applyEnhancedText(
   editor: Editor,
   enhancedText: string | JSONContent,
-  from: number,
-  to: number,
-  isFullDocumentSelected: boolean
+  {
+    from,
+    to,
+    isFullDocumentSelected,
+  }: { from: number; to: number; isFullDocumentSelected: boolean }
 ): ApplyEnhancedTextResult {
   if (isFullDocumentSelected) {
     editor.chain().focus().setContent(enhancedText).run()
@@ -160,14 +162,13 @@ async function handleEnhanceWithAIFunction({
     })
 
     if (success) {
-      const { highlightFrom, highlightTo } = applyEnhancedText(
-        editor,
-        text,
+      const { highlightFrom, highlightTo } = applyEnhancedText(editor, text, {
         from,
         to,
-        isFullDocumentSelected ||
-          textToEnhance.toString() === editor.getHTML().toString()
-      )
+        isFullDocumentSelected:
+          isFullDocumentSelected ||
+          textToEnhance.toString() === editor.getHTML().toString(),
+      })
       onSuccess({ from: highlightFrom, to: highlightTo })
     } else {
       onError(error)

--- a/packages/react/src/components/RichText/internal/Enhance/enhance.ts
+++ b/packages/react/src/components/RichText/internal/Enhance/enhance.ts
@@ -61,15 +61,21 @@ interface ApplyEnhancedTextResult {
   highlightTo: number
 }
 
-function applyEnhancedText(
-  editor: Editor,
-  enhancedText: string | JSONContent,
-  {
-    from,
-    to,
-    isFullDocumentSelected,
-  }: { from: number; to: number; isFullDocumentSelected: boolean }
-): ApplyEnhancedTextResult {
+type ApplyEnhancedTextOptions = {
+  editor: Editor
+  enhancedText: string | JSONContent
+  from: number
+  to: number
+  isFullDocumentSelected: boolean
+}
+
+function applyEnhancedText({
+  editor,
+  enhancedText,
+  from,
+  to,
+  isFullDocumentSelected,
+}: ApplyEnhancedTextOptions): ApplyEnhancedTextResult {
   if (isFullDocumentSelected) {
     editor.chain().focus().setContent(enhancedText).run()
     // For full document, highlight everything (1 to avoid the start, content.size - 1 to avoid the end)
@@ -162,7 +168,9 @@ async function handleEnhanceWithAIFunction({
     })
 
     if (success) {
-      const { highlightFrom, highlightTo } = applyEnhancedText(editor, text, {
+      const { highlightFrom, highlightTo } = applyEnhancedText({
+        editor,
+        enhancedText: text,
         from,
         to,
         isFullDocumentSelected:

--- a/packages/react/src/components/RichText/internal/Extensions/EnhanceHighlight/__tests__/index.test.ts
+++ b/packages/react/src/components/RichText/internal/Extensions/EnhanceHighlight/__tests__/index.test.ts
@@ -41,8 +41,8 @@ describe("EnhanceHighlight", () => {
     editor.commands.setEnhanceHighlight(0, to, { placeholder: "Loading..." })
 
     expect(
-      editor.view.dom.querySelectorAll(".enhance-highlight-placeholder").length
-    ).toBe(0)
+      editor.view.dom.querySelectorAll(".enhance-highlight-placeholder")
+    ).toHaveLength(0)
     expect(
       editor.view.dom.querySelectorAll(".enhance-highlight").length
     ).toBeGreaterThan(0)
@@ -52,7 +52,7 @@ describe("EnhanceHighlight", () => {
     const editor = createEditor("<p></p>")
     editor.commands.setEnhanceHighlight(0, editor.state.doc.content.size)
 
-    expect(editor.view.dom.querySelectorAll(".enhance-highlight").length).toBe(
+    expect(editor.view.dom.querySelectorAll(".enhance-highlight")).toHaveLength(
       0
     )
   })
@@ -68,8 +68,8 @@ describe("EnhanceHighlight", () => {
 
     editor.commands.clearEnhanceHighlight()
     expect(
-      editor.view.dom.querySelectorAll(".enhance-highlight-placeholder").length
-    ).toBe(0)
+      editor.view.dom.querySelectorAll(".enhance-highlight-placeholder")
+    ).toHaveLength(0)
   })
 
   it("clears decorations", () => {
@@ -79,7 +79,7 @@ describe("EnhanceHighlight", () => {
       editor.view.dom.querySelectorAll(".enhance-highlight").length
     ).toBeGreaterThan(0)
     editor.commands.clearEnhanceHighlight()
-    expect(editor.view.dom.querySelectorAll(".enhance-highlight").length).toBe(
+    expect(editor.view.dom.querySelectorAll(".enhance-highlight")).toHaveLength(
       0
     )
   })

--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -35,18 +35,15 @@ export const F0AvatarList = ({
   // destructuring, under these exact names, because the pattern is emitted
   // verbatim into the public .d.ts signature of `F0AvatarList`: dropping or
   // renaming them reads as a breaking public API change for props that still
-  // exist and still typecheck. `void` below satisfies `noUnusedLocals`.
+  // exist and still typecheck. The `_` names mark them as unused on purpose.
   //
   // `layout` is listed here rather than left out of the destructuring so the
   // ignore is deliberate in the code, not an omission a reader has to infer:
   // it was documented for long enough that both of its values already have a
   // home on `max` (unset = the old `"fill"`, a number = the old `"compact"`).
-  tooltipScroll,
-  layout,
+  tooltipScroll: _tooltipScroll,
+  layout: _layout,
 }: F0AvatarListProps) => {
-  void tooltipScroll
-  void layout
-
   // Check legacy size
   if (size && !avatarListSizes.includes(size)) {
     const sizesMappingList: Record<string, AvatarListSize> = {

--- a/packages/react/src/components/tags/F0TagBalance/types.ts
+++ b/packages/react/src/components/tags/F0TagBalance/types.ts
@@ -7,7 +7,7 @@ export interface NumericValue {
   number: number
   units?: string
   unitsPosition?: "left" | "right"
-  decimalPlaces?: number | undefined
+  decimalPlaces?: number
   locale?: string
 }
 

--- a/packages/react/src/deprecated/EntitySelect/index.stories.tsx
+++ b/packages/react/src/deprecated/EntitySelect/index.stories.tsx
@@ -763,7 +763,7 @@ export const WithDeactivatedEntities = {
   },
 }
 
-export const Error = {
+const ErrorState = {
   args: {
     ...defaultArgs,
     error: "This is an error",
@@ -785,3 +785,6 @@ export const Disabled = {
     disabled: true,
   },
 }
+
+// Exported under the global's name so the story id stays `--error`.
+export { ErrorState as Error }

--- a/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/__tests__/F0SegmentedControl.test.tsx
@@ -102,7 +102,7 @@ describe("F0SegmentedControl", () => {
     ]
     render(<F0SegmentedControl items={items} />)
     const svgs = document.querySelectorAll("svg")
-    expect(svgs.length).toBe(2)
+    expect(svgs).toHaveLength(2)
   })
 
   it("forwards ariaLabel to the underlying radiogroup", () => {

--- a/packages/react/src/experimental/F0MeetingCard/__tests__/utils.test.ts
+++ b/packages/react/src/experimental/F0MeetingCard/__tests__/utils.test.ts
@@ -244,13 +244,13 @@ describe("getDurationMinutes", () => {
     ).toBe(23)
     expect(
       getDurationMinutes(new Date("2026-03-12T09:00:00Z"), undefined)
-    ).toBe(undefined)
+    ).toBeUndefined()
     expect(
       getDurationMinutes(
         new Date("2026-03-12T09:00:00Z"),
         new Date("2026-03-12T09:00:00Z")
       )
-    ).toBe(undefined)
+    ).toBeUndefined()
   })
 })
 

--- a/packages/react/src/experimental/Lists/DataList/actions/CopyAction.tsx
+++ b/packages/react/src/experimental/Lists/DataList/actions/CopyAction.tsx
@@ -26,8 +26,8 @@ export const CopyAction = ({ text, children }: CopyActionProps) => {
     try {
       await navigator.clipboard.writeText(text)
       setCopied(true)
-    } catch (error) {
-      void error
+    } catch {
+      // Clipboard unavailable: leave the button as it is.
     }
   }
   return (

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/DragContext/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/DragContext/index.tsx
@@ -1,4 +1,5 @@
 import { createContext, ReactNode, useContext, useState } from "react"
+import { DropPosition } from "../types"
 
 interface DragContextType {
   isDragging: boolean
@@ -7,8 +8,8 @@ interface DragContextType {
   setDraggedItemId: (id: string | null) => void
   dragOverItemId: string | null
   setDragOverItemId: (id: string | null) => void
-  dragOverPosition: "before" | "after" | "inside" | null
-  setDragOverPosition: (position: "before" | "after" | "inside" | null) => void
+  dragOverPosition: DropPosition | null
+  setDragOverPosition: (position: DropPosition | null) => void
 }
 
 const DragContext = createContext<DragContextType | undefined>(undefined)
@@ -17,9 +18,9 @@ export function DragProvider({ children }: { children: ReactNode }) {
   const [isDragging, setIsDragging] = useState(false)
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null)
   const [dragOverItemId, setDragOverItemId] = useState<string | null>(null)
-  const [dragOverPosition, setDragOverPosition] = useState<
-    "before" | "after" | "inside" | null
-  >(null)
+  const [dragOverPosition, setDragOverPosition] = useState<DropPosition | null>(
+    null
+  )
   return (
     <DragContext.Provider
       value={{

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/Item/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/Item/index.tsx
@@ -7,7 +7,7 @@ import { motion } from "motion/react"
 import { ReactNode, useEffect, useMemo, useRef, useState } from "react"
 import { useDraggable } from "@/lib/dnd/hooks"
 import { cn } from "@/lib/utils"
-import { TOCItem } from "../types"
+import { DropPosition, TOCItem } from "../types"
 import { PrimitiveItem } from "./PrimitiveItem"
 
 interface TOCItemProps {
@@ -19,9 +19,9 @@ interface TOCItemProps {
   isExpanded?: boolean
   onToggleExpanded?: (id: string) => void
   children?: ReactNode
-  onDragOver?: (itemId: string, position: "before" | "after" | "inside") => void
+  onDragOver?: (itemId: string, position: DropPosition) => void
   onDragLeave?: () => void
-  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void
+  onDrop?: (itemId: string, position: DropPosition) => void
   canDropInside?: boolean
   currentParentId?: string | null
   draggedItemId?: string | null
@@ -190,7 +190,7 @@ export function Item({
       },
       onDrop: ({ self }) => {
         const data = self.data as { position?: string }
-        let position: "before" | "after" | "inside"
+        let position: DropPosition
 
         if (data.position === "inside") {
           position = "inside"

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/index.tsx
@@ -20,7 +20,13 @@ import { ScrollArea } from "@/ui/scrollarea"
 import { Item } from "./Item"
 import { ItemSectionHeader } from "./ItemSectionHeader"
 import { TOCFooter } from "./TOCFooter"
-import { TOCAction, TOCItem, TOCItemAction, TOCProps } from "./types"
+import {
+  DropPosition,
+  TOCAction,
+  TOCItem,
+  TOCItemAction,
+  TOCProps,
+} from "./types"
 import {
   calculateAdjustedIndex,
   convertToIds,
@@ -33,29 +39,48 @@ import {
   wouldCreateCycle,
 } from "./utils"
 
-function renderTOCItem(
-  item: TOCItem,
-  sortable: boolean,
-  depth: number,
-  activeItem?: string,
-  collapsible?: boolean,
-  hideChildrenCounter?: boolean,
-  expandedItems?: Set<string>,
-  onToggleExpanded?: (id: string) => void,
-  allItems?: TOCItem[],
-  draggedItemId?: string | null,
-  dragOverItemId?: string | null,
-  dragOverPosition?: "before" | "after" | "inside" | null,
-  onChildrenReorder?: (parentId: string) => (newOrder: TOCItem[]) => void,
-  currentParentId?: string | null,
-  onDragOver?: (
-    itemId: string,
-    position: "before" | "after" | "inside"
-  ) => void,
-  onDragLeave?: () => void,
-  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void,
+type RenderTOCItemProps = {
+  item: TOCItem
+  sortable: boolean
+  depth: number
+  activeItem?: string
+  collapsible?: boolean
+  hideChildrenCounter?: boolean
+  expandedItems?: Set<string>
+  onToggleExpanded?: (id: string) => void
+  allItems?: TOCItem[]
+  draggedItemId?: string | null
+  dragOverItemId?: string | null
+  dragOverPosition?: "before" | "after" | "inside" | null
+  onChildrenReorder?: (parentId: string) => (newOrder: TOCItem[]) => void
+  currentParentId?: string | null
+  onDragOver?: (itemId: string, position: "before" | "after" | "inside") => void
+  onDragLeave?: () => void
+  onDrop?: (itemId: string, position: "before" | "after" | "inside") => void
   justDroppedItemId?: string | null
-): ReactElement {
+}
+
+function renderTOCItem(props: RenderTOCItemProps): ReactElement {
+  const {
+    item,
+    sortable,
+    depth,
+    activeItem,
+    collapsible,
+    hideChildrenCounter,
+    expandedItems,
+    onToggleExpanded,
+    allItems,
+    draggedItemId,
+    dragOverItemId,
+    dragOverPosition,
+    onChildrenReorder,
+    currentParentId,
+    onDragOver,
+    onDragLeave,
+    onDrop,
+    justDroppedItemId,
+  } = props
   const Component = item.children ? ItemSectionHeader : Item
   const isExpanded = expandedItems?.has(item.id) ?? true
 
@@ -156,26 +181,13 @@ function renderTOCItem(
               )}
             >
               {item.children.map((child) => {
-                return renderTOCItem(
-                  child,
-                  sortable,
-                  depth + 1,
-                  activeItem,
-                  collapsible,
-                  hideChildrenCounter,
-                  expandedItems,
-                  onToggleExpanded,
-                  allItems,
-                  draggedItemId,
-                  dragOverItemId,
-                  dragOverPosition,
-                  sortable ? onChildrenReorder : undefined,
-                  item.id,
-                  onDragOver,
-                  onDragLeave,
-                  onDrop,
-                  justDroppedItemId
-                )
+                return renderTOCItem({
+                  ...props,
+                  item: child,
+                  depth: depth + 1,
+                  onChildrenReorder: sortable ? onChildrenReorder : undefined,
+                  currentParentId: item.id,
+                })
               })}
               {/* Placeholder when dragging inside and section is empty or collapsed */}
               {isDragOver &&
@@ -212,9 +224,9 @@ function EdgeDropZone({
 }: {
   targetItemId: string
   position: "before" | "after"
-  onDragOver: (itemId: string, position: "before" | "after" | "inside") => void
+  onDragOver: (itemId: string, position: DropPosition) => void
   onDragLeave: () => void
-  onDrop: (itemId: string, position: "before" | "after" | "inside") => void
+  onDrop: (itemId: string, position: DropPosition) => void
   visible: boolean
 }) {
   const ref = useRef<HTMLDivElement>(null)
@@ -401,9 +413,9 @@ function TOCContent({
   // State for drag and drop
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null)
   const [dragOverItemId, setDragOverItemId] = useState<string | null>(null)
-  const [dragOverPosition, setDragOverPosition] = useState<
-    "before" | "after" | "inside" | null
-  >(null)
+  const [dragOverPosition, setDragOverPosition] = useState<DropPosition | null>(
+    null
+  )
   const [justDroppedItemId, setJustDroppedItemId] = useState<string | null>(
     null
   )
@@ -414,13 +426,13 @@ function TOCContent({
   const handleDropCalledRef = useRef<boolean>(false)
   // Use refs to access current dragOver state in useDndEvents callback
   const dragOverItemIdRef = useRef<string | null>(null)
-  const dragOverPositionRef = useRef<"before" | "after" | "inside" | null>(null)
+  const dragOverPositionRef = useRef<DropPosition | null>(null)
 
   // Use refs to stabilize drag over updates and prevent flickering
   const dragOverTimeoutRef = useRef<NodeJS.Timeout | null>(null)
   const lastDragOverRef = useRef<{
     itemId: string
-    position: "before" | "after" | "inside"
+    position: DropPosition
   } | null>(null)
   const lastItemIndexRef = useRef<number | null>(null)
   // Track when the current state was set to add persistence
@@ -434,7 +446,7 @@ function TOCContent({
 
   // Handle drag over from Item component with debounce
   const handleDragOver = useCallback(
-    (itemId: string, position: "before" | "after" | "inside") => {
+    (itemId: string, position: DropPosition) => {
       // Cancel any pending timeout
       if (dragOverTimeoutRef.current) {
         clearTimeout(dragOverTimeoutRef.current)
@@ -605,7 +617,7 @@ function TOCContent({
 
   // Handle drop from Item component
   const handleDrop = useCallback(
-    (targetItemId: string, position: "before" | "after" | "inside") => {
+    (targetItemId: string, position: DropPosition) => {
       // Mark that handleDrop has been called to prevent safety timeout from clearing state
       handleDropCalledRef.current = true
 
@@ -934,26 +946,26 @@ function TOCContent({
               />
             ) : null}
             {displayItems.map((item) =>
-              renderTOCItem(
+              renderTOCItem({
                 item,
                 sortable,
-                0,
+                depth: 0,
                 activeItem,
                 collapsible,
                 hideChildrenCounter,
                 expandedItems,
-                handleToggleExpanded,
-                sortableItems,
+                onToggleExpanded: handleToggleExpanded,
+                allItems: sortableItems,
                 draggedItemId,
                 dragOverItemId,
                 dragOverPosition,
-                sortable ? handleChildrenReorder : undefined,
-                null,
-                handleDragOver,
-                handleDragLeave,
-                handleDrop,
-                justDroppedItemId
-              )
+                onChildrenReorder: sortable ? handleChildrenReorder : undefined,
+                currentParentId: null,
+                onDragOver: handleDragOver,
+                onDragLeave: handleDragLeave,
+                onDrop: handleDrop,
+                justDroppedItemId,
+              })
             )}
             {sortable && lastItem ? (
               <EdgeDropZone

--- a/packages/react/src/experimental/Navigation/F0TableOfContent/types.ts
+++ b/packages/react/src/experimental/Navigation/F0TableOfContent/types.ts
@@ -20,6 +20,8 @@ export type TOCItem<Depth extends 1 | 2 | 3 | 4 = 1> = BaseTOCItem & {
     : TOCItem<NextDepth<Depth>>[]
 }
 
+export type DropPosition = "before" | "after" | "inside"
+
 export type TOCItemAction =
   | {
       label: string

--- a/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
+++ b/packages/react/src/experimental/Navigation/Header/Breadcrumbs/internal/BreadcrumbCollectionSelect/index.test.tsx
@@ -185,9 +185,11 @@ const concretelyTypedItem = (
   getItemHref: (value: string, employee?: Employee) =>
     employee ? `/employees/${value}` : undefined,
 })
-void concretelyTypedItem
-
 describe("BreadcrumbCollectionSelect", () => {
+  it("accepts a concretely typed collection item", () => {
+    expect(concretelyTypedItem).toBeTypeOf("function")
+  })
+
   it("seeds the persisted filters and sortings into the fetch", async () => {
     localStorage.setItem(
       STORAGE_KEY,

--- a/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/store.test.ts
+++ b/packages/react/src/experimental/Overlays/F0Coachmark/__tests__/store.test.ts
@@ -100,7 +100,7 @@ describe("coachmarkStore", () => {
   // stacked on the same target.
   describe("renderer election", () => {
     it("elects the lowest mounted id and hands over on release", () => {
-      expect(coachmarkStore.getActiveRendererId()).toBe(null)
+      expect(coachmarkStore.getActiveRendererId()).toBeNull()
       expect(coachmarkStore.hasProvider()).toBe(false)
 
       const first = coachmarkStore.acquireRenderer()
@@ -114,7 +114,7 @@ describe("coachmarkStore", () => {
       expect(coachmarkStore.getActiveRendererId()).toBe(second.id)
 
       second.release()
-      expect(coachmarkStore.getActiveRendererId()).toBe(null)
+      expect(coachmarkStore.getActiveRendererId()).toBeNull()
       expect(coachmarkStore.hasProvider()).toBe(false)
     })
 

--- a/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
@@ -120,7 +120,7 @@ describe("useData", () => {
       })
       expect(result.current.isLoading).toBe(false)
       expect(result.current.isInitialLoading).toBe(false)
-      expect(result.current.error).toBe(null)
+      expect(result.current.error).toBeNull()
     })
 
     it("should handle synchronous paginated data", async () => {

--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -635,7 +635,7 @@ export function useData<
     currentPage?: number
     appendMode?: boolean
     cursor?: string | null
-    search?: string | undefined
+    search?: string
   }
 
   const fetchDataAndUpdate = useCallback(

--- a/packages/react/src/hooks/datasource/useDataSource.ts
+++ b/packages/react/src/hooks/datasource/useDataSource.ts
@@ -23,7 +23,7 @@ import { SearchOptions } from "./types/search.typings"
  */
 
 export const getDataSourcePaginationType = <
-  D extends { paginationType?: PaginationType | undefined },
+  D extends { paginationType?: PaginationType },
 >(
   dataAdapter: D
 ): PaginationType => {

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -626,8 +626,8 @@ describe("BarChart — stacked segment polish", () => {
     const series = getMainSeries()
     for (const entry of series) {
       expect(entry?.emphasis?.focus).toBe("series")
-      expect(entry?.blur?.itemStyle?.opacity).toBe(0.4)
-      expect(entry?.blur?.label?.opacity).toBe(0.4)
+      expect(entry?.blur?.itemStyle?.opacity).toBeCloseTo(0.4)
+      expect(entry?.blur?.label?.opacity).toBeCloseTo(0.4)
     }
   })
 
@@ -652,7 +652,7 @@ describe("BarChart — stacked segment polish", () => {
     // [main, target] — the ghost is a separate series, so `focus: "series"`
     // blurs it too; it must dim to the same 40%.
     const target = getMainSeries()[1]
-    expect(target?.blur?.itemStyle?.opacity).toBe(0.4)
+    expect(target?.blur?.itemStyle?.opacity).toBeCloseTo(0.4)
   })
 
   it("runs the blur cross-fade without animating entrance or updates", () => {
@@ -714,7 +714,7 @@ describe("BarChart — stacked segment polish", () => {
       // just arrives instantly instead of fading.
       expect(getAnimationOptions().stateAnimation?.duration).toBe(0)
       expect(getMainSeries()[0]?.emphasis?.focus).toBe("series")
-      expect(getMainSeries()[0]?.blur?.itemStyle?.opacity).toBe(0.4)
+      expect(getMainSeries()[0]?.blur?.itemStyle?.opacity).toBeCloseTo(0.4)
     })
 
     it("overrides a consumer-provided cross-fade duration", () => {

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -531,6 +531,8 @@ function buildBorderRadiusResolver(
  *  2. A stacked "target" bar showing `target - value` with a linear gradient fill
  */
 type BuildSeriesEntriesOptions = {
+  series: F0DataChartBarSeries
+  index: number
   isVertical: boolean
   showLabels: boolean
   stacked: boolean
@@ -543,22 +545,20 @@ type BuildSeriesEntriesOptions = {
   valueFormatter?: (value: number) => string
 }
 
-function buildSeriesEntries(
-  series: F0DataChartBarSeries,
-  index: number,
-  {
-    isVertical,
-    showLabels,
-    stacked,
-    highlightOverachievement,
-    labelColor,
-    stackGapColor,
-    labelFontSize,
-    resolveBorderRadius,
-    labelLayout,
-    valueFormatter,
-  }: BuildSeriesEntriesOptions
-): echarts.BarSeriesOption[] {
+function buildSeriesEntries({
+  series,
+  index,
+  isVertical,
+  showLabels,
+  stacked,
+  highlightOverachievement,
+  labelColor,
+  stackGapColor,
+  labelFontSize,
+  resolveBorderRadius,
+  labelLayout,
+  valueFormatter,
+}: BuildSeriesEntriesOptions): echarts.BarSeriesOption[] {
   const color = resolveColor(series, index)
   const hasTargetData = hasTargets(series)
   // When stacked, all series share "stacked"; when using targets, each series
@@ -877,20 +877,21 @@ function stackTotals(
  * still reads as the full total. The tooltip's total behaves the same way, so
  * the two stay consistent with each other.
  */
-function buildStackTotalSeries(
-  totals: number[],
-  {
-    labelColor,
-    labelFontSize,
-    containerWidth,
-    valueFormatter,
-  }: {
-    labelColor: string
-    labelFontSize: number
-    containerWidth: number
-    valueFormatter?: (value: number) => string
-  }
-): echarts.BarSeriesOption {
+type BuildStackTotalSeriesOptions = {
+  totals: number[]
+  labelColor: string
+  labelFontSize: number
+  containerWidth: number
+  valueFormatter?: (value: number) => string
+}
+
+function buildStackTotalSeries({
+  totals,
+  labelColor,
+  labelFontSize,
+  containerWidth,
+  valueFormatter,
+}: BuildStackTotalSeriesOptions): echarts.BarSeriesOption {
   return {
     name: STACK_TOTAL_SERIES_NAME,
     type: "bar",
@@ -1138,7 +1139,9 @@ export function useBarChartOptions(
 
     // Build all ECharts series (including target ghost bars)
     const echartsSeries = series.flatMap((s, i) =>
-      buildSeriesEntries(s, i, {
+      buildSeriesEntries({
+        series: s,
+        index: i,
         isVertical,
         showLabels,
         stacked,
@@ -1163,7 +1166,8 @@ export function useBarChartOptions(
         : undefined
     if (totals) {
       echartsSeries.push(
-        buildStackTotalSeries(totals, {
+        buildStackTotalSeries({
+          totals,
           labelColor: theme.colors.foregroundSecondary,
           labelFontSize: resolvedLabelFontSize,
           containerWidth,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -530,19 +530,34 @@ function buildBorderRadiusResolver(
  *  1. The main (solid) bar showing `value`
  *  2. A stacked "target" bar showing `target - value` with a linear gradient fill
  */
+type BuildSeriesEntriesOptions = {
+  isVertical: boolean
+  showLabels: boolean
+  stacked: boolean
+  highlightOverachievement: boolean
+  labelColor: string
+  stackGapColor: string
+  labelFontSize: number
+  resolveBorderRadius: BorderRadiusResolver | undefined
+  labelLayout?: echarts.BarSeriesOption["labelLayout"]
+  valueFormatter?: (value: number) => string
+}
+
 function buildSeriesEntries(
   series: F0DataChartBarSeries,
   index: number,
-  isVertical: boolean,
-  showLabels: boolean,
-  stacked: boolean,
-  highlightOverachievement: boolean,
-  labelColor: string,
-  stackGapColor: string,
-  labelFontSize: number,
-  resolveBorderRadius: BorderRadiusResolver | undefined,
-  labelLayout?: echarts.BarSeriesOption["labelLayout"],
-  valueFormatter?: (value: number) => string
+  {
+    isVertical,
+    showLabels,
+    stacked,
+    highlightOverachievement,
+    labelColor,
+    stackGapColor,
+    labelFontSize,
+    resolveBorderRadius,
+    labelLayout,
+    valueFormatter,
+  }: BuildSeriesEntriesOptions
 ): echarts.BarSeriesOption[] {
   const color = resolveColor(series, index)
   const hasTargetData = hasTargets(series)
@@ -864,10 +879,17 @@ function stackTotals(
  */
 function buildStackTotalSeries(
   totals: number[],
-  labelColor: string,
-  labelFontSize: number,
-  containerWidth: number,
-  valueFormatter?: (value: number) => string
+  {
+    labelColor,
+    labelFontSize,
+    containerWidth,
+    valueFormatter,
+  }: {
+    labelColor: string
+    labelFontSize: number
+    containerWidth: number
+    valueFormatter?: (value: number) => string
+  }
 ): echarts.BarSeriesOption {
   return {
     name: STACK_TOTAL_SERIES_NAME,
@@ -1116,20 +1138,19 @@ export function useBarChartOptions(
 
     // Build all ECharts series (including target ghost bars)
     const echartsSeries = series.flatMap((s, i) =>
-      buildSeriesEntries(
-        s,
-        i,
+      buildSeriesEntries(s, i, {
         isVertical,
         showLabels,
         stacked,
         highlightOverachievement,
-        theme.colors.foregroundSecondary,
-        theme.colors.containerBackground ?? theme.colors.background,
-        resolvedLabelFontSize,
+        labelColor: theme.colors.foregroundSecondary,
+        stackGapColor:
+          theme.colors.containerBackground ?? theme.colors.background,
+        labelFontSize: resolvedLabelFontSize,
         resolveBorderRadius,
         labelLayout,
-        valueFormatter
-      )
+        valueFormatter,
+      })
     )
 
     // A horizontal stacked bar reads as one quantity split into parts, so the
@@ -1142,13 +1163,12 @@ export function useBarChartOptions(
         : undefined
     if (totals) {
       echartsSeries.push(
-        buildStackTotalSeries(
-          totals,
-          theme.colors.foregroundSecondary,
-          resolvedLabelFontSize,
+        buildStackTotalSeries(totals, {
+          labelColor: theme.colors.foregroundSecondary,
+          labelFontSize: resolvedLabelFontSize,
           containerWidth,
-          valueFormatter
-        )
+          valueFormatter,
+        })
       )
     }
 

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -72,11 +72,19 @@ function buildAreaStyle(color: string): echarts.LineSeriesOption["areaStyle"] {
 function buildSeriesEntry(
   series: F0DataChartLineSeries,
   index: number,
-  globalLineType: F0DataChartLineType,
-  globalShowArea: boolean,
-  showDots: boolean,
-  showLabels: boolean,
-  labelColor: string
+  {
+    globalLineType,
+    globalShowArea,
+    showDots,
+    showLabels,
+    labelColor,
+  }: {
+    globalLineType: F0DataChartLineType
+    globalShowArea: boolean
+    showDots: boolean
+    showLabels: boolean
+    labelColor: string
+  }
 ): echarts.LineSeriesOption {
   const color = resolveColor(series, index)
   const lineType = series.lineType ?? globalLineType
@@ -182,11 +190,13 @@ export function useLineChartOptions(
         // accidentally re-enable area on a single series in `buildSeriesEntry`.
         isMultiSeries ? { ...s, showArea: false } : s,
         i,
-        lineType,
-        effectiveShowArea,
-        showDots,
-        showLabels,
-        theme.colors.foregroundSecondary
+        {
+          globalLineType: lineType,
+          globalShowArea: effectiveShowArea,
+          showDots,
+          showLabels,
+          labelColor: theme.colors.foregroundSecondary,
+        }
       )
     )
 

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -69,23 +69,25 @@ function buildAreaStyle(color: string): echarts.LineSeriesOption["areaStyle"] {
 /**
  * Build a single ECharts line series entry from an F0DataChartLineSeries.
  */
-function buildSeriesEntry(
-  series: F0DataChartLineSeries,
-  index: number,
-  {
-    globalLineType,
-    globalShowArea,
-    showDots,
-    showLabels,
-    labelColor,
-  }: {
-    globalLineType: F0DataChartLineType
-    globalShowArea: boolean
-    showDots: boolean
-    showLabels: boolean
-    labelColor: string
-  }
-): echarts.LineSeriesOption {
+type BuildSeriesEntryOptions = {
+  series: F0DataChartLineSeries
+  index: number
+  globalLineType: F0DataChartLineType
+  globalShowArea: boolean
+  showDots: boolean
+  showLabels: boolean
+  labelColor: string
+}
+
+function buildSeriesEntry({
+  series,
+  index,
+  globalLineType,
+  globalShowArea,
+  showDots,
+  showLabels,
+  labelColor,
+}: BuildSeriesEntryOptions): echarts.LineSeriesOption {
   const color = resolveColor(series, index)
   const lineType = series.lineType ?? globalLineType
   const showArea = series.showArea ?? globalShowArea
@@ -185,19 +187,17 @@ export function useLineChartOptions(
     const { showCategoryAxis, showValueAxis } = responsive
 
     const echartsSeries = series.map((s, i) =>
-      buildSeriesEntry(
-        // When forced off, also strip the per-series override so it doesn't
-        // accidentally re-enable area on a single series in `buildSeriesEntry`.
-        isMultiSeries ? { ...s, showArea: false } : s,
-        i,
-        {
-          globalLineType: lineType,
-          globalShowArea: effectiveShowArea,
-          showDots,
-          showLabels,
-          labelColor: theme.colors.foregroundSecondary,
-        }
-      )
+      buildSeriesEntry({
+        series: // When forced off, also strip the per-series override so it doesn't
+          // accidentally re-enable area on a single series in `buildSeriesEntry`.
+          isMultiSeries ? { ...s, showArea: false } : s,
+        index: i,
+        globalLineType: lineType,
+        globalShowArea: effectiveShowArea,
+        showDots,
+        showLabels,
+        labelColor: theme.colors.foregroundSecondary,
+      })
     )
 
     const legendData = series.map((s) => s.name)

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -644,7 +644,9 @@ export function buildTooltip({
       fontSize: 14,
     },
     // Smart position: flip tooltip to the other side of the cursor at the
-    // chart midpoint so it never clips outside the container
+    // chart midpoint so it never clips outside the container. The parameter
+    // list is ECharts' callback signature.
+    // oxlint-disable-next-line max-params
     position(
       point: [number, number],
       _params: unknown,

--- a/packages/react/src/kits/ai/F0ActionItem/components/globeSpinMath.ts
+++ b/packages/react/src/kits/ai/F0ActionItem/components/globeSpinMath.ts
@@ -71,6 +71,9 @@ function qRot(ax: number, ay: number, az: number, ang: number): Q {
 // hot loop doesn't allocate a 3-tuple per call (~1100 allocations/frame saved).
 const _scratchV: V = [0, 0, 0]
 
+// Hot path (runs per vertex per frame). Primitives avoid allocating a vector
+// per call.
+// oxlint-disable-next-line max-params
 function rotVecInto(q: Q, x: number, y: number, z: number, out: V): void {
   const w = q[0]
   const qx = q[1]

--- a/packages/react/src/kits/ai/F0AiChat/__stories__/_mock/MockAiChatRuntime.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__stories__/_mock/MockAiChatRuntime.tsx
@@ -201,6 +201,20 @@ const buildAssistantMessage = (content: string): F0Message => ({
   role: "assistant",
   content,
 })
+const withMessageContent = (
+  messages: F0Message[],
+  id: string,
+  content: string
+): F0Message[] => {
+  const idx = messages.findIndex((m) => m.id === id)
+  if (idx === -1) {
+    return messages
+  }
+  const next = messages.slice()
+  next[idx] = { ...next[idx], content }
+  return next
+}
+
 const buildUserMessage = (content: string): F0Message => ({
   id: nextId(),
   role: "user",
@@ -481,6 +495,26 @@ export const MockAiChatRuntimeProvider = ({
     []
   )
 
+  const streamText = useCallback((assistantId: string, response: string) => {
+    setMessages((prev) => [
+      ...prev,
+      { id: assistantId, role: "assistant", content: "" },
+    ])
+
+    let charIndex = 0
+    const streamInterval = setInterval(() => {
+      charIndex += 1
+      const partial = response.slice(0, charIndex)
+      setMessages((prev) => withMessageContent(prev, assistantId, partial))
+
+      if (charIndex >= response.length) {
+        clearInterval(streamInterval)
+        setInProgress(false)
+      }
+    }, CHAR_INTERVAL_MS)
+    intervalsRef.current.push(streamInterval)
+  }, [])
+
   const streamAssistantResponse = useCallback(() => {
     const thinkingSteps = pickRandomThinkingSteps(3)
     const response =
@@ -494,38 +528,15 @@ export const MockAiChatRuntimeProvider = ({
       const totalThinkingMs = emitThinkingSteps(thinkingSteps, thinkingId)
 
       // Once thinking is done, open the assistant text message and stream chars.
-      const startText = setTimeout(() => {
-        setMessages((prev) => [
-          ...prev,
-          { id: assistantId, role: "assistant", content: "" },
-        ])
-
-        let charIndex = 0
-        const streamInterval = setInterval(() => {
-          charIndex += 1
-          const partial = response.slice(0, charIndex)
-          setMessages((prev) => {
-            const idx = prev.findIndex((m) => m.id === assistantId)
-            if (idx === -1) {
-              return prev
-            }
-            const next = prev.slice()
-            next[idx] = { ...next[idx], content: partial }
-            return next
-          })
-
-          if (charIndex >= response.length) {
-            clearInterval(streamInterval)
-            setInProgress(false)
-          }
-        }, CHAR_INTERVAL_MS)
-        intervalsRef.current.push(streamInterval)
-      }, totalThinkingMs)
+      const startText = setTimeout(
+        () => streamText(assistantId, response),
+        totalThinkingMs
+      )
       timersRef.current.push(startText)
     }, THINKING_DELAY_MS)
 
     timersRef.current.push(startThinking)
-  }, [emitThinkingSteps])
+  }, [emitThinkingSteps, streamText])
 
   const sendMessage = useCallback(
     (text: string, options?: { replyQuote?: string }) => {
@@ -876,24 +887,28 @@ export const MockAiChatRuntimeProvider = ({
     [threads]
   )
 
+  const removeThread = useCallback((id: string) => {
+    setThreads((prev) => prev.filter((thread) => thread.id !== id))
+    // If the deleted thread is the one currently loaded, clear it.
+    setCurrentThreadId((current) => {
+      if (current !== id) {
+        return current
+      }
+      setCurrentThreadTitle(null)
+      return null
+    })
+  }, [])
+
   const deleteThread = useCallback<MockAiChatRuntime["deleteThread"]>(
     (id) =>
       new Promise((resolve) => {
         const t = setTimeout(() => {
-          setThreads((prev) => prev.filter((thread) => thread.id !== id))
-          // If the deleted thread is the one currently loaded, clear it.
-          setCurrentThreadId((current) => {
-            if (current !== id) {
-              return current
-            }
-            setCurrentThreadTitle(null)
-            return null
-          })
+          removeThread(id)
           resolve()
         }, 200)
         timersRef.current.push(t)
       }),
-    []
+    [removeThread]
   )
 
   const loadThread = useCallback<MockAiChatRuntime["loadThread"]>(

--- a/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -91,15 +91,16 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   const [chatWidth, setChatWidth] = usePersistedState<number>(
     CHAT_WIDTH_STORAGE_KEY,
     DEFAULT_CHAT_WIDTH,
-    (v): v is number =>
-      typeof v === "number" &&
-      !isNaN(v) &&
-      v >= CHAT_WIDTH_MIN &&
-      v <= CHAT_WIDTH_MAX,
-    undefined,
-    // The only continuously-changing persisted value: a drag would otherwise
-    // mean one synchronous localStorage write per animation frame.
-    CHAT_WIDTH_PERSIST_DEBOUNCE_MS
+    {
+      validate: (v): v is number =>
+        typeof v === "number" &&
+        !isNaN(v) &&
+        v >= CHAT_WIDTH_MIN &&
+        v <= CHAT_WIDTH_MAX,
+      // The only continuously-changing persisted value: a drag would otherwise
+      // mean one synchronous localStorage write per animation frame.
+      debounceMs: CHAT_WIDTH_PERSIST_DEBOUNCE_MS,
+    }
   )
 
   // Not persisted: this is the live state of a pointer drag, not a preference.
@@ -108,7 +109,7 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   const [open, setOpen] = usePersistedState<boolean>(
     CHAT_OPEN_STORAGE_KEY,
     defaultVisualizationMode === "fullscreen",
-    (v): v is boolean => typeof v === "boolean"
+    { validate: (v): v is boolean => typeof v === "boolean" }
   )
 
   const fallbackVisualizationMode: VisualizationMode =
@@ -119,8 +120,11 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
     usePersistedState<VisualizationMode>(
       CHAT_VISUALIZATION_MODE_STORAGE_KEY,
       fallbackVisualizationMode,
-      (v): v is VisualizationMode => v === "sidepanel" || v === "fullscreen",
-      isPersistableVisualizationMode
+      {
+        validate: (v): v is VisualizationMode =>
+          v === "sidepanel" || v === "fullscreen",
+        shouldWrite: isPersistableVisualizationMode,
+      }
     )
 
   const [mode, setMode] = useState<AiChatMode>("chat")
@@ -293,11 +297,9 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   // persist only its id so a reload can reopen WHAT was showing, not just that
   // the panel was open. The host re-mounts the content when it's loaded.
   const [persistedPanelContentId, setPersistedPanelContentId] =
-    usePersistedState<string | null>(
-      CHAT_PANEL_CONTENT_ID_STORAGE_KEY,
-      null,
-      (v): v is string | null => v === null || typeof v === "string"
-    )
+    usePersistedState<string | null>(CHAT_PANEL_CONTENT_ID_STORAGE_KEY, null, {
+      validate: (v): v is string | null => v === null || typeof v === "string",
+    })
 
   // Pending restore: the panel reopened (persisted `open`) while hosted
   // content was up on the last session. Until the host re-mounts it (via

--- a/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -88,44 +88,40 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   const [footer, setFooter] = useState<ReactNode | undefined>(initialFooter)
   const [enabledInternal, setEnabledInternal] = useState(enabled)
 
-  const [chatWidth, setChatWidth] = usePersistedState<number>(
-    CHAT_WIDTH_STORAGE_KEY,
-    DEFAULT_CHAT_WIDTH,
-    {
-      validate: (v): v is number =>
-        typeof v === "number" &&
-        !isNaN(v) &&
-        v >= CHAT_WIDTH_MIN &&
-        v <= CHAT_WIDTH_MAX,
-      // The only continuously-changing persisted value: a drag would otherwise
-      // mean one synchronous localStorage write per animation frame.
-      debounceMs: CHAT_WIDTH_PERSIST_DEBOUNCE_MS,
-    }
-  )
+  const [chatWidth, setChatWidth] = usePersistedState<number>({
+    key: CHAT_WIDTH_STORAGE_KEY,
+    fallback: DEFAULT_CHAT_WIDTH,
+    validate: (v): v is number =>
+      typeof v === "number" &&
+      !isNaN(v) &&
+      v >= CHAT_WIDTH_MIN &&
+      v <= CHAT_WIDTH_MAX,
+    // The only continuously-changing persisted value: a drag would otherwise
+    // mean one synchronous localStorage write per animation frame.
+    debounceMs: CHAT_WIDTH_PERSIST_DEBOUNCE_MS,
+  })
 
   // Not persisted: this is the live state of a pointer drag, not a preference.
   const [isResizing, setIsResizing] = useState(false)
 
-  const [open, setOpen] = usePersistedState<boolean>(
-    CHAT_OPEN_STORAGE_KEY,
-    defaultVisualizationMode === "fullscreen",
-    { validate: (v): v is boolean => typeof v === "boolean" }
-  )
+  const [open, setOpen] = usePersistedState<boolean>({
+    key: CHAT_OPEN_STORAGE_KEY,
+    fallback: defaultVisualizationMode === "fullscreen",
+    validate: (v): v is boolean => typeof v === "boolean",
+  })
 
   const fallbackVisualizationMode: VisualizationMode =
     defaultVisualizationMode === "canvas"
       ? "sidepanel"
       : defaultVisualizationMode
   const [visualizationMode, setVisualizationModeRaw] =
-    usePersistedState<VisualizationMode>(
-      CHAT_VISUALIZATION_MODE_STORAGE_KEY,
-      fallbackVisualizationMode,
-      {
-        validate: (v): v is VisualizationMode =>
-          v === "sidepanel" || v === "fullscreen",
-        shouldWrite: isPersistableVisualizationMode,
-      }
-    )
+    usePersistedState<VisualizationMode>({
+      key: CHAT_VISUALIZATION_MODE_STORAGE_KEY,
+      fallback: fallbackVisualizationMode,
+      validate: (v): v is VisualizationMode =>
+        v === "sidepanel" || v === "fullscreen",
+      shouldWrite: isPersistableVisualizationMode,
+    })
 
   const [mode, setMode] = useState<AiChatMode>("chat")
   const [shouldPlayEntranceAnimation, setShouldPlayEntranceAnimation] =
@@ -297,7 +293,9 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   // persist only its id so a reload can reopen WHAT was showing, not just that
   // the panel was open. The host re-mounts the content when it's loaded.
   const [persistedPanelContentId, setPersistedPanelContentId] =
-    usePersistedState<string | null>(CHAT_PANEL_CONTENT_ID_STORAGE_KEY, null, {
+    usePersistedState<string | null>({
+      key: CHAT_PANEL_CONTENT_ID_STORAGE_KEY,
+      fallback: null,
       validate: (v): v is string | null => v === null || typeof v === "string",
     })
 

--- a/packages/react/src/kits/ai/F0AiChat/providers/usePersistedState.ts
+++ b/packages/react/src/kits/ai/F0AiChat/providers/usePersistedState.ts
@@ -12,24 +12,31 @@ import {
  * @param key       localStorage key.
  * @param fallback  Value when nothing is stored or the stored value
  *                  fails `validate`.
- * @param validate  Optional predicate. Run against the stored value;
- *                  when it returns false the `fallback` is used.
- * @param shouldWrite Optional predicate that gates persistence. Defaults
- *                  to "always write". Useful for transient sub-states
- *                  that shouldn't be persisted (e.g. visualizationMode's
- *                  "canvas" overlay).
- * @param debounceMs Delay before persisting. Default 0 — durable state must
- *                  survive the tab closing on the next tick. Only continuous
- *                  values need it (the panel width changes once per frame for
- *                  the length of a drag, and each write is a synchronous
- *                  `localStorage.setItem`).
  */
 export function usePersistedState<T>(
   key: string,
   fallback: T,
-  validate?: (stored: unknown) => stored is T,
-  shouldWrite?: (value: T) => boolean,
-  debounceMs = 0
+  {
+    validate,
+    shouldWrite,
+    debounceMs = 0,
+  }: {
+    /** Run against the stored value; when it returns false the `fallback` is used. */
+    validate?: (stored: unknown) => stored is T
+    /**
+     * Gates persistence. Defaults to "always write". Useful for transient
+     * sub-states that shouldn't be persisted (e.g. visualizationMode's
+     * "canvas" overlay).
+     */
+    shouldWrite?: (value: T) => boolean
+    /**
+     * Delay before persisting. Default 0 — durable state must survive the tab
+     * closing on the next tick. Only continuous values need it (the panel
+     * width changes once per frame for the length of a drag, and each write
+     * is a synchronous `localStorage.setItem`).
+     */
+    debounceMs?: number
+  } = {}
 ): [T, React.Dispatch<React.SetStateAction<T>>] {
   const [value, setValue] = useState<T>(() => {
     if (typeof window === "undefined") {

--- a/packages/react/src/kits/ai/F0AiChat/providers/usePersistedState.ts
+++ b/packages/react/src/kits/ai/F0AiChat/providers/usePersistedState.ts
@@ -4,40 +4,40 @@ import {
   writeToLocalStorage,
 } from "../utils/local-storage"
 
+export type UsePersistedStateOptions<T> = {
+  /** localStorage key. */
+  key: string
+  /** Value when nothing is stored or the stored value fails `validate`. */
+  fallback: T
+  /** Run against the stored value; when it returns false the `fallback` is used. */
+  validate?: (stored: unknown) => stored is T
+  /**
+   * Gates persistence. Defaults to "always write". Useful for transient
+   * sub-states that shouldn't be persisted (e.g. visualizationMode's
+   * "canvas" overlay).
+   */
+  shouldWrite?: (value: T) => boolean
+  /**
+   * Delay before persisting. Default 0 — durable state must survive the tab
+   * closing on the next tick. Only continuous values need it (the panel
+   * width changes once per frame for the length of a drag, and each write
+   * is a synchronous `localStorage.setItem`).
+   */
+  debounceMs?: number
+}
+
 /**
  * State persisted to localStorage. Reads the stored value once on mount
  * (no re-reads, so a delayed mount of the provider still picks up the
  * persisted value), and writes back whenever the state changes.
- *
- * @param key       localStorage key.
- * @param fallback  Value when nothing is stored or the stored value
- *                  fails `validate`.
  */
-export function usePersistedState<T>(
-  key: string,
-  fallback: T,
-  {
-    validate,
-    shouldWrite,
-    debounceMs = 0,
-  }: {
-    /** Run against the stored value; when it returns false the `fallback` is used. */
-    validate?: (stored: unknown) => stored is T
-    /**
-     * Gates persistence. Defaults to "always write". Useful for transient
-     * sub-states that shouldn't be persisted (e.g. visualizationMode's
-     * "canvas" overlay).
-     */
-    shouldWrite?: (value: T) => boolean
-    /**
-     * Delay before persisting. Default 0 — durable state must survive the tab
-     * closing on the next tick. Only continuous values need it (the panel
-     * width changes once per frame for the length of a drag, and each write
-     * is a synchronous `localStorage.setItem`).
-     */
-    debounceMs?: number
-  } = {}
-): [T, React.Dispatch<React.SetStateAction<T>>] {
+export function usePersistedState<T>({
+  key,
+  fallback,
+  validate,
+  shouldWrite,
+  debounceMs = 0,
+}: UsePersistedStateOptions<T>): [T, React.Dispatch<React.SetStateAction<T>>] {
   const [value, setValue] = useState<T>(() => {
     if (typeof window === "undefined") {
       return fallback

--- a/packages/react/src/kits/ai/F0AiChatHistory/__stories__/F0AiChatHistory.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHistory/__stories__/F0AiChatHistory.stories.tsx
@@ -82,7 +82,7 @@ export const Empty: Story = {
   },
 }
 
-export const Error: Story = {
+const ErrorState: Story = {
   args: {
     ...baseArgs,
     threads: [],
@@ -111,3 +111,6 @@ export const WithPinned: Story = {
     pinnedIds: new Set(["t1", "t3"]),
   },
 }
+
+// Exported under the global's name so the story id stays `--error`.
+export { ErrorState as Error }

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/TypewriterPlaceholder.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/TypewriterPlaceholder.tsx
@@ -77,6 +77,25 @@ export const TypewriterPlaceholder = ({
     const pauseBeforeDelete = 2000
     const pauseBeforeNext = 1000
 
+    const startDeleting = () => {
+      deleteIntervalRef.current = setInterval(() => {
+        if (currentIndex > 0) {
+          currentIndex--
+          setDisplayedPlaceholder(placeholderText.slice(0, currentIndex))
+        } else {
+          if (deleteIntervalRef.current) {
+            clearInterval(deleteIntervalRef.current)
+            deleteIntervalRef.current = null
+          }
+          placeholderTimeoutRef.current = setTimeout(() => {
+            const nextIndex =
+              (currentPlaceholderIndex + 1) % Math.max(placeholders.length, 1)
+            setCurrentPlaceholderIndex(nextIndex)
+          }, pauseBeforeNext)
+        }
+      }, deleteSpeed)
+    }
+
     typeIntervalRef.current = setInterval(() => {
       if (currentIndex < placeholderText.length) {
         setDisplayedPlaceholder(placeholderText.slice(0, currentIndex + 1))
@@ -86,25 +105,10 @@ export const TypewriterPlaceholder = ({
           clearInterval(typeIntervalRef.current)
           typeIntervalRef.current = null
         }
-        placeholderTimeoutRef.current = setTimeout(() => {
-          deleteIntervalRef.current = setInterval(() => {
-            if (currentIndex > 0) {
-              currentIndex--
-              setDisplayedPlaceholder(placeholderText.slice(0, currentIndex))
-            } else {
-              if (deleteIntervalRef.current) {
-                clearInterval(deleteIntervalRef.current)
-                deleteIntervalRef.current = null
-              }
-              placeholderTimeoutRef.current = setTimeout(() => {
-                const nextIndex =
-                  (currentPlaceholderIndex + 1) %
-                  Math.max(placeholders.length, 1)
-                setCurrentPlaceholderIndex(nextIndex)
-              }, pauseBeforeNext)
-            }
-          }, deleteSpeed)
-        }, pauseBeforeDelete)
+        placeholderTimeoutRef.current = setTimeout(
+          startDeleting,
+          pauseBeforeDelete
+        )
       }
     }, typeSpeed)
 

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
@@ -97,18 +97,15 @@ function SurveyAnsweringFormDialog({
     schema,
     defaultValues: formDefaultValues,
     sections,
-  } = useSurveyFormSchema(
-    elements,
-    mode,
-    t,
+  } = useSurveyFormSchema(elements, mode, t, {
     defaultValues,
     currentQuestionId,
-    isStepped ? accumulatedValuesRef.current : undefined,
-    preview,
-    isReadonlyPreview,
+    accumulatedValues: isStepped ? accumulatedValuesRef.current : undefined,
+    previewMode: preview,
+    disableFields: isReadonlyPreview,
     useUpload,
-    datasets
-  )
+    datasets,
+  })
 
   const position: DialogPosition = isFullscreen
     ? "fullscreen"
@@ -417,18 +414,13 @@ function SurveyAnsweringFormInline({
     schema,
     defaultValues: formDefaultValues,
     sections,
-  } = useSurveyFormSchema(
-    elements,
-    "all-questions",
-    t,
+  } = useSurveyFormSchema(elements, "all-questions", t, {
     defaultValues,
-    undefined,
-    undefined,
-    true,
-    true,
+    previewMode: true,
+    disableFields: true,
     useUpload,
-    datasets
-  )
+    datasets,
+  })
 
   return (
     <SurveyFormBuilderProvider

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/SurveyAnsweringForm.tsx
@@ -97,7 +97,10 @@ function SurveyAnsweringFormDialog({
     schema,
     defaultValues: formDefaultValues,
     sections,
-  } = useSurveyFormSchema(elements, mode, t, {
+  } = useSurveyFormSchema({
+    elements,
+    mode,
+    t,
     defaultValues,
     currentQuestionId,
     accumulatedValues: isStepped ? accumulatedValuesRef.current : undefined,
@@ -414,7 +417,10 @@ function SurveyAnsweringFormInline({
     schema,
     defaultValues: formDefaultValues,
     sections,
-  } = useSurveyFormSchema(elements, "all-questions", t, {
+  } = useSurveyFormSchema({
+    elements,
+    mode: "all-questions",
+    t,
     defaultValues,
     previewMode: true,
     disableFields: true,

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
@@ -136,22 +136,8 @@ function buildDateSchema(
     })
 }
 
-function buildFileSchema(
-  isRequired: boolean,
-  t: (key: TranslationKey) => string
-) {
-  return z
-    .array(z.string())
-    .optional()
-    .superRefine((v, ctx) => {
-      if (isRequired && (!v || v.length === 0)) {
-        ctx.addIssue({
-          code: "custom",
-          message: t("forms.validation.required"),
-        })
-      }
-    })
-}
+// Uploaded files are a list of ids, the same shape as a multi select.
+const buildFileSchema = buildMultiSelectSchema
 
 function buildCheckboxSchema(
   isRequired: boolean,
@@ -217,14 +203,25 @@ export function extractFlatQuestions(
   return questions
 }
 
+type BuildFieldOptions = {
+  sectionId?: string
+  previewMode?: boolean
+  /** Defaults to `previewMode`. */
+  disableFields?: boolean
+  formUseUpload?: UseFileUpload
+  datasets?: SurveyDatasets
+}
+
 function buildFieldForQuestion(
   q: QuestionElement,
   t: (key: TranslationKey) => string,
-  sectionId?: string,
-  previewMode = false,
-  disableFields = previewMode,
-  formUseUpload?: UseFileUpload,
-  datasets?: SurveyDatasets
+  {
+    sectionId,
+    previewMode = false,
+    disableFields = previewMode,
+    formUseUpload,
+    datasets,
+  }: BuildFieldOptions = {}
 ): ZodTypeAny {
   const label = q.title ?? ""
   const baseConfig = {
@@ -650,17 +647,30 @@ function buildFieldForQuestion(
   }
 }
 
+export type UseSurveyFormSchemaOptions = {
+  defaultValues?: Partial<SurveyAnswers>
+  currentQuestionId?: string
+  accumulatedValues?: Record<string, unknown>
+  previewMode?: boolean
+  /** Defaults to `previewMode`. */
+  disableFields?: boolean
+  useUpload?: UseFileUpload
+  datasets?: SurveyDatasets
+}
+
 export function useSurveyFormSchema(
   elements: SurveyFormBuilderElement[],
   mode: SurveyAnsweringFormMode,
   t: (key: TranslationKey) => string,
-  defaultValues?: Partial<SurveyAnswers>,
-  currentQuestionId?: string,
-  accumulatedValues?: Record<string, unknown>,
-  previewMode = false,
-  disableFields = previewMode,
-  useUpload?: UseFileUpload,
-  datasets?: SurveyDatasets
+  {
+    defaultValues,
+    currentQuestionId,
+    accumulatedValues,
+    previewMode = false,
+    disableFields = previewMode,
+    useUpload,
+    datasets,
+  }: UseSurveyFormSchemaOptions = {}
 ) {
   return useMemo(() => {
     const shape: Record<string, ZodTypeAny> = {}
@@ -688,15 +698,13 @@ export function useSurveyFormSchema(
             continue
           }
 
-          shape[q.id] = buildFieldForQuestion(
-            q,
-            t,
-            mode === "all-questions" ? sectionId : undefined,
+          shape[q.id] = buildFieldForQuestion(q, t, {
+            sectionId: mode === "all-questions" ? sectionId : undefined,
             previewMode,
             disableFields,
-            useUpload,
-            datasets
-          )
+            formUseUpload: useUpload,
+            datasets,
+          })
           defaults[q.id] =
             accumulatedValues?.[q.id] ?? getDefaultValue(q, defaultValues)
         }
@@ -707,15 +715,12 @@ export function useSurveyFormSchema(
           continue
         }
 
-        shape[q.id] = buildFieldForQuestion(
-          q,
-          t,
-          undefined,
+        shape[q.id] = buildFieldForQuestion(q, t, {
           previewMode,
           disableFields,
-          useUpload,
-          datasets
-        )
+          formUseUpload: useUpload,
+          datasets,
+        })
         defaults[q.id] =
           accumulatedValues?.[q.id] ?? getDefaultValue(q, defaultValues)
       }

--- a/packages/react/src/kits/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
+++ b/packages/react/src/kits/surveys/SurveyAnsweringForm/hooks/useSurveyFormSchema.tsx
@@ -204,6 +204,8 @@ export function extractFlatQuestions(
 }
 
 type BuildFieldOptions = {
+  q: QuestionElement
+  t: (key: TranslationKey) => string
   sectionId?: string
   previewMode?: boolean
   /** Defaults to `previewMode`. */
@@ -212,17 +214,15 @@ type BuildFieldOptions = {
   datasets?: SurveyDatasets
 }
 
-function buildFieldForQuestion(
-  q: QuestionElement,
-  t: (key: TranslationKey) => string,
-  {
-    sectionId,
-    previewMode = false,
-    disableFields = previewMode,
-    formUseUpload,
-    datasets,
-  }: BuildFieldOptions = {}
-): ZodTypeAny {
+function buildFieldForQuestion({
+  q,
+  t,
+  sectionId,
+  previewMode = false,
+  disableFields = previewMode,
+  formUseUpload,
+  datasets,
+}: BuildFieldOptions): ZodTypeAny {
   const label = q.title ?? ""
   const baseConfig = {
     label,
@@ -648,6 +648,9 @@ function buildFieldForQuestion(
 }
 
 export type UseSurveyFormSchemaOptions = {
+  elements: SurveyFormBuilderElement[]
+  mode: SurveyAnsweringFormMode
+  t: (key: TranslationKey) => string
   defaultValues?: Partial<SurveyAnswers>
   currentQuestionId?: string
   accumulatedValues?: Record<string, unknown>
@@ -658,20 +661,18 @@ export type UseSurveyFormSchemaOptions = {
   datasets?: SurveyDatasets
 }
 
-export function useSurveyFormSchema(
-  elements: SurveyFormBuilderElement[],
-  mode: SurveyAnsweringFormMode,
-  t: (key: TranslationKey) => string,
-  {
-    defaultValues,
-    currentQuestionId,
-    accumulatedValues,
-    previewMode = false,
-    disableFields = previewMode,
-    useUpload,
-    datasets,
-  }: UseSurveyFormSchemaOptions = {}
-) {
+export function useSurveyFormSchema({
+  elements,
+  mode,
+  t,
+  defaultValues,
+  currentQuestionId,
+  accumulatedValues,
+  previewMode = false,
+  disableFields = previewMode,
+  useUpload,
+  datasets,
+}: UseSurveyFormSchemaOptions) {
   return useMemo(() => {
     const shape: Record<string, ZodTypeAny> = {}
     const defaults: Record<string, unknown> = {}
@@ -698,7 +699,9 @@ export function useSurveyFormSchema(
             continue
           }
 
-          shape[q.id] = buildFieldForQuestion(q, t, {
+          shape[q.id] = buildFieldForQuestion({
+            q,
+            t,
             sectionId: mode === "all-questions" ? sectionId : undefined,
             previewMode,
             disableFields,
@@ -715,7 +718,9 @@ export function useSurveyFormSchema(
           continue
         }
 
-        shape[q.id] = buildFieldForQuestion(q, t, {
+        shape[q.id] = buildFieldForQuestion({
+          q,
+          t,
           previewMode,
           disableFields,
           formUseUpload: useUpload,

--- a/packages/react/src/lib/F0GridStack/__tests__/F0GridStack.test.tsx
+++ b/packages/react/src/lib/F0GridStack/__tests__/F0GridStack.test.tsx
@@ -790,7 +790,7 @@ describe("F0GridStack", () => {
       }
 
       const allowed = node.allowedSizes ?? []
-      expect(allowed.length).toBe(0)
+      expect(allowed).toHaveLength(0)
     })
   })
 

--- a/packages/react/src/lib/data-testid/__tests__/withDataTestId.test.tsx
+++ b/packages/react/src/lib/data-testid/__tests__/withDataTestId.test.tsx
@@ -227,10 +227,10 @@ describe("withDataTestId", () => {
       type WrappedProps = WithDataTestIdPropsOf<typeof Wrapped>
 
       const _goodProps: WrappedProps = {
-        onChange: (value: DateValue | undefined, label: string | undefined) => {
-          void value
-          void label
-        },
+        onChange: (
+          _value: DateValue | undefined,
+          _label: string | undefined
+        ) => {},
         dataTestId: "test",
       }
       expect(_goodProps).toBeDefined()

--- a/packages/react/src/lib/limit-deep/__tests__/limit-deep.test.ts
+++ b/packages/react/src/lib/limit-deep/__tests__/limit-deep.test.ts
@@ -92,7 +92,7 @@ describe("limitDeep", () => {
     it("should handle null values in objects", () => {
       const obj = { value: null }
       const result = limitDeep(obj, 5)
-      expect(result.value).toBe(null)
+      expect(result.value).toBeNull()
     })
   })
 

--- a/packages/react/src/lib/linkHandler.spec.tsx
+++ b/packages/react/src/lib/linkHandler.spec.tsx
@@ -26,51 +26,40 @@ describe("useLink", () => {
     return <a href={href} data-is-active={isActive(href)} />
   }
 
-  test("isActive returns true if the current path is the same as the href", async () => {
+  test.each([
+    {
+      name: "the current path is the same as the href",
+      currentPath: "/foo",
+      href: "/foo",
+      expected: "true",
+    },
+    {
+      name: "the current path starts with the href and a slash",
+      currentPath: "/foo/bar",
+      href: "/foo",
+      expected: "true",
+    },
+    {
+      name: "the current path starts with the href without a slash",
+      currentPath: "/foo_bar",
+      href: "/foo",
+      expected: "false",
+    },
+    {
+      name: "the current path is not contained in the href",
+      currentPath: "/foo",
+      href: "/foo/bar",
+      expected: "false",
+    },
+  ])("isActive is $expected if $name", ({ currentPath, href, expected }) => {
     render(
-      <LinkProvider currentPath="/foo">
-        <Component href="/foo" />
+      <LinkProvider currentPath={currentPath}>
+        <Component href={href} />
       </LinkProvider>
     )
 
     expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
-      "true"
-    )
-  })
-
-  test("isActive returns true if the current path starts with href including trailing slash", async () => {
-    render(
-      <LinkProvider currentPath="/foo/bar">
-        <Component href="/foo" />
-      </LinkProvider>
-    )
-
-    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
-      "true"
-    )
-  })
-
-  test("isActive returns true if the current path starts with href with no trailing slash", async () => {
-    render(
-      <LinkProvider currentPath="/foo_bar">
-        <Component href="/foo" />
-      </LinkProvider>
-    )
-
-    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
-      "false"
-    )
-  })
-
-  test("isActive returns false if the current path is not contained in the href", async () => {
-    render(
-      <LinkProvider currentPath="/foo">
-        <Component href="/foo/bar" />
-      </LinkProvider>
-    )
-
-    expect(screen.getByRole("link").getAttribute("data-is-active")).toEqual(
-      "false"
+      expected
     )
   })
 

--- a/packages/react/src/lib/numeric/__tests__/index.test.ts
+++ b/packages/react/src/lib/numeric/__tests__/index.test.ts
@@ -38,10 +38,10 @@ describe("index.ts exports", () => {
       formatterOptions: {},
     }
 
-    expect(value.value).toBe(123.45)
-    expect(numeric).toBe(value.value)
+    expect(value.value).toBeCloseTo(123.45)
+    expect(numeric).toBeCloseTo(value.value)
     expect(options.decimalPlaces).toBe(2)
-    expect(withFormatter.numericValue.value).toBe(123.45)
+    expect(withFormatter.numericValue.value).toBeCloseTo(123.45)
   })
 
   it("should allow importing and using exported functions", () => {
@@ -61,7 +61,7 @@ describe("index.ts exports", () => {
   it("should allow importing and using numericFinalValue", () => {
     const value: NumericValue = { value: 123.45 }
     const result = numericFinalValue(value)
-    expect(result).toBe(123.45)
+    expect(result).toBeCloseTo(123.45)
   })
 
   it("should allow importing and using toNumericValue", () => {

--- a/packages/react/src/lib/numeric/__tests__/isEmptyNumeric.test.ts
+++ b/packages/react/src/lib/numeric/__tests__/isEmptyNumeric.test.ts
@@ -29,33 +29,15 @@ describe("isEmptyNumeric", () => {
   })
 
   describe("number values", () => {
-    it("should return false for zero", () => {
-      const result = isEmptyNumeric(0)
-      expect(result).toBe(false)
-    })
-
-    it("should return false for positive numbers", () => {
-      const result = isEmptyNumeric(123.45)
-      expect(result).toBe(false)
-    })
-
-    it("should return false for negative numbers", () => {
-      const result = isEmptyNumeric(-123.45)
-      expect(result).toBe(false)
-    })
-
-    it("should return false for very small numbers", () => {
-      const result = isEmptyNumeric(0.0001)
-      expect(result).toBe(false)
-    })
-
-    it("should return false for large numbers", () => {
-      const result = isEmptyNumeric(999999999.99)
-      expect(result).toBe(false)
-    })
-
-    it("should return false for integers", () => {
-      const result = isEmptyNumeric(42)
+    it.each([
+      { name: "zero", value: 0 },
+      { name: "positive numbers", value: 123.45 },
+      { name: "negative numbers", value: -123.45 },
+      { name: "very small numbers", value: 0.0001 },
+      { name: "large numbers", value: 999999999.99 },
+      { name: "integers", value: 42 },
+    ])("should return false for $name", ({ value }) => {
+      const result = isEmptyNumeric(value)
       expect(result).toBe(false)
     })
   })

--- a/packages/react/src/lib/numeric/__tests__/numericFinalValue.test.ts
+++ b/packages/react/src/lib/numeric/__tests__/numericFinalValue.test.ts
@@ -4,22 +4,16 @@ import { numericFinalValue } from "../utils/numericFinalValue"
 
 describe("numericFinalValue", () => {
   describe("value property", () => {
-    it("should return the value when value property exists", () => {
-      const numericValue: NumericValue = { value: 123.45 }
+    it.each([
+      { name: "the value when value property exists", value: 123.45 },
+      { name: "zero when value is zero", value: 0 },
+      { name: "negative value", value: -123.45 },
+      { name: "large numbers correctly", value: 999999999.99 },
+      { name: "very small numbers correctly", value: 0.001 },
+    ])("should return $name", ({ value }) => {
+      const numericValue: NumericValue = { value }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(123.45)
-    })
-
-    it("should return zero when value is zero", () => {
-      const numericValue: NumericValue = { value: 0 }
-      const result = numericFinalValue(numericValue)
-      expect(result).toBe(0)
-    })
-
-    it("should return negative value", () => {
-      const numericValue: NumericValue = { value: -123.45 }
-      const result = numericFinalValue(numericValue)
-      expect(result).toBe(-123.45)
+      expect(result).toBeCloseTo(value)
     })
 
     it("should return undefined when value is undefined", () => {
@@ -28,22 +22,10 @@ describe("numericFinalValue", () => {
       expect(result).toBeUndefined()
     })
 
-    it("should return large numbers correctly", () => {
-      const numericValue: NumericValue = { value: 999999999.99 }
-      const result = numericFinalValue(numericValue)
-      expect(result).toBe(999999999.99)
-    })
-
-    it("should return very small numbers correctly", () => {
-      const numericValue: NumericValue = { value: 0.001 }
-      const result = numericFinalValue(numericValue)
-      expect(result).toBe(0.001)
-    })
-
     it("should return value with units property", () => {
       const numericValue: NumericValue = { value: 123.45, units: "€" }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(123.45)
+      expect(result).toBeCloseTo(123.45)
     })
 
     it("should return value with unitsPosition property", () => {
@@ -53,27 +35,27 @@ describe("numericFinalValue", () => {
         unitsPosition: "prepend",
       }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(123.45)
+      expect(result).toBeCloseTo(123.45)
     })
   })
 
   describe("value_x100 property", () => {
-    it("should return value_x100 divided by 100", () => {
-      const numericValue: NumericValue = { value_x100: 12345 }
+    it.each([
+      {
+        name: "value_x100 divided by 100",
+        value_x100: 12345,
+        expected: 123.45,
+      },
+      { name: "zero when value_x100 is zero", value_x100: 0, expected: 0 },
+      {
+        name: "negative value_x100 divided by 100",
+        value_x100: -12345,
+        expected: -123.45,
+      },
+    ])("should return $name", ({ value_x100, expected }) => {
+      const numericValue: NumericValue = { value_x100 }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(123.45)
-    })
-
-    it("should return zero when value_x100 is zero", () => {
-      const numericValue: NumericValue = { value_x100: 0 }
-      const result = numericFinalValue(numericValue)
-      expect(result).toBe(0)
-    })
-
-    it("should return negative value_x100 divided by 100", () => {
-      const numericValue: NumericValue = { value_x100: -12345 }
-      const result = numericFinalValue(numericValue)
-      expect(result).toBe(-123.45)
+      expect(result).toBeCloseTo(expected)
     })
 
     it("should return undefined when value_x100 is undefined", () => {
@@ -93,19 +75,19 @@ describe("numericFinalValue", () => {
     it("should handle single digit value_x100", () => {
       const numericValue: NumericValue = { value_x100: 5 }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(0.05)
+      expect(result).toBeCloseTo(0.05)
     })
 
     it("should handle large value_x100", () => {
       const numericValue: NumericValue = { value_x100: 99999999999 }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(999999999.99)
+      expect(result).toBeCloseTo(999999999.99)
     })
 
     it("should return value_x100 with units property", () => {
       const numericValue: NumericValue = { value_x100: 12345, units: "€" }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(123.45)
+      expect(result).toBeCloseTo(123.45)
     })
 
     it("should return value_x100 with unitsPosition property", () => {
@@ -115,7 +97,7 @@ describe("numericFinalValue", () => {
         unitsPosition: "prepend",
       }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(123.45)
+      expect(result).toBeCloseTo(123.45)
     })
   })
 
@@ -123,7 +105,7 @@ describe("numericFinalValue", () => {
     it("should handle decimal value_x100 correctly", () => {
       const numericValue: NumericValue = { value_x100: 1234 }
       const result = numericFinalValue(numericValue)
-      expect(result).toBe(12.34)
+      expect(result).toBeCloseTo(12.34)
     })
 
     it("should handle value_x100 that results in whole number", () => {

--- a/packages/react/src/lib/numeric/__tests__/numericFormatter.test.ts
+++ b/packages/react/src/lib/numeric/__tests__/numericFormatter.test.ts
@@ -4,60 +4,29 @@ import { numericFormatter } from "../utils/numericFormatter"
 
 describe("numericFormatter", () => {
   describe("basic number formatting", () => {
-    it("should format a simple number value", () => {
-      const value: NumericValue = { value: 123.456 }
-      const result = numericFormatter(value)
-      expect(result).toBe("123.46")
-    })
-
-    it("should format a whole number", () => {
-      const value: NumericValue = { value: 100 }
-      const result = numericFormatter(value)
-      expect(result).toBe("100")
-    })
-
-    it("should format zero", () => {
-      const value: NumericValue = { value: 0 }
-      const result = numericFormatter(value)
-      expect(result).toBe("0")
-    })
-
-    it("should format negative numbers", () => {
-      const value: NumericValue = { value: -123.456 }
-      const result = numericFormatter(value)
-      expect(result).toBe("-123.46")
-    })
-
-    it("should format large numbers", () => {
-      const value: NumericValue = { value: 1234567.89 }
-      const result = numericFormatter(value)
-      expect(result).toBe("1,234,567.89")
+    it.each([
+      { name: "a simple number value", value: 123.456, expected: "123.46" },
+      { name: "a whole number", value: 100, expected: "100" },
+      { name: "zero", value: 0, expected: "0" },
+      { name: "negative numbers", value: -123.456, expected: "-123.46" },
+      { name: "large numbers", value: 1234567.89, expected: "1,234,567.89" },
+    ])("should format $name", ({ value, expected }) => {
+      const numericValue: NumericValue = { value }
+      const result = numericFormatter(numericValue)
+      expect(result).toBe(expected)
     })
   })
 
   describe("value_x100 formatting", () => {
-    it("should format value_x100 correctly", () => {
-      const value: NumericValue = { value_x100: 12345 }
+    it.each([
+      { name: "value_x100 correctly", value_x100: 12345, expected: "123.45" },
+      { name: "value_x100 with zero", value_x100: 0, expected: "0" },
+      { name: "negative value_x100", value_x100: -12345, expected: "-123.45" },
+      { name: "value_x100 with single digit", value_x100: 5, expected: "0.05" },
+    ])("should format $name", ({ value_x100, expected }) => {
+      const value: NumericValue = { value_x100 }
       const result = numericFormatter(value)
-      expect(result).toBe("123.45")
-    })
-
-    it("should format value_x100 with zero", () => {
-      const value: NumericValue = { value_x100: 0 }
-      const result = numericFormatter(value)
-      expect(result).toBe("0")
-    })
-
-    it("should format negative value_x100", () => {
-      const value: NumericValue = { value_x100: -12345 }
-      const result = numericFormatter(value)
-      expect(result).toBe("-123.45")
-    })
-
-    it("should format value_x100 with single digit", () => {
-      const value: NumericValue = { value_x100: 5 }
-      const result = numericFormatter(value)
-      expect(result).toBe("0.05")
+      expect(result).toBe(expected)
     })
   })
 
@@ -209,28 +178,23 @@ describe("numericFormatter", () => {
   })
 
   describe("Numeric type - direct number values", () => {
-    it("should format a direct number value", () => {
-      const value: Numeric = 123.456
-      const result = numericFormatter(value)
-      expect(result).toBe("123.46")
-    })
-
-    it("should format a direct whole number", () => {
-      const value: Numeric = 100
-      const result = numericFormatter(value)
-      expect(result).toBe("100")
-    })
-
-    it("should format a direct negative number", () => {
-      const value: Numeric = -123.456
-      const result = numericFormatter(value)
-      expect(result).toBe("-123.46")
-    })
-
-    it("should format a direct number without units", () => {
-      const value: Numeric = 123.45
-      const result = numericFormatter(value)
-      expect(result).toBe("123.45")
+    it.each([
+      { name: "a direct number value", value: 123.456, expected: "123.46" },
+      { name: "a direct whole number", value: 100, expected: "100" },
+      {
+        name: "a direct negative number",
+        value: -123.456,
+        expected: "-123.46",
+      },
+      {
+        name: "a direct number without units",
+        value: 123.45,
+        expected: "123.45",
+      },
+    ])("should format $name", ({ value, expected }) => {
+      const numeric: Numeric = value
+      const result = numericFormatter(numeric)
+      expect(result).toBe(expected)
     })
 
     it("should format a direct number with custom decimal places", () => {

--- a/packages/react/src/lib/objectPaths.spec.ts
+++ b/packages/react/src/lib/objectPaths.spec.ts
@@ -63,68 +63,68 @@ describe("getValueByPath", () => {
 
   describe("handling null and undefined values", () => {
     it("should return null values correctly", () => {
-      expect(getValueByPath(testObject, "b.c.e")).toBe(null)
+      expect(getValueByPath(testObject, "b.c.e")).toBeNull()
     })
 
     it("should return undefined values correctly", () => {
-      expect(getValueByPath(testObject, "b.c.f")).toBe(undefined)
+      expect(getValueByPath(testObject, "b.c.f")).toBeUndefined()
     })
   })
 
   describe("invalid paths", () => {
     it("should return undefined for non-existent top-level properties", () => {
-      expect(getValueByPath(testObject, "nonExistent")).toBe(undefined)
+      expect(getValueByPath(testObject, "nonExistent")).toBeUndefined()
     })
 
     it("should return undefined for non-existent nested properties", () => {
-      expect(getValueByPath(testObject, "a.nonExistent")).toBe(undefined)
-      expect(getValueByPath(testObject, "b.nonExistent")).toBe(undefined)
-      expect(getValueByPath(testObject, "b.c.nonExistent")).toBe(undefined)
+      expect(getValueByPath(testObject, "a.nonExistent")).toBeUndefined()
+      expect(getValueByPath(testObject, "b.nonExistent")).toBeUndefined()
+      expect(getValueByPath(testObject, "b.c.nonExistent")).toBeUndefined()
     })
 
     it("should return undefined when traversing through non-object values", () => {
-      expect(getValueByPath(testObject, "a.b.c")).toBe(undefined)
-      expect(getValueByPath(testObject, "stringValue.length")).toBe(undefined)
-      expect(getValueByPath(testObject, "booleanValue.toString")).toBe(
-        undefined
-      )
+      expect(getValueByPath(testObject, "a.b.c")).toBeUndefined()
+      expect(getValueByPath(testObject, "stringValue.length")).toBeUndefined()
+      expect(
+        getValueByPath(testObject, "booleanValue.toString")
+      ).toBeUndefined()
     })
 
     it("should return undefined for paths that go beyond available nesting", () => {
-      expect(getValueByPath(testObject, "b.c.d.e.f")).toBe(undefined)
-      expect(getValueByPath(testObject, "emptyObject.nonExistent.deep")).toBe(
-        undefined
-      )
+      expect(getValueByPath(testObject, "b.c.d.e.f")).toBeUndefined()
+      expect(
+        getValueByPath(testObject, "emptyObject.nonExistent.deep")
+      ).toBeUndefined()
     })
   })
 
   describe("edge cases", () => {
     it("should handle empty path strings", () => {
-      expect(getValueByPath(testObject, "")).toBe(undefined)
+      expect(getValueByPath(testObject, "")).toBeUndefined()
     })
 
     it("should handle null objects", () => {
-      expect(getValueByPath(null, "a")).toBe(undefined)
-      expect(getValueByPath(null, "a.b.c")).toBe(undefined)
+      expect(getValueByPath(null, "a")).toBeUndefined()
+      expect(getValueByPath(null, "a.b.c")).toBeUndefined()
     })
 
     it("should handle undefined objects", () => {
-      expect(getValueByPath(undefined, "a")).toBe(undefined)
-      expect(getValueByPath(undefined, "a.b.c")).toBe(undefined)
+      expect(getValueByPath(undefined, "a")).toBeUndefined()
+      expect(getValueByPath(undefined, "a.b.c")).toBeUndefined()
     })
 
     it("should handle non-object inputs", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- to test the function
-      expect(getValueByPath("string" as any, "a")).toBe(undefined)
+      expect(getValueByPath("string" as any, "a")).toBeUndefined()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- to test the function
-      expect(getValueByPath(42 as any, "a")).toBe(undefined)
+      expect(getValueByPath(42 as any, "a")).toBeUndefined()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any -- to test the function
-      expect(getValueByPath(true as any, "a")).toBe(undefined)
+      expect(getValueByPath(true as any, "a")).toBeUndefined()
     })
 
     it("should handle empty objects", () => {
-      expect(getValueByPath({}, "a")).toBe(undefined)
-      expect(getValueByPath({}, "a.b.c")).toBe(undefined)
+      expect(getValueByPath({}, "a")).toBeUndefined()
+      expect(getValueByPath({}, "a.b.c")).toBeUndefined()
     })
 
     it("should handle paths with single dots", () => {
@@ -135,8 +135,8 @@ describe("getValueByPath", () => {
         },
       }
       // The function splits by dots, so it won't find keys that contain dots
-      expect(getValueByPath(objWithDots, "a.b")).toBe(undefined)
-      expect(getValueByPath(objWithDots, "c.d.e")).toBe(undefined)
+      expect(getValueByPath(objWithDots, "a.b")).toBeUndefined()
+      expect(getValueByPath(objWithDots, "c.d.e")).toBeUndefined()
     })
   })
 

--- a/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import type { ReactElement } from "react"
+import { assertType, describe, expect, it } from "vitest"
 import { aiTranslations } from "@/kits/ai/F0AiChat"
 import { I18nProvider, TranslationsType, useI18n } from "./i18n-provider"
 import { defaultTranslations } from "./i18n-provider-defaults"
@@ -139,21 +140,21 @@ describe("I18nProvider", () => {
 
   // Type tests - these will fail at compile time if types are wrong
   it.skip("maintains type safety for translation overrides", () => {
-    render(
+    assertType<ReactElement>(
       // @ts-expect-error - Invalid translation key should be caught by TypeScript
       <I18nProvider translations={{ invalidKey: "test" }}>
         <div />
       </I18nProvider>
     )
 
-    render(
+    assertType<ReactElement>(
       // @ts-expect-error - Missing required translation keys should be caught by TypeScript
       <I18nProvider translations={{}}>
         <div />
       </I18nProvider>
     )
 
-    render(
+    assertType<ReactElement>(
       // @ts-expect-error - Translations are required
       <I18nProvider>
         <div />

--- a/packages/react/src/lib/providers/l10n/l10n-provider.spec.tsx
+++ b/packages/react/src/lib/providers/l10n/l10n-provider.spec.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react"
-import { describe, expect, it } from "vitest"
+import type { ReactElement } from "react"
+import { assertType, describe, expect, it } from "vitest"
 import { WeekStartDay } from "@/components/OneCalendar/types"
 import { L10nProvider, useL10n } from "./l10n-provider"
 
@@ -24,21 +25,21 @@ describe("L10nProvider", () => {
 
   // Type tests - these will fail at compile time if types are wrong
   it.skip("maintains type safety for l10n props", () => {
-    render(
+    assertType<ReactElement>(
       // @ts-expect-error - Invalid l10n prop should be caught by TypeScript
       <L10nProvider l10n={{ invalidKey: "test" }}>
         <div />
       </L10nProvider>
     )
 
-    render(
+    assertType<ReactElement>(
       // @ts-expect-error - Missing required locale should be caught by TypeScript
       <L10nProvider l10n={{}}>
         <div />
       </L10nProvider>
     )
 
-    render(
+    assertType<ReactElement>(
       // @ts-expect-error - L10n prop is required
       <L10nProvider>
         <div />

--- a/packages/react/src/lib/strip-native-title.test.tsx
+++ b/packages/react/src/lib/strip-native-title.test.tsx
@@ -62,6 +62,6 @@ describe("stripNativeTitle", () => {
 
   test("returns non-element children untouched", () => {
     expect(stripNativeTitle("plain text")).toBe("plain text")
-    expect(stripNativeTitle(null)).toBe(null)
+    expect(stripNativeTitle(null)).toBeNull()
   })
 })

--- a/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.canvasInset.test.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.canvasInset.test.tsx
@@ -85,15 +85,20 @@ const canvasContainer = (): HTMLElement => {
 
 // The inset animates, so an assertion has to wait for a settled value: an
 // unwritten edge reads as "" and an in-flight one as some fraction of the
-// target. Assert the exact px so a wrong-but-nonzero inset can't pass.
-const waitForEdge = (edge: "left" | "right", px: number) =>
-  waitFor(() => expect(canvasContainer().style[edge]).toBe(`${px}px`))
+// target. Wait for the exact px so a wrong-but-nonzero inset can't pass, then
+// return it so each test states its own expectation.
+const settledEdge = async (edge: "left" | "right", px: number) => {
+  await waitFor(() => expect(canvasContainer().style[edge]).toBe(`${px}px`))
+  return canvasContainer().style[edge]
+}
 
-const waitForReservedEdge = (edge: "left" | "right") =>
-  waitForEdge(edge, DEFAULT_CHAT_WIDTH)
+const RESERVED_EDGE = `${DEFAULT_CHAT_WIDTH}px`
+const FLUSH_EDGE = "0px"
 
-const waitForFlushEdge = (edge: "left" | "right") =>
-  waitFor(() => expect(canvasContainer().style[edge]).toBe("0px"))
+const reservedEdge = (edge: "left" | "right") =>
+  settledEdge(edge, DEFAULT_CHAT_WIDTH)
+
+const flushEdge = (edge: "left" | "right") => settledEdge(edge, 0)
 
 describe("ApplicationFrame canvas inset", () => {
   beforeEach(() => {
@@ -107,20 +112,20 @@ describe("ApplicationFrame canvas inset", () => {
 
     // Default behavior: the canvas hugs the seam and leaves the chat's width
     // free on that edge.
-    await waitForReservedEdge("right")
+    expect(await reservedEdge("right")).toBe(RESERVED_EDGE)
   })
 
   it("reserves nothing for canvas content that covers the chat", async () => {
     renderFrame()
     await userEvent.click(screen.getByText("open-covering"))
 
-    await waitForFlushEdge("right")
+    expect(await flushEdge("right")).toBe(FLUSH_EDGE)
   })
 
   it("keeps the chat mounted underneath a covering canvas", async () => {
     renderFrame()
     await userEvent.click(screen.getByText("open-covering"))
-    await waitForFlushEdge("right")
+    expect(await flushEdge("right")).toBe(FLUSH_EDGE)
 
     // Covered, not closed: the conversation keeps its state, so dismissing the
     // canvas returns to exactly the step the user left.
@@ -133,41 +138,43 @@ describe("ApplicationFrame canvas inset", () => {
 
     // Mirrored: the canvas sits opposite the panel, so a left-docked chat is
     // reserved on the left and the right edge stays flush.
-    await waitForReservedEdge("left")
-    await waitForFlushEdge("right")
+    expect(await reservedEdge("left")).toBe(RESERVED_EDGE)
+    expect(await flushEdge("right")).toBe(FLUSH_EDGE)
   })
 
   it("clears the mirrored inset for covering content too", async () => {
     renderFrame("left")
     await userEvent.click(screen.getByText("open-covering"))
 
-    await waitForFlushEdge("left")
-    await waitForFlushEdge("right")
+    expect(await flushEdge("left")).toBe(FLUSH_EDGE)
+    expect(await flushEdge("right")).toBe(FLUSH_EDGE)
   })
 
   it("animates the inset away when open content starts covering the chat", async () => {
     renderFrame()
     await userEvent.click(screen.getByText("open-docked"))
-    await waitForReservedEdge("right")
+    expect(await reservedEdge("right")).toBe(RESERVED_EDGE)
 
     // The canvas stays mounted across this swap (content is non-null
     // throughout), so this is the one path that actually animates rather than
     // mounting at its target — motion seeds `initial` from `animate` on mount.
     await userEvent.click(screen.getByText("open-covering"))
-    await waitForFlushEdge("right")
+    expect(await flushEdge("right")).toBe(FLUSH_EDGE)
 
     // ...and back, so a one-way write can't pass.
     await userEvent.click(screen.getByText("open-docked"))
-    await waitForReservedEdge("right")
+    expect(await reservedEdge("right")).toBe(RESERVED_EDGE)
   })
 
   it("tracks the chat width while resizable", async () => {
     renderFrame(undefined, { resizable: true })
     await userEvent.click(screen.getByText("open-docked"))
-    await waitForReservedEdge("right")
+    expect(await reservedEdge("right")).toBe(RESERVED_EDGE)
 
     await userEvent.click(screen.getByText("widen-chat"))
-    await waitForEdge("right", RESIZED_CHAT_WIDTH)
+    expect(await settledEdge("right", RESIZED_CHAT_WIDTH)).toBe(
+      `${RESIZED_CHAT_WIDTH}px`
+    )
   })
 
   it("broadcasts the handle drag so the frame can track it 1:1", async () => {
@@ -180,7 +187,7 @@ describe("ApplicationFrame canvas inset", () => {
     renderFrame(undefined, { resizable: true })
     // The handle only exists once the panel is open and docked.
     await userEvent.click(screen.getByText("open-docked"))
-    await waitForReservedEdge("right")
+    expect(await reservedEdge("right")).toBe(RESERVED_EDGE)
     expect(screen.getByText("resizing:false")).toBeInTheDocument()
 
     const handle = await waitFor(() => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useCollectionDownloadActions.ts
@@ -25,7 +25,7 @@ const EXPORT_PAGE_SIZE = 100
  */
 type DownloadableSource = {
   dataAdapter: {
-    paginationType?: "pages" | "infinite-scroll" | undefined
+    paginationType?: "pages" | "infinite-scroll"
     fetchData: (params: Record<string, unknown>) => unknown
     exportFetchData?: (params: Record<string, unknown>) => unknown
   }

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -581,18 +581,22 @@ export interface F0AiFormDescription {
   defaultValuesParams?: Record<string, unknown>
 }
 
+export interface F0AiFormRegisterOptions {
+  sections?: Record<string, F0SectionConfig>
+  defaultValuesParamsSchema?: ZodType
+  defaultValuesFn?: (
+    params: Record<string, unknown>
+  ) => Promise<Record<string, unknown>>
+  description?: string
+  module?: ModuleId
+}
+
 interface F0AiFormRegistryContextValue {
   register: (
     name: string,
     ref: React.MutableRefObject<F0FormRef | null>,
     schema: F0FormSchema,
-    sections?: Record<string, F0SectionConfig>,
-    defaultValuesParamsSchema?: ZodType,
-    defaultValuesFn?: (
-      params: Record<string, unknown>
-    ) => Promise<Record<string, unknown>>,
-    description?: string,
-    module?: ModuleId
+    options?: F0AiFormRegisterOptions
   ) => void
   unregister: (name: string) => void
   get: (name: string) => F0AiFormEntry | undefined
@@ -828,13 +832,13 @@ export function F0AiFormRegistryProvider({
       name: string,
       ref: React.MutableRefObject<F0FormRef | null>,
       schema: F0FormSchema,
-      sections?: Record<string, F0SectionConfig>,
-      defaultValuesParamsSchema?: ZodType,
-      defaultValuesFn?: (
-        params: Record<string, unknown>
-      ) => Promise<Record<string, unknown>>,
-      description?: string,
-      module?: ModuleId
+      {
+        sections,
+        defaultValuesParamsSchema,
+        defaultValuesFn,
+        description,
+        module,
+      }: F0AiFormRegisterOptions = {}
     ) => {
       // Rendered forms always take precedence over virtual entries.
       // Preserve onSubmit from a previous virtual entry so canvas-submitted

--- a/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
+++ b/packages/react/src/patterns/F0Form/F0AiFormRegistry.tsx
@@ -581,22 +581,18 @@ export interface F0AiFormDescription {
   defaultValuesParams?: Record<string, unknown>
 }
 
-export interface F0AiFormRegisterOptions {
-  sections?: Record<string, F0SectionConfig>
-  defaultValuesParamsSchema?: ZodType
-  defaultValuesFn?: (
-    params: Record<string, unknown>
-  ) => Promise<Record<string, unknown>>
-  description?: string
-  module?: ModuleId
-}
-
 interface F0AiFormRegistryContextValue {
   register: (
     name: string,
     ref: React.MutableRefObject<F0FormRef | null>,
     schema: F0FormSchema,
-    options?: F0AiFormRegisterOptions
+    sections?: Record<string, F0SectionConfig>,
+    defaultValuesParamsSchema?: ZodType,
+    defaultValuesFn?: (
+      params: Record<string, unknown>
+    ) => Promise<Record<string, unknown>>,
+    description?: string,
+    module?: ModuleId
   ) => void
   unregister: (name: string) => void
   get: (name: string) => F0AiFormEntry | undefined
@@ -828,17 +824,18 @@ export function F0AiFormRegistryProvider({
   }, [])
 
   const register = useCallback(
+    // oxlint-disable-next-line max-params -- public signature through useF0AiFormRegistry, change with a deprecation
     (
       name: string,
       ref: React.MutableRefObject<F0FormRef | null>,
       schema: F0FormSchema,
-      {
-        sections,
-        defaultValuesParamsSchema,
-        defaultValuesFn,
-        description,
-        module,
-      }: F0AiFormRegisterOptions = {}
+      sections?: Record<string, F0SectionConfig>,
+      defaultValuesParamsSchema?: ZodType,
+      defaultValuesFn?: (
+        params: Record<string, unknown>
+      ) => Promise<Record<string, unknown>>,
+      description?: string,
+      module?: ModuleId
     ) => {
       // Rendered forms always take precedence over virtual entries.
       // Preserve onSubmit from a previous virtual entry so canvas-submitted

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -1185,13 +1185,16 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       if (!formRef) {
         internalFormRef.current = buildRefMethods()
       }
-      aiFormRegistry.register(name, registryFormRef, schema, {
+      aiFormRegistry.register(
+        name,
+        registryFormRef,
+        schema,
         sections,
         defaultValuesParamsSchema,
         defaultValuesFn,
         description,
-        module,
-      })
+        module
+      )
       return () => {
         aiFormRegistry.unregister(name)
       }

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -1185,16 +1185,13 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       if (!formRef) {
         internalFormRef.current = buildRefMethods()
       }
-      aiFormRegistry.register(
-        name,
-        registryFormRef,
-        schema,
+      aiFormRegistry.register(name, registryFormRef, schema, {
         sections,
         defaultValuesParamsSchema,
         defaultValuesFn,
         description,
-        module
-      )
+        module,
+      })
       return () => {
         aiFormRegistry.unregister(name)
       }

--- a/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0Form.test.tsx
@@ -405,23 +405,19 @@ describe("inferFieldType", () => {
     expect(inferFieldType(schema, config)).toBe("text")
   })
 
-  it("infers number type from ZodNumber", () => {
-    const schema = z.number()
-    const config = { label: "Test", fieldType: "number" } as const
-    expect(inferFieldType(schema, config)).toBe("number")
-  })
-
-  it("infers duration type from explicit fieldType", () => {
-    const schema = z.number()
-    const config = { label: "Test", fieldType: "duration" } as const
-    expect(inferFieldType(schema, config)).toBe("duration")
-  })
-
-  it("infers switch type from ZodBoolean", () => {
-    const schema = z.boolean()
-    const config = { label: "Test", fieldType: "switch" } as const
-    expect(inferFieldType(schema, config)).toBe("switch")
-  })
+  it.each([
+    { fieldType: "number", schema: z.number() },
+    { fieldType: "duration", schema: z.number() },
+    { fieldType: "switch", schema: z.boolean() },
+    { fieldType: "percentage", schema: z.number() },
+    { fieldType: "money", schema: z.number() },
+  ] as const)(
+    "infers $fieldType type from explicit fieldType",
+    ({ fieldType, schema }) => {
+      const config = { label: "Test", fieldType } as const
+      expect(inferFieldType(schema, config)).toBe(fieldType)
+    }
+  )
 
   it("infers textarea from rows config", () => {
     const schema = z.string()
@@ -449,18 +445,6 @@ describe("inferFieldType", () => {
       fieldType: "checkbox",
     } as const
     expect(inferFieldType(schema, config)).toBe("checkbox")
-  })
-
-  it("infers percentage type from explicit fieldType", () => {
-    const schema = z.number()
-    const config = { label: "Test", fieldType: "percentage" } as const
-    expect(inferFieldType(schema, config)).toBe("percentage")
-  })
-
-  it("infers money type from explicit fieldType", () => {
-    const schema = z.number()
-    const config = { label: "Test", fieldType: "money" } as const
-    expect(inferFieldType(schema, config)).toBe("money")
   })
 })
 

--- a/packages/react/src/patterns/F0Form/components/SwitchGroupRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/components/SwitchGroupRenderer.tsx
@@ -31,6 +31,8 @@ import { RowRenderer } from "./RowRenderer"
  * Check if a switch schema requires the value to be `true`.
  * This is the case for z.literal(true) schemas.
  */
+const rowKey = (row: RowDefinition) => row.fields.map((f) => f.id).join("-")
+
 function isMustBeTrue(schema: ZodTypeAny): boolean {
   const inner = unwrapZodSchema(schema)
   return isZodType(inner, "ZodLiteral") && inner._def.value === true
@@ -132,7 +134,7 @@ export function SwitchGroupRenderer({
               if ("type" in dep && dep.type === "row") {
                 return (
                   <RowRenderer
-                    key={dep.fields.map((f) => f.id).join("-")}
+                    key={rowKey(dep)}
                     row={dep}
                     sectionId={sectionId}
                   />
@@ -153,7 +155,7 @@ export function SwitchGroupRenderer({
                       {deps.map((innerDep) =>
                         "type" in innerDep && innerDep.type === "row" ? (
                           <RowRenderer
-                            key={innerDep.fields.map((fd) => fd.id).join("-")}
+                            key={rowKey(innerDep)}
                             row={innerDep}
                             sectionId={sectionId}
                           />

--- a/packages/react/src/patterns/F0Form/f0Schema.ts
+++ b/packages/react/src/patterns/F0Form/f0Schema.ts
@@ -859,7 +859,7 @@ export namespace f0FormField {
     config: TextConfig & { optional: true }
   ): z.ZodOptional<z.ZodString> & F0ZodType<z.ZodOptional<z.ZodString>>
   export function text(
-    config: TextConfig & { optional?: false | undefined }
+    config: TextConfig & { optional?: false }
   ): z.ZodString & F0ZodType<z.ZodString>
   export function text({
     optional,
@@ -890,7 +890,7 @@ export namespace f0FormField {
     config: EmailConfig & { optional: true }
   ): z.ZodOptional<z.ZodString> & F0ZodType<z.ZodOptional<z.ZodString>>
   export function email(
-    config: EmailConfig & { optional?: false | undefined }
+    config: EmailConfig & { optional?: false }
   ): z.ZodString & F0ZodType<z.ZodString>
   export function email({ optional, ...config }: EmailConfig) {
     const schema = optional ? z.string().email().optional() : z.string().email()
@@ -908,7 +908,7 @@ export namespace f0FormField {
     config: TextareaConfig & { optional: true }
   ): z.ZodOptional<z.ZodString> & F0ZodType<z.ZodOptional<z.ZodString>>
   export function textarea(
-    config: TextareaConfig & { optional?: false | undefined }
+    config: TextareaConfig & { optional?: false }
   ): z.ZodString & F0ZodType<z.ZodString>
   export function textarea({ optional, ...config }: TextareaConfig) {
     const schema = optional ? z.string().optional() : z.string().min(1)
@@ -932,7 +932,7 @@ export namespace f0FormField {
     config: NumberConfig & { optional: true }
   ): z.ZodOptional<z.ZodNumber> & F0ZodType<z.ZodOptional<z.ZodNumber>>
   export function number(
-    config: NumberConfig & { optional?: false | undefined }
+    config: NumberConfig & { optional?: false }
   ): z.ZodNumber & F0ZodType<z.ZodNumber>
   export function number({
     optional,
@@ -966,7 +966,7 @@ export namespace f0FormField {
     config: SwitchConfig & { optional: true }
   ): z.ZodBoolean & F0ZodType<z.ZodBoolean>
   export function boolean(
-    config: SwitchConfig & { optional?: false | undefined }
+    config: SwitchConfig & { optional?: false }
   ): z.ZodLiteral<true> & F0ZodType<z.ZodLiteral<true>>
   export function boolean({ optional, ...config }: SwitchConfig) {
     const schema = optional ? z.boolean() : z.literal(true as const)
@@ -987,7 +987,7 @@ export namespace f0FormField {
     config: CheckboxConfig & { optional: true }
   ): z.ZodBoolean & F0ZodType<z.ZodBoolean>
   export function checkbox(
-    config: CheckboxConfig & { optional?: false | undefined }
+    config: CheckboxConfig & { optional?: false }
   ): z.ZodLiteral<true> & F0ZodType<z.ZodLiteral<true>>
   export function checkbox({ optional, ...config }: CheckboxConfig) {
     const schema = optional ? z.boolean() : z.literal(true as const)
@@ -1008,7 +1008,7 @@ export namespace f0FormField {
     config: DateConfig & { optional: true }
   ): z.ZodOptional<z.ZodDate> & F0ZodType<z.ZodOptional<z.ZodDate>>
   export function date(
-    config: DateConfig & { optional?: false | undefined }
+    config: DateConfig & { optional?: false }
   ): z.ZodDate & F0ZodType<z.ZodDate>
   export function date({ optional, ...config }: DateConfig) {
     const schema = optional ? z.date().optional() : z.date()
@@ -1026,7 +1026,7 @@ export namespace f0FormField {
     config: UrlConfig & { optional: true }
   ): z.ZodOptional<z.ZodString> & F0ZodType<z.ZodOptional<z.ZodString>>
   export function url(
-    config: UrlConfig & { optional?: false | undefined }
+    config: UrlConfig & { optional?: false }
   ): z.ZodString & F0ZodType<z.ZodString>
   export function url({ optional, ...config }: UrlConfig) {
     const schema = optional ? z.string().url().optional() : z.string().url()
@@ -1044,7 +1044,7 @@ export namespace f0FormField {
     config: MoneyConfig & { optional: true }
   ): z.ZodOptional<z.ZodNumber> & F0ZodType<z.ZodOptional<z.ZodNumber>>
   export function money(
-    config: MoneyConfig & { optional?: false | undefined }
+    config: MoneyConfig & { optional?: false }
   ): z.ZodNumber & F0ZodType<z.ZodNumber>
   export function money({ optional, ...config }: MoneyConfig) {
     const schema = optional ? z.number().optional() : z.number()
@@ -1067,7 +1067,7 @@ export namespace f0FormField {
     config: PercentageConfig & { optional: true }
   ): z.ZodOptional<z.ZodNumber> & F0ZodType<z.ZodOptional<z.ZodNumber>>
   export function percentage(
-    config: PercentageConfig & { optional?: false | undefined }
+    config: PercentageConfig & { optional?: false }
   ): z.ZodNumber & F0ZodType<z.ZodNumber>
   export function percentage({
     optional,
@@ -1105,7 +1105,7 @@ export namespace f0FormField {
   ): z.ZodOptional<z.ZodEnum<[V, ...V[]]>> &
     F0ZodType<z.ZodOptional<z.ZodEnum<[V, ...V[]]>>>
   export function cardSelect<const V extends string>(
-    config: CardSelectConfig<V> & { optional?: false | undefined }
+    config: CardSelectConfig<V> & { optional?: false }
   ): z.ZodEnum<[V, ...V[]]> & F0ZodType<z.ZodEnum<[V, ...V[]]>>
   export function cardSelect<const V extends string>(
     config: CardSelectConfig<V>
@@ -1135,7 +1135,7 @@ export namespace f0FormField {
     config: FileConfig & { optional: true }
   ): z.ZodOptional<z.ZodString> & F0ZodType<z.ZodOptional<z.ZodString>>
   export function file(
-    config: FileConfig & { optional?: false | undefined }
+    config: FileConfig & { optional?: false }
   ): z.ZodString & F0ZodType<z.ZodString>
   export function file({ optional, ...config }: FileConfig) {
     const schema = optional ? z.string().optional() : z.string().min(1)
@@ -1157,7 +1157,7 @@ export namespace f0FormField {
   ): z.ZodOptional<z.ZodArray<z.ZodString>> &
     F0ZodType<z.ZodOptional<z.ZodArray<z.ZodString>>>
   export function multiFile(
-    config: MultiFileConfig & { optional?: false | undefined }
+    config: MultiFileConfig & { optional?: false }
   ): z.ZodArray<z.ZodString> & F0ZodType<z.ZodArray<z.ZodString>>
   export function multiFile({ optional, ...config }: MultiFileConfig) {
     const schema = optional
@@ -1180,7 +1180,7 @@ export namespace f0FormField {
     config: TimeConfig & { optional: true }
   ): z.ZodOptional<z.ZodDate> & F0ZodType<z.ZodOptional<z.ZodDate>>
   export function time(
-    config: TimeConfig & { optional?: false | undefined }
+    config: TimeConfig & { optional?: false }
   ): z.ZodDate & F0ZodType<z.ZodDate>
   export function time({ optional, ...config }: TimeConfig) {
     const schema = optional ? z.date().optional() : z.date()
@@ -1201,7 +1201,7 @@ export namespace f0FormField {
     config: DateTimeConfig & { optional: true }
   ): z.ZodOptional<z.ZodDate> & F0ZodType<z.ZodOptional<z.ZodDate>>
   export function datetime(
-    config: DateTimeConfig & { optional?: false | undefined }
+    config: DateTimeConfig & { optional?: false }
   ): z.ZodDate & F0ZodType<z.ZodDate>
   export function datetime({ optional, ...config }: DateTimeConfig) {
     const schema = optional ? z.date().optional() : z.date()
@@ -1222,7 +1222,7 @@ export namespace f0FormField {
     config: DurationConfig & { optional: true }
   ): z.ZodOptional<z.ZodNumber> & F0ZodType<z.ZodOptional<z.ZodNumber>>
   export function duration(
-    config: DurationConfig & { optional?: false | undefined }
+    config: DurationConfig & { optional?: false }
   ): z.ZodNumber & F0ZodType<z.ZodNumber>
   export function duration({ optional, ...config }: DurationConfig) {
     const schema = optional ? z.number().optional() : z.number()
@@ -1246,7 +1246,7 @@ export namespace f0FormField {
   ): z.ZodOptional<DateRangeObjectSchema> &
     F0ZodType<z.ZodOptional<DateRangeObjectSchema>>
   export function dateRange(
-    config: DateRangeConfig & { optional?: false | undefined }
+    config: DateRangeConfig & { optional?: false }
   ): DateRangeObjectSchema & F0ZodType<DateRangeObjectSchema>
   export function dateRange({ optional, ...config }: DateRangeConfig) {
     const baseSchema = z.object({ from: z.date(), to: z.date() })
@@ -1276,7 +1276,7 @@ export namespace f0FormField {
   ): z.ZodOptional<z.ZodNullable<PeriodValueSchema>> &
     F0ZodType<z.ZodOptional<z.ZodNullable<PeriodValueSchema>>>
   export function datePeriod(
-    config: DatePeriodConfig & { optional?: false | undefined }
+    config: DatePeriodConfig & { optional?: false }
   ): PeriodValueSchema & F0ZodType<PeriodValueSchema>
   export function datePeriod({ optional, ...config }: DatePeriodConfig) {
     const base = z.object({
@@ -1328,7 +1328,7 @@ export namespace f0FormField {
   ): z.ZodOptional<PhoneObjectSchema> &
     F0ZodType<z.ZodOptional<PhoneObjectSchema>>
   export function phone(
-    config: PhoneFieldShortcutConfig & { optional?: false | undefined }
+    config: PhoneFieldShortcutConfig & { optional?: false }
   ): PhoneObjectSchema & F0ZodType<PhoneObjectSchema>
   export function phone({
     optional,
@@ -1385,7 +1385,7 @@ export namespace f0FormField {
   ): z.ZodOptional<RichTextObjectSchema> &
     F0ZodType<z.ZodOptional<RichTextObjectSchema>>
   export function richText(
-    config: RichTextConfig & { optional?: false | undefined }
+    config: RichTextConfig & { optional?: false }
   ): RichTextObjectSchema & F0ZodType<RichTextObjectSchema>
   export function richText({ optional, ...config }: RichTextConfig) {
     const base = z.object({
@@ -1423,7 +1423,7 @@ export namespace f0FormField {
   >(
     config: SelectConfig<R> & {
       options: ({ value: V } & Record<string, unknown>)[]
-      optional?: false | undefined
+      optional?: false
     }
   ): z.ZodEnum<[V, ...V[]]> & F0ZodType<z.ZodEnum<[V, ...V[]]>>
   // Without options → z.string()
@@ -1435,7 +1435,7 @@ export namespace f0FormField {
   export function select<
     R extends Record<string, unknown> = Record<string, unknown>,
   >(
-    config: SelectConfig<R> & { optional?: false | undefined }
+    config: SelectConfig<R> & { optional?: false }
   ): z.ZodString & F0ZodType<z.ZodString>
   export function select(config: unknown) {
     if (typeof config !== "object" || config === null) {
@@ -1482,7 +1482,7 @@ export namespace f0FormField {
   export function multiSelect<const V extends string>(
     config: Omit<MultiSelectConfig, "options"> & {
       options: ({ value: V } & Record<string, unknown>)[]
-      optional?: false | undefined
+      optional?: false
     }
   ): z.ZodArray<z.ZodEnum<[V, ...V[]]>> &
     F0ZodType<z.ZodArray<z.ZodEnum<[V, ...V[]]>>>
@@ -1498,7 +1498,7 @@ export namespace f0FormField {
     V extends string | number = string,
     R extends Record<string, unknown> = Record<string, unknown>,
   >(
-    config: MultiSelectConfig<V, R> & { optional?: false | undefined }
+    config: MultiSelectConfig<V, R> & { optional?: false }
   ): z.ZodArray<z.ZodString> & F0ZodType<z.ZodArray<z.ZodString>>
   export function multiSelect(config: unknown) {
     if (typeof config !== "object" || config === null) {
@@ -1634,7 +1634,7 @@ export namespace f0FormField {
   ): OptionalEntitiesListArray<TItem> &
     F0ZodType<z.ZodOptional<z.ZodArray<TItem>>>
   export function entitiesList<TItem extends z.ZodObject<z.ZodRawShape>>(
-    config: EntitiesListSingleConfig<TItem> & { optional?: false | undefined }
+    config: EntitiesListSingleConfig<TItem> & { optional?: false }
   ): EntitiesListArray<TItem> & F0ZodType<z.ZodArray<TItem>>
   // Split-form overloads: the value type follows the update form's schema.
   export function entitiesList<
@@ -1649,7 +1649,7 @@ export namespace f0FormField {
     TUpdate extends z.ZodObject<z.ZodRawShape>,
   >(
     config: EntitiesListFormDefsConfig<TCreate, TUpdate> & {
-      optional?: false | undefined
+      optional?: false
     }
   ): EntitiesListArray<TUpdate> & F0ZodType<z.ZodArray<TUpdate>>
   export function entitiesList(

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
@@ -60,6 +60,13 @@ type EntitiesListError =
  */
 type EntitiesListRow = { __key: string } & Record<string, unknown>
 
+const patchRow = (
+  rows: EntitiesListRow[],
+  key: string,
+  partial: Partial<EntitiesListItem>
+): EntitiesListRow[] =>
+  rows.map((r) => (r.__key === key ? { ...r, ...partial } : r))
+
 interface EntitiesListFieldRendererProps {
   field: ResolvedField<F0EntitiesListField>
   formField: ControllerRenderProps
@@ -749,12 +756,7 @@ export function EntitiesListFieldRenderer({
             action.onClick({
               item,
               index,
-              update: (partial) =>
-                commit(
-                  rows.map((r) =>
-                    r.__key === row.__key ? { ...r, ...partial } : r
-                  )
-                ),
+              update: (partial) => commit(patchRow(rows, row.__key, partial)),
               // Route through the confirm + persist path so custom actions that
               // call remove() also confirm and hit onRemove.
               remove: () => void performRemove(row),
@@ -881,10 +883,7 @@ export function EntitiesListFieldRenderer({
           action.onClick({
             item,
             index,
-            update: (partial) =>
-              commit(
-                rows.map((r) => (r.__key === rowKey ? { ...r, ...partial } : r))
-              ),
+            update: (partial) => commit(patchRow(rows, rowKey, partial)),
             // Route through the confirm + persist path so custom actions that
             // call remove() also confirm and hit onRemove.
             remove: () => void performRemove(rows[index]),

--- a/packages/react/src/patterns/F0Form/fields/richtext/RichTextFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/richtext/RichTextFieldRenderer.tsx
@@ -7,6 +7,8 @@ import {
 import type { ResolvedField } from "../types"
 import type { F0RichTextField, RichTextValue } from "./types"
 
+type RichTextFieldValue = RichTextValue | string | undefined
+
 interface RichTextFieldRendererProps {
   field: ResolvedField<F0RichTextField>
   formField: ControllerRenderProps
@@ -28,7 +30,7 @@ function haveEqualMentionIds(
 }
 
 function areEquivalentRichTextValues(
-  currentValue: RichTextValue | string | undefined,
+  currentValue: RichTextFieldValue,
   nextValue: RichTextValue
 ) {
   const currentContent =
@@ -55,12 +57,10 @@ export function RichTextFieldRenderer({
   loading,
 }: RichTextFieldRendererProps) {
   const { ref: formRef, ...formFieldRest } = formField
-  const rawValue = formField.value as RichTextValue | string | undefined
+  const rawValue = formField.value as RichTextFieldValue
   const editorRef = useRef<RichTextEditorHandle>(null)
   const lastInternalContentRef = useRef<string>("")
-  const lastAcceptedValueRef = useRef<RichTextValue | string | undefined>(
-    rawValue
-  )
+  const lastAcceptedValueRef = useRef<RichTextFieldValue>(rawValue)
 
   // Compose react-hook-form's ref (used for shouldFocusError) with our own
   const composedRef = useCallback(

--- a/packages/react/src/patterns/F0Form/useErrorNavigation.ts
+++ b/packages/react/src/patterns/F0Form/useErrorNavigation.ts
@@ -45,7 +45,7 @@ const applyErrorNavigationHighlight = (element: HTMLElement) => {
 
   // Remove and re-add class to restart animation
   element.classList.remove(errorNavigateClassName)
-  void element.offsetWidth // Force reflow
+  element.getBoundingClientRect() // Force reflow
   element.classList.add(errorNavigateClassName)
 
   const timeout = setTimeout(() => {

--- a/packages/react/src/patterns/F0FormField/__stories__/F0FormField.stories.tsx
+++ b/packages/react/src/patterns/F0FormField/__stories__/F0FormField.stories.tsx
@@ -119,7 +119,7 @@ export const Textarea: Story = {
 /**
  * A number input field.
  */
-export const Number: Story = {
+const NumberField: Story = {
   render() {
     const [value, setValue] = useState<number | undefined>(undefined)
 
@@ -177,7 +177,7 @@ export const Select: Story = {
 /**
  * A date picker field.
  */
-export const Date: Story = {
+const DateField: Story = {
   render() {
     const [value, setValue] = useState<globalThis.Date | undefined>(undefined)
 
@@ -734,3 +734,9 @@ export const LoadingState: Story = {
     )
   },
 }
+
+// Exported under the global's name so the story id stays `--number`.
+export { NumberField as Number }
+
+// Exported under the global's name so the story id stays `--date`.
+export { DateField as Date }

--- a/packages/react/src/patterns/F0FormField/__tests__/F0FormField.test.tsx
+++ b/packages/react/src/patterns/F0FormField/__tests__/F0FormField.test.tsx
@@ -551,7 +551,7 @@ describe("F0FormField", () => {
 
       // No help text in the document
       const helpTexts = screen.queryAllByText(/Username/)
-      expect(helpTexts.length).toBe(1) // Only label, no help text
+      expect(helpTexts).toHaveLength(1) // Only label, no help text
     })
   })
 

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.focusNoRefire.test.tsx
@@ -87,7 +87,7 @@ describe("F0Graph — focusedNode fly-to does not re-fire on layout changes", ()
     settle()
 
     // No extra fly-to: the effect only reacts to a focusedNode change.
-    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry)
+    expect(mockReactFlow.fitView.mock.calls).toHaveLength(afterEntry)
   })
 
   it("applies the initial frame once and does not re-frame on a later collapse", () => {
@@ -124,7 +124,7 @@ describe("F0Graph — focusedNode fly-to does not re-fire on layout changes", ()
     settle()
 
     // No re-frame: the initial frame is one-shot.
-    expect(mockReactFlow.setCenter.mock.calls.length).toBe(afterEntry)
+    expect(mockReactFlow.setCenter.mock.calls).toHaveLength(afterEntry)
   })
 
   it("still flies when focusedNode changes to a new value", () => {
@@ -153,7 +153,7 @@ describe("F0Graph — focusedNode fly-to does not re-fire on layout changes", ()
     )
     settle()
 
-    expect(mockReactFlow.fitView.mock.calls.length).toBe(afterEntry + 1)
+    expect(mockReactFlow.fitView.mock.calls).toHaveLength(afterEntry + 1)
     expect(mockReactFlow.fitView).toHaveBeenLastCalledWith(
       expect.objectContaining({ nodes: [{ id: "a" }] })
     )

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.initialFocusFrame.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.initialFocusFrame.test.tsx
@@ -104,7 +104,7 @@ describe("F0Graph — initial focus frame is measurement-independent", () => {
       </div>
     )
     settle()
-    expect(mockReactFlow.setCenter.mock.calls.length).toBe(afterEntry)
+    expect(mockReactFlow.setCenter.mock.calls).toHaveLength(afterEntry)
   })
 
   it("still frames when a re-render churns the node set before the settle delay", () => {

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.stackedHoverReveal.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.stackedHoverReveal.test.tsx
@@ -140,7 +140,7 @@ describe("revealing a stacked parent's collapse button from inside its column", 
     fireEvent.pointerMove(tree(), { clientX: 400, clientY: 300 })
 
     expect(revealFlags()).toContain("true")
-    expect(renderNode.mock.calls.length).toBe(before)
+    expect(renderNode.mock.calls).toHaveLength(before)
   })
 
   it("does no work at all for a pointer that stays inside one column", () => {
@@ -155,6 +155,6 @@ describe("revealing a stacked parent's collapse button from inside its column", 
     flowPoint = { x: 130, y: 260 }
     fireEvent.pointerMove(tree(), { clientX: 401, clientY: 340 })
 
-    expect(renderNode.mock.calls.length).toBe(afterFirst)
+    expect(renderNode.mock.calls).toHaveLength(afterFirst)
   })
 })

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphRenderModel.test.ts
@@ -25,6 +25,8 @@ const wrapper = ({ children }: { children: ReactNode }) =>
 const renderModel = (options: Parameters<typeof useGraphRenderModel>[0]) =>
   renderHook(() => useGraphRenderModel(options), { wrapper })
 
+// Fixture builder: 39 call sites read better positionally than as objects.
+// oxlint-disable-next-line max-params
 const treeNode = (
   id: string,
   parentId: string | null,

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphZoomLevel.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useGraphZoomLevel.test.ts
@@ -10,25 +10,18 @@ function renderZoomLevel(
 }
 
 describe("useGraphZoomLevel", () => {
-  it("returns 'detail' for zoom factor 1.0", () => {
-    const { result } = renderZoomLevel(1.0)
-    expect(result.current).toBe("detail")
-  })
-
-  it("returns 'compact' for zoom factor 0.5", () => {
-    const { result } = renderZoomLevel(0.5)
-    expect(result.current).toBe("compact")
-  })
-
-  it("returns 'dot' for zoom factor 0.2", () => {
-    const { result } = renderZoomLevel(0.2)
-    expect(result.current).toBe("dot")
-  })
-
-  it("returns 'dot' for zoom factor 0.05", () => {
-    const { result } = renderZoomLevel(0.05)
-    expect(result.current).toBe("dot")
-  })
+  it.each([
+    { zoomFactor: 1.0, level: "detail" },
+    { zoomFactor: 0.5, level: "compact" },
+    { zoomFactor: 0.2, level: "dot" },
+    { zoomFactor: 0.05, level: "dot" },
+  ])(
+    "returns '$level' for zoom factor $zoomFactor",
+    ({ zoomFactor, level }) => {
+      const { result } = renderZoomLevel(zoomFactor)
+      expect(result.current).toBe(level)
+    }
+  )
 
   it("hysteresis prevents flicker at threshold boundaries", () => {
     // Use explicit thresholds so this test is independent of default preset changes.

--- a/packages/react/src/patterns/F0Graph/hooks/__tests__/useViewportDataLoader.test.ts
+++ b/packages/react/src/patterns/F0Graph/hooks/__tests__/useViewportDataLoader.test.ts
@@ -12,8 +12,8 @@ afterEach(() => vi.useRealTimers())
 describe("useViewportDataLoader", () => {
   it("does nothing when loadVisibleNodeData is undefined", () => {
     renderHook(() => useViewportDataLoader({ nodeIds: ["a", "b"] }))
-    // No callback → nothing to assert beyond "no throw"; advancing timers is safe.
-    act(() => vi.advanceTimersByTime(1000))
+    // No callback → nothing to load; advancing timers must be a no-op.
+    expect(() => act(() => vi.advanceTimersByTime(1000))).not.toThrow()
   })
 
   it("flushes newly-visible ids as one batch after the debounce", () => {

--- a/packages/react/src/patterns/F0Graph/utils.ts
+++ b/packages/react/src/patterns/F0Graph/utils.ts
@@ -46,6 +46,9 @@ export interface ViewportRect {
  * Whether a node box (top-left `x`/`y`, size `width`/`height`) overlaps `rect`.
  * Pure AABB intersection — the core predicate behind node-array windowing.
  */
+// Hot path (runs per node on every pan and zoom). Primitives avoid allocating
+// a box object per call.
+// oxlint-disable-next-line max-params
 export function nodeIntersectsRect(
   x: number,
   y: number,

--- a/packages/react/src/patterns/F0Map/F0Map.tsx
+++ b/packages/react/src/patterns/F0Map/F0Map.tsx
@@ -163,16 +163,23 @@ const framedCoords = (
   ...arcs.flatMap((a) => [a.from, a.to]),
 ]
 
-const fitToPoints = (
-  map: maplibregl.Map,
-  points: F0MapPoint[],
-  animate: boolean,
-  {
-    routes = [],
-    arcs = [],
-    padding = 64,
-  }: { routes?: F0MapRoute[]; arcs?: F0MapArc[]; padding?: number } = {}
-) => {
+type FitToPointsOptions = {
+  map: maplibregl.Map
+  points: F0MapPoint[]
+  animate: boolean
+  routes?: F0MapRoute[]
+  arcs?: F0MapArc[]
+  padding?: number
+}
+
+const fitToPoints = ({
+  map,
+  points,
+  animate,
+  routes = [],
+  arcs = [],
+  padding = 64,
+}: FitToPointsOptions) => {
   const coords = framedCoords(points, routes, arcs)
   if (coords.length === 0) {
     return
@@ -320,7 +327,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   const handleZoomOut = useCallback(() => mapRef.current?.zoomOut(), [])
   const handleFit = useCallback(() => {
     if (mapRef.current) {
-      fitToPoints(mapRef.current, markersRef.current, !reduceMotion, {
+      fitToPoints({
+        map: mapRef.current,
+        points: markersRef.current,
+        animate: !reduceMotion,
         routes: routesRef.current,
         arcs: arcsRef.current,
       })
@@ -366,7 +376,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
       },
       fitToMarkers: () => {
         if (mapRef.current) {
-          fitToPoints(mapRef.current, markersRef.current, !reduceMotion, {
+          fitToPoints({
+            map: mapRef.current,
+            points: markersRef.current,
+            animate: !reduceMotion,
             routes: routesRef.current,
             arcs: arcsRef.current,
           })
@@ -438,7 +451,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
       setTileError(false)
       map.resize()
       if (shouldFit) {
-        fitToPoints(map, markersRef.current, false, {
+        fitToPoints({
+          map,
+          points: markersRef.current,
+          animate: false,
           routes: routesRef.current,
           arcs: arcsRef.current,
         })

--- a/packages/react/src/patterns/F0Map/F0Map.tsx
+++ b/packages/react/src/patterns/F0Map/F0Map.tsx
@@ -167,9 +167,11 @@ const fitToPoints = (
   map: maplibregl.Map,
   points: F0MapPoint[],
   animate: boolean,
-  routes: F0MapRoute[] = [],
-  arcs: F0MapArc[] = [],
-  padding = 64
+  {
+    routes = [],
+    arcs = [],
+    padding = 64,
+  }: { routes?: F0MapRoute[]; arcs?: F0MapArc[]; padding?: number } = {}
 ) => {
   const coords = framedCoords(points, routes, arcs)
   if (coords.length === 0) {
@@ -318,13 +320,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
   const handleZoomOut = useCallback(() => mapRef.current?.zoomOut(), [])
   const handleFit = useCallback(() => {
     if (mapRef.current) {
-      fitToPoints(
-        mapRef.current,
-        markersRef.current,
-        !reduceMotion,
-        routesRef.current,
-        arcsRef.current
-      )
+      fitToPoints(mapRef.current, markersRef.current, !reduceMotion, {
+        routes: routesRef.current,
+        arcs: arcsRef.current,
+      })
     }
   }, [reduceMotion])
   const handleLocate = useCallback(() => {
@@ -367,13 +366,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
       },
       fitToMarkers: () => {
         if (mapRef.current) {
-          fitToPoints(
-            mapRef.current,
-            markersRef.current,
-            !reduceMotion,
-            routesRef.current,
-            arcsRef.current
-          )
+          fitToPoints(mapRef.current, markersRef.current, !reduceMotion, {
+            routes: routesRef.current,
+            arcs: arcsRef.current,
+          })
         }
       },
       clearSelection: () => selectRef.current(null),
@@ -442,13 +438,10 @@ const F0MapBase = forwardRef<F0MapHandle, F0MapProps>(function F0Map(
       setTileError(false)
       map.resize()
       if (shouldFit) {
-        fitToPoints(
-          map,
-          markersRef.current,
-          false,
-          routesRef.current,
-          arcsRef.current
-        )
+        fitToPoints(map, markersRef.current, false, {
+          routes: routesRef.current,
+          arcs: arcsRef.current,
+        })
       }
       map.setProjection({ type: projectionRef.current })
     })

--- a/packages/react/src/patterns/F0Map/components/F0MapMarkersLayer.tsx
+++ b/packages/react/src/patterns/F0Map/components/F0MapMarkersLayer.tsx
@@ -226,7 +226,7 @@ export const F0MapMarkersLayer = ({
   const reduceMotion = useReducedMotion()
   // Clustering is always on - markers gather when zoomed out and separate as
   // you zoom in. It is intrinsic to the map, not a mode the caller opts into.
-  const { clusters, singles } = useClusters(map, points, true)
+  const { clusters, singles } = useClusters({ map, points, enabled: true })
   // Markers bump one size step up once POI names appear (see POI_LABEL_ZOOM).
   const poiZoom = useZoomAtLeast(map, POI_LABEL_ZOOM)
   const sizeStep: BaseMapMarkerSize = poiZoom ? "lg" : "md"

--- a/packages/react/src/patterns/F0Map/components/F0MapVectorLayer.tsx
+++ b/packages/react/src/patterns/F0Map/components/F0MapVectorLayer.tsx
@@ -57,13 +57,19 @@ interface LineCollection {
   features: LineFeature[]
 }
 
-const feature = (
-  id: string,
-  kind: LineKind,
-  coordinates: [number, number][],
-  style: F0MapLineStyle,
+const feature = ({
+  id,
+  kind,
+  coordinates,
+  style,
+  isDark,
+}: {
+  id: string
+  kind: LineKind
+  coordinates: [number, number][]
+  style: F0MapLineStyle
   isDark: boolean
-): LineFeature => ({
+}): LineFeature => ({
   type: "Feature",
   // Top-level id (via `promoteId`) is what `setFeatureState` keys on for hover.
   id,
@@ -86,9 +92,23 @@ const buildCollection = (
 ): LineCollection => ({
   type: "FeatureCollection",
   features: [
-    ...routes.map((r) => feature(r.id, "route", r.coordinates, r, isDark)),
+    ...routes.map((r) =>
+      feature({
+        id: r.id,
+        kind: "route",
+        coordinates: r.coordinates,
+        style: r,
+        isDark,
+      })
+    ),
     ...arcs.map((a) =>
-      feature(a.id, "arc", arcLineString(a.from, a.to, a.curvature), a, isDark)
+      feature({
+        id: a.id,
+        kind: "arc",
+        coordinates: arcLineString(a.from, a.to, a.curvature),
+        style: a,
+        isDark,
+      })
     ),
   ],
 })

--- a/packages/react/src/patterns/F0Map/components/F0MapVectorLayer.tsx
+++ b/packages/react/src/patterns/F0Map/components/F0MapVectorLayer.tsx
@@ -57,19 +57,21 @@ interface LineCollection {
   features: LineFeature[]
 }
 
+type LineFeatureOptions = {
+  id: string
+  kind: LineKind
+  coordinates: [number, number][]
+  style: F0MapLineStyle
+  isDark: boolean
+}
+
 const feature = ({
   id,
   kind,
   coordinates,
   style,
   isDark,
-}: {
-  id: string
-  kind: LineKind
-  coordinates: [number, number][]
-  style: F0MapLineStyle
-  isDark: boolean
-}): LineFeature => ({
+}: LineFeatureOptions): LineFeature => ({
   type: "Feature",
   // Top-level id (via `promoteId`) is what `setFeatureState` keys on for hover.
   id,

--- a/packages/react/src/patterns/F0Map/hooks/useClusters.ts
+++ b/packages/react/src/patterns/F0Map/hooks/useClusters.ts
@@ -29,15 +29,21 @@ export interface F0MapClusterResult {
  * points within the looser `clusterRadius`. This keeps individual markers
  * distinct while still gathering the rest of a dense pocket into one pile.
  */
-export const useClusters = (
-  map: maplibregl.Map | null,
-  points: F0MapPoint[],
-  enabled: boolean,
-  {
-    radius = 12,
-    clusterRadius = 164,
-  }: { radius?: number; clusterRadius?: number } = {}
-): F0MapClusterResult => {
+type UseClustersOptions = {
+  map: maplibregl.Map | null
+  points: F0MapPoint[]
+  enabled: boolean
+  radius?: number
+  clusterRadius?: number
+}
+
+export const useClusters = ({
+  map,
+  points,
+  enabled,
+  radius = 12,
+  clusterRadius = 164,
+}: UseClustersOptions): F0MapClusterResult => {
   const [result, setResult] = useState<F0MapClusterResult>({
     clusters: [],
     singles: points,

--- a/packages/react/src/patterns/F0Map/hooks/useClusters.ts
+++ b/packages/react/src/patterns/F0Map/hooks/useClusters.ts
@@ -33,8 +33,10 @@ export const useClusters = (
   map: maplibregl.Map | null,
   points: F0MapPoint[],
   enabled: boolean,
-  radius = 12,
-  clusterRadius = 164
+  {
+    radius = 12,
+    clusterRadius = 164,
+  }: { radius?: number; clusterRadius?: number } = {}
 ): F0MapClusterResult => {
   const [result, setResult] = useState<F0MapClusterResult>({
     clusters: [],

--- a/packages/react/src/patterns/F0Map/hooks/useLabelCollision.ts
+++ b/packages/react/src/patterns/F0Map/hooks/useLabelCollision.ts
@@ -42,15 +42,15 @@ export const measureLabel = (text: string, fontPx: number): number => {
 }
 
 // Label box for a given placement, relative to a head centered at (cx, cy).
-const labelBox = (
-  placement: BaseMapMarkerLabelPlacement,
-  {
-    cx,
-    cy,
-    point,
-    size,
-  }: { cx: number; cy: number; point: F0MapPoint; size: BaseMapMarkerSize }
-): Box => {
+type LabelBoxOptions = {
+  placement: BaseMapMarkerLabelPlacement
+  cx: number
+  cy: number
+  point: F0MapPoint
+  size: BaseMapMarkerSize
+}
+
+const labelBox = ({ placement, cx, cy, point, size }: LabelBoxOptions): Box => {
   const m = getMarkerMetrics(size)
   const raw = measureLabel(point.label ?? "", m.label) + 2
   const half = m.d / 2
@@ -147,7 +147,7 @@ export const useLabelCollision = (
 
         let chosen: BaseMapMarkerLabelPlacement | null = null
         for (const placement of candidates) {
-          const box = labelBox(placement, { cx: s.x, cy: s.y, point: p, size })
+          const box = labelBox({ placement, cx: s.x, cy: s.y, point: p, size })
           const hitsHead = heads.some((h) => boxesOverlap(box, h))
           const hitsLabel = placedLabels.some((l) => boxesOverlap(box, l))
           if (!hitsHead && !hitsLabel) {

--- a/packages/react/src/patterns/F0Map/hooks/useLabelCollision.ts
+++ b/packages/react/src/patterns/F0Map/hooks/useLabelCollision.ts
@@ -44,10 +44,12 @@ export const measureLabel = (text: string, fontPx: number): number => {
 // Label box for a given placement, relative to a head centered at (cx, cy).
 const labelBox = (
   placement: BaseMapMarkerLabelPlacement,
-  cx: number,
-  cy: number,
-  point: F0MapPoint,
-  size: BaseMapMarkerSize
+  {
+    cx,
+    cy,
+    point,
+    size,
+  }: { cx: number; cy: number; point: F0MapPoint; size: BaseMapMarkerSize }
 ): Box => {
   const m = getMarkerMetrics(size)
   const raw = measureLabel(point.label ?? "", m.label) + 2
@@ -145,7 +147,7 @@ export const useLabelCollision = (
 
         let chosen: BaseMapMarkerLabelPlacement | null = null
         for (const placement of candidates) {
-          const box = labelBox(placement, s.x, s.y, p, size)
+          const box = labelBox(placement, { cx: s.x, cy: s.y, point: p, size })
           const hitsHead = heads.some((h) => boxesOverlap(box, h))
           const hitsLabel = placedLabels.some((l) => boxesOverlap(box, l))
           if (!hitsHead && !hitsLabel) {

--- a/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
+++ b/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
@@ -158,15 +158,7 @@ function useWizardActionBar() {
 // Step derivation
 // =============================================================================
 
-function deriveWizardSteps({
-  sectionIds,
-  sections,
-  customSteps,
-  isStepAllDisabled,
-  onNextForStep,
-  hasErrorsForStep,
-  isStepDataFilled,
-}: {
+type DeriveWizardStepsOptions = {
   sectionIds: string[]
   sections:
     | Record<string, F0SectionConfig | F0PerSectionSectionConfig>
@@ -176,7 +168,17 @@ function deriveWizardSteps({
   onNextForStep: (stepIndex: number) => () => Promise<void>
   hasErrorsForStep?: (stepIndex: number) => boolean
   isStepDataFilled?: (stepIndex: number) => boolean
-}): F0WizardStep[] {
+}
+
+function deriveWizardSteps({
+  sectionIds,
+  sections,
+  customSteps,
+  isStepAllDisabled,
+  onNextForStep,
+  hasErrorsForStep,
+  isStepDataFilled,
+}: DeriveWizardStepsOptions): F0WizardStep[] {
   const stepsConfig: F0WizardFormStep[] =
     customSteps ??
     sectionIds.map((id) => ({

--- a/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
+++ b/packages/react/src/patterns/F0WizardForm/F0WizardForm.tsx
@@ -158,17 +158,25 @@ function useWizardActionBar() {
 // Step derivation
 // =============================================================================
 
-function deriveWizardSteps(
-  sectionIds: string[],
+function deriveWizardSteps({
+  sectionIds,
+  sections,
+  customSteps,
+  isStepAllDisabled,
+  onNextForStep,
+  hasErrorsForStep,
+  isStepDataFilled,
+}: {
+  sectionIds: string[]
   sections:
     | Record<string, F0SectionConfig | F0PerSectionSectionConfig>
-    | undefined,
-  customSteps: F0WizardFormStep[] | undefined,
-  isStepAllDisabled: (sectionIds: string[]) => boolean,
-  onNextForStep: (stepIndex: number) => () => Promise<void>,
-  hasErrorsForStep?: (stepIndex: number) => boolean,
+    | undefined
+  customSteps: F0WizardFormStep[] | undefined
+  isStepAllDisabled: (sectionIds: string[]) => boolean
+  onNextForStep: (stepIndex: number) => () => Promise<void>
+  hasErrorsForStep?: (stepIndex: number) => boolean
   isStepDataFilled?: (stepIndex: number) => boolean
-): F0WizardStep[] {
+}): F0WizardStep[] {
   const stepsConfig: F0WizardFormStep[] =
     customSteps ??
     sectionIds.map((id) => ({
@@ -373,15 +381,15 @@ function F0WizardFormPerSection<T extends F0PerSectionSchema>({
 
   const wizardSteps = useMemo(
     () =>
-      deriveWizardSteps(
+      deriveWizardSteps({
         sectionIds,
         sections,
-        effectiveSteps,
+        customSteps: effectiveSteps,
         isStepAllDisabled,
         onNextForStep,
         hasErrorsForStep,
-        autoSkipCompletedSteps ? isStepDataFilled : undefined
-      ),
+        isStepDataFilled: autoSkipCompletedSteps ? isStepDataFilled : undefined,
+      }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       sectionIds,
@@ -718,15 +726,15 @@ function F0WizardFormSingleSchema<TSchema extends F0FormSchema>({
 
   const wizardSteps = useMemo(
     () =>
-      deriveWizardSteps(
+      deriveWizardSteps({
         sectionIds,
         sections,
-        resolvedSteps,
+        customSteps: resolvedSteps,
         isStepAllDisabled,
         onNextForStep,
         hasErrorsForStep,
-        autoSkipCompletedSteps ? isStepDataFilled : undefined
-      ),
+        isStepDataFilled: autoSkipCompletedSteps ? isStepDataFilled : undefined,
+      }),
     [
       sectionIds,
       sections,

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatProvider.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatProvider.tsx
@@ -43,6 +43,45 @@ export type SidebarChatProviderProps = {
   initialActiveChatId?: string
 }
 
+const patchChatIn = (
+  groups: SidebarChatGroup[],
+  id: string,
+  patch: Partial<SidebarChat>
+) =>
+  mapChats(groups, (chats) =>
+    chats.map((c) => (c.id === id ? { ...c, ...patch } : c))
+  )
+
+const removeChatFrom = (groups: SidebarChatGroup[], id: string) =>
+  mapChats(groups, (chats) => chats.filter((c) => c.id !== id))
+
+const upsertChatIn = (
+  groups: SidebarChatGroup[],
+  groupId: string,
+  chat: SidebarChat
+) => {
+  const exists = groups.some((group) =>
+    group.chats.some((c) => c.id === chat.id)
+  )
+  if (exists) {
+    return patchChatIn(groups, chat.id, chat)
+  }
+  return mapGroup(groups, groupId, (group) => ({
+    ...group,
+    chats: [...group.chats, chat],
+  }))
+}
+
+const reorderChats = (group: SidebarChatGroup, orderedIds: string[]) => {
+  const byId = new Map(group.chats.map((c) => [c.id, c]))
+  const reordered = orderedIds
+    .map((id) => byId.get(id))
+    .filter((c): c is SidebarChat => Boolean(c))
+  // Keep any chat not referenced in orderedIds at the end.
+  const rest = group.chats.filter((c) => !orderedIds.includes(c.id))
+  return { ...group, chats: [...reordered, ...rest] }
+}
+
 export const SidebarChatProvider = ({
   children,
   initialGroups = [],
@@ -61,47 +100,15 @@ export const SidebarChatProvider = ({
       setGroups,
       setActiveChat: (id) => setActiveChatId(id ?? undefined),
       upsertChat: (groupId, chat) =>
-        setGroups((prev) => {
-          const exists = prev.some((group) =>
-            group.chats.some((c) => c.id === chat.id)
-          )
-          if (exists) {
-            return mapChats(prev, (chats) =>
-              chats.map((c) => (c.id === chat.id ? { ...c, ...chat } : c))
-            )
-          }
-          return mapGroup(prev, groupId, (group) => ({
-            ...group,
-            chats: [...group.chats, chat],
-          }))
-        }),
+        setGroups((prev) => upsertChatIn(prev, groupId, chat)),
       updateChat: (id, patch) =>
-        setGroups((prev) =>
-          mapChats(prev, (chats) =>
-            chats.map((c) => (c.id === id ? { ...c, ...patch } : c))
-          )
-        ),
-      removeChat: (id) =>
-        setGroups((prev) =>
-          mapChats(prev, (chats) => chats.filter((c) => c.id !== id))
-        ),
+        setGroups((prev) => patchChatIn(prev, id, patch)),
+      removeChat: (id) => setGroups((prev) => removeChatFrom(prev, id)),
       setUnread: (id, count) =>
-        setGroups((prev) =>
-          mapChats(prev, (chats) =>
-            chats.map((c) => (c.id === id ? { ...c, unreadCount: count } : c))
-          )
-        ),
+        setGroups((prev) => patchChatIn(prev, id, { unreadCount: count })),
       reorder: (groupId, orderedIds) =>
         setGroups((prev) =>
-          mapGroup(prev, groupId, (group) => {
-            const byId = new Map(group.chats.map((c) => [c.id, c]))
-            const reordered = orderedIds
-              .map((id) => byId.get(id))
-              .filter((c): c is SidebarChat => Boolean(c))
-            // Keep any chat not referenced in orderedIds at the end.
-            const rest = group.chats.filter((c) => !orderedIds.includes(c.id))
-            return { ...group, chats: [...reordered, ...rest] }
-          })
+          mapGroup(prev, groupId, (group) => reorderChats(group, orderedIds))
         ),
     }),
     []

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/__tests__/SidebarChatList.test.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/__tests__/SidebarChatList.test.tsx
@@ -1035,7 +1035,7 @@ describe("SidebarChatList unread navigation", () => {
     expect(
       screen.queryByRole("button", { name: /unread chats? above/ })
     ).not.toBeInTheDocument()
-    expect(MockIntersectionObserver.instances.length).toBe(
+    expect(MockIntersectionObserver.instances).toHaveLength(
       observersBeforeStandalone
     )
   })

--- a/packages/react/src/patterns/Navigation/Sidebar/Tabs/__tests__/Tabs.test.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Tabs/__tests__/Tabs.test.tsx
@@ -228,6 +228,6 @@ describe("SidebarTabs persistence", () => {
     const onTabChange = vi.fn()
     renderTabs({ onTabChange })
     expect(onTabChange).not.toHaveBeenCalled()
-    expect(localStorage.length).toBe(0)
+    expect(localStorage).toHaveLength(0)
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -812,6 +812,30 @@ const OneDataCollectionComp = <
       ? source.bulkActions(selectedItems)
       : undefined
 
+    const settleBulkAction = (
+      bulkAction: BulkActionDefinition,
+      result: Promise<void>
+    ) => {
+      setInternalBulkActionStatus("loading")
+      result.then(
+        () => {
+          setInternalBulkActionStatus("success")
+          // Always wipe on success — prevents already-processed items from
+          // mixing with new selections made during loading.
+          scheduleDismiss(() => {
+            if (!bulkAction.keepSelection) {
+              clearSelectedItems()
+            }
+            setInternalBulkActionStatus("idle")
+          }, !bulkAction.keepSelection)
+        },
+        () => {
+          setInternalBulkActionStatus("error")
+          actionBarRef.current?.wiggle({ errorHighlight: true })
+        }
+      )
+    }
+
     const mapBulkActions = (
       action: BulkActionDefinition | { type: "separator" }
     ): MappedBulkAction => {
@@ -852,24 +876,7 @@ const OneDataCollectionComp = <
             return
           }
 
-          setInternalBulkActionStatus("loading")
-          ;(result as Promise<void>).then(
-            () => {
-              setInternalBulkActionStatus("success")
-              // Always wipe on success — prevents already-processed items from
-              // mixing with new selections made during loading.
-              scheduleDismiss(() => {
-                if (!bulkAction.keepSelection) {
-                  clearSelectedItems()
-                }
-                setInternalBulkActionStatus("idle")
-              }, !bulkAction.keepSelection)
-            },
-            () => {
-              setInternalBulkActionStatus("error")
-              actionBarRef.current?.wiggle({ errorHighlight: true })
-            }
-          )
+          settleBulkAction(bulkAction, result as Promise<void>)
         },
       }
     }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.stories.tsx
@@ -1487,12 +1487,12 @@ export const WithSynchronousData: Story = {
         fetchData: ({ filters, sortings, navigationFilters }) => {
           // Ensure sortings are properly applied
           return {
-            records: filterUsers(
-              mockUsers,
-              filters,
-              sortings,
-              navigationFilters
-            ),
+            records: filterUsers({
+              users: mockUsers,
+              filterValues: filters,
+              sortingState: sortings,
+              navigationFilters,
+            }),
           }
         },
       },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -76,6 +76,9 @@ import {
 import { OnBulkActionCallback } from "../types"
 import { Visualization, VisualizationType } from "../visualizations/collection"
 
+type FrozenColumns = 0 | 1 | 2
+type NestedRecordsType = "basic" | "detailed" | "mixed"
+
 const CHILDREN_PER_PAGE = 2
 
 // Mock data for nested subfilters (office → space → desk)
@@ -365,9 +368,9 @@ export const mockUsers = generateMockUsers(10)
 
 export const getMockVisualizations = (options?: {
   // @deprecated
-  frozenColumns?: 0 | 1 | 2
+  frozenColumns?: FrozenColumns
   table?: {
-    frozenColumns?: 0 | 1 | 2
+    frozenColumns?: FrozenColumns
     allowColumnHiding?: boolean
     allowColumnReordering?: boolean
     noSorting?: boolean
@@ -1036,13 +1039,19 @@ export const sortings = {
 } as const
 
 // Helper function to filter users based on filters
-export const filterUsers = (
-  users: MockUser[],
-  filterValues: FiltersState<typeof filters>,
-  sortingState: SortingsStateMultiple,
-  navigationFilters?: NavigationFiltersState<NavigationFiltersDefinition>,
+export const filterUsers = ({
+  users,
+  filterValues,
+  sortingState,
+  navigationFilters,
+  search,
+}: {
+  users: MockUser[]
+  filterValues: FiltersState<typeof filters>
+  sortingState: SortingsStateMultiple
+  navigationFilters?: NavigationFiltersState<NavigationFiltersDefinition>
   search?: string
-) => {
+}) => {
   let filteredUsers = [...users]
 
   const searchValue = filterValues.search
@@ -1164,12 +1173,12 @@ export const createObservableDataFetch = (delay = 0) => {
       })
 
       const timeoutId = setTimeout(() => {
-        const filteredData = filterUsers(
-          mockUsers,
-          filters,
-          sortingsState,
-          navigationFilters
-        )
+        const filteredData = filterUsers({
+          users: mockUsers,
+          filterValues: filters,
+          sortingState: sortingsState,
+          navigationFilters,
+        })
 
         // Calculate summaries like in createPromiseDataFetch
         const summaries = {
@@ -1259,7 +1268,7 @@ const createdDetailedNestedRecords = (filteredData: MockUser[]) => {
 
 const createdNestedRecords = (
   filteredData: MockUser[],
-  nestedRecordsType?: "basic" | "detailed" | "mixed"
+  nestedRecordsType?: NestedRecordsType
 ) => {
   if (nestedRecordsType === "mixed") {
     return createdMixedNestedRecords(filteredData)
@@ -1276,7 +1285,7 @@ export const createPromiseDataFetch = (
   delay = 500,
   cache?: MockDataCache<MockUser>,
   nestedRecords = false,
-  nestedRecordsType?: "basic" | "detailed" | "mixed"
+  nestedRecordsType?: NestedRecordsType
 ) => {
   return (
     options: DataCollectionBaseFetchOptions<
@@ -1297,13 +1306,13 @@ export const createPromiseDataFetch = (
       setTimeout(() => {
         // Use cache if provided, otherwise use static mockUsers
         const sourceData = cache ? cache.getData() : mockUsers
-        const filteredData = filterUsers(
-          sourceData,
-          filters,
-          sortingsState,
+        const filteredData = filterUsers({
+          users: sourceData,
+          filterValues: filters,
+          sortingState: sortingsState,
           navigationFilters,
-          search
-        )
+          search,
+        })
 
         const summaries = {
           salary: filteredData.reduce((total, user) => {
@@ -1384,7 +1393,7 @@ export const ExampleComponent = ({
   usePresets?: boolean
   /** Override the developer-provided presets used when `usePresets` is true. */
   presets?: PresetsDefinition<typeof filters>
-  frozenColumns?: 0 | 1 | 2
+  frozenColumns?: FrozenColumns
   fullHeight?: boolean
   visualizations?: readonly Visualization<
     MockUser,
@@ -1410,7 +1419,7 @@ export const ExampleComponent = ({
   onBulkAction?: OnBulkActionCallback<MockUser, FiltersType>
   navigationFilters?: NavigationFiltersDefinition
   totalItemSummary?: true | ((totalItems: number) => string)
-  grouping?: GroupingDefinition<MockUser> | undefined
+  grouping?: GroupingDefinition<MockUser>
   currentGrouping?: GroupingState<MockUser, GroupingDefinition<MockUser>>
   noSorting?: boolean
   paginationType?: PaginationType
@@ -1429,7 +1438,7 @@ export const ExampleComponent = ({
   currentNavigationFilters?: NavigationFiltersState<NavigationFiltersDefinition>
   tmpFullWidth?: boolean
   nestedRecords?: boolean
-  nestedRecordsType?: "basic" | "detailed" | "mixed"
+  nestedRecordsType?: NestedRecordsType
   csvExport?: boolean | { filename?: string }
 }) => {
   // Create a cache instance to simulate Apollo cache behavior
@@ -1627,6 +1636,25 @@ export const ExampleComponent = ({
   )
 }
 
+const inSelection = (selection: string[], id: string | undefined) =>
+  selection.length === 0 || (id !== undefined && selection.includes(id))
+
+// Narrow by the nested workplace selections (office/space/desk).
+const applyWorkplaceSelection = (
+  users: WorkplaceMockUser[],
+  f: FiltersState<NestedFiltersType>
+) => {
+  const officeSel = (f.office as string[] | undefined) ?? []
+  const spaceSel = (f.space as string[] | undefined) ?? []
+  const deskSel = (f.desk as string[] | undefined) ?? []
+  return users.filter(
+    (u) =>
+      inSelection(officeSel, u.officeId) &&
+      inSelection(spaceSel, u.spaceId) &&
+      inSelection(deskSel, u.deskId)
+  )
+}
+
 export const SubfiltersExampleComponent = () => {
   const dataAdapterMemoized = useMemo(
     () => ({
@@ -1643,33 +1671,14 @@ export const SubfiltersExampleComponent = () => {
             // nested workplace selections (office/space/desk) it doesn't know
             // about. `filterUsers` only filters/sorts, so the surviving items
             // are still the original WorkplaceMockUser objects.
-            const base = filterUsers(
-              subfilterMockUsers,
-              f as FiltersState<FiltersType>,
-              s,
-              undefined,
-              search
-            ) as WorkplaceMockUser[]
+            const base = filterUsers({
+              users: subfilterMockUsers,
+              filterValues: f as FiltersState<FiltersType>,
+              sortingState: s,
+              search,
+            }) as WorkplaceMockUser[]
 
-            const officeSel = (f.office as string[] | undefined) ?? []
-            const spaceSel = (f.space as string[] | undefined) ?? []
-            const deskSel = (f.desk as string[] | undefined) ?? []
-
-            const filtered = base.filter((u) => {
-              if (officeSel.length && !officeSel.includes(u.officeId)) {
-                return false
-              }
-              if (spaceSel.length && !spaceSel.includes(u.spaceId)) {
-                return false
-              }
-              if (
-                deskSel.length &&
-                (!u.deskId || !deskSel.includes(u.deskId))
-              ) {
-                return false
-              }
-              return true
-            })
+            const filtered = applyWorkplaceSelection(base, f)
             resolve({ records: filtered })
           }, 100)
         })

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -1039,19 +1039,21 @@ export const sortings = {
 } as const
 
 // Helper function to filter users based on filters
+type FilterUsersOptions = {
+  users: MockUser[]
+  filterValues: FiltersState<typeof filters>
+  sortingState: SortingsStateMultiple
+  navigationFilters?: NavigationFiltersState<NavigationFiltersDefinition>
+  search?: string
+}
+
 export const filterUsers = ({
   users,
   filterValues,
   sortingState,
   navigationFilters,
   search,
-}: {
-  users: MockUser[]
-  filterValues: FiltersState<typeof filters>
-  sortingState: SortingsStateMultiple
-  navigationFilters?: NavigationFiltersState<NavigationFiltersDefinition>
-  search?: string
-}) => {
+}: FilterUsersOptions) => {
   let filteredUsers = [...users]
 
   const searchValue = filterValues.search

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1283,7 +1283,7 @@ export const TableWithHighlightedHeaderGroup: Story = {
     const highlightedHeaders = canvasElement.querySelectorAll(
       "th[data-highlighted]"
     )
-    expect(highlightedHeaders.length).toBe(4)
+    expect(highlightedHeaders).toHaveLength(4)
     highlightedHeaders.forEach((header) => {
       expect(header.className).toContain(highlightClass)
     })
@@ -1298,7 +1298,7 @@ export const TableWithHighlightedHeaderGroup: Story = {
         "th[data-highlighted]"
       )
       // The group header plus the remaining total column.
-      expect(collapsedHighlighted.length).toBe(2)
+      expect(collapsedHighlighted).toHaveLength(2)
       expect(
         collapsedHighlighted[collapsedHighlighted.length - 1].className
       ).toContain(highlightClass)

--- a/packages/react/src/patterns/OneDataCollection/__tests__/bulkActionStatus.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/bulkActionStatus.test.tsx
@@ -566,7 +566,7 @@ describe("OneDataCollection bulk-action status", () => {
 
     // Bar should be dismissed and ALL selection cleared (including the new row).
     await waitFor(() => {
-      expect(queryArchiveButtons().length).toBe(0)
+      expect(queryArchiveButtons()).toHaveLength(0)
     })
 
     vi.useRealTimers()

--- a/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/ActionBar/OneDataCollectionActionBar.tsx
@@ -14,9 +14,11 @@ import { useI18n } from "@/lib/providers/i18n"
 
 export type { ActionBarGroup, ActionBarItem, ActionBarStatus, F0ActionBarRef }
 
+type PrimaryActions = ActionBarItem[] | ActionBarGroup[] | ActionBarGroup
+
 interface OneDataCollectionActionBarProps {
   isOpen: boolean
-  primaryActions?: ActionBarItem[] | ActionBarGroup[] | ActionBarGroup
+  primaryActions?: PrimaryActions
   secondaryActions?: ActionBarItem[]
   selectedNumber?: number
   onUnselect?: () => void
@@ -39,9 +41,7 @@ const WarningAlert = ({ message }: { message: string }) => (
  * loading + disabled. Used to shift the loading indicator from the bar level
  * down to the button/dropdown level.
  */
-function withLoadingOnActions(
-  actions: ActionBarItem[] | ActionBarGroup[] | ActionBarGroup
-): ActionBarItem[] | ActionBarGroup[] | ActionBarGroup {
+function withLoadingOnActions(actions: PrimaryActions): PrimaryActions {
   const markItem = (item: ActionBarItem): ActionBarItem => ({
     ...item,
     loading: true,

--- a/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.test.ts
@@ -192,9 +192,9 @@ describe("useSearchPreview", () => {
     const callsBefore = (preview.search as ReturnType<typeof vi.fn>).mock.calls
       .length
     act(() => result.current.onLoadMore())
-    expect((preview.search as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
-      callsBefore
-    )
+    expect(
+      (preview.search as ReturnType<typeof vi.fn>).mock.calls
+    ).toHaveLength(callsBefore)
     expect(result.current.results).toHaveLength(12)
   })
 
@@ -235,9 +235,9 @@ describe("useSearchPreview", () => {
       .length
     act(() => result.current.onLoadMore())
     // No `hasMore`, so load-more is a no-op — no extra fetch.
-    expect((preview.search as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
-      callsBefore
-    )
+    expect(
+      (preview.search as ReturnType<typeof vi.fn>).mock.calls
+    ).toHaveLength(callsBefore)
   })
 
   it("drops a stale response when the query changes before it resolves", async () => {

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/usePerVisualizationFilters.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/usePerVisualizationFilters.test.ts
@@ -516,7 +516,7 @@ describe("usePerVisualizationFilters", () => {
 
       rerender({ currentViz: 0 })
 
-      expect(sourceSetCurrentFilters.mock.calls.length).toBe(
+      expect(sourceSetCurrentFilters.mock.calls).toHaveLength(
         callCountAfterFirst
       )
     })

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/validateStorageKey.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/validateStorageKey.test.ts
@@ -119,11 +119,11 @@ describe("parseStorageKey", () => {
 
   describe("invalid keys", () => {
     it("should return null for invalid keys", () => {
-      expect(parseStorageKey("")).toBe(null)
-      expect(parseStorageKey("employees")).toBe(null)
-      expect(parseStorageKey("/v1")).toBe(null)
-      expect(parseStorageKey("employees/1")).toBe(null)
-      expect(parseStorageKey("employees/v")).toBe(null)
+      expect(parseStorageKey("")).toBeNull()
+      expect(parseStorageKey("employees")).toBeNull()
+      expect(parseStorageKey("/v1")).toBeNull()
+      expect(parseStorageKey("employees/1")).toBeNull()
+      expect(parseStorageKey("employees/v")).toBeNull()
     })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/types.ts
@@ -23,7 +23,7 @@ export type DataCollectionStatus<
   grouping?: GroupingState<RecordType, GroupingDefinition<RecordType>>
   sortings?: SortingsState<SortingsDefinition>
   filters?: CurrentFiltersState
-  search?: string | undefined
+  search?: string
   navigationFilters?: NavigationFiltersState<NavigationFiltersDefinition>
   visualization?: number
   /** Per-visualization filter states, keyed by visualization index.

--- a/packages/react/src/patterns/OneDataCollection/property-render.ts
+++ b/packages/react/src/patterns/OneDataCollection/property-render.ts
@@ -55,18 +55,21 @@ const undefinedValueByVisualization: Partial<
   list: undefined,
 }
 
-export const renderProperty = <R extends RecordType>(
-  item: R,
-  property: PropertyDefinition<R>,
-  visualization: VisualizationType,
-  {
-    i18n,
-    tableAlign,
-  }: {
-    i18n: TranslationsType
-    tableAlign?: ValueDisplayTableAlignment
-  }
-): ReactNode => {
+type RenderPropertyOptions<R extends RecordType> = {
+  item: R
+  property: PropertyDefinition<R>
+  visualization: VisualizationType
+  i18n: TranslationsType
+  tableAlign?: ValueDisplayTableAlignment
+}
+
+export const renderProperty = <R extends RecordType>({
+  item,
+  property,
+  visualization,
+  i18n,
+  tableAlign,
+}: RenderPropertyOptions<R>): ReactNode => {
   const renderDefinition = property.render(item)
 
   const undefinedValue =

--- a/packages/react/src/patterns/OneDataCollection/property-render.ts
+++ b/packages/react/src/patterns/OneDataCollection/property-render.ts
@@ -59,8 +59,11 @@ export const renderProperty = <R extends RecordType>(
   item: R,
   property: PropertyDefinition<R>,
   visualization: VisualizationType,
-  i18n: TranslationsType,
-  options?: {
+  {
+    i18n,
+    tableAlign,
+  }: {
+    i18n: TranslationsType
     tableAlign?: ValueDisplayTableAlignment
   }
 ): ReactNode => {
@@ -76,7 +79,7 @@ export const renderProperty = <R extends RecordType>(
     {
       visualization,
       i18n,
-      tableAlign: options?.tableAlign,
+      tableAlign,
     },
     undefinedValue
   )

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.test.tsx
@@ -274,7 +274,7 @@ describe("CardCollection", () => {
       // Wait for loading state to finish
       await waitFor(() => {
         const cards = document.querySelectorAll('[role="article"]')
-        expect(cards.length).toBe(0)
+        expect(cards).toHaveLength(0)
       })
     })
 
@@ -416,7 +416,7 @@ describe("CardCollection", () => {
 
       // Should show exactly 12 cards (next multiple of 2, 3, and 4 after 10)
       const cards = screen.getAllByRole("article")
-      expect(cards.length).toBe(12)
+      expect(cards).toHaveLength(12)
     })
 
     it("defaults to 24 items per page when perPage is not specified", async () => {
@@ -481,7 +481,7 @@ describe("CardCollection", () => {
 
       // Should show exactly 24 cards (default)
       const cards = screen.getAllByRole("article")
-      expect(cards.length).toBe(24)
+      expect(cards).toHaveLength(24)
     })
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableCellRenderer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/EditableCellRenderer.test.tsx
@@ -276,8 +276,9 @@ describe("EditableCellRenderer", () => {
       const input = screen.getByRole("textbox")
       await user.clear(input)
 
-      // Error message should appear after the change is processed
-      // This depends on how TextCell/Input displays errors
+      await waitFor(() => expect(onCellChange).toHaveBeenCalled())
+      // The message renders inline and in the error tooltip.
+      expect(await screen.findAllByText("Name is required")).not.toHaveLength(0)
     })
 
     it("applies right border except for last column", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MultiSelectCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MultiSelectCell.tsx
@@ -44,7 +44,12 @@ export function MultiSelectCell<R extends RecordType>({
     }
     return (
       <BaseCell>
-        {renderProperty(item, editableColumn, "editableTable", { i18n })}
+        {renderProperty({
+          item,
+          property: editableColumn,
+          visualization: "editableTable",
+          i18n,
+        })}
       </BaseCell>
     )
   }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MultiSelectCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/MultiSelectCell.tsx
@@ -44,7 +44,7 @@ export function MultiSelectCell<R extends RecordType>({
     }
     return (
       <BaseCell>
-        {renderProperty(item, editableColumn, "editableTable", i18n)}
+        {renderProperty(item, editableColumn, "editableTable", { i18n })}
       </BaseCell>
     )
   }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
@@ -137,7 +137,7 @@ export function ReadOnlyCellContent<R extends RecordType>({
         <span className="min-w-0 truncate">
           {formattedDate ??
             multiSelectLabel ??
-            renderProperty(item, editableColumn, "editableTable", i18n)}
+            renderProperty(item, editableColumn, "editableTable", { i18n })}
         </span>
         {!unitsBefore ? unit : null}
       </span>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
@@ -137,7 +137,12 @@ export function ReadOnlyCellContent<R extends RecordType>({
         <span className="min-w-0 truncate">
           {formattedDate ??
             multiSelectLabel ??
-            renderProperty(item, editableColumn, "editableTable", { i18n })}
+            renderProperty({
+              item,
+              property: editableColumn,
+              visualization: "editableTable",
+              i18n,
+            })}
         </span>
         {!unitsBefore ? unit : null}
       </span>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
@@ -30,7 +30,12 @@ export function SelectCell<R extends RecordType>({
     }
     return (
       <BaseCell>
-        {renderProperty(item, editableColumn, "editableTable", { i18n })}
+        {renderProperty({
+          item,
+          property: editableColumn,
+          visualization: "editableTable",
+          i18n,
+        })}
       </BaseCell>
     )
   }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
@@ -30,7 +30,7 @@ export function SelectCell<R extends RecordType>({
     }
     return (
       <BaseCell>
-        {renderProperty(item, editableColumn, "editableTable", i18n)}
+        {renderProperty(item, editableColumn, "editableTable", { i18n })}
       </BaseCell>
     )
   }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/settings/__tests__/SettingsRenderer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/settings/__tests__/SettingsRenderer.test.tsx
@@ -68,7 +68,7 @@ describe("Graph SettingsRenderer", () => {
     renderSettings(baseOptions)
     const switches = screen.getAllByRole("switch")
     const disabled = switches.filter((s) => s.hasAttribute("disabled"))
-    expect(disabled.length).toBe(1)
+    expect(disabled).toHaveLength(1)
   })
 
   it("renders a locked tag as OFF + disabled, and locked wins over pinned", () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.test.tsx
@@ -408,7 +408,7 @@ describe("useDataCollectionTreeData — two-phase hydration", () => {
       result.current.nodes.find((node) => node.id === "vp1")?.data.name
     ).toBe("Renamed")
     expect(result.current.expandedNodes.has("ceo")).toBe(true)
-    expect(fetchData.mock.calls.length).toBe(fetchesBefore)
+    expect(fetchData.mock.calls).toHaveLength(fetchesBefore)
     expect(result.current.nodes.map((node) => node.id)).not.toContain("mgr1")
   })
 
@@ -440,7 +440,7 @@ describe("useDataCollectionTreeData — two-phase hydration", () => {
     expect(
       result.current.nodes.find((node) => node.id === "vp3")?.parentId
     ).toBe("ceo")
-    expect(fetchData.mock.calls.length).toBe(fetchesBefore)
+    expect(fetchData.mock.calls).toHaveLength(fetchesBefore)
   })
 
   it("liveUpdate remove drops a node with its descendants and prunes expansion", async () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -25,6 +25,8 @@ import type {
 import { KanbanBoard } from "./KanbanBoard"
 import { KanbanCollectionProps } from "./types"
 
+type ItemCount = number | undefined
+
 const isInfiniteScrollPaginationInfo = (
   paginationInfo: PaginationInfo | undefined | null
 ): paginationInfo is InfiniteScrollPaginatedResponse<unknown> => {
@@ -303,7 +305,7 @@ export const KanbanCollection = <
             itemCount?: (
               groupId: unknown,
               filters: unknown
-            ) => number | undefined | Promise<number | undefined>
+            ) => ItemCount | Promise<ItemCount>
           }
         >
       | undefined

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -78,7 +78,7 @@ export const Row = <
     item: Record,
     property: ListPropertyDefinition<Record, Sortings>
   ) => {
-    return renderProperty(item, property, "list", i18n)
+    return renderProperty(item, property, "list", { i18n })
   }
 
   const itemHref = source.itemUrl ? source.itemUrl(item) : undefined

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/List/components/Row.tsx
@@ -78,7 +78,7 @@ export const Row = <
     item: Record,
     property: ListPropertyDefinition<Record, Sortings>
   ) => {
-    return renderProperty(item, property, "list", { i18n })
+    return renderProperty({ item, property, visualization: "list", i18n })
   }
 
   const itemHref = source.itemUrl ? source.itemUrl(item) : undefined

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -168,15 +168,15 @@ export const TableCollection = <
     lockedColumnIds !== undefined || !!onLockedColumnIdsChange
 
   // Sorted and hidden columns
-  const { columns: orderedColumns, stickyColumnIds } = useColumns(
+  const { columns: orderedColumns, stickyColumnIds } = useColumns({
     originalColumns,
     frozenColumns,
-    visualizationSettings ?? settings.visualization?.table,
-    allowColumnReordering,
-    allowColumnHiding,
+    settings: visualizationSettings ?? settings.visualization?.table,
+    allowSorting: allowColumnReordering,
+    allowHiding: allowColumnHiding,
     lockedColumnIds,
-    usesExplicitColumnLocking
-  )
+    usesExplicitColumnLocking,
+  })
   const stickyColumnIdSet = useMemo(
     () => new Set(stickyColumnIds),
     [stickyColumnIds]

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -3317,7 +3317,7 @@ describe("TableCollection", () => {
       })
       await user.click(engineeringHeading)
 
-      expect(onSelectItems.mock.calls.length).toBe(callCountAfterRender)
+      expect(onSelectItems.mock.calls).toHaveLength(callCountAfterRender)
     })
   })
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -41,6 +41,7 @@ import type {
   ColId,
   RowWrapperProps,
   TableColumnDefinition,
+  TableRowRef,
 } from "../types"
 import { AddRowRow } from "./AddRow"
 import { LoadMoreRow } from "./LoadMore"
@@ -126,10 +127,7 @@ const NestedRowContent = <
     NavigationFilters,
     Grouping
   >,
-  externalRef:
-    | ((element: HTMLTableRowElement | null) => void)
-    | React.RefObject<HTMLTableRowElement>
-    | null
+  externalRef: TableRowRef
 ) => {
   const internalRowRef = useRef<HTMLTableRowElement | null>(null)
 
@@ -510,10 +508,7 @@ const NestedRowComponentInner = <
     NavigationFilters,
     Grouping
   >,
-  ref:
-    | ((element: HTMLTableRowElement | null) => void)
-    | React.RefObject<HTMLTableRowElement>
-    | null
+  ref: TableRowRef
 ) => {
   // Provider is mounted at Table level when tableWithChildren is true, so we
   // never wrap here. This keeps expansion state and fetched data in a single
@@ -539,10 +534,7 @@ const NestedRowContentWithRef = forwardRef(NestedRowContent) as <
     NavigationFilters,
     Grouping
   > & {
-    ref?:
-      | ((element: HTMLTableRowElement | null) => void)
-      | React.RefObject<HTMLTableRowElement>
-      | null
+    ref?: TableRowRef
   }
 ) => ReturnType<typeof NestedRowContent>
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -242,7 +242,8 @@ const RowComponentInner = <
     item: R,
     column: TableColumnDefinition<R, Sortings, Summaries>
   ) => {
-    return renderProperty(item, column, "table", i18n, {
+    return renderProperty(item, column, "table", {
+      i18n,
       tableAlign: column.align ?? "left",
     })
   }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -242,7 +242,10 @@ const RowComponentInner = <
     item: R,
     column: TableColumnDefinition<R, Sortings, Summaries>
   ) => {
-    return renderProperty(item, column, "table", {
+    return renderProperty({
+      item,
+      property: column,
+      visualization: "table",
       i18n,
       tableAlign: column.align ?? "left",
     })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/RowLoading/index.tsx
@@ -11,6 +11,7 @@ import { ItemActionsDefinition } from "@/patterns/OneDataCollection/item-actions
 import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
 import { SummariesDefinition } from "@/patterns/OneDataCollection/summary"
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
+import type { TableRowRef } from "../../types"
 import { Row, RowProps } from "../Row"
 
 export const DEFAULT_LOADING_ROWS_COUNT = 5
@@ -53,10 +54,7 @@ const SingleLoadingRowInner = <
     shouldHideBorder?: boolean
     fromVisualization?: TableVisualizationType
   },
-  ref:
-    | ((element: HTMLTableRowElement | null) => void)
-    | React.RefObject<HTMLTableRowElement>
-    | null
+  ref: TableRowRef
 ) => {
   const loadingRowRef = useRef<HTMLTableRowElement | null>(null)
   const rowRefCurrent = rowRef?.current
@@ -130,10 +128,7 @@ const SingleLoadingRow = forwardRef(SingleLoadingRowInner) as <
     rowIndex: number
     shouldHideBorder?: boolean
   } & {
-    ref?:
-      | ((element: HTMLTableRowElement | null) => void)
-      | React.RefObject<HTMLTableRowElement>
-      | null
+    ref?: TableRowRef
   }
 ) => JSX.Element
 
@@ -172,10 +167,7 @@ const RowLoadingInner = <
     shouldHideBorder?: boolean
     fromVisualization?: TableVisualizationType
   },
-  ref:
-    | ((element: HTMLTableRowElement | null) => void)
-    | React.RefObject<HTMLTableRowElement>
-    | null
+  ref: TableRowRef
 ) => {
   const childrenCount = props.source.childrenCount?.({
     item: props.item,
@@ -247,10 +239,7 @@ export const RowLoading = forwardRef(RowLoadingInner) as <
     >
     paginationInfo?: ChildrenPaginationInfo
   } & {
-    ref?:
-      | ((element: HTMLTableRowElement | null) => void)
-      | React.RefObject<HTMLTableRowElement>
-      | null
+    ref?: TableRowRef
     shouldHideBorder?: boolean
   }
 ) => JSX.Element

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/TableSettings.tsx
@@ -44,15 +44,15 @@ export const TableSettings = ({
 
   const usesExplicitColumnLocking =
     lockedColumnIds !== undefined || !!onLockedColumnIdsChange
-  const { columnsWithStatus, savedOrder, managedLockedColumnIds } = useColumns(
+  const { columnsWithStatus, savedOrder, managedLockedColumnIds } = useColumns({
     originalColumns,
     frozenColumns,
-    visualizationSettings,
+    settings: visualizationSettings,
     allowSorting,
     allowHiding,
     lockedColumnIds,
-    usesExplicitColumnLocking
-  )
+    usesExplicitColumnLocking,
+  })
 
   const items = useMemo(() => {
     const visibleUnlockedIds = new Set(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumns.settings.test.ts
@@ -18,13 +18,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        mockColumns,
+      useColumns({
+        originalColumns: mockColumns,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // column2 and column3 should be hidden as per developer defaults
@@ -45,13 +45,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        mockColumns,
+      useColumns({
+        originalColumns: mockColumns,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // All columns should be visible because user explicitly set hidden to []
@@ -74,13 +74,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        mockColumns,
+      useColumns({
+        originalColumns: mockColumns,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // column3 and column4 should be hidden per user preferences (overriding developer defaults)
@@ -102,13 +102,13 @@ describe("useColumns with settings", () => {
     const allowHiding = false
 
     const { result } = renderHook(() =>
-      useColumns(
-        mockColumns,
+      useColumns({
+        originalColumns: mockColumns,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // Should use developer defaults even when settings exist
@@ -128,13 +128,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        columnsWithOrder,
+      useColumns({
+        originalColumns: columnsWithOrder,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // Should respect developer-defined order
@@ -155,13 +155,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        columnsWithOrder,
+      useColumns({
+        originalColumns: columnsWithOrder,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // Should respect user-defined order
@@ -182,13 +182,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        columnsWithOrder,
+      useColumns({
+        originalColumns: columnsWithOrder,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // Empty array means no columns in saved order, so all maintain definition order
@@ -222,13 +222,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        columnsWithNewHidden,
+      useColumns({
+        originalColumns: columnsWithNewHidden,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // column4 should be hidden because it's NEW (not in saved settings) and has hidden: true
@@ -257,13 +257,13 @@ describe("useColumns with settings", () => {
     const allowHiding = true
 
     const { result } = renderHook(() =>
-      useColumns(
-        columnsWithNewVisible,
+      useColumns({
+        originalColumns: columnsWithNewVisible,
         frozenColumns,
         settings,
         allowSorting,
-        allowHiding
-      )
+        allowHiding,
+      })
     )
 
     // column4 should be visible (no hidden: true)
@@ -282,13 +282,13 @@ describe("useColumns with settings", () => {
 
     const { result, rerender } = renderHook(
       ({ settings }) =>
-        useColumns(
-          mockColumns,
+        useColumns({
+          originalColumns: mockColumns,
           frozenColumns,
           settings,
           allowSorting,
-          allowHiding
-        ),
+          allowHiding,
+        }),
       { initialProps: { settings } }
     )
 
@@ -317,13 +317,13 @@ describe("useColumns with settings", () => {
 
     const { result, rerender } = renderHook(
       ({ settings }) =>
-        useColumns(
-          columnsWithOrder,
+        useColumns({
+          originalColumns: columnsWithOrder,
           frozenColumns,
           settings,
           allowSorting,
-          allowHiding
-        ),
+          allowHiding,
+        }),
       { initialProps: { settings } }
     )
 
@@ -339,15 +339,15 @@ describe("useColumns with settings", () => {
 
   it("uses controlled locks instead of implicitly locking the first column", () => {
     const { result } = renderHook(() =>
-      useColumns(
-        mockColumns,
-        0,
-        { hidden: ["column2"] },
-        true,
-        true,
-        ["column2", "column3"],
-        true
-      )
+      useColumns({
+        originalColumns: mockColumns,
+        frozenColumns: 0,
+        settings: { hidden: ["column2"] },
+        allowSorting: true,
+        allowHiding: true,
+        lockedColumnIds: ["column2", "column3"],
+        usesExplicitColumnLocking: true,
+      })
     )
 
     const first = result.current.columnsWithStatus.find(
@@ -395,7 +395,15 @@ describe("useColumns with settings", () => {
     }
     const { result, rerender } = renderHook(
       ({ lockedColumnIds }) =>
-        useColumns(mockColumns, 0, settings, true, true, lockedColumnIds, true),
+        useColumns({
+          originalColumns: mockColumns,
+          frozenColumns: 0,
+          settings,
+          allowSorting: true,
+          allowHiding: true,
+          lockedColumnIds,
+          usesExplicitColumnLocking: true,
+        }),
       { initialProps: { lockedColumnIds: ["column3"] } }
     )
 
@@ -418,7 +426,15 @@ describe("useColumns with settings", () => {
 
   it("allows every non-frozen column to be editable when controlled locks are empty", () => {
     const { result } = renderHook(() =>
-      useColumns(mockColumns, 0, {}, true, true, [], true)
+      useColumns({
+        originalColumns: mockColumns,
+        frozenColumns: 0,
+        settings: {},
+        allowSorting: true,
+        allowHiding: true,
+        lockedColumnIds: [],
+        usesExplicitColumnLocking: true,
+      })
     )
 
     expect(result.current.columnsWithStatus).toEqual(
@@ -435,7 +451,15 @@ describe("useColumns with settings", () => {
 
   it("keeps frozen columns permanently locked alongside controlled locks", () => {
     const { result } = renderHook(() =>
-      useColumns(mockColumns, 1, {}, true, true, ["column2", "column3"], true)
+      useColumns({
+        originalColumns: mockColumns,
+        frozenColumns: 1,
+        settings: {},
+        allowSorting: true,
+        allowHiding: true,
+        lockedColumnIds: ["column2", "column3"],
+        usesExplicitColumnLocking: true,
+      })
     )
 
     expect(result.current.columnsWithStatus.slice(0, 3)).toEqual([
@@ -464,15 +488,15 @@ describe("useColumns with settings", () => {
 
   it("leaves the final ordered column visible and unlocked when every managed column is requested", () => {
     const { result } = renderHook(() =>
-      useColumns(
-        mockColumns,
-        0,
-        { hidden: ["column4"] },
-        true,
-        true,
-        ["column1", "column2", "column3", "column4"],
-        true
-      )
+      useColumns({
+        originalColumns: mockColumns,
+        frozenColumns: 0,
+        settings: { hidden: ["column4"] },
+        allowSorting: true,
+        allowHiding: true,
+        lockedColumnIds: ["column1", "column2", "column3", "column4"],
+        usesExplicitColumnLocking: true,
+      })
     )
 
     expect(result.current.managedLockedColumnIds).toEqual([
@@ -498,15 +522,15 @@ describe("useColumns with settings", () => {
 
   it("restores a hidden unlocked column when every scrollable column is hidden", () => {
     const { result } = renderHook(() =>
-      useColumns(
-        mockColumns,
-        0,
-        { hidden: ["column3", "column4"] },
-        true,
-        true,
-        ["column1", "column2"],
-        true
-      )
+      useColumns({
+        originalColumns: mockColumns,
+        frozenColumns: 0,
+        settings: { hidden: ["column3", "column4"] },
+        allowSorting: true,
+        allowHiding: true,
+        lockedColumnIds: ["column1", "column2"],
+        usesExplicitColumnLocking: true,
+      })
     )
 
     expect(result.current.columns.map((column) => column.id)).toEqual([
@@ -527,7 +551,13 @@ describe("useColumns with settings", () => {
 
   it("does not turn the legacy non-editable first column into a sticky column", () => {
     const { result } = renderHook(() =>
-      useColumns(mockColumns, 0, {}, true, true)
+      useColumns({
+        originalColumns: mockColumns,
+        frozenColumns: 0,
+        settings: {},
+        allowSorting: true,
+        allowHiding: true,
+      })
     )
 
     expect(result.current.stickyColumnIds).toEqual([])

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColums.ts
@@ -82,25 +82,40 @@ type UseColumnsReturn<
   }[]
 }
 
+type UseColumnsOptions<
+  R extends RecordType,
+  Sortings extends SortingsDefinition,
+  Summaries extends SummariesDefinition,
+> = {
+  originalColumns: Readonly<TableColumnDefinition<R, Sortings, Summaries>[]>
+  frozenColumns: number
+  settings?: TableVisualizationSettings
+  allowSorting?: boolean
+  allowHiding?: boolean
+  lockedColumnIds?: readonly ColId[]
+  usesExplicitColumnLocking?: boolean
+}
+
 /**
  * Hook to manage the columns state of the table (hide, order, etc)
- * @param originalColumns
- * @param frozenColumns
- * @returns
  */
 export const useColumns = <
   R extends RecordType,
   Sortings extends SortingsDefinition,
   Summaries extends SummariesDefinition,
->(
-  originalColumns: Readonly<TableColumnDefinition<R, Sortings, Summaries>[]>,
-  frozenColumns: number,
-  settings?: TableVisualizationSettings,
-  allowSorting?: boolean,
-  allowHiding?: boolean,
-  lockedColumnIds?: readonly ColId[],
-  usesExplicitColumnLocking?: boolean
-): UseColumnsReturn<R, Sortings, Summaries> => {
+>({
+  originalColumns,
+  frozenColumns,
+  settings,
+  allowSorting,
+  allowHiding,
+  lockedColumnIds,
+  usesExplicitColumnLocking,
+}: UseColumnsOptions<R, Sortings, Summaries>): UseColumnsReturn<
+  R,
+  Sortings,
+  Summaries
+> => {
   // Merge user preferences with developer defaults for NEW columns
   // New columns (not in saved order) should respect their hidden: true default
   const getMergedHidden = () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -1,4 +1,4 @@
-import { ComponentProps, ComponentType, ReactNode } from "react"
+import { ComponentProps, ComponentType, ReactNode, RefObject } from "react"
 import { TableHead } from "@/experimental/OneTable"
 import {
   FiltersDefinition,
@@ -350,3 +350,9 @@ export type TableCustomizationProps<
   /** Override the visualization settings key (column order/visibility). If not provided, uses the "table" key. */
   visualizationSettings?: TableVisualizationSettings
 }
+
+/** The `ref` a table row accepts, as callback or object. */
+export type TableRowRef =
+  | ((element: HTMLTableRowElement | null) => void)
+  | RefObject<HTMLTableRowElement>
+  | null

--- a/packages/react/src/patterns/OneFilterPicker/__test__/index.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/__test__/index.test.tsx
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest"
 import userEvent from "@testing-library/user-event"
-import { describe, expect, it, vi } from "vitest"
+import type { ReactElement } from "react"
+import { assertType, describe, expect, it, vi } from "vitest"
 import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
 import { ChipsList, Controls, OneFilterPicker, Root } from ".."
 import type { FiltersDefinition } from "../types"
@@ -682,7 +683,7 @@ describe("Presets - Chip Visibility", () => {
 describe("Filters Type Safety", () => {
   it.skip("should enforce type safety in props", () => {
     // Valid usage - this should type check
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -703,7 +704,7 @@ describe("Filters Type Safety", () => {
       />
     )
 
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -719,7 +720,7 @@ describe("Filters Type Safety", () => {
       />
     )
 
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -735,7 +736,7 @@ describe("Filters Type Safety", () => {
       />
     )
 
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -757,7 +758,7 @@ describe("Filters Type Safety", () => {
       />
     )
 
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -779,7 +780,7 @@ describe("Filters Type Safety", () => {
       />
     )
 
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -801,7 +802,7 @@ describe("Filters Type Safety", () => {
       />
     )
 
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -820,7 +821,7 @@ describe("Filters Type Safety", () => {
 
   it.skip("should enforce type safety in presets", () => {
     // Valid usage - this should type check
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {
@@ -847,7 +848,7 @@ describe("Filters Type Safety", () => {
       />
     )
 
-    render(
+    assertType<ReactElement>(
       <OneFilterPicker
         filters={
           {

--- a/packages/react/src/sds/Home/slotRenderers.test-d.ts
+++ b/packages/react/src/sds/Home/slotRenderers.test-d.ts
@@ -57,7 +57,9 @@ test("left decides the avatar data every row must carry", () => {
 })
 
 test("right decides the trailing data every row must carry", () => {
-  listSlot({ right: "counter" }, [{ id: 1, title: "x", count: 3 }])
+  assertType<HomeWidgetSlot>(
+    listSlot({ right: "counter" }, [{ id: 1, title: "x", count: 3 }])
+  )
   listSlot({ right: "person" }, [{ id: 1, title: "x", rightAvatar: ada }])
   listSlot({ right: "person-list" }, [
     { id: 1, title: "x", avatars: [ada], remainingCount: 2 },
@@ -78,7 +80,9 @@ test("right decides the trailing data every row must carry", () => {
 })
 
 test("the schema's text voices are required — and forbidden when not declared", () => {
-  listSlot({ subtitleRequired: true }, [{ id: 1, title: "x", subtitle: "y" }])
+  assertType<HomeWidgetSlot>(
+    listSlot({ subtitleRequired: true }, [{ id: 1, title: "x", subtitle: "y" }])
+  )
   listSlot({ descriptionRequired: true }, [
     { id: 1, title: "x", description: "y" },
   ])
@@ -102,7 +106,9 @@ test("the schema's text voices are required — and forbidden when not declared"
 })
 
 test("clickBehavior: link is the ONLY click behavior — href, never onClick", () => {
-  listSlot({ clickBehavior: "link" }, [{ id: 1, title: "x", href: "/x" }])
+  assertType<HomeWidgetSlot>(
+    listSlot({ clickBehavior: "link" }, [{ id: 1, title: "x", href: "/x" }])
+  )
 
   listSlot({ clickBehavior: "link" }, [
     // @ts-expect-error link rows demand an href
@@ -122,12 +128,19 @@ test("clickBehavior: link is the ONLY click behavior — href, never onClick", (
 
 test("the OPTIONAL flags let a feed mix rows the schema would otherwise even out", () => {
   // Some rows two-line, some one — and some trailing a face, some nothing.
-  listSlot(
-    { right: "person", rightOptional: true, descriptionOptional: true },
-    [
-      { id: 1, title: "with both", description: "Due Today", rightAvatar: ada },
-      { id: 2, title: "with neither" },
-    ]
+  assertType<HomeWidgetSlot>(
+    listSlot(
+      { right: "person", rightOptional: true, descriptionOptional: true },
+      [
+        {
+          id: 1,
+          title: "with both",
+          description: "Due Today",
+          rightAvatar: ada,
+        },
+        { id: 2, title: "with neither" },
+      ]
+    )
   )
 
   listSlot({ right: "counter", rightOptional: true }, [
@@ -154,10 +167,12 @@ test("the OPTIONAL flags let a feed mix rows the schema would otherwise even out
 })
 
 test("a row's subtitle may be critical — wherever a subtitle is declared at all", () => {
-  listSlot({ subtitleRequired: true }, [
-    { id: 1, title: "x", subtitle: "2 days overdue", subtitleCritical: true },
-    { id: 2, title: "y", subtitle: "Due Friday" },
-  ])
+  assertType<HomeWidgetSlot>(
+    listSlot({ subtitleRequired: true }, [
+      { id: 1, title: "x", subtitle: "2 days overdue", subtitleCritical: true },
+      { id: 2, title: "y", subtitle: "Due Friday" },
+    ])
+  )
   listSlot({ subtitleOptional: true }, [
     { id: 1, title: "x", subtitle: "2 days overdue", subtitleCritical: true },
     { id: 2, title: "y" },
@@ -170,15 +185,17 @@ test("a row's subtitle may be critical — wherever a subtitle is declared at al
 })
 
 test("a row's second line may be critical — wherever a description is declared at all", () => {
-  listSlot({ descriptionRequired: true }, [
-    {
-      id: 1,
-      title: "x",
-      description: "Rejected by Finance",
-      descriptionCritical: true,
-    },
-    { id: 2, title: "y", description: "Due Friday" },
-  ])
+  assertType<HomeWidgetSlot>(
+    listSlot({ descriptionRequired: true }, [
+      {
+        id: 1,
+        title: "x",
+        description: "Rejected by Finance",
+        descriptionCritical: true,
+      },
+      { id: 2, title: "y", description: "Due Friday" },
+    ])
+  )
   listSlot({ descriptionOptional: true }, [
     {
       id: 1,
@@ -196,19 +213,21 @@ test("a row's second line may be critical — wherever a description is declared
 })
 
 test("a second line may be a LIST of facts, each with its own tone", () => {
-  listSlot({ descriptionRequired: true }, [
-    {
-      id: 1,
-      title: "Expenses",
-      description: [
-        { text: "2 days overdue", critical: true },
-        { text: "€340" },
-        { text: "12 receipts" },
-      ],
-    },
-    // The plain string form still works beside it, in the same list.
-    { id: 2, title: "Onboarding", description: "Due Friday" },
-  ])
+  assertType<HomeWidgetSlot>(
+    listSlot({ descriptionRequired: true }, [
+      {
+        id: 1,
+        title: "Expenses",
+        description: [
+          { text: "2 days overdue", critical: true },
+          { text: "€340" },
+          { text: "12 receipts" },
+        ],
+      },
+      // The plain string form still works beside it, in the same list.
+      { id: 2, title: "Onboarding", description: "Due Friday" },
+    ])
+  )
 
   listSlot({ descriptionOptional: true }, [
     { id: 1, title: "x", description: [{ text: "Rejected", critical: true }] },
@@ -241,28 +260,32 @@ test("a second line may be a LIST of facts, each with its own tone", () => {
 })
 
 test("the two murmuring lines carry their tone independently", () => {
-  listSlot({ subtitleRequired: true, descriptionRequired: true }, [
-    {
-      id: 1,
-      title: "x",
-      subtitle: "Travel",
-      description: "Rejected by Finance",
-      descriptionCritical: true,
-    },
-    {
-      id: 2,
-      title: "y",
-      subtitle: "2 days overdue",
-      subtitleCritical: true,
-      description: "Submitted Monday",
-    },
-  ])
+  assertType<HomeWidgetSlot>(
+    listSlot({ subtitleRequired: true, descriptionRequired: true }, [
+      {
+        id: 1,
+        title: "x",
+        subtitle: "Travel",
+        description: "Rejected by Finance",
+        descriptionCritical: true,
+      },
+      {
+        id: 2,
+        title: "y",
+        subtitle: "2 days overdue",
+        subtitleCritical: true,
+        description: "Submitted Monday",
+      },
+    ])
+  )
 })
 
 test("an icon row may be tinted, and only with a colour from the palette", () => {
-  listSlot({ left: "icon" }, [
-    { id: 1, title: "Row", avatar: { icon: PalmTree, color: "purple" } },
-  ])
+  assertType<HomeWidgetSlot>(
+    listSlot({ left: "icon" }, [
+      { id: 1, title: "Row", avatar: { icon: PalmTree, color: "purple" } },
+    ])
+  )
 
   // A hex of its own, for a colour that is already data.
   listSlot({ left: "icon" }, [
@@ -280,14 +303,16 @@ test("an icon row may be tinted, and only with a colour from the palette", () =>
 })
 
 test("a row's actions are its own — no schema flag gates them", () => {
-  listSlot({}, [
-    {
-      id: 1,
-      title: "x",
-      actions: [{ label: "Dismiss", icon: PalmTree, onClick: () => {} }],
-    },
-    { id: 2, title: "y" },
-  ])
+  assertType<HomeWidgetSlot>(
+    listSlot({}, [
+      {
+        id: 1,
+        title: "x",
+        actions: [{ label: "Dismiss", icon: PalmTree, onClick: () => {} }],
+      },
+      { id: 2, title: "y" },
+    ])
+  )
 
   listSlot({}, [
     {
@@ -300,6 +325,7 @@ test("a row's actions are its own — no schema flag gates them", () => {
 })
 
 test("the schema only speaks the declared kinds", () => {
+  assertType<HomeWidgetSlot>(listSlot({}, []))
   // @ts-expect-error not a left kind
   listSlot({ left: "banana" }, [])
   // @ts-expect-error not a right kind

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatBubble.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatBubble.test.tsx
@@ -25,25 +25,23 @@ const makeMessage = (body: string): F0ChatMessage => ({
 })
 
 describe("ChatBubble emoji rendering", () => {
-  it("renders a plain message as text with no emoji image", () => {
-    render(<ChatBubble message={makeMessage("hello world")} isMine={false} />)
-    expect(screen.getByText("hello world")).toBeInTheDocument()
-    expect(screen.queryByRole("img")).not.toBeInTheDocument()
-  })
-
-  it("leaves an emoji in the body as text for the OS to draw", () => {
-    render(<ChatBubble message={makeMessage("hi 👋 there")} isMine={false} />)
-    // The glyph stays in the text content — no <img>, no network request, and
-    // the reader gets the emoji their own machine draws.
-    expect(screen.getByText("hi 👋 there")).toBeInTheDocument()
-    expect(screen.queryByRole("img")).not.toBeInTheDocument()
-  })
-
-  it("keeps multi-codepoint sequences intact", () => {
-    // A ZWJ family and a skin-tone modifier both survive as single characters:
-    // splitting them is what produces the "man + woman + girl + boy" render.
-    render(<ChatBubble message={makeMessage("👨‍👩‍👧‍👦 ship it 👋🏽")} isMine={false} />)
-    expect(screen.getByText("👨‍👩‍👧‍👦 ship it 👋🏽")).toBeInTheDocument()
+  // The body stays in the text content — no <img>, no network request, and the
+  // reader gets the emoji their own machine draws. A ZWJ family and a skin-tone
+  // modifier both survive as single characters: splitting them is what produces
+  // the "man + woman + girl + boy" render.
+  it.each([
+    {
+      name: "renders a plain message as text with no emoji image",
+      body: "hello world",
+    },
+    {
+      name: "leaves an emoji in the body as text for the OS to draw",
+      body: "hi 👋 there",
+    },
+    { name: "keeps multi-codepoint sequences intact", body: "👨‍👩‍👧‍👦 ship it 👋🏽" },
+  ])("$name", ({ body }) => {
+    render(<ChatBubble message={makeMessage(body)} isMine={false} />)
+    expect(screen.getByText(body)).toBeInTheDocument()
     expect(screen.queryByRole("img")).not.toBeInTheDocument()
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatVoiceAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatVoiceAttachment.test.tsx
@@ -40,7 +40,7 @@ describe("ChatVoiceAttachment", () => {
     expect(audio?.getAttribute("src")).toBe(VOICE.url)
 
     const waveform = screen.getByTestId("chat-voice-waveform")
-    expect(waveform.querySelectorAll("span").length).toBe(32)
+    expect(waveform.querySelectorAll("span")).toHaveLength(32)
   })
 
   it("serializes waveform decoding across voice notes", async () => {

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -60,15 +60,18 @@ const person = (
   id: string,
   firstName: string,
   lastName: string,
-  subtitle: string,
   // `image` (index into the mock photo set) gives a photo avatar; omit it to use
   // the initials + colour avatar — the mock mixes both on purpose.
-  opts: {
+  {
+    subtitle,
+    ...opts
+  }: {
+    subtitle: string
     online?: boolean
     vacation?: boolean
     image?: number
     avatarColor?: F0ChatSenderColor
-  } = {}
+  }
 ): MockPerson =>
   ({
     id,
@@ -97,55 +100,64 @@ const person = (
 
 // A deliberate mix: some people have a photo (`image`), others fall back to the
 // initials + colour avatar (and their name is tinted to match — WhatsApp-style).
-export const ME = person("me", "Jordan", "Avery", "Product Manager", {
+export const ME = person("me", "Jordan", "Avery", {
+  subtitle: "Product Manager",
   online: true,
   image: 4,
 })
 // Online people reply when you message them; offline people never do.
-const ELEANOR = person(
-  "u_eleanor",
-  "Eleanor",
-  "Whitfield",
-  "Senior Product Designer",
-  { online: true, image: 0 }
-)
-const MARCUS = person("u_marcus", "Marcus", "Bennett", "Engineering Manager", {
+const ELEANOR = person("u_eleanor", "Eleanor", "Whitfield", {
+  subtitle: "Senior Product Designer",
+  online: true,
+  image: 0,
+})
+const MARCUS = person("u_marcus", "Marcus", "Bennett", {
+  subtitle: "Engineering Manager",
   online: true,
   image: 1,
 })
-const PRIYA = person("u_priya", "Priya", "Raman", "Account Executive", {
+const PRIYA = person("u_priya", "Priya", "Raman", {
+  subtitle: "Account Executive",
   online: true,
   vacation: true,
   image: 2,
 })
 // No photo — initials + colour avatar.
-const THEO = person("u_theo", "Theo", "Lindqvist", "On vacation until Monday", {
+const THEO = person("u_theo", "Theo", "Lindqvist", {
+  subtitle: "On vacation until Monday",
   vacation: true,
 })
-const NADIA = person("u_nadia", "Nadia", "Costa", "Recruiter")
-const OWEN = person("u_owen", "Owen", "Carter", "Finance Analyst", {
+const NADIA = person("u_nadia", "Nadia", "Costa", { subtitle: "Recruiter" })
+const OWEN = person("u_owen", "Owen", "Carter", {
+  subtitle: "Finance Analyst",
   online: true,
   image: 3,
 })
-const HARPER = person("u_harper", "Harper", "Quinn", "Customer Success", {
+const HARPER = person("u_harper", "Harper", "Quinn", {
+  subtitle: "Customer Success",
   online: true,
   image: 7,
 })
 // No photo — initials + colour avatar.
-const GRACE = person("u_grace", "Grace", "Liang", "Data Analyst", {
+const GRACE = person("u_grace", "Grace", "Liang", {
+  subtitle: "Data Analyst",
   online: true,
 })
-const SAM = person("u_sam", "Sam", "Okafor", "Frontend Engineer", {
+const SAM = person("u_sam", "Sam", "Okafor", {
+  subtitle: "Frontend Engineer",
   online: true,
   image: 5,
 })
-const NOAH = person("u_noah", "Noah", "Bergström", "QA Engineer")
-const ISLA = person("u_isla", "Isla", "Romano", "Content Strategist", {
+const NOAH = person("u_noah", "Noah", "Bergström", { subtitle: "QA Engineer" })
+const ISLA = person("u_isla", "Isla", "Romano", {
+  subtitle: "Content Strategist",
   online: true,
   image: 6,
 })
 // No photo — initials + colour avatar.
-const VIKTOR = person("u_viktor", "Viktor", "Hale", "Staff Engineer")
+const VIKTOR = person("u_viktor", "Viktor", "Hale", {
+  subtitle: "Staff Engineer",
+})
 
 /** The brand mark, the same one the ApplicationFrame sidebar shows. */
 const FACTORIAL_AVATAR: AvatarVariant = {
@@ -172,12 +184,9 @@ const FACTORIAL: MockPerson = {
  * so the message-info list has a realistic overflow state. */
 const RECEIPT_DEMO_READERS = Array.from({ length: 42 }, (_, index) => {
   const number = String(index + 1).padStart(2, "0")
-  return person(
-    `u_receipt_demo_${number}`,
-    "Demo",
-    `Reader ${number}`,
-    "Quarterly Reporting member"
-  )
+  return person(`u_receipt_demo_${number}`, "Demo", `Reader ${number}`, {
+    subtitle: "Quarterly Reporting member",
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -56,106 +56,151 @@ const PHOTO_AVATAR_COLORS = [
   "camel",
 ] as const satisfies readonly F0ChatSenderColor[]
 
-const person = (
-  id: string,
-  firstName: string,
-  lastName: string,
+type PersonSeed = {
+  id: string
+  firstName: string
+  lastName: string
+  subtitle: string
+  online?: boolean
+  vacation?: boolean
   // `image` (index into the mock photo set) gives a photo avatar; omit it to use
   // the initials + colour avatar — the mock mixes both on purpose.
-  {
-    subtitle,
-    ...opts
-  }: {
-    subtitle: string
-    online?: boolean
-    vacation?: boolean
-    image?: number
-    avatarColor?: F0ChatSenderColor
-  }
-): MockPerson =>
-  ({
-    id,
-    name: `${firstName} ${lastName}`,
-    subtitle,
-    avatar: {
-      type: "person",
-      firstName,
-      lastName,
-      ...(opts.image !== undefined
-        ? { src: mockImage("person", opts.image) }
-        : {}),
-    },
-    ...(opts.avatarColor
-      ? { avatarColor: opts.avatarColor }
-      : opts.image !== undefined
-        ? {
-            avatarColor:
-              PHOTO_AVATAR_COLORS[opts.image % PHOTO_AVATAR_COLORS.length],
-          }
-        : {}),
-    profileHref: `/people/${id}`,
-    online: opts.online ?? false,
-    vacation: opts.vacation,
-  })
+  image?: number
+  avatarColor?: F0ChatSenderColor
+}
+
+const person = ({
+  id,
+  firstName,
+  lastName,
+  subtitle,
+  ...opts
+}: PersonSeed): MockPerson => ({
+  id,
+  name: `${firstName} ${lastName}`,
+  subtitle,
+  avatar: {
+    type: "person",
+    firstName,
+    lastName,
+    ...(opts.image !== undefined
+      ? { src: mockImage("person", opts.image) }
+      : {}),
+  },
+  ...(opts.avatarColor
+    ? { avatarColor: opts.avatarColor }
+    : opts.image !== undefined
+      ? {
+          avatarColor:
+            PHOTO_AVATAR_COLORS[opts.image % PHOTO_AVATAR_COLORS.length],
+        }
+      : {}),
+  profileHref: `/people/${id}`,
+  online: opts.online ?? false,
+  vacation: opts.vacation,
+})
 
 // A deliberate mix: some people have a photo (`image`), others fall back to the
 // initials + colour avatar (and their name is tinted to match — WhatsApp-style).
-export const ME = person("me", "Jordan", "Avery", {
+export const ME = person({
+  id: "me",
+  firstName: "Jordan",
+  lastName: "Avery",
   subtitle: "Product Manager",
   online: true,
   image: 4,
 })
 // Online people reply when you message them; offline people never do.
-const ELEANOR = person("u_eleanor", "Eleanor", "Whitfield", {
+const ELEANOR = person({
+  id: "u_eleanor",
+  firstName: "Eleanor",
+  lastName: "Whitfield",
   subtitle: "Senior Product Designer",
   online: true,
   image: 0,
 })
-const MARCUS = person("u_marcus", "Marcus", "Bennett", {
+const MARCUS = person({
+  id: "u_marcus",
+  firstName: "Marcus",
+  lastName: "Bennett",
   subtitle: "Engineering Manager",
   online: true,
   image: 1,
 })
-const PRIYA = person("u_priya", "Priya", "Raman", {
+const PRIYA = person({
+  id: "u_priya",
+  firstName: "Priya",
+  lastName: "Raman",
   subtitle: "Account Executive",
   online: true,
   vacation: true,
   image: 2,
 })
 // No photo — initials + colour avatar.
-const THEO = person("u_theo", "Theo", "Lindqvist", {
+const THEO = person({
+  id: "u_theo",
+  firstName: "Theo",
+  lastName: "Lindqvist",
   subtitle: "On vacation until Monday",
   vacation: true,
 })
-const NADIA = person("u_nadia", "Nadia", "Costa", { subtitle: "Recruiter" })
-const OWEN = person("u_owen", "Owen", "Carter", {
+const NADIA = person({
+  id: "u_nadia",
+  firstName: "Nadia",
+  lastName: "Costa",
+  subtitle: "Recruiter",
+})
+const OWEN = person({
+  id: "u_owen",
+  firstName: "Owen",
+  lastName: "Carter",
   subtitle: "Finance Analyst",
   online: true,
   image: 3,
 })
-const HARPER = person("u_harper", "Harper", "Quinn", {
+const HARPER = person({
+  id: "u_harper",
+  firstName: "Harper",
+  lastName: "Quinn",
   subtitle: "Customer Success",
   online: true,
   image: 7,
 })
 // No photo — initials + colour avatar.
-const GRACE = person("u_grace", "Grace", "Liang", {
+const GRACE = person({
+  id: "u_grace",
+  firstName: "Grace",
+  lastName: "Liang",
   subtitle: "Data Analyst",
   online: true,
 })
-const SAM = person("u_sam", "Sam", "Okafor", {
+const SAM = person({
+  id: "u_sam",
+  firstName: "Sam",
+  lastName: "Okafor",
   subtitle: "Frontend Engineer",
   online: true,
   image: 5,
 })
-const NOAH = person("u_noah", "Noah", "Bergström", { subtitle: "QA Engineer" })
-const ISLA = person("u_isla", "Isla", "Romano", {
+const NOAH = person({
+  id: "u_noah",
+  firstName: "Noah",
+  lastName: "Bergström",
+  subtitle: "QA Engineer",
+})
+const ISLA = person({
+  id: "u_isla",
+  firstName: "Isla",
+  lastName: "Romano",
   subtitle: "Content Strategist",
   online: true,
   image: 6,
 })
 // No photo — initials + colour avatar.
-const VIKTOR = person("u_viktor", "Viktor", "Hale", {
+const VIKTOR = person({
+  id: "u_viktor",
+  firstName: "Viktor",
+  lastName: "Hale",
   subtitle: "Staff Engineer",
 })
 
@@ -184,7 +229,10 @@ const FACTORIAL: MockPerson = {
  * so the message-info list has a realistic overflow state. */
 const RECEIPT_DEMO_READERS = Array.from({ length: 42 }, (_, index) => {
   const number = String(index + 1).padStart(2, "0")
-  return person(`u_receipt_demo_${number}`, "Demo", `Reader ${number}`, {
+  return person({
+    id: `u_receipt_demo_${number}`,
+    firstName: "Demo",
+    lastName: `Reader ${number}`,
     subtitle: "Quarterly Reporting member",
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/album-layout.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/album-layout.test.ts
@@ -10,11 +10,11 @@ describe("singlePhotoRatio", () => {
   })
 
   it("clamps a tower so it can't push the conversation off screen", () => {
-    expect(singlePhotoRatio(100, 1000)).toBe(1.4)
+    expect(singlePhotoRatio(100, 1000)).toBeCloseTo(1.4)
   })
 
   it("clamps a panorama so it doesn't collapse to a strip", () => {
-    expect(singlePhotoRatio(1000, 100)).toBe(0.6)
+    expect(singlePhotoRatio(1000, 100)).toBeCloseTo(0.6)
   })
 
   it("falls back to a square without intrinsic dimensions", () => {

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/chat-motion.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/chat-motion.test.ts
@@ -38,8 +38,8 @@ describe("chat-motion vocabulary", () => {
   })
 
   it("micro presences stay in the discreet 120-160ms band", () => {
-    expect(microEnterTransition.duration).toBe(0.16)
-    expect(microExitTransition.duration).toBe(0.12)
+    expect(microEnterTransition.duration).toBeCloseTo(0.16)
+    expect(microExitTransition.duration).toBeCloseTo(0.12)
   })
 
   it("layout shifts carry an explicit tween (framer's default bounces)", () => {

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/virtuoso-chat.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/virtuoso-chat.test.ts
@@ -84,30 +84,49 @@ describe("classifyWindowChange", () => {
 
 describe("nextFirstItemIndex", () => {
   it("starts at (and resets to) PREPEND_OFFSET", () => {
-    expect(nextFirstItemIndex(123, "initial", 0, 10)).toBe(PREPEND_OFFSET)
-    expect(nextFirstItemIndex(123, "replace", 10, 10)).toBe(PREPEND_OFFSET)
+    expect(
+      nextFirstItemIndex(123, "initial", { prevRowCount: 0, rowCount: 10 })
+    ).toBe(PREPEND_OFFSET)
+    expect(
+      nextFirstItemIndex(123, "replace", { prevRowCount: 10, rowCount: 10 })
+    ).toBe(PREPEND_OFFSET)
   })
 
   it("decreases by the net ROW delta on prepend", () => {
     // 20 messages landed but the old head's day separator merged away:
     // 12 rows → 31 rows is a net +19.
-    expect(nextFirstItemIndex(PREPEND_OFFSET, "prepend", 12, 31)).toBe(
-      PREPEND_OFFSET - 19
-    )
+    expect(
+      nextFirstItemIndex(PREPEND_OFFSET, "prepend", {
+        prevRowCount: 12,
+        rowCount: 31,
+      })
+    ).toBe(PREPEND_OFFSET - 19)
   })
 
   it("increases on a head removal so surviving rows keep their index", () => {
-    expect(nextFirstItemIndex(1000, "prepend", 10, 9)).toBe(1001)
+    expect(
+      nextFirstItemIndex(1000, "prepend", { prevRowCount: 10, rowCount: 9 })
+    ).toBe(1001)
   })
 
   it("keeps the index on append and none", () => {
-    expect(nextFirstItemIndex(1000, "append", 10, 11)).toBe(1000)
-    expect(nextFirstItemIndex(1000, "none", 10, 10)).toBe(1000)
+    expect(
+      nextFirstItemIndex(1000, "append", { prevRowCount: 10, rowCount: 11 })
+    ).toBe(1000)
+    expect(
+      nextFirstItemIndex(1000, "none", { prevRowCount: 10, rowCount: 10 })
+    ).toBe(1000)
   })
 
   it("shifts a grow by how far the surviving head moved, not the net delta", () => {
     // 3 rows landed on top and 5 at the bottom: only the 3 may move the base.
-    expect(nextFirstItemIndex(1000, "grow", 10, 18, 3)).toBe(997)
+    expect(
+      nextFirstItemIndex(1000, "grow", {
+        prevRowCount: 10,
+        rowCount: 18,
+        headShift: 3,
+      })
+    ).toBe(997)
   })
 })
 

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/virtuoso-chat.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/virtuoso-chat.test.ts
@@ -85,10 +85,20 @@ describe("classifyWindowChange", () => {
 describe("nextFirstItemIndex", () => {
   it("starts at (and resets to) PREPEND_OFFSET", () => {
     expect(
-      nextFirstItemIndex(123, "initial", { prevRowCount: 0, rowCount: 10 })
+      nextFirstItemIndex({
+        prev: 123,
+        change: "initial",
+        prevRowCount: 0,
+        rowCount: 10,
+      })
     ).toBe(PREPEND_OFFSET)
     expect(
-      nextFirstItemIndex(123, "replace", { prevRowCount: 10, rowCount: 10 })
+      nextFirstItemIndex({
+        prev: 123,
+        change: "replace",
+        prevRowCount: 10,
+        rowCount: 10,
+      })
     ).toBe(PREPEND_OFFSET)
   })
 
@@ -96,7 +106,9 @@ describe("nextFirstItemIndex", () => {
     // 20 messages landed but the old head's day separator merged away:
     // 12 rows → 31 rows is a net +19.
     expect(
-      nextFirstItemIndex(PREPEND_OFFSET, "prepend", {
+      nextFirstItemIndex({
+        prev: PREPEND_OFFSET,
+        change: "prepend",
         prevRowCount: 12,
         rowCount: 31,
       })
@@ -105,23 +117,40 @@ describe("nextFirstItemIndex", () => {
 
   it("increases on a head removal so surviving rows keep their index", () => {
     expect(
-      nextFirstItemIndex(1000, "prepend", { prevRowCount: 10, rowCount: 9 })
+      nextFirstItemIndex({
+        prev: 1000,
+        change: "prepend",
+        prevRowCount: 10,
+        rowCount: 9,
+      })
     ).toBe(1001)
   })
 
   it("keeps the index on append and none", () => {
     expect(
-      nextFirstItemIndex(1000, "append", { prevRowCount: 10, rowCount: 11 })
+      nextFirstItemIndex({
+        prev: 1000,
+        change: "append",
+        prevRowCount: 10,
+        rowCount: 11,
+      })
     ).toBe(1000)
     expect(
-      nextFirstItemIndex(1000, "none", { prevRowCount: 10, rowCount: 10 })
+      nextFirstItemIndex({
+        prev: 1000,
+        change: "none",
+        prevRowCount: 10,
+        rowCount: 10,
+      })
     ).toBe(1000)
   })
 
   it("shifts a grow by how far the surviving head moved, not the net delta", () => {
     // 3 rows landed on top and 5 at the bottom: only the 3 may move the base.
     expect(
-      nextFirstItemIndex(1000, "grow", {
+      nextFirstItemIndex({
+        prev: 1000,
+        change: "grow",
         prevRowCount: 10,
         rowCount: 18,
         headShift: 3,

--- a/packages/react/src/sds/chat/F0Chat/utils/virtuoso-chat.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/virtuoso-chat.ts
@@ -104,9 +104,11 @@ export function classifyWindowChange(
 export function nextFirstItemIndex(
   prev: number,
   change: WindowChange,
-  prevRowCount: number,
-  rowCount: number,
-  headShift = 0
+  {
+    prevRowCount,
+    rowCount,
+    headShift = 0,
+  }: { prevRowCount: number; rowCount: number; headShift?: number }
 ): number {
   if (change === "initial" || change === "replace") {
     return PREPEND_OFFSET
@@ -213,13 +215,11 @@ export function advanceChatWindow(
   const headShift =
     survivingHeadIndex != null ? survivingHeadIndex - prev.headRowIndex : 0
 
-  const firstItemIndex = nextFirstItemIndex(
-    prev.firstItemIndex,
-    change,
-    prev.rowCount,
+  const firstItemIndex = nextFirstItemIndex(prev.firstItemIndex, change, {
+    prevRowCount: prev.rowCount,
     rowCount,
-    headShift
-  )
+    headShift,
+  })
 
   const last = messages[messages.length - 1]
   const ownGlide =

--- a/packages/react/src/sds/chat/F0Chat/utils/virtuoso-chat.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/virtuoso-chat.ts
@@ -101,15 +101,21 @@ export function classifyWindowChange(
  * the old head never sat at row 0 and its raw new index over-shifts by at least
  * one row (see `chatWindowHeadRowIndex`).
  */
-export function nextFirstItemIndex(
-  prev: number,
-  change: WindowChange,
-  {
-    prevRowCount,
-    rowCount,
-    headShift = 0,
-  }: { prevRowCount: number; rowCount: number; headShift?: number }
-): number {
+export type NextFirstItemIndexOptions = {
+  prev: number
+  change: WindowChange
+  prevRowCount: number
+  rowCount: number
+  headShift?: number
+}
+
+export function nextFirstItemIndex({
+  prev,
+  change,
+  prevRowCount,
+  rowCount,
+  headShift = 0,
+}: NextFirstItemIndexOptions): number {
   if (change === "initial" || change === "replace") {
     return PREPEND_OFFSET
   }
@@ -215,7 +221,9 @@ export function advanceChatWindow(
   const headShift =
     survivingHeadIndex != null ? survivingHeadIndex - prev.headRowIndex : 0
 
-  const firstItemIndex = nextFirstItemIndex(prev.firstItemIndex, change, {
+  const firstItemIndex = nextFirstItemIndex({
+    prev: prev.firstItemIndex,
+    change,
     prevRowCount: prev.rowCount,
     rowCount,
     headShift,

--- a/packages/react/src/ui/DatePickerPopup/utils.ts
+++ b/packages/react/src/ui/DatePickerPopup/utils.ts
@@ -1,6 +1,8 @@
 import { DatePickerValue } from "./types"
 
-const coerceToDate = (value: Date | string | number): Date =>
+type DateLike = Date | string | number
+
+const coerceToDate = (value: DateLike): Date =>
   value instanceof Date ? value : new Date(value)
 
 /**
@@ -25,8 +27,8 @@ export const reviveDatePickerValue = (
     return value
   }
   const { from, to } = value.value as {
-    from: Date | string | number
-    to: Date | string | number
+    from: DateLike
+    to: DateLike
   }
   if (from instanceof Date && to instanceof Date) {
     return value

--- a/packages/react/src/ui/Kanban/components/KanbanLane.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanLane.tsx
@@ -599,10 +599,8 @@ export function KanbanLane<TRecord extends RecordType>({
       const originalHeight = outer.style.height
       outer.style.height = "auto"
 
-      // Force reflow to ensure accurate measurement
-      void measure.offsetHeight
-
-      // Get natural content height by looking at the Lane component inside
+      // Get natural content height by looking at the Lane component inside.
+      // Reading scrollHeight forces the reflow after the height change above.
       const contentHeight = measure.scrollHeight
 
       // Restore constraint

--- a/packages/react/src/ui/Toast/__stories__/F0Toast.stories.tsx
+++ b/packages/react/src/ui/Toast/__stories__/F0Toast.stories.tsx
@@ -105,7 +105,7 @@ export const Success: Story = {
   ),
 }
 
-export const Error: Story = {
+const ErrorState: Story = {
   args: {
     title: "Error occurred",
     description: "Something went wrong. Please try again.",
@@ -364,3 +364,6 @@ export const AllVariants: Story = {
     </div>
   ),
 }
+
+// Exported under the global's name so the story id stays `--error`.
+export { ErrorState as Error }

--- a/packages/react/src/ui/value-display/__stories__/shared.tsx
+++ b/packages/react/src/ui/value-display/__stories__/shared.tsx
@@ -83,5 +83,5 @@ export function Cell({
   property: PropertyDefinition<typeof mockItem>
 }) {
   const i18n = useI18n()
-  return renderProperty(item, property, "table", i18n)
+  return renderProperty(item, property, "table", { i18n })
 }

--- a/packages/react/src/ui/value-display/__stories__/shared.tsx
+++ b/packages/react/src/ui/value-display/__stories__/shared.tsx
@@ -83,5 +83,5 @@ export function Cell({
   property: PropertyDefinition<typeof mockItem>
 }) {
   const i18n = useI18n()
-  return renderProperty(item, property, "table", { i18n })
+  return renderProperty({ item, property, visualization: "table", i18n })
 }

--- a/packages/react/src/ui/value-display/types/barSeries/barSeries.test.tsx
+++ b/packages/react/src/ui/value-display/types/barSeries/barSeries.test.tsx
@@ -46,7 +46,7 @@ describe("BarSeriesCell", () => {
     ).toBeInTheDocument()
     const barSeriesEl = container.querySelector('[data-cell-type="barSeries"]')
     const bars = barSeriesEl?.querySelectorAll(':scope > * [role="img"]') ?? []
-    expect(bars.length).toBe(2)
+    expect(bars).toHaveLength(2)
   })
 
   it("renders with secondaryValue (under/over semantics)", () => {
@@ -64,7 +64,7 @@ describe("BarSeriesCell", () => {
     ).toBeInTheDocument()
     const barSeriesEl = container.querySelector('[data-cell-type="barSeries"]')
     const bars = barSeriesEl?.querySelectorAll(':scope > * [role="img"]') ?? []
-    expect(bars.length).toBe(2)
+    expect(bars).toHaveLength(2)
   })
 
   it("renders empty bar (value 0) with grey bottom border", () => {

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
@@ -49,7 +49,7 @@ describe("CategoryBarChartCell", () => {
       container.querySelector('[data-cell-type="categoryBarChart"]')
     ).toBeInTheDocument()
     const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
-    expect(segments.length).toBe(2)
+    expect(segments).toHaveLength(2)
   })
 
   it("renders fallback dash when total is zero", () => {
@@ -76,7 +76,7 @@ describe("CategoryBarChartCell", () => {
     const { container } = render(CategoryBarChartCell(args, defaultMeta))
 
     const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
-    expect(segments.length).toBe(1)
+    expect(segments).toHaveLength(1)
   })
 
   it("formats percentage correctly in aria-label", () => {
@@ -121,7 +121,7 @@ describe("CategoryBarChartCell", () => {
     const { container } = render(CategoryBarChartCell(args, defaultMeta))
 
     const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
-    expect(segments.length).toBe(3)
+    expect(segments).toHaveLength(3)
     segments.forEach((segment) => {
       expect(segment.getAttribute("style")).toContain("background-color")
     })
@@ -138,7 +138,7 @@ describe("CategoryBarChartCell", () => {
     const { container } = render(CategoryBarChartCell(args, defaultMeta))
 
     const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
-    expect(segments.length).toBe(2)
+    expect(segments).toHaveLength(2)
     // legacy tokens resolve to a CSS var
     expect(segments[0]?.getAttribute("style")).toContain(
       "--chart-categorical-3"
@@ -228,7 +228,7 @@ describe("CategoryBarChartCell", () => {
 
     // Radix marks its trigger with data-state; there must be exactly one for
     // the whole bar so hovering any segment (or the gaps) opens the same tooltip
-    expect(container.querySelectorAll("[data-state]").length).toBe(1)
+    expect(container.querySelectorAll("[data-state]")).toHaveLength(1)
   })
 
   it("lists every segment in the tooltip, not only the hovered one", async () => {
@@ -385,7 +385,7 @@ describe("CategoryBarChartCell", () => {
 
     const { container } = render(CategoryBarChartCell(args, defaultMeta))
 
-    expect(container.querySelectorAll('[tabindex="0"]').length).toBe(1)
+    expect(container.querySelectorAll('[tabindex="0"]')).toHaveLength(1)
   })
 
   it("handles duplicate names with unique keys", () => {
@@ -399,6 +399,6 @@ describe("CategoryBarChartCell", () => {
     const { container } = render(CategoryBarChartCell(args, defaultMeta))
 
     const segments = container.querySelectorAll('[role="img"][aria-label*="%"]')
-    expect(segments.length).toBe(2)
+    expect(segments).toHaveLength(2)
   })
 })

--- a/packages/react/src/ui/value-display/types/number/number.tsx
+++ b/packages/react/src/ui/value-display/types/number/number.tsx
@@ -12,7 +12,7 @@ interface NumberValue extends WithPlaceholder {
   number: number | undefined
   units?: string
   unitsPosition?: "left" | "right"
-  decimalPlaces?: number | undefined
+  decimalPlaces?: number
 }
 
 export type NumberCellValue = number | undefined | NumberValue


### PR DESCRIPTION
Turns on ten rules that were listed as debt in `.oxlintrc.json` and fixes their 249 sites. No autofix exists for any of them, so every change is a hand edit.

## Rules

| Rule | Fixed | Why |
| --- | --- | --- |
| `sonarjs/prefer-specific-assertions` | 75 | `expect(x).toHaveLength(1)` reports the actual length on failure; `expect(x.length).toBe(1)` reports `2`. Same for `toBeNull`, `toBeUndefined`. |
| `sonarjs/no-redundant-optional` | 34 | `foo?: T \| undefined` says the same thing twice. `exactOptionalPropertyTypes` is off, so `foo?: T` is the same type. |
| `sonarjs/no-floating-point-equality` | 25 | `toBe(0.16)` on a computed float is a test that breaks on rounding. `toBeCloseTo` is what it means. |
| `max-params` (max 4) | 24 | Five or more positional arguments are read by position at every call site. Convention: at five or more, all parameters move into one options object with a named type, never positionals plus an object. Four hot-path or library-shaped functions keep a disable comment with the reason. |
| `sonarjs/assertions-in-tests` | 23 | A test without an `expect` passes as long as nothing throws. Each of these now asserts what it renders or checks a type with `assertType`. |
| `sonarjs/use-type-alias` | 21 | The same union spelled out three times in a file drifts. One alias, one name. |
| `sonarjs/no-nested-functions` (depth 5) | 17 | Callbacks nested six deep are hard to follow. The inner ones are now named helpers. The default depth of 4 has 110 hits, most of them JSX callbacks inside hooks, so the limit is 5. |
| `sonarjs/parameterized-tests` | 12 groups | Three or more tests that differ only in input and output become one `it.each` table. |
| `sonarjs/void-use` | 10 | `void expr` hides why a value is read or dropped. Each site now says it: `getBoundingClientRect()` for a forced reflow, `_`-prefixed bindings for deprecated props, a real test for a type check. |
| `sonarjs/no-globals-shadowing` | 6 | Stories exported as `Error`, `Number`, `Date` shadow the globals in that module. They are now local consts re-exported under the same name, so Storybook ids and URLs are unchanged. |
| `sonarjs/no-identical-functions` | 2 | Two identical function bodies in one file. Off for stories and tests, where each case is meant to read on its own. |

Off on purpose, with the reason in the config: `sonarjs/pseudo-random` (Math.random is used for ids and shuffles, never for security), `sonarjs/redundant-type-aliases` (aliases like `type ColId = string` name intent and most are exported), `sonarjs/super-linear-regex` (the flagged regexes run on short strings we build ourselves).

Still debt: `sonarjs/cognitive-complexity` (187 functions at the default threshold of 15, goes to the lint ratchet in the next PR) and `sonarjs/todo-tag`.

## Signature changes

All callers in the repo are updated and none of these is re-exported from a public entry point (`f0.ts`, `experimental.ts`, the `exports.ts` files):

- `useColumns`, `usePersistedState`, `renderProperty`, `useSurveyFormSchema`, `buildMonthOptions`, `nextFirstItemIndex` and `useClusters` now take a single options object (`UseColumnsOptions`, `UsePersistedStateOptions`, and so on) instead of positional parameters. `register` from `useF0AiFormRegistry` is public and keeps its eight positional parameters with a disable comment.
- New exported types: `TableRowRef` (OneDataCollection Table), `CalendarSelection` and `OptionalCalendarSelection` (OneCalendar, public), `DropPosition` (F0TableOfContent), `UseSurveyFormSchemaOptions`. All additive.

## Behavior notes

- `ApplicationFrame.canvasInset` tests: the helpers now return the settled value and each test asserts it. Same waits, same values.
- Four skipped tests that exist only for `@ts-expect-error` checks now use `assertType`, so the compile check stays and the rule is satisfied.
