### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.90.0",
+  "packages/react": "6.90.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.90.1](https://github.com/factorialco/f0/compare/f0-react-v6.90.0...f0-react-v6.90.1) (2026-09-08)
+
+
+### Bug Fixes
+
+* **F0Chat:** show message length validation ([#5466](https://github.com/factorialco/f0/issues/5466)) ([b1e593c](https://github.com/factorialco/f0/commit/b1e593c2d6fab500f74fb78d0e0e32024388ec66))
+
 ## [6.90.0](https://github.com/factorialco/f0/compare/f0-react-v6.89.0...f0-react-v6.90.0) (2026-09-08)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.90.0",
+  "version": "6.90.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.90.1</summary>

## [6.90.1](https://github.com/factorialco/f0/compare/f0-react-v6.90.0...f0-react-v6.90.1) (2026-09-08)


### Bug Fixes

* **F0Chat:** show message length validation ([#5466](https://github.com/factorialco/f0/issues/5466)) ([b1e593c](https://github.com/factorialco/f0/commit/b1e593c2d6fab500f74fb78d0e0e32024388ec66))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).