### PR TITLE
feat(F0AiChatTextArea): [FCT-63305] let the host set the credit warning text and action label

### DIFF
--- a/packages/react/src/kits/ai/F0AiChat/types.ts
+++ b/packages/react/src/kits/ai/F0AiChat/types.ts
@@ -168,6 +168,10 @@ export type AiChatCredits = {
 export type AiChatCreditWarning = {
   /** The severity level of the warning. */
   level: "soft"
+  /** Host-localized message; defaults to `ai.creditWarning.soft`. */
+  text?: string
+  /** Host-localized label of the action button; defaults to `ai.creditWarning.getCredits`. */
+  actionLabel?: string
   /** Called when the user dismisses the credit warning banner. */
   onDismiss?: () => void
   /** Called when the user clicks the "Get Credits" button. */

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -855,7 +855,7 @@ export const WithCreditWarning: Story = {
   },
 }
 
-export const WithCreditWarningHostCopy: Story = {
+export const WithCustomCreditWarning: Story = {
   args: {
     creditWarning: {
       ...CREDIT_WARNING,

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -855,6 +855,16 @@ export const WithCreditWarning: Story = {
   },
 }
 
+export const WithCreditWarningHostCopy: Story = {
+  args: {
+    creditWarning: {
+      ...CREDIT_WARNING,
+      text: "You've run out of One",
+      actionLabel: "Request",
+    },
+  },
+}
+
 export const WithPendingContext: Story = {
   args: {
     initialPendingContext: PENDING_CONTEXT,

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.creditWarning.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/F0AiChatTextArea.creditWarning.test.tsx
@@ -1,0 +1,53 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+import { Upsell } from "@/icons/app"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+import { F0AiChatTextArea } from "../F0AiChatTextArea"
+
+describe("F0AiChatTextArea creditWarning", () => {
+  it("falls back to the i18n copy", () => {
+    render(
+      <F0AiChatTextArea
+        onSubmit={vi.fn()}
+        creditWarning={{
+          level: "soft",
+          onGetCredits: vi.fn(),
+          getCreditsIcon: Upsell,
+        }}
+      />
+    )
+
+    expect(
+      screen.getByText("You're running low on AI credits.")
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Get credits" })
+    ).toBeInTheDocument()
+  })
+
+  it("renders the host copy and wires the actions", async () => {
+    const onGetCredits = vi.fn()
+    const onDismiss = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <F0AiChatTextArea
+        onSubmit={vi.fn()}
+        creditWarning={{
+          level: "soft",
+          text: "You've run out of One",
+          actionLabel: "Request",
+          onGetCredits,
+          onDismiss,
+          getCreditsIcon: Upsell,
+        }}
+      />
+    )
+
+    expect(screen.getByText("You've run out of One")).toBeInTheDocument()
+    await user.click(screen.getByRole("button", { name: "Request" }))
+    await user.click(screen.getByRole("button", { name: "Dismiss" }))
+
+    expect(onGetCredits).toHaveBeenCalledTimes(1)
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/CreditWarningWrapper.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/CreditWarningWrapper.tsx
@@ -31,8 +31,10 @@ export const CreditWarningWrapper = ({
 
   const config = {
     ...creditWarningConfig[creditWarning.level],
-    text: translation.ai.creditWarning.soft,
+    text: creditWarning.text ?? translation.ai.creditWarning.soft,
   }
+  const actionLabel =
+    creditWarning.actionLabel ?? translation.ai.creditWarning.getCredits ?? ""
 
   return (
     <div
@@ -47,11 +49,11 @@ export const CreditWarningWrapper = ({
         <div className="flex shrink-0 items-center gap-1">
           {creditWarning.onGetCredits ? (
             <F0Button
-              label={translation.ai.creditWarning.getCredits ?? ""}
+              label={actionLabel}
               size="sm"
               variant="outline"
               icon={creditWarning.getCreditsIcon}
-              tooltip={translation.ai.creditWarning.getCredits ?? ""}
+              tooltip={actionLabel}
               onClick={creditWarning.onGetCredits}
             />
           ) : null}


### PR DESCRIPTION
## Description

Let the host set the copy of the credit warning banner that `F0AiChatTextArea` renders above the composer. `AiChatCreditWarning` gains two optional, host-localized fields: `text` (the message) and `actionLabel` (the button label). Both fall back to the existing `ai.creditWarning.soft` / `ai.creditWarning.getCredits` strings, so current consumers are unaffected.

Why: the One chat shows this banner for several situations that need different remedies. The employee who hit their personal allowance should see **"You've run out of One"** with a **Request** button (Figma below), while an admin gets "Update settings" and a company that exhausted its pool gets "Upgrade". Today the label comes from one app-wide i18n string, so the banner cannot name the remedy the way the in-chat cards already do (factorialco/factorial#111668), and the copy cannot avoid the word "credits", which product decided not to show to end users.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Screenshots

Story `Kits/AI/F0AiChatTextArea → With Custom Credit Warning`.

<!-- drop story_custom_credit_warning.png here -->
<img width="660" height="180" alt="story_custom_credit_warning" src="https://github.com/user-attachments/assets/69977eb0-42d1-4807-86bb-0154bf2f22c5" />

[Link to Figma Design](https://www.figma.com/design/QJYICrUkHjdb2rM5LhvrHo/One-pricing?node-id=29524-15459)

## Implementation details

- `AiChatCreditWarning` (`kits/ai/F0AiChat/types.ts`): new optional `text?: string` and `actionLabel?: string`.
- `CreditWarningWrapper`: uses them when present, otherwise the i18n defaults. The action button's label and tooltip share the same value.
- Story `WithCustomCreditWarning` and a test file covering the fallback copy, the host copy and both callbacks.
- No changes to layout, tokens or the `level` union.
