### PR TITLE
fix(f0compose): move company selector to employee menu

### DIFF
--- a/packages/f0compose/src/prototypes/home/HomeNav.tsx
+++ b/packages/f0compose/src/prototypes/home/HomeNav.tsx
@@ -81,7 +81,7 @@ import { motionKeyFor } from "./iconMotion"
 import { openInboxTasks } from "./inbox/inboxTasks"
 import { MenuDivider, MenuRow } from "./MenuRow"
 import {
-  LegalEntityMenu,
+  CompanyLogo,
   RailHelpMenu,
   RailPersonalMenu,
 } from "./navigation/RailMenus"
@@ -1352,7 +1352,7 @@ export function HomeNav() {
             (24px). The logo file is f0's own storybook asset, re-exported
             from fixtures; without `src` this falls back to initials. */}
         <div className="flex h-[60px] shrink-0 items-center justify-center">
-          <LegalEntityMenu />
+          <CompanyLogo />
         </div>
         <div className="flex w-full flex-col gap-2 px-1.5">
           {RAIL_SECTIONS.map((s) => (

--- a/packages/f0compose/src/prototypes/home/navigation/RailMenus.tsx
+++ b/packages/f0compose/src/prototypes/home/navigation/RailMenus.tsx
@@ -17,19 +17,11 @@ import { PROFILE_PEOPLE } from "../fixtures"
 import { goHome } from "../one/conversationStore"
 import { useProfile } from "../profileStore"
 import factorial from "./assets/factorial.svg"
-import jira from "./assets/jira.svg"
-import planes from "./assets/planes.svg"
-import {
-  EntityMenu,
-  HelpMenu,
-  ProfileMenu,
-  type HelpRow,
-} from "./ReferenceMenus"
+import { HelpMenu, ProfileMenu, type HelpRow } from "./ReferenceMenus"
 
 const entities = [
   { id: "factorial", name: "Factorial", src: factorial },
-  { id: "jira", name: "Jira", src: jira },
-  { id: "planes", name: "Planes", src: planes },
+  { id: "test-de-verdad", name: "Test de verdad" },
 ]
 const ENTITY_KEY = "f0compose:home:legal-entity"
 // These destinations are placeholders in the reference; the prototype does not contact support.
@@ -54,40 +46,20 @@ const helpRows: HelpRow[] = [
   { kind: "item", label: "What's new?", icon: Megaphone },
   { kind: "footer", text: "User ID: #4079271" },
 ]
-export function LegalEntityMenu() {
+export function CompanyLogo() {
+  return <F0AvatarCompany name="Factorial" src={factorial} size="sm" />
+}
+export function RailHelpMenu() {
+  return <HelpMenu label="Help" rows={helpRows} />
+}
+export function RailPersonalMenu() {
   const [selected, setSelected] = useState(() => {
     const stored = window.localStorage.getItem(ENTITY_KEY)
     return entities.some((entity) => entity.id === stored)
       ? stored!
       : "factorial"
   })
-  const active =
-    entities.find((entity) => entity.id === selected) ?? entities[0]
-  return (
-    <EntityMenu
-      entities={entities}
-      selected={selected}
-      actions={[]}
-      onSelect={(id) => {
-        setSelected(id)
-        window.localStorage.setItem(ENTITY_KEY, id)
-      }}
-    >
-      <button
-        type="button"
-        aria-label={`Change legal entity: ${active.name}`}
-        aria-haspopup="menu"
-        className="flex size-8 cursor-pointer items-center justify-center rounded-lg hover:bg-f1-background-hover"
-      >
-        <F0AvatarCompany name={active.name} src={active.src} size="sm" />
-      </button>
-    </EntityMenu>
-  )
-}
-export function RailHelpMenu() {
-  return <HelpMenu label="Help" rows={helpRows} />
-}
-export function RailPersonalMenu() {
+
   useEffect(() => {
     const theme =
       window.localStorage.getItem("f0compose:theme") === "dark"
@@ -115,6 +87,13 @@ export function RailPersonalMenu() {
   ]
   return (
     <ProfileMenu
+      accountEmail="alicia.keys@factorial.co"
+      entities={entities}
+      selectedEntity={selected}
+      onSelectEntity={(id) => {
+        setSelected(id)
+        window.localStorage.setItem(ENTITY_KEY, id)
+      }}
       personal={personal}
       help={helpRows}
       labels={{

--- a/packages/f0compose/src/prototypes/home/navigation/ReferenceMenus.tsx
+++ b/packages/f0compose/src/prototypes/home/navigation/ReferenceMenus.tsx
@@ -1,7 +1,7 @@
 import { F0AvatarCompany, F0Icon, type IconType } from "@factorialco/f0-react"
 import {
   Bell,
-  CheckCircleLine,
+  Check,
   ChevronRight,
   ExternalLink,
   Question,
@@ -22,12 +22,20 @@ export type HelpRow =
   | { kind: "separator" }
   | { kind: "item"; label: string; icon: IconType; href?: string }
 export function ProfileMenu({
+  accountEmail,
+  entities,
+  selectedEntity,
+  onSelectEntity,
   personal,
   help,
   labels,
   collapsed = false,
   children,
 }: {
+  accountEmail: string
+  entities: Entity[]
+  selectedEntity: string
+  onSelectEntity: (id: string) => void
   personal: {
     label: string
     icon: IconType
@@ -113,8 +121,37 @@ export function ProfileMenu({
               <div
                 role="menu"
                 aria-label="Navigation menu"
-                className="w-[216px] rounded-[14px] border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-md"
+                className="w-[248px] rounded-[14px] border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-md"
               >
+                <div className="p-2 text-sm font-medium text-f1-foreground-secondary">
+                  {accountEmail}
+                </div>
+                {entities.map((entity) => (
+                  <button
+                    key={entity.id}
+                    type="button"
+                    role="menuitemradio"
+                    aria-checked={entity.id === selectedEntity}
+                    className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-base font-medium text-f1-foreground hover:bg-f1-background-hover"
+                    onClick={() => onSelectEntity(entity.id)}
+                  >
+                    <F0AvatarCompany
+                      name={entity.name}
+                      src={entity.src}
+                      size="xs"
+                    />
+                    <span className="min-w-0 flex-1 truncate">
+                      {entity.name}
+                    </span>
+                    {entity.id === selectedEntity && (
+                      <F0Icon icon={Check} size="sm" color="info" />
+                    )}
+                  </button>
+                ))}
+                <div
+                  role="separator"
+                  className="my-1 h-px bg-f1-border-secondary"
+                />
                 {collapsed ? (
                   <>
                     {/* Folded only: Help and Notifications have lost their own
@@ -251,129 +288,6 @@ type Entity = {
   mark?: string
   tone?: string
   src?: string
-}
-
-/**
- * The legal-entity switcher's menu. F0's `Dropdown` takes flat `{label, icon}`
- * rows, so it can't render the brand marks, the current-entity tick, or the rule
- * that separates the entities from Settings / Billing. Same portaled-popover
- * approach as `HelpMenu` below, opening DOWNWARD from the header.
- */
-export function EntityMenu({
-  entities,
-  selected,
-  onSelect,
-  actions,
-  children,
-}: {
-  entities: Entity[]
-  selected: string
-  onSelect: (id: string) => void
-  actions: { label: string; icon: IconType; onClick: () => void }[]
-  children: ReactNode
-}) {
-  const [open, setOpen] = useState(false)
-  const anchorRef = useRef<HTMLDivElement>(null)
-  const popRef = useRef<HTMLDivElement>(null)
-  const [pos, setPos] = useState<{ left: number; top: number } | null>(null)
-
-  const toggle = () => {
-    const r = anchorRef.current?.getBoundingClientRect()
-    if (r) setPos({ left: r.left, top: r.bottom + 6 })
-    setOpen((o) => !o)
-  }
-
-  useEffect(() => {
-    if (!open) return
-    const onDown = (e: MouseEvent) => {
-      const target = e.target as Node
-      if (
-        !anchorRef.current?.contains(target) &&
-        !popRef.current?.contains(target)
-      )
-        setOpen(false)
-    }
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && setOpen(false)
-    const close = () => setOpen(false)
-    document.addEventListener("mousedown", onDown)
-    document.addEventListener("keydown", onKey)
-    window.addEventListener("resize", close)
-    window.addEventListener("scroll", close, true)
-    return () => {
-      document.removeEventListener("mousedown", onDown)
-      document.removeEventListener("keydown", onKey)
-      window.removeEventListener("resize", close)
-      window.removeEventListener("scroll", close, true)
-    }
-  }, [open])
-
-  return (
-    <div ref={anchorRef} style={{ position: "relative", display: "flex" }}>
-      <div onClick={toggle}>{children}</div>
-      {open && pos
-        ? createPortal(
-            <div
-              ref={popRef}
-              role="menu"
-              aria-label="Navigation menu"
-              className="w-[216px] rounded-[14px] border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-md"
-              style={{
-                position: "fixed",
-                left: pos.left,
-                top: pos.top,
-                zIndex: 60,
-              }}
-            >
-              {entities.map((e) => (
-                <button
-                  key={e.id}
-                  type="button"
-                  role="menuitemradio"
-                  aria-checked={e.id === selected}
-                  className={`flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-base font-medium text-f1-foreground hover:bg-f1-background-hover${e.id === selected ? " bg-f1-background-secondary" : ""}`}
-                  onClick={() => {
-                    onSelect(e.id)
-                    setOpen(false)
-                  }}
-                >
-                  <F0AvatarCompany name={e.name} src={e.src} size="xs" />
-                  <span className="min-w-0 flex-1 truncate">{e.name}</span>
-                  {e.id === selected ? (
-                    <CheckCircleLine
-                      width={20}
-                      height={20}
-                      className="shrink-0 text-f1-foreground-secondary"
-                    />
-                  ) : null}
-                </button>
-              ))}
-              {actions.length > 0 && (
-                <div className="mx-2 my-1 h-px bg-f1-border-secondary" />
-              )}
-              {actions.map((a) => {
-                const Icon = a.icon
-                return (
-                  <button
-                    key={a.label}
-                    type="button"
-                    role="menuitem"
-                    className="flex w-full cursor-pointer items-center gap-2 rounded-lg px-2 py-1.5 text-left text-base font-medium text-f1-foreground hover:bg-f1-background-hover"
-                    onClick={() => {
-                      setOpen(false)
-                      a.onClick()
-                    }}
-                  >
-                    <Icon width={20} height={20} className="shrink-0" />
-                    <span className="min-w-0 flex-1 truncate">{a.label}</span>
-                  </button>
-                )
-              })}
-            </div>,
-            document.body
-          )
-        : null}
-    </div>
-  )
 }
 
 export function HelpMenu({ label, rows }: { label: string; rows: HelpRow[] }) {


### PR DESCRIPTION
Moves the company selector from the top Factorial logo into the employee menu in #4085. The employee menu shows the account email, Factorial and Test de verdad with a selected indicator, then a divider before the existing personal actions. The top logo is static and the employee menu continues opening to the right.

Validation: TypeScript, prototype checks (186 files), git diff --check, and browser verification of company selection, divider and removal of the logo dropdown. Home + Onboarding remains excluded.
