### PR TITLE
feat(OneDataCollection): open on a given preset with defaultPresetId

### DIFF
--- a/packages/react/src/hooks/datasource/types/datasource.typings.ts
+++ b/packages/react/src/hooks/datasource/types/datasource.typings.ts
@@ -41,6 +41,12 @@ export type DataSourceDefinition<
   currentFilters?: FiltersState<Filters>
   /** Predefined filter configurations that can be applied */
   presets?: PresetsDefinition<Filters>
+  /**
+   * Id of the preset the collection opens on, selected as if the user had clicked it. Matched
+   * against `presets[].id`, so the preset has to declare one. Applied once on mount: a later change
+   * is ignored, since the user may have moved off it since.
+   */
+  defaultPresetId?: string
   /** Whether presets are currently loading */
   presetsLoading?: boolean
   /*******************************************************/

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -294,6 +294,7 @@ const OneDataCollectionComp = <
     setCurrentFilters,
     presets,
     presetsLoading,
+    defaultPresetId,
     // Navigation filter
     currentNavigationFilters,
     navigationFilters,
@@ -1152,6 +1153,23 @@ const OneDataCollectionComp = <
       getPresetCapturedState,
     ]
   )
+
+  // Opens on the preset the consumer named, exactly as clicking it would: the chip reads as
+  // selected and the preset's captured state is applied. Once only — by the time anything else
+  // changes, the user may have moved off it — but deferred until the preset exists, since custom
+  // presets arrive from storage after mount.
+  const appliedDefaultPresetRef = useRef(false)
+  useEffect(() => {
+    if (appliedDefaultPresetRef.current || !defaultPresetId) {
+      return
+    }
+    if (!mergedPresets.some((preset) => preset.id === defaultPresetId)) {
+      return
+    }
+
+    appliedDefaultPresetRef.current = true
+    applyPreset(defaultPresetId)
+  }, [defaultPresetId, mergedPresets, applyPreset])
 
   // Tracks the selected developer preset's applied snapshot and whether the view
   // has *settled* onto it. Auto-deselect only fires after settling, so applying a

--- a/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/presets.test.tsx
@@ -77,11 +77,13 @@ const visualizations = [
  */
 function Harness({
   presets,
+  defaultPresetId,
   id = "presets-test/v1",
   onState,
   urlSync = false,
 }: {
   presets?: PresetsDefinition<typeof filters>
+  defaultPresetId?: string
   id?: string
   onState?: (state: {
     filters: unknown
@@ -97,6 +99,7 @@ function Harness({
     sortings,
     grouping,
     presets,
+    defaultPresetId,
     dataAdapter: { fetchData: async () => ({ records }) },
   })
 
@@ -308,6 +311,44 @@ describe("OneDataCollection - presets", () => {
       expect(chip()).not.toHaveClass("bg-f1-background-selected-secondary")
     )
     expect(screen.getAllByText("Save view").length).toBeGreaterThan(0)
+  })
+
+  it("opens on the preset named by defaultPresetId, selected and applied", async () => {
+    const devPresets: PresetsDefinition<typeof filters> = [
+      { id: "dev-eng", label: "Eng team", filter: { department: ["eng"] } },
+    ]
+    const onState = vi.fn()
+    renderHarness({ presets: devPresets, defaultPresetId: "dev-eng", onState })
+
+    const chip = () =>
+      screen
+        .getAllByText("Eng team")
+        .find((el) => !el.closest('[aria-hidden="true"]'))!
+        .closest("label")!
+
+    await waitFor(() =>
+      expect(chip()).toHaveClass("bg-f1-background-selected-secondary")
+    )
+    await waitFor(() =>
+      expect(onState).toHaveBeenCalledWith(
+        expect.objectContaining({ filters: { department: ["eng"] } })
+      )
+    )
+  })
+
+  it("ignores a defaultPresetId that names no preset", async () => {
+    const devPresets: PresetsDefinition<typeof filters> = [
+      { id: "dev-eng", label: "Eng team", filter: { department: ["eng"] } },
+    ]
+    renderHarness({ presets: devPresets, defaultPresetId: "dev-sales" })
+
+    await waitFor(() => expect(screen.getByText("John")).toBeInTheDocument())
+
+    const chip = screen
+      .getAllByText("Eng team")
+      .find((el) => !el.closest('[aria-hidden="true"]'))!
+      .closest("label")!
+    expect(chip).not.toHaveClass("bg-f1-background-selected-secondary")
   })
 
   it("de-selects a developer preset (offering 'Save view') when the view is edited", async () => {


### PR DESCRIPTION
## Why

Found while building the One Members table in Factorial, where an inbox task deep-links to "the people still waiting on a plan".

A collection can already be opened with filters applied — `defaultFilters` does that. What it cannot do is open with the **preset that carries those filters selected**: `selectedPresetId` is internal state that only `applyPreset` sets, and `applyPreset` only runs from a click. So the table comes up filtered while every chip reads as untouched, which tells the user the list is complete when it isn't.

`dc_view` is not an answer either. It restores the selection marker but deliberately leaves the captured filters to the other URL params, so a link has to carry the whole encoded view to express "open here".

## What

`defaultPresetId` on the source definition, next to `presets`. On mount the collection applies that preset exactly as a click would — chip selected, captured state applied — so the consumer names one value instead of keeping a preset and a matching `defaultFilters` in sync.

- Applied **once**: by the time anything changes it, the user may have moved off it.
- **Deferred until the preset exists**, rather than a bare `[]` effect, so a custom preset still loading from storage is not missed.
- An id matching no preset is ignored.

## Testing

Two new cases in `presets.test.tsx` — the chip is selected and the filter applied on mount; an unknown id changes nothing. Full `OneDataCollection` suite passes (746 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)