### PR TITLE
fix(OneEmptyState): keep its width when it is a container

### DIFF
--- a/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
+++ b/packages/react/src/components/OneEmptyState/OneEmptyState.tsx
@@ -15,7 +15,7 @@ function _OneEmptyState({
 }: Types.OneEmptyStateProps) {
   return (
     <div
-      className="@container flex flex-col items-center justify-center gap-5 p-8"
+      className="@container flex w-full flex-col items-center justify-center gap-5 p-8"
       {...rest}
     >
       {variant === "default" ? (

--- a/packages/react/src/components/OneEmptyState/__tests__/OneEmptyState.actions.test.tsx
+++ b/packages/react/src/components/OneEmptyState/__tests__/OneEmptyState.actions.test.tsx
@@ -51,3 +51,18 @@ describe("OneEmptyState's actions", () => {
     expect(actionsRow().parentElement).toHaveClass("@container")
   })
 })
+
+describe("OneEmptyState's own width", () => {
+  it("fills its parent, so being a container cannot collapse it", () => {
+    // `@container` applies inline-size containment, which drops the empty
+    // state's content from its intrinsic width. In a shrink-to-fit parent (a
+    // flex column with `items-center`, say) that leaves it as wide as its
+    // padding and nothing else, so it has to take its width from the parent.
+    render(<OneEmptyState emoji="🧾" title="No expenses yet" />)
+
+    const root = screen.getByText("No expenses yet").closest("div")
+      ?.parentElement as HTMLElement
+
+    expect(root).toHaveClass("@container", "w-full")
+  })
+})


### PR DESCRIPTION
## Description

#5383 made the empty state a container query root so its actions could stack from their own width rather than the viewport's, but `@container` also applies inline-size containment — the empty state's content stops counting towards its own intrinsic width. Any parent that sizes it shrink-to-fit therefore collapses it to its `p-8` padding and nothing else, so this takes the width from the parent instead, which is what a block-level flex box did before it became a container and what the `@sm` query wants to measure anyway.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

Widths measured in Storybook at a 1200px viewport, each docs preview 522px wide:

| story / call site | parent | before | after |
| --- | --- | --- | --- |
| `Basic`, `WithDataTestId`, `WithUpsell` | block | 522px | 522px |
| `WithAlert` | `flex flex-col items-center gap-4` | **64px** | 522px |
| `Snapshot` | `flex flex-col items-center gap-8` | **64px** | 522px |

Live before/after: [deployed `WithAlert`](https://f0.factorial.dev/?path=/docs/components-emptystate--documentation#with-alert) against the same story on this branch's preview.

The `EmptyState/Snapshot` Chromatic snapshot changes on purpose — its four states go from 64px to full width.

## Implementation details

- fix: give the empty state's root `w-full`, so inline-size containment cannot collapse it

  <details>
  <summary>Why the collapse only shows up in some parents</summary>

  Inline-size containment zeroes the element's min- and max-content contributions. In normal block flow the width comes from the parent regardless, so nothing changes; in a shrink-to-fit context — a flex column with `items-center`, a flex item in a row, a grid auto track — the width is resolved *from* those contributions, and there is nothing left but padding.

  Three call sites hit exactly that pattern and were collapsed on `main` too, not just the stories: `OneDataCollection`'s no-data/no-results/error states (`flex flex-1 flex-col items-center justify-center`), `F0Chat`'s `ChatEmptyState` (flex row with `items-center`), and `SurveyAnsweringForm`'s empty step (`F0Box` column with `alignItems="center"`).
  </details>

- test: add a regression test that the root carries both `@container` and `w-full`

  <details>
  <summary>Red-green</summary>

  Reverting only the component change fails it: `Expected "@container w-full", received "@container flex flex-col items-center justify-center gap-5 p-8"`.
  </details>

### Verified

#5383's behaviour is preserved — driving a host box through 1100 / 500 / 396 / 300px, the root now tracks the host width exactly and the actions row still flips between `row` and `column` off the container query, with no overflow at any width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)