### PR TITLE
feat(WidgetContainer): mark every widget's box, arrangeable or not

### DIFF
--- a/packages/react/src/sds/Home/WidgetContainer/WidgetMotion.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/WidgetMotion.tsx
@@ -46,6 +46,14 @@ export interface WidgetMotionProps {
    * against a box with no height of its own.
    */
   fullHeight?: boolean
+  /**
+   * WHICH WIDGET'S BOX THIS IS, when nothing else says so. In an arrangeable
+   * column `SortableWidget` is the box and carries the id itself; everywhere
+   * else this wrapper is the only element between the column and the card, so
+   * without it a widget the reader cannot drag is a widget nothing outside f0
+   * can point at — a coachmark, a tour, a test.
+   */
+  widgetId?: string
   children: ReactNode
 }
 
@@ -77,6 +85,7 @@ export const WidgetMotion = ({
   arrival,
   stow,
   fullHeight,
+  widgetId,
   children,
 }: WidgetMotionProps) => {
   const reducedMotion = useReducedMotion()
@@ -96,6 +105,7 @@ export const WidgetMotion = ({
 
   return (
     <motion.div
+      data-widget-id={widgetId}
       className={cn(fullHeight && "h-full")}
       initial={
         arrival?.arriving

--- a/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.spec.tsx
@@ -36,8 +36,8 @@ const Scroller = ({ children }: { children: React.ReactNode }) => (
 )
 
 /**
- * Which widgets are in the DOM, by id — read off the boxes a draggable column
- * marks every widget's card with.
+ * Which widgets are in the DOM, by id — read off the box every widget's card
+ * gets marked with, draggable column or not.
  */
 const mountedIds = (container: HTMLElement) =>
   [...container.querySelectorAll("[data-widget-id]")].map((el) =>
@@ -110,6 +110,30 @@ describe("WidgetContainer", () => {
     expect(
       screen.getByRole("button", { name: "Add widget" })
     ).toBeInTheDocument()
+  })
+
+  // A column nobody can rearrange still has to be addressable from outside f0 —
+  // a coachmark pointing at one of its widgets, a tour, a test.
+  test("marks every widget's box, arrangeable column or not", () => {
+    const { container } = zeroRender(
+      <WidgetContainer widgets={WIDGETS} onReorder={() => {}} />
+    )
+    expect(mountedIds(container)).toEqual(["clock", "events"])
+
+    const still = zeroRender(<WidgetContainer widgets={WIDGETS} />)
+    expect(mountedIds(still.container)).toEqual(["clock", "events"])
+  })
+
+  // Two nested elements answering to the same id would make which one a
+  // `querySelector` returns an accident of the tree.
+  test("marks it once, on one box", () => {
+    const { container } = zeroRender(
+      <WidgetContainer widgets={[widget("clock")]} onReorder={() => {}} />
+    )
+
+    expect(container.querySelectorAll('[data-widget-id="clock"]')).toHaveLength(
+      1
+    )
   })
 
   test("offers no menu at all without onRemoveWidget", () => {

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -800,9 +800,20 @@ export function WidgetContainer({
    * nothing to do must not leave a box behind, because that box is the flex item
    * the widget itself would have been.
    */
-  const enter = (order: number, node: ReactNode, widget?: HomeWidgetItem) => {
+  const enter = (
+    order: number,
+    node: ReactNode,
+    widget?: HomeWidgetItem,
+    /**
+     * Set only where nothing else marks the box — an arrangeable column's
+     * `SortableWidget` already carries the id one level up, and marking it here
+     * too would put the same attribute on two nested elements.
+     */
+    widgetId?: string
+  ) => {
     const widgetStow = widget ? stowOf(widget) : undefined
-    if (!arrival && !widgetStow) {
+    // The id needs a box to sit on, so asking for one is reason enough to wrap.
+    if (!arrival && !widgetStow && !widgetId) {
       return node
     }
     return (
@@ -818,6 +829,7 @@ export function WidgetContainer({
         }
         stow={widgetStow}
         fullHeight={widget?.fullHeight}
+        widgetId={widgetId}
       >
         {node}
       </WidgetMotion>
@@ -853,7 +865,9 @@ export function WidgetContainer({
             {(state) => enter(order, render(widget, state), widget)}
           </SortableWidget>
         ) : (
-          enter(order, render(widget), widget)
+          // No sortable to carry it here, so the arrival wrapper is the box the
+          // id goes on — see `enter`.
+          enter(order, render(widget), widget, widget.id)
         )}
       </WidgetStage>
     </WidgetSlot>


### PR DESCRIPTION
## Description

`data-widget-id` was `SortableWidget`'s, so only a column you can **rearrange** said which widget each box belonged to. Everywhere else the widget reaches the DOM through `WidgetSlot`, which is `display: contents` by design, and there is no box left to name it by:

- a main column rendered without `onReorder`
- any container with `disableEdition`

A widget nobody can drag is a widget nothing outside f0 can point at — no coachmark, no tour, no test.

### Where it goes, and why not a wrapper

`WidgetMotion` — the arrival wrapper — already **is** the flex item the card used to be; it carries the `fullHeight` chain for exactly that reason. Naming it costs no box that was not already there, which matters because `WidgetSlot`'s `display: contents` is deliberately protecting the column's gap, `fullHeight` and every child selector. A wrapper of its own would have broken the very thing that comment defends.

It is set from the **non-arrangeable branch only**. `SortableWidget` keeps the attribute where it exists, so the id is never on two nested elements and `querySelector` keeps returning the one box a caller meant. `enter()` now treats being asked for an id as reason enough to wrap, since the id needs a box to sit on.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Observable behavior

- Every widget's card is addressable by `[data-widget-id="<id>"]`, in any container.
- Arrangeable columns are unchanged — same element, same single match.
- No new box: `fullHeight`, the column gap and child selectors land exactly where they did.

## Tests

Two added to `WidgetContainer/index.spec.tsx` — every widget marked with and without `onReorder`, and marked exactly once so nesting cannot make `querySelector` an accident of the tree. Full `src/sds/Home` suite green (31 files, 420 tests).

`mountedIds`'s doc comment said it read "the boxes a draggable column marks"; that is now every column, so the comment was updated with it.

## Context

Found while pointing a first-run coachmark at Home's "needs you" widget in the monorepo. It lives in the main column, which is not arrangeable there, so the step silently dropped — f0 waits ~2s for a target and then walks on without it. Nothing else in the public surface reaches a widget's box: `HomeWidgetItem` has no props escape hatch, `HomeRenderCtx` does not identify the widget, `SlotWidget` is not exported (so `renderWidget` means reimplementing the card), and `widgetHostFor` is internal to the stacked layout.
