### PR TITLE
feat(f0compose): personal agent entry across Home and navigation

### DIFF
--- a/packages/f0compose/src/prototypes/home/FactorialAgentIcon.tsx
+++ b/packages/f0compose/src/prototypes/home/FactorialAgentIcon.tsx
@@ -1,0 +1,46 @@
+import {
+  forwardRef,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+  type SVGProps,
+} from "react"
+
+import {
+  approvedAgentArtwork,
+  mountApprovedAgentMotion,
+} from "./approvedAgentMotion.js"
+
+/** The approved artwork supplied as an F0Button icon, without rebuilding its animation. */
+export const FactorialAgentIcon = forwardRef<
+  SVGSVGElement,
+  SVGProps<SVGSVGElement> & { animate?: "normal" | "animate" }
+>(function FactorialAgentIcon(
+  { animate: _animate, className, ...props },
+  forwardedRef
+) {
+  const scene = useRef<SVGSVGElement>(null)
+  useImperativeHandle(forwardedRef, () => scene.current!, [])
+  useEffect(
+    () => (scene.current ? mountApprovedAgentMotion(scene.current) : undefined),
+    []
+  )
+  // F0's standard icon wrapper forces thin path strokes; the approved eyes own their stroke weight.
+  const motionClassName = className
+    ?.split(" ")
+    .filter((token) => !token.includes("]:stroke-"))
+    .join(" ")
+  return (
+    <svg
+      {...props}
+      className={motionClassName}
+      ref={scene}
+      viewBox="100 0 400 400"
+      overflow="hidden"
+      aria-hidden="true"
+      focusable="false"
+      data-factorial-agent-icon
+      dangerouslySetInnerHTML={{ __html: approvedAgentArtwork }}
+    />
+  )
+})

--- a/packages/f0compose/src/prototypes/home/Home.tsx
+++ b/packages/f0compose/src/prototypes/home/Home.tsx
@@ -1476,7 +1476,7 @@ function HomeCanvas() {
             {/* See showPromptBar: the calendar and People frames carry no
               composer. Every other screen keeps ONE pinned. */}
             {showPromptBar && (
-              <div data-home-promptbar className="relative w-full shrink-0">
+              <div data-home-promptbar className="relative w-[712px] max-w-full shrink-0">
                 <div data-hybrid-target />
               </div>
             )}

--- a/packages/f0compose/src/prototypes/home/Home.tsx
+++ b/packages/f0compose/src/prototypes/home/Home.tsx
@@ -5,7 +5,12 @@ import {
   type ModuleId,
 } from "@factorialco/f0-react"
 import { F0AvatarModule } from "@factorialco/f0-react/dist/experimental"
-import { Ellipsis, Reaction, Settings } from "@factorialco/f0-react/icons/app"
+import {
+  Cross,
+  Ellipsis,
+  Reaction,
+  Settings,
+} from "@factorialco/f0-react/icons/app"
 import { useEffect, useLayoutEffect, useRef, useState } from "react"
 import { useSearchParams } from "react-router-dom"
 
@@ -15,6 +20,7 @@ import type { WindowId } from "./windows/types"
 
 import { AgentsScreen } from "./agents/AgentsScreen"
 import { agentById } from "./agents/agentStore"
+import { CalendarScreen } from "./calendar/CalendarScreen"
 import {
   animateChatClose,
   ChatsColumn,
@@ -23,7 +29,11 @@ import {
   MaximizedChat,
   useChats,
 } from "./comms/ChatsColumn"
-import { onChatRequest, setOpenChats } from "./comms/chatStore"
+import {
+  onChatRequest,
+  onChatsCloseRequest,
+  setOpenChats,
+} from "./comms/chatStore"
 import { EmployeeCanvas } from "./EmployeeCanvas"
 import {
   PROFILE_PEOPLE,
@@ -31,25 +41,24 @@ import {
   type ProfilePerson,
 } from "./fixtures"
 import { HomeNav } from "./HomeNav"
+import { HybridHome } from "./HybridHome"
+import { ModuleScreen } from "./ModuleScreen"
 import { NeedsYouItem } from "./NeedsYouItem"
 import { phaseFor, useNeedsYou, visibleTasks } from "./needsYouStore"
 import {
+  goHome,
   onWindowRequest,
   onWindowsCollapseRequest,
   useConversations,
 } from "./one/conversationStore"
 import { ConversationView } from "./one/ConversationView"
 import { PlayOutline } from "./one/PlayOutline"
-import { OnePromptBar } from "./OnePromptBar"
+import { PeopleScreen } from "./people/PeopleScreen"
 import { PoliciesScreen } from "./policies/PoliciesScreen"
 import { useProfile } from "./profileStore"
 import { SectionHeader } from "./SectionHeader"
 import { ClockInButton } from "./windows/ClockInButton"
-import {
-  isModulePane,
-  isModuleWindowView,
-  modulePaneId,
-} from "./windows/ModulePane"
+import { isModulePane, modulePaneId } from "./windows/ModulePane"
 import { CANVAS_MIN_PEEK, stackWidth } from "./windows/stack"
 import { useWindows } from "./windows/useWindows"
 import {
@@ -956,6 +965,14 @@ const GREETINGS = [
 ]
 
 export default function Home() {
+  return (
+    <HybridHome>
+      <HomeCanvas />
+    </HybridHome>
+  )
+}
+
+function HomeCanvas() {
   useTransientScrollbars()
   useFullBleedChrome()
   useSingleTooltip()
@@ -971,35 +988,23 @@ export default function Home() {
   const windows = useWindows()
   const chats = useChats()
   const { conversations, activeId } = useConversations()
-  const activeConversation = conversations.find((c) => c.id === activeId)
   // Sub-screens have distinct URLs (?view=policies); an open conversation
   // always takes the canvas over the screen.
   const [searchParams, setSearchParams] = useSearchParams()
   const view = searchParams.get("view")
-  /**
-   * A Hub section shown as a WINDOW over One rather than instead of One
-   * (Oskar, 2026-09-08: "a modo ventana para mantener como suelo de la
-   * aplicacion a One"). Deliberately NOT derived from
-   * `activeConversation`: the whole point is that both are on screen at
-   * once, so a conversation must not cancel the window the way it cancels
-   * a screen.
-   */
-  const windowView = isModuleWindowView(view) ? view : null
+  const activeConversation =
+    !view && !chats.state.open.some(isTicket)
+      ? conversations.find((conversation) => conversation.id === activeId)
+      : undefined
+  // Module screens now occupy the canvas. The persistent agent entry owns
+  // the adjacent conversation, while the existing widget stacks stay intact.
+  const windowView = null
   useResetParam(searchParams)
-  /**
-   * The screen the canvas is actually showing. An open conversation takes
-   * the canvas over, so every screen-shaped rule below — the title, the
-   * edge-to-edge gutters, whether the composer shows — has to stop
-   * applying while one is open, or an expanded conversation inherits the
-   * People screen's "no composer, no scroller" layout.
-   */
-  const screenView = activeConversation || windowView ? null : view
-  // Only SCREENS title the navbar, and Agents is no longer one of them
-  // (Oskar, 2026-09-08: "quita lo de arriba a la izquierda que pone
-  // agents" — its face has to match New's, and New has no screen title).
-  // `people` and `calendar` fall through too: a window carries its title
-  // in its own 44px header.
-  const screenTitle = screenView === "policies" ? "Policies" : undefined
+  const screenView = view
+  const screenTitle = screenView
+    ? screenView.charAt(0).toUpperCase() +
+      screenView.slice(1).replaceAll("-", " ")
+    : undefined
   // Screens that run EDGE TO EDGE and scroll their own content: nesting
   // them inside the canvas gutters plus its scroller would give them a
   // second scrollbar inside the first.
@@ -1007,16 +1012,9 @@ export default function Home() {
     screenView === "calendar" ||
     screenView === "people" ||
     screenView === "agents"
-  // Screens whose frame carries no ONE composer. The calendar's grid uses
-  // the full height and a floating composer would cover the hours you are
-  // reading; the People screen reaches One from the button ON its
-  // headcount banner instead; and Agents has its OWN brief box, pinned at
-  // the bottom of its canvas, so a second composer below it would be two
-  // places to type the same thing. Agents keeps ownership of that one
-  // deliberately: it has to vanish on the list face, it carries its own
-  // placeholder and submit handler, and the suggestions bridge listens on
-  // `document` — so two mounted instances would fight for the events.
-  const showPromptBar = !fullWidthView
+  // Agents owns its specialized brief composer; other screens reserve the
+  // shared agent strip below their scrolling content and fixed actions.
+  const showPromptBar = screenView !== "agents"
   /**
    * The widgets are the HOME canvas's, and they belong to it AT REST: the
    * moment any window occupies the canvas area they go (Oskar,
@@ -1270,11 +1268,30 @@ export default function Home() {
     console.log("open", task.id)
   }
 
+  useEffect(
+    () =>
+      onChatsCloseRequest(() => {
+        if (!chats.state.open.length) return
+        let pending = chats.state.open.length
+        chats.state.open.forEach((id) =>
+          animateChatClose(id, () => {
+            pending -= 1
+            if (!pending) chats.closeAll()
+          })
+        )
+      }),
+    [chats.state.open, chats.closeAll]
+  )
+
   // A maximized window takes over the whole canvas (Figma 1365:12972) —
   // navbar, content, and prompt bar give way until it's restored.
   if (windows.state.maximized) {
     return (
-      <div className="flex min-h-full w-full overflow-hidden">
+      <div
+        data-hybrid-source
+        data-hybrid-maximized
+        className="flex min-h-full w-full overflow-hidden"
+      >
         <MaximizedWindow
           id={windows.state.maximized}
           onRestore={() => windows.toggleMaximized(windows.state.maximized!)}
@@ -1287,7 +1304,11 @@ export default function Home() {
   // same window system, so maximize behaves identically on either side.
   if (chats.state.maximized) {
     return (
-      <div className="flex min-h-full w-full overflow-hidden">
+      <div
+        data-hybrid-source
+        data-hybrid-maximized
+        className="flex min-h-full w-full overflow-hidden"
+      >
         <MaximizedChat
           id={chats.state.maximized}
           onRestore={() => chats.toggleMaximized(chats.state.maximized!)}
@@ -1298,7 +1319,7 @@ export default function Home() {
   }
 
   return (
-    <div className="flex min-h-full w-full overflow-hidden">
+    <div data-hybrid-source className="flex min-h-full w-full overflow-hidden">
       {/* The pane the window stacks measure themselves against. The split
           conversation panel sits OUTSIDE it, so an overlaying stack
           (`absolute right-0`) pins to the panel's edge instead of covering
@@ -1346,7 +1367,7 @@ export default function Home() {
                   // The module dock is a left overlay too.
                   marginLeft: overlayChats ? "auto" : undefined,
                 }
-              : { flex: "1 1 0%", minWidth: CANVAS_MIN_WIDTH }
+              : { flex: "1 1 0%", minWidth: 0 }
           }
         >
           <div className="flex flex-col">
@@ -1385,17 +1406,40 @@ export default function Home() {
               }`}
             >
               {activeConversation ? (
-                <ConversationView conversation={activeConversation} />
+                <div
+                  data-home-inline-conversation
+                  className="flex w-full min-w-0 flex-col"
+                  role="region"
+                  aria-label="Conversation"
+                >
+                  <div className="flex justify-end">
+                    <F0Button
+                      label="Close conversation"
+                      icon={Cross}
+                      hideLabel
+                      variant="ghost"
+                      size="md"
+                      onClick={goHome}
+                    />
+                  </div>
+                  <ConversationView conversation={activeConversation} />
+                </div>
               ) : /* WINDOW views are absent from this chain on
                      purpose: they render in the layer below instead, and
                      One's floor has to fall through to the greeting so it
                      is still there underneath them. `screenView` is null
                      for them, which is what makes the fall-through
                      automatic rather than a second list to maintain. */
-              screenView === "policies" ? (
+              screenView === "people" ? (
+                <PeopleScreen />
+              ) : screenView === "calendar" ? (
+                <CalendarScreen />
+              ) : screenView === "policies" ? (
                 <PoliciesScreen />
               ) : screenView === "agents" ? (
                 <AgentsScreen />
+              ) : screenView ? (
+                <ModuleScreen title={screenTitle ?? screenView} />
               ) : (
                 <div className="flex w-[712px] max-w-full flex-col gap-8">
                   <div className="flex items-center gap-3">
@@ -1432,11 +1476,8 @@ export default function Home() {
             {/* See showPromptBar: the calendar and People frames carry no
               composer. Every other screen keeps ONE pinned. */}
             {showPromptBar && (
-              <div
-                data-home-promptbar
-                className="relative w-[712px] max-w-full shrink-0 pb-1.5"
-              >
-                <OnePromptBar />
+              <div data-home-promptbar className="relative w-full shrink-0">
+                <div data-hybrid-target />
               </div>
             )}
           </div>

--- a/packages/f0compose/src/prototypes/home/HomeNav.tsx
+++ b/packages/f0compose/src/prototypes/home/HomeNav.tsx
@@ -80,6 +80,7 @@ import { Bot } from "./Bot"
 import { TEAM_ABSENCE_FILTERS, WORKPLACES } from "./calendar/calendarFixtures"
 import { CalGroup, MiniMonth } from "./calendar/MiniMonth"
 import { CHANNEL_CHATS, DIRECT_CHATS } from "./comms/chats"
+import { requestChatsClose } from "./comms/chatStore"
 import { requestChat, useOpenChats } from "./comms/chatStore"
 import { factorialLogo, PROFILE_PEOPLE } from "./fixtures"
 import { motionKeyFor } from "./iconMotion"
@@ -1014,7 +1015,8 @@ function HubPanelBody() {
       {groups.map((group) => (
         <SidebarGroup key={group.label} label={group.label}>
           {group.items.map((label) => {
-            const screen = HUB_VIEWS[label]
+            const screen =
+              HUB_VIEWS[label] ?? label.toLowerCase().replaceAll(" ", "-")
             return (
               <NavRow
                 key={label}
@@ -1306,7 +1308,11 @@ export function HomeNav() {
     // Cal is the one section that is also a DESTINATION: the frame shows
     // its panel beside the week grid, not beside Home (Figma 2621:29173).
     // Comms/Inbox/Hub stay side panels and leave the canvas alone.
-    if (id === "cal") {
+    if (id === "home") {
+      requestChatsClose()
+      goHome()
+      setSearchParams({})
+    } else if (id === "cal") {
       // Also the way back if you closed the calendar WINDOW with its own
       // ✕ while staying in this section: the rail row is still lit and
       // the panel is still open, so clicking it has to reopen the window

--- a/packages/f0compose/src/prototypes/home/HybridHome.tsx
+++ b/packages/f0compose/src/prototypes/home/HybridHome.tsx
@@ -71,6 +71,17 @@ export function HybridHome({ children }: { children: ReactNode }) {
     const timer = window.setTimeout(focusField, 380)
     return () => window.clearTimeout(timer)
   }, [mode])
+  // Collapse the entry without consuming the outside interaction or moving focus.
+  useEffect(() => {
+    if (mode !== "expanded" || !view) return
+    const dismissOutside = (event: PointerEvent) => {
+      if (event.composedPath().includes(composer.current!)) return
+      setMode("idle")
+      setNotice("")
+    }
+    document.addEventListener("pointerdown", dismissOutside, true)
+    return () => document.removeEventListener("pointerdown", dismissOutside, true)
+  }, [mode, view])
   // The composer stays mounted. Only its geometry follows the destination.
   useLayoutEffect(() => {
     const container = work.current,

--- a/packages/f0compose/src/prototypes/home/HybridHome.tsx
+++ b/packages/f0compose/src/prototypes/home/HybridHome.tsx
@@ -1,0 +1,326 @@
+import { F0Button, F0Heading, F0Text } from "@factorialco/f0-react"
+import { Textarea as F0TextAreaInput } from "@factorialco/f0-react/dist/experimental"
+import {
+  ArrowUp,
+  Cross,
+  Maximize,
+  Minimize,
+  Microphone,
+  Paperclip,
+  Sparkles,
+} from "@factorialco/f0-react/icons/app"
+import {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from "react"
+import { type ReactNode } from "react"
+import { useSearchParams } from "react-router-dom"
+
+import { suggestionFor, type Presentation } from "./agentEntryData"
+import { isTicket } from "./comms/ChatsColumn"
+import { useOpenChats } from "./comms/chatStore"
+import { FactorialAgentIcon } from "./FactorialAgentIcon"
+import {
+  goHome,
+  startConversation,
+  sendMessage,
+  useConversations,
+} from "./one/conversationStore"
+import { ConversationView } from "./one/ConversationView"
+import "./agent-entry.css"
+import { useProfile } from "./profileStore"
+
+export function HybridHome({ children }: { children: ReactNode }) {
+  const { conversations, activeId } = useConversations()
+  const activeConversation = conversations.find((c) => c.id === activeId)
+  const [params] = useSearchParams()
+  const openChats = useOpenChats()
+  const profile = useProfile()
+  const view = params.get("view") ?? (openChats.some(isTicket) ? "inbox" : null)
+  const suggestion = suggestionFor(view, profile)
+  const [mode, setMode] = useState<Presentation>("idle")
+  const [draft, setDraft] = useState("")
+  const [notice, setNotice] = useState("")
+  const root = useRef<HTMLDivElement>(null)
+  const composer = useRef<HTMLDivElement>(null)
+  const work = useRef<HTMLDivElement>(null)
+  const previousView = useRef(view)
+  const open = mode === "side" || mode === "focus"
+  useEffect(() => {
+    if (activeId) setMode(view ? "side" : "focus")
+    else setMode("idle")
+  }, [activeId])
+  const compact = !!view && mode === "idle"
+  const typing = draft.length > 0
+  function focusField() {
+    root.current
+      ?.querySelector<HTMLTextAreaElement>("[data-hybrid-composer] textarea")
+      ?.focus()
+  }
+  useEffect(() => {
+    if (previousView.current !== view) {
+      previousView.current = view
+      setMode("idle")
+    }
+  }, [view])
+  useEffect(() => {
+    if (mode === "idle") return
+    const timer = window.setTimeout(focusField, 380)
+    return () => window.clearTimeout(timer)
+  }, [mode])
+  // The composer stays mounted. Only its geometry follows the destination.
+  useLayoutEffect(() => {
+    const container = work.current,
+      floating = composer.current
+    if (
+      !(container instanceof HTMLElement) ||
+      !(floating instanceof HTMLElement)
+    )
+      return
+    let frame = 0
+    const measure = () => {
+      const destination = container.querySelector<HTMLElement>(
+        open && view
+          ? "[data-hybrid-chat-target]"
+          : view
+            ? "[data-hybrid-dock]"
+            : "[data-hybrid-target]"
+      )
+      if (!destination) return
+      const parent = container.getBoundingClientRect(),
+        target = destination.getBoundingClientRect()
+      const width = compact
+        ? 260
+        : Math.min(
+            open && mode === "side" ? target.width - 28 : 780,
+            target.width - (view ? 24 : 0)
+          )
+      const height = compact ? 40 : typing || open ? 136 : 176
+      const x = target.left - parent.left + (target.width - width) / 2
+      const y = target.bottom - parent.top - height - (compact ? 4 : 8)
+      floating.style.setProperty("--composer-x", `${x}px`)
+      floating.style.setProperty("--composer-y", `${Math.max(0, y)}px`)
+      floating.style.setProperty(
+        "--composer-width",
+        `${Math.max(180, width)}px`
+      )
+      floating.style.setProperty("--composer-height", `${height}px`)
+    }
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(measure)
+    })
+    observer.observe(container)
+    const targets = container.querySelectorAll<HTMLElement>(
+      "[data-hybrid-target], [data-hybrid-chat-target], [data-hybrid-dock]"
+    )
+    targets.forEach((target) => observer.observe(target))
+    measure()
+    return () => {
+      observer.disconnect()
+      cancelAnimationFrame(frame)
+    }
+  }, [view, mode, compact, typing, open])
+  function close() {
+    goHome()
+    setMode("idle")
+    window.setTimeout(() => {
+      if (view)
+        root.current
+          ?.querySelector<HTMLButtonElement>("[data-hybrid-trigger] button")
+          ?.focus()
+      else focusField()
+    }, 420)
+  }
+  function send(text = draft) {
+    if (!text.trim()) return
+    if (activeId) sendMessage(text.trim(), activeId)
+    else startConversation(text.trim())
+    setMode(view ? "side" : "focus")
+    setDraft("")
+  }
+  function keys(event: KeyboardEvent<HTMLElement>) {
+    if (event.key === "Escape") {
+      event.preventDefault()
+      close()
+    }
+    if (
+      event.key === "Enter" &&
+      !event.shiftKey &&
+      event.target instanceof HTMLTextAreaElement &&
+      !!event.target.closest("[data-hybrid-composer]") &&
+      !event.nativeEvent.isComposing
+    ) {
+      event.preventDefault()
+      send()
+    }
+  }
+  return (
+    <div
+      className="flex h-full min-h-0 w-full bg-f1-background"
+      ref={root}
+      data-hybrid-root
+      data-mode={view ? mode : "idle"}
+      data-view={view ?? "home"}
+      data-typing={typing}
+      onKeyDown={keys}
+    >
+      <div className="h-full min-w-0 flex-1" ref={work} data-hybrid-work>
+        <div className="h-full" data-hybrid-canvas>
+          {children}
+        </div>
+        <div data-hybrid-dock aria-hidden="true" />
+        <div
+          className="bg-f1-background"
+          data-hybrid-chat
+          data-open={open && !!view}
+          role={open && view ? "region" : undefined}
+          aria-label="Conversation"
+          aria-hidden={!open || !view}
+        >
+          <div className="flex items-center justify-between gap-2 p-4">
+            <F0Heading content="New conversation" variant="heading" />
+            <div className="flex gap-1">
+              {open && view && (
+                <F0Button
+                  label={
+                    mode === "side" ? "Expand conversation" : "Show beside page"
+                  }
+                  icon={mode === "side" ? Maximize : Minimize}
+                  hideLabel
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setMode(mode === "side" ? "focus" : "side")}
+                />
+              )}
+              <F0Button
+                label="Close conversation"
+                icon={Cross}
+                hideLabel
+                variant="ghost"
+                size="sm"
+                onClick={close}
+              />
+            </div>
+          </div>
+          <div
+            className="flex flex-col gap-6 p-6"
+            data-hybrid-messages
+            aria-live="polite"
+          >
+            {view && activeConversation && (
+              <ConversationView conversation={activeConversation} />
+            )}
+          </div>
+          <div data-hybrid-chat-target />
+        </div>
+        <div
+          className="rounded-2xl border border-solid border-f1-border-secondary bg-f1-background"
+          ref={composer}
+          data-hybrid-composer
+          data-compact={compact}
+          data-writing={typing || open}
+        >
+          <div data-hybrid-trigger aria-hidden={!compact}>
+            <F0Button
+              label="What can I do for you?"
+              icon={FactorialAgentIcon}
+              size="md"
+              variant="ghost"
+              onClick={() => {
+                setMode("expanded")
+                setNotice("")
+              }}
+            />
+          </div>
+          <div data-hybrid-editor aria-hidden={compact}>
+            <div
+              className="flex gap-1"
+              data-hybrid-suggestions
+              aria-hidden={typing || open}
+            >
+              <F0Button
+                label={suggestion.label}
+                icon={Sparkles}
+                variant="neutral"
+                size="sm"
+                onClick={() => {
+                  send(suggestion.prompt)
+                }}
+              />
+            </div>
+            <div data-hybrid-field>
+              <F0TextAreaInput
+                label="Message your agent"
+                hideLabel
+                placeholder="Let me know what I can do for you"
+                value={draft}
+                onChange={setDraft}
+                rows={2}
+                maxHeight={72}
+              />
+            </div>
+            <div
+              className="flex items-center justify-between"
+              data-hybrid-actions
+            >
+              <F0Button
+                label="Attach a file"
+                icon={Paperclip}
+                hideLabel
+                size="md"
+                variant="outline"
+                onClick={() =>
+                  setNotice(
+                    "Attachments are not enabled in this interaction prototype."
+                  )
+                }
+              />
+              <div className="flex items-center gap-1">
+                <F0Button
+                  label="Record audio"
+                  icon={Microphone}
+                  hideLabel
+                  size="md"
+                  variant="ghost"
+                  onClick={() =>
+                    setNotice(
+                      "Audio recording is not enabled in this interaction prototype."
+                    )
+                  }
+                />
+                <F0Button
+                  label="Send message"
+                  icon={ArrowUp}
+                  hideLabel
+                  size="md"
+                  disabled={!draft.trim()}
+                  onClick={() => send()}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        {notice && (
+          <div
+            className="rounded-md border border-solid border-f1-border-secondary bg-f1-background p-2"
+            data-hybrid-notice
+            role="status"
+          >
+            <F0Text content={notice} variant="description" />
+            <F0Button
+              label="Dismiss"
+              icon={Cross}
+              variant="ghost"
+              size="sm"
+              onClick={() => setNotice("")}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/f0compose/src/prototypes/home/ModuleScreen.tsx
+++ b/packages/f0compose/src/prototypes/home/ModuleScreen.tsx
@@ -1,0 +1,13 @@
+import { OneEmptyState } from "@factorialco/f0-react"
+
+/** Keep unsupported destinations honest while exercising the shared navigation. */
+export function ModuleScreen({ title }: { title: string }) {
+  return (
+    <div className="flex w-full flex-1 flex-col p-6">
+      <OneEmptyState
+        title={title}
+        description="This section has no sample content in this prototype yet. You can start a conversation from the bar below."
+      />
+    </div>
+  )
+}

--- a/packages/f0compose/src/prototypes/home/agent-entry-plan.md
+++ b/packages/f0compose/src/prototypes/home/agent-entry-plan.md
@@ -1,0 +1,20 @@
+# Personal agent entry
+
+Built on `feat/f0compose` at `2264235f5`, reusing its Home, navigation, People, Calendar, widgets, agent screens and scripted conversation store.
+
+## Behavior
+
+- Home keeps its existing background, widgets and navigation. Sending a message replaces only the central greeting and Needs you content with the conversation. Closing restores that content.
+- Opening Hub changes only the navigation menu. Choosing a destination, opening Calendar or opening an Inbox task minimizes the agent into a reserved bottom strip.
+- The page has its own inset frame. The strip shares the navigation background. The menu divider appears only on Home.
+- The entry is an F0 ghost button with a 20px animated icon and larger eyes. Clicking it expands the same mounted composer over the page with a medium shadow; the page does not resize.
+- One suggestion reflects the current page/profile and sends immediately when clicked. There is no suggestion overflow menu.
+- The composer contracts from 176px to 136px from its top edge when typing or conversing. Text and action controls are anchored to the bottom. Actions use F0's medium buttons, matching One.
+- Outside Home, sending opens the conversation on the right. Only the expand control switches to the large conversation view, retaining navigation. Closing restores the page and compact entry.
+- Drafts and the mounted textarea survive layout changes. Conversation history uses the existing store. Agents retains its specialized brief composer.
+
+## Validation and limitations
+
+TypeScript and prototype static checks pass. Browser checks exercised Home, People, Calendar and Inbox, direct suggestion submission, right-side and expanded conversations, closing and draft retention. The Home inline conversation was verified to preserve widget/composer bounds and use a transparent background. The final compact conversation height was observed at 136px; continuous animation timing still merits design review.
+
+All responses remain scripted prototype data. Attachment/audio actions show their prototype limitation. Hub destinations without existing content use explicit empty states. No shared shell, F0 library components or build configuration are changed.

--- a/packages/f0compose/src/prototypes/home/agent-entry.css
+++ b/packages/f0compose/src/prototypes/home/agent-entry.css
@@ -1,0 +1,87 @@
+[data-hybrid-root] { overflow:hidden; min-height:0; }
+    [data-hybrid-root] [data-home-nav] { flex-shrink:0; height:100%; }
+    [data-hybrid-work] { position:relative; overflow:hidden; }
+    [data-hybrid-canvas] { width:100%; transition:width 420ms cubic-bezier(.22,1,.36,1),opacity 280ms ease,visibility 420ms; }
+    [data-hybrid-source] { height:100%; min-height:0!important; }
+    [data-hybrid-target] { height:156px; transition:height 420ms cubic-bezier(.22,1,.36,1); }
+    [data-hybrid-root]:not([data-view=home]) [data-hybrid-target] { height:38px; }
+    [data-hybrid-root][data-mode=expanded] [data-hybrid-target] { height:124px; }
+    [data-hybrid-root][data-mode=side] [data-hybrid-target], [data-hybrid-root][data-mode=focus] [data-hybrid-target] { height:0; }
+    [data-hybrid-root][data-mode=side] [data-hybrid-canvas] { width:calc(100% - 410px); }
+    [data-hybrid-root][data-mode=focus] [data-hybrid-canvas] { opacity:0; visibility:hidden; pointer-events:none; }
+    [data-hybrid-chat] { position:absolute; top:0; right:0; bottom:0; width:410px; display:flex; flex-direction:column; opacity:0; visibility:hidden; transform:translateX(40px); transition:width 420ms cubic-bezier(.22,1,.36,1),transform 420ms cubic-bezier(.22,1,.36,1),opacity 250ms ease,visibility 420ms; }
+    [data-hybrid-chat][data-open=true] { opacity:1; visibility:visible; transform:translateX(0); }
+    [data-hybrid-root][data-mode=focus] [data-hybrid-chat] { width:100%; }
+    [data-hybrid-messages] { flex:1; min-height:0; overflow:auto; }
+    [data-hybrid-root][data-mode=focus] [data-hybrid-messages] { width:min(100%,720px); margin:24px auto 0; }
+    [data-hybrid-message=user] { margin-left:48px; }
+    [data-hybrid-chat-target] { height:132px; width:100%; flex-shrink:0; }
+    [data-hybrid-composer] { position:absolute; z-index:30; left:0; top:0; transform:translate(var(--composer-x,0),var(--composer-y,0)); width:var(--composer-width,640px); height:var(--composer-height,104px); transition:transform 420ms cubic-bezier(.22,1,.36,1),width 420ms cubic-bezier(.22,1,.36,1),height 320ms cubic-bezier(.22,1,.36,1),border-radius 320ms ease; }
+    [data-hybrid-composer][data-compact=true] { border-radius:10px; box-shadow:0 2px 6px hsl(var(--neutral-90)/.10); }
+    [data-hybrid-trigger] { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; opacity:0; visibility:hidden; transition:opacity 180ms ease,visibility 180ms; }
+    [data-hybrid-composer][data-compact=true] [data-hybrid-trigger] { opacity:1; visibility:visible; transition-delay:180ms; }
+    [data-hybrid-editor] { position:absolute; inset:0; opacity:1; visibility:visible; transition:opacity 180ms ease,visibility 180ms; }
+    [data-hybrid-composer][data-compact=true] [data-hybrid-editor] { opacity:0; visibility:hidden; pointer-events:none; }
+    [data-hybrid-suggestions] { position:absolute; left:12px; right:12px; top:10px; overflow:hidden; white-space:nowrap; transition:transform 220ms cubic-bezier(.22,1,.36,1),opacity 180ms ease,visibility 220ms; }
+    [data-hybrid-suggestions] > * { flex-shrink:1; min-width:0; }
+    [data-hybrid-suggestions] > :last-child { flex-shrink:0; }
+    [data-hybrid-suggestions] button { min-width:0; }
+    [data-hybrid-composer][data-writing=true] [data-hybrid-suggestions] { transform:translateY(-18px); opacity:0; visibility:hidden; }
+    [data-hybrid-field] { position:absolute; top:45px; left:42px; right:80px; height:45px; transition:top 260ms cubic-bezier(.22,1,.36,1),left 260ms ease,right 260ms ease; }
+    [data-hybrid-field] textarea { border:0!important; box-shadow:none!important; resize:none; padding:4px 0!important; min-height:36px!important; font-size:14px; }
+    [data-hybrid-field] > div { border:0!important; box-shadow:none!important; background:transparent!important; }
+    [data-hybrid-field] fieldset, [data-hybrid-field] [data-testid="input-field-wrapper"] { border:0!important; box-shadow:none!important; background:transparent!important; }
+    [data-hybrid-field] [data-slot="placeholder"] { padding-left:0!important; }
+    [data-hybrid-actions] { position:absolute; top:48px; left:10px; right:10px; pointer-events:none; transition:transform 260ms cubic-bezier(.22,1,.36,1); }
+    [data-hybrid-actions] button { pointer-events:auto; }
+    [data-hybrid-composer][data-writing=true] [data-hybrid-field] { top:10px; left:14px; right:14px; }
+    [data-hybrid-composer][data-writing=true] [data-hybrid-actions] { transform:translateY(26px); }
+    [data-hybrid-notice] { position:absolute; right:16px; top:16px; z-index:60; max-width:340px; }
+    @media(max-width:900px) {
+      [data-hybrid-root][data-mode=side] [data-hybrid-canvas] { width:calc(100% - 340px); }
+      [data-hybrid-chat] { width:340px; }
+    }
+    @media(max-width:700px) {
+      [data-hybrid-root][data-mode=side] [data-hybrid-canvas] { opacity:0; pointer-events:none; }
+      [data-hybrid-chat] { width:100%; }
+
+    }
+    @media(prefers-reduced-motion:reduce) { [data-hybrid-root] * { transition:none!important; animation:none!important; } }
+
+[data-hybrid-root][data-view=agents][data-mode=idle] [data-hybrid-composer] { display:none; }
+[data-hybrid-root][data-view=agents] [data-hybrid-target] { height:0; }
+
+/* Shared application floor: the framed page is separate from the agent dock. */
+[data-hybrid-root], [data-hybrid-work] { background:hsl(var(--page)); }
+[data-hybrid-canvas] { transition:width 420ms cubic-bezier(.22,1,.36,1),height 420ms cubic-bezier(.22,1,.36,1),opacity 280ms ease,visibility 420ms,border-radius 420ms; }
+[data-hybrid-root]:not([data-view=home]) [data-hybrid-canvas] { margin:4px 4px 0 0; width:calc(100% - 4px); height:calc(100% - 52px); border:1px solid hsl(var(--neutral-10)); border-radius:20px; overflow:hidden; background:hsl(var(--neutral-0)); }
+[data-hybrid-dock] { position:absolute; bottom:0; left:0; right:4px; height:48px; pointer-events:none; }
+[data-hybrid-target] { height:196px; }
+[data-hybrid-root]:not([data-view=home]) [data-hybrid-target], [data-hybrid-root]:not([data-view=home])[data-mode=expanded] [data-hybrid-target] { height:0; }
+[data-hybrid-root][data-mode=side] [data-hybrid-canvas] { width:calc(100% - 414px); height:calc(100% - 8px); }
+[data-hybrid-root][data-mode=side] [data-hybrid-target], [data-hybrid-root][data-mode=focus] [data-hybrid-target] { height:0; }
+[data-hybrid-root] .home-canvas-scroll { mask-image:none!important; -webkit-mask-image:none!important; }
+[data-hybrid-composer] { height:var(--composer-height,176px); transition:transform 420ms cubic-bezier(.22,1,.36,1),width 420ms cubic-bezier(.22,1,.36,1),height 420ms cubic-bezier(.22,1,.36,1),border-radius 420ms,background-color 240ms,border-color 240ms,box-shadow 240ms; }
+[data-hybrid-composer][data-compact=true] { background:transparent; border-color:transparent; box-shadow:none; }
+[data-hybrid-root]:not([data-view=home])[data-mode=expanded] [data-hybrid-composer] { box-shadow:0 4px 20px 0 hsl(var(--shadow) / .08); }
+[data-hybrid-suggestions] { top:16px; left:16px; right:16px; }
+[data-hybrid-field] { top:auto; bottom:58px; left:16px; right:16px; height:58px; transform:none; transition:none; }
+[data-hybrid-composer][data-writing=true] [data-hybrid-field] { top:auto; bottom:58px; left:16px; right:16px; transform:none; }
+[data-hybrid-field] textarea { font-size:16px; }
+[data-hybrid-actions] { top:auto; bottom:12px; left:12px; right:12px; transform:none!important; }
+[data-hybrid-chat-target] { height:196px; }
+[data-hybrid-trigger] [data-factorial-agent-icon] { width:20px!important; height:20px!important; }
+@media(max-width:900px) { [data-hybrid-root][data-mode=side] [data-hybrid-canvas] { width:calc(100% - 344px); } }
+
+[data-hybrid-maximized] > div { padding:0; }
+[data-hybrid-maximized] [data-home-window] { border:0!important; box-shadow:none!important; border-radius:0!important; }
+
+/* Match the original navigation floor; only the inset page owns a border. */
+[data-home-nav], [data-home-rail], [data-home-panel], [data-hybrid-root], [data-hybrid-work] { background:#FCFCFC!important; }
+[data-home-panel], .dark [data-home-panel] { box-shadow:none!important; border-right:0!important; }
+.dark [data-home-nav], .dark [data-home-rail], .dark [data-home-panel], .dark [data-hybrid-root], .dark [data-hybrid-work] { background:linear-gradient(hsl(var(--page)),hsl(var(--page))),hsl(var(--neutral-0))!important; }
+
+/* Home has no inset page frame, so its menu supplies the shared divider. */
+body:has([data-hybrid-root][data-view="home"]) [data-home-panel] {
+  box-shadow:inset -1px 0 0 hsl(var(--neutral-10))!important;
+}

--- a/packages/f0compose/src/prototypes/home/agentEntryData.ts
+++ b/packages/f0compose/src/prototypes/home/agentEntryData.ts
@@ -1,0 +1,48 @@
+export type Presentation = "idle" | "expanded" | "side" | "focus"
+/** One relevant starting point, using the existing profile and current page. */
+export function suggestionFor(
+  view: string | null,
+  profile: "admin" | "employee"
+) {
+  if (view === "inbox")
+    return {
+      label: "Help me resolve this task",
+      prompt:
+        "Review this task, summarize what needs my attention and suggest the next step for my approval.",
+    }
+  if (view === "people")
+    return {
+      label: "Review pending onboarding",
+      prompt:
+        "Review this page and identify people with pending onboarding or account activation. Suggest the next steps for my approval.",
+    }
+  if (view === "calendar")
+    return {
+      label: "Help me plan this week",
+      prompt:
+        "Review this calendar and help me plan the week, highlighting conflicts and upcoming commitments.",
+    }
+  if (view === "policies")
+    return {
+      label: "Review policies needing attention",
+      prompt:
+        "Review this page and highlight policies that need updating or acknowledgment.",
+    }
+  if (view)
+    return {
+      label: "What needs attention here?",
+      prompt:
+        "Review this page, identify what needs my attention and propose the next steps.",
+    }
+  return profile === "employee"
+    ? {
+        label: "Help me plan my day",
+        prompt:
+          "Help me plan my day around upcoming commitments and pending tasks.",
+      }
+    : {
+        label: "What needs my attention today?",
+        prompt:
+          "Review pending HR approvals, upcoming onboardings and employee incidents. Prioritize what needs my attention today and prepare next steps for my approval.",
+      }
+}

--- a/packages/f0compose/src/prototypes/home/approvedAgentMotion.d.ts
+++ b/packages/f0compose/src/prototypes/home/approvedAgentMotion.d.ts
@@ -1,0 +1,2 @@
+export declare const approvedAgentArtwork: string
+export declare function mountApprovedAgentMotion(scene: SVGSVGElement): () => void

--- a/packages/f0compose/src/prototypes/home/approvedAgentMotion.js
+++ b/packages/f0compose/src/prototypes/home/approvedAgentMotion.js
@@ -1,0 +1,52 @@
+/** Imported from Jonathan's approved factorial-agent/index.html.
+ * SVG paths and per-frame motion are preserved. Adaptations: scoped element lookup,
+ * automatic 7s + 450ms + 3s cycle, visibility lifecycle and cleanup.
+ */
+export const approvedAgentArtwork = "\n<g><g data-agent-part=\"outer\" fill=\"#E51943\"><path d=\"M6.91895 16.2844C5.94243 15.1275 5.35384 13.6325 5.35384 12C5.35384 8.32943 8.32943 5.35384 12 5.35384C15.6706 5.35384 18.6461 8.32943 18.6461 12C18.6461 13.6325 18.0576 15.1275 17.0811 16.2844C17.417 16.4944 17.739 16.7244 18.0453 16.973L18.1792 17.0815C19.3168 15.6997 20 13.9296 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 13.9296 4.68318 15.6997 5.82087 17.0815L5.95467 16.973C6.26096 16.7244 6.58297 16.4944 6.91895 16.2844Z\"/></g><g data-agent-part=\"shoulders\" fill=\"#E51943\"><path d=\"M17.0353 18.2143C15.66 19.3302 13.9072 19.9989 11.9981 19.9989C10.089 19.9989 8.33619 19.3302 6.96094 18.2143C8.33619 17.0984 10.089 16.4297 11.9981 16.4297C13.9072 16.4297 15.66 17.0984 17.0353 18.2143Z\"/></g>\n<g data-agent-part=\"character\"><g data-agent-part=\"head\" fill=\"#E51943\"><path d=\"M12.0007 14.7046C13.6321 14.7046 14.9546 13.3821 14.9546 11.7508C14.9546 10.1194 13.6321 8.79688 12.0007 8.79688C10.3693 8.79688 9.04688 10.1194 9.04688 11.7508C9.04688 13.3821 10.3693 14.7046 12.0007 14.7046Z\"/></g><g data-agent-part=\"face\" fill=\"none\" stroke=\"white\" stroke-linecap=\"round\"><path data-agent-part=\"eye-left\"/><path data-agent-part=\"eye-right\"/></g></g></g>\n";
+export function mountApprovedAgentMotion(scene) {
+
+const $=id=>scene.querySelector(`[data-agent-part="${id}"]`), outer=$('outer'),shoulders=$('shoulders'),head=$('head'),character=$('character'),face=$('face'),left=$('eye-left'),right=$('eye-right');
+let ringScale=86;const resizeObserver=new ResizeObserver(()=>{const b=scene.getBoundingClientRect();const unit=Math.min(b.width/400,b.height/400);ringScale=Math.hypot(b.width/unit,b.height/unit)/2/6.646+12;});resizeObserver.observe(scene);
+const silhouette=head.querySelector('path'),originalHead=silhouette.getAttribute('d');
+const reduced=matchMedia('(prefers-reduced-motion: reduce)');
+let p=0,target=0,from=0,started=0,duration=525,phase='rest',pointer={x:0,y:0},pointerInside=false,look={x:0,y:0},eyeLook={x:0,y:0},prev=0;
+const clamp=x=>Math.max(0,Math.min(1,x));const smooth=x=>{x=clamp(x);return x*x*(3-2*x)};const ease=x=>1-Math.pow(1-x,4);
+function label(next){phase=next;}
+function setActive(active){const value=active?1:0;if(target===value)return;from=p;target=value;started=performance.now();duration=reduced.matches?180:(active?525:450);label(active?'in':'out');}
+const pointerMove=e=>{pointerInside=true;const b=scene.getBoundingClientRect();pointer={x:Math.max(-1,Math.min(1,(e.clientX-b.left)/b.width*2-1)),y:Math.max(-1,Math.min(1,(e.clientY-b.top)/b.height*2-1))}};const pointerLeave=()=>{pointerInside=false;pointer={x:0,y:0}};scene.addEventListener('pointermove',pointerMove);scene.addEventListener('pointerleave',pointerLeave);
+const gazeStops=[[0,0],[0,-1],[.9,-.45],[1,.1],[0,0],[-1,-.15],[-.5,.65],[0,0]];
+let raf=0,cycleStart=performance.now();
+const host=scene.closest('[data-hybrid-composer]');
+let visible=!host || host.getAttribute('data-compact')==='true';
+const visibilityObserver=new MutationObserver(()=>{
+  const next=host.getAttribute('data-compact')==='true';
+  if(next===visible)return;
+  visible=next;
+  if(visible)cycleStart=performance.now();
+  else pointerLeave();
+  setActive(visible);
+});
+if(host)visibilityObserver.observe(host,{attributes:true,attributeFilter:['data-compact']});
+function frame(now){
+setActive(visible && (now-cycleStart)%10450<7000);
+const dt=Math.min((now-prev)/1000,.05);prev=now;const t=clamp((now-started)/duration);p=from+(target-from)*ease(t);if(t===1)label(target?'alive':'rest');const sec=now/1000;const eyeSec=sec*2;const gazeIndex=Math.floor(sec/1.8)%gazeStops.length;const autoGaze=gazeStops[gazeIndex];const gaze=pointerInside?pointer:{x:autoGaze[0],y:autoGaze[1]};const eyeBlend=1-Math.exp(-dt*10);eyeLook.x+=(gaze.x-eyeLook.x)*eyeBlend;eyeLook.y+=(gaze.y-eyeLook.y)*eyeBlend;const motion=reduced.matches?0:p;const blend=1-Math.exp(-dt*4);look.x+=(gaze.x-look.x)*blend;look.y+=(gaze.y-look.y)*blend;
+const bob=motion*Math.sin(sec*1.8)*3;const tilt=motion*(Math.sin(sec*.85)*2.4+look.x*4);const impulse=reduced.matches?0:Math.sin(Math.PI*t)*Math.exp(-5*t)*Math.abs(target-from)*(target?1:-1);const stretch=1+motion*.014*Math.sin(sec*1.8)+impulse*.32;const settle=reduced.matches?0:Math.sin(Math.PI*t)*Math.sin(2*Math.PI*t)*Math.abs(target-from)*1.4;const scale=23+37*p+settle;const cx=300+.0161*(1-p),cy=200-5.7316*(1-p)+bob;
+outer.setAttribute('transform',`translate(300 200) scale(${23+(ringScale-23)*p}) translate(-12 -12)`);
+const tuck=smooth(p/.55);shoulders.setAttribute('transform',`translate(300 ${200-28*tuck}) scale(${23*(1-.72*tuck)}) translate(-12 -12)`);
+character.setAttribute('transform',`translate(${cx} ${cy}) rotate(${tilt}) scale(${1/stretch} ${stretch})`);head.setAttribute('transform',`scale(${scale}) translate(-12.0007 -11.7508)`);
+const visibility=smooth((p-.35)/.55);face.setAttribute('opacity',visibility);face.setAttribute('transform',`translate(${motion*eyeLook.x*62} ${motion*(eyeLook.y*58-4)}) scale(${(.7+1.7*p)*(1-.12*motion*Math.abs(eyeLook.x))} ${(.7+1.7*p)*(1-.08*motion*Math.abs(eyeLook.y))})`);
+const cycle=eyeSec%5.3;let blink=1;if(!reduced.matches&&cycle>4.85&&cycle<5.09)blink=1-.94*Math.sin((cycle-4.85)/.24*Math.PI);
+const expression=reduced.matches?0:eyeSec%12;
+const happy=motion*smooth((expression-6)/.8)*(1-smooth((expression-9.2)/.8));
+const curious=motion*smooth((expression-2)/.7)*(1-smooth((expression-4.3)/.8));
+[left,right].forEach((eye,i)=>{const x=i===0?-27:27;const size=1+curious*(i===0?.3:-.12);const width=(.15+10.5*happy)*size;const bend=-18*happy;eye.setAttribute('d',`M${x-width} -3 Q${x} ${-3+bend} ${x+width} -3`);eye.setAttribute('stroke-width',(29-12*happy)*size);eye.setAttribute('transform',`translate(0 -3) scale(1 ${blink}) translate(0 3)`)});
+if(p===0){silhouette.setAttribute('d',originalHead)}else{
+const points=Array.from({length:12},(_,i)=>{const a=i*Math.PI/6;const r=2.95386*(1+motion*.032*Math.sin(3*a+sec*.95)+motion*.018*Math.sin(2*a-sec*.7));return [12.0007+r*Math.cos(a),11.7508+r*Math.sin(a)]});
+let d=`M${points[0][0]} ${points[0][1]}`;for(let i=0;i<12;i++){const a=points[(i+11)%12],b=points[i],c=points[(i+1)%12],e=points[(i+2)%12];d+=` C${b[0]+(c[0]-a[0])/6} ${b[1]+(c[1]-a[1])/6} ${c[0]-(e[0]-b[0])/6} ${c[1]-(e[1]-b[1])/6} ${c[0]} ${c[1]}`;}silhouette.setAttribute('d',d+'Z');}
+
+scene.dataset.gaze=pointerInside?'pointer':String(gazeIndex);scene.dataset.progress=p.toFixed(4);scene.dataset.phase=phase;raf=requestAnimationFrame(frame);
+}raf=requestAnimationFrame(frame);
+
+return () => { cancelAnimationFrame(raf); resizeObserver.disconnect(); visibilityObserver.disconnect(); scene.removeEventListener('pointermove',pointerMove); scene.removeEventListener('pointerleave',pointerLeave); };
+
+}

--- a/packages/f0compose/src/prototypes/home/comms/chatStore.ts
+++ b/packages/f0compose/src/prototypes/home/comms/chatStore.ts
@@ -60,3 +60,14 @@ export function useOpenChats(): LeftPaneId[] {
     () => openChats
   )
 }
+
+const closeListeners = new Set<() => void>()
+export function onChatsCloseRequest(listener: () => void) {
+  closeListeners.add(listener)
+  return () => {
+    closeListeners.delete(listener)
+  }
+}
+export function requestChatsClose() {
+  closeListeners.forEach((listener) => listener())
+}


### PR DESCRIPTION
Integrates the personal agent entry into the existing Home and navigation, reusing the current screens, widgets and scripted conversation history.

On Home, sending replaces only the greeting and Needs you area with the conversation, preserving the background and right-hand widgets. Elsewhere, the agent contracts into a 20px-icon ghost entry in a reserved bottom strip. Opening overlays the composer without resizing the page; sending opens a right-hand conversation, with an explicit control to expand it.

The same mounted composer follows each layout. One contextual suggestion sends immediately; typing removes its space by contracting the box from the top, with the text and medium F0 action buttons anchored below. Returning Home restores its content and divider. The Home composer matches the width and alignment of Needs you. Clicking outside the expanded entry minimizes it without losing the draft or consuming the outside interaction.

### Review scope
- Targets `feat/f0compose` so Oskar can incorporate these changes into #4085, not directly into `main`.
- People and Calendar now render as destination pages instead of module windows over Home. Existing Inbox/Comms windows and specialized Agents composer remain available.
- Other Hub destinations without existing screens show explicit prototype empty states.
- Replies remain scripted; attachment and audio actions explain their prototype limitation.
- Changes are confined to the Home prototype. No shared shell, F0 library or build configuration changes.

### Entry refinements
- Clicking outside the expanded composer collapses it; Home and open conversations retain their existing behavior.
- The Home composer shares the Needs you column width, including its responsive constraint.

### Validation
- `pnpm --filter @factorialco/f0compose tsc` passed.
- Prototype static checks passed across 81 files.
- Browser checks also verified outside-click dismissal with draft retention and matching left/right bounds for the Home composer and Needs you.
- Browser exercises covered Home, People, Calendar, Inbox, suggestion submission, side/expanded conversations, closing and draft retention.
- Home inline conversation preserved widget/composer bounds and used a transparent background. Final compact conversation height observed at 136px; animation timing remains a useful focus for design review.

This PR shares the implementation; it does not publish a hosted preview. The local development URL is `http://127.0.0.1:5176/p/home`.

