### PR TITLE
feat(F0Chat): mark messages drafted with One

### DIFF
--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -641,6 +641,9 @@ export const defaultTranslations = {
     edit: "Edit",
     editing: "Editing",
     edited: "edited",
+    // Muted label on a message drafted with One and approved by its sender.
+    // "One" is the product name and stays untranslated.
+    aiAssisted: "Drafted with One",
     cancelEdit: "Cancel edit",
     saveEdit: "Save",
     // Shown as the quoted sender's name when the replied-to message is your own.

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -781,7 +781,8 @@ export const Default: Story = {
  * `grp-everything-stress` — a year of history, ten extra pages, every message
  * shape (albums of 1/2/3/4/7, a 1:10 tower, a dimensionless photo, video,
  * voice, location, pdf/sheet/docx/text cards, file chips, link previews,
- * replies, mentions, reactions, edits, deletions, failures, system rows) and a
+ * replies, mentions, reactions, edits, AI-assisted drafts, deletions, failures,
+ * system rows) and a
  * live typing indicator.
  *
  * What to exercise here:

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -166,6 +166,23 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
       </tr>
       <tr>
         <td>
+          <code>message.aiAssisted</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          The message was drafted with One and approved by its author, who
+          remains the sender. Shows the muted “Drafted with One” label in the
+          meta cluster after the body, before “edited” and the time. Hidden on
+          deleted tombstones. Map it from server-set message metadata, never
+          from body text.
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>runtime.loadReactionUsers</code>
         </td>
         <td>
@@ -355,6 +372,7 @@ memoization is required of the host.
 - WHEN `canSend` is false and the host does not set `canReply` → THEN Reply is hidden, because replying needs a composer to reply into.
 - WHEN the current user cannot send in a channel → THEN the composer is replaced by `channel.readOnlyNotice` (or a generic line), and dragging files over the panel no longer offers a drop affordance.
 - WHEN a channel is an announcement → THEN messages carry no per-message clock and the day separator carries the time instead, because those posts are seeded rather than sent and their minute would be invented. The header also drops its ellipsis: a fixed, short transcript has nothing to search.
+- WHEN a message has `aiAssisted` → THEN the meta cluster reads “Drafted with One · edited · time”, each part only when present, on every surface that shows the message: the text bubble, and the media or the line under it for an attachment-only message. A deleted tombstone shows only the time.
 - WHEN a message carries a `kind: "card"` attachment → THEN F0 renders an `F0Card` at the shared media width from the host's data (avatar, title, description, image, one footer action). It keeps its own border and radius rather than chaining into the bubble stack, and it is not editable — the composer has no affordance for a card, so loading one into it could only drop it on save.
 - WHEN a group has an explicit emoji → THEN the sidebar and chat header render that emoji.
 - WHEN a group has neither an emoji nor a custom team/company image → THEN the sidebar and chat header render `＃` instead of an empty generated avatar.
@@ -472,7 +490,7 @@ The message action menu opens the Info panel with standard button navigation. It
 
 ### Screen reader behavior
 
-Reaction buttons announce their emoji label, count, and pressed state. Group reader lists use the localized “Read by” count as their accessible name. The final-message footer is a polite, atomic status region, so assistive technology announces the asynchronous transition from “Sent” to “Read”. It reports delivery only — the time belongs to the message itself, which carries it in its own bubble.
+Reaction buttons announce their emoji label, count, and pressed state. Group reader lists use the localized “Read by” count as their accessible name. The final-message footer is a polite, atomic status region, so assistive technology announces the asynchronous transition from “Sent” to “Read”. It reports delivery only — the time belongs to the message itself, which carries it in its own bubble. The visible meta cluster is hidden from assistive technology, and a hidden copy after the content repeats it, so the “Drafted with One” and “edited” markers are read in the same order sighted readers see them — for attachment-only messages too.
 
 Attachment actions include the filename in their accessible names. Each video
 player is contained in a figure named after its file and exposes a contextual

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -102,6 +102,8 @@ const BubblePalette = (): ReactNode => {
     body: "My neutral bubble",
     createdAt: "2026-01-01T12:00:00.000Z",
     isMine: true,
+    aiAssisted: true,
+    editedAt: "2026-01-01T12:05:00.000Z",
     attachments: [
       {
         kind: "voice",

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatBubble.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatBubble.test.tsx
@@ -370,6 +370,63 @@ describe("ChatBubble meta cluster", () => {
     )
   })
 
+  it("puts 'Drafted with One' in the meta cluster of an AI-assisted message", () => {
+    render(
+      <ChatBubble
+        message={{ ...makeMessage("Reminder: timesheets"), aiAssisted: true }}
+        isMine
+      />
+    )
+    expect(screen.getByTestId("chat-message-time")).toHaveTextContent(
+      `Drafted with One · ${nowClock}`
+    )
+  })
+
+  it("orders the cluster as origin, edited, time", () => {
+    render(
+      <ChatBubble
+        message={{
+          ...makeMessage("Reminder: timesheets"),
+          aiAssisted: true,
+          editedAt: now,
+        }}
+        isMine
+      />
+    )
+    expect(screen.getByTestId("chat-message-time")).toHaveTextContent(
+      `Drafted with One · edited · ${nowClock}`
+    )
+  })
+
+  it("repeats 'Drafted with One' for assistive tech in reading order", () => {
+    const { container } = render(
+      <ChatBubble
+        message={{ ...makeMessage("Reminder: timesheets"), aiAssisted: true }}
+        isMine
+      />
+    )
+    expect(container.querySelector(".sr-only")).toHaveTextContent(
+      `Drafted with One · ${nowClock}`
+    )
+  })
+
+  it("drops both 'Drafted with One' and 'edited' on a deleted tombstone", () => {
+    render(
+      <ChatBubble
+        message={{
+          ...makeMessage(""),
+          deleted: true,
+          aiAssisted: true,
+          editedAt: now,
+        }}
+        isMine
+      />
+    )
+    expect(screen.getByTestId("chat-message-time")).toHaveTextContent(
+      new RegExp(`^${nowClock}$`)
+    )
+  })
+
   it("does not show 'edited' on a deleted tombstone", () => {
     render(
       <ChatBubble

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.announcement.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.announcement.test.tsx
@@ -143,6 +143,18 @@ describe("announcement channel", () => {
     expect(screen.getByTestId("chat-date-separator")).toBeInTheDocument()
   })
 
+  // The meta cluster is what would carry the marker, and it is off here for
+  // everyone: the sr-only twin must stay silent too, not only the visible copy.
+  it("does not announce 'Drafted with One' either, since the meta cluster is off", () => {
+    renderChat(
+      makeRuntime({
+        messages: [{ ...welcome, aiAssisted: true }, cardMessage()],
+      })
+    )
+    // queryByText also matches sr-only text, so this covers the hidden twin.
+    expect(screen.queryByText(/Drafted with One/)).not.toBeInTheDocument()
+  })
+
   it("renders the card and lets it act — the one interactive thing here", async () => {
     const onClick = vi.fn()
     renderChat(makeRuntime({ messages: [welcome, cardMessage(onClick)] }))

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -470,6 +470,36 @@ describe("F0Chat", () => {
     )
   })
 
+  it("shows and announces 'Drafted with One' on an AI-assisted attachment-only message (no text bubble)", () => {
+    const { container } = renderChat(
+      makeRuntime({
+        messages: [
+          {
+            id: "a-ai",
+            author: { id: "me", name: "Me" },
+            body: "",
+            createdAt: now,
+            isMine: true,
+            status: "read",
+            aiAssisted: true,
+            attachments: [
+              { kind: "image", url: "blob:img", name: "photo.png" },
+            ],
+          },
+        ],
+      })
+    )
+    expect(screen.getAllByTestId("chat-message-time")[0]).toHaveTextContent(
+      /^Drafted with One · /
+    )
+    // The header has its own sr-only labels; the twin is the one that starts
+    // with the marker.
+    const twins = Array.from(container.querySelectorAll(".sr-only")).filter(
+      (el) => (el.textContent ?? "").startsWith("Drafted with One · ")
+    )
+    expect(twins).toHaveLength(1)
+  })
+
   it("colors media attachments but keeps file items neutral", () => {
     const author = {
       id: "other",

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
@@ -20,7 +20,7 @@ import { ChatCardAttachment } from "./ChatCardAttachment"
 import { ChatDocumentAttachmentCard } from "./ChatDocumentAttachmentCard"
 import { ChatImageTile } from "./ChatImageTile"
 import { ChatLocationAttachment } from "./ChatLocationAttachment"
-import { ChatMessageMeta } from "./ChatMessageMeta"
+import { ChatMessageMeta, ChatMessageMetaLabel } from "./ChatMessageMeta"
 import { ChatVideoAttachment } from "./ChatVideoAttachment"
 import { ChatVoiceAttachment } from "./ChatVoiceAttachment"
 
@@ -312,6 +312,11 @@ export const ChatMessageAttachments = ({
       {metaHost === "below" ? (
         <ChatMessageMeta message={message} placement="below" />
       ) : null}
+      {/* No caption means no bubble, and the bubble is where the sr-only
+          twin normally lives — so an attachment-only message carries its own,
+          after the content in reading order. `metaHost` is non-null exactly
+          when the bubble is absent, so this never double-announces. */}
+      {metaHost !== null ? <ChatMessageMetaLabel message={message} /> : null}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageMeta.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageMeta.tsx
@@ -17,7 +17,9 @@ import { formatClock } from "../utils/natural-time"
  *   chips, whose markup we don't own.
  *
  * `edited` joins the same cluster instead of trailing the body on its own —
- * again what WhatsApp does, and it keeps a single meta group per message.
+ * again what WhatsApp does, and it keeps a single meta group per message. So
+ * does the "Drafted with One" marker of an AI-assisted message: one cluster
+ * per message, and the `sr-only` twin carries it to assistive technology.
  *
  * One type scale across all three (`text-xs`): the clock reads as the same
  * piece of information wherever it lands, and a message with a photo above its
@@ -41,7 +43,7 @@ export const ChatMessageMeta = ({
 }): ReactNode => {
   const i18n = useI18n()
   const channelType = useF0ChatChannelType()
-  const label = metaLabel(message, i18n.chat.edited)
+  const label = <MetaText parts={metaParts(message, i18n.chat)} />
 
   if (channelType === "announcement") {
     return null
@@ -84,6 +86,13 @@ export const ChatMessageMeta = ({
   // stays correct for any body length or label ("22:14" vs "edited · 22:14").
   //
   // The pin's offsets mirror the body box's px-3.5 py-2.5.
+  //
+  // Neither copy is nowrap as a whole: on a narrow bubble the "Drafted with
+  // One" origin may fold onto its own line while "edited · 22:14" stays
+  // together (see MetaText). Both copies wrap at the same point because they
+  // get the same width — the twin is capped at the content width and the pin
+  // spans it (left-3 to right-3), each with the same 1.5 leading gap — so the
+  // reserve stays exactly as tall as the pin.
   return (
     <>
       <span
@@ -91,7 +100,7 @@ export const ChatMessageMeta = ({
         // Must track the pinned copy's type scale exactly — this is what
         // reserves its width, and a narrower twin lets the time overlap the
         // last word.
-        className="invisible ml-1.5 inline-block select-none whitespace-nowrap align-bottom text-xs leading-none"
+        className="invisible ml-1.5 inline-block max-w-full select-none align-bottom text-xs leading-none"
         data-testid="chat-message-time-reserve"
       >
         {label}
@@ -101,7 +110,7 @@ export const ChatMessageMeta = ({
       <span
         aria-hidden
         className={cn(
-          "absolute bottom-2.5 right-3 select-none whitespace-nowrap text-xs leading-none [unicode-bidi:isolate]",
+          "absolute bottom-2.5 left-3 right-3 select-none pl-1.5 text-right text-xs leading-none [unicode-bidi:isolate]",
           // `f1-foreground-secondary` is white 50% in dark, which lands just
           // under AA on the coloured bubbles; 60% clears it on every hue.
           "text-f1-foreground-tertiary dark:text-[hsl(var(--neutral-100)/0.6)]"
@@ -126,13 +135,46 @@ export const ChatMessageMetaLabel = ({
   if (channelType === "announcement") {
     return null
   }
-  return <span className="sr-only">{metaLabel(message, i18n.chat.edited)}</span>
+  return (
+    <span className="sr-only">{metaLabel(metaParts(message, i18n.chat))}</span>
+  )
 }
 
-const metaLabel = (message: F0ChatMessage, editedLabel: string): string => {
-  const time = formatClock(new Date(message.createdAt))
-  // A tombstone never carries the edit history of what it replaced.
-  return message.editedAt && !message.deleted
-    ? `${editedLabel} · ${time}`
-    : time
+type MetaParts = {
+  /** "Drafted with One", or null when the message was not AI-assisted. */
+  origin: string | null
+  /** "edited · 22:14" or "22:14" — never split across lines. */
+  tail: string
 }
+
+const metaParts = (
+  message: F0ChatMessage,
+  labels: { edited: string; aiAssisted: string }
+): MetaParts => {
+  const time = formatClock(new Date(message.createdAt))
+  // A tombstone never carries the edit history, nor the origin, of what it
+  // replaced.
+  if (message.deleted) {
+    return { origin: null, tail: time }
+  }
+  return {
+    origin: message.aiAssisted ? labels.aiAssisted : null,
+    tail: message.editedAt ? `${labels.edited} · ${time}` : time,
+  }
+}
+
+const metaLabel = ({ origin, tail }: MetaParts): string =>
+  origin ? `${origin} · ${tail}` : tail
+
+/**
+ * The visible cluster. The only allowed line break is between the origin and
+ * the tail: the edited marker and the time read as one unit.
+ */
+const MetaText = ({ parts }: { parts: MetaParts }): ReactNode =>
+  parts.origin ? (
+    <>
+      {parts.origin} · <span className="whitespace-nowrap">{parts.tail}</span>
+    </>
+  ) : (
+    parts.tail
+  )

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMessageMeta.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatMessageMeta.test.tsx
@@ -28,6 +28,21 @@ describe("ChatMessageMeta", () => {
     }
   )
 
+  it.each(["bubble", "overlay", "below"] as const)(
+    "leads the %s cluster with 'Drafted with One' on an AI-assisted message",
+    (placement) => {
+      render(
+        <ChatMessageMeta
+          message={{ ...MESSAGE, aiAssisted: true }}
+          placement={placement}
+        />
+      )
+      expect(screen.getByTestId("chat-message-time")).toHaveTextContent(
+        `Drafted with One · ${formatClock(new Date(CREATED_AT))}`
+      )
+    }
+  )
+
   it("writes the clock in the reader's own locale", () => {
     render(<ChatMessageMeta message={MESSAGE} placement="below" />)
     // Through the shared formatter, not a hand-rolled 24-hour string: on a

--- a/packages/react/src/sds/chat/F0Chat/mocks/__tests__/mockSeeds.everything-stress.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/__tests__/mockSeeds.everything-stress.test.ts
@@ -54,6 +54,7 @@ describe("Everything Chat stress seed", () => {
     )
     expect(messages.some((message) => message.deleted)).toBe(true)
     expect(messages.some((message) => message.edited)).toBe(true)
+    expect(messages.some((message) => message.aiAssisted)).toBe(true)
   })
 
   it("covers every outgoing status and membership event", () => {
@@ -87,6 +88,10 @@ describe("Everything Chat stress seed", () => {
     expect(sending?.readAt).toBeUndefined()
     expect(messages.some((message) => message.deleted)).toBe(true)
     expect(messages.some((message) => message.editedAt)).toBe(true)
+    expect(messages.some((message) => message.aiAssisted)).toBe(true)
+    expect(
+      messages.some((message) => message.aiAssisted && message.editedAt)
+    ).toBe(true)
     expect(messages.some((message) => message.readByCount === 57)).toBe(true)
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -213,6 +213,8 @@ type MessageLine = {
   deleted?: boolean
   /** Marks the message as edited shortly after it was sent. */
   edited?: boolean
+  /** Marks the message as drafted with One and approved by its sender. */
+  aiAssisted?: boolean
 }
 
 /** A membership event in the transcript — becomes a centered system row. */
@@ -750,6 +752,17 @@ const everythingStressLines = (): Line[] => {
     body: "This message intentionally demonstrates a failed send",
     status: "failed",
     failureReason: "Simulated network error for the stress fixture",
+  })
+  add({
+    from: MARCUS,
+    body: "Reminder: timesheets close on Friday, please submit yours by noon.",
+    aiAssisted: true,
+  })
+  add({
+    from: MARCUS,
+    body: "Reminder: timesheets close on Friday, please submit yours by 11:00.",
+    aiAssisted: true,
+    edited: true,
   })
   add({
     from: MARCUS,
@@ -1724,6 +1737,7 @@ export const buildSeedMessages = (seed: Seed): F0ChatItem[] => {
       editedAt: line.edited
         ? new Date(sentMs + 5 * 60_000).toISOString()
         : undefined,
+      aiAssisted: line.aiAssisted,
     }
   })
   // Second pass: resolve reply references now that every message has an id.

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -354,6 +354,14 @@ export type F0ChatMessage = {
    * reactions/read updates), so it never false-positives the label.
    */
   editedAt?: string
+  /**
+   * The message was drafted with One (Factorial's AI) and approved by its
+   * author, who remains the sender. Drives the muted "Drafted with One" label
+   * after the body, next to the edited marker, so the reader and assistive
+   * technology learn it on every surface that shows the content. The host maps
+   * it from server-set message metadata, never from body text.
+   */
+  aiAssisted?: boolean
 }
 
 /**


### PR DESCRIPTION
## Description

Adds `aiAssisted` to `F0ChatMessage` so a message drafted with One and approved by its sender shows a muted "drafted with One" label in the per-message meta cluster ("drafted with One · edited · 22:14"), on every surface that shows the message, and reaches assistive technology through the existing sr-only twin. Needed by Factorial Chat's AI-assisted direct messages (factorialco/factorial#113479): the product rule requires the marker wherever the content renders, never as body text.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots (if applicable)

Storybook: `Domain specific / Communications / F0Chat → Snapshot`, the "Sender surface palette" own bubble shows the full cluster; `ApplicationFrame → EverythingChannel` has two Marcus messages with the marker, one of them edited. On a narrow bubble the origin folds onto its own line and "edited · time" stays together.

## Implementation details

- feat: add `aiAssisted?: boolean` to `F0ChatMessage`, mapped by hosts from server-set message metadata
- feat: render "drafted with One" in `ChatMessageMeta` as the first part of the meta cluster, hidden on deleted tombstones; i18n key `chat.aiAssisted`, product name untranslated
- fix: render the sr-only meta twin on attachment-only messages, which had none, so the marker and "edited" are announced there too

  <details>
  <summary>Why?</summary>

  The twin lived only in the text bubble. An attachment-only message skips the bubble, so its meta was `aria-hidden` with no readable copy. `ChatMessageAttachments` now renders the twin after the content exactly when the bubble is absent, so nothing is announced twice.
  </details>

- fix: let the meta cluster wrap between the origin and the nowrap "edited · time" tail instead of overflowing a narrow bubble
- test: ChatBubble, ChatMessageMeta, F0Chat, announcement and seed tests for the new field, the ordering, the tombstone, the twin, and the wrap; Snapshot palette message and everything-stress seed carry the marker
- docs: MDX props row, behavior rule and screen-reader note
- 
<img width="361" height="156" alt="image" src="https://github.com/user-attachments/assets/7994f3db-4098-4ef5-8ef9-8727423004d6" />



