### PR TITLE
feat(OneDataCollection): allow an icon override per visualization

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/Settings/components/__tests__/useVisualizationMeta.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/__tests__/useVisualizationMeta.test.tsx
@@ -45,6 +45,26 @@ describe("useVisualizationMeta", () => {
     expect(withOverride.icon).toBe(withoutOverride.icon)
   })
 
+  it("uses the per-instance icon override for built-in visualizations", () => {
+    const resolve = renderResolver()
+
+    const meta = resolve(
+      viz({ type: "table", label: "Monthly", icon: CustomIcon, options: {} })
+    )
+
+    expect(meta.icon).toBe(CustomIcon)
+    expect(meta.label).toBe("Monthly")
+  })
+
+  it("keeps the built-in label when only the icon is overridden", () => {
+    const resolve = renderResolver()
+
+    const meta = resolve(viz({ type: "table", icon: CustomIcon, options: {} }))
+
+    expect(meta.icon).toBe(CustomIcon)
+    expect(meta.label).toBe("Table")
+  })
+
   it("honors the label and icon of a custom visualization", () => {
     const resolve = renderResolver()
 

--- a/packages/react/src/patterns/OneDataCollection/Settings/components/useVisualizationMeta.ts
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/useVisualizationMeta.ts
@@ -41,7 +41,8 @@ export const useVisualizationMeta = () => {
     }
 
     return {
-      icon: collectionVisualizations[visualization.type].icon,
+      icon:
+        visualization.icon ?? collectionVisualizations[visualization.type].icon,
       label:
         visualization.label ??
         i18n.collections.visualizations[visualization.type],

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
@@ -67,10 +67,12 @@ visualization's icon and label.
 ## Renaming the switcher chips
 
 By default each built-in visualization uses its localized name — "Table",
-"Graph", "List", etc. To rename a chip for a specific collection, pass an
-optional `label` on the visualization. Different collections can label the same
-type differently — e.g. the `graph` view as "Org chart" for employees, or the
-`table` view as "Teams" for teams.
+"Graph", "List", etc. — and the icon of its type. To rename a chip for a
+specific collection, pass an optional `label` on the visualization; to give it
+an icon of its own, pass an optional `icon`. Different collections can label the
+same type differently — e.g. the `graph` view as "Org chart" for employees, or
+the `table` view as "Teams" for teams — and two views of the same type can be
+told apart, e.g. a "Total" and a "Monthly" table.
 
 ```tsx
 <OneDataCollection
@@ -78,18 +80,29 @@ type differently — e.g. the `graph` view as "Org chart" for employees, or the
   visualizations={[
     // Renames the chip to "Org chart"; the built-in graph icon is kept.
     { type: "graph", label: "Org chart", options: {} },
-    // Omit `label` to keep the default localized name ("Table").
-    { type: "table", options: {} },
+    // Two tables: the label and the icon are what tell them apart.
+    { type: "table", label: "Total", options: totalOptions },
+    {
+      type: "table",
+      label: "Monthly",
+      icon: Calendar,
+      options: monthlyOptions,
+    },
   ]}
 />
 ```
 
-- `label` is optional; when omitted the localized built-in label is used, so
-  existing collections keep showing "Table" and "Graph".
-- Only the text is customizable — the icon still comes from the visualization
-  type. For a fully custom icon and label, use a `type: "custom"` visualization.
+- `label` and `icon` are optional; when omitted the localized built-in label and
+  the type's icon are used, so existing collections keep showing "Table" and
+  "Graph" as they did.
+- For a fully custom view, use a `type: "custom"` visualization, where both are
+  required.
 
 In the example below the two chips read "Org chart" and "Directory" instead of
 the defaults "Graph" and "Table":
 
 <Canvas of={GraphStories.CustomViewLabels} />
+
+And here each chip carries its own icon as well:
+
+<Canvas of={GraphStories.CustomViewIcons} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
@@ -3,7 +3,8 @@ import { Meta, StoryObj } from "@storybook/react-vite"
 import { useRef, useState } from "react"
 import { F0AvatarPerson } from "@/components/avatars/F0AvatarPerson"
 import { F0Button } from "@/components/F0Button"
-import { Calendar, Office } from "@/icons/app"
+import { IconType } from "@/components/F0Icon"
+import { Calendar, List, Office } from "@/icons/app"
 import { F0Dialog } from "@/patterns/F0Dialog"
 import type { F0GraphNodeTag } from "@/patterns/F0Graph"
 import { OneDataCollection } from "../.."
@@ -711,6 +712,8 @@ const OrgChartExample = ({
   initialSelectedNodeId,
   graphLabel,
   tableLabel,
+  graphIcon,
+  tableIcon,
   lockedTagTypes,
 }: {
   defaultExpandDepth: number
@@ -721,6 +724,10 @@ const OrgChartExample = ({
   graphLabel?: string
   /** Custom label for the table chip; falls back to the localized "Table". */
   tableLabel?: string
+  /** Custom icon for the graph chip; falls back to the built-in graph icon. */
+  graphIcon?: IconType
+  /** Custom icon for the table chip; falls back to the built-in table icon. */
+  tableIcon?: IconType
   /** Tag columns locked (OFF + disabled + tooltip) in the settings, per reason. */
   lockedTagTypes?: Partial<Record<(typeof NODE_TAG_TYPES)[number], string>>
 }) => {
@@ -737,6 +744,7 @@ const OrgChartExample = ({
           {
             ...graphVisualization,
             label: graphLabel,
+            icon: graphIcon,
             options: {
               ...graphVisualization.options,
               defaultExpandDepth,
@@ -746,7 +754,7 @@ const OrgChartExample = ({
               lockedTagTypes,
             },
           },
-          { ...tableVisualization, label: tableLabel },
+          { ...tableVisualization, label: tableLabel, icon: tableIcon },
         ]}
       />
       <F0Dialog
@@ -1155,6 +1163,25 @@ export const CustomViewLabels: Story = {
       defaultExpandDepth={1}
       graphLabel="Org chart"
       tableLabel="Directory"
+    />
+  ),
+}
+
+/**
+ * The view-switcher chips can carry an icon of their own too, with the optional
+ * `icon` on each built-in visualization — here the office for the org chart and
+ * a list for the directory. Omit `icon` to keep the built-in one. Together with
+ * `label` this tells two views of the same type apart, e.g. a "Total" and a
+ * "Monthly" table.
+ */
+export const CustomViewIcons: Story = {
+  render: () => (
+    <OrgChartExample
+      defaultExpandDepth={1}
+      graphLabel="Org chart"
+      graphIcon={Office}
+      tableLabel="Directory"
+      tableIcon={List}
     />
   ),
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations.tsx
@@ -180,14 +180,14 @@ export const VisualizationSelector = <
               const IconVisualization: IconType =
                 visualization.type === "custom"
                   ? visualization.icon
-                  : visualization.type === "table"
-                    ? Table
-                    : Kanban
+                  : (visualization.icon ??
+                    (visualization.type === "table" ? Table : Kanban))
 
               const label =
                 visualization.type === "custom"
                   ? visualization.label
-                  : i18n.collections.visualizations[visualization.type]
+                  : (visualization.label ??
+                    i18n.collections.visualizations[visualization.type])
 
               return (
                 <button

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts
@@ -47,18 +47,23 @@ export type VisualizationFilterOverrides<
 }
 
 /**
- * Optional per-visualization label override for built-in visualization types.
+ * Optional per-visualization chip overrides for built-in visualization types.
  * When omitted, the localized built-in label from
- * `i18n.collections.visualizations[type]` (e.g. "Table", "Graph") is used.
+ * `i18n.collections.visualizations[type]` (e.g. "Table", "Graph") and the icon of
+ * the built-in registry for the type are used.
  *
  * Lets consumers rename the view switcher chip per instance, e.g. show "Org chart"
- * instead of "Graph" for employees, or "Teams" instead of "Table". The icon still
- * comes from the built-in registry for the visualization type.
+ * instead of "Graph" for employees, or "Teams" instead of "Table" — and tell two
+ * views of the same type apart, e.g. a "Total" and a "Monthly" table with an icon
+ * of their own each.
  */
 export type VisualizationLabelOverrides = {
   /** Custom label shown in the view switcher chip and Settings selector.
    *  Defaults to the localized built-in label for this visualization type. */
   label?: string
+  /** Custom icon shown in the view switcher chip and Settings selector.
+   *  Defaults to the built-in icon for this visualization type. */
+  icon?: IconType
 }
 
 /**


### PR DESCRIPTION
## Description

Built-in visualizations can already rename their view-switcher chip with `label`, but the icon stays fixed by type, so two views of the same type — say a "Total" and a "Monthly" table on Headcount planning's overview — read as twins. This adds an optional `icon` beside `label`, honored by the header switcher and the Settings selector; omitted, everything looks as it does today.

## Type of change

- [x] Variant or improvement of existing pattern

## Implementation details

- feat: `icon?: IconType` on the built-in visualization chip overrides (`VisualizationLabelOverrides`), resolved by `useVisualizationMeta` and the legacy settings popover with the built-in icon as fallback
- test: resolver cases for an icon override with and without a label
- docs: `CustomViewIcons` story and the "Renaming the switcher chips" section now cover the icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)