### PR TITLE
fix(virtuoso): revert "chore(deps): drop the react-virtuoso patch for 4.18.13"

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -144,7 +144,7 @@
     "prosemirror-view": "^1.38.1",
     "react-phone-number-input": "^3.4.17",
     "react-remove-scroll": "^2.7.1",
-    "react-virtuoso": "^4.18.13",
+    "react-virtuoso": "^4.18.10",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/patches/react-virtuoso@4.18.11.patch
+++ b/patches/react-virtuoso@4.18.11.patch
@@ -1,0 +1,74 @@
+diff --git a/dist/index.mjs b/dist/index.mjs
+index b1ccd3a27eeabe74abd770b5e2d03bf8552942b8..2d837ed111f52d62ff0c258ad0bb95fe89e549d7 100644
+--- a/dist/index.mjs
++++ b/dist/index.mjs
+@@ -399,7 +399,7 @@ function $e(t, e, n) {
+ }
+ const It = j(
+   () => {
+-    const t = U(), e = U(), n = T(0), o = U(), r = T(0), s = U(), i = U(), l = T(0), c = T(0), d = T(0), m = T(0), v = U(), p = U(), I = T(!1), w = T(!1), R = T(!1);
++    const t = U(), e = U(), n = T(0), o = U(), r = T(0), s = U(), i = U(), l = T(0), c = T(0), d = T(0), m = T(0), v = U(), p = U(), I = T(!1), w = T(!1), R = T(!1), Dc = U();
+     return z(
+       x(
+         t,
+@@ -414,6 +414,7 @@ const It = j(
+       i
+     ), z(e, r), {
+       deviation: n,
++      deviationCommitted: Dc,
+       fixedFooterHeight: d,
+       fixedHeaderHeight: c,
+       footerHeight: m,
+@@ -2063,13 +2064,21 @@ function no(t) {
+ }
+ const rr = no(() => /iP(ad|od|hone)/i.test(navigator.userAgent) && /WebKit/i.test(navigator.userAgent)), sr = j(
+   ([
+-    { deviation: t, scrollBy: e, scrollingInProgress: n, scrollTop: o },
++    { deviation: t, deviationCommitted: Dk, scrollBy: e, scrollingInProgress: n, scrollTop: o },
+     { isAtBottom: r, isScrolling: s, lastJumpDueToItemResize: i, scrollDirection: l },
+     { listState: c },
+     { beforeUnshiftWith: d, gap: m, shiftWithOffset: v, sizes: p },
+     { log: I },
+     { recalcInProgress: w }
+   ]) => {
++    let Pq = null, Pa = !1, Pd = 0;
++    const Pc = (f) => {
++      if (Pq !== f) return;
++      Pq = null;
++      M(e, { top: f }), requestAnimationFrame(() => {
++        M(t, 0), M(w, !1), Pd = 0;
++      });
++    };
+     const R = Tt(
+       x(
+         c,
+@@ -2129,13 +2138,14 @@ const rr = no(() => /iP(ad|od|hone)/i.test(navigator.userAgent) && /WebKit/i.tes
+         })
+       ),
+       (f) => {
++        Pa = Pd !== f, Pq = f, Pd = f;
+         M(t, f), requestAnimationFrame(() => {
+-          M(e, { top: f }), requestAnimationFrame(() => {
+-            M(t, 0), M(w, !1);
+-          });
++          Pc(f);
+         });
+       }
+-    ), { deviation: t };
++    ), Y(Dk, (cv) => {
++      Pq !== null && Pa && cv === Pq && Pc(cv);
++    }), { deviation: t };
+   },
+   rt(It, pe, Kt, Lt, Gt, Ue)
+ ), ir = j(
+@@ -2471,6 +2481,10 @@ const ur = /* @__PURE__ */ j(() => {
+   on("deviation", (F) => {
+     a !== F && S(F);
+   });
++  const Dp = Ct("deviationCommitted");
++  (typeof document === "undefined" ? E.useEffect : E.useLayoutEffect)(() => {
++    Dp(a);
++  }, [a, Dp]);
+   const H = A("EmptyPlaceholder"), y = A("ScrollSeekPlaceholder") ?? dr, k = A("ListComponent"), u = A("ItemComponent"), g = A("GroupComponent"), C = A("computeItemKey"), L = A("isSeeking"), O = A("groupIndices").length > 0, V = A("alignToBottom"), N = A("initialItemFinalLocationReached"), Z = e ? {} : {
+     boxSizing: "border-box",
+     ...h ? {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,11 @@ overrides:
   '@factorialco/f0-react-native>react-dom': 19.2.3
   '@factorialco/f0-react-native>react-test-renderer': 19.2.3
 
+patchedDependencies:
+  react-virtuoso@4.18.11:
+    hash: 569197f359405782672f6be75b86ca9e056899d093310ad38389369e98676812
+    path: patches/react-virtuoso@4.18.11.patch
+
 importers:
 
   .:
@@ -459,8 +464,8 @@ importers:
         specifier: ^2.7.1
         version: 2.7.1(@types/react@18.3.18)(react@18.3.1)
       react-virtuoso:
-        specifier: ^4.18.13
-        version: 4.18.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^4.18.10
+        version: 4.18.11(patch_hash=569197f359405782672f6be75b86ca9e056899d093310ad38389369e98676812)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^2.12.7
         version: 2.15.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -10850,8 +10855,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-virtuoso@4.18.13:
-    resolution: {integrity: sha512-M4kP7zbV7JmLrnJYs0X2FBA8gnNlHisSYuKMyeJVYtWz31CAJeP57dgPJzfneUdKDKmL9SiqvcBQ32si8CfQSQ==}
+  react-virtuoso@4.18.11:
+    resolution: {integrity: sha512-Qeeq9vqa5seCxACvzbQTUeq3s2/Bu+VlwOMF0jfy3E/ZKHLiXWwJpXBhv2rckqYkvm1XRVFLCBMCmqCU8JNEJg==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -24397,7 +24402,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.18
 
-  react-virtuoso@4.18.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  react-virtuoso@4.18.11(patch_hash=569197f359405782672f6be75b86ca9e056899d093310ad38389369e98676812)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,6 @@ packages:
   - "packages/*"
   - "packages/examples/*"
   - "ownership"
+
+patchedDependencies:
+  react-virtuoso@4.18.11: patches/react-virtuoso@4.18.11.patch


### PR DESCRIPTION
Reverts factorialco/f0#5419. We need to still wait 4 days more for the 7 day policy of new stable versions from third party, in thi scase, react-virtuoso 4.18.13 is only 3 days live