### PR TITLE
fix(OneDataCollection): persist which view is selected

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -1505,6 +1505,10 @@ const OneDataCollectionComp = <
         value: customPresets,
         setValue: setCustomPresets,
       },
+      selectedPresetId: {
+        value: selectedPresetId,
+        setValue: setSelectedPresetId,
+      },
       ...(hasPerVisualizationFilters
         ? {
             visualizationFilters: {

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/__tests__/useDataCollectionStorage.test.tsx
@@ -465,3 +465,72 @@ describe("useDataCollectionStorage — pre-hydration write race", () => {
     }
   })
 })
+
+describe("useDataCollectionStorage — the selected view", () => {
+  // The views themselves are always persisted; which one is active belongs with
+  // them, so a consumer that allowlists only its filters still gets both.
+  const features: DataCollectionStorageFeaturesDefinition = ["filters"]
+
+  const providersWith = (
+    value: string | undefined,
+    setValue: (value: string | undefined) => void
+  ) =>
+    ({
+      selectedPresetId: { value, setValue },
+    }) as unknown as AnyFeatureProviders
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("restores it, despite the consumer's features listing neither it nor the views", async () => {
+    const { handler, resolveGet } = createDeferredHandler()
+    const setValue = vi.fn()
+
+    zeroRenderHook(
+      () =>
+        useDataCollectionStorage(
+          "test/v1",
+          features,
+          providersWith(undefined, setValue)
+        ),
+      { wrapper: wrapperWith(handler) }
+    )
+
+    await act(async () => {
+      resolveGet({ selectedPresetId: "mine" })
+    })
+    await flushMicrotasks()
+
+    expect(setValue).toHaveBeenCalledWith("mine")
+  })
+
+  it("persists it", async () => {
+    const { handler, resolveGet, state } = createDeferredHandler()
+
+    zeroRenderHook(
+      () =>
+        useDataCollectionStorage(
+          "test/v1",
+          features,
+          providersWith("mine", vi.fn())
+        ),
+      { wrapper: wrapperWith(handler) }
+    )
+
+    await act(async () => {
+      resolveGet({})
+    })
+    await flushMicrotasks()
+    await act(async () => {
+      vi.advanceTimersByTime(500)
+    })
+
+    expect(state.value.selectedPresetId).toBe("mine")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/types.ts
@@ -31,6 +31,9 @@ export type DataCollectionStatus<
   visualizationFilters?: Record<string, CurrentFiltersState>
   /** User-created custom presets persisted alongside the rest of the state. */
   customPresets?: PresetsDefinition<FiltersDefinition>
+  /** The active view's id, so a revisit restores which view is selected and not
+   *  just the views themselves. */
+  selectedPresetId?: string
 }
 
 export type DataCollectionStatusComplete<
@@ -109,5 +112,9 @@ export type FeatureProviders<
   customPresets?: {
     value: PresetsDefinition<Filters>
     setValue: React.Dispatch<React.SetStateAction<PresetsDefinition<Filters>>>
+  }
+  selectedPresetId?: {
+    value: string | undefined
+    setValue: (value: string | undefined) => void
   }
 }

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/useDataCollectionStorage.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataColectionStorage/useDataCollectionStorage.ts
@@ -62,10 +62,16 @@ export const useDataCollectionStorage = <
   }
 
   const storageFeatures = useMemo(
-    // Settings and customPresets are always included, regardless of the
-    // consumer's `features` allowlist: presets are a first-class, always-on
-    // capability and must persist whenever a storage key is present.
-    () => [...getFeatures(featuresDef), "settings", "customPresets"],
+    // Settings, the views and which one is selected are always included,
+    // regardless of the consumer's `features` allowlist: views are a
+    // first-class, always-on capability and must persist whenever a storage key
+    // is present.
+    () => [
+      ...getFeatures(featuresDef),
+      "settings",
+      "customPresets",
+      "selectedPresetId",
+    ],
     // eslint-disable-next-line react-hooks/exhaustive-deps -- This is intentional
     [JSON.stringify(featuresDef)]
   )


### PR DESCRIPTION
## Description

The views a user saves already persist, but **which one is active did not**.

`selectedPresetId` was URL-only: it initialised to `undefined`, never appeared in `dataCollectionStorageFeatures`, and had no provider in the storage hook. So a collection that restored its filters, search, sortings and column layout from storage came back with the view bar **unselected** — the filter chips showing the restored state, but no view looking active. Reloading the same URL worked (`dc_view` carried it); navigating away and back did not.

Reported from the goals list in factorial, where filter persistence was just switched on and the asymmetry became visible: factorialco/factorial#113433.

## Type of change

- [x] Bug fix

## Implementation details

`selectedPresetId` now rides along with `customPresets` as an always-on storage feature — the two are the same capability (the saved views, and which of them is selected), so an allowlist that persists neither still gets both:

```ts
() => [...getFeatures(featuresDef), "settings", "customPresets", "selectedPresetId"]
```

Three small pieces: the field on `DataCollectionStatus`, the slot on `FeatureProviders`, and the provider entry next to `customPresets` in `OneDatacollection.tsx`.

Nothing else needed changing, because the surrounding code was already built for a restored selection:

- **The URL still wins.** `useDataCollectionUrlSync` applies its params after `storageReady`, and only the ones present — so a link keeps overriding storage exactly as before.
- **The deselect tracker already handles it.** Its own comment says it *"works for both click- and URL-restored selections (it keys off `selectedPresetId`, not `applyPreset`)"* — a storage-restored selection takes the same path.
- **A stale id degrades as before.** `mergedPresets.find(...)` returns nothing for a view that no longer exists, so the tracker clears and nothing shows selected.
- **Deselecting clears it.** `undefined` is filtered out of the write and the handler replaces the whole key, so no stored id survives a deselect.

### One wrinkle worth a reviewer's eye

When a consumer's `features` allowlist excludes a dimension the view captured (say `visualization`), the restored state can differ from the view's snapshot, so the tracker never arms its deselect — the view stays selected until the state first matches it. Erring towards keeping the selection seemed right, but say the word if you'd rather it deselect on a mismatch.

## Verification

- `check:bugfix-red-green` run locally: *"the changed unit tests fail on latest main and pass with this PR's changes"*.
- Two unit tests, one per direction: it restores under a `["filters"]`-only allowlist, and it persists.
- `format:check`, `lint --type-aware` (0 warnings, 0 errors), `build:types` (exit 0).
- `vitest --project=unit src/patterns/OneDataCollection`: 742 passed / 78 files.

Additive optional field on an exported type, so no API break.
