### PR TITLE
ci(workflows): give main's runs per-SHA concurrency groups

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -8,8 +8,15 @@ on:
 env:
   PUBLIC_BUILD: true
 
+# `github.sha`, not `github.ref`, for the push side: on main every commit shares
+# `refs/heads/main`, so a single group covered them all and the release-please
+# commit that lands ~90s after each merge cancelled the previous commit's run —
+# turning that commit's `✅` gate red for no reason (the gate counts a
+# cancellation as fatal, and rightly so). Main's commits arrive serially, so
+# per-SHA groups cancel nothing worth keeping. PRs are unaffected: their runs
+# still group by PR number, so a new push supersedes the one in flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -5,8 +5,15 @@ on:
     branches:
       - "main"
 
+# `github.sha`, not `github.ref`, for the push side: on main every commit shares
+# `refs/heads/main`, so a single group covered them all and the release-please
+# commit that lands ~90s after each merge cancelled the previous commit's run —
+# turning that commit's `✅` gate red for no reason (the gate counts a
+# cancellation as fatal, and rightly so). Main's commits arrive serially, so
+# per-SHA groups cancel nothing worth keeping. PRs are unaffected: their runs
+# still group by PR number, so a new push supersedes the one in flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,8 +5,15 @@ on:
     branches:
       - "main"
 
+# `github.sha`, not `github.ref`, for the push side: on main every commit shares
+# `refs/heads/main`, so a single group covered them all and the release-please
+# commit that lands ~90s after each merge cancelled the previous commit's run —
+# turning that commit's `✅` gate red for no reason (the gate counts a
+# cancellation as fatal, and rightly so). Main's commits arrive serially, so
+# per-SHA groups cancel nothing worth keeping. PRs are unaffected: their runs
+# still group by PR number, so a new push supersedes the one in flight.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

Almost every `feat`/`fix` commit on main currently shows red `✅ Chromatic`, `✅ Storybook Tests` and `✅ Unit Tests` checks, and none of them are real failures — the runs were cancelled by the release-please commit that lands about 90 seconds later, because on a push all of main's commits shared one concurrency group. Keying the push side of the group on the SHA instead of the ref gives each commit its own group, so a new commit on main no longer kills the run in flight for its predecessor.

## Implementation details

- fix: key the push concurrency group on `github.sha` instead of `github.ref` in `chromatic.yml`, `storybook-tests.yaml` and `test.yaml` — the three workflows that trigger on `push` to `main`

  <details>
  <summary>Why the old group cancelled real runs</summary>

  On a `push` event `github.event.pull_request.number` is empty, so
  `${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}`
  collapsed to `<workflow>-refs/heads/main` — a single group covering every
  commit on main. With `cancel-in-progress: true`, the next push to main
  cancelled the run in flight.

  release-please pushes its `chore: release main` commit right after each
  merge, well inside a Chromatic or Storybook build, so the feature commit's
  run was killed mid-flight. The `if: always()` gate jobs then correctly
  reported that cancellation as a failure.

  The most recent instance at the time of writing:

  | time (UTC) | commit | Chromatic run |
  | --- | --- | --- |
  | 15:02:13 | `148d1d3dd` feat(F0Dialog): optional dismiss control | [34242154884](https://github.com/factorialco/f0/actions/runs/34242154884) → **cancelled** |
  | 15:03:51 | `5652caccd` chore: release main (#5464) | [34242335135](https://github.com/factorialco/f0/actions/runs/34242335135) → success |

  All 11 react jobs on `148d1d3dd` were `cancelled` and all three gates
  `failure`. The gate log reads `Dependency results: success cancelled`.

  Commits *not* followed by a release commit (`758db48a9`, `23fabd1bd`,
  `9320fad30`) are green, which is what pins the cause to the release push
  rather than to anything in the builds themselves.
  </details>

- chore: record the reasoning inline, so the `github.ref` fallback does not get restored as a tidy-up

## Notes for the reviewer

Nothing is lost by not cancelling on main. Commits there arrive serially, so the cancelled run was never redundant work — and for Chromatic it is specifically the run that publishes the next baseline (`autoAcceptChanges: "main"`).

PR behaviour is untouched: `github.event.pull_request.number` is still set on `pull_request` events, so a new push to a PR keeps superseding the run in flight. The other workflows that share the same group expression (`api-surface`, `ownership`, `storybook-docs-index`, `quality`, `size`) are PR-only or `workflow_dispatch`, so their `github.ref` fallback is unreachable and they are left alone.

One caveat on verification: a `.github/`-only PR skips the react matrices, so this PR's own gates pass on skip and cannot exercise the change. Confirmation has to come from watching the next real merge to main — the commit before a `chore: release main` should stay green.