### PR TITLE
feat(EditableTable): forward select actions to the cell

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -1892,6 +1892,17 @@ export const EditableTableWithStatusPillSelect: Story = {
                   selectConfig: {
                     placeholder: "Status",
                     showSearchBox: false,
+                    actions: (item: MockUser) =>
+                      item.status === "pending"
+                        ? [
+                            {
+                              label: "Withdraw request",
+                              icon: Delete,
+                              variant: "ghost" as const,
+                              onClick: () => alert(`Withdrawn: ${item.name}`),
+                            },
+                          ]
+                        : undefined,
                     options: STATUS_VALUES.map((id) => ({
                       value: id,
                       label: STATUS_LABEL[id],

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/SelectCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/SelectCell.test.tsx
@@ -71,6 +71,51 @@ describe("SelectCell", () => {
     item: testItem,
   }
 
+  it("renders the configured actions below the options", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+    render(
+      <SelectCell
+        {...defaultProps}
+        editableColumn={makeSelectColumn({
+          selectConfig: {
+            options: staticOptions,
+            actions: [{ label: "Cancel scheduled change", onClick }],
+          },
+        })}
+      />
+    )
+
+    await openSelect(user)
+    await user.click(
+      screen.getByRole("button", { name: "Cancel scheduled change" })
+    )
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("resolves the actions per row", async () => {
+    const user = userEvent.setup()
+    const actions = vi
+      .fn()
+      .mockReturnValue([{ label: "Row action", onClick: vi.fn() }])
+    render(
+      <SelectCell
+        {...defaultProps}
+        editableColumn={makeSelectColumn({
+          selectConfig: { options: staticOptions, actions },
+        })}
+      />
+    )
+
+    await openSelect(user)
+
+    expect(actions).toHaveBeenCalledWith(testItem)
+    expect(
+      screen.getByRole("button", { name: "Row action" })
+    ).toBeInTheDocument()
+  })
+
   it("renders F0Select with static options", async () => {
     const user = userEvent.setup()
     render(<SelectCell {...defaultProps} />)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/SelectCell.tsx
@@ -57,6 +57,10 @@ export function SelectCell<R extends RecordType>({
     defaultItem: config.defaultItem?.(item),
     multiple: false as const,
     onOpenChange: setIsOpen,
+    actions:
+      typeof config.actions === "function"
+        ? config.actions(item)
+        : config.actions,
   }
 
   const clearableProps = config.clearable

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -3,6 +3,7 @@ import type {
   F0SelectItemObject,
   F0SelectItemProps,
 } from "@/components/F0Select"
+import type { Action as SelectAction } from "@/components/F0Select/components/SelectBottomActions"
 import {
   DataSourceDefinition,
   FiltersDefinition,
@@ -105,6 +106,11 @@ export type SelectCellConfig<R extends RecordType> = {
   clearable?: boolean
   showSearchBox?: boolean
   defaultItem?: (item: R) => F0SelectItemObject<string, RecordType> | undefined
+  /**
+   * Buttons rendered below the options, for what a value cannot express —
+   * dropping a scheduled change, say. Pass a function to decide them per row.
+   */
+  actions?: SelectAction[] | ((item: R) => SelectAction[] | undefined)
 } & (
   | {
       options:


### PR DESCRIPTION
## Why

In the new One Members table, where users select the plan the want to apply, we need an option to cancel a scheduled plan change:

<img width="486" height="422" alt="image" src="https://github.com/user-attachments/assets/e79decac-aa09-4fd1-98db-a969843a7ef9" />

`F0Select` already has `actions` which renders buttons below the options via `SelectBottomActions`. The editable table just never passed them through, so the only way to offer one from a table was a separate row action sitting outside the cell it belongs to.

## What

`SelectCellConfig` gains an `actions` prop, forwarded to the `F0Select` the cell renders:

```ts
actions?: SelectAction[] | ((item: R) => SelectAction[] | undefined)
```

It takes a function as well as an array so the actions can be decided per row — in the case that prompted this, only members with a pending change get one.

## Changes

- **`SelectCellConfig`** — new optional `actions`, typed against `F0Select`'s own `Action`.
- **`SelectCell`** — resolves it the same way it already resolves `options`, and passes it to both the static-options and `source` variants.
- **Tests** — the action fires when clicked, and the function form receives the row item.
- **Story** — the existing status-select example now shows a per-row "Withdraw request" action on pending rows.

## Verification

`oxlint --type-aware` clean, `tsc --project tsconfig-build.json` clean, 111 tests pass across the EditableTable suite.
