### PR TITLE
fix(ai-canvas): add BulkResolveInconsistenciesCanvasContent to the canvas union

### DIFF
--- a/packages/react/src/kits/ai/F0AiChat/index.ts
+++ b/packages/react/src/kits/ai/F0AiChat/index.ts
@@ -24,6 +24,7 @@ export type {
   DashboardCanvasContent,
   DataDownloadCanvasContent,
   AutofillTimesheetCanvasContent,
+  BulkResolveInconsistenciesCanvasContent,
   F0AIMessage,
   F0AiChatWelcomeCard,
   F0Message,

--- a/packages/react/src/kits/ai/F0AiChat/types.ts
+++ b/packages/react/src/kits/ai/F0AiChat/types.ts
@@ -9,6 +9,7 @@ import type {
   DataDownloadCanvasContent,
   FormCanvasContent,
   AutofillTimesheetCanvasContent,
+  BulkResolveInconsistenciesCanvasContent,
 } from "../canvas/types"
 
 /**
@@ -56,6 +57,7 @@ export type {
   DataDownloadCanvasContent,
   FormCanvasContent,
   AutofillTimesheetCanvasContent,
+  BulkResolveInconsistenciesCanvasContent,
 }
 
 export type { PersonProfile } from "./components/markdownRenderers/entityRef/entities/person/types"

--- a/packages/react/src/kits/ai/canvas/index.ts
+++ b/packages/react/src/kits/ai/canvas/index.ts
@@ -16,6 +16,7 @@ export type {
   DataDownloadCanvasContent,
   DataDownloadDataset,
   AutofillTimesheetCanvasContent,
+  BulkResolveInconsistenciesCanvasContent,
   AutofillTimesheetShift,
   DashboardCanvasActions,
   DashboardMetadata,

--- a/packages/react/src/kits/ai/canvas/types.ts
+++ b/packages/react/src/kits/ai/canvas/types.ts
@@ -85,6 +85,21 @@ export type AutofillTimesheetCanvasContent = CanvasContentBase & {
 }
 
 /**
+ * Bulk-resolve-inconsistencies canvas content — renders an AI-grouped proposal
+ * for resolving open time-tracking inconsistencies (a reviewable collection of
+ * employees/rows the user can trim and apply). Carries scope identity only:
+ * the proposal rows live in host state, keyed by this scope.
+ */
+export type BulkResolveInconsistenciesCanvasContent = CanvasContentBase & {
+  type: "bulkResolveInconsistencies"
+  /** Analysed period, YYYY-MM-DD. */
+  periodStart: string
+  periodEnd: string
+  /** Exact row ids the proposal was scoped to; null when the whole period was analysed. */
+  scopeInconsistencyIds?: string[] | null
+}
+
+/**
  * Discriminated union for canvas panel content.
  * Add new entity types to this union as they are implemented.
  */
@@ -93,6 +108,7 @@ export type CanvasContent =
   | FormCanvasContent
   | DataDownloadCanvasContent
   | AutofillTimesheetCanvasContent
+  | BulkResolveInconsistenciesCanvasContent
 
 // ---------------------------------------------------------------------------
 // Entity definition contract


### PR DESCRIPTION
## What

Adds `BulkResolveInconsistenciesCanvasContent` to the canvas `CanvasContent` union, following the exact shape of #5033 (type-only, additive, no renderer by design — the canvas registry is host-supplied, so this only unblocks `openCanvas({ type: "bulkResolveInconsistencies", … })` type-checking on the factorial side).

The content carries scope identity only (`periodStart`, `periodEnd`, optional `scopeInconsistencyIds`) — the proposal rows live in host state, per the write-once canvas-content convention.

Consumer: Factorial's Time domain is moving One's bulk time-tracking-inconsistency resolution from in-chat cards to a canvas Data Collection (monorepo PR to follow, pinned on this PR's alpha build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)