### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "6.91.0",
+  "packages/react": "6.91.1",
   "packages/react-native": "0.59.1",
   "packages/core": "2.2.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [6.91.1](https://github.com/factorialco/f0/compare/f0-react-v6.91.0...f0-react-v6.91.1) (2026-09-09)
+
+
+### Bug Fixes
+
+* **OneEmptyState:** keep its width when it is a container ([#5484](https://github.com/factorialco/f0/issues/5484)) ([85762f2](https://github.com/factorialco/f0/commit/85762f2e547feb64ebb500ee850f46b90bfd3218))
+
 ## [6.91.0](https://github.com/factorialco/f0/compare/f0-react-v6.90.2...f0-react-v6.91.0) (2026-09-09)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "6.91.0",
+  "version": "6.91.1",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/factorialco/f0.git",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 6.91.1</summary>

## [6.91.1](https://github.com/factorialco/f0/compare/f0-react-v6.91.0...f0-react-v6.91.1) (2026-09-09)


### Bug Fixes

* **OneEmptyState:** keep its width when it is a container ([#5484](https://github.com/factorialco/f0/issues/5484)) ([85762f2](https://github.com/factorialco/f0/commit/85762f2e547feb64ebb500ee850f46b90bfd3218))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).