### PR TITLE
fix(F0Select): close the dropdown when a bottom action is clicked

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -893,6 +893,21 @@ const F0SelectComponent = forwardRef(function Select<
     handleChangeOpenLocal(false)
   }, [handleChangeOpenLocal])
 
+  // A bottom action ends the interaction with the list — it navigates away, opens a dialog or
+  // resets the selection — so leaving the dropdown open would stack it over whatever the action
+  // put on screen.
+  const bottomActions = useMemo(
+    () =>
+      actions?.map((action) => ({
+        ...action,
+        onClick: () => {
+          handleChangeOpenLocal(false)
+          action.onClick()
+        },
+      })),
+    [actions, handleChangeOpenLocal]
+  )
+
   const handleApply = useCallback(() => {
     if (hasDeferredApply) {
       const nextCommittedSelection = cloneSelectedState(selectedState)
@@ -1168,7 +1183,7 @@ const F0SelectComponent = forwardRef(function Select<
       bottom={
         !isFiltersOpen ? (
           <SelectBottomActions
-            actions={actions}
+            actions={bottomActions}
             showApplyButton={showApplyButton}
             applyLabel={applySelectionLabel}
             onApply={handleApply}

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -1474,6 +1474,27 @@ describe("Select", () => {
     expect(handleChange).not.toHaveBeenCalled()
   })
 
+  it("closes the dropdown when a bottom action is clicked", async () => {
+    const handleAction = vi.fn()
+    const user = userEvent.setup()
+
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        actions={[{ label: "Reset", onClick: handleAction }]}
+      />
+    )
+
+    await openSelect(user)
+    await user.click(screen.getByRole("button", { name: "Reset" }))
+
+    expect(handleAction).toHaveBeenCalledOnce()
+    await waitFor(() => {
+      expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    })
+  })
+
   it("renders a custom apply-button label when applySelectionLabel is provided", async () => {
     const user = userEvent.setup()
 


### PR DESCRIPTION
## Why

Found while building a plan-picker column with `editableTable` in Factorial.

The Members table puts a \"Cancel scheduled change\" action under the plan options; clicking it opens a confirmation dialog. The dropdown stayed open on top of the dialog it had just raised — two competing surfaces, and no obvious way back.

## What

`F0Select` wraps each `actions` entry so the dropdown closes before the consumer's `onClick` runs. Bottom actions are terminal by nature — they navigate away, open a dialog, or reset the selection — so none of them wants the list still open behind the result.

## Testing

New unit test covers the dropdown closing on a bottom action. The full `F0Select` suite passes (67 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)