### PR TITLE
test(F0CommandPalette): wait for the search answer, not for a task of our own

### DIFF
--- a/packages/react/src/experimental/Overlays/F0CommandPalette/__tests__/F0CommandPalette.test.tsx
+++ b/packages/react/src/experimental/Overlays/F0CommandPalette/__tests__/F0CommandPalette.test.tsx
@@ -5,6 +5,7 @@ import {
   fireEvent,
   screen,
   userEvent,
+  waitFor,
   zeroRender as render,
 } from "@/testing/test-utils"
 import { F0CommandPaletteProvider, useCommandPalette } from ".."
@@ -236,8 +237,13 @@ const open = async (options: SetupOptions = {}) => {
 
 const ZWSP = "​"
 
-/** Let a deferred state update land: the search hook defers by one task. */
 const flushTask = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+/** The hook defers each answer by a task, so wait for it, not for a timer. */
+const settled = () =>
+  waitFor(() =>
+    expect(screen.getByRole("listbox")).not.toHaveAttribute("aria-busy")
+  )
 
 const chipsOf = (field: HTMLElement) =>
   Array.from(field.querySelectorAll("[data-scope-chip]"))
@@ -1126,19 +1132,13 @@ describe("remote entity search", () => {
     }
     return {
       provider,
-      // Resolving queues a microtask AND the hook defers the state update by a
-      // task (see `onNextTask`), so both have to be flushed before asserting.
       release: async (refs: CommandEntityRef[]) => {
-        await act(async () => {
-          release(refs)
-          await flushTask()
-        })
+        release(refs)
+        await settled()
       },
       reject: async () => {
-        await act(async () => {
-          reject()
-          await flushTask()
-        })
+        reject()
+        await settled()
       },
     }
   }
@@ -1216,10 +1216,9 @@ describe("remote entity search", () => {
       id: "d-2",
       label: 'MacBook Air 13"',
     }
-    await act(async () => {
-      answers[1]!([air])
-      await flushTask()
-    })
+    answers[1]!([air])
+    await settled()
+    // The stale answer gets its task too, and is expected to do nothing with it.
     await act(async () => {
       answers[0]!([laptopRef])
       await flushTask()


### PR DESCRIPTION
## Description

Fixes the flaky unit test that broke `main`'s Unit Tests job ([run 34354297223](https://github.com/factorialco/f0/actions/runs/34354297223/job/102475023234)): `F0CommandPalette > remote entity search > says so when a provider cannot be reached`.

Nothing was wrong with the palette — the test's synchronisation was.

## Type of change

- [x] Bug fix <!-- flaky test, test-only change -->

## Implementation details

`useEntitySearch` deliberately lands every provider answer on a fresh task (`onNextTask`, which exists to keep the update out of the dialog's own commit). The tests waited for that by racing a `setTimeout(0)` of their own:

```ts
await act(async () => {
  reject()
  await flushTask() // ← its timer is armed BEFORE the hook's
})
expect(screen.getByRole("option", { name: /Could not load these results/ }))
```

Both timers are armed in the same tick, so whether the hook's expires first is luck. On a loaded runner the microtask drain that arms it slips past the test's timer, `act` resolves, and the assertion reads a listbox that is still `aria-busy` with no row rendered — exactly what the CI log shows (`aria-busy="true"`, no `option` in the accessible-roles dump).

The fix waits for the *state the answer produces*: the listbox drops `aria-busy` once no provider is outstanding, whether the provider answered with records or rejected. One `settled()` helper covers both paths, so `release()` / `reject()` no longer need their own `act` + flush. The one remaining bare `flushTask` is the stale-answer test, where the late answer is *expected* to change nothing and so has nothing observable to wait for.

Reproduced locally in a throwaway test by stalling the microtask drain 200 ms between the two timers — the same shape as a busy runner. The old assertion fails with the identical `Unable to find an accessible element with the role "option" and name /Could not load these results/`; the `waitFor`-based one passes.

## Checklist

- [x] Unit tests green (67/67), including three runs under four saturating CPU hogs
- [x] `pnpm check:lint-debt` → `114 warning(s) (baseline 114), no new debt`
- [x] `pnpm lint` clean
- [x] No production code touched — test-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
