### PR TITLE
fix(F0Chat): harden Unicode mention editing

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -401,6 +401,7 @@ memoization is required of the host.
 - WHEN the running platform cannot draw an emoji — a release newer than its font, or a sequence it splits into parts → THEN F0 leaves that emoji out of the picker and the `:` suggestions instead of offering a tofu box. Emoji arriving in a received message are shown as-is.
 - WHEN emoji support cannot be measured (no canvas, a sandboxed frame, server rendering) → THEN F0 offers the complete set rather than hiding emoji on the strength of a failed probe.
 - WHEN emoji are typed into the composer → THEN the highlight overlay stays off and the native textarea keeps its own text, so IME composition remains visible. Only mentions and ghost completions turn the overlay on.
+- WHEN a message body and its mention metadata use canonically equivalent Unicode spellings → THEN F0 preserves the body’s exact mention span and its associated person. Editing immediately before or after that span keeps the mention; editing inside it removes the complete mention.
 - WHEN an image, PDF, spreadsheet, Word document, or text file enters the composer → THEN F0 renders an image-sized square preview immediately while the upload continues.
 - WHEN a video enters the composer → THEN F0 keeps the same compact height but renders a wider 16:9 preview so its media type is visually distinct.
 - WHEN an uploaded attachment replaces its local composer preview → THEN F0 preserves the preview's stable key and shape, swaps to the host URL, and revokes the temporary object URL.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -193,6 +193,27 @@ const carmen: F0ChatUser = {
   avatar: { type: "person", firstName: "Carmen", lastName: "Rodríguez" },
   profileHref: "/people/carmen",
 }
+const unicodeNfc: F0ChatUser = {
+  id: "unicode-nfc",
+  name: "Garc\u00EDa",
+  subtitle: "NFC profile",
+  avatar: { type: "person", firstName: "NFC", lastName: "García" },
+  profileHref: "/people/unicode-nfc",
+}
+const unicodeNfd: F0ChatUser = {
+  id: "unicode-nfd",
+  name: "Garci\u0301a",
+  subtitle: "NFD profile",
+  avatar: { type: "person", firstName: "NFD", lastName: "García" },
+  profileHref: "/people/unicode-nfd",
+}
+const unicodeHangul: F0ChatUser = {
+  id: "unicode-hangul",
+  name: "\uAC01",
+  subtitle: "Composed Hangul profile",
+  avatar: { type: "person", firstName: "각", lastName: "" },
+  profileHref: "/people/unicode-hangul",
+}
 
 const groupChannel = {
   id: "grp-product",
@@ -261,6 +282,87 @@ const GroupConversation = (): ReactNode => {
         <F0Chat headerActions={headerActions} />
       </F0ChatProvider>
     </Frame>
+  )
+}
+
+/** Manual regression surface for canonically equivalent mention spellings. */
+const UnicodeMentionConversation = (): ReactNode => {
+  const runtime = useMockChatRuntime({
+    channel: { ...groupChannel, id: "grp-unicode-mentions" },
+    me,
+    others: [unicodeNfc, unicodeNfd, unicodeHangul],
+    initialCount: 0,
+    olderPages: 0,
+    ambientEveryMs: 0,
+    extraMessages: [
+      {
+        id: "unicode-edit-accent",
+        author: me,
+        body: "Before @Garci\u0301a, after",
+        createdAt: new Date().toISOString(),
+        isMine: true,
+        mentions: [{ id: unicodeNfc.id, name: unicodeNfc.name }],
+      },
+      {
+        id: "unicode-distinct-identities",
+        author: me,
+        body: "Two people: @Garc\u00EDa and @Garci\u0301a",
+        createdAt: new Date().toISOString(),
+        isMine: true,
+        mentions: [unicodeNfc, unicodeNfd],
+      },
+      {
+        id: "unicode-edit-hangul",
+        author: me,
+        body: "Hangul: @\u1100\u1161\u11A8, ready",
+        createdAt: new Date().toISOString(),
+        isMine: true,
+        mentions: [{ id: unicodeHangul.id, name: unicodeHangul.name }],
+      },
+    ],
+  })
+
+  return (
+    <div className="flex w-full flex-col gap-4 bg-f1-background p-4 text-f1-foreground lg:flex-row">
+      <aside className="w-full shrink-0 rounded-lg border border-solid border-f1-border p-4 lg:w-80">
+        <h2 className="mb-2 text-lg font-medium">Manual mention checks</h2>
+        <ol className="list-decimal space-y-2 pl-5 text-sm">
+          <li>Open the first message’s actions menu and choose Edit.</li>
+          <li>
+            Insert text immediately before the mention. Only the mention stays
+            highlighted.
+          </li>
+          <li>
+            Change a character inside the mention. The entire mention is
+            removed.
+          </li>
+          <li>
+            Reopen it and change the comma immediately after the mention. The
+            mention stays highlighted.
+          </li>
+          <li>
+            Focus or hover both mentions in “Two people”. Their profile
+            subtitles must stay distinct and the keyboard focus ring must be
+            visible.
+          </li>
+          <li>
+            Edit the Hangul message. Its decomposed body remains one complete
+            mention.
+          </li>
+          <li>
+            With a screen reader, confirm each focused mention is announced once
+            with its profile subtitle.
+          </li>
+        </ol>
+      </aside>
+      <div className="min-w-0 flex-1">
+        <Frame>
+          <F0ChatProvider runtime={runtime}>
+            <F0Chat />
+          </F0ChatProvider>
+        </Frame>
+      </div>
+    </div>
   )
 }
 
@@ -1333,6 +1435,135 @@ export const ComposerHotkeys: Story = {
 export const Group: Story = {
   name: "Group with mentions",
   render: () => <GroupConversation />,
+}
+
+/** Canonical Unicode mention spans, identity, and edit-boundary QA. */
+export const UnicodeMentionEditing: Story = {
+  name: "Unicode mention editing (QA)",
+  tags: ["unicode-mention-regression"],
+  render: () => <UnicodeMentionConversation />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const document = within(canvasElement.ownerDocument.body)
+    const composer = (): HTMLTextAreaElement =>
+      canvas.getByRole("combobox", {
+        name: /write something here/i,
+      }) as HTMLTextAreaElement
+    const surfaceFor = async (text: string): Promise<HTMLElement> => {
+      const surfaces = await canvas.findAllByTestId("chat-message-surface")
+      const surface = surfaces.find((candidate) =>
+        candidate.textContent?.includes(text)
+      )
+      expect(surface).toBeDefined()
+      return surface!
+    }
+    const openEdit = async (text: string): Promise<HTMLTextAreaElement> => {
+      const surface = await surfaceFor(text)
+      const messageRow = surface.parentElement
+      expect(messageRow).toBeDefined()
+      await userEvent.hover(surface)
+      const menu = await waitFor(() => {
+        const trigger = within(messageRow!).getByRole("button", {
+          name: /message actions/i,
+        })
+        expect(trigger).toHaveAttribute("aria-expanded", "false")
+        return trigger
+      })
+      await userEvent.click(menu)
+      await userEvent.click(
+        await document.findByRole("button", { name: /^Edit$/i })
+      )
+      await waitFor(() =>
+        expect(
+          canvas.getByRole("button", { name: /cancel edit/i })
+        ).toBeVisible()
+      )
+      return composer()
+    }
+    const highlightedMention = (text: string): HTMLElement | undefined => {
+      const composerSurface = canvas.getByTestId("chat-composer-surface")
+      return [
+        ...composerSurface.querySelectorAll<HTMLElement>("[aria-hidden] span"),
+      ].find((node) => node.textContent === text)
+    }
+
+    await step(
+      "Keep an insertion before the mention outside its span",
+      async () => {
+        const field = await openEdit("Before")
+        const at = field.value.indexOf("@")
+        await userEvent.click(field)
+        field.setSelectionRange(at, at)
+        await userEvent.type(field, "x", { skipClick: true })
+
+        await waitFor(() =>
+          expect(field).toHaveValue("Before x@Garci\u0301a, after")
+        )
+        await waitFor(() =>
+          expect(highlightedMention("@Garci\u0301a")).toBeVisible()
+        )
+        expect(highlightedMention("x@Garci\u0301a")).toBeUndefined()
+      }
+    )
+
+    await step("Remove the whole mention when editing inside it", async () => {
+      const field = composer()
+      const at = field.value.indexOf("@")
+      field.setSelectionRange(at + 1, at + 2)
+      await userEvent.type(field, "X", { skipClick: true })
+
+      await waitFor(() => expect(field).toHaveValue("Before x, after"))
+      expect(highlightedMention("@Garci\u0301a")).toBeUndefined()
+      await userEvent.click(
+        canvas.getByRole("button", { name: /cancel edit/i })
+      )
+    })
+
+    await step(
+      "Keep canonically equal occurrences tied to each profile",
+      async () => {
+        const nfc = canvas.getByRole("link", {
+          name: "@García, NFC profile",
+        })
+        const nfd = canvas.getByRole("link", {
+          name: "@García, NFD profile",
+        })
+
+        await userEvent.hover(nfc)
+        await expect(
+          await document.findByText("NFC profile")
+        ).toBeInTheDocument()
+        await userEvent.unhover(nfc)
+        await waitFor(() =>
+          expect(document.queryByText("NFC profile")).not.toBeInTheDocument()
+        )
+        await userEvent.hover(nfd)
+        await expect(
+          await document.findByText("NFD profile")
+        ).toBeInTheDocument()
+        await userEvent.unhover(nfd)
+
+        nfc.focus()
+        await expect(nfc).toHaveFocus()
+        await expect(
+          await document.findByText("NFC profile")
+        ).toBeInTheDocument()
+        nfd.focus()
+        await expect(nfd).toHaveFocus()
+        await expect(
+          await document.findByText("NFD profile")
+        ).toBeInTheDocument()
+      }
+    )
+
+    await step("Anchor the complete decomposed Hangul occurrence", async () => {
+      const field = await openEdit("Hangul")
+      await expect(field).toHaveValue("Hangul: @\u1100\u1161\u11A8, ready")
+      await waitFor(() =>
+        expect(highlightedMention("@\u1100\u1161\u11A8")).toBeVisible()
+      )
+    })
+  },
 }
 
 /** Membership events as centered system rows (added / left / removed) with

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatBubble.mentions.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatBubble.mentions.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { zeroRender as render, screen } from "@/testing/test-utils"
+import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 import { ChatBubble } from "../components/ChatBubble"
 import { type F0ChatMessage } from "../types"
 
@@ -30,6 +30,7 @@ describe("ChatBubble mentions", () => {
     )
     const chip = screen.getByText("@Ana García")
     expect(chip.className).toContain("text-f1-foreground-secondary")
+    expect(chip).toHaveTextContent("@Ana García, Product Designer")
     // Wrapped in the hover-card trigger (same affordance as the sender avatar).
     expect(chip.closest("[data-state]")).not.toBeNull()
   })
@@ -64,5 +65,76 @@ describe("ChatBubble mentions", () => {
     const chip = screen.getByText("@here")
     expect(chip.className).toContain("text-f1-foreground-secondary")
     expect(chip.closest("[data-state]")).toBeNull()
+  })
+
+  it("keeps canonically equivalent occurrences tied to their profiles", async () => {
+    const { container } = render(
+      <ChatBubble
+        message={makeMessage({
+          body: "Before @Garc\u00EDa and @Garci\u0301a, after",
+          mentions: [
+            {
+              id: "nfc",
+              name: "Garc\u00EDa",
+              subtitle: "NFC profile",
+              profileHref: "/people/nfc",
+            },
+            {
+              id: "nfd",
+              name: "Garci\u0301a",
+              subtitle: "NFD profile",
+              profileHref: "/people/nfd",
+            },
+          ],
+        })}
+        isMine
+        currentUserId="me"
+      />
+    )
+
+    expect(container).toHaveTextContent("Before @García and @García, after")
+
+    const nfc = screen.getByRole("link", {
+      name: "@García, NFC profile",
+    })
+    const nfd = screen.getByRole("link", {
+      name: "@García, NFD profile",
+    })
+    expect(nfc).toHaveAttribute("href", "/people/nfc")
+    expect(nfd).toHaveAttribute("href", "/people/nfd")
+
+    await userEvent.hover(nfc)
+    expect(await screen.findByText("NFC profile")).toBeVisible()
+    await userEvent.unhover(nfc)
+    await userEvent.hover(nfd)
+    expect(await screen.findByText("NFD profile")).toBeVisible()
+  })
+
+  it("opens a mention profile from keyboard focus", async () => {
+    render(
+      <ChatBubble
+        message={makeMessage({
+          body: "Ping @Ana García",
+          mentions: [
+            {
+              id: "ana-g",
+              name: "Ana García",
+              subtitle: "Product Designer",
+              profileHref: "/people/ana-g",
+            },
+          ],
+        })}
+        isMine
+        currentUserId="me"
+      />
+    )
+
+    await userEvent.tab()
+    const mention = screen.getByRole("link", {
+      name: "@Ana García, Product Designer",
+    })
+    expect(mention).toHaveAttribute("href", "/people/ana-g")
+    expect(mention).toHaveFocus()
+    expect(await screen.findByText("Product Designer")).toBeVisible()
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
@@ -1,7 +1,8 @@
-import { act, renderHook, waitFor } from "@testing-library/react"
+import { act, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { zeroRenderHook as renderHook } from "@/testing/test-utils"
 import { type F0ChatUser } from "../../types"
-import { type MentionEntry, useMentions } from "../useMentions"
+import { mentionEnd, type MentionEntry, useMentions } from "../useMentions"
 
 const MEMBERS: F0ChatUser[] = [
   { id: "ana-g", name: "Ana García" },
@@ -176,6 +177,7 @@ describe("useMentions", () => {
 // `@Name` is followed by whitespace — which a saved body often isn't.
 describe("useMentions — a mention survives an edit", () => {
   const ANA: MentionEntry = { id: "ana-g", name: "Ana García" }
+  const NFD_ANA: MentionEntry = { id: "ana-nfd", name: "Ana Garci\u0301a" }
 
   const withValue = (body: string, over: Partial<Props> = {}) =>
     makeProps({ inputValue: body, cursorPosition: body.length, ...over })
@@ -226,6 +228,126 @@ describe("useMentions — a mention survives an edit", () => {
       expect(result.current.getMentions().mentions).toEqual([ANA])
     )
     expect(setInputValue).not.toHaveBeenCalled()
+  })
+
+  it("keeps text inserted immediately before a mention outside its highlight", async () => {
+    let value = "Hola @Ana García, ¿vienes?"
+    const { result, rerender } = openForEditing(value, [ANA])
+
+    value = "Hola x@Ana García, ¿vienes?"
+    rerender(withValue(value))
+
+    await waitFor(() => expect(result.current.mentions[0]?.start).toBe(6))
+    const mention = result.current.mentions[0]!
+    expect(value.slice(mention.start, mentionEnd(mention))).toBe("@Ana García")
+  })
+
+  it("highlights the full body spelling when its canonical length differs", async () => {
+    const body = "Hola @Ana Garci\u0301a, ¿vienes?"
+    const { result } = openForEditing(body, [ANA])
+
+    await waitFor(() => expect(result.current.mentions).toHaveLength(1))
+    const mention = result.current.mentions[0]!
+    expect(body.slice(mention.start, mentionEnd(mention))).toBe(
+      `@${NFD_ANA.name}`
+    )
+  })
+
+  it("uses the composed body span for a decomposed metadata name", async () => {
+    const body = "Hola @Ana García, ¿vienes?"
+    const { result } = openForEditing(body, [NFD_ANA])
+
+    await waitFor(() => expect(result.current.mentions).toHaveLength(1))
+    const mention = result.current.mentions[0]!
+    expect(body.slice(mention.start, mentionEnd(mention))).toBe("@Ana García")
+  })
+
+  it("updates an existing anchor when reseeding changes only its body length", () => {
+    const { result } = renderHook((p: Props) => useMentions(p), {
+      initialProps: makeProps(),
+    })
+    const decomposedBody = "Hola @Ana Garci\u0301a"
+    const composedBody = "Hola @Ana García"
+
+    act(() => result.current.seedMentions([ANA], decomposedBody))
+    expect(result.current.mentions[0]?.length).toBe("@Ana Garci\u0301a".length)
+
+    act(() => result.current.seedMentions([ANA], composedBody))
+    expect(result.current.mentions[0]?.length).toBe("@Ana García".length)
+  })
+
+  it("preserves distinct canonical identities in the outgoing payload", async () => {
+    const nfc: MentionEntry = { id: "nfc", name: "Garc\u00EDa" }
+    const nfd: MentionEntry = { id: "nfd", name: "Garci\u0301a" }
+    const { result } = openForEditing(`@${nfd.name} and @${nfc.name}`, [
+      nfc,
+      nfd,
+    ])
+
+    await waitFor(() =>
+      expect(result.current.getMentions().mentions).toEqual([nfd, nfc])
+    )
+  })
+
+  it("keeps a cross-spelling mention when punctuation immediately after it changes", async () => {
+    let value = "Hola @Ana García, ¿vienes?"
+    const setInputValue = vi.fn((next: string) => {
+      value = next
+    })
+    const { result, rerender } = openForEditing(value, [NFD_ANA], {
+      setInputValue,
+    })
+
+    value = "Hola @Ana García! ¿vienes?"
+    rerender(withValue(value, { setInputValue }))
+
+    await waitFor(() =>
+      expect(result.current.getMentions().mentions).toEqual([NFD_ANA])
+    )
+    expect(setInputValue).not.toHaveBeenCalled()
+  })
+
+  it("removes a cross-spelling mention when its final character changes", async () => {
+    let value = "Hola @Ana Garci\u0301a, ¿vienes?"
+    const setInputValue = vi.fn((next: string) => {
+      value = next
+    })
+    const { result, rerender } = openForEditing(value, [ANA], { setInputValue })
+
+    value = "Hola @Ana Garci\u0301o, ¿vienes?"
+    rerender(
+      makeProps({ inputValue: value, cursorPosition: 16, setInputValue })
+    )
+
+    await waitFor(() =>
+      expect(setInputValue).toHaveBeenCalledWith("Hola , ¿vienes?")
+    )
+    expect(result.current.getMentions().mentions).toEqual([])
+  })
+
+  it("anchors and removes a composed Hangul name in a jamo body", async () => {
+    const hangul: MentionEntry = { id: "hangul", name: "\uAC01" }
+    let value = "Ping @\u1100\u1161\u11A8, now"
+    const setInputValue = vi.fn((next: string) => {
+      value = next
+    })
+    const { result, rerender } = openForEditing(value, [hangul], {
+      setInputValue,
+    })
+
+    await waitFor(() => expect(result.current.mentions).toHaveLength(1))
+    const mention = result.current.mentions[0]!
+    expect(value.slice(mention.start, mentionEnd(mention))).toBe(
+      "@\u1100\u1161\u11A8"
+    )
+
+    value = "Ping @\u1100\u1165\u11A8, now"
+    rerender(makeProps({ inputValue: value, cursorPosition: 7, setInputValue }))
+
+    await waitFor(() =>
+      expect(setInputValue).toHaveBeenCalledWith("Ping , now")
+    )
+    expect(result.current.getMentions().mentions).toEqual([])
   })
 
   it("removes the whole mention when the user edits inside it", async () => {

--- a/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
@@ -33,11 +33,13 @@ export type MentionEntry = {
 export type AnchoredMention = MentionEntry & {
   /** Index of the `@` in the composer text. */
   start: number
+  /** Length of the `@name` occurrence as it is spelled in composer text. */
+  length: number
 }
 
 /** Index just past the last character of an anchored mention's name. */
 export const mentionEnd = (mention: AnchoredMention): number =>
-  mention.start + mention.name.length + 1
+  mention.start + mention.length
 
 /** A row in the mention popover: a group member, or the "everyone" option. */
 export type MentionCandidate =
@@ -180,7 +182,7 @@ const reanchorMentions = (
   // Positions inside the changed span have no image in `next`; clamp a start
   // down and an end up so an erased range covers the whole disturbed region.
   const mapStart = (pos: number): number =>
-    pos <= prefix ? pos : pos >= prevEnd ? pos + delta : prefix
+    pos < prefix ? pos : pos >= prevEnd ? pos + delta : prefix
   const mapEnd = (pos: number): number =>
     pos <= prefix ? pos : pos >= prevEnd ? pos + delta : nextEnd
 
@@ -366,7 +368,8 @@ export function useMentions({
           candidate !== undefined &&
           candidate.id === mention.id &&
           candidate.name === mention.name &&
-          candidate.start === mention.start
+          candidate.start === mention.start &&
+          candidate.length === mention.length
         )
       })
     if (unchanged) {
@@ -537,7 +540,7 @@ export function useMentions({
         .map((m) =>
           m.start >= cursorPosition ? { ...m, start: m.start + shift } : m
         )
-      anchored.push({ ...entry, start: atIndex })
+      anchored.push({ ...entry, start: atIndex, length: name.length + 1 })
       anchored.sort((a, b) => a.start - b.start)
       prevValueRef.current = newValue
       commitMentions(anchored)
@@ -621,7 +624,7 @@ export function useMentions({
     // Anchors are per occurrence; the payload is a set of people, so the same
     // person mentioned twice is sent once.
     const users = new Map<string, MentionEntry>()
-    for (const { start: _start, ...entry } of mentions) {
+    for (const { start: _start, length: _length, ...entry } of mentions) {
       if (entry.id === MENTION_EVERYONE_ID) {
         continue
       }
@@ -637,32 +640,12 @@ export function useMentions({
       const text = forText ?? inputValueRef.current
       prevValueRef.current = text
 
-      // A saved message carries a set of people, not positions, so the text is
-      // what says where they are. Occurrences of one `@name` are handed out to
-      // the entries sharing that name in order — two people with the same
-      // display name get one each, while one person named twice keeps both.
-      const byName = new Map<string, MentionEntry[]>()
-      for (const entry of entries) {
-        const group = byName.get(entry.name)
-        if (group) {
-          group.push(entry)
-        } else {
-          byName.set(entry.name, [entry])
-        }
-      }
-
-      const taken = new Map<string, number>()
       commitMentions(
-        locateMentions(
-          text,
-          [...byName.keys()].map((name) => ({ name }))
-        ).flatMap(({ entry: { name }, start }) => {
-          const group = byName.get(name) ?? []
-          const index = taken.get(name) ?? 0
-          taken.set(name, index + 1)
-          const picked = group[Math.min(index, group.length - 1)]
-          return picked ? [{ ...picked, start }] : []
-        })
+        locateMentions(text, entries).map(({ entry, start, end }) => ({
+          ...entry,
+          start,
+          length: end - start,
+        }))
       )
     },
     [commitMentions]

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest"
+import { locateMentions } from "../mention-ranges"
+import { sanitizeDisplayText } from "../sanitize-text"
+
+// Written as escapes on purpose: the two spellings are the point of these
+// tests and are indistinguishable when pasted as literal characters.
+/** `Garcia` with a precomposed i-acute (U+00ED) — the NFC spelling. */
+const NFC_NAME = "Garc\u00EDa"
+/** The same name as `i` + U+0301 COMBINING ACUTE ACCENT — the NFD spelling. */
+const NFD_NAME = "Garci\u0301a"
+
+describe("locateMentions", () => {
+  it("locates a plain ASCII name", () => {
+    expect(locateMentions("hi @Ana!", [{ name: "Ana" }])).toEqual([
+      { entry: { name: "Ana" }, start: 3, end: 7 },
+    ])
+  })
+
+  it("prefers the longest name and drops the overlap", () => {
+    const entries = [{ name: "Ana" }, { name: "Ana Maria" }]
+    expect(locateMentions("hi @Ana Maria!", entries)).toEqual([
+      { entry: { name: "Ana Maria" }, start: 3, end: 13 },
+    ])
+  })
+
+  it("locates a decomposed name in a body the renderer already composed", () => {
+    const body = sanitizeDisplayText(`hi @${NFD_NAME}!`)
+    const located = locateMentions(body, [{ name: NFD_NAME }])
+
+    expect(located).toHaveLength(1)
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFC_NAME}`)
+  })
+
+  it("locates a composed name in a body that is still decomposed", () => {
+    const body = `hi @${NFD_NAME}!`
+    const located = locateMentions(body, [{ name: NFC_NAME }])
+
+    expect(located).toHaveLength(1)
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFD_NAME}`)
+  })
+
+  it("locates both occurrences when the two spellings are mixed in one body", () => {
+    const body = `@${NFC_NAME} and @${NFD_NAME}`
+    const located = locateMentions(body, [{ name: NFC_NAME }])
+
+    expect(located).toHaveLength(2)
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFC_NAME}`)
+    expect(body.slice(located[1]!.start, located[1]!.end)).toBe(`@${NFD_NAME}`)
+  })
+
+  it("marks only the `@` occurrence when the name also appears as plain text", () => {
+    const body = `${NFC_NAME} wrote: hi @${NFD_NAME}`
+    const located = locateMentions(body, [{ name: NFD_NAME }])
+
+    expect(located).toHaveLength(1)
+    expect(located[0]!.start).toBe(body.indexOf("@"))
+    expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFD_NAME}`)
+  })
+
+  it("does not swallow the accent of the character that ends the name", () => {
+    expect(locateMentions("hi @Ana\u0301!", [{ name: "Ana" }])).toEqual([])
+  })
+
+  // `hooks/useMentions.ts` (`seedMentions`) calls this with bare `{ name }`
+  // objects and reads back `{ entry: { name }, start }` to anchor a saved
+  // message's mentions on its text. That shape has to keep resolving.
+  it("keeps the `seedMentions` call shape resolving", () => {
+    const text = `hi @${NFD_NAME}, ping @Ana`
+    const byName = new Map([
+      [NFC_NAME, [{ id: "1", name: NFC_NAME }]],
+      ["Ana", [{ id: "2", name: "Ana" }]],
+    ])
+
+    const anchored = locateMentions(
+      text,
+      [...byName.keys()].map((name) => ({ name }))
+    ).flatMap(({ entry: { name }, start }) => {
+      const picked = byName.get(name)?.[0]
+      return picked ? [{ ...picked, start }] : []
+    })
+
+    expect(anchored).toEqual([
+      { id: "1", name: NFC_NAME, start: 3 },
+      { id: "2", name: "Ana", start: text.indexOf("@Ana") },
+    ])
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -95,6 +95,36 @@ describe("locateMentions", () => {
     ).toEqual([])
   })
 
+  // The same walk is why a name *held* as jamo needs the spelling it was given
+  // as well as the composed one: jamo compose with each other rather than as
+  // marks, so the walk can never reach them and the name would stop being
+  // found in the very spelling it is stored in.
+  it("locates a name held as jamo in a body spelled the same way", () => {
+    const jamo = "\u1100\u1161\u11A8"
+    const body = `hi @${jamo}!`
+
+    expect(locateMentions(body, [{ name: jamo }])).toEqual([
+      { entry: { name: jamo }, start: 3, end: body.indexOf("!") },
+    ])
+  })
+
+  it("locates a name held as jamo in a body that composed it", () => {
+    const jamo = "\u1100\u1161\u11A8"
+    const body = "hi @\uAC01!"
+
+    expect(locateMentions(body, [{ name: jamo }])).toEqual([
+      { entry: { name: jamo }, start: 3, end: body.indexOf("!") },
+    ])
+  })
+
+  it("does not swallow the accent that follows a name held as jamo", () => {
+    expect(
+      locateMentions("hi @\u1100\u1161\u11A8\u0301", [
+        { name: "\u1100\u1161\u11A8" },
+      ])
+    ).toEqual([])
+  })
+
   it("gives up on a trailing `@`", () => {
     expect(locateMentions("hi @", [{ name: "Ana" }])).toEqual([])
   })

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -140,6 +140,12 @@ describe("locateMentions", () => {
     expect(locateMentions("hi @Ana\u0301!", [{ name: "Ana" }])).toEqual([])
   })
 
+  // A mark outside the BMP is two code units, and a lone surrogate is not
+  // `\p{M}`, so reading one unit at the end of a match waves it straight past.
+  it("does not swallow an astral combining mark either", () => {
+    expect(locateMentions("hi @Ana\u{1D167} x", [{ name: "Ana" }])).toEqual([])
+  })
+
   // `hooks/useMentions.ts` (`seedMentions`) calls this with bare `{ name }`
   // objects and reads back `{ entry: { name }, start }` to anchor a saved
   // message's mentions on its text. That shape has to keep resolving.

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -117,6 +117,28 @@ describe("locateMentions", () => {
     ])
   })
 
+  // Jamo compose with each other rather than as marks, so a jamo name sits
+  // inside a longer jamo syllable exactly the way `@Ana` sits inside `@Aná`.
+  // Neither literal spelling may end there, and neither may the fold.
+  it("does not chip a syllable whose jamo a shorter name prefixes", () => {
+    expect(
+      locateMentions("@\u1100\u1175\u11B7 hi", [{ name: "\u1100\u1175" }])
+    ).toEqual([])
+  })
+
+  it("does not chip a syllable open on its leading jamo", () => {
+    expect(locateMentions("@\u1100\u1161 hi", [{ name: "\u1100" }])).toEqual([])
+  })
+
+  it("still matches a jamo name that a new syllable follows", () => {
+    const name = "\u1100\u1161\u11A8"
+    const body = `@${name}\u1100\u1161 hi`
+
+    expect(locateMentions(body, [{ name }])).toEqual([
+      { entry: { name }, start: 0, end: 1 + name.length },
+    ])
+  })
+
   it("does not swallow the accent that follows a name held as jamo", () => {
     expect(
       locateMentions("hi @\u1100\u1161\u11A8\u0301", [

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -55,6 +55,55 @@ describe("locateMentions", () => {
     expect(located).toHaveLength(1)
     expect(located[0]!.start).toBe(body.indexOf("@"))
     expect(body.slice(located[0]!.start, located[0]!.end)).toBe(`@${NFD_NAME}`)
+    // Text and name spelled alike: the span an existing caller derives from
+    // the name length is still the span this returns.
+    expect(located[0]!.end).toBe(located[0]!.start + NFD_NAME.length + 1)
+  })
+
+  // `end` is the only authority on where an occurrence stops. A caller that
+  // measures the name instead lands one index short here, which is why the
+  // field says so and why this case is pinned.
+  it("reports an end no caller can derive from the name length", () => {
+    const body = `hi @${NFD_NAME}!`
+    const [located] = locateMentions(body, [{ name: NFC_NAME }])
+
+    expect(located!.end).toBe(body.indexOf("!"))
+    expect(located!.end).not.toBe(located!.start + NFC_NAME.length + 1)
+  })
+
+  it("folds a singleton so a legacy code point still matches", () => {
+    const angstrom = "\u212Bngel"
+    const letterA = "\u00C5ngel"
+    const located = locateMentions(`hi @${angstrom}`, [{ name: letterA }])
+
+    expect(located).toHaveLength(1)
+  })
+
+  it("keeps a surrogate pair whole", () => {
+    const name = "Ana\u{1F916}"
+    const body = `hi @${name} there`
+    expect(locateMentions(body, [{ name }])).toEqual([
+      { entry: { name }, start: 3, end: body.indexOf(" there") },
+    ])
+  })
+
+  it("leaves a Hangul syllable written as jamo alone", () => {
+    // The boundary walk groups marks, not jamo, so a syllable could be cut in
+    // half here. It is not: the run stops being a canonical prefix first.
+    expect(
+      locateMentions("@\u1100\u1161\u11A8 hi", [{ name: "\uAC00" }])
+    ).toEqual([])
+  })
+
+  it("gives up on a trailing `@`", () => {
+    expect(locateMentions("hi @", [{ name: "Ana" }])).toEqual([])
+  })
+
+  it("keeps scanning past an `@` that is not a mention", () => {
+    const body = "write a@b.example or ping @Ana"
+    expect(locateMentions(body, [{ name: "Ana" }])).toEqual([
+      { entry: { name: "Ana" }, start: body.indexOf("@Ana"), end: body.length },
+    ])
   })
 
   it("does not swallow the accent of the character that ends the name", () => {

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/mention-ranges.test.ts
@@ -48,6 +48,47 @@ describe("locateMentions", () => {
     expect(body.slice(located[1]!.start, located[1]!.end)).toBe(`@${NFD_NAME}`)
   })
 
+  it("assigns canonically equal spellings to distinct entries", () => {
+    const entries = [
+      { id: "nfc", name: NFC_NAME },
+      { id: "nfd", name: NFD_NAME },
+    ]
+    const body = `@${NFC_NAME} and @${NFD_NAME}`
+
+    expect(locateMentions(body, entries).map(({ entry }) => entry.id)).toEqual([
+      "nfc",
+      "nfd",
+    ])
+  })
+
+  it("keeps repeated exact spellings on their exact identity", () => {
+    const entries = [
+      { id: "nfc", name: NFC_NAME },
+      { id: "nfd", name: NFD_NAME },
+    ]
+    const body = `@${NFC_NAME} @${NFC_NAME} @${NFD_NAME}`
+
+    expect(locateMentions(body, entries).map(({ entry }) => entry.id)).toEqual([
+      "nfc",
+      "nfc",
+      "nfd",
+    ])
+  })
+
+  it("allocates canonical-only matches once before reusing the last entry", () => {
+    const entries = [
+      { id: "composed", name: "\u00C5ngel" },
+      { id: "decomposed", name: "A\u030Angel" },
+    ]
+    const body = "@\u212Bngel @\u212Bngel @\u212Bngel"
+
+    expect(locateMentions(body, entries).map(({ entry }) => entry.id)).toEqual([
+      "composed",
+      "decomposed",
+      "decomposed",
+    ])
+  })
+
   it("marks only the `@` occurrence when the name also appears as plain text", () => {
     const body = `${NFC_NAME} wrote: hi @${NFD_NAME}`
     const located = locateMentions(body, [{ name: NFD_NAME }])
@@ -77,6 +118,33 @@ describe("locateMentions", () => {
     const located = locateMentions(`hi @${angstrom}`, [{ name: letterA }])
 
     expect(located).toHaveLength(1)
+  })
+
+  it("matches through a stripped bidi control while keeping raw offsets", () => {
+    const body = "hi @A\u202Ena!"
+    const [located] = locateMentions(body, [{ name: "Ana" }])
+
+    expect(located).toEqual({
+      entry: { name: "Ana" },
+      start: body.indexOf("@"),
+      end: body.indexOf("!"),
+    })
+    expect(sanitizeDisplayText(body.slice(located!.start, located!.end))).toBe(
+      "@Ana"
+    )
+  })
+
+  it("matches a capped combining stack while keeping raw offsets", () => {
+    const keptMarks = "\u0301".repeat(4)
+    const excessMarks = "\u0301".repeat(6)
+    const name = `A${keptMarks}na`
+    const body = `hi @A${excessMarks}na!`
+    const [located] = locateMentions(body, [{ name }])
+
+    expect(sanitizeDisplayText(`@${name}`)).toBe(
+      sanitizeDisplayText(body.slice(located!.start, located!.end))
+    )
+    expect(located!.end).toBe(body.indexOf("!"))
   })
 
   it("keeps a surrogate pair whole", () => {
@@ -114,6 +182,15 @@ describe("locateMentions", () => {
 
     expect(locateMentions(body, [{ name: jamo }])).toEqual([
       { entry: { name: jamo }, start: 3, end: body.indexOf("!") },
+    ])
+  })
+
+  it("locates a composed Hangul name in a body held as jamo", () => {
+    const jamo = "\u1100\u1161\u11A8"
+    const body = `hi @${jamo}!`
+
+    expect(locateMentions(body, [{ name: "\uAC01" }])).toEqual([
+      { entry: { name: "\uAC01" }, start: 3, end: body.indexOf("!") },
     ])
   })
 
@@ -166,29 +243,5 @@ describe("locateMentions", () => {
   // `\p{M}`, so reading one unit at the end of a match waves it straight past.
   it("does not swallow an astral combining mark either", () => {
     expect(locateMentions("hi @Ana\u{1D167} x", [{ name: "Ana" }])).toEqual([])
-  })
-
-  // `hooks/useMentions.ts` (`seedMentions`) calls this with bare `{ name }`
-  // objects and reads back `{ entry: { name }, start }` to anchor a saved
-  // message's mentions on its text. That shape has to keep resolving.
-  it("keeps the `seedMentions` call shape resolving", () => {
-    const text = `hi @${NFD_NAME}, ping @Ana`
-    const byName = new Map([
-      [NFC_NAME, [{ id: "1", name: NFC_NAME }]],
-      ["Ana", [{ id: "2", name: "Ana" }]],
-    ])
-
-    const anchored = locateMentions(
-      text,
-      [...byName.keys()].map((name) => ({ name }))
-    ).flatMap(({ entry: { name }, start }) => {
-      const picked = byName.get(name)?.[0]
-      return picked ? [{ ...picked, start }] : []
-    })
-
-    expect(anchored).toEqual([
-      { id: "1", name: NFC_NAME, start: 3 },
-      { id: "2", name: "Ana", start: text.indexOf("@Ana") },
-    ])
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
@@ -5,6 +5,7 @@ import {
   renderBodyWithLinks,
   renderBodyWithMentions,
 } from "../render-body"
+import { sanitizeDisplayText } from "../sanitize-text"
 
 describe("renderBodyWithMentions", () => {
   it("returns the plain body when there are no mentions", () => {
@@ -75,8 +76,9 @@ describe("renderBodyWithMentions", () => {
     expect(screen.getByText("@Ana María")).toBeInTheDocument()
   })
 
-  // The body is composed before the ranges are taken, so a name carrying the
-  // decomposed spelling reaches a chip only if matching folds both sides.
+  // Ranges are taken from the raw body before each rendered slice is composed,
+  // so a name carrying the decomposed spelling must match without losing its
+  // original boundaries.
   // Escapes, not literal characters: the two spellings are the point here and
   // are indistinguishable on screen.
   it("chips a name whose accent is stored decomposed", () => {
@@ -94,6 +96,36 @@ describe("renderBodyWithMentions", () => {
       <div>{renderBodyWithMentions(`hi @${decomposed}!`, tokens)}</div>
     )
     expect(screen.getByText(`@${composed}`).className).toContain(
+      "text-f1-foreground-secondary"
+    )
+  })
+
+  it("keeps a profile mention when display sanitization strips a bidi control", () => {
+    const tokens: MentionToken[] = [
+      {
+        name: "Ana",
+        isSelf: false,
+        isEveryone: false,
+        user: { id: "1", name: "Ana", profileHref: "/people/ana" },
+      },
+    ]
+
+    zeroRender(<div>{renderBodyWithMentions("hi @A\u202Ena!", tokens)}</div>)
+
+    expect(screen.getByRole("link", { name: "@Ana" })).toHaveAttribute(
+      "href",
+      "/people/ana"
+    )
+  })
+
+  it("keeps a mention when display sanitization caps combining marks", () => {
+    const name = `A${"\u0301".repeat(4)}na`
+    const bodyName = `A${"\u0301".repeat(6)}na`
+    const tokens: MentionToken[] = [{ name, isSelf: false, isEveryone: false }]
+
+    zeroRender(<div>{renderBodyWithMentions(`hi @${bodyName}!`, tokens)}</div>)
+
+    expect(screen.getByText(sanitizeDisplayText(`@${name}`))).toHaveClass(
       "text-f1-foreground-secondary"
     )
   })

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/render-body.test.tsx
@@ -74,6 +74,29 @@ describe("renderBodyWithMentions", () => {
     zeroRender(<div>{renderBodyWithMentions("hey @Ana María", tokens)}</div>)
     expect(screen.getByText("@Ana María")).toBeInTheDocument()
   })
+
+  // The body is composed before the ranges are taken, so a name carrying the
+  // decomposed spelling reaches a chip only if matching folds both sides.
+  // Escapes, not literal characters: the two spellings are the point here and
+  // are indistinguishable on screen.
+  it("chips a name whose accent is stored decomposed", () => {
+    const decomposed = "Garci\u0301a"
+    const composed = "Garc\u00EDa"
+    const tokens: MentionToken[] = [
+      {
+        name: decomposed,
+        isSelf: false,
+        isEveryone: false,
+        user: { id: "1", name: decomposed },
+      },
+    ]
+    zeroRender(
+      <div>{renderBodyWithMentions(`hi @${decomposed}!`, tokens)}</div>
+    )
+    expect(screen.getByText(`@${composed}`).className).toContain(
+      "text-f1-foreground-secondary"
+    )
+  })
 })
 
 describe("renderBodyWithLinks (preview titles)", () => {

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -1,3 +1,5 @@
+import { CANONICAL_FORM } from "./sanitize-text"
+
 /** A `@name` occurrence located in a body of text. */
 export type LocatedMention<T> = {
   entry: T
@@ -8,11 +10,53 @@ export type LocatedMention<T> = {
 }
 
 /**
+ * One code point plus the combining marks that belong to it. Canonical
+ * composition joins a base with its marks, so a candidate may only start or
+ * end here — cut between the two and a bare `a` gets compared against an `á`.
+ */
+const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
+
+const nextBoundary = (text: string, at: number): number => {
+  BASE_WITH_MARKS.lastIndex = at
+  return BASE_WITH_MARKS.exec(text) ? BASE_WITH_MARKS.lastIndex : text.length
+}
+
+/**
+ * Index just past the run starting at `from` whose canonical form is
+ * `pattern`, or `-1` when no run there has it.
+ *
+ * Comparing canonical forms instead of raw code units is what lets a name held
+ * as `i` + combining acute match a body the renderer already composed to `í`,
+ * and the reverse. The index counts characters of `text` exactly as the caller
+ * passed it, so a caller can still slice or anchor on its own string.
+ */
+const canonicalMatchEnd = (
+  text: string,
+  from: number,
+  pattern: string
+): number => {
+  let cursor = from
+  while (true) {
+    const seen = text.slice(from, cursor).normalize(CANONICAL_FORM)
+    if (seen === pattern) {
+      return cursor
+    }
+    if (cursor === text.length || seen.length > pattern.length) {
+      return -1
+    }
+    cursor = nextBoundary(text, cursor)
+  }
+}
+
+/**
  * Locate every `@name` occurrence of the given entries in `text`.
  *
  * Longest names first so `@Ana María` wins over `@Ana`, then overlaps are
  * dropped left to right. Entry order breaks ties, which is what makes two
  * different people who share a display name land on one occurrence each.
+ *
+ * Names and body are matched by canonical form, so which of the two spellings
+ * of `í` each side happens to carry never decides whether a mention is found.
  *
  * The single place `@name` text is matched: the bubble, the composer overlay
  * and the composer's own anchoring all resolve through here, so they cannot
@@ -23,17 +67,26 @@ export const locateMentions = <T extends { name: string }>(
   entries: readonly T[]
 ): LocatedMention<T>[] => {
   const found: LocatedMention<T>[] = []
-  const byLength = [...entries].sort((a, b) => b.name.length - a.name.length)
-  for (const entry of byLength) {
-    const pattern = `@${entry.name}`
+  const byLength = entries
+    .map((entry) => ({
+      entry,
+      pattern: `@${entry.name}`.normalize(CANONICAL_FORM),
+    }))
+    .sort((a, b) => b.pattern.length - a.pattern.length)
+  for (const { entry, pattern } of byLength) {
     let from = 0
     while (true) {
-      const idx = text.indexOf(pattern, from)
-      if (idx === -1) {
+      const at = text.indexOf("@", from)
+      if (at === -1) {
         break
       }
-      found.push({ entry, start: idx, end: idx + pattern.length })
-      from = idx + pattern.length
+      const end = canonicalMatchEnd(text, at, pattern)
+      if (end === -1) {
+        from = at + 1
+        continue
+      }
+      found.push({ entry, start: at, end })
+      from = end
     }
   }
   found.sort((a, b) => a.start - b.start)

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -71,24 +71,48 @@ const canonicalMatchEnd = (
 }
 
 /**
+ * Index just past `needle` sitting literally at `from`, or `-1`. The mark test
+ * is what keeps the shortcut honest: `@Ana` sits inside a decomposed `@Aná`,
+ * and matching it there chips somebody else's name and strands the accent
+ * outside the chip.
+ */
+const literalMatchEnd = (
+  text: string,
+  from: number,
+  needle: string
+): number => {
+  const end = from + needle.length
+  return text.startsWith(needle, from) && !COMBINING_MARK.test(text.charAt(end))
+    ? end
+    : -1
+}
+
+/**
  * Both sides spelled the same way is the overwhelming majority — the renderer
  * composes the body one line before it asks — and needs no normalizing at all.
- * The mark test is what keeps the shortcut honest: `@Ana` sits inside a
- * decomposed `@Aná`, and matching it there chips somebody else's name and
- * strands the accent outside the chip.
+ *
+ * The name as it is actually held is tried too, and is not redundant with the
+ * fold: {@link canonicalMatchEnd} walks base+mark groups, while Hangul jamo
+ * compose with each other rather than as marks, so a run of jamo is never a
+ * canonical prefix of the syllable it composes to. Without this a name kept as
+ * jamo would stop being found in a body carrying those very same jamo.
  */
 const matchEnd = (
   text: string,
   from: number,
   pattern: string,
+  asWritten: string,
   foldable: boolean
 ): number => {
-  const exact = from + pattern.length
-  if (
-    text.startsWith(pattern, from) &&
-    !COMBINING_MARK.test(text.charAt(exact))
-  ) {
-    return exact
+  const composed = literalMatchEnd(text, from, pattern)
+  if (composed !== -1) {
+    return composed
+  }
+  if (asWritten !== pattern) {
+    const literal = literalMatchEnd(text, from, asWritten)
+    if (literal !== -1) {
+      return literal
+    }
   }
   return foldable ? canonicalMatchEnd(text, from, pattern) : -1
 }
@@ -113,20 +137,20 @@ export const locateMentions = <T extends { name: string }>(
 ): LocatedMention<T>[] => {
   const found: LocatedMention<T>[] = []
   const byLength = entries
-    .map((entry) => ({
-      entry,
-      pattern: `@${entry.name}`.normalize(CANONICAL_FORM),
-    }))
+    .map((entry) => {
+      const asWritten = `@${entry.name}`
+      return { entry, asWritten, pattern: asWritten.normalize(CANONICAL_FORM) }
+    })
     .sort((a, b) => b.pattern.length - a.pattern.length)
   const foldable = NON_ASCII.test(text)
-  for (const { entry, pattern } of byLength) {
+  for (const { entry, asWritten, pattern } of byLength) {
     let from = 0
     while (true) {
       const at = text.indexOf("@", from)
       if (at === -1) {
         break
       }
-      const end = matchEnd(text, at, pattern, foldable)
+      const end = matchEnd(text, at, pattern, asWritten, foldable)
       if (end === -1) {
         from = at + 1
         continue

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -116,12 +116,16 @@ const literalMatchEnd = (
  * canonical prefix of the syllable it composes to. Without this a name kept as
  * jamo would stop being found in a body carrying those very same jamo.
  */
+type MatchOptions = {
+  pattern: string
+  asWritten: string
+  foldable: boolean
+}
+
 const matchEnd = (
   text: string,
   from: number,
-  pattern: string,
-  asWritten: string,
-  foldable: boolean
+  { pattern, asWritten, foldable }: MatchOptions
 ): number => {
   const composed = literalMatchEnd(text, from, pattern)
   if (composed !== -1) {
@@ -202,7 +206,11 @@ export const locateMentions = <T extends { name: string }>(
         (matchedEnd, { asWritten }) =>
           Math.max(
             matchedEnd,
-            matchEnd(text, at, group.pattern, asWritten, foldable)
+            matchEnd(text, at, {
+              pattern: group.pattern,
+              asWritten,
+              foldable,
+            })
           ),
         -1
       )

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -1,4 +1,4 @@
-import { CANONICAL_FORM } from "./sanitize-text"
+import { sanitizeDisplayText } from "./sanitize-text"
 
 /** A `@name` occurrence located in a body of text. */
 export type LocatedMention<T> = {
@@ -18,7 +18,7 @@ export type LocatedMention<T> = {
  * One code point plus the combining marks that belong to it. A candidate may
  * only start or end here — cut between a letter and its accent and a bare `a`
  * gets compared against an `á`. Marks are the only thing this covers: Hangul
- * jamo compose with each other, and {@link canonicalMatchEnd} is what keeps a
+ * jamo compose with each other, and {@link sanitizedMatchEnd} is what keeps a
  * syllable from being cut in half.
  */
 const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
@@ -58,8 +58,8 @@ const nextBoundary = (text: string, at: number): number => {
 }
 
 /**
- * Index just past the run starting at `from` whose canonical form is
- * `pattern`, or `-1` when no run there has it.
+ * Index just past the run starting at `from` whose displayed form is `pattern`,
+ * or `-1` when no run there has it.
  *
  * Comparing canonical forms instead of raw code units is what lets a name held
  * as `i` + combining acute match a body the renderer already composed to `í`.
@@ -68,18 +68,21 @@ const nextBoundary = (text: string, at: number): number => {
  * above would cut a syllable between its jamo, and the prefix test rejects
  * that rather than chipping two thirds of it.
  */
-const canonicalMatchEnd = (
+const sanitizedMatchEnd = (
   text: string,
   from: number,
   pattern: string
 ): number => {
   let cursor = from
   while (true) {
-    const seen = text.slice(from, cursor).normalize(CANONICAL_FORM)
+    const seen = sanitizeDisplayText(text.slice(from, cursor))
     if (seen === pattern) {
       return continuesPrevious(text, cursor) ? -1 : cursor
     }
-    if (cursor === text.length || !pattern.startsWith(seen)) {
+    if (
+      cursor === text.length ||
+      (!pattern.startsWith(seen) && !continuesPrevious(text, cursor))
+    ) {
       return -1
     }
     cursor = nextBoundary(text, cursor)
@@ -104,11 +107,11 @@ const literalMatchEnd = (
 }
 
 /**
- * Both sides spelled the same way is the overwhelming majority — the renderer
- * composes the body one line before it asks — and needs no normalizing at all.
+ * Both sides spelled the same way is the overwhelming majority and needs no
+ * normalization or sanitization at all.
  *
  * The name as it is actually held is tried too, and is not redundant with the
- * fold: {@link canonicalMatchEnd} walks base+mark groups, while Hangul jamo
+ * fold: {@link sanitizedMatchEnd} walks base+mark groups, while Hangul jamo
  * compose with each other rather than as marks, so a run of jamo is never a
  * canonical prefix of the syllable it composes to. Without this a name kept as
  * jamo would stop being found in a body carrying those very same jamo.
@@ -130,7 +133,7 @@ const matchEnd = (
       return literal
     }
   }
-  return foldable ? canonicalMatchEnd(text, from, pattern) : -1
+  return foldable ? sanitizedMatchEnd(text, from, pattern) : -1
 }
 
 /**
@@ -151,33 +154,72 @@ export const locateMentions = <T extends { name: string }>(
   text: string,
   entries: readonly T[]
 ): LocatedMention<T>[] => {
-  const found: LocatedMention<T>[] = []
-  const byLength = entries
-    .map((entry) => {
+  type Candidate = {
+    entry: T
+    asWritten: string
+    pattern: string
+  }
+  type CanonicalGroup = {
+    pattern: string
+    candidates: Candidate[]
+  }
+  type LocatedGroup = {
+    group: CanonicalGroup
+    start: number
+    end: number
+  }
+
+  const groupsByPattern = new Map<string, CanonicalGroup>()
+  for (const entry of entries) {
+    const candidate = (() => {
       const asWritten = `@${entry.name}`
-      return { entry, asWritten, pattern: asWritten.normalize(CANONICAL_FORM) }
-    })
-    .sort((a, b) => b.pattern.length - a.pattern.length)
+      return { entry, asWritten, pattern: sanitizeDisplayText(asWritten) }
+    })()
+    const group = groupsByPattern.get(candidate.pattern)
+    if (group) {
+      group.candidates.push(candidate)
+    } else {
+      groupsByPattern.set(candidate.pattern, {
+        pattern: candidate.pattern,
+        candidates: [candidate],
+      })
+    }
+  }
+
+  const groups = [...groupsByPattern.values()].sort(
+    (a, b) => b.pattern.length - a.pattern.length
+  )
+  const found: LocatedGroup[] = []
   const foldable = NON_ASCII.test(text)
-  for (const { entry, asWritten, pattern } of byLength) {
+  for (const group of groups) {
     let from = 0
     while (true) {
       const at = text.indexOf("@", from)
       if (at === -1) {
         break
       }
-      const end = matchEnd(text, at, pattern, asWritten, foldable)
+      const end = group.candidates.reduce(
+        (matchedEnd, { asWritten }) =>
+          Math.max(
+            matchedEnd,
+            matchEnd(text, at, group.pattern, asWritten, foldable)
+          ),
+        -1
+      )
       if (end === -1) {
         from = at + 1
         continue
       }
-      found.push({ entry, start: at, end })
+      found.push({ group, start: at, end })
       from = end
     }
   }
-  found.sort((a, b) => a.start - b.start)
+  found.sort(
+    (a, b) =>
+      a.start - b.start || b.group.pattern.length - a.group.pattern.length
+  )
 
-  const clean: LocatedMention<T>[] = []
+  const clean: LocatedGroup[] = []
   let lastEnd = 0
   for (const range of found) {
     if (range.start < lastEnd) {
@@ -186,5 +228,26 @@ export const locateMentions = <T extends { name: string }>(
     clean.push(range)
     lastEnd = range.end
   }
-  return clean
+
+  const usedByGroup = new Map<CanonicalGroup, Set<number>>()
+  return clean.map(({ group, start, end }) => {
+    const used = usedByGroup.get(group) ?? new Set<number>()
+    usedByGroup.set(group, used)
+    const exact = group.candidates
+      .map((candidate, index) => ({ candidate, index }))
+      .filter(
+        ({ candidate }) =>
+          literalMatchEnd(text, start, candidate.asWritten) === end
+      )
+    const picked = exact.find(({ index }) => !used.has(index)) ??
+      exact.at(-1) ??
+      group.candidates
+        .map((candidate, index) => ({ candidate, index }))
+        .find(({ index }) => !used.has(index)) ?? {
+        candidate: group.candidates[group.candidates.length - 1]!,
+        index: group.candidates.length - 1,
+      }
+    used.add(picked.index)
+    return { entry: picked.candidate.entry, start, end }
+  })
 }

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -5,20 +5,40 @@ export type LocatedMention<T> = {
   entry: T
   /** Index of the `@`. */
   start: number
-  /** Index just past the last character of the name. */
+  /**
+   * Index just past the occurrence **as it is spelled in `text`**, which is
+   * not always `start + 1 + name.length`: an accent held decomposed on one
+   * side and composed on the other takes one more index there than here.
+   * Slice and anchor on this, never on the length of the name.
+   */
   end: number
 }
 
 /**
- * One code point plus the combining marks that belong to it. Canonical
- * composition joins a base with its marks, so a candidate may only start or
- * end here — cut between the two and a bare `a` gets compared against an `á`.
+ * One code point plus the combining marks that belong to it. A candidate may
+ * only start or end here — cut between a letter and its accent and a bare `a`
+ * gets compared against an `á`. Marks are the only thing this covers: Hangul
+ * jamo compose with each other, and {@link canonicalMatchEnd} is what keeps a
+ * syllable from being cut in half.
  */
 const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
 
+/** Marks never open a name, so one sitting after a match extends the letter. */
+const COMBINING_MARK = /\p{M}/u
+
+/**
+ * No ASCII character carries an accent or composes with a neighbour, so in a
+ * body without one there is nothing for a canonical fold to find that an exact
+ * comparison has not already found — whatever the names are spelled like.
+ */
+const NON_ASCII = /\P{ASCII}/u
+
 const nextBoundary = (text: string, at: number): number => {
   BASE_WITH_MARKS.lastIndex = at
-  return BASE_WITH_MARKS.exec(text) ? BASE_WITH_MARKS.lastIndex : text.length
+  BASE_WITH_MARKS.exec(text)
+  // The walk ends by reaching the end of the text, so the cursor may never
+  // stand still, whatever the regex leaves behind.
+  return Math.max(BASE_WITH_MARKS.lastIndex, at + 1)
 }
 
 /**
@@ -26,9 +46,11 @@ const nextBoundary = (text: string, at: number): number => {
  * `pattern`, or `-1` when no run there has it.
  *
  * Comparing canonical forms instead of raw code units is what lets a name held
- * as `i` + combining acute match a body the renderer already composed to `í`,
- * and the reverse. The index counts characters of `text` exactly as the caller
- * passed it, so a caller can still slice or anchor on its own string.
+ * as `i` + combining acute match a body the renderer already composed to `í`.
+ * Giving up the moment the run stops being a canonical prefix keeps a wrong
+ * `@` cheap, and is also what leaves decomposed Hangul alone: the boundary
+ * above would cut a syllable between its jamo, and the prefix test rejects
+ * that rather than chipping two thirds of it.
  */
 const canonicalMatchEnd = (
   text: string,
@@ -41,11 +63,34 @@ const canonicalMatchEnd = (
     if (seen === pattern) {
       return cursor
     }
-    if (cursor === text.length || seen.length > pattern.length) {
+    if (cursor === text.length || !pattern.startsWith(seen)) {
       return -1
     }
     cursor = nextBoundary(text, cursor)
   }
+}
+
+/**
+ * Both sides spelled the same way is the overwhelming majority — the renderer
+ * composes the body one line before it asks — and needs no normalizing at all.
+ * The mark test is what keeps the shortcut honest: `@Ana` sits inside a
+ * decomposed `@Aná`, and matching it there chips somebody else's name and
+ * strands the accent outside the chip.
+ */
+const matchEnd = (
+  text: string,
+  from: number,
+  pattern: string,
+  foldable: boolean
+): number => {
+  const exact = from + pattern.length
+  if (
+    text.startsWith(pattern, from) &&
+    !COMBINING_MARK.test(text.charAt(exact))
+  ) {
+    return exact
+  }
+  return foldable ? canonicalMatchEnd(text, from, pattern) : -1
 }
 
 /**
@@ -73,6 +118,7 @@ export const locateMentions = <T extends { name: string }>(
       pattern: `@${entry.name}`.normalize(CANONICAL_FORM),
     }))
     .sort((a, b) => b.pattern.length - a.pattern.length)
+  const foldable = NON_ASCII.test(text)
   for (const { entry, pattern } of byLength) {
     let from = 0
     while (true) {
@@ -80,7 +126,7 @@ export const locateMentions = <T extends { name: string }>(
       if (at === -1) {
         break
       }
-      const end = canonicalMatchEnd(text, at, pattern)
+      const end = matchEnd(text, at, pattern, foldable)
       if (end === -1) {
         from = at + 1
         continue

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -23,8 +23,18 @@ export type LocatedMention<T> = {
  */
 const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
 
-/** Marks never open a name, so one sitting after a match extends the letter. */
-const COMBINING_MARK = /\p{M}/u
+/**
+ * Marks never open a name, so one sitting after a match extends the letter.
+ * Sticky rather than a single-character test: a mark outside the BMP is two
+ * code units and a lone surrogate is not `\p{M}`, so reading one unit would
+ * wave an astral mark straight past the guard.
+ */
+const COMBINING_MARK = /\p{M}/uy
+
+const startsWithMark = (text: string, at: number): boolean => {
+  COMBINING_MARK.lastIndex = at
+  return COMBINING_MARK.test(text)
+}
 
 /**
  * No ASCII character carries an accent or composes with a neighbour, so in a
@@ -82,9 +92,7 @@ const literalMatchEnd = (
   needle: string
 ): number => {
   const end = from + needle.length
-  return text.startsWith(needle, from) && !COMBINING_MARK.test(text.charAt(end))
-    ? end
-    : -1
+  return text.startsWith(needle, from) && !startsWithMark(text, end) ? end : -1
 }
 
 /**

--- a/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/mention-ranges.ts
@@ -24,16 +24,22 @@ export type LocatedMention<T> = {
 const BASE_WITH_MARKS = /[\s\S]\p{M}*/uy
 
 /**
- * Marks never open a name, so one sitting after a match extends the letter.
+ * A code point that composes with whatever precedes it, so no match may end
+ * just before one. Combining marks are the general case; Hangul jungseong and
+ * jongseong are the rest of it, because they compose with a preceding jamo
+ * rather than as marks — a name held as `\uAE30` in jamo sits inside a
+ * jamo-spelled `\uAE40` exactly the way `@Ana` sits inside a decomposed
+ * `@Aná`, and ending there chips two thirds of somebody's syllable.
+ *
  * Sticky rather than a single-character test: a mark outside the BMP is two
  * code units and a lone surrogate is not `\p{M}`, so reading one unit would
- * wave an astral mark straight past the guard.
+ * wave an astral mark straight past.
  */
-const COMBINING_MARK = /\p{M}/uy
+const CONTINUES_PREVIOUS = /[\p{M}\u1161-\u1175\u11A8-\u11C2]/uy
 
-const startsWithMark = (text: string, at: number): boolean => {
-  COMBINING_MARK.lastIndex = at
-  return COMBINING_MARK.test(text)
+const continuesPrevious = (text: string, at: number): boolean => {
+  CONTINUES_PREVIOUS.lastIndex = at
+  return CONTINUES_PREVIOUS.test(text)
 }
 
 /**
@@ -71,7 +77,7 @@ const canonicalMatchEnd = (
   while (true) {
     const seen = text.slice(from, cursor).normalize(CANONICAL_FORM)
     if (seen === pattern) {
-      return cursor
+      return continuesPrevious(text, cursor) ? -1 : cursor
     }
     if (cursor === text.length || !pattern.startsWith(seen)) {
       return -1
@@ -81,10 +87,10 @@ const canonicalMatchEnd = (
 }
 
 /**
- * Index just past `needle` sitting literally at `from`, or `-1`. The mark test
- * is what keeps the shortcut honest: `@Ana` sits inside a decomposed `@Aná`,
- * and matching it there chips somebody else's name and strands the accent
- * outside the chip.
+ * Index just past `needle` sitting literally at `from`, or `-1`. The
+ * continuation test is what keeps the shortcut honest: `@Ana` sits inside a
+ * decomposed `@Aná`, and matching it there chips somebody else's name and
+ * strands the accent outside the chip.
  */
 const literalMatchEnd = (
   text: string,
@@ -92,7 +98,9 @@ const literalMatchEnd = (
   needle: string
 ): number => {
   const end = from + needle.length
-  return text.startsWith(needle, from) && !startsWithMark(text, end) ? end : -1
+  return text.startsWith(needle, from) && !continuesPrevious(text, end)
+    ? end
+    : -1
 }
 
 /**

--- a/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
@@ -154,9 +154,9 @@ export const renderBodyWithMentions = (
     ) : token.user ? (
       <span className="cursor-default text-f1-foreground-secondary">
         {label}
-        {token.user.subtitle && (
+        {token.user.subtitle ? (
           <span className="sr-only">, {token.user.subtitle}</span>
-        )}
+        ) : null}
       </span>
     ) : (
       <span className="text-f1-foreground-secondary">{label}</span>

--- a/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
+++ b/packages/react/src/sds/chat/F0Chat/utils/render-body.tsx
@@ -1,6 +1,6 @@
 import { Fragment, type ReactNode } from "react"
 import { F0Link } from "@/components/F0Link"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import { ChatUserHoverCard } from "../components/ChatUserHoverCard"
 import { type F0ChatLinkPreview, type F0ChatUser } from "../types"
 import { locateMentions } from "./mention-ranges"
@@ -109,15 +109,17 @@ export const renderBodyWithMentions = (
   tokens: MentionToken[],
   previews?: F0ChatLinkPreview[]
 ): ReactNode => {
-  // Sanitize BEFORE the range math so mention indices match what renders.
-  const body = sanitizeDisplayText(rawBody)
   if (tokens.length === 0) {
-    return renderBodyWithLinks(body, previews)
+    return renderBodyWithLinks(rawBody, previews)
   }
 
-  const clean = locateMentions(body, tokens)
+  // Resolve identity against the original spelling before sanitization can
+  // compose canonically equivalent occurrences into the same text. Each raw
+  // range is sanitized independently below, so its offsets never address a
+  // differently sized normalized string.
+  const clean = locateMentions(rawBody, tokens)
   if (clean.length === 0) {
-    return renderBodyWithLinks(body, previews)
+    return renderBodyWithLinks(rawBody, previews)
   }
 
   const nodes: ReactNode[] = []
@@ -126,17 +128,38 @@ export const renderBodyWithMentions = (
     if (range.start > cursor) {
       nodes.push(
         <Fragment key={`t-${i}`}>
-          {renderBodyWithLinks(body.slice(cursor, range.start), previews)}
+          {renderBodyWithLinks(rawBody.slice(cursor, range.start), previews)}
         </Fragment>
       )
     }
     const token = range.entry
-    const chip = (
-      <span
-        className={cn("text-f1-foreground-secondary hover:text-f1-foreground")}
+    const label = sanitizeDisplayText(rawBody.slice(range.start, range.end))
+    const accessibleLabel = token.user?.subtitle
+      ? `${label}, ${token.user.subtitle}`
+      : label
+    const mentionClassName = cn(
+      "cursor-pointer rounded-sm border-0 bg-transparent p-0 text-f1-foreground-secondary hover:text-f1-foreground",
+      focusRing()
+    )
+    const chip = token.user?.profileHref ? (
+      <F0Link
+        href={token.user.profileHref}
+        variant="unstyled"
+        stopPropagation
+        aria-label={accessibleLabel}
+        className={mentionClassName}
       >
-        {body.slice(range.start, range.end)}
+        {label}
+      </F0Link>
+    ) : token.user ? (
+      <span className="cursor-default text-f1-foreground-secondary">
+        {label}
+        {token.user.subtitle && (
+          <span className="sr-only">, {token.user.subtitle}</span>
+        )}
       </span>
+    ) : (
+      <span className="text-f1-foreground-secondary">{label}</span>
     )
     // A person mention opens their profile card on hover, mirroring the
     // sender-avatar affordance. `@here` is a broadcast — no single person.
@@ -151,10 +174,10 @@ export const renderBodyWithMentions = (
     )
     cursor = range.end
   })
-  if (cursor < body.length) {
+  if (cursor < rawBody.length) {
     nodes.push(
       <Fragment key="t-last">
-        {renderBodyWithLinks(body.slice(cursor), previews)}
+        {renderBodyWithLinks(rawBody.slice(cursor), previews)}
       </Fragment>
     )
   }

--- a/packages/react/src/sds/chat/F0Chat/utils/sanitize-text.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/sanitize-text.ts
@@ -10,12 +10,19 @@ const EXCESS_COMBINING_MARKS = /(\p{M}{3})\p{M}+/gu
 const BIDI_CONTROLS = /[\u202A-\u202E\u2066-\u2069]/g
 
 /**
+ * The one Unicode form displayed text is folded into. Exported because mention
+ * matching has to fold names the same way: two spellings of the same name
+ * compare equal only in a shared form.
+ */
+export const CANONICAL_FORM = "NFC"
+
+/**
  * Make an untrusted message string safe to DISPLAY: normalize to NFC, cap
  * combining-mark stacks (zalgo) and drop bidi overrides. Emojis (ZWJ
  * sequences, variation selectors, skin tones) pass through untouched.
  */
 export const sanitizeDisplayText = (text: string): string =>
   text
-    .normalize("NFC")
+    .normalize(CANONICAL_FORM)
     .replace(EXCESS_COMBINING_MARKS, "$1")
     .replace(BIDI_CONTROLS, "")

--- a/packages/react/src/sds/chat/F0Chat/utils/sanitize-text.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/sanitize-text.ts
@@ -10,11 +10,9 @@ const EXCESS_COMBINING_MARKS = /(\p{M}{3})\p{M}+/gu
 const BIDI_CONTROLS = /[\u202A-\u202E\u2066-\u2069]/g
 
 /**
- * The one Unicode form displayed text is folded into. Exported because mention
- * matching has to fold names the same way: two spellings of the same name
- * compare equal only in a shared form.
+ * The one Unicode form displayed text is folded into.
  */
-export const CANONICAL_FORM = "NFC"
+const CANONICAL_FORM = "NFC"
 
 /**
  * Make an untrusted message string safe to DISPLAY: normalize to NFC, cap


### PR DESCRIPTION
## Description

Hardens the Unicode mention handling introduced in #5430 so editing, rendering, and identity resolution remain correct across canonically equivalent spellings, sanitizer-changing text, and keyboard interaction.

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [ ] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [ ] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [x] Bug fix
- [ ] Documentation only
- [ ] Refactor / internal change (no API or behavior change)
- [ ] Other

## Screenshots (pending)

https://github.com/user-attachments/assets/b932d3c4-a9a0-4ed4-a64a-0184776af1a3



## Implementation details

- fix: preserve raw mention spans when display names use different canonical Unicode spellings
- fix: keep insertions immediately before mentions outside their highlight and remove a mention atomically when edited inside
- fix: retain distinct user identities for canonically equivalent names and sanitizer-changing text
- fix: expose profile-backed mentions as keyboard-operable links and name-only mentions as informational text
- test: cover NFC/NFD accents, reciprocal Hangul composition, identity allocation, bidi controls, capped combining marks, edit boundaries, and rendered profile destinations
- test: add a responsive Storybook QA surface with automated pointer, focus, and edit interactions
- docs: document the canonical-equivalence and editing contract

## Verification

- `pnpm format:check`
- `pnpm tsc --noEmit`
- `pnpm lint`
- F0Chat focused regressions: 65 passed
- Complete F0Chat unit suite: 72 files, 743 tests passed
- Storybook `Unicode mention editing (QA)` interaction: passed in Chromium

## Related work

- Hardens #5430 without modifying its branch or review history.

## Side notes for the reviewer

- The screenshot or video is intentionally pending while this PR remains a draft.
- The Storybook accessibility scan still reports the existing F0Chat message-time contrast debt; no accessibility skip or allowlist increase was added.
