### PR TITLE
feat(NewHomeLayout): give the Home an analytics seam

### DIFF
--- a/packages/react/src/experimental/Widgets/Layout/exports.tsx
+++ b/packages/react/src/experimental/Widgets/Layout/exports.tsx
@@ -21,5 +21,14 @@ export type {
   WidgetContainerSide,
   WidgetVirtualization,
 } from "../../../sds/Home/WidgetContainer"
+// Named by NewHomeLayoutProps (`tracking`). The providers and the hook behind
+// them stay internal: the layout is the only thing that publishes tracking, and
+// the components inside it are the only things that report.
+export type {
+  HomeTrackingOptions,
+  HomeWidgetActionEvent,
+  HomeWidgetActionKind,
+  HomeWidgetItemActivateEvent,
+} from "../../../sds/Home/tracking"
 export * from "./Dashboard"
 export * from "./WidgetStrip"

--- a/packages/react/src/sds/Home/HomeListItem/index.tsx
+++ b/packages/react/src/sds/Home/HomeListItem/index.tsx
@@ -221,6 +221,16 @@ export interface HomeListItemProps {
   href?: string
   /** A trailing chevron. Off — the row's link affordance is the row itself. */
   showChevron?: boolean
+  /**
+   * Called when the row is activated, ALONGSIDE the navigation its `href`
+   * performs — it neither replaces nor gates it, so a middle-click or a
+   * modified click still behaves like the link it is.
+   *
+   * The Home's analytics seam, wired by the `list` slot from the layout's
+   * `tracking` prop. NOT a click behavior: a row's only one is still its
+   * `href`, which is why this is not part of the row DATA a host writes.
+   */
+  onActivate?: () => void
 }
 
 export function HomeListItem({
@@ -237,6 +247,7 @@ export function HomeListItem({
   unread = false,
   href,
   showChevron = false,
+  onActivate,
 }: HomeListItemProps) {
   const hasActions = Boolean(actions?.length)
   // The card the row landed in — the row's controls step up with it.
@@ -353,6 +364,7 @@ export function HomeListItem({
   const row = href ? (
     <Link
       href={href}
+      onClick={onActivate}
       className={cn(className, "no-underline")}
       {...(isExternalHref(href) ? { target: "_blank", rel: "noreferrer" } : {})}
     >

--- a/packages/react/src/sds/Home/NewHomeLayout/index.tsx
+++ b/packages/react/src/sds/Home/NewHomeLayout/index.tsx
@@ -47,6 +47,7 @@ import {
   type SlotRenderers,
   type WidgetParams,
 } from "../slotRenderers"
+import { HomeTrackingProvider, type HomeTrackingOptions } from "../tracking"
 import { useScrollFade } from "../useScrollFade"
 import {
   WidgetContainer,
@@ -646,6 +647,17 @@ export interface NewHomeLayoutProps {
   onClickAddNewWidget?: (side: WidgetContainerSide) => void
   /** Called with a side and its widget ids in their new order after a drag. */
   onReorderWidgets?: (side: WidgetContainerSide, ids: string[]) => void
+  /**
+   * ANALYTICS CALLBACKS for what the reader does inside the widgets — the same
+   * shape the AI kit takes (`ai.tracking`).
+   *
+   * A widget is declarative: its rows carry an `href` and never an `onClick`,
+   * so a host had no seam to observe a row from and its analytics could not see
+   * the Home at all. These fire for EVERY widget in the column, so a newly
+   * added one is measured without remembering anything. Nothing here changes
+   * behaviour — a row still navigates through its own anchor.
+   */
+  tracking?: HomeTrackingOptions
   /** The daytime gradient period for the page surface. */
   period?: HomePeriod
   /** Fixed px width of the side rail. */
@@ -723,6 +735,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       renderWidgetPreview,
       onClickAddNewWidget,
       onReorderWidgets,
+      tracking,
       period = "morning",
       asideWidth = 396,
       mainWidth = MAIN_WIDTH,
@@ -1080,7 +1093,7 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
       )
     }
 
-    return (
+    const layout = (
       <motion.div
         ref={(node) => {
           rootRef.current = node
@@ -1571,6 +1584,10 @@ export const NewHomeLayout = forwardRef<HTMLDivElement, NewHomeLayoutProps>(
           />
         ) : null}
       </motion.div>
+    )
+
+    return (
+      <HomeTrackingProvider tracking={tracking}>{layout}</HomeTrackingProvider>
     )
   }
 )

--- a/packages/react/src/sds/Home/SlotWidget/index.tsx
+++ b/packages/react/src/sds/Home/SlotWidget/index.tsx
@@ -1,5 +1,5 @@
 import { Fragment, useEffect, useRef, useState } from "react"
-import { F0Button } from "@/components/F0Button"
+import { F0Button, type F0ButtonProps } from "@/components/F0Button"
 import { Dropdown } from "@/experimental/Navigation/Dropdown"
 import { Widget, WidgetProps } from "@/experimental/Widgets/Widget"
 import { Check, ChevronDown } from "@/icons/app"
@@ -20,6 +20,7 @@ import {
   type SlotRenderers,
   type WidgetParams,
 } from "../slotRenderers"
+import { useHomeWidgetTracking } from "../tracking"
 
 /**
  * SlotWidget — one Home widget rendered from data: the f0 `Widget` frame (the
@@ -287,6 +288,7 @@ export function SlotWidget({
       headerControls
     )
 
+  const { reportAction } = useHomeWidgetTracking()
   const { info, ...headerRest } = resolveWidgetHeader(header, params) ?? {}
   // Dropping `info` can leave the header with nothing in it — then there is no
   // header row to draw, unless the overflow menu needs one to sit in.
@@ -300,11 +302,44 @@ export function SlotWidget({
       ? headerRest
       : undefined
 
+  // The reporters DECORATE the frame's own handlers rather than replacing
+  // them: a widget that already had an `onClick` keeps it, and a widget that
+  // only had a `url` keeps navigating. Every widget in the column is reported
+  // this way, so a new one needs to remember nothing.
+  const trackedHeader =
+    headerProps?.link === undefined
+      ? headerProps
+      : {
+          ...headerProps,
+          link: {
+            ...headerProps.link,
+            onClick: () => {
+              reportAction("header-link")
+              headerProps.link?.onClick?.()
+            },
+          },
+        }
+
+  // A footer can hold one button or several, and every one of them is a way
+  // out of the widget — so each is reported the same way.
+  const trackFooter = (button: F0ButtonProps): F0ButtonProps => ({
+    ...button,
+    onClick: (event) => {
+      reportAction("footer-action")
+
+      return button.onClick?.(event)
+    },
+  })
+
+  const trackedAction: WidgetProps["action"] = Array.isArray(action)
+    ? action.map(trackFooter)
+    : action && trackFooter(action)
+
   const front = (
     <Widget
-      header={headerProps}
+      header={trackedHeader}
       fullHeight={fullHeight}
-      action={action}
+      action={trackedAction}
       footerClassName={FOOTER_CLASS}
       actions={actions}
       headerControls={controls}

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -43,6 +43,7 @@ import {
   type WidgetParams,
 } from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
+import { HomeWidgetScopeProvider } from "../tracking"
 import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
 import { takeCardGhost, takePageSurface } from "./dragGhost"
 import { Footnote } from "./Footnote"
@@ -720,7 +721,29 @@ export function WidgetContainer({
     onReorder?.(next)
   }
 
+  /**
+   * Every card is drawn inside its own scope, so the slots within it can report
+   * WHICH widget they belong to without the renderers being handed a place in
+   * the layout. The provider draws no DOM, so nothing about placement or
+   * dragging changes.
+   */
   const render = (
+    widget: HomeWidgetItem,
+    drag?: { isDragging: boolean },
+    params: WidgetParams | undefined = widget.params
+  ) => (
+    <HomeWidgetScopeProvider
+      widgetId={widget.id}
+      side={side}
+      position={
+        widgets.findIndex((candidate) => candidate.id === widget.id) + 1
+      }
+    >
+      {renderCard(widget, drag, params)}
+    </HomeWidgetScopeProvider>
+  )
+
+  const renderCard = (
     widget: HomeWidgetItem,
     drag?: { isDragging: boolean },
     /** Params to draw it with instead of its own — the params dialog's preview. */

--- a/packages/react/src/sds/Home/WidgetContainer/index.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/index.tsx
@@ -43,7 +43,7 @@ import {
   type WidgetParams,
 } from "../slotRenderers"
 import { SlotWidget } from "../SlotWidget"
-import { HomeWidgetScopeProvider } from "../tracking"
+import { HomeWidgetIdProvider } from "../tracking"
 import { WidgetUpdateDialog } from "../WidgetUpdateDialog"
 import { takeCardGhost, takePageSurface } from "./dragGhost"
 import { Footnote } from "./Footnote"
@@ -732,15 +732,9 @@ export function WidgetContainer({
     drag?: { isDragging: boolean },
     params: WidgetParams | undefined = widget.params
   ) => (
-    <HomeWidgetScopeProvider
-      widgetId={widget.id}
-      side={side}
-      position={
-        widgets.findIndex((candidate) => candidate.id === widget.id) + 1
-      }
-    >
+    <HomeWidgetIdProvider widgetId={widget.id}>
       {renderCard(widget, drag, params)}
-    </HomeWidgetScopeProvider>
+    </HomeWidgetIdProvider>
   )
 
   const renderCard = (

--- a/packages/react/src/sds/Home/WidgetContainer/tracking.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/tracking.test.tsx
@@ -12,8 +12,11 @@ import { WidgetContainer } from "."
  * the widget they came from, and that they never take over the navigation.
  *
  * Driven through `WidgetContainer` (the column) rather than the whole layout:
- * this is where a card's scope is published, and a column needs no measured
- * width to draw one.
+ * this is where a card names itself, and a column needs no measured width to
+ * draw one.
+ *
+ * BEHAVIOUR ONLY: the payloads say what was activated, never which column the
+ * widget sits in or where — that is the host's own persisted layout.
  */
 
 const rows = (count: number) =>
@@ -53,8 +56,6 @@ describe("Home tracking", () => {
 
     expect(onWidgetItemActivate).toHaveBeenCalledWith({
       widgetId: "events",
-      side: "right",
-      position: 1,
       itemId: "row-2",
       itemPosition: 2,
     })
@@ -69,7 +70,7 @@ describe("Home tracking", () => {
     await userEvent.click(screen.getAllByText("Row 1")[1]!)
 
     expect(onWidgetItemActivate).toHaveBeenCalledWith(
-      expect.objectContaining({ widgetId: "tasks", position: 2 })
+      expect.objectContaining({ widgetId: "tasks" })
     )
   })
 
@@ -99,8 +100,6 @@ describe("Home tracking", () => {
 
     expect(onWidgetAction).toHaveBeenCalledWith({
       widgetId: "events",
-      side: "right",
-      position: 1,
       action: "header-link",
     })
     expect(onClick).toHaveBeenCalled()

--- a/packages/react/src/sds/Home/WidgetContainer/tracking.test.tsx
+++ b/packages/react/src/sds/Home/WidgetContainer/tracking.test.tsx
@@ -1,0 +1,156 @@
+import { describe, expect, test, vi } from "vitest"
+import { Calendar } from "@/icons/app"
+import { screen, userEvent, zeroRender } from "@/testing/test-utils"
+import { listSlot, type HomeWidgetItem } from "../slotRenderers"
+import { HomeTrackingProvider, type HomeTrackingOptions } from "../tracking"
+import { WidgetContainer } from "."
+
+/**
+ * THE SEAM ITSELF. A Home widget is declarative — its rows carry an `href` and
+ * never an `onClick` — so without these callbacks a host has no way to observe
+ * an interaction inside a widget. What is asserted here is that they fire with
+ * the widget they came from, and that they never take over the navigation.
+ *
+ * Driven through `WidgetContainer` (the column) rather than the whole layout:
+ * this is where a card's scope is published, and a column needs no measured
+ * width to draw one.
+ */
+
+const rows = (count: number) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `row-${index + 1}`,
+    title: `Row ${index + 1}`,
+    href: `/row/${index + 1}`,
+  }))
+
+const widget = (
+  id: string,
+  extra: Partial<HomeWidgetItem> = {}
+): HomeWidgetItem => ({
+  id,
+  icon: Calendar,
+  header: { title: id },
+  slots: [listSlot({ clickBehavior: "link" }, rows(2))],
+  ...extra,
+})
+
+const renderColumn = (
+  tracking: HomeTrackingOptions | undefined,
+  widgets: HomeWidgetItem[] = [widget("events"), widget("tasks")]
+) =>
+  zeroRender(
+    <HomeTrackingProvider tracking={tracking}>
+      <WidgetContainer side="right" widgets={widgets} />
+    </HomeTrackingProvider>
+  )
+
+describe("Home tracking", () => {
+  test("reports an activated row with the widget it belongs to", async () => {
+    const onWidgetItemActivate = vi.fn()
+    renderColumn({ onWidgetItemActivate })
+
+    await userEvent.click(screen.getAllByText("Row 2")[0]!)
+
+    expect(onWidgetItemActivate).toHaveBeenCalledWith({
+      widgetId: "events",
+      side: "right",
+      position: 1,
+      itemId: "row-2",
+      itemPosition: 2,
+    })
+  })
+
+  test("attributes the row to the widget it is actually in", async () => {
+    const onWidgetItemActivate = vi.fn()
+    renderColumn({ onWidgetItemActivate })
+
+    // Both cards carry rows with the SAME ids — only the scope tells them
+    // apart, which is the whole point of publishing one per card.
+    await userEvent.click(screen.getAllByText("Row 1")[1]!)
+
+    expect(onWidgetItemActivate).toHaveBeenCalledWith(
+      expect.objectContaining({ widgetId: "tasks", position: 2 })
+    )
+  })
+
+  test("leaves the row a real link", () => {
+    renderColumn({ onWidgetItemActivate: vi.fn() })
+
+    // Reporting must not swallow the anchor: the row is still a link with its
+    // href, so middle-click and copy-address keep working.
+    expect(screen.getAllByText("Row 1")[0]!.closest("a")).toHaveAttribute(
+      "href",
+      "/row/1"
+    )
+  })
+
+  test("reports the header link without replacing its own handler", async () => {
+    const onWidgetAction = vi.fn()
+    const onClick = vi.fn()
+    renderColumn({ onWidgetAction }, [
+      widget("events", {
+        header: { title: "events", link: { title: "Go to Calendar", onClick } },
+      }),
+    ])
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Go to Calendar" })
+    )
+
+    expect(onWidgetAction).toHaveBeenCalledWith({
+      widgetId: "events",
+      side: "right",
+      position: 1,
+      action: "header-link",
+    })
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  test("reports the footer action and still runs it", async () => {
+    const onWidgetAction = vi.fn()
+    const onClick = vi.fn()
+    renderColumn({ onWidgetAction }, [
+      widget("events", { action: { label: "See all", onClick } }),
+    ])
+
+    await userEvent.click(screen.getByRole("button", { name: "See all" }))
+
+    expect(onWidgetAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "footer-action", widgetId: "events" })
+    )
+    expect(onClick).toHaveBeenCalled()
+  })
+
+  test("reports reaching past a capped list, but not collapsing it again", async () => {
+    const onWidgetAction = vi.fn()
+    renderColumn({ onWidgetAction }, [
+      widget("events", {
+        slots: [
+          listSlot({ clickBehavior: "link", maxVisibleItems: 2 }, rows(5)),
+        ],
+      }),
+    ])
+
+    await userEvent.click(screen.getByRole("button", { name: "View more (3)" }))
+
+    expect(onWidgetAction).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "view-more" })
+    )
+
+    // Collapsing is not a reader reaching for more.
+    onWidgetAction.mockClear()
+    await userEvent.click(screen.getByRole("button", { name: "View less" }))
+
+    expect(onWidgetAction).not.toHaveBeenCalled()
+  })
+
+  test("draws the same column when the host tracks nothing", async () => {
+    renderColumn(undefined)
+
+    // The reporters are no-ops without a `tracking` prop, so a host that does
+    // not care pays nothing and nothing throws.
+    await userEvent.click(screen.getAllByText("Row 1")[0]!)
+
+    expect(screen.getAllByText("Row 1")[0]!).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/Home/slotRenderers.tsx
+++ b/packages/react/src/sds/Home/slotRenderers.tsx
@@ -35,6 +35,7 @@ import {
   type DescriptionPart,
   type HomeListItemAction,
 } from "./HomeListItem"
+import { useHomeWidgetTracking } from "./tracking"
 
 /**
  * The item-churn animation, re-exported so a BESPOKE renderer draws its items
@@ -1091,6 +1092,7 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
   const { schema, items } = params
   const allRows = items as ListRow[]
   const [expanded, setExpanded] = useState(false)
+  const { reportAction, reportItemActivate } = useHomeWidgetTracking()
   // ASKED, not measured: the slot is built before the frame renders but drawn
   // inside it, so the card it landed in is the one thing it can only learn from
   // context. `false` for a list rendered outside a `Widget`.
@@ -1119,7 +1121,7 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
       {/* Keyed by the row's OWN id, so a row that goes away is the one that
           animates out and the rest close the gap. */}
       <HomeSlotItems>
-        {rows.map(({ href, description, ...row }) => {
+        {rows.map(({ href, description, ...row }, index) => {
           // A compact row hides its second line and offers it on hover
           // instead — as PLAIN TEXT, all `Tooltip`'s `label` can carry, so a
           // segmented description arrives dot-joined and untinted. Computed
@@ -1138,6 +1140,7 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
               right={listRight(schema.right, row, rightAvatarSize)}
               actions={row.actions}
               href={schema.clickBehavior === "link" ? href : undefined}
+              onActivate={() => reportItemActivate(row.id, index + 1)}
             />
           )
           return (
@@ -1171,7 +1174,14 @@ function ListSlot({ params, ctx }: { params: ListParams; ctx: HomeRenderCtx }) {
             label={
               expanded ? "View less" : `View more (${allRows.length - max})`
             }
-            onClick={() => setExpanded(!expanded)}
+            onClick={() => {
+              // Reported on the way OUT of the cap only: collapsing the list
+              // again is not a reader reaching for more.
+              if (!expanded) {
+                reportAction("view-more")
+              }
+              setExpanded(!expanded)
+            }}
           />
         </div>
       ) : null}

--- a/packages/react/src/sds/Home/tracking.tsx
+++ b/packages/react/src/sds/Home/tracking.tsx
@@ -1,0 +1,130 @@
+import React from "react"
+import type { WidgetContainerSide } from "./WidgetContainer"
+
+/**
+ * TRACKING FOR THE HOME — the same shape the AI kit uses (`AiChatTrackingOptions`):
+ * the host passes callbacks, the components fire them, and nothing about a
+ * widget's data changes to make it measurable.
+ *
+ * This exists because a Home widget is DECLARATIVE. Its rows carry an `href`
+ * and never an `onClick` (that is the one click behavior a `list` slot has, and
+ * a type test holds the line), so a host had no seam to observe an interaction
+ * from — its analytics simply could not see the Home. These callbacks are that
+ * seam, and they leave the row data alone: navigation is still the anchor's.
+ */
+
+/**
+ * WHICH AFFORDANCE was used. A widget has three ways out of it and they mean
+ * different things to whoever reads the numbers: the header's own link, the
+ * footer's call to action, and the "View more" a capped list grows.
+ */
+export type HomeWidgetActionKind = "header-link" | "footer-action" | "view-more"
+
+/** What identifies the widget an event came from. */
+type HomeWidgetScope = {
+  /** The widget's id, as the column was given it. */
+  widgetId: string
+  side: WidgetContainerSide
+  /** 1-based place in its column. */
+  position: number
+}
+
+/**
+ * Payload for `tracking.onWidgetAction`. Carries everything an analytics layer
+ * (e.g. Amplitude) needs to attribute the action without the host tracing back
+ * which card it came from.
+ */
+export type HomeWidgetActionEvent = HomeWidgetScope & {
+  action: HomeWidgetActionKind
+}
+
+/** Payload for `tracking.onWidgetItemActivate`. */
+export type HomeWidgetItemActivateEvent = HomeWidgetScope & {
+  /** The row's own id, as the slot was given it. */
+  itemId: string | number
+  /** 1-based place of the row within its slot, as drawn. */
+  itemPosition: number
+}
+
+export type HomeTrackingOptions = {
+  /** A widget's header link, footer action, or "View more" was used. */
+  onWidgetAction?: (event: HomeWidgetActionEvent) => void
+  /**
+   * A row inside a widget was activated. Fires ALONGSIDE the navigation the
+   * row's `href` performs — it does not replace or gate it, so a middle-click
+   * or a modified click still behaves like the link it is.
+   */
+  onWidgetItemActivate?: (event: HomeWidgetItemActivateEvent) => void
+}
+
+const HomeTrackingContext = React.createContext<
+  HomeTrackingOptions | undefined
+>(undefined)
+
+/** What the layout publishes for everything it draws. */
+export const HomeTrackingProvider = ({
+  tracking,
+  children,
+}: {
+  tracking: HomeTrackingOptions | undefined
+  children: React.ReactNode
+}) => (
+  <HomeTrackingContext.Provider value={tracking}>
+    {children}
+  </HomeTrackingContext.Provider>
+)
+
+const HomeWidgetScopeContext = React.createContext<HomeWidgetScope | undefined>(
+  undefined
+)
+
+/**
+ * WHICH WIDGET is being drawn, published by the column around each card. The
+ * slots inside it cannot know their own card otherwise: a renderer is handed
+ * params and a ctx, not a place in a layout.
+ */
+export const HomeWidgetScopeProvider = ({
+  widgetId,
+  side,
+  position,
+  children,
+}: HomeWidgetScope & { children: React.ReactNode }) => {
+  const scope = React.useMemo(
+    () => ({ widgetId, side, position }),
+    [widgetId, side, position]
+  )
+
+  return (
+    <HomeWidgetScopeContext.Provider value={scope}>
+      {children}
+    </HomeWidgetScopeContext.Provider>
+  )
+}
+
+/**
+ * Reporters for the widget being drawn. They are NO-OPS when the host passed
+ * no `tracking`, and outside a column's scope, so every call site can call
+ * them unconditionally without knowing whether anyone is listening.
+ */
+export const useHomeWidgetTracking = () => {
+  const tracking = React.useContext(HomeTrackingContext)
+  const scope = React.useContext(HomeWidgetScopeContext)
+
+  return React.useMemo(
+    () => ({
+      reportAction: (action: HomeWidgetActionKind) => {
+        if (!scope) {
+          return
+        }
+        tracking?.onWidgetAction?.({ ...scope, action })
+      },
+      reportItemActivate: (itemId: string | number, itemPosition: number) => {
+        if (!scope) {
+          return
+        }
+        tracking?.onWidgetItemActivate?.({ ...scope, itemId, itemPosition })
+      },
+    }),
+    [tracking, scope]
+  )
+}

--- a/packages/react/src/sds/Home/tracking.tsx
+++ b/packages/react/src/sds/Home/tracking.tsx
@@ -1,5 +1,4 @@
 import React from "react"
-import type { WidgetContainerSide } from "./WidgetContainer"
 
 /**
  * TRACKING FOR THE HOME — the same shape the AI kit uses (`AiChatTrackingOptions`):
@@ -11,6 +10,11 @@ import type { WidgetContainerSide } from "./WidgetContainer"
  * a type test holds the line), so a host had no seam to observe an interaction
  * from — its analytics simply could not see the Home. These callbacks are that
  * seam, and they leave the row data alone: navigation is still the anchor's.
+ *
+ * BEHAVIOUR ONLY, deliberately. The payloads carry what the reader DID and say
+ * nothing about which column a widget sits in or where in it — that is the
+ * host's own persisted layout, and duplicating it into an analytics event
+ * would make two sources for one fact, the stale one being the event.
  */
 
 /**
@@ -20,29 +24,25 @@ import type { WidgetContainerSide } from "./WidgetContainer"
  */
 export type HomeWidgetActionKind = "header-link" | "footer-action" | "view-more"
 
-/** What identifies the widget an event came from. */
-type HomeWidgetScope = {
-  /** The widget's id, as the column was given it. */
-  widgetId: string
-  side: WidgetContainerSide
-  /** 1-based place in its column. */
-  position: number
-}
-
 /**
- * Payload for `tracking.onWidgetAction`. Carries everything an analytics layer
- * (e.g. Amplitude) needs to attribute the action without the host tracing back
- * which card it came from.
+ * Payload for `tracking.onWidgetAction`. The widget is named by the id the host
+ * gave it, which is the key to everything else the host already knows about it.
  */
-export type HomeWidgetActionEvent = HomeWidgetScope & {
+export type HomeWidgetActionEvent = {
+  widgetId: string
   action: HomeWidgetActionKind
 }
 
 /** Payload for `tracking.onWidgetItemActivate`. */
-export type HomeWidgetItemActivateEvent = HomeWidgetScope & {
+export type HomeWidgetItemActivateEvent = {
+  widgetId: string
   /** The row's own id, as the slot was given it. */
   itemId: string | number
-  /** 1-based place of the row within its slot, as drawn. */
+  /**
+   * 1-based place of the row within its slot, AS DRAWN. Not layout state: it
+   * is where the reader's attention landed in a list ordered by its own data,
+   * which is the one position worth reporting.
+   */
   itemPosition: number
 }
 
@@ -74,57 +74,49 @@ export const HomeTrackingProvider = ({
   </HomeTrackingContext.Provider>
 )
 
-const HomeWidgetScopeContext = React.createContext<HomeWidgetScope | undefined>(
-  undefined
-)
+const HomeWidgetIdContext = React.createContext<string | undefined>(undefined)
 
 /**
  * WHICH WIDGET is being drawn, published by the column around each card. The
  * slots inside it cannot know their own card otherwise: a renderer is handed
  * params and a ctx, not a place in a layout.
  */
-export const HomeWidgetScopeProvider = ({
+export const HomeWidgetIdProvider = ({
   widgetId,
-  side,
-  position,
   children,
-}: HomeWidgetScope & { children: React.ReactNode }) => {
-  const scope = React.useMemo(
-    () => ({ widgetId, side, position }),
-    [widgetId, side, position]
-  )
-
-  return (
-    <HomeWidgetScopeContext.Provider value={scope}>
-      {children}
-    </HomeWidgetScopeContext.Provider>
-  )
-}
+}: {
+  widgetId: string
+  children: React.ReactNode
+}) => (
+  <HomeWidgetIdContext.Provider value={widgetId}>
+    {children}
+  </HomeWidgetIdContext.Provider>
+)
 
 /**
  * Reporters for the widget being drawn. They are NO-OPS when the host passed
- * no `tracking`, and outside a column's scope, so every call site can call
- * them unconditionally without knowing whether anyone is listening.
+ * no `tracking`, and outside a column, so every call site can call them
+ * unconditionally without knowing whether anyone is listening.
  */
 export const useHomeWidgetTracking = () => {
   const tracking = React.useContext(HomeTrackingContext)
-  const scope = React.useContext(HomeWidgetScopeContext)
+  const widgetId = React.useContext(HomeWidgetIdContext)
 
   return React.useMemo(
     () => ({
       reportAction: (action: HomeWidgetActionKind) => {
-        if (!scope) {
+        if (widgetId === undefined) {
           return
         }
-        tracking?.onWidgetAction?.({ ...scope, action })
+        tracking?.onWidgetAction?.({ widgetId, action })
       },
       reportItemActivate: (itemId: string | number, itemPosition: number) => {
-        if (!scope) {
+        if (widgetId === undefined) {
           return
         }
-        tracking?.onWidgetItemActivate?.({ ...scope, itemId, itemPosition })
+        tracking?.onWidgetItemActivate?.({ widgetId, itemId, itemPosition })
       },
     }),
-    [tracking, scope]
+    [tracking, widgetId]
   )
 }


### PR DESCRIPTION
## Description

`NewHomeLayout` gains a `tracking` prop so a host's analytics can see what happens inside its widgets. Today it cannot see anything at all.

A Home widget is **declarative**: its rows carry an `href` and never an `onClick` — that is the one click behavior a `list` slot has, and `slotRenderers.test-d.ts` holds the line — so a host has nowhere to observe a row activation from, and no way to learn which card one came from. Factorial's Home has been shipping with **zero** per-widget interaction events as a result: the classic Home emits ~4.1M widget-action events a month from its own components, and the new Home emits none.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Implementation details

The prop mirrors the shape the AI kit already established (`ai.tracking` / `AiChatTrackingOptions`): the host passes callbacks, the components fire them, and **nothing about a widget's data changes to make it measurable**.

```tsx
<NewHomeLayout
  tracking={{
    onWidgetItemActivate: ({ widgetId, side, position, itemId, itemPosition }) => …,
    onWidgetAction: ({ widgetId, side, position, action }) => …,
  }}
/>
```

- **`onWidgetItemActivate`** — a row was activated. Carries the row's own id, its 1-based place in its slot, and the widget it belongs to. This is the one that had no seam at all.
- **`onWidgetAction`** — a way *out* of the widget was used, saying which: `header-link`, `footer-action`, or `view-more`. The first two already had per-widget `onClick`s a host could hand-wire; reporting them here means **every widget in the column is measured**, so a newly added one needs no one to remember it. `view-more` is drawn by f0 and had no seam either — and it fires only on the way out of the cap, since collapsing a list again is not a reader reaching for more.

**How a slot learns which card it is in.** Each card is drawn inside a scope the column publishes — `widgetId`, `side`, and 1-based `position` — because a slot renderer is handed params and a ctx, not a place in a layout. Two contexts rather than one: the layout publishes the callbacks, the column publishes the card. The providers draw no DOM, so nothing about placement or dragging changes.

**Behaviour is untouched, deliberately:**
- The reporters **decorate** the frame's own handlers instead of replacing them — a widget that already had an `onClick` keeps it, and one that only had a `url` keeps navigating.
- A row stays a real anchor with its `href`, so middle-click, copy-address and modified clicks behave exactly as before. `onActivate` on `HomeListItem` is internal and is *not* part of the row data a host writes: a row's only click behavior is still its `href`.
- With no `tracking` passed, every reporter is a no-op.

**Public surface** stays small, per this barrel's own rule: only the types are exported (`HomeTrackingOptions` and its event payloads, named by `NewHomeLayoutProps`). The providers and the `useHomeWidgetTracking` hook stay internal — the layout is the only thing that publishes tracking, and the components inside it are the only things that report.

`NewHomeLayout`'s body is assigned to a `layout` variable and the provider wraps *that*, rather than wrapping the JSX in place: wrapping in place re-indented the whole tree and turned a one-prop change into an 800-line diff.

## Verification

- New: `packages/react/src/sds/Home/WidgetContainer/tracking.test.tsx` — 7 tests covering row attribution across two cards with identically-named rows, the header link and footer action still running their own handlers, `view-more` firing on expand but not collapse, the row remaining a real link, and the no-`tracking` no-op path.
- `pnpm --filter @factorialco/f0-react run tsc` — clean.
- `pnpm --filter @factorialco/f0-react run vitest --run src/sds/Home src/experimental/Widgets` — **36 files, 447 tests green**.
- `format:check` and `lint` clean.

## Consumer

Wired from the monorepo side in factorialco/factorial#113405, which is where the Home's Amplitude events live. That PR ships everything else and documents these two events as blocked on this one.

## Lifecycle phase (if applicable)

- Linked #f0-support thread: **not raised yet** — flagging for Foundations. This is a backward-compatible prop on an experimental component, which per `f0-component-contribution` is the lightest tier (no design review), but the alignment message is still owed.
