### PR TITLE
fix(OneDataCollection): stop the empty state collapsing to its padding

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -1809,7 +1809,10 @@ const OneDataCollectionComp = <
         ) : null}
       </div>
       {emptyState ? (
-        <div className="flex flex-1 flex-col items-center justify-center">
+        // Stretch, never center: OneEmptyState is an inline-size container, so a
+        // shrink-to-fit parent leaves it with no content to measure and it
+        // collapses to its own padding. It centers its own contents anyway.
+        <div className="flex flex-1 flex-col items-stretch justify-center">
           <OneEmptyState
             emoji={emptyState.emoji}
             title={emptyState.title}

--- a/packages/react/src/patterns/OneDataCollection/__tests__/emptyStateStretch.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/emptyStateStretch.test.tsx
@@ -1,0 +1,63 @@
+import { screen, waitFor } from "@testing-library/react"
+import { describe, expect, test } from "vitest"
+import { defaultTranslations, I18nProvider } from "@/lib/providers/i18n"
+import { zeroRender as render } from "@/testing/test-utils"
+import { OneDataCollection } from ".."
+import { useDataCollectionSource } from "../hooks/useDataCollectionSource"
+
+/**
+ * OneEmptyState is an inline-size container, so its contents no longer count
+ * towards its own width. Centring it on the cross axis sizes it shrink-to-fit,
+ * and the pair leaves it at its padding with a 0px-wide action button.
+ *
+ * jsdom does no layout, so the width itself is not observable here; the markup
+ * contract that produces it is what this pins.
+ */
+
+type Person = { id: string; name: string }
+
+const Collection = () => {
+  const source = useDataCollectionSource<Person>({
+    dataAdapter: { fetchData: async () => ({ records: [] }) },
+  })
+
+  return (
+    <I18nProvider translations={defaultTranslations}>
+      <OneDataCollection
+        source={source}
+        visualizations={[
+          {
+            type: "table",
+            options: {
+              columns: [{ label: "Name", render: (item: Person) => item.name }],
+            },
+          },
+        ]}
+        emptyStates={{
+          "no-data": {
+            emoji: "💼",
+            title: "No levels yet",
+            description: "Add one to get started",
+            actions: [{ label: "New level", onClick: () => {} }],
+          },
+        }}
+      />
+    </I18nProvider>
+  )
+}
+
+describe("OneDataCollection empty state", () => {
+  test("gives the empty state the full width of its slot", async () => {
+    render(<Collection />)
+
+    const title = await screen.findByText("No levels yet")
+    await waitFor(() => expect(screen.getByText("New level")).toBeVisible())
+
+    const emptyState = title.closest("div.\\@container")
+    expect(emptyState).not.toBeNull()
+
+    const slot = emptyState!.parentElement!
+    expect(slot.classList.contains("items-center")).toBe(false)
+    expect(slot.classList.contains("items-stretch")).toBe(true)
+  })
+})


### PR DESCRIPTION
## What

`OneDataCollection` centres its empty state on the cross axis:

```tsx
<div className="flex flex-1 flex-col items-center justify-center">
  <OneEmptyState … />
```

`items-center` sizes the child shrink-to-fit. Since #5383 `OneEmptyState`'s root carries `@container`, so it has `container-type: inline-size` and its contents no longer contribute to its own inline size. Shrink-to-fit plus inline-size containment leaves it at its own padding — 64px — with the title and description wrapping to slivers, the `@sm:` queries never firing, and the action button at **0px wide and unclickable**.

The wrapper now stretches. `OneEmptyState` centres its own contents, so nothing moves visually except that the box is the width of its slot again.

## Measured, on a live page (Factorial job catalog, an empty role, f0 6.84.2)

| | empty state | "New level" button |
|---|---|---|
| before #5383 (`container-type: normal`) | 448px | 122 × 32, visible |
| on 6.84.2 today | **64px** | **0 × 32, `isVisible() === false`** |
| with this fix (`items-stretch`) | 1354px | 122 × 32, visible |

Both counterfactuals were applied in the browser on the same page, so the two halves of the cause are each independently confirmed.

## Blast radius

That wrapper is the only place `OneEmptyState` is rendered from a collection, and it renders every empty-state type — `no-data`, `no-results`, `error`. The default `no-results` state ships a "Clear filters" action and `error` ships "Retry", so on 6.84.1+ **every empty collection in a consuming app has an invisible primary action**, not just those with a custom empty state. It surfaced as a customer bug on Factorial (FCT-63200) five days after the bump.

## Testing

`emptyStateStretch.test.tsx` fails on main and passes with the fix.

jsdom does no layout, so the width itself is not observable in a unit test — the test pins the markup contract that produces it (the slot must not shrink-wrap an inline-size container). The widths above are the real evidence.
