### PR TITLE
feat(F0ResourceHeader): accept a md as the description

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
@@ -1,13 +1,16 @@
 import { motion } from "motion/react"
-import { useEffect, useRef, useState } from "react"
+import { ReactNode, useEffect, useId, useRef, useState } from "react"
 import { useResizeObserver } from "usehooks-ts"
+import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
-export const Description = ({ description }: { description: string }) => {
+export const Description = ({ description }: { description: ReactNode }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [needsTruncation, setNeedsTruncation] = useState(false)
   const translations = useI18n()
+  const descriptionId = useId()
+  const reducedMotion = useReducedMotion()
 
   /*
    * We render a hidden block (`measure`) which we then use to read the height of the
@@ -29,6 +32,17 @@ export const Description = ({ description }: { description: string }) => {
   return (
     <div className="flex max-w-[640px] flex-col gap-1">
       <motion.div
+        /*
+         * The clamp hides overflowing lines with `overflow: hidden`, which clips
+         * them visually but leaves them focusable. A description can hold a link,
+         * so expand as soon as focus reaches one — otherwise tabbing lands on a
+         * control nobody can see (WCAG 2.4.7).
+         */
+        onFocusCapture={() => {
+          if (needsTruncation) {
+            setIsExpanded(true)
+          }
+        }}
         initial={false}
         animate={{
           height: isExpanded
@@ -36,7 +50,7 @@ export const Description = ({ description }: { description: string }) => {
             : (descriptionSize.height ?? "3rem"),
         }}
         transition={{
-          duration: needsTruncation ? 0.15 : 0,
+          duration: reducedMotion || !needsTruncation ? 0 : 0.15,
           ease: [0.165, 0.84, 0.44, 1],
         }}
         className={cn(
@@ -53,6 +67,7 @@ export const Description = ({ description }: { description: string }) => {
         </div>
         <div
           ref={descriptionRef}
+          id={descriptionId}
           className={cn(
             "text-lg text-f1-foreground-secondary",
             !isExpanded && "line-clamp-2"
@@ -63,8 +78,14 @@ export const Description = ({ description }: { description: string }) => {
       </motion.div>
       {needsTruncation || isExpanded ? (
         <button
+          type="button"
+          aria-controls={descriptionId}
+          aria-expanded={isExpanded}
           onClick={() => setIsExpanded((current) => !current)}
-          className="relative w-fit font-medium text-f1-foreground after:absolute after:-bottom-0.5 after:left-0 after:right-0 after:h-[1.5px] after:bg-f1-border after:transition-all after:content-[''] hover:after:bg-f1-border-hover"
+          className={cn(
+            "relative w-fit font-medium text-f1-foreground after:absolute after:-bottom-0.5 after:left-0 after:right-0 after:h-[1.5px] after:bg-f1-border after:transition-all after:content-[''] hover:after:bg-f1-border-hover",
+            focusRing()
+          )}
         >
           {isExpanded
             ? translations.actions.showLess

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
@@ -32,12 +32,8 @@ export const Description = ({ description }: { description: ReactNode }) => {
   return (
     <div className="flex max-w-[640px] flex-col gap-1">
       <motion.div
-        /*
-         * The clamp hides overflowing lines with `overflow: hidden`, which clips
-         * them visually but leaves them focusable. A description can hold a link,
-         * so expand as soon as focus reaches one — otherwise tabbing lands on a
-         * control nobody can see (WCAG 2.4.7).
-         */
+        // The clamp only hides overflow, so a clamped-away link stays focusable:
+        // expand on focus or it is reachable while invisible (WCAG 2.4.7).
         onFocusCapture={() => {
           if (needsTruncation) {
             setIsExpanded(true)

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
@@ -1,11 +1,16 @@
 import { motion } from "motion/react"
-import { ReactNode, useEffect, useId, useRef, useState } from "react"
+import { useEffect, useId, useRef, useState } from "react"
 import { useResizeObserver } from "usehooks-ts"
+import { F0RichTextDisplay } from "@/components/RichText/F0RichTextDisplay"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
 
-export const Description = ({ description }: { description: ReactNode }) => {
+// The description is a single run of prose, so the paragraphs markdown wraps it
+// in must not add their own vertical rhythm inside the two-line clamp.
+const PROSE = "[&>p]:m-0 [&>p+p]:mt-2"
+
+export const Description = ({ description }: { description: string }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const [needsTruncation, setNeedsTruncation] = useState(false)
   const translations = useI18n()
@@ -59,7 +64,11 @@ export const Description = ({ description }: { description: ReactNode }) => {
           className="pointer-events-none invisible absolute left-0 top-0 -z-10 text-lg text-f1-foreground-secondary"
           aria-hidden="true"
         >
-          {description}
+          <F0RichTextDisplay
+            format="markdown"
+            content={description}
+            className={PROSE}
+          />
         </div>
         <div
           ref={descriptionRef}
@@ -69,7 +78,11 @@ export const Description = ({ description }: { description: ReactNode }) => {
             !isExpanded && "line-clamp-2"
           )}
         >
-          {description}
+          <F0RichTextDisplay
+            format="markdown"
+            content={description}
+            className={PROSE}
+          />
         </div>
       </motion.div>
       {needsTruncation || isExpanded ? (

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/Description.tsx
@@ -1,7 +1,9 @@
 import { motion } from "motion/react"
 import { useEffect, useId, useRef, useState } from "react"
 import { useResizeObserver } from "usehooks-ts"
+import { F0Icon } from "@/components/F0Icon"
 import { F0RichTextDisplay } from "@/components/RichText/F0RichTextDisplay"
+import { ChevronDown } from "@/icons/app"
 import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
@@ -92,13 +94,23 @@ export const Description = ({ description }: { description: string }) => {
           aria-expanded={isExpanded}
           onClick={() => setIsExpanded((current) => !current)}
           className={cn(
-            "relative w-fit font-medium text-f1-foreground after:absolute after:-bottom-0.5 after:left-0 after:right-0 after:h-[1.5px] after:bg-f1-border after:transition-all after:content-[''] hover:after:bg-f1-border-hover",
+            "flex w-fit items-center gap-1 font-medium text-f1-foreground transition-colors hover:text-f1-foreground-secondary",
             focusRing()
           )}
         >
           {isExpanded
             ? translations.actions.showLess
             : translations.actions.showAll}
+          {/* Decorative: the button is already named by its own label. */}
+          <F0Icon
+            icon={ChevronDown}
+            size="sm"
+            aria-hidden
+            className={cn(
+              !reducedMotion && "transition-transform duration-200 ease-out",
+              isExpanded && "rotate-180"
+            )}
+          />
         </button>
       ) : null}
     </div>

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment, ReactNode } from "react"
+import { Fragment } from "react"
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Button } from "@/components/F0Button"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
@@ -47,8 +47,12 @@ interface BaseHeaderProps {
       }
     | AvatarVariant
 
-  /** Clamped to two lines behind a "show all" toggle. */
-  description?: ReactNode
+  /**
+   * Markdown. Inline formatting only — a link out to the resource's source of
+   * truth is the case this exists for. Clamped to two lines behind a "show all"
+   * toggle.
+   */
+  description?: string
   primaryAction?: PrimaryActionButton | PrimaryDropdownAction<string>
   secondaryActions?: HeaderSecondaryAction[]
   otherActions?: (DropdownItem & { isVisible?: boolean })[]

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react"
+import { Fragment, ReactNode } from "react"
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Button } from "@/components/F0Button"
 import { F0ButtonDropdown } from "@/components/F0ButtonDropdown"
@@ -47,7 +47,13 @@ interface BaseHeaderProps {
       }
     | AvatarVariant
 
-  description?: string
+  /**
+   * Supporting text under the title. Accepts a node so a consumer can render
+   * formatted copy — a link back to the source of truth, for instance — rather
+   * than flattening it to plain text. Clamped to two lines with a "show all"
+   * toggle either way.
+   */
+  description?: ReactNode
   primaryAction?: PrimaryActionButton | PrimaryDropdownAction<string>
   secondaryActions?: HeaderSecondaryAction[]
   otherActions?: (DropdownItem & { isVisible?: boolean })[]

--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -47,12 +47,7 @@ interface BaseHeaderProps {
       }
     | AvatarVariant
 
-  /**
-   * Supporting text under the title. Accepts a node so a consumer can render
-   * formatted copy — a link back to the source of truth, for instance — rather
-   * than flattening it to plain text. Clamped to two lines with a "show all"
-   * toggle either way.
-   */
+  /** Clamped to two lines behind a "show all" toggle. */
   description?: ReactNode
   primaryAction?: PrimaryActionButton | PrimaryDropdownAction<string>
   secondaryActions?: HeaderSecondaryAction[]

--- a/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
@@ -90,15 +90,11 @@ describe("F0ResourceHeader", () => {
     expect(screen.getAllByText("Quarterly revenue")).toHaveLength(2)
   })
 
-  it("renders a node description, keeping its links interactive", () => {
+  it("renders a markdown link in the description", () => {
     render(
       <F0ResourceHeader
         title="Reports"
-        description={
-          <>
-            See the <a href="https://example.com/rubric">rubric</a>
-          </>
-        }
+        description="See the [rubric](https://example.com/rubric)"
       />
     )
 
@@ -114,11 +110,7 @@ describe("F0ResourceHeader", () => {
     render(
       <F0ResourceHeader
         title="Reports"
-        description={
-          <>
-            See the <a href="https://example.com/rubric">rubric</a>
-          </>
-        }
+        description="See the [rubric](https://example.com/rubric)"
       />
     )
 

--- a/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
@@ -86,8 +86,7 @@ describe("F0ResourceHeader", () => {
   it("renders a plain string description as text", () => {
     render(<F0ResourceHeader title="Reports" description="Quarterly revenue" />)
 
-    // Rendered twice: the visible copy plus the hidden one that measures the
-    // unclamped height.
+    // Twice: the visible copy plus the hidden one that measures unclamped height.
     expect(screen.getAllByText("Quarterly revenue")).toHaveLength(2)
   })
 
@@ -103,8 +102,7 @@ describe("F0ResourceHeader", () => {
       />
     )
 
-    // The header mirrors the description into an aria-hidden node to measure its
-    // unclamped height, so only the visible link reaches the a11y tree.
+    // Only the visible copy reaches the a11y tree, not the measure clone.
     expect(screen.getAllByRole("link")).toHaveLength(1)
     expect(screen.getByRole("link", { name: "rubric" })).toHaveAttribute(
       "href",
@@ -124,9 +122,8 @@ describe("F0ResourceHeader", () => {
       />
     )
 
-    // Focus expands the description so a clamped-away link cannot be reached
-    // while invisible. A description short enough to fit was never hidden, so
-    // focusing it must not raise a "show less" toggle over nothing.
+    // Focus expands a clamped description; one that always fit hid nothing, so
+    // it must not raise a "show less" toggle over nothing.
     await act(async () => {
       screen.getByRole("link", { name: "rubric" }).focus()
     })

--- a/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/__tests__/F0ResourceHeader.test.tsx
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest"
 import { Download } from "@/icons/app"
-import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
+import {
+  act,
+  zeroRender as render,
+  screen,
+  userEvent,
+} from "@/testing/test-utils"
 import { F0ResourceHeader } from ".."
 
 describe("F0ResourceHeader", () => {
@@ -77,5 +82,57 @@ describe("F0ResourceHeader", () => {
         expect.objectContaining({ value: "csv", label: "Export CSV" })
       )
     )
+  })
+  it("renders a plain string description as text", () => {
+    render(<F0ResourceHeader title="Reports" description="Quarterly revenue" />)
+
+    // Rendered twice: the visible copy plus the hidden one that measures the
+    // unclamped height.
+    expect(screen.getAllByText("Quarterly revenue")).toHaveLength(2)
+  })
+
+  it("renders a node description, keeping its links interactive", () => {
+    render(
+      <F0ResourceHeader
+        title="Reports"
+        description={
+          <>
+            See the <a href="https://example.com/rubric">rubric</a>
+          </>
+        }
+      />
+    )
+
+    // The header mirrors the description into an aria-hidden node to measure its
+    // unclamped height, so only the visible link reaches the a11y tree.
+    expect(screen.getAllByRole("link")).toHaveLength(1)
+    expect(screen.getByRole("link", { name: "rubric" })).toHaveAttribute(
+      "href",
+      "https://example.com/rubric"
+    )
+  })
+
+  it("leaves an unclamped description alone when focus enters it", async () => {
+    render(
+      <F0ResourceHeader
+        title="Reports"
+        description={
+          <>
+            See the <a href="https://example.com/rubric">rubric</a>
+          </>
+        }
+      />
+    )
+
+    // Focus expands the description so a clamped-away link cannot be reached
+    // while invisible. A description short enough to fit was never hidden, so
+    // focusing it must not raise a "show less" toggle over nothing.
+    await act(async () => {
+      screen.getByRole("link", { name: "rubric" }).focus()
+    })
+
+    expect(
+      screen.queryByRole("button", { name: /show/i })
+    ).not.toBeInTheDocument()
   })
 })

--- a/packages/react/src/patterns/F0ResourceHeader/index.mdx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.mdx
@@ -56,15 +56,11 @@ Designed to display information about a team.
 
 - Keep titles concise and descriptive, with 2-5 words and no punctuation
 - Write descriptions with meaningful context in 1-2 sentences
-- `description` takes a node as well as a string, so a description can carry
-  formatted copy — typically a link out to the source of truth the resource is
-  tracked against. Keep it to inline content: the header clamps the description
-  to two lines behind a "show all" toggle, so block-level layout inside it does
-  not survive the clamp
-- The description node is rendered twice — once visibly, once in a hidden copy
-  used to measure its unclamped height. Keep it pure: no `id`s, no form
-  controls, nothing that fires an effect on mount, or the duplicate will shadow
-  the original (an IDREF resolves to the hidden copy, which comes first)
+- `description` is markdown, so it can carry a link out to the source of truth
+  the resource is tracked against — the doc it is planned in, the dashboard it
+  is measured from. Keep to inline formatting: the header clamps the description
+  to two lines behind a "show all" toggle, and block-level markdown (headings,
+  lists, tables) does not survive that clamp
 - Use action verbs in [verb + noun] format (e.g., "Edit profile" instead of
   "Profile edition"). Capitalize only the first word unless it's a proper noun
   (e.g., "Add to Factorial")

--- a/packages/react/src/patterns/F0ResourceHeader/index.mdx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.mdx
@@ -56,6 +56,15 @@ Designed to display information about a team.
 
 - Keep titles concise and descriptive, with 2-5 words and no punctuation
 - Write descriptions with meaningful context in 1-2 sentences
+- `description` takes a node as well as a string, so a description can carry
+  formatted copy — typically a link out to the source of truth the resource is
+  tracked against. Keep it to inline content: the header clamps the description
+  to two lines behind a "show all" toggle, so block-level layout inside it does
+  not survive the clamp
+- The description node is rendered twice — once visibly, once in a hidden copy
+  used to measure its unclamped height. Keep it pure: no `id`s, no form
+  controls, nothing that fires an effect on mount, or the duplicate will shadow
+  the original (an IDREF resolves to the hidden copy, which comes first)
 - Use action verbs in [verb + noun] format (e.g., "Edit profile" instead of
   "Profile edition"). Capitalize only the first word unless it's a proper noun
   (e.g., "Add to Factorial")
@@ -347,6 +356,10 @@ import { F0ResourceHeader } from "@factorialco/f0-react"
 ### Default
 
 <Canvas of={ResourceHeaderStories.Default} />
+
+### With a rich description
+
+<Canvas of={ResourceHeaderStories.WithRichDescription} />
 
 ### With dropdown action
 

--- a/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
@@ -601,7 +601,8 @@ export const RichDescriptionFocusExpands: Story = {
     await expect(toggle).toHaveAttribute("aria-expanded", "false")
 
     // Tabbable while the clamp hides it, so focus has to expand (WCAG 2.4.7).
-    canvas.getByRole("link", { name: "interview rubric" }).focus()
+    // F0Link appends an sr-only "(opens in new tab)" to the accessible name.
+    canvas.getByRole("link", { name: /interview rubric/ }).focus()
 
     await waitFor(() => expect(toggle).toHaveAttribute("aria-expanded", "true"))
   },

--- a/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { ComponentProps } from "react"
-import { expect, fn, userEvent, within } from "storybook/test"
+import { expect, fn, userEvent, waitFor, within } from "storybook/test"
+import { F0Link } from "@/components/F0Link"
 import { PrimaryDropdownAction } from "@/experimental/Information/utils"
 import * as Icon from "@/icons/app"
 import { Archive, Comment, Download, ExternalLink, Pencil } from "@/icons/app"
@@ -20,7 +21,8 @@ const meta: Meta<typeof F0ResourceHeader> = {
       description: "Main heading identifying the resource",
     },
     description: {
-      description: "Supporting text providing additional context",
+      description:
+        "Supporting text providing additional context. Accepts a node, so it can carry inline formatting such as a link",
     },
     status: {
       description: "Visual indicator of the resource's current state",
@@ -562,6 +564,50 @@ export const WithLongDescription: Story = {
   },
 }
 
+export const WithRichDescription: Story = {
+  tags: ["!dev"],
+  args: {
+    ...Default.args,
+    description: (
+      <>
+        Owns the hiring bar for the design org. See the{" "}
+        <F0Link href="https://example.com/rubric" target="_blank">
+          interview rubric
+        </F0Link>{" "}
+        before scheduling a loop.
+      </>
+    ),
+  },
+}
+
+export const RichDescriptionFocusExpands: Story = {
+  tags: ["!dev", "!autodocs"],
+  args: {
+    ...Default.args,
+    description: (
+      <>
+        Owns the hiring bar for the design org, from the first screen through to
+        the debrief, and keeps the loop calibrated across every panel. See the{" "}
+        <F0Link href="https://example.com/rubric" target="_blank">
+          interview rubric
+        </F0Link>{" "}
+        before scheduling a loop, and log the debrief the same day.
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const toggle = await canvas.findByRole("button", { name: /show/i })
+    await expect(toggle).toHaveAttribute("aria-expanded", "false")
+
+    // The clamp only hides overflow, so this link is tabbable while invisible.
+    // Focus has to open the description (WCAG 2.4.7).
+    canvas.getByRole("link", { name: "interview rubric" }).focus()
+
+    await waitFor(() => expect(toggle).toHaveAttribute("aria-expanded", "true"))
+  },
+}
+
 export const NoDescription: Story = {
   tags: ["!dev"],
   args: {
@@ -644,6 +690,9 @@ export const Snapshot: Story = {
         <F0ResourceHeader {...(Default.args as F0ResourceHeaderProps)} />
         <F0ResourceHeader
           {...(WithLongDescription.args as F0ResourceHeaderProps)}
+        />
+        <F0ResourceHeader
+          {...(WithRichDescription.args as F0ResourceHeaderProps)}
         />
         <F0ResourceHeader
           {...(WithDropdownAction.args as F0ResourceHeaderProps)}

--- a/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { ComponentProps } from "react"
 import { expect, fn, userEvent, waitFor, within } from "storybook/test"
-import { F0Link } from "@/components/F0Link"
 import { PrimaryDropdownAction } from "@/experimental/Information/utils"
 import * as Icon from "@/icons/app"
 import { Archive, Comment, Download, ExternalLink, Pencil } from "@/icons/app"
@@ -22,7 +21,7 @@ const meta: Meta<typeof F0ResourceHeader> = {
     },
     description: {
       description:
-        "Supporting text providing additional context. Accepts a node, so it can carry inline formatting such as a link",
+        "Supporting text providing additional context. Markdown, so it can carry inline formatting such as a link",
     },
     status: {
       description: "Visual indicator of the resource's current state",
@@ -568,15 +567,8 @@ export const WithRichDescription: Story = {
   tags: ["!dev"],
   args: {
     ...Default.args,
-    description: (
-      <>
-        Owns the hiring bar for the design org. See the{" "}
-        <F0Link href="https://example.com/rubric" target="_blank">
-          interview rubric
-        </F0Link>{" "}
-        before scheduling a loop.
-      </>
-    ),
+    description:
+      "Owns the hiring bar for the design org. See the [interview rubric](https://example.com/rubric) before scheduling a loop.",
   },
 }
 
@@ -584,16 +576,8 @@ export const RichDescriptionFocusExpands: Story = {
   tags: ["!dev", "!autodocs"],
   args: {
     ...Default.args,
-    description: (
-      <>
-        Owns the hiring bar for the design org, from the first screen through to
-        the debrief, and keeps the loop calibrated across every panel. See the{" "}
-        <F0Link href="https://example.com/rubric" target="_blank">
-          interview rubric
-        </F0Link>{" "}
-        before scheduling a loop, and log the debrief the same day.
-      </>
-    ),
+    description:
+      "Owns the hiring bar for the design org, from the first screen through to the debrief, and keeps the loop calibrated across every panel. See the [interview rubric](https://example.com/rubric) before scheduling a loop, and log the debrief the same day.",
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement)
@@ -601,8 +585,7 @@ export const RichDescriptionFocusExpands: Story = {
     await expect(toggle).toHaveAttribute("aria-expanded", "false")
 
     // Tabbable while the clamp hides it, so focus has to expand (WCAG 2.4.7).
-    // F0Link appends an sr-only "(opens in new tab)" to the accessible name.
-    canvas.getByRole("link", { name: /interview rubric/ }).focus()
+    canvas.getByRole("link", { name: "interview rubric" }).focus()
 
     await waitFor(() => expect(toggle).toHaveAttribute("aria-expanded", "true"))
   },

--- a/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/F0ResourceHeader/index.stories.tsx
@@ -600,8 +600,7 @@ export const RichDescriptionFocusExpands: Story = {
     const toggle = await canvas.findByRole("button", { name: /show/i })
     await expect(toggle).toHaveAttribute("aria-expanded", "false")
 
-    // The clamp only hides overflow, so this link is tabbable while invisible.
-    // Focus has to open the description (WCAG 2.4.7).
+    // Tabbable while the clamp hides it, so focus has to expand (WCAG 2.4.7).
     canvas.getByRole("link", { name: "interview rubric" }).focus()
 
     await waitFor(() => expect(toggle).toHaveAttribute("aria-expanded", "true"))


### PR DESCRIPTION
## Description

A resource almost always has context living somewhere else — the doc it is planned in, the dashboard it is measured from, the ticket that opened it — but `description` only took a `string`, so consumers either flattened their markup away (Trainings does exactly this: `DOMPurify.sanitize(description, { ALLOWED_TAGS: [] })`) or gave up and moved the description out of the header into the page body, losing the title/description/metadata reading order the header exists to provide. This widens `description` to `ReactNode` so it can carry a link, and fixes the two accessibility problems that widening exposes.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Lifecycle phase (if applicable)

- Linked #f0-support thread: **not yet raised — this draft is the artifact to bring to that conversation.** `F0ResourceHeader` is stable, so this needs Foundations sign-off before it is more than a draft. Opening it first per the "bring whatever exists: … a draft PR" guidance in the contribution docs.

## Screenshots (if applicable)

No new visual states for existing callers — a `string` description renders exactly as before. The new `WithRichDescription` story is included in the Chromatic `Snapshot` story, so the added path is covered there.

## Implementation details

- feat: widen `BaseHeaderProps["description"]` from `string` to `ReactNode`. `F0ResourceHeader` picks the prop through, so its public API widens with it. The component already rendered the value as children, so nothing but the type changed for existing callers.

- fix: expand a clamped description when focus enters it

  <details>
  <summary>Why?</summary>

  The two-line clamp hides overflow with `overflow: hidden`, which clips content visually but leaves it in the tab order and the a11y tree. While `description` was a `string` the clamped-away region held nothing focusable, so this could not happen; a link in it means a keyboard user lands on a control that is nowhere on screen (WCAG 2.4.7 Focus Visible). The clamp box is also a scroll container, so the browser scrolls line 1 out of view with no way to bring it back — the outer wrapper is `overflow-clip` and cannot compensate.

  Guarded on `needsTruncation`, so a description short enough to fit is left alone rather than sprouting a "show less" toggle over nothing.
  </details>

- fix: give the show all/show less toggle disclosure semantics — `aria-expanded`, `aria-controls`, the `type="button"` it always needed (it would submit an enclosing form), and the shared `focusRing()`. Mirrors `ExpandDescriptionButton` in `sds/Home/Communities`. This matters more now the collapsed region can hold content the user needs to reach.

- fix: honour `useReducedMotion()` on the expand/collapse transition, per `packages/react/AGENTS.md`.

- test: four unit tests — a string description still renders, a node description keeps its link in the a11y tree and exactly once (the measure clone stays out), and focus on an unclamped description raises no toggle. Each was checked red before green.

- test: a `RichDescriptionFocusExpands` play story for the focus-expands behaviour. It cannot be a unit test — Vitest stubs `ResizeObserver` with a no-op, so `needsTruncation` is never true under jsdom and the clamp never engages.

- feat: restyle the show all/show less toggle as a label plus a chevron rather than underlined text, at design's request. The chevron is `aria-hidden` (the button is named by its own label) and rotates only when motion is allowed.

- docs: MDX guidance for the new shape, including the constraint below.

## Notes for the reviewer

**`check:api-surface` will flag this as breaking.** `.scripts/check-api-surface.ts` classifies any property whose type changed as BREAKING, so CI will post that comment. It is a widening — `string` is assignable to `ReactNode` — and no consumer needs to change. I traced every one: `F0DialogHeader` passes a `resourceHeader` object through but only reads `.title`; `kits/surveys/SurveyAnsweringForm` `Omit`s `description` and declares its own `string`. Nothing does `.length`, interpolation, or passes it to a string-typed parameter. Please don't cut a major for it.

**Open question — F0 has no inline-prose link.** `actionVariants` gives every variant, `link` included, a base of `inline-flex items-center gap-1 text-base font-medium`, and the `link` variant overrides neither the display nor the size. Inside the description's `text-lg`, an `F0Link` therefore renders a step small (16px in 18px copy) and as a flex box rather than inline, which `-webkit-box` line-clamping does not lay out as part of the text. The story still uses `F0Link` because that is what F0's own markdown renderer uses for inline links (`kits/ai/…/markdownRenderers/components/Link.tsx`), so the snapshot shows the mismatch rather than hiding it. Worth deciding whether the fix is an inline link variant, or size-inheriting link styles in prose contexts. Happy to follow up separately either way.

**Known, left alone deliberately:**

- The description node is rendered twice — once visibly, once in a hidden copy that measures the unclamped height. Harmless for a string; with a node, an `id` inside it would be duplicated and every IDREF would resolve to the hidden copy, which comes first in document order. Documented in the MDX as a constraint for now. Replacing the clone with `scrollHeight > clientHeight` on the single visible node would make the whole hazard class impossible — a good follow-up, but a behaviour change to the truncation detection and beyond this PR.
- The measure clone is safe today because Tailwind `invisible` removes it from focus navigation, not because of `aria-hidden`. That makes the class load-bearing now the slot can hold focusable content. `inert` would make the guarantee explicit and CSS-independent, but React is pinned at 18.3.1 here, where `inert` is not a clean boolean prop.
- When expanded, the description is a `max-h-80 overflow-y-scroll` region that is not keyboard-scrollable (WCAG 2.1.1, axe `scrollable-region-focusable`). Pre-existing, and unrelated to the type.
