### PR TITLE
feat(OneTable): add a column maxWidth that caps without pinning

### DIFF
--- a/packages/react/src/experimental/OneTable/TableCell/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableCell/index.tsx
@@ -50,6 +50,14 @@ interface TableCellProps {
   minWidth?: number | "auto"
 
   /**
+   * Optional maximum width for the cell. When provided, overrides the
+   * maxWidth derived from `width`, so the cell stops growing at this value
+   * while still shrinking to fit its content. Use it to keep one long value
+   * from stretching its column — see the note on `TableHead.maxWidth`.
+   */
+  maxWidth?: number | "auto"
+
+  /**
    * When true, the header cell will stick in the specified position when scrolling horizontally
    * @default undefined
    */
@@ -112,6 +120,7 @@ export function TableCell({
   onClick,
   width = "auto",
   minWidth,
+  maxWidth,
   firstCell = false,
   sticky,
   colSpan,
@@ -133,6 +142,10 @@ export function TableCell({
 
   const colWidth = getColWidth(width)
   const colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth
+  const colMaxWidth = maxWidth !== undefined ? getColWidth(maxWidth) : colWidth
+  // A capped cell has to clip, or the cap only moves the overflow instead of
+  // containing it.
+  const constrained = width !== "auto" || maxWidth !== undefined
 
   const linkRef = useRef<HTMLAnchorElement>(null)
   const depth = nestedRowProps?.depth ?? 0
@@ -169,7 +182,7 @@ export function TableCell({
       // Min and max width is needed to prevent the cell from shrinking or expanding when the table is scrolled
       style={{
         width: colWidth,
-        maxWidth: colWidth,
+        maxWidth: colMaxWidth,
         minWidth: colMinWidth,
         left: stickyLeft,
         right: stickyRight,
@@ -237,7 +250,7 @@ export function TableCell({
             ) : (
               <div
                 className={cn(
-                  width !== "auto" && "overflow-hidden",
+                  constrained && "overflow-hidden",
                   "relative z-[1] h-full"
                 )}
                 style={{

--- a/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/__tests__/TableHead.test.tsx
@@ -208,3 +208,62 @@ describe("TableHead and TableCell highlighted", () => {
     expect(plainCell.className).not.toContain(highlightClass)
   })
 })
+
+describe("TableHead column width", () => {
+  const renderWidths = (props: {
+    width?: number
+    minWidth?: number
+    maxWidth?: number
+  }) =>
+    zeroRender(
+      <OneTable>
+        <TableHeader>
+          <TableRow>
+            <TableHead {...props}>Índice vs empresa</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          <TableRow>
+            <TableCell {...props}>3,20</TableCell>
+          </TableRow>
+        </TableBody>
+      </OneTable>
+    )
+
+  it("pins the cell when given a width, so the label has to absorb the deficit", () => {
+    renderWidths({ width: 80 })
+
+    const header = screen.getByRole("columnheader")
+    expect(header.style.width).toBe("80px")
+    expect(header.style.maxWidth).toBe("80px")
+    expect(header.style.minWidth).toBe("80px")
+  })
+
+  it("caps without pinning when given only a maxWidth", () => {
+    renderWidths({ maxWidth: 500 })
+
+    const header = screen.getByRole("columnheader")
+    // No width and no minWidth: the column still sizes itself to the wider of
+    // its content and its own header label, it just stops growing at the cap.
+    expect(header.style.width).toBe("")
+    expect(header.style.minWidth).toBe("")
+    expect(header.style.maxWidth).toBe("500px")
+  })
+
+  it("lets maxWidth override the ceiling that width would have set", () => {
+    renderWidths({ width: 80, maxWidth: 500 })
+
+    const header = screen.getByRole("columnheader")
+    expect(header.style.width).toBe("80px")
+    expect(header.style.minWidth).toBe("80px")
+    expect(header.style.maxWidth).toBe("500px")
+  })
+
+  it("caps the body cell too, so the cap holds for the whole column", () => {
+    renderWidths({ maxWidth: 500 })
+
+    const cell = screen.getByRole("cell")
+    expect(cell.style.maxWidth).toBe("500px")
+    expect(cell.style.width).toBe("")
+  })
+})

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -37,6 +37,20 @@ interface TableHeadProps {
   minWidth?: ColumnWidth
 
   /**
+   * Optional maximum width for the header cell. When provided, overrides the
+   * maxWidth derived from `width`, so the column stops growing at this value
+   * while still shrinking to fit its content.
+   *
+   * Prefer this over `width` to stop one long value from stretching a column:
+   * `width` pins the cell (it is used as the width, the min and the max at
+   * once), which leaves the header label as the only part able to absorb a
+   * narrow column and lets it collapse to nothing. A `maxWidth` is a ceiling
+   * only, so the column still sizes itself to the wider of its content and
+   * its own header.
+   */
+  maxWidth?: ColumnWidth
+
+  /**
    * When true, the header cell will stick in the specified position when scrolling horizontally
    * @default undefined
    */
@@ -109,6 +123,7 @@ export function TableHead({
   children,
   width = "auto",
   minWidth,
+  maxWidth,
   sortState = "none",
   onSortClick,
   onClick,
@@ -146,6 +161,13 @@ export function TableHead({
         }
       : undefined
 
+  const colWidth = getColWidth(width)
+  const colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth
+  const colMaxWidth = maxWidth !== undefined ? getColWidth(maxWidth) : colWidth
+  // A capped cell has to clip, or the cap only moves the overflow instead of
+  // containing it.
+  const constrained = width !== "auto" || maxWidth !== undefined
+
   const content = (
     <div
       className={cn(
@@ -155,11 +177,11 @@ export function TableHead({
       )}
     >
       {typeof children === "string" ? (
-        <OneEllipsis className={cn(width !== "auto" && "overflow-hidden")}>
+        <OneEllipsis className={cn(constrained && "overflow-hidden")}>
           {children}
         </OneEllipsis>
       ) : (
-        <div className={cn("truncate", width !== "auto" && "overflow-hidden")}>
+        <div className={cn("truncate", constrained && "overflow-hidden")}>
           {children}
         </div>
       )}
@@ -228,9 +250,6 @@ export function TableHead({
     </div>
   )
 
-  const colWidth = getColWidth(width)
-  const colMinWidth = minWidth !== undefined ? getColWidth(minWidth) : colWidth
-
   return (
     <TableHeadRoot
       className={cn(
@@ -256,7 +275,7 @@ export function TableHead({
       // Min and max width is needed to prevent the cell from shrinking or expanding when the table is scrolled
       style={{
         width: colWidth,
-        maxWidth: colWidth,
+        maxWidth: colMaxWidth,
         minWidth: colMinWidth,
         left: stickyLeft,
         right: stickyRight,

--- a/packages/react/src/kits/ai/canvas/types.ts
+++ b/packages/react/src/kits/ai/canvas/types.ts
@@ -425,7 +425,14 @@ export interface ChatDashboardColumn {
   id: string
   /** Display header label */
   label: string
-  /** Optional fixed width in pixels */
+  /**
+   * @deprecated A fixed pixel width pins the column (`width` is applied as the
+   * width, the min and the max at once), and a column pinned narrower than its
+   * header label renders no label — the ⓘ, the sort button and the padding in
+   * a header cell never shrink, so the label is the only part that can. The
+   * host ignores this field; it stays for dashboards saved while it was still
+   * being written. Cap a column with the table column's `maxWidth` instead.
+   */
   width?: number
   /**
    * Optional header tooltip explaining what the column represents — formula

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -1064,6 +1064,7 @@ export const TableCollection = <
                           key={`summary-${String(column.label)}`}
                           firstCell={cellIndex === 0}
                           width={column.width}
+                          maxWidth={column.maxWidth}
                           sticky={getStickyPosition(cellIndex)}
                           highlighted={!!column.highlighted}
                           className={cn(

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -443,6 +443,7 @@ const RowComponentInner = <
             onClick={itemOnClick}
             width={column.width}
             minWidth={column.minWidth}
+            maxWidth={column.maxWidth}
             sticky={getStickyPosition(cellIndex)}
             loading={loading}
             nestedRowProps={{

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -41,6 +41,18 @@ export type WithOptionalSorting<
    * `width` that should not shrink below a given size.
    */
   minWidth?: number
+
+  /**
+   * Optional maximum width for the column in pixels. A ceiling only: the
+   * column still sizes itself to its content, it just stops growing here.
+   *
+   * Reach for this, not `width`, when the goal is to stop one long value from
+   * stretching a column. `width` is applied as the width, the min AND the max
+   * at once, which pins the column — and since the header label is the only
+   * part of a header cell that can shrink, a pinned column too narrow for its
+   * label renders no label at all.
+   */
+  maxWidth?: number
 }
 
 export type ColId = string
@@ -52,7 +64,13 @@ export type TableColumnDefinition<
 > = WithOptionalSorting<R, Sortings> &
   Pick<
     ComponentProps<typeof TableHead>,
-    "hidden" | "info" | "infoIcon" | "sticky" | "width" | "minWidth"
+    | "hidden"
+    | "info"
+    | "infoIcon"
+    | "sticky"
+    | "width"
+    | "minWidth"
+    | "maxWidth"
   > & {
     /**
      * Optional summary configuration for this column


### PR DESCRIPTION
## Description

Adds `maxWidth` to the table column API, so a caller can stop one long value from stretching a column **without** pinning the column.

Today the only tool for this is `width`, and `width` is applied as the width, the min *and* the max at once:

```ts
style={{ width: colWidth, maxWidth: colWidth, minWidth: colMinWidth }}
```

That pins the column, and a pinned column has a nasty failure mode in the header. A header cell spends ~72px on things that never shrink:

| part | width |
|---|---|
| cell padding (`px-3`) | 24px |
| ⓘ info hint (`h-6 w-6`) | 24px |
| sort button (`h-5 w-5`) | 20px — `opacity-0` until hover, but always occupying layout |
| gap (`gap-1`) | 4px |

The label is an `OneEllipsis` with `min-w-0 max-w-full overflow-hidden`, so it is the only part that *can* shrink — and it can shrink to zero. **Visible label = declared width − 72px.** A column pinned at 110px shows `Plant…`; at or below 72px it shows nothing at all.

This is not hypothetical — it is what a real analytics dashboard looked like, where every column was pinned by an upstream caller:

`Equipos ⓘ | Plant… ⓘ | B ⓘ | ⓘ | ⓘ | Ta… ⓘ | Í. ⓘ`

`maxWidth` is a ceiling only. The column still sizes itself to the wider of its content and its own header label — it just stops growing at the cap. A long value truncates without the header paying for it.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Deprecation (adds `@deprecated`)

## Implementation details

- `TableHead` / `TableCell`: new optional `maxWidth`. It overrides the `maxWidth` that `width` would have derived; when unset, behaviour is byte-for-byte what it is today.
- The `overflow-hidden` that a constrained cell needs is now keyed on `width !== "auto" || maxWidth !== undefined`, so a capped cell clips instead of just relocating its overflow.
- `TableColumnDefinition` exposes `maxWidth`, forwarded to header cells (via the existing `{...column}` spread), body cells (`Row.tsx`) and summary cells (`Table.tsx`).
- `ChatDashboardColumn.width` is marked `@deprecated` pointing at the column `maxWidth`. That field is what let an LLM author a pin in the first place.

Purely additive — no existing call site changes behaviour.

## Verification

- 4 new unit tests in `TableHead.test.tsx` covering: `width` pins (width/min/max all set), `maxWidth` alone caps without pinning (no `width`, no `minWidth`), `maxWidth` overriding the ceiling `width` would have set, and the cap reaching body cells so it holds for the whole column.
- `pnpm vitest run src/experimental/OneTable` — 16 passed.
- `pnpm build:types` clean; `pnpm check:lint-debt` reports 114 warnings against a 114 baseline, i.e. no new debt.

The header arithmetic above was measured in the browser against a replica of this markup, not read off the stylesheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Companion PRs

- factorialco/factorial#113785 — the caller that was pinning every column; ignores the authored `width` and caps at 500px using the `maxWidth` added here.
- factorialco/factorial-agent#3159 — removes the schema field that let an LLM author the pin.

---

## ⚠️ No longer required — optional cleanup

The consumer fix (factorialco/factorial#113785) now lands **without any f0 change**. I was wrong that a cap couldn't be expressed with the current API: passing `minWidth` *replaces* the floor that `width` sets while its derived `maxWidth` stays, so `{ width: 500, minWidth: 1 }` is already a ceiling with no floor. Measured over 5 columns in a 990px container — narrow columns keep their natural 180/167/194/218px, only the runaway column is capped 564 → 500px.

What this PR still offers, if we want it:

1. **Intent.** `maxWidth: 500` says what it means. `width: 500, minWidth: 1` needs a paragraph of comment explaining that the `minWidth` is there to *disable* something.
2. **A doc fix.** The current `minWidth` comment says it allows "the column to grow past `width`", which is only true when `minWidth > width`. It says nothing about the far more useful case — a smaller `minWidth` releasing the floor and turning the pin into a cap. That's the behaviour the whole bug hinged on and it is undocumented.
3. **The `width` trap itself**, which is what actually caused the bug: a caller reaching for "don't let this column get too wide" reasonably reaches for `width`, gets a pin, and blanks the header. Worth a warning on `width` at minimum.

Happy to close this and keep only the doc changes if the new prop isn't wanted — the deprecation on `ChatDashboardColumn.width` is the part I'd most want to keep either way.